### PR TITLE
Fix magic link URL path to match router definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+## 1.2.0 - 2025-09-03
+
+### Added
+- User settings system with customizable time zone, date format, and time format preferences
+- Comprehensive session management system for admin interface with real-time tracking
+- Live data updates system for admin panels with automatic refresh capabilities
+- Automatic user logout functionality when role changes occur for enhanced security
+- DateTime formatting functions with Timex library integration for better date/time handling
+- Enhanced authentication session management for improved user experience
+
+### Changed
+- Authentication components updated with GitHub-inspired design and unified development notices
+- Date handling refactored into separate PhoenixKit.Date module (aliased as PKDate) for better organization
+- User dashboard "Registered" field now uses enhanced date formatting from settings
+- Improved code quality and PubSub integration for better real-time communication
+
+### Fixed
+- Missing admin routes for settings and modules sections
+- Dialyzer type errors resolved across the codebase
+- Live Activity link in dashboard now correctly navigates to intended destination
+- Settings tab information updated with accurate user preferences display
+
 ## 1.1.1 - 2025-09-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ mix phoenix_kit.install --router-path lib/my_app_web/router.ex
 
 ### Manual Installation
 
-1. Add `{:phoenix_kit, "~> 2"}` to `mix.exs`
+1. Add `{:phoenix_kit, "~> 1.2"}` to `mix.exs`
 2. Run `mix deps.get && mix phoenix_kit.gen.migration`
 3. Configure repository: `config :phoenix_kit, repo: MyApp.Repo`
 4. Add `phoenix_kit_routes()` to your router

--- a/lib/phoenix_kit/users/magic_link.ex
+++ b/lib/phoenix_kit/users/magic_link.ex
@@ -223,14 +223,14 @@ defmodule PhoenixKit.Users.MagicLink do
   ## Examples
 
       iex> PhoenixKit.Users.MagicLink.magic_link_url("token123")
-      "http://localhost:4000/phoenix_kit/magic_link/token123"
+      "http://localhost:4000/phoenix_kit/users/magic-link/token123"
       
       iex> PhoenixKit.Users.MagicLink.magic_link_url("token123", "https://myapp.com")
-      "https://myapp.com/phoenix_kit/magic_link/token123"
+      "https://myapp.com/phoenix_kit/users/magic-link/token123"
   """
   def magic_link_url(token, base_url \\ nil) when is_binary(token) do
     base = base_url || get_base_url()
-    "#{base}/phoenix_kit/magic_link/#{token}"
+    "#{base}/phoenix_kit/users/magic-link/#{token}"
   end
 
   @doc """


### PR DESCRIPTION
- Update magic_link_url/2 to generate /phoenix_kit/users/magic-link/ paths
- Fix documentation examples to reflect correct URL structure
- Add in CHANGELOG info about version change