### PR TITLE
Simplify CONTRIBUTING.md with Phoenix built-in live reloading only

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,6 @@ defp deps do
   [
     {:phoenix_kit, path: "../phoenix_kit"},
     {:igniter, "~> 0.6.0", only: [:dev]},      # Required for phoenix_kit.install task
-    {:file_system, "~> 1.1.0", only: [:dev]},  # Required for live reloading
     # ... other Phoenix dependencies
   ]
 end
@@ -72,20 +71,65 @@ mix phx.server
 
 You can now visit [`http://localhost:4000`](http://localhost:4000) to see your development app running with PhoenixKit. Keep in mind, that any changes you make to files in the `phoenix_kit` directory will require manually running `mix deps.compile phoenix_kit --force` and refreshing your browser to see the changes.
 
+10. **Configure Live Reloading**: The basic setup above requires manually recompiling PhoenixKit after each change. To enable automatic hot reloading that detects changes and recompiles automatically, configure Phoenix's built-in systems:
+
+**Note**: The following configuration is added to your Phoenix development project (not in the phoenix_kit directory).
+
+   a. **Configure Phoenix.CodeReloader**: Add to your `config/dev.exs`:
+
+   ```elixir
+   config :your_app, YourAppWeb.Endpoint,
+     # ... existing config ...
+     reloadable_apps: [:your_app, :phoenix_kit],
+     reload_lib_dirs: ["lib", "../phoenix_kit/lib"]
+   ```
+
+   b. **Configure Phoenix.LiveReloader**: Add to your `config/dev.exs`:
+
+   ```elixir
+   # Configure Phoenix LiveReloader to watch the phoenix_kit library (sibling project)
+   config :phoenix_live_reload, :dirs, ["", "../phoenix_kit"]
+
+   # Add phoenix_kit pattern to live reload patterns
+   config :your_app, YourAppWeb.Endpoint,
+     live_reload: [
+       patterns: [
+         ~r"priv/static/(?!uploads/).*(js|css|png|jpeg|jpg|gif|svg)$",
+         ~r"priv/gettext/.*(po)$",
+         ~r"lib/your_app_web/(?:controllers|live|components|router)/?.*\.(ex|heex)$",
+         ~r"../phoenix_kit/lib/.*\.(ex|heex)$"  # Add this line
+       ]
+     ]
+   ```
+
+   c. **Restart your Phoenix server**:
+
+   ```bash
+   # In your development project directory
+   mix phx.server
+   ```
+
+   **How it works:**
+   - When you edit phoenix_kit files, Phoenix.LiveReloader detects changes and triggers browser refresh
+   - During the refresh request, Phoenix.CodeReloader automatically recompiles changed files
+   - You see updated code immediately without manual recompilation
+
 ## Contribution Workflow
+
+Once you have your development environment set up with live reloading, follow these steps to contribute:
 
 1. **Switch to dev branch**:
 ```bash
 git checkout dev
 ```
 
-2. **Make your first test change** in the `phoenix_kit` directory
+2. **Make your changes** in the `phoenix_kit` directory - you'll see them live in your browser thanks to the live reloading setup
 
 3. **Commit and push** your changes:
 ```bash
-git add changed_file
-git commit
-git push
+git add .
+git commit -m "Your descriptive commit message"
+git push origin dev
 ```
 
 4. **Create Pull Request**:
@@ -96,185 +140,3 @@ git push
    - Enter a title and description of your changes
    - Ensure the base branch is set to `BeamLabEU/phoenix_kit:dev` (not main)
    - Click "Create pull request" to submit
-
-## Development with Live Reloading
-
-The basic setup above requires manually recompiling PhoenixKit after each change. To enable automatic hot reloading that detects changes and recompiles automatically, follow these steps:
-
-### Method 1: Phoenix Built-in Systems (Recommended)
-
-**Note**: The following steps are performed in your Phoenix development project (not in the phoenix_kit directory).
-
-This method uses Phoenix's built-in CodeReloader and LiveReloader systems for automatic recompilation and browser refresh.
-
-1. **Configure Phoenix.CodeReloader**: Add to your `config/dev.exs`:
-
-```elixir
-config :your_app, YourAppWeb.Endpoint,
-  # ... existing config ...
-  reloadable_apps: [:your_app, :phoenix_kit],
-  reload_lib_dirs: ["lib", "../phoenix_kit/lib"]
-```
-
-2. **Configure Phoenix.LiveReloader**: Add to your `config/dev.exs`:
-
-```elixir
-# Configure Phoenix LiveReloader to watch the phoenix_kit library (sibling project)
-config :phoenix_live_reload, :dirs, ["", "../phoenix_kit"]
-
-# Add phoenix_kit pattern to live reload patterns
-config :your_app, YourAppWeb.Endpoint,
-  live_reload: [
-    patterns: [
-      ~r"priv/static/(?!uploads/).*(js|css|png|jpeg|jpg|gif|svg)$",
-      ~r"priv/gettext/.*(po)$",
-      ~r"lib/your_app_web/(?:controllers|live|components|router)/?.*\.(ex|heex)$",
-      ~r"../phoenix_kit/lib/.*\.(ex|heex)$"  # Add this line
-    ]
-  ]
-```
-
-3. **Restart your Phoenix server**:
-
-```bash
-# In your development project directory
-iex -S mix phx.server
-```
-
-**How it works:**
-- When you edit phoenix_kit files, Phoenix.LiveReloader detects changes and triggers browser refresh
-- During the refresh request, Phoenix.CodeReloader automatically recompiles changed files
-- You see updated code immediately without manual recompilation
-
-### Method 2: Custom FileWatcher (Fallback)
-
-If the Phoenix built-in method doesn't work for your setup, you can use this custom approach:
-
-**Note**: This method requires more custom code but provides the same user experience as Method 1. Use this only if the Phoenix built-in method doesn't work for your specific project structure or setup.
-
-1. **Add FileWatcher Module**: Create a GenServer that monitors file changes in your development app at `lib/your_app/file_watcher.ex`:
-
-```elixir
-defmodule YourApp.FileWatcher do
-  use GenServer
-  require Logger
-
-  def start_link(dirs) do
-    GenServer.start_link(__MODULE__, dirs, name: __MODULE__)
-  end
-
-  def init(dirs) do
-    {:ok, watcher_pid} = FileSystem.start_link(dirs: dirs)
-    FileSystem.subscribe(watcher_pid)
-    Logger.info("File watcher started for: #{inspect(dirs)}")
-    {:ok, %{watcher_pid: watcher_pid}}
-  end
-
-  def handle_info({:file_event, _watcher_pid, {path, events}}, state) do
-    ext = Path.extname(path)
-    Logger.info("File event detected - Path: #{path}, Extension: #{ext}, Events: #{inspect(events)}")
-
-    if ext in [".ex", ".exs", ".heex", ".eex", ".leex"] do
-      Logger.info("Processing change in #{path}, recompiling...")
-
-      Task.start(fn ->
-        :timer.sleep(100)
-
-        # Recompile phoenix_kit dependency
-        {output, _} = System.cmd("mix", ["deps.compile", "phoenix_kit", "--force"],
-          cd: File.cwd!(), stderr_to_stdout: true)
-        Logger.debug("Phoenix kit compile output: #{output}")
-
-        # Compile main project
-        {compile_output, _} = System.cmd("mix", ["compile"],
-          cd: File.cwd!(), stderr_to_stdout: true)
-        Logger.debug("Main project compile output: #{compile_output}")
-
-        # Purge and reload modules
-        purge_phoenix_kit_modules()
-
-        # Trigger browser refresh
-        trigger_browser_refresh()
-
-        Logger.info("✅ External library reload complete - browser should refresh automatically")
-      end)
-    else
-      Logger.debug("Ignoring file event for non-Elixir file: #{path}")
-    end
-
-    {:noreply, state}
-  end
-
-  defp purge_phoenix_kit_modules do
-    :code.all_loaded()
-    |> Enum.filter(fn {module, _} ->
-      module_name = Atom.to_string(module)
-      String.starts_with?(module_name, "Elixir.PhoenixKit")
-    end)
-    |> Enum.each(fn {module, _} ->
-      Logger.info("Purging module: #{module}")
-      :code.purge(module)
-      :code.delete(module)
-    end)
-  end
-
-  defp trigger_browser_refresh do
-    # Touch CSS to trigger Phoenix LiveReload
-    css_file = "priv/static/assets/app.css"
-    if File.exists?(css_file) do
-      File.touch!(css_file)
-    else
-      # Fallback: create temporary JS file
-      dummy_file = "priv/static/phoenix_kit_reload.js"
-      File.write!(dummy_file, "// Auto-reload trigger #{:erlang.system_time()}")
-      Task.start(fn ->
-        :timer.sleep(1000)
-        File.rm(dummy_file)
-      end)
-    end
-  end
-end
-```
-
-2. **Start FileWatcher in Application**: Update your development app's `application.ex`:
-
-```elixir
-def start(_type, _args) do
-  children = [
-    # ... other children
-    file_watcher_child(),
-    YourAppWeb.Endpoint
-  ]
-  # ...
-end
-
-defp file_watcher_child do
-  if Mix.env() == :dev do
-    {YourApp.FileWatcher, ["../phoenix_kit/lib"]}  # Path to your local phoenix_kit
-  else
-    []
-  end
-end
-```
-
-## How Live Reloading Works
-
-### Method 1 (Phoenix Built-in):
-- **Phoenix.LiveReloader** monitors file changes and triggers browser refresh
-- **Phoenix.CodeReloader** recompiles during the browser refresh request
-- **Zero custom code** - uses standard Phoenix development workflow
-- **Same user experience** - automatic refresh with updated code
-
-### Method 2 (Custom FileWatcher):
-- **FileWatcher** monitors all Elixir files and templates
-- **Background recompilation** when files change (before browser refresh)
-- **Module purging** to ensure fresh code is loaded
-- **Custom browser refresh triggering** via file system manipulation
-- **Same user experience** - automatic refresh with updated code
-
-## Benefits of Live Reloading
-
-- **Instant Feedback**: See your changes immediately in the browser
-- **No Manual Steps**: No need to manually run `mix deps.compile` or restart the server
-- **Template Support**: Works with both Elixir code and Phoenix templates
-- **Browser Sync**: Automatic browser refresh on every change


### PR DESCRIPTION
- Remove custom FileWatcher method entirely (200+ lines removed)
- Integrate live reloading as Step 10 of initial setup (not optional)
- Move Contribution Workflow to end after all setup is complete
- Remove redundant sections (Benefits, duplicate How It Works)
- Standardize all commands to use simple mix phx.server
- Focus on Phoenix CodeReloader and LiveReloader configuration only
- Cleaner, simpler documentation for contributors

🤖 Generated with [Claude Code](https://claude.ai/code)