### PR TITLE
Fix admin role access with PubSub scope refresh

### DIFF
--- a/lib/phoenix_kit/users/auth.ex
+++ b/lib/phoenix_kit/users/auth.ex
@@ -107,6 +107,22 @@ defmodule PhoenixKit.Users.Auth do
   @doc """
   Gets a single user.
 
+  Returns `nil` if the user does not exist.
+
+  ## Examples
+
+      iex> get_user(123)
+      %User{}
+
+      iex> get_user(456)
+      nil
+
+  """
+  def get_user(id) when is_integer(id), do: Repo.get(User, id)
+
+  @doc """
+  Gets a single user.
+
   Raises `Ecto.NoResultsError` if the User does not exist.
 
   ## Examples
@@ -653,7 +669,8 @@ defmodule PhoenixKit.Users.Auth do
       iex> assign_role(user, "NonexistentRole")
       {:error, :role_not_found}
   """
-  defdelegate assign_role(user, role_name, assigned_by \\ nil), to: PhoenixKit.Users.Roles
+  defdelegate assign_role(user, role_name, assigned_by \\ nil, opts \\ []),
+    to: PhoenixKit.Users.Roles
 
   @doc """
   Removes a role from a user.
@@ -666,7 +683,7 @@ defmodule PhoenixKit.Users.Auth do
       iex> remove_role(user, "NonexistentRole")
       {:error, :assignment_not_found}
   """
-  defdelegate remove_role(user, role_name), to: PhoenixKit.Users.Roles
+  defdelegate remove_role(user, role_name, opts \\ []), to: PhoenixKit.Users.Roles
 
   @doc """
   Checks if a user has a specific role.

--- a/lib/phoenix_kit/users/scope_notifier.ex
+++ b/lib/phoenix_kit/users/scope_notifier.ex
@@ -1,0 +1,60 @@
+defmodule PhoenixKit.Users.ScopeNotifier do
+  @moduledoc """
+  Handles PubSub notifications for user scope refreshes.
+
+  When a user's roles change, we broadcast a message on a user-specific topic
+  so any connected LiveViews can refresh their cached authentication scope
+  without requiring a full reconnect.
+  """
+
+  alias PhoenixKit.PubSub.Manager
+  alias PhoenixKit.Users.Auth.User
+
+  @topic_prefix "phoenix_kit:user_scope:"
+
+  @doc """
+  Broadcasts a scope refresh notification for the given user.
+  """
+  @spec broadcast_roles_updated(User.t() | integer() | nil) :: :ok
+  def broadcast_roles_updated(nil), do: :ok
+
+  def broadcast_roles_updated(%User{id: user_id}) do
+    broadcast_roles_updated(user_id)
+  end
+
+  def broadcast_roles_updated(user_id) when is_integer(user_id) do
+    Manager.broadcast(topic(user_id), {:phoenix_kit_scope_roles_updated, user_id})
+  end
+
+  def broadcast_roles_updated(_), do: :ok
+
+  @doc """
+  Subscribes the current process to scope refresh notifications for the user.
+  """
+  @spec subscribe(User.t() | integer()) :: :ok | {:error, term()}
+  def subscribe(%User{id: user_id}), do: subscribe(user_id)
+
+  def subscribe(user_id) when is_integer(user_id) do
+    Manager.subscribe(topic(user_id))
+  end
+
+  def subscribe(_), do: :ok
+
+  @doc """
+  Unsubscribes the current process from scope refresh notifications.
+  """
+  @spec unsubscribe(User.t() | integer() | nil) :: :ok
+  def unsubscribe(nil), do: :ok
+
+  def unsubscribe(%User{id: user_id}) do
+    unsubscribe(user_id)
+  end
+
+  def unsubscribe(user_id) when is_integer(user_id) do
+    Manager.unsubscribe(topic(user_id))
+  end
+
+  def unsubscribe(_), do: :ok
+
+  defp topic(user_id), do: "#{@topic_prefix}#{user_id}"
+end

--- a/lib/phoenix_kit_web/components/core/flash.ex
+++ b/lib/phoenix_kit_web/components/core/flash.ex
@@ -35,7 +35,7 @@ defmodule PhoenixKitWeb.Components.Core.Flash do
       id={@id}
       phx-click={JS.push("lv:clear-flash", value: %{key: @kind}) |> hide_flash("##{@id}")}
       role="alert"
-      class="toast toast-top toast-end z-50"
+      class="toast toast-top toast-end z-[1000]"
       {@rest}
     >
       <div class={[


### PR DESCRIPTION
## Fix: Admin Role Access with Real-time Scope Refresh

  ### Problem
  When roles were assigned to already-logged-in users, their LiveView sessions never updated the cached
  authentication scope. This caused users with the Admin role in the database to be denied access to admin
  pages because the in-memory scope still showed their old role list.

  ### Solution
  Implemented a PubSub-based scope refresh system that updates sessions in real-time without forcing
  logouts:

  - **New Module**: `PhoenixKit.Users.ScopeNotifier` manages user-specific PubSub topics for role changes
  - **LiveView Integration**: Sessions automatically subscribe to their user's topic and rebuild the cached
  scope when roles change
  - **Admin Demotion Handling**: Users who lose admin privileges are immediately redirected from admin pages
   with clear error messaging
  - **Transaction Safety**: Role mutations use broadcast flags to prevent partial-state notifications during
   database transactions

  ### Additional Improvements
  - **Better Error Messages**: Now distinguishes between "not logged in" vs "logged in but insufficient
  role" scenarios
  - **Subscription Lifecycle**: Proper subscription management when users switch or sessions end
  - **Safe User Fetching**: Added `get_user/1` helper that returns `nil` instead of raising exceptions

  ### Technical Details
  - Broadcasts happen on `phoenix_kit:user_scope:#{user_id}` topics
  - LiveViews attach a `:handle_info` hook to process `{:phoenix_kit_scope_roles_updated, user_id}` messages
  - Scope refresh compares old vs new admin status to trigger redirects only when necessary
  - Edge cases handled: user deletion mid-session, owner role protection, non-admin page refreshes