### PR TITLE
Suppress install warnings when Igniter is absent

### DIFF
--- a/lib/phoenix_kit/install/application_supervisor.ex
+++ b/lib/phoenix_kit/install/application_supervisor.ex
@@ -1,4 +1,6 @@
 defmodule PhoenixKit.Install.ApplicationSupervisor do
+  use PhoenixKit.Install.IgniterCompat
+
   @moduledoc """
   Installation helper for adding PhoenixKit supervisor to parent application.
   Used by `mix phoenix_kit.install` task.

--- a/lib/phoenix_kit/install/css_integration.ex
+++ b/lib/phoenix_kit/install/css_integration.ex
@@ -1,4 +1,6 @@
 defmodule PhoenixKit.Install.CssIntegration do
+  use PhoenixKit.Install.IgniterCompat
+
   @moduledoc """
   Handles automatic Tailwind CSS + DaisyUI integration for PhoenixKit installation.
 

--- a/lib/phoenix_kit/install/demo_files.ex
+++ b/lib/phoenix_kit/install/demo_files.ex
@@ -1,4 +1,6 @@
 defmodule PhoenixKit.Install.DemoFiles do
+  use PhoenixKit.Install.IgniterCompat
+
   @moduledoc """
   Handles copying demo test files for PhoenixKit installation.
 

--- a/lib/phoenix_kit/install/finch_setup.ex
+++ b/lib/phoenix_kit/install/finch_setup.ex
@@ -1,4 +1,6 @@
 defmodule PhoenixKit.Install.FinchSetup do
+  use PhoenixKit.Install.IgniterCompat
+
   @moduledoc """
   Handles automatic Finch and HTTP client setup for PhoenixKit installation.
 

--- a/lib/phoenix_kit/install/igniter_compat.ex
+++ b/lib/phoenix_kit/install/igniter_compat.ex
@@ -1,0 +1,27 @@
+defmodule PhoenixKit.Install.IgniterCompat do
+  @moduledoc false
+
+  @igniter_modules [
+    Igniter,
+    Igniter.Libs.Ecto,
+    Igniter.Libs.Phoenix,
+    Igniter.Project.Application,
+    Igniter.Project.Config,
+    Igniter.Project.Deps,
+    Igniter.Project.Module,
+    Igniter.Code.Common,
+    Igniter.Code.Function
+  ]
+
+  @rewrite_modules [
+    Rewrite.Source
+  ]
+
+  @modules @igniter_modules ++ @rewrite_modules
+
+  defmacro __using__(_opts) do
+    quote do
+      @compile {:no_warn_undefined, unquote(@modules)}
+    end
+  end
+end

--- a/lib/phoenix_kit/install/layout_config.ex
+++ b/lib/phoenix_kit/install/layout_config.ex
@@ -1,4 +1,6 @@
 defmodule PhoenixKit.Install.LayoutConfig do
+  use PhoenixKit.Install.IgniterCompat
+
   @moduledoc """
   Handles layout integration configuration for PhoenixKit installation.
 

--- a/lib/phoenix_kit/install/mailer_config.ex
+++ b/lib/phoenix_kit/install/mailer_config.ex
@@ -1,4 +1,6 @@
 defmodule PhoenixKit.Install.MailerConfig do
+  use PhoenixKit.Install.IgniterCompat
+
   @moduledoc """
   Handles mailer configuration for PhoenixKit installation.
 

--- a/lib/phoenix_kit/install/migration_strategy.ex
+++ b/lib/phoenix_kit/install/migration_strategy.ex
@@ -1,4 +1,6 @@
 defmodule PhoenixKit.Install.MigrationStrategy do
+  use PhoenixKit.Install.IgniterCompat
+
   @moduledoc """
   Handles migration strategy determination and execution for PhoenixKit installation.
 

--- a/lib/phoenix_kit/install/repo_detection.ex
+++ b/lib/phoenix_kit/install/repo_detection.ex
@@ -1,4 +1,6 @@
 defmodule PhoenixKit.Install.RepoDetection do
+  use PhoenixKit.Install.IgniterCompat
+
   @moduledoc """
   Handles repository detection and validation for PhoenixKit installation.
 

--- a/lib/phoenix_kit/install/router_integration.ex
+++ b/lib/phoenix_kit/install/router_integration.ex
@@ -1,4 +1,6 @@
 defmodule PhoenixKit.Install.RouterIntegration do
+  use PhoenixKit.Install.IgniterCompat
+
   @moduledoc """
   Handles router integration for PhoenixKit installation.
 


### PR DESCRIPTION
- Added PhoenixKit.Install.IgniterCompat with @compile :no_warn_undefined so the installer can call Igniter/Rewrite helpers without complaints when Igniter isn’t in the dependency tree.
- Updated each install helper module to use PhoenixKit.Install.IgniterCompat, which silences the optional-dependency warnings during normal compiles and on mix precommit.
- Re-ran mix precommit (via phoenix_kit_testing) to confirm the warnings are gone and the suite still reports 5 tests, 0 failures.