### PR TITLE
Fix Ueberauth MatchError with multi-layer OAuth config system

### DIFF
--- a/lib/phoenix_kit/supervisor.ex
+++ b/lib/phoenix_kit/supervisor.ex
@@ -11,6 +11,9 @@ defmodule PhoenixKit.Supervisor do
   @impl true
   def init(_init_arg) do
     children = [
+      # OAuth config loader MUST be first to ensure configuration
+      # is available before any OAuth requests are processed
+      PhoenixKit.Workers.OAuthConfigLoader,
       PhoenixKit.PubSub.Manager,
       PhoenixKit.Admin.SimplePresence,
       {PhoenixKit.Cache.Registry, []},

--- a/lib/phoenix_kit/users/oauth_config.ex
+++ b/lib/phoenix_kit/users/oauth_config.ex
@@ -26,14 +26,14 @@ defmodule PhoenixKit.Users.OAuthConfig do
       :ok
   """
   def configure_providers do
-    # Skip configuration if OAuth is globally disabled
-    if Settings.get_boolean_setting("oauth_enabled", false) do
-      configure_ueberauth_base()
-      configure_google()
-      configure_apple()
-      configure_github()
-      configure_facebook()
-    end
+    # Always configure Ueberauth base with available providers
+    # This ensures Ueberauth has providers configured even if oauth_enabled is false
+    # The oauth_enabled flag controls UI visibility, not the underlying OAuth infrastructure
+    configure_ueberauth_base()
+    configure_google()
+    configure_apple()
+    configure_github()
+    configure_facebook()
 
     :ok
   end
@@ -59,14 +59,18 @@ defmodule PhoenixKit.Users.OAuthConfig do
   defp configure_ueberauth_base do
     providers = build_provider_list()
 
-    # Only configure and log if there are providers to configure
-    if providers != %{} do
-      config = [
-        providers: providers
-      ]
+    config = [
+      providers: providers
+    ]
 
-      Application.put_env(:ueberauth, Ueberauth, config)
+    # Always update Ueberauth configuration, even if providers list is empty
+    # This ensures Ueberauth has a valid configuration at all times
+    Application.put_env(:ueberauth, Ueberauth, config)
+
+    if providers != %{} do
       Logger.debug("OAuth: Configured Ueberauth with providers: #{inspect(Map.keys(providers))}")
+    else
+      Logger.debug("OAuth: Configured Ueberauth with no active providers")
     end
   end
 

--- a/lib/phoenix_kit/workers/oauth_config_loader.ex
+++ b/lib/phoenix_kit/workers/oauth_config_loader.ex
@@ -1,0 +1,112 @@
+defmodule PhoenixKit.Workers.OAuthConfigLoader do
+  @moduledoc """
+  GenServer worker that ensures OAuth configuration is loaded from database
+  before any OAuth requests are processed.
+
+  This worker runs synchronously during application startup to prevent timing
+  issues where Ueberauth plug is initialized before OAuth providers are configured.
+
+  ## Startup Sequence
+
+  1. Worker starts as first child in PhoenixKit.Supervisor
+  2. Waits for Settings cache to be ready (with timeout)
+  3. Loads OAuth configuration from database
+  4. Configures Ueberauth with available providers
+  5. Returns :ok when complete
+
+  ## Why This Is Needed
+
+  Parent applications typically start services in this order:
+  - Repo (database ready)
+  - PubSub
+  - Parent Endpoint (router compiles, Ueberauth.init() runs)
+  - PhoenixKit.Supervisor (OAuth config should load here)
+
+  If PhoenixKit.Supervisor starts AFTER Parent Endpoint, the OAuth configuration
+  arrives too late and Ueberauth fails with MatchError.
+
+  This worker ensures OAuth configuration is available as early as possible
+  during PhoenixKit.Supervisor initialization.
+  """
+
+  use GenServer
+  require Logger
+
+  @max_retries 10
+  @retry_delay 100
+
+  ## Client API
+
+  @doc """
+  Starts the OAuth configuration loader.
+
+  Blocks until OAuth configuration is successfully loaded or max retries exceeded.
+  """
+  def start_link(_opts) do
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  ## Server Callbacks
+
+  @impl true
+  def init(_) do
+    # Load OAuth configuration synchronously during initialization
+    # This ensures configuration is ready before supervisor completes startup
+    case load_oauth_config_with_retry() do
+      :ok ->
+        Logger.debug("OAuth config loaded successfully during startup")
+        {:ok, %{}}
+
+      {:error, reason} ->
+        Logger.warning("OAuth config loading failed: #{inspect(reason)}")
+        # Don't fail supervisor startup if OAuth config fails
+        # The fallback plug will handle this case
+        {:ok, %{}}
+    end
+  end
+
+  ## Private Helpers
+
+  defp load_oauth_config_with_retry(attempt \\ 1) do
+    case load_oauth_config() do
+      :ok ->
+        :ok
+
+      {:error, :cache_not_ready} when attempt < @max_retries ->
+        Logger.debug("Settings cache not ready, retrying... (attempt #{attempt}/#{@max_retries})")
+        Process.sleep(@retry_delay)
+        load_oauth_config_with_retry(attempt + 1)
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp load_oauth_config do
+    # Check if required modules are loaded
+    if Code.ensure_loaded?(PhoenixKit.Users.OAuthConfig) and
+         Code.ensure_loaded?(PhoenixKit.Settings) do
+      do_load_oauth_config()
+    else
+      Logger.debug("OAuth modules not loaded, skipping configuration")
+      {:error, :modules_not_loaded}
+    end
+  end
+
+  defp do_load_oauth_config do
+    # Verify Settings cache is ready by attempting to read a setting
+    # Try to read any setting to verify cache is operational
+    _ = PhoenixKit.Settings.get_setting("oauth_enabled", "false")
+
+    # Configure OAuth providers from database
+    alias PhoenixKit.Users.OAuthConfig
+    OAuthConfig.configure_providers()
+
+    :ok
+  rescue
+    error ->
+      # Cache might not be ready yet
+      Logger.debug("Settings cache not ready: #{inspect(error)}")
+      {:error, :cache_not_ready}
+  end
+end

--- a/lib/phoenix_kit_web/integration.ex
+++ b/lib/phoenix_kit_web/integration.ex
@@ -441,7 +441,7 @@ defmodule PhoenixKitWeb.Integration do
   defmacro phoenix_kit_routes do
     # Initialize OAuth configuration from database on router setup
     # This ensures OAuth providers are configured before any requests
-    # Only runs if OAuth is enabled in settings
+    # Runs regardless of oauth_enabled setting to ensure Ueberauth always has valid configuration
     if Code.ensure_loaded?(PhoenixKit.Users.OAuthConfig) and
          Code.ensure_loaded?(PhoenixKit.Settings) do
       spawn(fn ->
@@ -449,15 +449,14 @@ defmodule PhoenixKitWeb.Integration do
         Process.sleep(100)
 
         try do
-          # Only configure if OAuth is enabled in settings
-          if PhoenixKit.Settings.get_boolean_setting("oauth_enabled", false) do
-            alias PhoenixKit.Users.OAuthConfig
-            OAuthConfig.configure_providers()
-          end
+          # Always configure providers to ensure Ueberauth has valid configuration
+          # The oauth_enabled flag controls UI visibility, not provider initialization
+          alias PhoenixKit.Users.OAuthConfig
+          OAuthConfig.configure_providers()
         rescue
           error ->
             require Logger
-            Logger.debug("OAuth config initialization skipped: #{inspect(error)}")
+            Logger.debug("OAuth config initialization error: #{inspect(error)}")
         end
       end)
     end

--- a/lib/phoenix_kit_web/plugs/ensure_oauth_config.ex
+++ b/lib/phoenix_kit_web/plugs/ensure_oauth_config.ex
@@ -1,0 +1,94 @@
+defmodule PhoenixKitWeb.Plugs.EnsureOAuthConfig do
+  @moduledoc """
+  Plug that ensures OAuth configuration is loaded before processing OAuth requests.
+
+  This plug serves as a fallback safety mechanism for cases where:
+  - PhoenixKit.Supervisor starts AFTER parent application's Endpoint
+  - OAuthConfigLoader worker failed to load configuration
+  - Configuration was cleared or lost for any reason
+
+  ## How It Works
+
+  1. Checks if Ueberauth has :providers configured
+  2. If configuration is missing or invalid, loads it synchronously
+  3. If loading fails, returns 503 Service Unavailable error
+  4. Otherwise, allows request to proceed normally
+
+  ## Usage
+
+  Add this plug BEFORE Ueberauth plug in OAuth controller:
+
+      plug PhoenixKitWeb.Plugs.EnsureOAuthConfig
+      plug Ueberauth
+
+  ## Why This Is Needed
+
+  Ueberauth plug expects :providers key to exist in application config.
+  If it's missing, Ueberauth.get_providers/2 fails with MatchError.
+
+  This plug prevents that error by ensuring configuration exists before
+  Ueberauth plug runs.
+  """
+
+  import Plug.Conn
+  require Logger
+
+  def init(opts), do: opts
+
+  def call(conn, _opts) do
+    case ensure_oauth_config() do
+      :ok ->
+        conn
+
+      {:error, reason} ->
+        Logger.error("OAuth configuration unavailable: #{inspect(reason)}")
+
+        conn
+        |> put_resp_content_type("text/html")
+        |> send_resp(503, """
+        <html>
+          <head><title>Service Temporarily Unavailable</title></head>
+          <body>
+            <h1>OAuth Service Unavailable</h1>
+            <p>OAuth authentication is temporarily unavailable. Please try again later.</p>
+            <p>If this problem persists, please contact support.</p>
+          </body>
+        </html>
+        """)
+        |> halt()
+    end
+  end
+
+  defp ensure_oauth_config do
+    config = Application.get_env(:ueberauth, Ueberauth, [])
+
+    case Keyword.fetch(config, :providers) do
+      {:ok, _providers} ->
+        # Configuration exists, all good
+        :ok
+
+      :error ->
+        # Configuration missing, try to load it
+        Logger.warning("Ueberauth :providers missing, attempting to load OAuth configuration")
+        load_oauth_config()
+    end
+  end
+
+  defp load_oauth_config do
+    if Code.ensure_loaded?(PhoenixKit.Users.OAuthConfig) do
+      try do
+        alias PhoenixKit.Users.OAuthConfig
+        OAuthConfig.configure_providers()
+        Logger.info("OAuth configuration loaded successfully via fallback plug")
+        :ok
+      rescue
+        error ->
+          Logger.error("Failed to load OAuth configuration: #{inspect(error)}")
+          {:error, :configuration_load_failed}
+      end
+    else
+      Logger.error("PhoenixKit.Users.OAuthConfig module not available")
+      {:error, :oauth_module_not_loaded}
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule PhoenixKit.MixProject do
   use Mix.Project
 
-  @version "1.4.5"
+  @version "1.4.6"
   @description "PhoenixKit is a starter kit for building modern web applications with Elixir and Phoenix"
   @source_url "https://github.com/BeamLabEU/phoenix_kit"
 


### PR DESCRIPTION
## Summary
Fixed critical Ueberauth MatchError timing issue where OAuth config not loaded before first request.

## Solution
- **OAuthConfigLoader worker**: Synchronous load during supervisor startup
- **EnsureOAuthConfig plug**: Fallback check before each request  
- **Auto-enable providers**: When credentials saved
- **Always init config**: Regardless of oauth_enabled flag

## Changes
- New worker: `PhoenixKit.Workers.OAuthConfigLoader`
- New plug: `PhoenixKitWeb.Plugs.EnsureOAuthConfig`
- Enhanced: OAuth config initialization logic
- Enhanced: Auto-enable providers on credential save

## Version
1.4.6

## Testing
- [x] Compilation successful
- [x] Credo: no issues
- [x] Dialyzer passed
- [x] Code formatting verified