### PR TITLE
Fix username collision by ensuring uniqueness during generation

### DIFF
--- a/lib/phoenix_kit/users/auth/user.ex
+++ b/lib/phoenix_kit/users/auth/user.ex
@@ -397,17 +397,38 @@ defmodule PhoenixKit.Users.Auth.User do
   end
 
   defp maybe_generate_username_from_email(changeset) do
-    username = get_change(changeset, :username)
-    email = get_change(changeset, :email) || get_field(changeset, :email)
+    case get_change(changeset, :username) do
+      nil ->
+        email = get_change(changeset, :email) || get_field(changeset, :email)
 
-    # Only generate username if not provided and email is present
-    case {username, email} do
-      {nil, email} when is_binary(email) ->
-        generated_username = generate_username_from_email(email)
-        put_change(changeset, :username, generated_username)
+        if email do
+          generated_username = generate_unique_username_from_email(email)
+          put_change(changeset, :username, generated_username)
+        else
+          changeset
+        end
 
       _ ->
         changeset
+    end
+  end
+
+  # Generate a unique username from email by checking for collisions
+  defp generate_unique_username_from_email(email) do
+    base_username = generate_username_from_email(email)
+    ensure_unique_username(base_username, 0)
+  end
+
+  # Recursively ensure username is unique by adding numeric suffix if needed
+  defp ensure_unique_username(base_username, attempt) do
+    username = if attempt == 0, do: base_username, else: "#{base_username}_#{attempt}"
+
+    repo = PhoenixKit.RepoHelper.repo()
+
+    if repo.get_by(__MODULE__, username: username) do
+      ensure_unique_username(base_username, attempt + 1)
+    else
+      username
     end
   end
 


### PR DESCRIPTION
Add recursive uniqueness check when generating usernames from email addresses. If a username already exists, automatically append numeric suffix (_1, _2, etc) to prevent constraint violations during user registration.

This improves user experience by avoiding validation errors when multiple users register with similar email addresses (e.g., john.doe@gmail.com and john.doe@yahoo.com).