### PR TITLE
Restore PHK component rendering, image support, and docs

### DIFF
--- a/guides/phk_blogging_format.md
+++ b/guides/phk_blogging_format.md
@@ -1,331 +1,215 @@
-# .phk (PhoenixKit) Blogging Format Guide
+# .phk Blogging Format (Current Implementation)
 
-## Overview
+PhoenixKit’s blogging module stores every post as a `.phk` file. Each file is a **YAML frontmatter block** followed by regular **Markdown**. Authors can sprinkle inline PHK components (for example `<Image … />`) anywhere inside the Markdown, but there is no longer a root `<Post>` wrapper or XML layout.
 
-The `.phk` format is PhoenixKit's component-based post markup language. It allows you to create blog posts with structured content that can be styled with different design variants **without changing the content**.
+---
 
-## File Location
+## Where posts live
 
-Blog posts are stored at:
+Posts are kept under `priv/blogging/<blog>/…` inside your host application. The folder layout depends on the blog’s storage mode:
+
+| Blog mode | Path template | Example |
+|-----------|---------------|---------|
+| Timestamp (legacy/default) | `priv/blogging/<blog>/<YYYY-MM-DD>/<HH:MM>/<language>.phk` | `priv/blogging/news/2025-01-15/09:30/en.phk` |
+| Slug (new) | `priv/blogging/<blog>/<post-slug>/<language>.phk` | `priv/blogging/docs/getting-started/en.phk` |
+
+Each language/localisation of a post gets its own `.phk` file in the same directory.
+
+---
+
+## File anatomy
+
+```yaml
+---
+slug: simple-version-original-size
+title: Simple Version (Original Size)
+status: draft            # draft | published | archived
+published_at: 2025-11-07T22:42:00Z
+created_at: 2025-11-07T22:42:17.231679Z
+created_by_email: max@don.ee
+updated_by_email: max@don.ee
+---
+
+# Heading 1
+
+Standard **Markdown** lives here. Use `##` for subheadings, `-` for bullet lists, code fences, etc.
+
+Inline PHK components can appear anywhere in the Markdown body:
+
+<Image file_id="019a6f96-e895-74e2-a745-1b596ee235af" file_variant="medium" alt="Screenshot" />
+
+Continue writing Markdown below the component.
 ```
-priv/blogging/<blog>/<YYYY-MM-DD>/<HH:MM>/en.phk
+
+### Frontmatter keys
+
+Only a subset is required, but the blogging UI will populate everything shown above. Notable keys:
+
+- `slug` – used for slug-mode directories and public URLs.
+- `title` – displayed in admin tables and public templates.
+- `status` – controls whether the post is discoverable publicly (`published` only).
+- `published_at` – timestamp used for ordering and for timestamp-mode folders.
+- `created_by_* / updated_by_*` – audit metadata; the editor manages these.
+
+---
+
+## Markdown + inline PHK components
+
+After the frontmatter, everything is standard Markdown. The renderer automatically:
+
+1. Runs Markdown through Earmark (GitHub-flavoured Markdown).
+2. Scans for inline PHK components (`<Image />`, `<Hero>…</Hero>`, `<CTA />`, `<Headline>`, `<Subheadline>`).
+3. Renders those components with Phoenix components before returning HTML.
+
+This means you can drop components alongside text:
+
+```markdown
+You can mix **bold text** and inline components:
+
+<CTA primary="true" action="/signup">Start Free Trial</CTA>
+
+- Bullet one
+- Bullet two
 ```
 
-Example:
-```
-priv/blogging/blog/2025-10-28/14:30/en.phk
-```
+### Supported inline components
 
-## Basic Structure
+| Component | Notes |
+|-----------|-------|
+| `<Image … />` | Works with either `src="/path/to/file.jpg"` or `file_id="…"`. Optional `file_variant="thumbnail" | "small" | "medium" | "large"` picks a specific variant from PhoenixKit Storage. The renderer now always returns the natural dimensions; add your own `class` if you want to constrain width. |
+| `<Hero variant="split-image|centered|minimal"> … </Hero>` | A layout block that can wrap `<Headline>`, `<Subheadline>`, `<CTA />`, `<Image />`. Use sparingly inside Markdown (usually near the top). |
+| `<Headline>…</Headline>` | Renders a hero-style heading. |
+| `<Subheadline>…</Subheadline>` | Medium-sized supporting text. |
+| `<CTA primary="true|false" action="/path-or-anchor">Label</CTA>` | Button styled by the admin theme. |
 
-Every `.phk` blog post starts with a root `<Post>` element containing metadata:
+Additional components can be introduced by adding Phoenix components under `lib/phoenix_kit_web/components/blogging/` and registering them in the PageBuilder renderer.
 
-```xml
-<Post slug="home" title="Welcome" status="published" published_at="2025-10-28T14:00:00Z">
-  <!-- Your content components go here -->
-</Post>
-```
+---
 
-### Post Attributes
+## Storage integration & variants
 
-- `slug` - URL-friendly identifier (e.g., "home", "about-us")
-- `title` - Post title for SEO and display
-- `status` - Publication status: `draft`, `published`, or `archived`
-- `published_at` - ISO8601 timestamp (changes folder location when updated)
-- `description` (optional) - Meta description for SEO
+When an `<Image>` references `file_id="…"`, the renderer calls `PhoenixKit.Storage.get_public_url_by_id/2`. The storage layer:
 
-## Available Components
+1. Looks for a matching file + variant (`original`, `thumbnail`, `small`, `medium`, `large`, etc.).
+2. Returns the provider’s public URL if available (S3, R2, CDN…).
+3. Falls back to PhoenixKit’s signed `/phoenix_kit/file/:id/:variant/:token` route for local/dev setups.
 
-### Hero Component
+If a variant does not exist yet (for example someone references `medium` before the variant generator runs), the renderer falls back to `original`. The `<Image>` component now *always* renders the file at its natural size; supply your own classes (e.g. `class="w-full"`) if you need to stretch or constraint it.
 
-The Hero section is typically the first visual element users see. It comes with **3 design variants** that can be switched without changing content.
+---
 
-#### Variant 1: Split Image (`variant="split-image"`)
+## Complete example
 
-**Best for:** Landing pages, product showcases, marketing pages
+```yaml
+---
+slug: product-updates-oct-2025
+title: Product Updates – October 2025
+status: published
+published_at: 2025-10-31T09:00:00Z
+---
 
-**Features:**
-- Content on the left side
-- Large image on the right side
-- Gradient background (primary/secondary colors)
-- Responsive grid layout
+# October Highlights
 
-**Example:**
-```xml
+Thanks for building with PhoenixKit! Here are the highlights from this month.
+
 <Hero variant="split-image">
-  <Headline>Build Your SaaS Faster</Headline>
-  <Subheadline>Start shipping in days, not months</Subheadline>
-  <CTA primary="true" action="/signup">Start Free Trial</CTA>
-  <CTA action="#features">Learn More</CTA>
-  <Image src="/assets/dashboard.png" alt="Dashboard Preview" />
+  <Headline>Maintenance Mode v2</Headline>
+  <Subheadline>Plan downtime with confidence.</Subheadline>
+  <CTA primary="true" action="/admin/modules">Enable Module</CTA>
+  <Image file_id="018e3c4a-9f6b-7890-abcd-ef1234567890" alt="Maintenance Mode Screenshot" />
 </Hero>
-```
 
-**Result:**
-- 2-column layout on desktop (content | image)
-- Stacked layout on mobile
-- Eye-catching gradient background
-- Primary and secondary CTAs side-by-side
+## New referral analytics
+
+- Multi-touch attribution
+- CSV exports
+- Improved fraud detection
+
+<Image
+  file_id="019a6f96-e895-74e2-a745-1b596ee235af"
+  file_variant="thumbnail"
+  class="w-full"
+  alt="Referral dashboard"
+/>
+```
 
 ---
 
-#### Variant 2: Centered (`variant="centered"`)
+## Reference example – storage-focused post
 
-**Best for:** Welcome pages, announcements, simple messaging
+```yaml
+---
+slug: storage-integration-example
+title: Storage Integration Example
+status: draft
+published_at: 2025-07-01T10:00:00Z
+---
 
-**Features:**
-- All content centered
-- Neutral background
-- Maximum width container (4xl)
-- Generous spacing
+# Working with PhoenixKit Storage
 
-**Example:**
-```xml
+<!-- Example 1: Using direct URL -->
+<Hero variant="split-image">
+  <Headline>Direct URL Image Example</Headline>
+  <Subheadline>This uses a direct asset path to display an image.</Subheadline>
+  <CTA primary="true" action="/signup">Get Started</CTA>
+  <Image src="/assets/dashboard-preview.png" alt="Dashboard Preview" />
+</Hero>
+
+<!-- Example 2: Using file_id -->
 <Hero variant="centered">
-  <Headline>Welcome to PhoenixKit</Headline>
-  <Subheadline>Everything you need to build modern web applications</Subheadline>
-  <CTA primary="true" action="/get-started">Get Started</CTA>
-  <CTA action="/docs">Read Documentation</CTA>
-  <Image src="/assets/logo-large.png" alt="PhoenixKit Logo" />
+  <Headline>Storage File ID Example</Headline>
+  <Subheadline>This pulls from PhoenixKit Storage.</Subheadline>
+  <CTA primary="true" action="/upload">Upload Image</CTA>
+  <Image file_id="018e3c4a-9f6b-7890-abcd-ef1234567890" alt="Uploaded Image" />
 </Hero>
-```
 
-**Result:**
-- Single centered column
-- Clean, professional look
-- Works great with or without images
-- Text-focused presentation
-
----
-
-#### Variant 3: Minimal (`variant="minimal"`)
-
-**Best for:** Documentation, blog posts, content pages
-
-**Features:**
-- Simple, distraction-free design
-- Smaller padding
-- Maximum width container (3xl)
-- Text-only focused (images optional)
-
-**Example:**
-```xml
+<!-- Example 3: Using file_id with variant -->
 <Hero variant="minimal">
-  <Headline>Getting Started Guide</Headline>
-  <Subheadline>Learn how to build with PhoenixKit in 5 minutes</Subheadline>
-  <CTA primary="true" action="#content">Start Reading</CTA>
+  <Headline>Thumbnail Variant</Headline>
+  <Subheadline>Great for small inline previews.</Subheadline>
+  <Image
+    file_id="018e3c4a-9f6b-7890-abcd-ef1234567890"
+    file_variant="thumbnail"
+    alt="Thumbnail Image"
+  />
 </Hero>
-```
 
-**Result:**
-- Compact, focused layout
-- Quick to scan
-- No distracting backgrounds
-- Perfect for content consumption
-
----
-
-### Child Components
-
-These components work inside Hero (and other container components):
-
-#### Headline
-```xml
-<Headline>Your Main Message Here</Headline>
-```
-- Renders as large, bold text (4xl to 6xl)
-- Responsive sizing
-- Base content color
-
-#### Subheadline
-```xml
-<Subheadline>Supporting description or value proposition</Subheadline>
-```
-- Renders as medium text (lg to xl)
-- Slightly muted color (70% opacity)
-- Good for explanations
-
-#### CTA (Call-to-Action)
-```xml
-<CTA primary="true" action="/signup">Button Text</CTA>
-<CTA action="#section">Secondary Button</CTA>
-```
-
-**Attributes:**
-- `primary` - Set to `"true"` for primary styling (default: `"false"`)
-- `action` - URL or anchor link
-
-**Styling:**
-- Primary: Bold, colored button (btn-primary)
-- Secondary: Outlined button (btn-outline)
-
-#### Image
-```xml
-<Image src="/assets/hero-image.png" alt="Descriptive text" />
-```
-
-**Attributes:**
-- `src` - Image path (relative or absolute)
-- `alt` - Accessibility description
-
-**Features:**
-- Lazy loading enabled
-- Rounded corners
-- Drop shadow
-- Responsive sizing
-
----
-
-## Dynamic Data Placeholders
-
-Use `{{variable}}` syntax to inject dynamic content:
-
-```xml
-<Headline>Welcome back, {{user.name}}</Headline>
-<Subheadline>You have {{stats.active_projects}} active projects</Subheadline>
-```
-
-**Nested values** are supported:
-- `{{user.name}}` → accesses `assigns.user.name`
-- `{{stats.total_users}}` → accesses `assigns.stats.total_users`
-- `{{framework}}` → accesses `assigns.framework`
-
-**Preview mode** provides sample data:
-```elixir
-%{
-  user: %{name: "Preview User", greeting_time: "Today"},
-  stats: %{total_users: "1,000", active_projects: 5},
-  framework: "Phoenix"
-}
-```
-
----
-
-## Switching Design Variants
-
-The power of `.phk` is that you can **change the entire design without touching content**. Just change the `variant` attribute:
-
-**Before (Split Image):**
-```xml
+<!-- Example 4: Custom classes -->
 <Hero variant="split-image">
-  <Headline>Build Your SaaS Faster</Headline>
-  <Subheadline>Start shipping in days, not months</Subheadline>
-  <CTA primary="true" action="/signup">Get Started</CTA>
-</Hero>
-```
-
-**After (Centered) - Same content, different design:**
-```xml
-<Hero variant="centered">
-  <Headline>Build Your SaaS Faster</Headline>
-  <Subheadline>Start shipping in days, not months</Subheadline>
-  <CTA primary="true" action="/signup">Get Started</CTA>
+  <Headline>Custom Styling</Headline>
+  <Subheadline>Combine variants with Tailwind utility classes.</Subheadline>
+  <Image
+    file_id="018e3c4a-9f6b-7890-abcd-ef1234567890"
+    file_variant="medium"
+    class="border-4 border-primary"
+    alt="Styled Image"
+  />
 </Hero>
 ```
 
 ---
 
-## Complete Example
+## Rendering pipeline (current behaviour)
 
-See `priv/static/examples/sample_page.phk` for a complete example showing all three Hero variants in one file.
+1. **Frontmatter parsing** – YAML is parsed to capture metadata.
+2. **Markdown rendering** – Earmark converts the Markdown body to HTML.
+3. **Component pass** – the renderer finds inline PHK component tags and swaps them with Phoenix component output.
+4. **Storage resolution** – `<Image>` elements fetch URLs from `PhoenixKit.Storage`; caching and signed URLs ensure files are served even when only local storage exists.
+5. **Output** – the resulting HTML is cached for published posts to speed up public requests.
 
----
-
-## How the Rendering Works
-
-When a `.phk` file is rendered:
-
-1. **Parse XML** → Convert to AST (Abstract Syntax Tree)
-2. **Inject Data** → Replace `{{placeholders}}` with actual values
-3. **Resolve Components** → Map `<Hero>` → `PhoenixKitWeb.Components.Blogging.Hero`
-4. **Apply Variant** → Select the correct rendering function based on `variant` attribute
-5. **Render HTML** → Generate final HTML output
+There is no longer a pure-XML PageBuilder flow; Markdown is the primary content format. The legacy component pipeline still powers inline components, which is why the supporting modules remain in the codebase.
 
 ---
 
-## Adding New Components (Future)
+## Best practices
 
-The system is designed to be extensible. Future components might include:
-
-```xml
-<!-- Features Section -->
-<Features variant="grid">
-  <Feature icon="rocket">
-    <Title>Fast Development</Title>
-    <Description>Ship features quickly</Description>
-  </Feature>
-</Features>
-
-<!-- Testimonials -->
-<Testimonials variant="carousel">
-  <Testimonial author="Jane Doe" role="CTO" company="TechCorp">
-    This saved us months of development time.
-  </Testimonial>
-</Testimonials>
-
-<!-- CTA Section -->
-<CTASection variant="centered-form">
-  <Headline>Ready to get started?</Headline>
-  <EmailCapture button-text="Get Early Access" />
-</CTASection>
-```
-
-Each component would have its own `.ex` file with multiple variant implementations.
+- **Let Markdown do the heavy lifting.** Use inline components only when you need structured UI blocks.
+- **Always set `alt` text** for `<Image>` components.
+- **Reference the correct blog mode path.** If you switch a blog from timestamp to slug mode (or vice versa), migrate the files accordingly.
+- **Check variants in Storage.** If you expect `thumbnail` files, verify that automatic variant generation is enabled in Settings → Storage.
+- **Keep frontmatter clean.** Avoid adding arbitrary keys unless the blogging UI or your host app actually reads them.
+- **Preview before publishing.** The admin preview now uses the same renderer as the public site, so what you see there should match production output.
 
 ---
 
-## Best Practices
-
-### Content Organization
-- ✅ Use semantic component names (`<Hero>`, not `<Section1>`)
-- ✅ Keep content and structure separate from design decisions
-- ✅ Use descriptive alt text for images
-- ✅ Choose variants based on page purpose, not content
-
-### Dynamic Data
-- ✅ Use placeholders for user-specific content (`{{user.name}}`)
-- ✅ Use placeholders for stats that change (`{{stats.count}}`)
-- ❌ Don't use placeholders for static marketing copy
-
-### Variant Selection
-- `split-image` → Marketing pages, product showcases, conversions
-- `centered` → Welcome pages, announcements, feature launches
-- `minimal` → Documentation, blog posts, content-heavy pages
-
-### Accessibility
-- ✅ Always provide meaningful `alt` text for images
-- ✅ Use descriptive CTA button text ("Start Free Trial" not "Click Here")
-- ✅ Structure content logically (Headline → Subheadline → CTA)
-
----
-
-## Troubleshooting
-
-### "Failed to render preview"
-- Check XML syntax (all tags must be closed: `<Hero>...</Hero>`)
-- Ensure `variant` attribute is valid (`split-image`, `centered`, or `minimal`)
-- Verify all attributes are quoted: `primary="true"` not `primary=true`
-
-### Dynamic placeholders not working
-- Check placeholder syntax: `{{user.name}}` not `{user.name}`
-- Ensure the variable exists in preview assigns
-- Nested paths must match exactly (case-sensitive)
-
-### Content not displaying
-- Verify you're using child components inside `<Hero>` (not plain text)
-- Check that `<Page>` is the root element
-- Ensure all opening tags have matching closing tags
-
----
-
-## Reference: Hero Variants Comparison
-
-| Variant | Layout | Background | Best For | Image Required |
-|---------|--------|------------|----------|----------------|
-| `split-image` | 2-column (content \| image) | Gradient (primary/secondary) | Landing pages, marketing | Recommended |
-| `centered` | Single column, centered | Neutral (base-200) | Announcements, welcome | Optional |
-| `minimal` | Single column, centered | None | Documentation, content | Optional |
-
----
-
-Built with ❤️ for PhoenixKit
+Built with ❤️ for PhoenixKit (updated early 2025)

--- a/lib/phoenix_kit/storage/url_signer.ex
+++ b/lib/phoenix_kit/storage/url_signer.ex
@@ -1,4 +1,5 @@
 defmodule PhoenixKit.Storage.URLSigner do
+  # NOTE: Temporarily supporting the blogging component system until the storage/media team ships their replacement.
   import Bitwise
 
   alias PhoenixKit.Utils.Routes
@@ -50,10 +51,12 @@ defmodule PhoenixKit.Storage.URLSigner do
       iex> PhoenixKit.Storage.URLSigner.signed_url("018e3c4a-9f6b-7890", "thumbnail")
       "/phoenix_kit/file/018e3c4a-9f6b-7890/thumbnail/abc1"  # With default prefix
   """
-  def signed_url(file_id, instance_name) when is_binary(file_id) and is_binary(instance_name) do
+  def signed_url(file_id, instance_name, opts \\ [])
+      when is_binary(file_id) and is_binary(instance_name) do
     token = generate_token(file_id, instance_name)
     file_path = "/file/#{file_id}/#{instance_name}/#{token}"
-    Routes.path(file_path)
+    locale_option = Keyword.get(opts, :locale, :none)
+    Routes.path(file_path, locale: locale_option)
   end
 
   @doc """

--- a/lib/phoenix_kit_web/components/blogging/cta.ex
+++ b/lib/phoenix_kit_web/components/blogging/cta.ex
@@ -1,43 +1,35 @@
-# ============================================================================
-# COMMENTED OUT: Component-based rendering system - CTA Component
-# ============================================================================
-# This module was part of an experimental component-based page building system
-# using XML-style markup (.phk files) with swappable design variants.
-# Related to: lib/phoenix_kit/blogging/page_builder.ex
-# ============================================================================
+defmodule PhoenixKitWeb.Components.Blogging.CTA do
+  @moduledoc """
+  Call-to-action button component.
+  """
+  use Phoenix.Component
 
-# defmodule PhoenixKitWeb.Components.Blogging.CTA do
-#   @moduledoc """
-#   Call-to-action button component.
-#   """
-#   use Phoenix.Component
-#
-#   attr :content, :string, required: true
-#   attr :attributes, :map, default: %{}
-#   attr :variant, :string, default: "default"
-#
-#   def render(assigns) do
-#     is_primary = Map.get(assigns.attributes, "primary", "false") == "true"
-#     action = Map.get(assigns.attributes, "action", "#")
-#
-#     assigns =
-#       assigns
-#       |> assign(:is_primary, is_primary)
-#       |> assign(:action, action)
-#
-#     ~H"""
-#     <a
-#       href={@action}
-#       class={[
-#         "btn inline-block px-8 py-3 rounded-lg font-semibold transition-all",
-#         if(@is_primary,
-#           do: "btn-primary text-primary-content",
-#           else: "btn-outline"
-#         )
-#       ]}
-#     >
-#       {@content}
-#     </a>
-#     """
-#   end
-# end
+  attr :content, :string, required: true
+  attr :attributes, :map, default: %{}
+  attr :variant, :string, default: "default"
+
+  def render(assigns) do
+    is_primary = Map.get(assigns.attributes, "primary", "false") == "true"
+    action = Map.get(assigns.attributes, "action", "#")
+
+    assigns =
+      assigns
+      |> assign(:is_primary, is_primary)
+      |> assign(:action, action)
+
+    ~H"""
+    <a
+      href={@action}
+      class={[
+        "btn inline-block px-8 py-3 rounded-lg font-semibold transition-all",
+        if(@is_primary,
+          do: "btn-primary text-primary-content",
+          else: "btn-outline"
+        )
+      ]}
+    >
+      {@content}
+    </a>
+    """
+  end
+end

--- a/lib/phoenix_kit_web/components/blogging/headline.ex
+++ b/lib/phoenix_kit_web/components/blogging/headline.ex
@@ -1,26 +1,18 @@
-# ============================================================================
-# COMMENTED OUT: Component-based rendering system - Headline Component
-# ============================================================================
-# This module was part of an experimental component-based page building system
-# using XML-style markup (.phk files) with swappable design variants.
-# Related to: lib/phoenix_kit/blogging/page_builder.ex
-# ============================================================================
+defmodule PhoenixKitWeb.Components.Blogging.Headline do
+  @moduledoc """
+  Headline component for hero sections.
+  """
+  use Phoenix.Component
 
-# defmodule PhoenixKitWeb.Components.Blogging.Headline do
-#   @moduledoc """
-#   Headline component for hero sections.
-#   """
-#   use Phoenix.Component
-#
-#   attr :content, :string, required: true
-#   attr :attributes, :map, default: %{}
-#   attr :variant, :string, default: "default"
-#
-#   def render(assigns) do
-#     ~H"""
-#     <h1 class="text-4xl md:text-5xl lg:text-6xl font-bold text-base-content leading-tight">
-#       {@content}
-#     </h1>
-#     """
-#   end
-# end
+  attr :content, :string, required: true
+  attr :attributes, :map, default: %{}
+  attr :variant, :string, default: "default"
+
+  def render(assigns) do
+    ~H"""
+    <h1 class="text-4xl md:text-5xl lg:text-6xl font-bold text-base-content leading-tight">
+      {@content}
+    </h1>
+    """
+  end
+end

--- a/lib/phoenix_kit_web/components/blogging/hero.ex
+++ b/lib/phoenix_kit_web/components/blogging/hero.ex
@@ -1,107 +1,99 @@
-# ============================================================================
-# COMMENTED OUT: Component-based rendering system - Hero Component
-# ============================================================================
-# This module was part of an experimental component-based page building system
-# using XML-style markup (.phk files) with swappable design variants.
-# Related to: lib/phoenix_kit/blogging/page_builder.ex
-# ============================================================================
+defmodule PhoenixKitWeb.Components.Blogging.Hero do
+  @moduledoc """
+  Hero section component with multiple variants.
 
-# defmodule PhoenixKitWeb.Components.Blogging.Hero do
-#   @moduledoc """
-#   Hero section component with multiple variants.
-#
-#   Variants:
-#   - `split-image`: Hero with content on left, image on right
-#   - `centered`: Centered content with optional background
-#   - `minimal`: Simple centered text-only hero
-#
-#   Example usage in .phk file:
-#   ```xml
-#   <Hero variant="split-image">
-#     <Headline>Build Your SaaS Faster</Headline>
-#     <Subheadline>Start shipping in days, not months</Subheadline>
-#     <CTA primary="true" action="/signup">Get Started</CTA>
-#     <CTA action="#features">Learn More</CTA>
-#     <Image src="/assets/dashboard.png" alt="Dashboard" />
-#   </Hero>
-#   ```
-#   """
-#   use Phoenix.Component
-#
-#   attr :variant, :string, default: "centered"
-#   attr :children, :list, default: []
-#   attr :attributes, :map, default: %{}
-#   attr :content, :string, default: nil
-#
-#   def render(assigns) do
-#     case assigns.variant do
-#       "split-image" -> render_split_image(assigns)
-#       "centered" -> render_centered(assigns)
-#       "minimal" -> render_minimal(assigns)
-#       _ -> render_centered(assigns)
-#     end
-#   end
-#
-#   # Split Image Variant: Content on left, image on right
-#   defp render_split_image(assigns) do
-#     ~H"""
-#     <section class="phk-hero phk-hero--split-image py-20 bg-gradient-to-br from-primary/10 to-secondary/10">
-#       <div class="container mx-auto px-4">
-#         <div class="grid lg:grid-cols-2 gap-12 items-center">
-#           <div class="space-y-6">
-#             <%= for child <- @children do %>
-#               <%= if child.type in [:headline, :subheadline, :cta] do %>
-#                 {render_child(child, assigns)}
-#               <% end %>
-#             <% end %>
-#           </div>
-#           <div class="relative">
-#             <%= for child <- @children do %>
-#               <%= if child.type == :image do %>
-#                 {render_child(child, assigns)}
-#               <% end %>
-#             <% end %>
-#           </div>
-#         </div>
-#       </div>
-#     </section>
-#     """
-#   end
-#
-#   # Centered Variant: All content centered
-#   defp render_centered(assigns) do
-#     ~H"""
-#     <section class="phk-hero phk-hero--centered py-24 bg-base-200">
-#       <div class="container mx-auto px-4">
-#         <div class="max-w-4xl mx-auto text-center space-y-8">
-#           <%= for child <- @children do %>
-#             {render_child(child, assigns)}
-#           <% end %>
-#         </div>
-#       </div>
-#     </section>
-#     """
-#   end
-#
-#   # Minimal Variant: Simple text-only hero
-#   defp render_minimal(assigns) do
-#     ~H"""
-#     <section class="phk-hero phk-hero--minimal py-16">
-#       <div class="container mx-auto px-4">
-#         <div class="max-w-3xl mx-auto text-center space-y-4">
-#           <%= for child <- @children do %>
-#             {render_child(child, assigns)}
-#           <% end %>
-#         </div>
-#       </div>
-#     </section>
-#     """
-#   end
-#
-#   defp render_child(child, assigns) do
-#     case PhoenixKitWeb.Live.Modules.Blogging.PageBuilder.Renderer.render(child, assigns) do
-#       {:ok, html} -> html
-#       {:error, _} -> ""
-#     end
-#   end
-# end
+  Variants:
+  - `split-image`: Hero with content on left, image on right
+  - `centered`: Centered content with optional background
+  - `minimal`: Simple centered text-only hero
+
+  Example usage in .phk file:
+  ```xml
+  <Hero variant="split-image">
+    <Headline>Build Your SaaS Faster</Headline>
+    <Subheadline>Start shipping in days, not months</Subheadline>
+    <CTA primary="true" action="/signup">Get Started</CTA>
+    <CTA action="#features">Learn More</CTA>
+    <Image src="/assets/dashboard.png" alt="Dashboard" />
+  </Hero>
+  ```
+  """
+  use Phoenix.Component
+
+  attr :variant, :string, default: "centered"
+  attr :children, :list, default: []
+  attr :attributes, :map, default: %{}
+  attr :content, :string, default: nil
+
+  def render(assigns) do
+    case assigns.variant do
+      "split-image" -> render_split_image(assigns)
+      "centered" -> render_centered(assigns)
+      "minimal" -> render_minimal(assigns)
+      _ -> render_centered(assigns)
+    end
+  end
+
+  # Split Image Variant: Content on left, image on right
+  defp render_split_image(assigns) do
+    ~H"""
+    <section class="phk-hero phk-hero--split-image py-20 bg-gradient-to-br from-primary/10 to-secondary/10">
+      <div class="container mx-auto px-4">
+        <div class="grid lg:grid-cols-2 gap-12 items-center">
+          <div class="space-y-6">
+            <%= for child <- @children do %>
+              <%= if child.type in [:headline, :subheadline, :cta] do %>
+                {render_child(child, assigns)}
+              <% end %>
+            <% end %>
+          </div>
+          <div class="relative">
+            <%= for child <- @children do %>
+              <%= if child.type == :image do %>
+                {render_child(child, assigns)}
+              <% end %>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </section>
+    """
+  end
+
+  # Centered Variant: All content centered
+  defp render_centered(assigns) do
+    ~H"""
+    <section class="phk-hero phk-hero--centered py-24 bg-base-200">
+      <div class="container mx-auto px-4">
+        <div class="max-w-4xl mx-auto text-center space-y-8">
+          <%= for child <- @children do %>
+            {render_child(child, assigns)}
+          <% end %>
+        </div>
+      </div>
+    </section>
+    """
+  end
+
+  # Minimal Variant: Simple text-only hero
+  defp render_minimal(assigns) do
+    ~H"""
+    <section class="phk-hero phk-hero--minimal py-16">
+      <div class="container mx-auto px-4">
+        <div class="max-w-3xl mx-auto text-center space-y-4">
+          <%= for child <- @children do %>
+            {render_child(child, assigns)}
+          <% end %>
+        </div>
+      </div>
+    </section>
+    """
+  end
+
+  defp render_child(child, assigns) do
+    case PhoenixKitWeb.Live.Modules.Blogging.PageBuilder.Renderer.render(child, assigns) do
+      {:ok, html} -> html
+      {:error, _} -> ""
+    end
+  end
+end

--- a/lib/phoenix_kit_web/components/blogging/image.ex
+++ b/lib/phoenix_kit_web/components/blogging/image.ex
@@ -1,37 +1,95 @@
-# ============================================================================
-# COMMENTED OUT: Component-based rendering system - Image Component
-# ============================================================================
-# This module was part of an experimental component-based page building system
-# using XML-style markup (.phk files) with swappable design variants.
-# Related to: lib/phoenix_kit/blogging/page_builder.ex
-# ============================================================================
+defmodule PhoenixKitWeb.Components.Blogging.Image do
+  @moduledoc """
+  Image component with lazy loading and responsive sizing.
 
-# defmodule PhoenixKitWeb.Components.Blogging.Image do
-#   @moduledoc """
-#   Image component for hero sections and content.
-#   """
-#   use Phoenix.Component
-#
-#   attr :attributes, :map, default: %{}
-#   attr :variant, :string, default: "default"
-#   attr :content, :string, default: nil
-#
-#   def render(assigns) do
-#     src = Map.get(assigns.attributes, "src", "")
-#     alt = Map.get(assigns.attributes, "alt", "")
-#
-#     assigns =
-#       assigns
-#       |> assign(:src, src)
-#       |> assign(:alt, alt)
-#
-#     ~H"""
-#     <img
-#       src={@src}
-#       alt={@alt}
-#       class="w-full h-auto rounded-lg shadow-2xl"
-#       loading="lazy"
-#     />
-#     """
-#   end
-# end
+  Supports both direct URLs and PhoenixKit Storage file IDs with automatic variant selection.
+
+  ## Usage
+
+  ### With direct URL:
+
+      <Image src="/path/to/image.jpg" alt="Description" />
+
+  ### With PhoenixKit Storage file ID:
+
+      <Image file_id="018e3c4a-9f6b-7890-abcd-ef1234567890" alt="Description" />
+      <Image file_id="018e3c4a-9f6b-7890-abcd-ef1234567890" file_variant="thumbnail" alt="Description" />
+
+  ## Attributes
+
+  - `src` - Direct image URL (takes precedence over file_id)
+  - `file_id` - PhoenixKit Storage file ID
+  - `file_variant` - Storage variant to use (default: "original")
+    - Images: "original", "thumbnail", "small", "medium", "large"
+  - `alt` - Alt text for accessibility (required)
+  - `class` - Additional CSS classes (optional)
+  """
+  use Phoenix.Component
+
+  attr :attributes, :map, default: %{}
+  attr :variant, :string, default: "default"
+  attr :content, :string, default: nil
+
+  def render(assigns) do
+    # Extract attributes
+    src = Map.get(assigns.attributes, "src")
+    file_id = Map.get(assigns.attributes, "file_id")
+    file_variant = Map.get(assigns.attributes, "file_variant", "original")
+    alt = Map.get(assigns.attributes, "alt", "")
+    custom_class = Map.get(assigns.attributes, "class", "")
+
+    # Determine image source
+    image_src =
+      cond do
+        # Direct src takes precedence
+        src && src != "" ->
+          src
+
+        # Use file_id from PhoenixKit Storage
+        file_id && file_id != "" ->
+          get_file_url(file_id, file_variant)
+
+        # No source provided
+        true ->
+          nil
+      end
+
+    assigns =
+      assigns
+      |> assign(:src, image_src)
+      |> assign(:alt, alt)
+      |> assign(:custom_class, custom_class)
+
+    ~H"""
+    <%= if @src do %>
+      <img
+        src={@src}
+        alt={@alt}
+        loading="lazy"
+        class={["h-auto rounded-lg shadow-lg", @custom_class]}
+      />
+    <% else %>
+      <%!-- Fallback for missing image --%>
+      <div class="w-full h-48 bg-base-200 rounded-lg flex items-center justify-center">
+        <span class="text-base-content/50">Image not available</span>
+      </div>
+    <% end %>
+    """
+  end
+
+  # Helper function to get file URL from Storage
+  defp get_file_url(file_id, variant) do
+    case PhoenixKit.Storage.get_public_url_by_id(file_id, variant) do
+      nil ->
+        # Try without variant (fallback to original)
+        PhoenixKit.Storage.get_public_url_by_id(file_id)
+
+      url ->
+        url
+    end
+  rescue
+    _ ->
+      # Gracefully handle missing repo or file
+      nil
+  end
+end

--- a/lib/phoenix_kit_web/components/blogging/page.ex
+++ b/lib/phoenix_kit_web/components/blogging/page.ex
@@ -1,35 +1,27 @@
-# ============================================================================
-# COMMENTED OUT: Component-based rendering system - Page Component
-# ============================================================================
-# This module was part of an experimental component-based page building system
-# using XML-style markup (.phk files) with swappable design variants.
-# Related to: lib/phoenix_kit/blogging/page_builder.ex
-# ============================================================================
+defmodule PhoenixKitWeb.Components.Blogging.Page do
+  @moduledoc """
+  Root page component wrapper.
+  """
+  use Phoenix.Component
 
-# defmodule PhoenixKitWeb.Components.Blogging.Page do
-#   @moduledoc """
-#   Root page component wrapper.
-#   """
-#   use Phoenix.Component
-#
-#   attr :children, :list, default: []
-#   attr :attributes, :map, default: %{}
-#   attr :variant, :string, default: "default"
-#
-#   def render(assigns) do
-#     ~H"""
-#     <div class="phk-page" data-slug={@attributes["slug"]}>
-#       <%= for child <- @children do %>
-#         {render_child(child, assigns)}
-#       <% end %>
-#     </div>
-#     """
-#   end
-#
-#   defp render_child(child, assigns) do
-#     case PhoenixKitWeb.Live.Modules.Blogging.PageBuilder.Renderer.render(child, assigns) do
-#       {:ok, html} -> html
-#       {:error, _} -> ""
-#     end
-#   end
-# end
+  attr :children, :list, default: []
+  attr :attributes, :map, default: %{}
+  attr :variant, :string, default: "default"
+
+  def render(assigns) do
+    ~H"""
+    <div class="phk-page" data-slug={@attributes["slug"]}>
+      <%= for child <- @children do %>
+        {render_child(child, assigns)}
+      <% end %>
+    </div>
+    """
+  end
+
+  defp render_child(child, assigns) do
+    case PhoenixKitWeb.Live.Modules.Blogging.PageBuilder.Renderer.render(child, assigns) do
+      {:ok, html} -> html
+      {:error, _} -> ""
+    end
+  end
+end

--- a/lib/phoenix_kit_web/components/blogging/subheadline.ex
+++ b/lib/phoenix_kit_web/components/blogging/subheadline.ex
@@ -1,26 +1,18 @@
-# ============================================================================
-# COMMENTED OUT: Component-based rendering system - Subheadline Component
-# ============================================================================
-# This module was part of an experimental component-based page building system
-# using XML-style markup (.phk files) with swappable design variants.
-# Related to: lib/phoenix_kit/blogging/page_builder.ex
-# ============================================================================
+defmodule PhoenixKitWeb.Components.Blogging.Subheadline do
+  @moduledoc """
+  Subheadline component for supporting text.
+  """
+  use Phoenix.Component
 
-# defmodule PhoenixKitWeb.Components.Blogging.Subheadline do
-#   @moduledoc """
-#   Subheadline component for hero sections.
-#   """
-#   use Phoenix.Component
-#
-#   attr :content, :string, required: true
-#   attr :attributes, :map, default: %{}
-#   attr :variant, :string, default: "default"
-#
-#   def render(assigns) do
-#     ~H"""
-#     <p class="text-lg md:text-xl text-base-content/70 leading-relaxed">
-#       {@content}
-#     </p>
-#     """
-#   end
-# end
+  attr :content, :string, required: true
+  attr :attributes, :map, default: %{}
+  attr :variant, :string, default: "default"
+
+  def render(assigns) do
+    ~H"""
+    <p class="text-lg md:text-xl text-base-content/70 leading-relaxed">
+      {@content}
+    </p>
+    """
+  end
+end

--- a/lib/phoenix_kit_web/live/modules/blogging/context/page_builder.ex
+++ b/lib/phoenix_kit_web/live/modules/blogging/context/page_builder.ex
@@ -11,132 +11,120 @@ defmodule PhoenixKitWeb.Live.Modules.Blogging.PageBuilder do
   6. Render to HTML
   """
 
-  # ============================================================================
-  # COMMENTED OUT: Component-based rendering system
-  # ============================================================================
-  # This module was part of an experimental component-based page building system
-  # using XML-style markup (.phk files) with swappable design variants.
-  # See related files:
-  # - lib/phoenix_kit/blogging/page_builder/parser.ex
-  # - lib/phoenix_kit/blogging/page_builder/renderer.ex
-  # - lib/phoenix_kit_web/components/blogging/*.ex
-  # - priv/blogging/blog/*/en.phk (sample files)
-  # ============================================================================
+  alias PhoenixKitWeb.Live.Modules.Blogging.PageBuilder.Parser
+  alias PhoenixKitWeb.Live.Modules.Blogging.PageBuilder.Renderer
 
-  # alias PhoenixKitWeb.Live.Modules.Blogging.PageBuilder.Parser
-  # alias PhoenixKitWeb.Live.Modules.Blogging.PageBuilder.Renderer
+  @type assigns :: map()
+  @type ast :: map()
+  @type render_result :: {:ok, Phoenix.LiveView.Rendered.t()} | {:error, term()}
 
-  # @type assigns :: map()
-  # @type ast :: map()
-  # @type render_result :: {:ok, Phoenix.LiveView.Rendered.t()} | {:error, term()}
+  @doc """
+  Renders a .phk page file to HTML.
 
-  # @doc """
-  # Renders a .phk page file to HTML.
-  #
-  # ## Examples
-  #
-  #     iex> PageBuilder.render_page("/path/to/page.phk", %{user: %{name: "Alice"}})
-  #     {:ok, rendered_html}
-  # """
-  # @spec render_page(String.t(), assigns()) :: render_result()
-  # def render_page(page_path, assigns \\ %{}) do
-  #   with {:ok, content} <- read_page_file(page_path),
-  #        {:ok, ast} <- parse_to_ast(content),
-  #        {:ok, ast_with_data} <- inject_dynamic_data(ast, assigns),
-  #        {:ok, resolved} <- resolve_components(ast_with_data),
-  #        {:ok, themed} <- apply_theme(resolved, assigns),
-  #        {:ok, html} <- render_to_html(themed, assigns) do
-  #     {:ok, html}
-  #   else
-  #     {:error, reason} -> {:error, reason}
-  #   end
-  # end
+  ## Examples
 
-  # @doc """
-  # Renders .phk content directly (without file path).
-  # """
-  # @spec render_content(String.t(), assigns()) :: render_result()
-  # def render_content(content, assigns \\ %{}) do
-  #   with {:ok, ast} <- parse_to_ast(content),
-  #        {:ok, ast_with_data} <- inject_dynamic_data(ast, assigns),
-  #        {:ok, resolved} <- resolve_components(ast_with_data),
-  #        {:ok, themed} <- apply_theme(resolved, assigns),
-  #        {:ok, html} <- render_to_html(themed, assigns) do
-  #     {:ok, html}
-  #   else
-  #     {:error, reason} -> {:error, reason}
-  #   end
-  # end
+      iex> PageBuilder.render_page("/path/to/page.phk", %{user: %{name: "Alice"}})
+      {:ok, rendered_html}
+  """
+  @spec render_page(String.t(), assigns()) :: render_result()
+  def render_page(page_path, assigns \\ %{}) do
+    with {:ok, content} <- read_page_file(page_path),
+         {:ok, ast} <- parse_to_ast(content),
+         {:ok, ast_with_data} <- inject_dynamic_data(ast, assigns),
+         {:ok, resolved} <- resolve_components(ast_with_data),
+         {:ok, themed} <- apply_theme(resolved, assigns),
+         {:ok, html} <- render_to_html(themed, assigns) do
+      {:ok, html}
+    else
+      {:error, reason} -> {:error, reason}
+    end
+  end
 
-  # # Step 1: Read .phk file
-  # defp read_page_file(page_path) do
-  #   case File.read(page_path) do
-  #     {:ok, content} -> {:ok, content}
-  #     {:error, reason} -> {:error, {:file_read_error, reason}}
-  #   end
-  # end
+  @doc """
+  Renders .phk content directly (without file path).
+  """
+  @spec render_content(String.t(), assigns()) :: render_result()
+  def render_content(content, assigns \\ %{}) do
+    with {:ok, ast} <- parse_to_ast(content),
+         {:ok, ast_with_data} <- inject_dynamic_data(ast, assigns),
+         {:ok, resolved} <- resolve_components(ast_with_data),
+         {:ok, themed} <- apply_theme(resolved, assigns),
+         {:ok, html} <- render_to_html(themed, assigns) do
+      {:ok, html}
+    else
+      {:error, reason} -> {:error, reason}
+    end
+  end
 
-  # # Step 2: Parse XML to AST
-  # defp parse_to_ast(content) do
-  #   Parser.parse(content)
-  # end
+  # Step 1: Read .phk file
+  defp read_page_file(page_path) do
+    case File.read(page_path) do
+      {:ok, content} -> {:ok, content}
+      {:error, reason} -> {:error, {:file_read_error, reason}}
+    end
+  end
 
-  # # Step 3: Inject dynamic data (replace {{variable}} placeholders)
-  # defp inject_dynamic_data(ast, assigns) do
-  #   {:ok, inject_assigns(ast, assigns)}
-  # end
+  # Step 2: Parse XML to AST
+  defp parse_to_ast(content) do
+    Parser.parse(content)
+  end
 
-  # # Step 4: Resolve components (map XML tags to actual component modules)
-  # defp resolve_components(ast) do
-  #   {:ok, ast}
-  # end
+  # Step 3: Inject dynamic data (replace {{variable}} placeholders)
+  defp inject_dynamic_data(ast, assigns) do
+    {:ok, inject_assigns(ast, assigns)}
+  end
 
-  # # Step 5: Apply theme/variant settings
-  # defp apply_theme(ast, _assigns) do
-  #   {:ok, ast}
-  # end
+  # Step 4: Resolve components (map XML tags to actual component modules)
+  defp resolve_components(ast) do
+    {:ok, ast}
+  end
 
-  # # Step 6: Render to HTML
-  # defp render_to_html(ast, assigns) do
-  #   Renderer.render(ast, assigns)
-  # end
+  # Step 5: Apply theme/variant settings
+  defp apply_theme(ast, _assigns) do
+    {:ok, ast}
+  end
 
-  # # Recursively inject assigns into AST nodes
-  # defp inject_assigns(ast, assigns) when is_map(ast) do
-  #   ast
-  #   |> Map.update(:content, nil, &inject_assigns(&1, assigns))
-  #   |> Map.update(:attributes, %{}, &inject_assigns(&1, assigns))
-  #   |> Map.update(:children, [], &inject_assigns(&1, assigns))
-  # end
+  # Step 6: Render to HTML
+  defp render_to_html(ast, assigns) do
+    Renderer.render(ast, assigns)
+  end
 
-  # defp inject_assigns(ast, assigns) when is_list(ast) do
-  #   Enum.map(ast, &inject_assigns(&1, assigns))
-  # end
+  # Recursively inject assigns into AST nodes
+  defp inject_assigns(ast, assigns) when is_map(ast) do
+    ast
+    |> Map.update(:content, nil, &inject_assigns(&1, assigns))
+    |> Map.update(:attributes, %{}, &inject_assigns(&1, assigns))
+    |> Map.update(:children, [], &inject_assigns(&1, assigns))
+  end
 
-  # defp inject_assigns(content, assigns) when is_binary(content) do
-  #   interpolate_string(content, assigns)
-  # end
+  defp inject_assigns(ast, assigns) when is_list(ast) do
+    Enum.map(ast, &inject_assigns(&1, assigns))
+  end
 
-  # defp inject_assigns(value, _assigns), do: value
+  defp inject_assigns(content, assigns) when is_binary(content) do
+    interpolate_string(content, assigns)
+  end
 
-  # # Interpolate {{variable}} placeholders
-  # defp interpolate_string(string, assigns) do
-  #   Regex.replace(~r/\{\{([^}]+)\}\}/, string, fn _, path ->
-  #     get_nested_value(assigns, String.trim(path)) |> to_string()
-  #   end)
-  # end
+  defp inject_assigns(value, _assigns), do: value
 
-  # # Get nested value from assigns (e.g., "user.name" -> assigns.user.name)
-  # defp get_nested_value(map, path) do
-  #   path
-  #   |> String.split(".")
-  #   |> Enum.reduce(map, fn key, acc ->
-  #     case acc do
-  #       %{} -> Map.get(acc, key) || Map.get(acc, String.to_existing_atom(key))
-  #       _ -> nil
-  #     end
-  #   end)
-  # rescue
-  #   _ -> ""
-  # end
+  # Interpolate {{variable}} placeholders
+  defp interpolate_string(string, assigns) do
+    Regex.replace(~r/\{\{([^}]+)\}\}/, string, fn _, path ->
+      get_nested_value(assigns, String.trim(path)) |> to_string()
+    end)
+  end
+
+  # Get nested value from assigns (e.g., "user.name" -> assigns.user.name)
+  defp get_nested_value(map, path) do
+    path
+    |> String.split(".")
+    |> Enum.reduce(map, fn key, acc ->
+      case acc do
+        %{} -> Map.get(acc, key) || Map.get(acc, String.to_existing_atom(key))
+        _ -> nil
+      end
+    end)
+  rescue
+    _ -> ""
+  end
 end

--- a/lib/phoenix_kit_web/live/modules/blogging/context/page_builder/parser.ex
+++ b/lib/phoenix_kit_web/live/modules/blogging/context/page_builder/parser.ex
@@ -1,156 +1,152 @@
-# ============================================================================
-# COMMENTED OUT: Component-based rendering system - XML Parser
-# ============================================================================
-# This module was part of an experimental component-based page building system
-# using XML-style markup (.phk files) with swappable design variants.
-# Related to: lib/phoenix_kit/blogging/page_builder.ex
-# ============================================================================
+defmodule PhoenixKitWeb.Live.Modules.Blogging.PageBuilder.Parser do
+  @moduledoc """
+  Parses .phk (PhoenixKit) XML-style markup into an AST.
 
-# defmodule PhoenixKitWeb.Live.Modules.Blogging.PageBuilder.Parser do
-#   @moduledoc """
-#   Parses .phk (PhoenixKit) XML-style markup into an AST.
-#
-#   Example input:
-#   ```xml
-#   <Page slug="home">
-#     <Hero variant="split-image">
-#       <Headline>Welcome to PhoenixKit</Headline>
-#       <Subheadline>Build faster with {{framework}}</Subheadline>
-#       <CTA primary="true" action="/signup">Get Started</CTA>
-#     </Hero>
-#   </Page>
-#   ```
-#
-#   Output AST:
-#   ```elixir
-#   %{
-#     type: :page,
-#     attributes: %{slug: "home"},
-#     children: [
-#       %{
-#         type: :hero,
-#         attributes: %{variant: "split-image"},
-#         children: [
-#           %{type: :headline, content: "Welcome to PhoenixKit"},
-#           %{type: :subheadline, content: "Build faster with {{framework}}"},
-#           %{type: :cta, attributes: %{primary: "true", action: "/signup"}, content: "Get Started"}
-#         ]
-#       }
-#     ]
-#   }
-#   ```
-#   """
-#
-#   @doc """
-#   Parses .phk XML content into an AST.
-#   """
-#   @spec parse(String.t()) :: {:ok, map()} | {:error, term()}
-#   def parse(content) when is_binary(content) do
-#     content = String.trim(content)
-#
-#     case Saxy.parse_string(content, PhoenixKitWeb.Live.Modules.Blogging.PageBuilder.SaxHandler, []) do
-#       {:ok, ast} -> {:ok, ast}
-#       {:error, reason} -> {:error, {:parse_error, reason}}
-#     end
-#   rescue
-#     e -> {:error, {:parse_exception, e}}
-#   end
-#
-#   def parse(_), do: {:error, :invalid_content}
-# end
-#
-# defmodule PhoenixKitWeb.Live.Modules.Blogging.PageBuilder.SaxHandler do
-#   @moduledoc false
-#   @behaviour Saxy.Handler
-#
-#   def handle_event(:start_document, _prolog, _state) do
-#     {:ok, %{stack: [], result: nil}}
-#   end
-#
-#   def handle_event(:end_document, _data, state) do
-#     {:ok, state.result}
-#   end
-#
-#   def handle_event(:start_element, {name, attributes}, state) do
-#     node = %{
-#       type: normalize_tag_name(name),
-#       attributes: parse_attributes(attributes),
-#       children: [],
-#       content: nil
-#     }
-#
-#     new_state = %{state | stack: [node | state.stack]}
-#     {:ok, new_state}
-#   end
-#
-#   def handle_event(:end_element, _name, %{stack: [current | rest]} = state) do
-#     # Simplify node if it only has content and no children
-#     simplified =
-#       cond do
-#         current.children == [] and is_binary(current.content) ->
-#           %{
-#             type: current.type,
-#             attributes: current.attributes,
-#             content: String.trim(current.content)
-#           }
-#
-#         current.content == nil and current.children != [] ->
-#           %{
-#             type: current.type,
-#             attributes: current.attributes,
-#             children: Enum.reverse(current.children)
-#           }
-#
-#         true ->
-#           %{
-#             type: current.type,
-#             attributes: current.attributes,
-#             children: Enum.reverse(current.children),
-#             content: current.content && String.trim(current.content)
-#           }
-#       end
-#
-#     case rest do
-#       [] ->
-#         {:ok, %{state | stack: [], result: simplified}}
-#
-#       [parent | ancestors] ->
-#         updated_parent = %{parent | children: [simplified | parent.children]}
-#         {:ok, %{state | stack: [updated_parent | ancestors]}}
-#     end
-#   end
-#
-#   def handle_event(:characters, chars, %{stack: [current | rest]} = state) do
-#     trimmed = String.trim(chars)
-#
-#     updated_current =
-#       if trimmed != "" do
-#         case current.content do
-#           nil -> %{current | content: chars}
-#           existing -> %{current | content: existing <> chars}
-#         end
-#       else
-#         current
-#       end
-#
-#     {:ok, %{state | stack: [updated_current | rest]}}
-#   end
-#
-#   def handle_event(:characters, _chars, state) do
-#     {:ok, state}
-#   end
-#
-#   # Normalize tag names to atoms (Page -> :page, Hero -> :hero)
-#   defp normalize_tag_name(name) do
-#     name
-#     |> String.downcase()
-#     |> String.to_atom()
-#   end
-#
-#   # Convert attribute list to map with string keys
-#   defp parse_attributes(attrs) do
-#     Enum.into(attrs, %{}, fn {key, value} ->
-#       {String.downcase(key), value}
-#     end)
-#   end
-# end
+  Example input:
+  ```xml
+  <Page slug="home">
+    <Hero variant="split-image">
+      <Headline>Welcome to PhoenixKit</Headline>
+      <Subheadline>Build faster with {{framework}}</Subheadline>
+      <CTA primary="true" action="/signup">Get Started</CTA>
+    </Hero>
+  </Page>
+  ```
+
+  Output AST:
+  ```elixir
+  %{
+    type: :page,
+    attributes: %{slug: "home"},
+    children: [
+      %{
+        type: :hero,
+        attributes: %{variant: "split-image"},
+        children: [
+          %{type: :headline, content: "Welcome to PhoenixKit"},
+          %{type: :subheadline, content: "Build faster with {{framework}}"},
+          %{type: :cta, attributes: %{primary: "true", action: "/signup"}, content: "Get Started"}
+        ]
+      }
+    ]
+  }
+  ```
+  """
+
+  @doc """
+  Parses .phk XML content into an AST.
+  """
+  @spec parse(String.t()) :: {:ok, map()} | {:error, term()}
+  def parse(content) when is_binary(content) do
+    content = String.trim(content)
+
+    case Saxy.parse_string(
+           content,
+           PhoenixKitWeb.Live.Modules.Blogging.PageBuilder.SaxHandler,
+           []
+         ) do
+      {:ok, ast} -> {:ok, ast}
+      {:error, reason} -> {:error, {:parse_error, reason}}
+    end
+  rescue
+    e -> {:error, {:parse_exception, e}}
+  end
+
+  def parse(_), do: {:error, :invalid_content}
+end
+
+defmodule PhoenixKitWeb.Live.Modules.Blogging.PageBuilder.SaxHandler do
+  @moduledoc false
+  @behaviour Saxy.Handler
+
+  def handle_event(:start_document, _prolog, _state) do
+    {:ok, %{stack: [], result: nil}}
+  end
+
+  def handle_event(:end_document, _data, state) do
+    {:ok, state.result}
+  end
+
+  def handle_event(:start_element, {name, attributes}, state) do
+    node = %{
+      type: normalize_tag_name(name),
+      attributes: parse_attributes(attributes),
+      children: [],
+      content: nil
+    }
+
+    new_state = %{state | stack: [node | state.stack]}
+    {:ok, new_state}
+  end
+
+  def handle_event(:end_element, _name, %{stack: [current | rest]} = state) do
+    # Simplify node if it only has content and no children
+    simplified =
+      cond do
+        current.children == [] and is_binary(current.content) ->
+          %{
+            type: current.type,
+            attributes: current.attributes,
+            content: String.trim(current.content)
+          }
+
+        current.content == nil and current.children != [] ->
+          %{
+            type: current.type,
+            attributes: current.attributes,
+            children: Enum.reverse(current.children)
+          }
+
+        true ->
+          %{
+            type: current.type,
+            attributes: current.attributes,
+            children: Enum.reverse(current.children),
+            content: current.content && String.trim(current.content)
+          }
+      end
+
+    case rest do
+      [] ->
+        {:ok, %{state | stack: [], result: simplified}}
+
+      [parent | ancestors] ->
+        updated_parent = %{parent | children: [simplified | parent.children]}
+        {:ok, %{state | stack: [updated_parent | ancestors]}}
+    end
+  end
+
+  def handle_event(:characters, chars, %{stack: [current | rest]} = state) do
+    trimmed = String.trim(chars)
+
+    updated_current =
+      if trimmed != "" do
+        case current.content do
+          nil -> %{current | content: chars}
+          existing -> %{current | content: existing <> chars}
+        end
+      else
+        current
+      end
+
+    {:ok, %{state | stack: [updated_current | rest]}}
+  end
+
+  def handle_event(:characters, _chars, state) do
+    {:ok, state}
+  end
+
+  # Normalize tag names to atoms (Page -> :page, Hero -> :hero)
+  defp normalize_tag_name(name) do
+    name
+    |> String.downcase()
+    |> String.to_atom()
+  end
+
+  # Convert attribute list to map with string keys
+  defp parse_attributes(attrs) do
+    Enum.into(attrs, %{}, fn {key, value} ->
+      {String.downcase(key), value}
+    end)
+  end
+end

--- a/lib/phoenix_kit_web/live/modules/blogging/context/page_builder/renderer.ex
+++ b/lib/phoenix_kit_web/live/modules/blogging/context/page_builder/renderer.ex
@@ -1,107 +1,99 @@
-# ============================================================================
-# COMMENTED OUT: Component-based rendering system - AST to HTML Renderer
-# ============================================================================
-# This module was part of an experimental component-based page building system
-# using XML-style markup (.phk files) with swappable design variants.
-# Related to: lib/phoenix_kit/blogging/page_builder.ex
-# ============================================================================
+defmodule PhoenixKitWeb.Live.Modules.Blogging.PageBuilder.Renderer do
+  @moduledoc """
+  Renders AST nodes to HTML by delegating to component modules.
+  """
 
-# defmodule PhoenixKitWeb.Live.Modules.Blogging.PageBuilder.Renderer do
-#   @moduledoc """
-#   Renders AST nodes to HTML by delegating to component modules.
-#   """
-#
-#   @doc """
-#   Renders an AST node to HTML.
-#   """
-#   def render(ast, assigns) when is_map(ast) do
-#     case resolve_component(ast.type) do
-#       {:ok, component_module} ->
-#         render_component(component_module, ast, assigns)
-#
-#       {:error, :not_found} ->
-#         # Fallback for unknown components
-#         render_unknown(ast, assigns)
-#     end
-#   end
-#
-#   def render(ast, _assigns) when is_list(ast) do
-#     {:ok,
-#      Phoenix.HTML.raw(
-#        ast
-#        |> Enum.map(fn node ->
-#          case render(node, %{}) do
-#            {:ok, html} -> Phoenix.HTML.safe_to_string(html)
-#            {:error, _} -> ""
-#          end
-#        end)
-#        |> Enum.join()
-#      )}
-#   end
-#
-#   def render(content, _assigns) when is_binary(content) do
-#     {:ok, Phoenix.HTML.raw(content)}
-#   end
-#
-#   # Resolve component type to module
-#   defp resolve_component(:page), do: {:ok, PhoenixKitWeb.Components.Blogging.Page}
-#   defp resolve_component(:hero), do: {:ok, PhoenixKitWeb.Components.Blogging.Hero}
-#   defp resolve_component(:headline), do: {:ok, PhoenixKitWeb.Components.Blogging.Headline}
-#
-#   defp resolve_component(:subheadline),
-#     do: {:ok, PhoenixKitWeb.Components.Blogging.Subheadline}
-#
-#   defp resolve_component(:cta), do: {:ok, PhoenixKitWeb.Components.Blogging.CTA}
-#   defp resolve_component(:image), do: {:ok, PhoenixKitWeb.Components.Blogging.Image}
-#   defp resolve_component(_), do: {:error, :not_found}
-#
-#   # Render using the component module
-#   defp render_component(component_module, ast, assigns) do
-#     component_assigns = build_component_assigns(ast, assigns)
-#
-#     try do
-#       html = component_module.render(component_assigns)
-#       {:ok, html}
-#     rescue
-#       e ->
-#         {:error, {:render_error, e}}
-#     end
-#   end
-#
-#   # Build assigns map for component
-#   defp build_component_assigns(ast, parent_assigns) do
-#     base_assigns = %{
-#       __changed__: nil,
-#       variant: Map.get(ast.attributes, "variant", "default"),
-#       attributes: ast.attributes,
-#       content: ast[:content],
-#       children: ast[:children] || []
-#     }
-#
-#     Map.merge(parent_assigns, base_assigns)
-#   end
-#
-#   # Fallback renderer for unknown components
-#   defp render_unknown(ast, assigns) do
-#     content =
-#       cond do
-#         ast[:content] ->
-#           ast.content
-#
-#         ast[:children] ->
-#           ast.children
-#           |> Enum.map(fn child ->
-#             case render(child, assigns) do
-#               {:ok, html} -> Phoenix.HTML.safe_to_string(html)
-#               _ -> ""
-#             end
-#           end)
-#           |> Enum.join()
-#
-#         true ->
-#           ""
-#       end
-#
-#     {:ok, Phoenix.HTML.raw("<div class=\"unknown-component\">#{content}</div>")}
-#   end
-# end
+  @doc """
+  Renders an AST node to HTML.
+  """
+  def render(ast, assigns) when is_map(ast) do
+    case resolve_component(ast.type) do
+      {:ok, component_module} ->
+        render_component(component_module, ast, assigns)
+
+      {:error, :not_found} ->
+        # Fallback for unknown components
+        render_unknown(ast, assigns)
+    end
+  end
+
+  def render(ast, _assigns) when is_list(ast) do
+    {:ok,
+     Phoenix.HTML.raw(
+       ast
+       |> Enum.map(fn node ->
+         case render(node, %{}) do
+           {:ok, html} -> Phoenix.HTML.safe_to_string(html)
+           {:error, _} -> ""
+         end
+       end)
+       |> Enum.join()
+     )}
+  end
+
+  def render(content, _assigns) when is_binary(content) do
+    {:ok, Phoenix.HTML.raw(content)}
+  end
+
+  # Resolve component type to module
+  defp resolve_component(:page), do: {:ok, PhoenixKitWeb.Components.Blogging.Page}
+  defp resolve_component(:hero), do: {:ok, PhoenixKitWeb.Components.Blogging.Hero}
+  defp resolve_component(:headline), do: {:ok, PhoenixKitWeb.Components.Blogging.Headline}
+
+  defp resolve_component(:subheadline),
+    do: {:ok, PhoenixKitWeb.Components.Blogging.Subheadline}
+
+  defp resolve_component(:cta), do: {:ok, PhoenixKitWeb.Components.Blogging.CTA}
+  defp resolve_component(:image), do: {:ok, PhoenixKitWeb.Components.Blogging.Image}
+  defp resolve_component(_), do: {:error, :not_found}
+
+  # Render using the component module
+  defp render_component(component_module, ast, assigns) do
+    component_assigns = build_component_assigns(ast, assigns)
+
+    try do
+      html = component_module.render(component_assigns)
+      {:ok, html}
+    rescue
+      e ->
+        {:error, {:render_error, e}}
+    end
+  end
+
+  # Build assigns map for component
+  defp build_component_assigns(ast, parent_assigns) do
+    base_assigns = %{
+      __changed__: nil,
+      variant: Map.get(ast.attributes, "variant", "default"),
+      attributes: ast.attributes,
+      content: ast[:content],
+      children: ast[:children] || []
+    }
+
+    Map.merge(parent_assigns, base_assigns)
+  end
+
+  # Fallback renderer for unknown components
+  defp render_unknown(ast, assigns) do
+    content =
+      cond do
+        ast[:content] ->
+          ast.content
+
+        ast[:children] ->
+          ast.children
+          |> Enum.map(fn child ->
+            case render(child, assigns) do
+              {:ok, html} -> Phoenix.HTML.safe_to_string(html)
+              _ -> ""
+            end
+          end)
+          |> Enum.join()
+
+        true ->
+          ""
+      end
+
+    {:ok, Phoenix.HTML.raw("<div class=\"unknown-component\">#{content}</div>")}
+  end
+end

--- a/lib/phoenix_kit_web/live/modules/blogging/preview.html.heex
+++ b/lib/phoenix_kit_web/live/modules/blogging/preview.html.heex
@@ -89,6 +89,15 @@
               margin-top: 1rem;
               margin-bottom: 1rem;
               padding-left: 1.5rem;
+              list-style-position: outside;
+            }
+
+            .blogging-markdown ul {
+              list-style-type: disc;
+            }
+
+            .blogging-markdown ol {
+              list-style-type: decimal;
             }
 
             .blogging-markdown li {
@@ -171,7 +180,7 @@
             }
           </style>
           <div class="blogging-markdown prose prose-lg max-w-none">
-            {@rendered_content}
+            {raw(@rendered_content)}
           </div>
         </div>
       <% else %>


### PR DESCRIPTION
- Bring the blogging component stack (PageBuilder, CTA, Hero, Headline, Subheadline, Image, etc.) back online so inline PHK tags render inside Markdown posts.
- Enhance PhoenixKit.Blogging.Renderer and the preview LiveView to process mixed Markdown + components, normalize headings/lists, and surface shared rendering logic.
- Update storage helpers (URL signer, routes) to emit signed dev-friendly URLs when providers lack public URLs, ensuring `<Image file_id/variant>` works everywhere.
- Rewrite guides/phk_blogging_format.md with the current frontmatter + Markdown workflow and embed the storage-focused example.