### PR TITLE
Fix hardcoded paths in email export controller to support custom url_prefix

### DIFF
--- a/lib/phoenix_kit_web/controllers/email_export_controller.ex
+++ b/lib/phoenix_kit_web/controllers/email_export_controller.ex
@@ -23,6 +23,7 @@ defmodule PhoenixKitWeb.Controllers.EmailExportController do
   use PhoenixKitWeb, :controller
 
   alias PhoenixKit.Emails
+  alias PhoenixKit.Utils.Routes
 
   ## --- Email Logs Export ---
 
@@ -64,7 +65,7 @@ defmodule PhoenixKitWeb.Controllers.EmailExportController do
     else
       conn
       |> put_flash(:error, "Email management is not enabled")
-      |> redirect(to: "/phoenix_kit/admin/dashboard")
+      |> redirect(to: Routes.path("/admin/dashboard"))
     end
   end
 
@@ -102,7 +103,7 @@ defmodule PhoenixKitWeb.Controllers.EmailExportController do
     else
       conn
       |> put_flash(:error, "Email management is not enabled")
-      |> redirect(to: "/phoenix_kit/admin/dashboard")
+      |> redirect(to: Routes.path("/admin/dashboard"))
     end
   end
 
@@ -131,7 +132,7 @@ defmodule PhoenixKitWeb.Controllers.EmailExportController do
     else
       conn
       |> put_flash(:error, "Email management is not enabled")
-      |> redirect(to: "/phoenix_kit/admin/dashboard")
+      |> redirect(to: Routes.path("/admin/dashboard"))
     end
   end
 
@@ -169,17 +170,17 @@ defmodule PhoenixKitWeb.Controllers.EmailExportController do
         Ecto.NoResultsError ->
           conn
           |> put_flash(:error, "Email not found")
-          |> redirect(to: "/phoenix_kit/admin/emails")
+          |> redirect(to: Routes.path("/admin/emails"))
 
         ArgumentError ->
           conn
           |> put_flash(:error, "Invalid email ID")
-          |> redirect(to: "/phoenix_kit/admin/emails")
+          |> redirect(to: Routes.path("/admin/emails"))
       end
     else
       conn
       |> put_flash(:error, "Email management is not enabled")
-      |> redirect(to: "/phoenix_kit/admin/dashboard")
+      |> redirect(to: Routes.path("/admin/dashboard"))
     end
   end
 


### PR DESCRIPTION

Updated email_export_controller.ex to use Routes.path() for all redirect URLs instead of hardcoded /phoenix_kit/ paths. This ensures that the email export functionality works correctly when a custom url_prefix is configured.

Changes:
- Add PhoenixKit.Utils.Routes alias
- Replace all hardcoded '/phoenix_kit/admin/dashboard' redirects with Routes.path('/admin/dashboard')
- Replace all hardcoded '/phoenix_kit/admin/emails' redirects with Routes.path('/admin/emails')

This fix ensures consistent behavior across all PhoenixKit URLs regardless of the configured url_prefix setting.