### PR TITLE
Replace plug Ueberauth with dynamic run_request/run_callback calls

### DIFF
--- a/lib/phoenix_kit_web/plugs/ensure_oauth_config.ex
+++ b/lib/phoenix_kit_web/plugs/ensure_oauth_config.ex
@@ -1,33 +1,32 @@
 defmodule PhoenixKitWeb.Plugs.EnsureOAuthConfig do
   @moduledoc """
-  Plug that ensures OAuth configuration is loaded before processing OAuth requests.
+  Plug that ensures OAuth credentials are loaded into Application env before OAuth requests.
 
-  This plug serves as a fallback safety mechanism for cases where:
-  - PhoenixKit.Supervisor starts AFTER parent application's Endpoint
-  - OAuthConfigLoader worker failed to load configuration
-  - Configuration was cleared or lost for any reason
+  This plug loads OAuth provider credentials from the database and configures
+  them in Application env so that `Ueberauth.run_request/4` and `Ueberauth.run_callback/4`
+  can access them at runtime.
 
   ## How It Works
 
-  1. Checks if Ueberauth has :providers configured
-  2. If configuration is missing or invalid, loads it synchronously
+  1. Checks if Ueberauth configuration exists in Application env
+  2. If configuration is missing, loads credentials from database via `OAuthConfig.configure_providers()`
   3. If loading fails, returns 503 Service Unavailable error
-  4. Otherwise, allows request to proceed normally
+  4. Otherwise, allows request to proceed
 
   ## Usage
 
-  Add this plug BEFORE Ueberauth plug in OAuth controller:
+  Used in OAuth controller before dynamic Ueberauth calls:
 
       plug PhoenixKitWeb.Plugs.EnsureOAuthConfig
-      plug Ueberauth
+      # Then in controller actions:
+      # Ueberauth.run_request(conn, provider, provider_config)
+      # Ueberauth.run_callback(conn, provider, provider_config)
 
   ## Why This Is Needed
 
-  Ueberauth plug expects :providers key to exist in application config.
-  If it's missing, Ueberauth.get_providers/2 fails with MatchError.
-
-  This plug prevents that error by ensuring configuration exists before
-  Ueberauth plug runs.
+  PhoenixKit stores OAuth credentials in the database. This plug ensures
+  credentials are loaded into Application env before Ueberauth strategy
+  modules attempt to read them.
   """
 
   import Plug.Conn

--- a/lib/phoenix_kit_web/users/oauth.ex
+++ b/lib/phoenix_kit_web/users/oauth.ex
@@ -1,12 +1,18 @@
 if Code.ensure_loaded?(Ueberauth) do
   defmodule PhoenixKitWeb.Users.OAuth do
     @moduledoc """
-    OAuth authentication controller using Ueberauth.
+    OAuth authentication controller using Ueberauth with dynamic provider configuration.
+
+    This controller uses `Ueberauth.run_request/4` and `Ueberauth.run_callback/4` for
+    dynamic OAuth invocation, eliminating compile-time configuration requirements.
+    OAuth credentials are loaded from database at runtime.
 
     This controller requires the following optional dependencies to be installed:
     - ueberauth
     - ueberauth_google (for Google Sign-In)
     - ueberauth_apple (for Apple Sign-In)
+    - ueberauth_github (for GitHub Sign-In)
+    - ueberauth_facebook (for Facebook Sign-In)
 
     If these dependencies are not installed, a fallback controller will be used instead.
     """
@@ -14,10 +20,8 @@ if Code.ensure_loaded?(Ueberauth) do
     use PhoenixKitWeb, :controller
 
     plug PhoenixKitWeb.Plugs.EnsureOAuthScheme
-    # Ensure OAuth config is loaded before Ueberauth plug runs
-    # This prevents MatchError if configuration is missing
     plug PhoenixKitWeb.Plugs.EnsureOAuthConfig
-    plug Ueberauth
+    # NOTE: No `plug Ueberauth` - we call Ueberauth.run_request/4 and run_callback/4 dynamically
 
     alias PhoenixKit.Config
     alias PhoenixKit.Settings
@@ -28,52 +32,54 @@ if Code.ensure_loaded?(Ueberauth) do
 
     require Logger
 
+    # Map provider names (strings) to strategy modules
+    @provider_strategies %{
+      "google" => Ueberauth.Strategy.Google,
+      "apple" => Ueberauth.Strategy.Apple,
+      "github" => Ueberauth.Strategy.Github,
+      "facebook" => Ueberauth.Strategy.Facebook
+    }
+
     @doc """
     Initiates OAuth authentication flow.
+
+    Uses `Ueberauth.run_request/4` for dynamic OAuth invocation,
+    reading credentials from database at runtime.
     """
     def request(conn, %{"provider" => provider} = params) do
       Logger.debug("PhoenixKit OAuth request for provider: #{provider}")
 
       # Check if OAuth is enabled in settings
       if oauth_enabled_in_settings?() do
-        # Check if OAuth is properly configured
-        case get_ueberauth_providers() do
-          [] ->
-            Logger.warning("PhoenixKit OAuth: No providers configured")
+        # Check if provider is supported and enabled
+        case validate_provider(provider) do
+          {:ok, strategy_module} ->
+            handle_oauth_request(conn, provider, strategy_module, params)
+
+          {:error, :unknown_provider} ->
+            Logger.warning("PhoenixKit OAuth: Unknown provider '#{provider}'")
+
+            conn
+            |> put_flash(:error, "Unknown OAuth provider: #{provider}")
+            |> redirect(to: Routes.path("/users/log-in"))
+
+          {:error, :provider_disabled} ->
+            Logger.warning("PhoenixKit OAuth: Provider '#{provider}' is disabled in settings")
+
+            conn
+            |> put_flash(:error, "OAuth provider '#{provider}' is currently disabled.")
+            |> redirect(to: Routes.path("/users/log-in"))
+
+          {:error, :no_credentials} ->
+            Logger.warning(
+              "PhoenixKit OAuth: No credentials configured for provider '#{provider}'"
+            )
 
             conn
             |> put_flash(
               :error,
-              "OAuth authentication is not configured. To enable OAuth, please add provider configuration to your config.exs file. See PhoenixKit documentation for details."
+              "OAuth provider '#{provider}' is not configured. Please contact your administrator."
             )
-            |> redirect(to: Routes.path("/users/log-in"))
-
-          providers when providers != [] ->
-            provider_names =
-              Enum.map(providers, fn {provider, _strategy} -> to_string(provider) end)
-
-            Logger.debug("PhoenixKit OAuth: Available providers: #{inspect(provider_names)}")
-
-            if provider in provider_names do
-              handle_oauth_request(conn, params)
-            else
-              Logger.warning(
-                "PhoenixKit OAuth: Provider '#{provider}' not in configured providers: #{inspect(provider_names)}"
-              )
-
-              conn
-              |> put_flash(
-                :error,
-                "Provider '#{provider}' is not configured. Available providers: #{Enum.join(provider_names, ", ")}"
-              )
-              |> redirect(to: Routes.path("/users/log-in"))
-            end
-
-          error ->
-            Logger.error("PhoenixKit OAuth: Configuration error: #{inspect(error)}")
-
-            conn
-            |> put_flash(:error, "OAuth configuration error. Please contact your administrator.")
             |> redirect(to: Routes.path("/users/log-in"))
         end
       else
@@ -88,51 +94,50 @@ if Code.ensure_loaded?(Ueberauth) do
       end
     end
 
-    defp handle_oauth_request(conn, params) do
+    defp handle_oauth_request(conn, provider, strategy_module, params) do
+      # Store referral_code and return_to in session
       conn =
-        if referral_code = params["referral_code"] do
-          put_session(conn, :oauth_referral_code, referral_code)
-        else
-          conn
-        end
-
-      conn =
-        if return_to = params["return_to"] do
-          put_session(conn, :oauth_return_to, return_to)
-        else
-          conn
-        end
-
-      # Check if Ueberauth plug has already sent a response (e.g., a redirect)
-      # If response was already sent by Ueberauth, halt() to stop further processing
-      if conn.state != :unset do
-        # Response already sent by Ueberauth (e.g., redirect to OAuth provider)
-        halt(conn)
-      else
-        # No response sent - Ueberauth couldn't process the request
-        # This can happen if provider configuration is missing or invalid
-        Logger.error(
-          "PhoenixKit OAuth: Ueberauth plugin did not process request for provider. Check if GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET environment variables are set correctly."
-        )
-
         conn
-        |> put_flash(
-          :error,
-          "OAuth authentication unavailable. The provider credentials are not configured. Please contact your administrator or use another sign-in method."
-        )
-        |> redirect(to: Routes.path("/users/log-in"))
+        |> maybe_put_session(:oauth_referral_code, params["referral_code"])
+        |> maybe_put_session(:oauth_return_to, params["return_to"])
+
+      # Build provider config for dynamic Ueberauth call
+      base_path = Config.UeberAuth.get_base_path()
+
+      provider_config =
+        {strategy_module,
+         [
+           request_path: "#{base_path}/#{provider}",
+           callback_path: "#{base_path}/#{provider}/callback"
+         ]}
+
+      # Dynamic Ueberauth call - reads credentials from Application env
+      # (configured by EnsureOAuthConfig plug)
+      Ueberauth.run_request(conn, provider, provider_config)
+    end
+
+    defp validate_provider(provider) do
+      case Map.get(@provider_strategies, provider) do
+        nil ->
+          {:error, :unknown_provider}
+
+        strategy_module ->
+          # Check if provider is enabled in settings
+          if Settings.get_boolean_setting("oauth_#{provider}_enabled", false) do
+            # Check if credentials exist
+            if Settings.has_oauth_credentials_direct?(String.to_existing_atom(provider)) do
+              {:ok, strategy_module}
+            else
+              {:error, :no_credentials}
+            end
+          else
+            {:error, :provider_disabled}
+          end
       end
     end
 
-    defp get_ueberauth_providers do
-      providers = Config.UeberAuth.get_providers()
-
-      # Normalize Map or List to list of {provider_atom, strategy} tuples
-      case providers do
-        p when is_map(p) -> Map.to_list(p)
-        p when is_list(p) -> p
-      end
-    end
+    defp maybe_put_session(conn, _key, nil), do: conn
+    defp maybe_put_session(conn, key, value), do: put_session(conn, key, value)
 
     defp oauth_enabled_in_settings? do
       Settings.get_boolean_setting("oauth_enabled", false)
@@ -140,8 +145,42 @@ if Code.ensure_loaded?(Ueberauth) do
 
     @doc """
     Handles OAuth callback from provider.
+
+    Uses `Ueberauth.run_callback/4` for dynamic OAuth invocation,
+    then processes the result from conn.assigns.
     """
-    def callback(%{assigns: %{ueberauth_auth: auth}} = conn, _params) do
+    def callback(conn, %{"provider" => provider} = _params) do
+      Logger.debug("PhoenixKit OAuth callback for provider: #{provider}")
+
+      case Map.get(@provider_strategies, provider) do
+        nil ->
+          Logger.error("PhoenixKit OAuth: Unknown provider in callback: #{provider}")
+
+          conn
+          |> put_flash(:error, "Unknown OAuth provider: #{provider}")
+          |> redirect(to: Routes.path("/users/log-in"))
+
+        strategy_module ->
+          # Build provider config for dynamic Ueberauth call
+          base_path = Config.UeberAuth.get_base_path()
+
+          provider_config =
+            {strategy_module,
+             [
+               request_path: "#{base_path}/#{provider}",
+               callback_path: "#{base_path}/#{provider}/callback"
+             ]}
+
+          # Dynamic Ueberauth callback - processes OAuth response
+          conn = Ueberauth.run_callback(conn, provider, provider_config)
+
+          # Handle the result based on assigns set by Ueberauth
+          handle_callback_result(conn)
+      end
+    end
+
+    # Handle successful OAuth authentication
+    defp handle_callback_result(%{assigns: %{ueberauth_auth: auth}} = conn) do
       track_geolocation = Settings.get_boolean_setting("track_registration_geolocation", false)
       ip_address = IpAddress.extract_from_conn(conn)
       referral_code = get_session(conn, :oauth_referral_code)
@@ -193,7 +232,8 @@ if Code.ensure_loaded?(Ueberauth) do
       end
     end
 
-    def callback(%{assigns: %{ueberauth_failure: failure}} = conn, _params) do
+    # Handle OAuth authentication failure
+    defp handle_callback_result(%{assigns: %{ueberauth_failure: failure}} = conn) do
       error_message = format_ueberauth_failure(failure)
       Logger.warning("PhoenixKit: OAuth authentication failure: #{inspect(failure)}")
 
@@ -202,7 +242,8 @@ if Code.ensure_loaded?(Ueberauth) do
       |> redirect(to: Routes.path("/users/log-in"))
     end
 
-    def callback(conn, _params) do
+    # Handle unexpected callback without auth or failure
+    defp handle_callback_result(conn) do
       Logger.error("PhoenixKit: Unexpected OAuth callback without auth or failure")
 
       conn


### PR DESCRIPTION
## Summary

Eliminates compile-time vs runtime race condition in OAuth by using `Ueberauth.run_request/4` and `Ueberauth.run_callback/4` instead of static `plug Ueberauth`.

## Problem

The `plug Ueberauth` macro reads `providers` from Application env during module compilation. PhoenixKit loads OAuth credentials from database at runtime, creating a race condition where:
- New projects without credentials fail on first startup
- Credential changes via admin panel require app restart

## Solution

Replace static plug with dynamic calls:
- `request/2` now calls `Ueberauth.run_request(conn, provider, provider_config)`
- `callback/2` now calls `Ueberauth.run_callback(conn, provider, provider_config)`

## Benefits

- OAuth works on first startup without compile-time config
- Credential changes apply immediately without restart
- Dynamic provider enable/disable via admin panel

## Changes

- `lib/phoenix_kit_web/users/oauth.ex` - Replace plug with dynamic calls
- `lib/phoenix_kit_web/plugs/ensure_oauth_config.ex` - Update documentation
- `lib/phoenix_kit/install/oauth_config.ex` - Update documentation

## Test Plan

- [x] `mix compile` passes
- [x] `mix credo --strict` passes  
- [x] `mix dialyzer` passes
- [x] Manual Google OAuth flow testing completed