### PR TITLE
Remove static Ueberauth configuration requirements

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -6,10 +6,8 @@
   {"lib/mix/tasks/phoenix_kit.update.ex", :pattern_match, 1},
   {"lib/mix/tasks/phoenix_kit.modernize_layouts.ex", :unknown_function},
   {"lib/phoenix_kit/install/migration_strategy.ex", :unknown_function},
-  {"lib/phoenix_kit/install/repo_detection.ex", :unknown_function},
   {"lib/mix/tasks/phoenix_kit.status.ex", :unknown_function},
   {"lib/phoenix_kit/migrations/postgres.ex", :unknown_function},
-  {"lib/phoenix_kit/install/mailer_config.ex", :unknown_function},
   {"lib/mix/tasks/phoenix_kit/email_cleanup.ex", :unknown_function},
   {"lib/mix/tasks/phoenix_kit/email_export.ex", :unknown_function},
   {"lib/mix/tasks/phoenix_kit/email_stats.ex", :unknown_function},
@@ -63,9 +61,6 @@
   # Ecto.Multi opaque type false positives (code works correctly)
   ~r/lib\/phoenix_kit\/users\/auth\.ex:.*call_without_opaque/,
 
-  # Exact comparison warnings for nil checks (legacy warning format - Dialyzer bug)
-  # (No current warnings - exact_compare issue in configure_aws_ses.ex was fixed by using pattern matching)
-
-  # Ignore all test files - library tests are meant for integration testing
+  # Ignore test files - ExUnit internals not available to Dialyzer
   ~r|^test/.*|
 ]

--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,7 @@ memory.json
 CLAUDE.local.md
 
 *.tar
+*.zip
+
+# Uploaded media files
+/priv/media/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,60 +2,42 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## MCP Memory Knowledge Base
-
-⚠️ **IMPORTANT**: Always start working with the project by studying data in the MCP memory storage. Use the command:
-
-```
-mcp__memory__read_graph
-```
-
-This will help understand the current state of the project, implemented and planned components, architectural decisions.
-
-Update data in memory when discovering new components or changes in project architecture. Use:
-
-- `mcp__memory__create_entities` - for adding new modules/components
-- `mcp__memory__create_relations` - for relationships between components
-- `mcp__memory__add_observations` - for supplementing information about existing components
-
 ## Project Overview
 
-This is **PhoenixKit** - PhoenixKit is a starter kit for building modern web applications with Elixir and Phoenix with PostgreSQL support and streamlined setup. As a start it provides a complete authentication system that can be integrated into any Phoenix application without circular dependencies.
+**PhoenixKit** - a comprehensive starter kit for building modern web applications with Elixir and Phoenix. It provides authentication, content management, email system, and admin tools.
 
 **Key Characteristics:**
 
 - Library-first architecture (no OTP application)
-- Streamlined setup with automatic repository detection
-- Complete authentication system with Magic Links
+- Complete authentication system with Magic Links & OAuth
 - Role-based access control (Owner/Admin/User)
 - Built-in admin dashboard and user management
-- Modern theme system with daisyUI 5 and 35+ themes support
-- Professional versioned migration system
-- Layout integration with parent applications
-- Ready for production use
+- Modern theme system with daisyUI 5 (35+ themes)
+- Professional versioned migration system (V01-V28)
+
+**Content Management:** Blogging, Entities, Pages, Sitemap
+
+**Email System:** AWS SES/SNS/SQS integration, templates, delivery tracking
+
+**Additional Features:** Multi-language support, Maintenance mode, Referral codes, Audit logging, Session fingerprinting, Rate limiting
+
+## Development Guidelines
+
+### Keep It Simple
+
+- Only make changes that are directly requested or clearly necessary
+- Don't add features, refactor code, or make "improvements" beyond what was asked
+- Don't add error handling for scenarios that can't happen
+- Don't create helpers or abstractions for one-time operations
+- The right amount of complexity is the minimum needed for the current task
+
+### Code Reading First
+
+Read and understand relevant files before proposing code edits. Don't speculate about code you haven't inspected. If the user references a specific file/path, open and inspect it first.
 
 ## Development Commands
 
-### Setup and Dependencies
-
-- `mix setup` - Complete project setup (installs deps, sets up database)
-- `mix deps.get` - Install Elixir dependencies only
-
-### Database Operations
-
-- `mix ecto.create` - Create the database
-- `mix ecto.migrate` - Run database migrations
-- `mix ecto.reset` - Drop and recreate database with fresh data
-- `mix ecto.setup` - Create database, run migrations, and seed data
-
 ### PhoenixKit Installation System
-
-- `mix phoenix_kit.install` - Install PhoenixKit using igniter (for new projects)
-- `mix phoenix_kit.install --help` - Show detailed installation help and options
-- `mix phoenix_kit.update` - Update existing PhoenixKit installation to latest version
-- `mix phoenix_kit.update --help` - Show detailed update help and options
-- `mix phoenix_kit.update --status` - Check current version and available updates
-- `mix phoenix_kit.gen.migration` - Generate custom migration files
 
 **Key Features:**
 
@@ -63,717 +45,256 @@ This is **PhoenixKit** - PhoenixKit is a starter kit for building modern web app
 - **Prefix support** - Isolate PhoenixKit tables using PostgreSQL schemas
 - **Idempotent operations** - Safe to run migrations multiple times
 - **Multi-version upgrades** - Automatically handles upgrades across multiple versions
-- **PostgreSQL Validation** - Automatic database adapter detection with warnings for non-PostgreSQL setups
-- **Production Mailer Templates** - Auto-generated configuration examples for SMTP, SendGrid, Mailgun, Amazon SES
-- **Interactive Migration Runner** - Optional automatic migration execution with smart CI detection
-- **Built-in Help System** - Comprehensive help documentation accessible via `--help` flag
 
-**Installation Help:**
+**Commands:**
 
 ```bash
-# Show detailed installation options and examples
-mix phoenix_kit.install --help
+# Installation
+mix phoenix_kit.install                      # Basic with auto-detection
+mix phoenix_kit.install --repo MyApp.Repo    # Specify repository
+mix phoenix_kit.install --prefix auth        # Custom schema prefix
 
-# Quick examples from help:
-mix phoenix_kit.install                                   # Basic installation with auto-detection
-mix phoenix_kit.install --repo MyApp.Repo                 # Specify repository
-mix phoenix_kit.install --prefix auth                     # Custom schema prefix
-```
+# Setup (after installation)
+mix setup                                    # Complete project setup (deps + database)
 
-**Update Help:**
+# Update (when needed)
+mix phoenix_kit.update                       # Update to latest version
+mix phoenix_kit.update --status              # Check current version (alt: mix phoenix_kit.status)
+mix phoenix_kit.update --prefix auth         # Update with custom prefix
+mix phoenix_kit.update -y                    # Skip prompts (CI/CD)
 
-```bash
-# Show detailed update options and examples
-mix phoenix_kit.update --help
-
-# Quick examples from help:
-mix phoenix_kit.update                                    # Update to latest version
-mix phoenix_kit.update --status                           # Check current version
-mix phoenix_kit.update --prefix auth                      # Update with custom prefix
-mix phoenix_kit.update -y                                 # Skip confirmation prompts (CI/CD)
-mix phoenix_kit.update --force -y                         # Force update with auto-migration
+# Migrations
+mix phoenix_kit.gen.migration                # Generate custom migration
 ```
 
 ### Testing & Code Quality
 
-- `mix test` - Run smoke tests (module loading and configuration)
-- `mix format` - Format code according to .formatter.exs
-- `mix credo --strict` - Static code analysis
-- `mix dialyzer` - Type checking (requires PLT setup)
-- `mix quality` - Run all quality checks (format, credo, dialyzer)
+- `mix quality` - Run all checks (format + credo --strict + dialyzer)
+- `mix test` - Run smoke tests (optional)
 
-**Testing Philosophy for Library Modules:**
+### Commit Message Rules
 
-PhoenixKit is a **library module**, not a standalone application. Testing approach:
+Commits should focus on implemented functionality, not process.
 
-- ✅ **Smoke Tests** - Verify modules are loadable and properly structured
-- ✅ **Static Analysis** - Credo and Dialyzer catch logic and type errors
-- ✅ **Integration Testing** - Should be performed in parent Phoenix applications
+Start with action verbs: `Add`, `Update`, `Fix`, `Remove`, `Merge`
 
-**Why Minimal Unit Tests?**
-- Library code requires database, configuration, and runtime context
-- Unit tests would need complex mocking of Repo, Settings, and other dependencies
-- Real-world usage testing in parent applications provides better coverage
-- Smoke tests ensure library compiles and modules load correctly
-
-**For Contributors:**
-Test your changes by integrating PhoenixKit into a real Phoenix application.
-See CONTRIBUTING.md for development workflow with live reloading.
-
-### CI/CD
-
-PhoenixKit uses GitHub Actions for continuous integration:
-
-**Automated Checks:**
-- ✅ Code formatting validation (`mix format --check-formatted`)
-- ✅ Static analysis with Credo (`mix credo --strict`)
-- ✅ Type checking with Dialyzer
-- ✅ Compilation with warnings as errors (production code)
-- ✅ Dependency audit (non-blocking for transitive deps)
-- 📝 Smoke tests (optional - basic module loading verification)
-
-**CI Workflow:**
-- Runs on push to `main`, `dev`, and `claude/**` branches
-- Runs on all pull requests
-- Uses caching for dependencies and PLT files
-- Parallel execution for faster feedback
-
-**View CI Status:**
-- GitHub Actions: Check the "Actions" tab in the repository
-- Badge: See README.md for CI status badge
-
-### ⚠️ IMPORTANT: Pre-commit Checklist
-
-**ALWAYS run before git commit:**
-
-```bash
-mix format
-git add -A  # Add formatted files
-git commit -m "your message"
-```
-
-This ensures consistent code formatting across the project.
-
-### 📝 Commit Message Rules
-
-**ALWAYS start commit messages with action verbs:**
-
-- `Add` - for new features, files, or functionality
-- `Update` - for modifications to existing code or features
-- `Merge` - for merge commits or combining changes
-- `Fix` - for bug fixes
-- `Remove` - for deletions
-
-**Important commit message restrictions:**
-
-- ❌ **NEVER mention Claude or AI assistance** in commit messages
-- ❌ Avoid phrases like "Generated with Claude", "AI-assisted", etc.
-- ✅ Focus on **what** was changed and **why**
+**Restrictions:**
+- Don't mention Claude or AI assistance
+- Avoid phrases like "Generated with Claude", "AI-assisted", etc.
+- Focus on **what** was changed and **why**
 
 **Examples:**
-
 - ✅ `Add role system for user authorization management`
-- ✅ `Update rollback logic to handle single version migrations`
 - ✅ `Fix merge conflict markers in installation file`
 - ❌ `Enhanced migration system` (no action verb)
-- ❌ `migration fixes` (not descriptive enough)
 - ❌ `Add new feature with Claude assistance` (mentions AI)
 
-### 🏷️ Version Management Protocol
+### Version Management
 
-**Current Version**: 1.3.3 (in mix.exs)
-**Version Strategy**: Semantic versioning (MAJOR.MINOR.PATCH)
-**Migration Version**: V23 (latest migration version with session fingerprinting)
+**Current Version**: 1.6.15 (in mix.exs)
+**Migration Version**: V28 (sitemap tables)
 
-**MANDATORY steps for version updates:**
+**Update locations:** `mix.exs`, `CHANGELOG.md`, `README.md` (if needed)
 
-#### 1. Version Update Requirements
-
-```bash
-# Current version locations to update:
-# - mix.exs (@version constant)
-# - CHANGELOG.md (new version entry)
-# - README.md (if version mentioned in examples)
-```
-
-#### 2. Version Number Schema
-
-- **MAJOR**: Breaking changes, backward incompatibility
-- **MINOR**: New features, backward compatible
-- **PATCH**: Bug fixes, backward compatible
-
-#### 3. Update Process Checklist
-
-**Step 1: Update mix.exs**
-
-```elixir
-@version "1.0.1"  # Increment from current version
-```
-
-**Step 2: Update CHANGELOG.md**
-
-```markdown
-## [1.0.1] - 2025-08-20
-
-### Added
-- Description of new features
-
-### Changed
-- Description of modifications
-
-### Fixed
-- Description of bug fixes
-
-### Removed
-- Description of deletions
-```
-
-**Step 3: Commit Version Changes**
-
-```bash
-git add mix.exs CHANGELOG.md README.md
-git commit -m "Update version to 1.0.1 with comprehensive changelog"
-```
-
-#### 4. Version Validation
-
-**Before committing version changes:**
-
-- ✅ Mix compiles without errors: `mix compile`
-- ✅ Tests pass: `mix test` (run existing tests to ensure no regressions)
-- ✅ Code formatted: `mix format`
-- ✅ Credo passes: `mix credo --strict`
-- ✅ CI checks pass: Verify GitHub Actions workflow succeeds
-- ✅ CHANGELOG.md includes current date
-- ✅ Version number incremented correctly
-
-**⚠️ Critical Notes:**
-
-- **NEVER ship without updating CHANGELOG.md**
-- **ALWAYS validate version number increments**
-- **NEVER reference old version in new documentation**
+**Before committing:**
+- Mix compiles without errors
+- Code formatted
+- Credo passes
+- CHANGELOG.md updated
 
 ### Publishing
 
 - `mix hex.build` - Build package for Hex.pm
-- `mix hex.publish` - Publish to Hex.pm (requires auth)
-- `mix docs` - Generate documentation with ExDoc
+- `mix hex.publish` - Publish to Hex.pm
+- `mix docs` - Generate documentation
 
 ## Code Style Guidelines
 
 ### Template Comments
 
-**ALWAYS use EEx comments in Phoenix templates and components:**
+Use EEx comments in Phoenix templates:
 
 ```heex
-<%!-- EEx comments (CORRECT) --%>
-<div class="container">
-  <%!-- This is the preferred way to comment in .heex templates --%>
-  <h1>My App</h1>
-</div>
-
-<!-- HTML comments (AVOID) -->
-<div class="container">
-  <!-- This should be avoided in Phoenix templates -->
-  <h1>My App</h1>
-</div>
-```
-
-**Why EEx comments are preferred:**
-
-- ✅ **Server-side processing** - EEx comments (`<%!-- --%>`) are processed server-side and never sent to the client
-- ✅ **Performance** - Reduces HTML payload size since comments don't appear in browser
-- ✅ **Security** - Internal comments and notes remain private on the server
-- ✅ **Consistency** - Matches Phoenix LiveView and EEx template conventions
-
-**When to use:**
-
-- ✅ All `.heex` template files
-- ✅ LiveView components
-- ✅ Phoenix templates and layouts
-- ✅ Documentation and section dividers in templates
-- ✅ Temporary code comments during development
-
-**Template Comment Examples:**
-
-```heex
-<%!-- Header Section --%>
-<header class="w-full relative mb-6">
-  <%!-- Back Button (Left aligned) --%>
-  <.link navigate="/dashboard" class="btn btn-outline">
-    Back to Dashboard
-  </.link>
-
-  <%!-- Title Section --%>
-  <div class="text-center">
-    <h1>Page Title</h1>
-  </div>
-</header>
-
-<%!-- Main Content Area --%>
-<main class="container mx-auto">
-  <%!-- TODO: Add pagination controls --%>
-  <div class="content">
-    <!-- This HTML comment will appear in browser source -->
-    <%!-- This EEx comment stays on the server --%>
-  </div>
-</main>
-```
-
-**Code Comments in Elixir Files:**
-
-For regular Elixir code (`.ex` files), continue using standard Elixir comments:
-
-```elixir
-# Standard Elixir comment for code documentation
-def my_function do
-  # Inline comment explaining logic
-  :ok
-end
+<%!-- EEx comments (correct - server-side only) --%>
+<!-- HTML comments (avoid - sent to client) -->
 ```
 
 ### Helper Functions: Use Components, Not Private Functions
 
 **CRITICAL RULE**: Never create private helper functions (`defp`) that are called directly from HEEX templates.
 
-**❌ WRONG - Compiler Cannot See Usage:**
-
+**❌ Wrong - Compiler Cannot See Usage:**
 ```elixir
-# lib/my_app_web/live/users_live.ex
-defmodule MyAppWeb.UsersLive do
-  use MyAppWeb, :live_view
-
-  # ❌ BAD: Compiler shows "function format_date/1 is unused"
-  defp format_date(date) do
-    Calendar.strftime(date, "%B %d, %Y")
-  end
+defp format_date(date) do
+  Calendar.strftime(date, "%B %d, %Y")
 end
 ```
-
 ```heex
-<!-- lib/my_app_web/live/users_live.html.heex -->
-{format_date(user.created_at)}  <%!-- ❌ Compiler doesn't see this call --%>
+{format_date(user.created_at)}  <%!-- Compiler shows "unused function" warning --%>
 ```
 
-**✅ CORRECT - Use Phoenix Components:**
-
+**✅ Correct - Use Phoenix Components:**
 ```elixir
 # lib/phoenix_kit_web/components/core/time_display.ex
-defmodule PhoenixKitWeb.Components.Core.TimeDisplay do
-  use Phoenix.Component
+attr :date, :any, required: true
+attr :format, :string, default: "%B %d, %Y"
 
-  @doc """
-  Displays formatted date.
-
-  ## Examples
-      <.formatted_date date={user.created_at} />
-  """
-  attr :date, :any, required: true
-  attr :format, :string, default: "%B %d, %Y"
-
-  def formatted_date(assigns) do
-    ~H"""
-    <span>{Calendar.strftime(@date, @format)}</span>
-    """
-  end
-
-  # ✅ GOOD: Private helper INSIDE component
-  defp format_time(time), do: ...
+def formatted_date(assigns) do
+  ~H"<span>{Calendar.strftime(@date, @format)}</span>"
 end
 ```
-
 ```heex
-<!-- lib/my_app_web/live/users_live.html.heex -->
-<.formatted_date date={user.created_at} />  <%!-- ✅ Compiler sees component usage --%>
+<.formatted_date date={user.created_at} />  <%!-- Compiler sees component usage --%>
 ```
 
 **Why This Matters:**
+1. **Compiler Visibility** - Component calls (`<.component />`) are visible to compiler, function calls in templates are not
+2. **Type Safety** - Components use `attr` macros for compile-time validation
+3. **Reusability** - Components work across all LiveView modules without duplication
+4. **No Warnings** - Prevents false-positive "unused function" warnings
 
-1. **Compiler Visibility**: Component calls (`<.component />`) are visible to Elixir compiler, function calls in templates are not
-2. **Type Safety**: Components use `attr` macros for compile-time validation
-3. **Reusability**: Components work across all LiveView modules without duplication
-4. **Documentation**: Components have structured `@doc` with examples
-5. **No Warnings**: Prevents false-positive "unused function" warnings
+**Existing Core Components:**
+- `badge.ex` - Role badges, status badges
+- `time_display.ex` - Relative time, expiration dates
+- `user_info.ex` - User roles, counts, statistics
+- `button.ex`, `input.ex`, `select.ex`, `textarea.ex`, `checkbox.ex` - Form components
+- `pagination.ex`, `stat_card.ex`, `flash.ex`, `theme_switcher.ex`
 
-**Where to Put Components:**
-
-- **New helper component**: `lib/phoenix_kit_web/components/core/[category].ex`
-- **Import in**: `lib/phoenix_kit_web.ex` → `core_components()` function
-- **Available everywhere**: Automatically imported in all LiveViews
-
-**Existing Core Component Categories:**
-
-- `badge.ex` - Role badges, status badges, code status badges
-- `time_display.ex` - Relative time, expiration dates, age badges
-- `user_info.ex` - User roles, user counts, user statistics
-- `button.ex`, `input.ex`, `select.ex`, etc. - Form components
-
-**Adding New Component Category:**
-
+**Adding New Component:**
 1. Create file: `lib/phoenix_kit_web/components/core/my_category.ex`
 2. Add import: `lib/phoenix_kit_web.ex` → `import PhoenixKitWeb.Components.Core.MyCategory`
 3. Use in templates: `<.my_component attr={value} />`
 
-**Example: Adding New Helper Component:**
-
-```elixir
-# 1. Create component file
-# lib/phoenix_kit_web/components/core/currency.ex
-defmodule PhoenixKitWeb.Components.Core.Currency do
-  use Phoenix.Component
-
-  attr :amount, :integer, required: true
-  attr :currency, :string, default: "USD"
-
-  def price(assigns) do
-    ~H"""
-    <span class="font-semibold">{format_price(@amount, @currency)}</span>
-    """
-  end
-
-  defp format_price(amount, "USD"), do: "$#{amount / 100}"
-  defp format_price(amount, "EUR"), do: "€#{amount / 100}"
-end
-
-# 2. Add import to lib/phoenix_kit_web.ex
-def core_components do
-  quote do
-    # ... existing imports ...
-    import PhoenixKitWeb.Components.Core.Currency  # ← Add this
-  end
-end
-
-# 3. Use in any LiveView template
-# <.price amount={product.price_cents} currency="USD" />
-```
-
-**Component Best Practices:**
-
-1. **One category per file**: Group related helpers (time, currency, badges, etc.)
-2. **Document everything**: Use `@doc`, `attr`, examples
-3. **Private helpers OK**: Use `defp` INSIDE components for internal logic
-4. **Validation**: Use `attr` with `:required`, `:default`, `:values`
-5. **Naming**: Use clear, semantic names (`<.time_ago />` not `<.format_t />`)
-
-**Migration Pattern:**
-
-```elixir
-# BEFORE (helper function)
-defp format_time_ago(datetime) do
-  # logic...
-end
-
-# Template: {format_time_ago(session.connected_at)}
-
-# AFTER (component)
-# Move to lib/phoenix_kit_web/components/core/time_display.ex
-attr :datetime, :any, required: true
-def time_ago(assigns) do
-  ~H"""
-  <span>{format_time_ago(@datetime)}</span>
-  """
-end
-defp format_time_ago(datetime), do: # logic...
-
-# Template: <.time_ago datetime={session.connected_at} />
-```
-
 ## Architecture
 
-### Config Architecture
+### Config & Settings
 
-- PhoenixKit basic configuration via default Config module in a parent project
-- **PhoenixKit.Config** - Used to work with static configuration instead of `Application.get_env/3`
+- **PhoenixKit.Config** - Static configuration
+- **PhoenixKit.Settings** - Database-stored system settings (admin UI at `{prefix}/admin/settings`)
 
-### Settings System Architecture
+**Core Settings:** `time_zone`, `date_format`, `time_format`
 
-- **PhoenixKit.Settings** - Settings context for system-wide configuration management
-- **PhoenixKit.Settings.Setting** - Settings schema with key/value storage and timestamps
-- **PhoenixKitWeb.Live.Settings** - Settings management interface at `{prefix}/admin/settings`
-
-**Core Settings:**
-
-- **time_zone** - System timezone offset (UTC-12 to UTC+12)
-- **date_format** - Date display format (Y-m-d, m/d/Y, d/m/Y, d.m.Y, d-m-Y, F j, Y)
-- **time_format** - Time display format (H:i for 24-hour, h:i A for 12-hour)
-
-**Email Settings:**
-
-- **email_enabled** - Enable/disable email system (default: false)
-- **email_save_body** - Save full email content vs preview only (default: false)
-- **email_ses_events** - Enable AWS SES event processing (default: false)
-- **email_retention_days** - Data retention period (default: 90 days)
-- **email_sampling_rate** - Percentage of emails to fully track (default: 100%)
-
-**Key Features:**
-
-- **Database Storage** - Settings persisted in phoenix_kit_settings table
-- **Admin Interface** - Complete settings management at `{prefix}/admin/settings`
-- **Default Values** - Fallback defaults for all settings (UTC+0, Y-m-d, H:i)
-- **Validation** - Form validation with real-time preview examples
-- **Integration** - Automatic integration with date formatting utilities
-- **Email System UI** - Dedicated section for email system configuration
+**Email Settings:** `email_enabled`, `email_save_body`, `email_ses_events`, `email_retention_days`, `email_sampling_rate`
 
 ### Authentication Structure
 
-- **PhoenixKit.Users.Auth** - Main authentication context with public interface
-- **PhoenixKit.Users.Auth.User** - User schema with validations, authentication, and role helpers
-- **PhoenixKit.Users.Auth.UserToken** - Token management for email confirmation and password reset
-- **PhoenixKit.Users.MagicLink** - Magic link authentication system
-- **PhoenixKit.Users.Auth.Scope** - Authentication scope management with role integration
-- **PhoenixKit.Users.RateLimiter** - Rate limiting protection for authentication endpoints
+- **PhoenixKit.Users.Auth** - Main authentication context
+- **PhoenixKit.Users.Auth.User** - User schema
+- **PhoenixKit.Users.Auth.UserToken** - Token management
+- **PhoenixKit.Users.Auth.Scope** - Authentication scope with role integration
+- **PhoenixKit.Users.MagicLink** - Magic link authentication
+- **PhoenixKit.Users.RateLimiter** - Rate limiting protection
 
-### Rate Limiting Architecture
+### Rate Limiting
 
-Protection against brute-force attacks, token enumeration, and spam using Hammer library. Configuration is automatically added to parent app's `config.exs` during installation.
-
-**Protected Endpoints:**
+Protection against brute-force attacks using Hammer library (use `hammer_backend_redis` for production):
 - Login: 5/min per email + IP limiting
 - Magic Link: 3/5min per email
 - Password Reset: 3/5min per email
 - Registration: 3/hour per email + 10/hour per IP
 
-**Configuration:**
+### Session Fingerprinting
+
+- IP Address Tracking
+- User Agent Hashing
+- Configurable strictness (log warnings or force re-auth)
+
 ```elixir
-# config/config.exs
-config :hammer,
-  backend: {Hammer.Backend.ETS, [expiry_ms: 60_000, cleanup_interval_ms: 60_000]}
-
-config :phoenix_kit, PhoenixKit.Users.RateLimiter,
-  login_limit: 5, login_window_ms: 60_000,
-  magic_link_limit: 3, magic_link_window_ms: 300_000,
-  password_reset_limit: 3, password_reset_window_ms: 300_000,
-  registration_limit: 3, registration_window_ms: 3_600_000,
-  registration_ip_limit: 10, registration_ip_window_ms: 3_600_000
-```
-
-**Production:** Use `hammer_backend_redis` for distributed systems.
-
-### Session Fingerprinting Architecture
-
-- **PhoenixKit.Utils.SessionFingerprint** - Session fingerprinting utilities for hijacking prevention
-- **PhoenixKit.Users.Auth.UserToken** - Extended with ip_address and user_agent_hash fields
-- **PhoenixKitWeb.Users.Auth** - Integrated fingerprint verification in authentication plugs
-- **Migration V23** - Database migration adding fingerprinting columns
-
-**Security Features:**
-- **IP Address Tracking** - Detects when session is used from different IP address
-- **User Agent Hashing** - Detects when session is used from different browser/device
-- **Configurable Strictness** - Can log warnings or force re-authentication
-- **Backward Compatible** - Existing sessions without fingerprints remain valid
-- **Privacy Focused** - User agents are hashed for storage efficiency
-
-**Configuration:**
-```elixir
-# In your config/config.exs
 config :phoenix_kit,
-  session_fingerprint_enabled: true,  # Enable fingerprinting (default: true)
-  session_fingerprint_strict: false   # Strict mode forces re-auth on mismatch (default: false)
+  session_fingerprint_enabled: true,
+  session_fingerprint_strict: false
 ```
 
 **Verification Behavior:**
-- **Non-strict mode (default)**: Logs warnings but allows access when fingerprints change
-- **Strict mode**: Forces re-authentication if both IP and user agent change
-- **Partial changes**: Single changes (IP or UA) logged as warnings but allowed
+- **Non-strict (default)** - Logs warnings but allows access when fingerprints change
+- **Strict mode** - Forces re-authentication if both IP and user agent change
 
-**Use Cases:**
-- Detect stolen session tokens being used from different locations
-- Identify suspicious session activity patterns
-- Provide audit trail for security investigations
-- Balance security with user experience (mobile users, VPNs)
+### Role System
 
-### Role System Architecture
+- **PhoenixKit.Users.Role** - Role schema
+- **PhoenixKit.Users.RoleAssignment** - Role assignments with audit trail
+- **PhoenixKit.Users.Roles** - Role management API
 
-- **PhoenixKit.Users.Role** - Role schema with system role protection
-- **PhoenixKit.Users.RoleAssignment** - Many-to-many role assignments with audit trail
-- **PhoenixKit.Users.Roles** - Role management API and business logic
-- **PhoenixKitWeb.Live.Dashboard** - Admin dashboard with system statistics
-- **PhoenixKitWeb.Live.Users** - User management interface with role controls
-- **PhoenixKit.Users.Auth.register_user/1** - User registration with integrated role assignment
+Three system roles: Owner, Admin, User (first user becomes Owner)
 
-**Key Features:**
+Admin interfaces: `{prefix}/admin/dashboard`, `{prefix}/admin/users`
 
-- **Three System Roles** - Owner, Admin, User with automatic assignment
-- **Elixir Logic** - First user automatically becomes Owner
-- **Admin Dashboard** - Built-in dashboard at `{prefix}/admin/dashboard` for system statistics
-- **User Management** - Complete user management interface at `{prefix}/admin/users`
-- **Role API** - Comprehensive role management with `PhoenixKit.Users.Roles`
-- **Security Features** - Owner protection, audit trail, self-modification prevention
-- **Scope Integration** - Role checks via `PhoenixKit.Users.Auth.Scope`
-
-### Date Formatting Architecture
-
-- **PhoenixKit.Utils.Date** - Date and time formatting utilities using Timex
-- **Settings Integration** - Automatic user preference loading from Settings system
-- **Template Integration** - Direct usage in LiveView templates with UtilsDate alias
-
-**Core Functions:**
-
-- **format_date/2** - Format dates with PHP-style format codes
-- **format_time/2** - Format times with PHP-style format codes
-- **format_datetime/2** - Format datetime values with date formats
-- **format_datetime_with_user_format/1** - Auto-load user's date_format setting
-- **format_date_with_user_format/1** - Auto-load user's date_format setting
-- **format_time_with_user_format/1** - Auto-load user's time_format setting
-
-**Supported Formats:**
-
-- **Date Formats** - Y-m-d (ISO), m/d/Y (US), d/m/Y (European), d.m.Y (German), d-m-Y, F j, Y (Long)
-- **Time Formats** - H:i (24-hour), h:i A (12-hour with AM/PM)
-- **Examples** - Dynamic format preview with current date/time examples
-- **Timex Integration** - Robust internationalized formatting with extensive format support
-
-**Template Usage:**
+### Date Formatting
 
 ```heex
-<!-- Settings-aware formatting (recommended) -->
 {UtilsDate.format_datetime_with_user_format(user.inserted_at)}
-{UtilsDate.format_date_with_user_format(user.confirmed_at)}
-{UtilsDate.format_time_with_user_format(Time.utc_now())}
-
-<!-- Manual formatting -->
 {UtilsDate.format_date(Date.utc_today(), "F j, Y")}
 {UtilsDate.format_time(Time.utc_now(), "h:i A")}
 ```
 
-**Emails module:** See `lib/phoenix_kit_web/live/modules/emails/README.md` for architecture, configuration, and troubleshooting guidance.
+### Content Modules
 
-**Blogging module:** See `lib/phoenix_kit_web/live/modules/blogging/README.md` for dual storage modes, multi-language support, and filesystem-based content management.
+**Blogging:** See `lib/phoenix_kit_web/live/modules/blogging/README.md`
+**Emails:** See `lib/phoenix_kit_web/live/modules/emails/README.md`
 
 ### Migration Architecture
 
-- **PhoenixKit.Migrations.Postgres** - PostgreSQL-specific migrator with Oban-style versioning
-- **PhoenixKit.Migrations.Postgres.V01** - Version 1: Basic authentication tables with role system
-- **Mix.Tasks.PhoenixKit.Install** - Igniter-based installation for new projects
-- **Mix.Tasks.PhoenixKit.Update** - Versioned updates for existing installations
-- **Mix.Tasks.PhoenixKit.Gen.Migration** - Custom migration generator
-- **Mix.Tasks.PhoenixKit.MigrateToDaisyui5** - Migration tool for daisyUI 5 upgrade
+- **PhoenixKit.Migrations.Postgres** - PostgreSQL migrator with Oban-style versioning
+- **Mix.Tasks.PhoenixKit.Install** - Igniter-based installation
+- **Mix.Tasks.PhoenixKit.Update** - Versioned updates
 
 ### Key Design Principles
 
 - **No Circular Dependencies** - Optional Phoenix deps prevent import cycles
-- **Library-First Architecture** - No OTP application, no supervision tree, can be used as dependency
-  - No `Application.start/2` callback
-  - No Telemetry supervisor (uses `Plug.Telemetry` in endpoint)
-  - No dev-only routes (PageController removed)
-  - Parent apps provide their own home pages and layouts
-- **Professional Testing** - DataCase pattern with database sandbox
-- **Production Ready** - Complete authentication system with security best practices
-- **Clean Codebase** - Removed standard Phoenix template boilerplate (telemetry.ex, page controllers, API pipeline)
-
-### Database Integration
-
-- **PostgreSQL** - Primary database with Ecto integration
-- **Repository Pattern** - Auto-detection or explicit configuration
-- **Migration Support** - V01 migration with authentication, role, and settings tables
-- **Role System Tables** - phoenix_kit_user_roles, phoenix_kit_user_role_assignments
-- **Settings Table** - phoenix_kit_settings with key/value/timestamp storage
-- **Race Condition Protection** - FOR UPDATE locking in Ecto transactions
-- **Test Database** - Separate test database with sandbox
-
-### Professional Features
-
-- **Hex Publishing** - Complete package.exs configuration
-- **Documentation** - ExDoc ready with comprehensive docs
-- **Quality Tools** - Credo, Dialyzer, code formatting configured
-- **Testing Framework** - Complete test suite with fixtures
+- **Library-First Architecture** - No OTP application, no supervision tree
+- **Production Ready** - Complete authentication with security best practices
 
 ## PhoenixKit Integration
 
 ### Setup Steps
 
-1. **Install PhoenixKit**: Run `mix phoenix_kit.install --repo YourApp.Repo`
-2. **Run Migrations**: Database tables created automatically (V16 includes OAuth providers and magic link registration)
-3. **Add Routes**: Use `phoenix_kit_routes()` macro in your router
-4. **Configure Mailer**: PhoenixKit auto-detects and uses your app's mailer, or set up email delivery in `config/config.exs`
-5. **Configure Layout** (Optional): Set custom layouts in `config/config.exs`
-6. **Theme Support**: DaisyUI 5 theme system with 35+ themes is automatically enabled
-7. **Settings Management**: Access admin settings at `{prefix}/admin/settings`
-8. **Email System** (Optional): Enable email system and AWS SES integration
+1. Run `mix phoenix_kit.install --repo YourApp.Repo`
+2. Add `phoenix_kit_routes()` macro to router
+3. Configure mailer in `config/config.exs`
+4. Access admin at `{prefix}/admin/dashboard`
 
-> **Note**: `{prefix}` represents your configured PhoenixKit URL prefix (default: `/phoenix_kit`).
-> This can be customized via `config :phoenix_kit, url_prefix: "/your_custom_prefix"`.
-
-### Integration Pattern
+### Configuration
 
 ```elixir
-# In your Phoenix app's config/config.exs
+# config/config.exs
 config :phoenix_kit,
   repo: MyApp.Repo,
-  mailer: MyApp.Mailer  # Optional: Use your app's mailer (auto-detected by installer)
+  mailer: MyApp.Mailer
 
-# Configure your app's mailer (PhoenixKit will use it automatically if mailer is set)
-config :my_app, MyApp.Mailer, adapter: Swoosh.Adapters.Local
-
-# Alternative: Configure PhoenixKit's built-in mailer (legacy approach)
-# config :phoenix_kit, PhoenixKit.Mailer, adapter: Swoosh.Adapters.Local
-
-# Configure Layout Integration (optional - defaults to PhoenixKit layouts)
+# Layout Integration (optional)
 config :phoenix_kit,
-  layout: {MyAppWeb.Layouts, :app},        # Use your app's layout
-  root_layout: {MyAppWeb.Layouts, :root},  # Optional: custom root layout
-  page_title_prefix: "Auth"                # Optional: page title prefix
+  layout: {MyAppWeb.Layouts, :app},
+  root_layout: {MyAppWeb.Layouts, :root}
 
-# Configure DaisyUI 5 Theme System (optional)
+# DaisyUI 5 Theme System (optional)
 config :phoenix_kit,
   theme: %{
-    theme: "auto",                   # Any of 35+ daisyUI themes or "auto"
-    primary_color: "#3b82f6",       # Primary brand color (OKLCH format supported)
-    storage: :local_storage,        # :local_storage, :session, :cookie
-    theme_controller: true,         # Enable theme-controller integration
-    categories: [:light, :dark, :colorful]  # Theme categories to show in switcher
+    theme: "auto",
+    primary_color: "#3b82f6",
+    storage: :local_storage,
+    categories: [:light, :dark, :colorful]
   }
 
-# Migrate existing installations to daisyUI 5
-# Run: mix phoenix_kit.migrate_to_daisyui5
-
-# Settings System Configuration (optional defaults)
-config :phoenix_kit,
-  default_settings: %{
-    time_zone: "0",          # UTC+0 (GMT)
-    date_format: "Y-m-d",    # ISO format: 2025-09-03
-    time_format: "H:i"       # 24-hour format: 15:30
-  }
-
-# Password Requirements Configuration (optional)
-# Configure password strength requirements for user registration and password changes
+# Password Requirements (optional)
 config :phoenix_kit, :password_requirements,
-  min_length: 8,            # Minimum password length (default: 8)
-  max_length: 72,           # Maximum password length (default: 72, bcrypt limit)
-  require_uppercase: false, # Require at least one uppercase letter (default: false)
-  require_lowercase: false, # Require at least one lowercase letter (default: false)
-  require_digit: false,     # Require at least one digit (default: false)
-  require_special: false    # Require at least one special character (!?@#$%^&*_) (default: false)
+  min_length: 8,
+  max_length: 72,
+  require_uppercase: false,
+  require_lowercase: false,
+  require_digit: false,
+  require_special: false
 
-# Example: Strong password requirements for production
-# config :phoenix_kit, :password_requirements,
-#   min_length: 12,
-#   require_uppercase: true,
-#   require_lowercase: true,
-#   require_digit: true,
-#   require_special: true
-
-# In your Phoenix app's mix.exs
-def deps do
-  [
-    {:phoenix_kit, "~> 1.2"}
-  ]
-end
+# mix.exs
+{:phoenix_kit, "~> 1.6"}
+```
 
 ### Date Formatting Helpers
 
-- Use `UtilsDate.format_datetime_with_user_format/1`, `format_date_with_user_format/1`, and
-  `format_time_with_user_format/1` in templates to respect admin-configured formats.
-- For hard-coded output, `UtilsDate.format_date/2` and `format_time/2` accept PHP-style format
-  strings such as `"F j, Y"` or `"h:i A"`.
+Use `UtilsDate.format_datetime_with_user_format/1`, `format_date_with_user_format/1`, and `format_time_with_user_format/1` in templates to respect admin-configured formats.
 
-### Optional Authentication Modules
+### Optional Authentication
 
-- **OAuth & Magic Link registration:** Setup instructions, environment variables, and feature
-  details now live in `guides/oauth_and_magic_link_setup.md`. Review that guide when enabling the
-  optional authentication flows in a host application.
-
-
+OAuth & Magic Link setup: See `guides/oauth_and_magic_link_setup.md`
 
 ## Key File Structure
 
@@ -782,60 +303,33 @@ end
 - `lib/phoenix_kit.ex` - Main API module
 - `lib/phoenix_kit/users/auth.ex` - Authentication context
 - `lib/phoenix_kit/users/auth/user.ex` - User schema
-- `lib/phoenix_kit/users/auth/user_token.ex` - Token management
 - `lib/phoenix_kit/users/magic_link.ex` - Magic link authentication
-- `lib/phoenix_kit/users/magic_link_registration.ex` - Magic link registration (V16+)
-- `lib/phoenix_kit/users/oauth.ex` - OAuth authentication context (V16+)
-- `lib/phoenix_kit/users/oauth_provider.ex` - OAuth provider schema (V16+)
-- `lib/phoenix_kit/users/role*.ex` - Role system (Role, RoleAssignment, Roles)
-- `lib/phoenix_kit/settings.ex` - Settings context and management
-- `lib/phoenix_kit/utils/date.ex` - Date formatting utilities with Settings integration
-- `lib/phoenix_kit/emails/*.ex` - Email system modules
-- `lib/phoenix_kit/mailer.ex` - Mailer with automatic email system integration
+- `lib/phoenix_kit/users/oauth.ex` - OAuth authentication
+- `lib/phoenix_kit/users/roles.ex` - Role management API
+- `lib/phoenix_kit/settings/settings.ex` - Settings context
+- `lib/phoenix_kit/emails/*.ex` - Email system (16 modules)
+- `lib/phoenix_kit/mailer.ex` - Mailer
+
+### Content Management
+
+- `lib/phoenix_kit/blogging/renderer.ex` - Blog post rendering
+- `lib/phoenix_kit/entities/*.ex` - Entities system
+- `lib/phoenix_kit/pages/*.ex` - Pages system
+- `lib/phoenix_kit/sitemap/*.ex` - Sitemap generation
 
 ### Web Integration
 
-- `lib/phoenix_kit_web/router.ex` - Library router (dev/test only, parent apps use `phoenix_kit_routes()`)
-- `lib/phoenix_kit_web/integration.ex` - Router integration macro for parent applications
-- `lib/phoenix_kit_web/endpoint.ex` - Phoenix endpoint (uses `Plug.Telemetry`, no custom supervisor)
-- `lib/phoenix_kit_web/users/oauth_controller.ex` - OAuth authentication controller (V16+)
-- `lib/phoenix_kit_web/users/magic_link_registration_controller.ex` - Magic link registration controller (V16+)
-- `lib/phoenix_kit_web/users/magic_link_registration.ex` - Registration completion LiveView (V16+)
-- `lib/phoenix_kit_web/users/auth.ex` - Web authentication plugs
-- `lib/phoenix_kit_web/users/*.ex` - LiveView components (login, registration, settings, etc.)
-- `lib/phoenix_kit_web/live/*.ex` - Admin interfaces (dashboard, users, sessions, settings, modules)
-- `lib/phoenix_kit_web/live/settings.ex` - Settings management interface
-- `lib/phoenix_kit_web/live/modules/emails/*.ex` - Email system LiveView interfaces
-- `lib/phoenix_kit_web/components/core_components.ex` - UI components
-- `lib/phoenix_kit_web/components/layouts.ex` - Layout module (fallback for parent apps)
-- `lib/phoenix_kit_web/controllers/error_html.ex` - HTML error rendering
-- `lib/phoenix_kit_web/controllers/error_json.ex` - JSON error rendering
+- `lib/phoenix_kit_web/router.ex` - Library router
+- `lib/phoenix_kit_web/plugs/integration.ex` - Router integration macro
+- `lib/phoenix_kit_web/live/` - LiveView modules
+- `lib/phoenix_kit_web/components/core/` - 30+ components
 
-### Migration & Config
+### Migrations (V01-V28)
 
-- `lib/phoenix_kit/migrations/postgres/v01.ex` - V01 migration (basic auth)
-- `lib/phoenix_kit/migrations/postgres/v07.ex` - V07 migration (email system tables)
-- `lib/phoenix_kit/migrations/postgres/v09.ex` - V09 migration (email blocklist)
-- `lib/phoenix_kit/migrations/postgres/v16.ex` - V16 migration (OAuth providers table)
-- `lib/mix/tasks/phoenix_kit.migrate_to_daisyui5.ex` - DaisyUI 5 migration tool
-- `config/config.exs` - Library configuration
-- `mix.exs` - Project and package configuration
-- `scripts/aws_ses_sqs_setup.sh` - AWS SES infrastructure automation
+Key versions: V01 (auth), V07 (email), V16 (OAuth), V17 (blogging/entities), V22 (audit), V23 (fingerprinting), V28 (sitemap)
 
-### DaisyUI 5 Assets
+## Additional Documentation
 
-- `priv/static/assets/phoenix_kit_daisyui5.css` - Modern CSS with @plugin directives
-- `priv/static/assets/phoenix_kit_daisyui5.js` - Enhanced theme system with controller integration
-- `priv/static/examples/tailwind_config_daisyui5.js` - Tailwind CSS 3 example config
-- `priv/static/examples/tailwind_css4_config.css` - Tailwind CSS 4 example config
-
-## Development Workflow
-
-PhoenixKit supports a complete professional development workflow:
-
-1. **Development** - Local development with PostgreSQL
-2. **Testing** - Comprehensive test suite with database integration
-3. **Quality** - Static analysis and type checking
-4. **Documentation** - Generated docs with usage examples
-5. **Publishing** - Ready for Hex.pm with proper versioning
-```
+- **Emails:** `lib/phoenix_kit_web/live/modules/emails/README.md`
+- **Blogging:** `lib/phoenix_kit_web/live/modules/blogging/README.md`
+- **OAuth/Magic Link:** `guides/oauth_and_magic_link_setup.md`

--- a/lib/mix/tasks/phoenix_kit.install.ex
+++ b/lib/mix/tasks/phoenix_kit.install.ex
@@ -192,7 +192,6 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
             ❌ Configuration was not added successfully after automatic retry.
 
             Please check config/config.exs manually and ensure it contains:
-            - config :ueberauth, Ueberauth (with providers: %{})
             - config :hammer (with backend and expiry_ms)
             - config :phoenix_kit, Oban (with queues configuration)
 
@@ -317,7 +316,6 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
       ⚠️  Required configuration is missing from config/config.exs
 
       PhoenixKit requires configuration for:
-      - Ueberauth (OAuth authentication)
       - Hammer (rate limiting)
       - Oban (background jobs for file processing)
 
@@ -338,15 +336,6 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
         lines = String.split(content, "\n")
 
         cond do
-          # Missing Ueberauth configuration entirely
-          !String.contains?(content, "config :ueberauth") ->
-            :missing
-
-          # Incorrect Ueberauth configuration (providers: [] instead of providers: %{})
-          String.contains?(content, "config :ueberauth, Ueberauth") &&
-              Regex.match?(~r/providers:\s*\[\s*\]/, content) ->
-            :missing
-
           # Missing Hammer configuration (check for active, non-commented config)
           !has_active_hammer_config?(lines) ->
             :missing

--- a/lib/mix/tasks/phoenix_kit.update.ex
+++ b/lib/mix/tasks/phoenix_kit.update.ex
@@ -12,7 +12,7 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
     To prevent configuration timing issues, the update process uses a two-pass strategy:
 
     1. **First Pass** (if configuration is missing): Adds required configuration (e.g.,
-       Ueberauth settings) via Igniter and prompts you to run the command again.
+       Hammer rate limiter, Oban) via Igniter and prompts you to run the command again.
 
     2. **Second Pass** (configuration present): Safely starts the application and
        completes the update process.
@@ -79,8 +79,6 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
     - Rollback-capable (can be reverted if needed)
     """
     use Igniter.Mix.Task
-
-    alias Igniter.Project.Config
 
     alias PhoenixKit.Install.{
       ApplicationSupervisor,
@@ -235,7 +233,6 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
       ⚠️  Required configuration is missing from config/config.exs
 
       PhoenixKit requires configuration for:
-      - Ueberauth (OAuth authentication)
       - Hammer (rate limiting)
       - Oban (background jobs for file processing)
 
@@ -256,15 +253,6 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
         lines = String.split(content, "\n")
 
         cond do
-          # Missing Ueberauth configuration entirely
-          !String.contains?(content, "config :ueberauth") ->
-            :missing
-
-          # Incorrect Ueberauth configuration (providers: [] instead of providers: %{})
-          String.contains?(content, "config :ueberauth, Ueberauth") &&
-              Regex.match?(~r/providers:\s*\[\s*\]/, content) ->
-            :missing
-
           # Missing Hammer configuration (check for active, non-commented config)
           !has_active_hammer_config?(lines) ->
             :missing
@@ -330,9 +318,6 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
     defp perform_igniter_update(igniter, opts) do
       prefix = opts[:prefix] || "public"
       force = opts[:force] || false
-
-      # Validate and fix Ueberauth configuration before update
-      igniter = validate_and_fix_ueberauth_config(igniter)
 
       # Ensure Hammer rate limiter configuration exists
       igniter = validate_and_add_hammer_config(igniter)
@@ -674,7 +659,7 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
 
       TWO-PASS UPDATE STRATEGY
         If required configuration is missing, the update process will:
-        1. First run: Add missing configuration (e.g., Ueberauth settings)
+        1. First run: Add missing configuration (e.g., Hammer, Oban settings)
         2. Prompt you to run the command again
         3. Second run: Complete the update with all configuration present
 
@@ -818,86 +803,6 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
       Then start your server:
         mix phx.server
       """)
-    end
-
-    # Validate and fix Ueberauth configuration
-    defp validate_and_fix_ueberauth_config(igniter) do
-      # Read current config.exs to check Ueberauth configuration
-      config_file = "config/config.exs"
-
-      if File.exists?(config_file) do
-        content = File.read!(config_file)
-
-        # Check Ueberauth configuration status
-        cond do
-          # Case 1: Incorrect configuration with providers: []
-          String.contains?(content, "config :ueberauth, Ueberauth") &&
-              Regex.match?(~r/providers:\s*\[\s*\]/, content) ->
-            fix_ueberauth_providers_config(igniter, content)
-
-          # Case 2: Configuration exists and is correct (providers: %{} or with values)
-          String.contains?(content, "config :ueberauth, Ueberauth") ->
-            igniter
-
-          # Case 3: Configuration is missing - add it
-          true ->
-            add_missing_ueberauth_config(igniter)
-        end
-      else
-        # config.exs doesn't exist, skip validation
-        igniter
-      end
-    end
-
-    # Fix Ueberauth providers configuration from [] to %{}
-    defp fix_ueberauth_providers_config(igniter, _content) do
-      igniter
-      |> Igniter.update_file("config/config.exs", fn source ->
-        content = Rewrite.Source.get(source, :content)
-
-        # Replace providers: [] with providers: %{}
-        updated_content =
-          Regex.replace(
-            ~r/(config\s+:ueberauth,\s+Ueberauth,\s+providers:\s*)\[\s*\]/,
-            content,
-            "\\1%{}"
-          )
-
-        Rewrite.Source.update(source, :content, updated_content)
-      end)
-      |> add_ueberauth_fix_notice()
-    end
-
-    # Add notice about Ueberauth configuration fix
-    defp add_ueberauth_fix_notice(igniter) do
-      notice = """
-      ✅ Fixed Ueberauth configuration: providers: [] → providers: %{}
-         OAuth authentication will now work correctly.
-      """
-
-      Igniter.add_notice(igniter, String.trim(notice))
-    end
-
-    # Add missing Ueberauth configuration
-    defp add_missing_ueberauth_config(igniter) do
-      igniter
-      |> Config.configure_new(
-        "config.exs",
-        :ueberauth,
-        [Ueberauth],
-        providers: %{}
-      )
-      |> add_ueberauth_added_notice()
-    end
-
-    # Add notice about Ueberauth configuration being added
-    defp add_ueberauth_added_notice(igniter) do
-      notice = """
-      ✅ Added missing Ueberauth configuration: providers: %{}
-         OAuth authentication configured for runtime loading.
-      """
-
-      Igniter.add_notice(igniter, String.trim(notice))
     end
 
     # Validate and add Hammer rate limiter configuration if missing

--- a/lib/phoenix_kit/install/oauth_config.ex
+++ b/lib/phoenix_kit/install/oauth_config.ex
@@ -1,9 +1,9 @@
 defmodule PhoenixKit.Install.OAuthConfig do
   @moduledoc """
-  Handles Ueberauth OAuth configuration for PhoenixKit installation.
+  Handles OAuth configuration notices for PhoenixKit installation.
 
-  PhoenixKit uses **dynamic OAuth invocation** via `Ueberauth.run_request/4` and
-  `Ueberauth.run_callback/4`, eliminating compile-time configuration requirements.
+  PhoenixKit uses **fully dynamic OAuth** - no compile-time configuration required.
+  All OAuth providers are configured at runtime from database settings.
 
   ## How It Works
 
@@ -17,18 +17,9 @@ defmodule PhoenixKit.Install.OAuthConfig do
   ```
 
   This approach allows:
-  - **No compile-time configuration required** - OAuth works without any providers in config
+  - **No compile-time configuration required** - OAuth works without any config.exs entries
   - **Database-driven credentials** - Credentials loaded from Settings table at runtime
   - **Dynamic provider management** - Add/remove/modify providers without app restart
-
-  ## Configuration
-
-  While compile-time configuration is no longer required, we still add a minimal
-  Ueberauth config for compatibility with libraries that may check for it:
-
-  ```elixir
-  config :ueberauth, Ueberauth, providers: %{}  # Empty map for compatibility
-  ```
 
   ## Runtime OAuth Flow
 
@@ -41,23 +32,23 @@ defmodule PhoenixKit.Install.OAuthConfig do
 
   ## Related Modules
 
-  - `PhoenixKit.Users.OAuthConfig` - Configures credentials in Application env
+  - `PhoenixKit.Users.OAuthConfig` - Configures credentials in Application env at runtime
+  - `PhoenixKit.Workers.OAuthConfigLoader` - Loads OAuth config on app startup
   - `PhoenixKitWeb.Plugs.EnsureOAuthConfig` - Ensures credentials loaded before OAuth
   - `PhoenixKitWeb.Users.OAuth` - OAuth controller with dynamic Ueberauth calls
   """
-  use PhoenixKit.Install.IgniterCompat
 
   @doc """
-  Adds minimal Ueberauth configuration required for PhoenixKit OAuth functionality.
+  Adds OAuth configuration notice for PhoenixKit installation.
 
-  This function adds compile-time configuration with an empty providers map.
-  Runtime configuration will populate providers from the database.
+  No compile-time configuration is added - OAuth is fully dynamic.
+  This function only adds an informational notice.
 
   ## Parameters
   - `igniter` - The igniter context
 
   ## Returns
-  Updated igniter with Ueberauth configuration and informational notice.
+  Updated igniter with informational notice about dynamic OAuth.
 
   ## Example
   ```elixir
@@ -66,47 +57,15 @@ defmodule PhoenixKit.Install.OAuthConfig do
   ```
   """
   def add_oauth_configuration(igniter) do
-    igniter
-    |> add_ueberauth_config()
-    |> add_oauth_configuration_notice()
-  end
-
-  # Add minimal Ueberauth configuration with empty providers map
-  defp add_ueberauth_config(igniter) do
-    # Add compile-time Ueberauth config with empty map (not empty list!)
-    # Runtime configuration (OAuthConfigLoader) will populate providers from database
-
-    ueberauth_config = """
-
-    # Configure Ueberauth (minimal configuration for compilation)
-    # Applications using PhoenixKit should configure their own providers
-    config :ueberauth, Ueberauth, providers: %{}
-    """
-
-    try do
-      Igniter.update_file(igniter, "config/config.exs", fn source ->
-        current_content = Rewrite.Source.get(source, :content)
-
-        # Check if already configured
-        if String.contains?(current_content, "config :ueberauth, Ueberauth") do
-          source
-        else
-          # Append to end of file
-          updated_content = current_content <> ueberauth_config
-          Rewrite.Source.update(source, :content, updated_content)
-        end
-      end)
-    rescue
-      _ ->
-        # If update fails, return igniter as-is (better than failing install)
-        igniter
-    end
+    # No static config needed - OAuth is fully dynamic
+    # Just add informational notice
+    add_oauth_configuration_notice(igniter)
   end
 
   # Add informational notice about OAuth configuration
   defp add_oauth_configuration_notice(igniter) do
     notice = """
-    🔐 OAuth configured (providers loaded at runtime from database)
+    🔐 OAuth ready (providers configured dynamically from database at runtime)
     """
 
     Igniter.add_notice(igniter, String.trim(notice))


### PR DESCRIPTION
## Summary
- OAuth is now fully dynamic - no compile-time Ueberauth config needed
- Providers loaded from database at runtime via OAuthConfigLoader

## Changes
### OAuth System
- Remove Ueberauth from install/update configuration checks
- Remove `validate_and_fix_ueberauth_config` from update task
- Simplify `oauth_config.ex` to only add informational notice

### Documentation
- Simplify CLAUDE.md structure, remove verbose sections
- Update to current version 1.6.15 and migration V28

### Maintenance
- Clean up `.dialyzer_ignore.exs` (remove unnecessary skips)
- Add `*.zip` and `/priv/media/` to gitignore

## Test Plan
- [x] `mix compile` passes
- [x] `mix credo --strict` passes (no issues)
- [x] `mix dialyzer` passes (0 unnecessary skips)