### PR TITLE
Fix blogging editor issues and add publish button

### DIFF
--- a/lib/phoenix_kit_web/components/layout_wrapper.ex
+++ b/lib/phoenix_kit_web/components/layout_wrapper.ex
@@ -74,12 +74,14 @@ defmodule PhoenixKitWeb.Components.LayoutWrapper do
 
   def app_layout(assigns) do
     # Batch load all page settings in a single operation for optimal database performance
+    # Note: blogging_blogs uses assign/2 instead of assign_new/2 to ensure fresh data
+    # after creating/deleting blogs (LiveView push_navigate preserves assigns)
     assigns =
       assigns
       |> assign_new(:content_language, fn ->
         PhoenixKit.Settings.get_content_language()
       end)
-      |> assign_new(:blogging_blogs, fn -> load_blogging_blogs() end)
+      |> assign(:blogging_blogs, load_blogging_blogs())
       |> assign_new(:seo_no_index, fn -> SEO.no_index_enabled?() end)
 
     # Handle both inner_content (Phoenix 1.7-) and inner_block (Phoenix 1.8+)
@@ -1052,84 +1054,15 @@ defmodule PhoenixKitWeb.Components.LayoutWrapper do
     end
   end
 
-  # Load blogging blogs configuration with legacy migration support
+  # Load blogging blogs configuration
+  # Uses Blogging.list_blogs() which handles caching, legacy migration, and normalization
   defp load_blogging_blogs do
     if Blogging.enabled?() do
-      json_defaults = %{
-        "blogging_blogs" => nil,
-        "blogging_categories" => %{"types" => []}
-      }
-
-      json_settings =
-        PhoenixKit.Settings.get_json_settings_cached(
-          ["blogging_blogs", "blogging_categories"],
-          json_defaults
-        )
-
-      extract_and_normalize_blogs(json_settings)
+      Blogging.list_blogs()
     else
       []
     end
   end
-
-  defp extract_and_normalize_blogs(json_settings) do
-    case json_settings["blogging_blogs"] do
-      %{"blogs" => blogs} when is_list(blogs) ->
-        normalize_blogs(blogs)
-
-      list when is_list(list) ->
-        normalize_blogs(list)
-
-      _ ->
-        handle_legacy_blogging_categories(json_settings)
-    end
-  end
-
-  defp handle_legacy_blogging_categories(json_settings) do
-    legacy =
-      case json_settings["blogging_categories"] do
-        %{"types" => types} when is_list(types) -> types
-        other when is_list(other) -> other
-        _ -> []
-      end
-
-    migrate_legacy_categories_if_present(legacy)
-    normalize_blogs(legacy)
-  end
-
-  defp migrate_legacy_categories_if_present([]), do: :ok
-
-  defp migrate_legacy_categories_if_present(legacy) do
-    PhoenixKit.Settings.update_json_setting("blogging_blogs", %{"blogs" => legacy})
-  end
-
-  # Normalize blogs list to ensure consistent structure
-  defp normalize_blogs(blogs) do
-    blogs
-    |> Enum.map(&normalize_blog_keys/1)
-    |> Enum.map(fn
-      %{"mode" => mode} = blog when mode in ["timestamp", "slug"] ->
-        blog
-
-      blog ->
-        Map.put(blog, "mode", "timestamp")
-    end)
-  end
-
-  defp normalize_blog_keys(blog) when is_map(blog) do
-    Enum.reduce(blog, %{}, fn
-      {key, value}, acc when is_binary(key) ->
-        Map.put(acc, key, value)
-
-      {key, value}, acc when is_atom(key) ->
-        Map.put(acc, Atom.to_string(key), value)
-
-      {key, value}, acc ->
-        Map.put(acc, to_string(key), value)
-    end)
-  end
-
-  defp normalize_blog_keys(other), do: other
 
   # Language switcher component for admin sidebar
   attr :current_path, :string, required: true

--- a/lib/phoenix_kit_web/controllers/blog_html.ex
+++ b/lib/phoenix_kit_web/controllers/blog_html.ex
@@ -96,6 +96,18 @@ defmodule PhoenixKitWeb.BlogHTML do
     |> Date.to_iso8601()
   end
 
+  def format_date_for_url(datetime_string) when is_binary(datetime_string) do
+    case DateTime.from_iso8601(datetime_string) do
+      {:ok, datetime, _} ->
+        datetime
+        |> DateTime.to_date()
+        |> Date.to_iso8601()
+
+      _ ->
+        "2025-01-01"
+    end
+  end
+
   def format_date_for_url(_), do: "2025-01-01"
 
   @doc """
@@ -107,6 +119,20 @@ defmodule PhoenixKitWeb.BlogHTML do
     |> Time.truncate(:second)
     |> Time.to_string()
     |> String.slice(0..4)
+  end
+
+  def format_time_for_url(datetime_string) when is_binary(datetime_string) do
+    case DateTime.from_iso8601(datetime_string) do
+      {:ok, datetime, _} ->
+        datetime
+        |> DateTime.to_time()
+        |> Time.truncate(:second)
+        |> Time.to_string()
+        |> String.slice(0..4)
+
+      _ ->
+        "00:00"
+    end
   end
 
   def format_time_for_url(_), do: "00:00"

--- a/lib/phoenix_kit_web/live/modules/blogging/editor.ex
+++ b/lib/phoenix_kit_web/live/modules/blogging/editor.ex
@@ -344,6 +344,20 @@ defmodule PhoenixKitWeb.Live.Modules.Blogging.Editor do
     perform_save(socket)
   end
 
+  def handle_event("publish", _params, socket) do
+    # Update the form status to published and trigger a save
+    updated_form =
+      socket.assigns.form
+      |> Map.put("status", "published")
+
+    socket =
+      socket
+      |> assign(:form, updated_form)
+      |> assign(:has_pending_changes, true)
+
+    perform_save(socket)
+  end
+
   def handle_event("noop", _params, socket), do: {:noreply, socket}
 
   def handle_event("preview", _params, socket) do
@@ -631,6 +645,7 @@ defmodule PhoenixKitWeb.Live.Modules.Blogging.Editor do
             else: gettext("Post saved")
 
         form = post_form(post)
+        language = editor_language(socket.assigns)
 
         socket =
           socket
@@ -638,6 +653,7 @@ defmodule PhoenixKitWeb.Live.Modules.Blogging.Editor do
           |> assign_form_with_tracking(form)
           |> assign(:content, post.content)
           |> assign(:has_pending_changes, false)
+          |> assign(:public_url, build_public_url(post, language))
           |> push_event("changes-status", %{has_changes: false})
           |> maybe_update_current_path(old_path, post.path)
 
@@ -694,6 +710,7 @@ defmodule PhoenixKitWeb.Live.Modules.Blogging.Editor do
             else: success_message
 
         form = post_form(updated_post)
+        language = editor_language(socket.assigns)
 
         socket =
           socket
@@ -702,6 +719,7 @@ defmodule PhoenixKitWeb.Live.Modules.Blogging.Editor do
           |> assign(:content, updated_post.content)
           |> assign(:available_languages, updated_post.available_languages)
           |> assign(:has_pending_changes, false)
+          |> assign(:public_url, build_public_url(updated_post, language))
           |> assign(extra_assigns)
           |> push_event("changes-status", %{has_changes: false})
           |> push_patch(
@@ -1440,12 +1458,16 @@ defmodule PhoenixKitWeb.Live.Modules.Blogging.Editor do
       lang_info = Blogging.get_language_info(lang_code)
       file_exists = lang_code in available_languages
 
-      # Build the path for this language version
+      # Build the path for this language version (handle nil post_path for new posts)
       lang_path =
-        Path.join([
-          Path.dirname(post_path),
-          "#{lang_code}.phk"
-        ])
+        if post_path do
+          Path.join([
+            Path.dirname(post_path),
+            "#{lang_code}.phk"
+          ])
+        else
+          nil
+        end
 
       # For the current language, use the form status (real-time updates)
       # For other languages, read from disk
@@ -1454,7 +1476,7 @@ defmodule PhoenixKitWeb.Live.Modules.Blogging.Editor do
           lang_code == current_language && current_form_status != nil ->
             current_form_status
 
-          file_exists ->
+          file_exists && lang_path != nil ->
             case Blogging.read_post(blog_slug, lang_path) do
               {:ok, lang_post} -> lang_post.metadata.status
               _ -> nil

--- a/lib/phoenix_kit_web/live/modules/blogging/editor.html.heex
+++ b/lib/phoenix_kit_web/live/modules/blogging/editor.html.heex
@@ -317,13 +317,22 @@
             tabindex={if @has_pending_changes, do: "-1", else: "0"}
             title={
               if(@has_pending_changes,
-                do: "Save the post before viewing the public page",
-                else: "View this post on the public site"
+                do: gettext("Save the post before viewing the public page"),
+                else: gettext("View this post on the public site")
               )
             }
           >
-            <.icon name="hero-globe-alt" class="w-4 h-4 mr-1" /> View Public
+            <.icon name="hero-globe-alt" class="w-4 h-4 mr-1" /> {gettext("View Public")}
           </a>
+        <% else %>
+          <button
+            type="button"
+            class="btn btn-success btn-sm shadow-none"
+            phx-click="publish"
+            title={gettext("Publish this post")}
+          >
+            <.icon name="hero-globe-alt" class="w-4 h-4 mr-1" /> {gettext("Publish")}
+          </button>
         <% end %>
       </div>
     </div>


### PR DESCRIPTION
Description:
  ## TL;DR
  Fixes several bugs in the blogging editor: new post creation crash, incorrect timestamp URLs, stale navigation subtabs, and adds a convenient
  Publish button.

  ## Summary
  - Fix crash when creating new blog posts (FunctionClauseError on nil post_path)
  - Add Publish button that appears for draft posts, switches to View Public link when published
  - Fix timestamp-based blog URLs showing wrong date/time (was always 2025-01-01/00:00)
  - Fix blog subtabs not appearing in navigation after creating a new blog

  ## Changes

  ### Editor fixes
  - Handle `nil` post_path in `build_editor_languages` for new posts
  - Update `public_url` assign after save so View Public button appears immediately
  - Add `publish` event handler that sets status to published and saves

  ### URL generation fix
  - Add string handling to `format_date_for_url` and `format_time_for_url` to parse ISO8601 datetime strings from metadata

  ### Navigation fix
  - Use `Blogging.list_blogs()` directly instead of cached settings that weren't refreshing after blog creation