### PR TITLE
Add smart timestamp URL handling for blog posts

### DIFF
--- a/lib/phoenix_kit_web/controllers/blog_html.ex
+++ b/lib/phoenix_kit_web/controllers/blog_html.ex
@@ -32,6 +32,10 @@ defmodule PhoenixKitWeb.BlogHTML do
   Builds a post URL based on mode.
   When multiple languages are enabled, always includes locale prefix.
   When languages module is off or only one language, uses clean URLs.
+
+  For timestamp mode posts:
+  - If only one post exists on the date, uses date-only URL (e.g., /blog/2025-12-09)
+  - If multiple posts exist on the date, includes time (e.g., /blog/2025-12-09/16:26)
   """
   def build_post_url(blog_slug, post, language) do
     case post.mode do
@@ -45,12 +49,24 @@ defmodule PhoenixKitWeb.BlogHTML do
 
       :timestamp ->
         date = format_date_for_url(post.metadata.published_at)
-        time = format_time_for_url(post.metadata.published_at)
+
+        # Check if we need time in URL (only if multiple posts on same date)
+        post_count = count_posts_on_date(blog_slug, date)
 
         segments =
-          if single_language_mode?(),
-            do: [blog_slug, date, time],
-            else: [language, blog_slug, date, time]
+          if post_count > 1 do
+            # Multiple posts - include time
+            time = format_time_for_url(post.metadata.published_at)
+
+            if single_language_mode?(),
+              do: [blog_slug, date, time],
+              else: [language, blog_slug, date, time]
+          else
+            # Single post or no posts - date only
+            if single_language_mode?(),
+              do: [blog_slug, date],
+              else: [language, blog_slug, date]
+          end
 
         build_public_path(segments)
 
@@ -62,6 +78,19 @@ defmodule PhoenixKitWeb.BlogHTML do
 
         build_public_path(segments)
     end
+  end
+
+  @doc """
+  Builds a public path with explicit date and time (always includes time).
+  Used when redirecting from date-only URLs to full timestamp URLs.
+  """
+  def build_public_path_with_time(language, blog_slug, date, time) do
+    segments =
+      if single_language_mode?(),
+        do: [blog_slug, date, time],
+        else: [language, blog_slug, date, time]
+
+    build_public_path(segments)
   end
 
   @doc """
@@ -86,6 +115,46 @@ defmodule PhoenixKitWeb.BlogHTML do
   end
 
   def format_date(_), do: ""
+
+  @doc """
+  Formats a date with time for display.
+  Used when multiple posts exist on the same date.
+  """
+  def format_date_with_time(datetime) when is_struct(datetime, DateTime) do
+    Calendar.strftime(datetime, "%B %d, %Y at %H:%M")
+  end
+
+  def format_date_with_time(datetime_string) when is_binary(datetime_string) do
+    case DateTime.from_iso8601(datetime_string) do
+      {:ok, datetime, _} ->
+        Calendar.strftime(datetime, "%B %d, %Y at %H:%M")
+
+      _ ->
+        datetime_string
+    end
+  end
+
+  def format_date_with_time(_), do: ""
+
+  @doc """
+  Formats a post's publication date, including time only when multiple posts exist on the same date.
+  """
+  def format_post_date(post, blog_slug) do
+    case post.mode do
+      :timestamp ->
+        date = format_date_for_url(post.metadata.published_at)
+        post_count = count_posts_on_date(blog_slug, date)
+
+        if post_count > 1 do
+          format_date_with_time(post.metadata.published_at)
+        else
+          format_date(post.metadata.published_at)
+        end
+
+      _ ->
+        format_date(post.metadata.published_at)
+    end
+  end
 
   @doc """
   Formats a date for URL.
@@ -209,6 +278,13 @@ defmodule PhoenixKitWeb.BlogHTML do
   # Returns true when languages module is off OR only one language is enabled
   defp single_language_mode? do
     not Languages.enabled?() or length(Languages.get_enabled_languages()) <= 1
+  end
+
+  # Counts posts on a given date for a blog
+  # Used to determine if time should be included in URLs
+  defp count_posts_on_date(blog_slug, date) do
+    alias PhoenixKitWeb.Live.Modules.Blogging.Storage
+    Storage.count_posts_on_date(blog_slug, date)
   end
 
   @doc """

--- a/lib/phoenix_kit_web/controllers/blog_html/show.html.heex
+++ b/lib/phoenix_kit_web/controllers/blog_html/show.html.heex
@@ -24,7 +24,7 @@
     <%!-- Post Header --%>
     <header class="mb-8 border-b pb-6">
       <div class="flex items-center gap-2 text-sm text-base-content/70">
-        <%!-- Publication Date --%>
+        <%!-- Publication Date (includes time when multiple posts on same date) --%>
         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path
             stroke-linecap="round"
@@ -34,7 +34,7 @@
           />
         </svg>
         <time datetime={@post.metadata.published_at}>
-          {format_date(@post.metadata.published_at)}
+          {format_post_date(@post, @blog_slug)}
         </time>
       </div>
       <%!-- Language Switcher --%>


### PR DESCRIPTION
TL;DR

  Blog post URLs now omit the time component when only one post exists on a date (cleaner URLs), and automatically include time when multiple posts
  share the same date. Also fixes a bug where blog listings showed 0 posts when using base language codes.

  ---
  Summary

  - Smart URL generation: Timestamp-based blog posts now use date-only URLs (/blog/2025-12-09) when there's only one post on that date, and include
  time (/blog/2025-12-09/16:26) only when multiple posts exist on the same date
  - Date-only URL resolution: Visiting a date-only URL renders the single post directly, or redirects to the first post (with time) if multiple exist
  - Conditional time display: Post headers show publication time only when multiple posts share the same date
  - Language matching fix: Blog listing now properly matches posts when URL uses base language codes (e.g., "en" matches "en-US.phk" files)

  Test plan

  - Create a timestamp blog with one post on a date - verify URL is date-only
  - Create a second post on the same date - verify both URLs now include time
  - Visit a date-only URL with one post - verify post renders directly
  - Visit a date-only URL with multiple posts - verify redirect to first post with time
  - Check post header shows time only when multiple posts on same date
  - Test blog listing with base language code (e.g., /en/blog) shows posts with dialect files (e.g., en-US.phk)