### PR TITLE
Add authentication-aware route filtering for sitemap

### DIFF
--- a/lib/phoenix_kit/sitemap/sources/router_discovery.ex
+++ b/lib/phoenix_kit/sitemap/sources/router_discovery.ex
@@ -11,6 +11,7 @@ defmodule PhoenixKit.Sitemap.Sources.RouterDiscovery do
   - `sitemap_router_discovery_enabled` - Enable/disable auto-discovery (default: true)
   - `sitemap_router_discovery_exclude_patterns` - JSON array of regex patterns to exclude
   - `sitemap_router_discovery_include_only` - JSON array of regex patterns for whitelist mode
+  - `sitemap_protected_pipelines` - JSON array of pipeline names that require authentication
 
   ## Default Exclusions
 
@@ -21,6 +22,20 @@ defmodule PhoenixKit.Sitemap.Sources.RouterDiscovery do
   - `^/dev` - Development routes
   - `:[a-z_]+` - Routes with parameters
   - `\\*` - Wildcard routes
+
+  Additionally, routes using authentication pipelines are automatically excluded:
+  - `:phoenix_kit_require_authenticated` - Routes requiring user authentication
+  - `:phoenix_kit_admin_only` - Routes requiring admin/owner role
+  - `:authenticated` - Common name for authentication pipeline
+  - `:require_authenticated` - Alternative authentication pipeline name
+  - `:admin` - Common admin pipeline name
+  - `:admin_only` - Alternative admin pipeline name
+
+  Custom pipelines can be added via `sitemap_protected_pipelines` setting.
+
+  LiveView routes using authentication `on_mount` hooks are also excluded:
+  - `{PhoenixKitWeb.Users.Auth, :phoenix_kit_ensure_authenticated_scope}` - Ensures user is authenticated
+  - `{PhoenixKitWeb.Users.Auth, :phoenix_kit_redirect_if_authenticated_scope}` - Redirects if already authenticated
 
   ## Examples
 
@@ -34,6 +49,10 @@ defmodule PhoenixKit.Sitemap.Sources.RouterDiscovery do
       # Whitelist mode - only include specific paths
       Settings.update_setting("sitemap_router_discovery_include_only",
         Jason.encode!(["^/products", "^/categories"]))
+
+      # Custom protected pipelines (add to defaults)
+      Settings.update_setting("sitemap_protected_pipelines",
+        Jason.encode!(["my_auth_pipeline", "member_only"]))
 
   ## Sitemap Properties
 
@@ -55,6 +74,24 @@ defmodule PhoenixKit.Sitemap.Sources.RouterDiscovery do
     "^/dev",
     ":[a-z_]+",
     "\\*"
+  ]
+
+  # Default pipelines that require authentication - routes using these should not appear in sitemap
+  # Can be extended via Settings: sitemap_protected_pipelines
+  @default_protected_pipelines [
+    :phoenix_kit_require_authenticated,
+    :phoenix_kit_admin_only,
+    :authenticated,
+    :require_authenticated,
+    :admin,
+    :admin_only
+  ]
+
+  # Default on_mount hooks that require authentication (for LiveView routes)
+  # Format: {Module, hook_name} - matches against on_mount id tuples
+  @default_protected_on_mount_hooks [
+    {PhoenixKitWeb.Users.Auth, :phoenix_kit_ensure_authenticated_scope},
+    {PhoenixKitWeb.Users.Auth, :phoenix_kit_redirect_if_authenticated_scope}
   ]
 
   @impl true
@@ -93,8 +130,91 @@ defmodule PhoenixKit.Sitemap.Sources.RouterDiscovery do
   defp valid_for_sitemap?(route, exclude_patterns, include_only) do
     get_route?(route) and
       not excluded?(route.path, exclude_patterns) and
-      included?(route.path, include_only)
+      included?(route.path, include_only) and
+      not protected_route?(route) and
+      not protected_liveview_route?(route)
   end
+
+  # Check if route uses authentication pipelines
+  # Uses Phoenix.Router.route_info/4 to get pipe_through info (not available in __routes__)
+  defp protected_route?(route) do
+    route_pipelines = get_route_pipelines(route.path)
+    protected_pipelines = get_protected_pipelines()
+    Enum.any?(protected_pipelines, &(&1 in route_pipelines))
+  end
+
+  # Get pipelines for a route using Phoenix.Router.route_info/4
+  defp get_route_pipelines(path) do
+    case RouteResolver.get_router() do
+      nil ->
+        []
+
+      router ->
+        case Phoenix.Router.route_info(router, "GET", path, "localhost") do
+          %{pipe_through: pipelines} when is_list(pipelines) -> pipelines
+          _ -> []
+        end
+    end
+  rescue
+    _ -> []
+  end
+
+  # Check if LiveView route uses authentication on_mount hooks
+  defp protected_liveview_route?(route) do
+    on_mount_hooks = get_route_on_mount_hooks(route.path)
+    protected_hooks = @default_protected_on_mount_hooks
+    Enum.any?(protected_hooks, &(&1 in on_mount_hooks))
+  end
+
+  # Get on_mount hook IDs for a LiveView route
+  defp get_route_on_mount_hooks(path) do
+    case RouteResolver.get_router() do
+      nil ->
+        []
+
+      router ->
+        case Phoenix.Router.route_info(router, "GET", path, "localhost") do
+          %{phoenix_live_view: {_module, _action, _opts, %{extra: %{on_mount: hooks}}}}
+          when is_list(hooks) ->
+            Enum.map(hooks, & &1.id)
+
+          _ ->
+            []
+        end
+    end
+  rescue
+    _ -> []
+  end
+
+  defp get_protected_pipelines do
+    custom_pipelines = get_custom_protected_pipelines()
+    @default_protected_pipelines ++ custom_pipelines
+  end
+
+  defp get_custom_protected_pipelines do
+    case Settings.get_setting("sitemap_protected_pipelines") do
+      nil ->
+        []
+
+      json_string when is_binary(json_string) ->
+        case Jason.decode(json_string) do
+          {:ok, pipelines} when is_list(pipelines) ->
+            Enum.map(pipelines, &safe_to_atom/1)
+
+          _ ->
+            []
+        end
+
+      pipelines when is_list(pipelines) ->
+        Enum.map(pipelines, &safe_to_atom/1)
+
+      _ ->
+        []
+    end
+  end
+
+  defp safe_to_atom(value) when is_atom(value), do: value
+  defp safe_to_atom(value) when is_binary(value), do: String.to_atom(value)
 
   defp get_route?(route) do
     route.verb == :get


### PR DESCRIPTION
## Summary
- Exclude routes with authentication pipelines from sitemap
- Detect LiveView on_mount authentication hooks  
- Support custom protected pipelines via Settings
- Fix timestamp mode blog URLs to match actual routing

## Changes
### Router Discovery (`router_discovery.ex`)
- Use `Phoenix.Router.route_info/4` for accurate pipeline detection
- Add default protected pipelines: `:authenticated`, `:admin`, `:phoenix_kit_require_authenticated`
- Add LiveView on_mount hook detection for `:phoenix_kit_ensure_authenticated_scope`
- Support custom pipelines via `sitemap_protected_pipelines` setting

### Blogging Source (`blogging.ex`)
- Fix timestamp mode URLs to use date/time format instead of slug
- Use `Storage.count_posts_on_date/2` to determine URL format

## Test Plan
- [x] Routes with `:authenticated` pipeline excluded from sitemap
- [x] LiveView routes with `on_mount` auth hooks excluded
- [x] Public routes still included correctly
- [x] `mix quality` passes