### PR TITLE
Optimize sitemap generation and fix routing issues

### DIFF
--- a/lib/phoenix_kit/sitemap/sources/static.ex
+++ b/lib/phoenix_kit/sitemap/sources/static.ex
@@ -63,7 +63,9 @@ defmodule PhoenixKit.Sitemap.Sources.Static do
       "changefreq" => "daily",
       "title" => "Home",
       "category" => "Main",
-      "prefixed" => false
+      "prefixed" => false,
+      # Don't add language prefix to homepage - it usually doesn't have localized route
+      "skip_language_prefix" => true
     },
     %{
       "plug" => "PhoenixKitWeb.Users.Registration",
@@ -167,9 +169,19 @@ defmodule PhoenixKit.Sitemap.Sources.Static do
 
     if path do
       prefixed = Map.get(config, "prefixed", false)
+      skip_language = Map.get(config, "skip_language_prefix", false)
+
       # Canonical path without language prefix (for hreflang grouping)
       canonical_path = if prefixed, do: Routes.path(path), else: path
-      localized_path = build_path_with_language(canonical_path, language, is_default)
+
+      # Build localized path (skip language prefix if configured)
+      localized_path =
+        if skip_language do
+          canonical_path
+        else
+          build_path_with_language(canonical_path, language, is_default)
+        end
+
       url = build_url_from_localized_path(localized_path, base_url, prefixed)
 
       UrlEntry.new(%{


### PR DESCRIPTION
## Summary
- Optimize sitemap source modules to reduce RouteResolver calls
- Fix entities not appearing when using catchall routes
- Fix homepage appearing as /en/ instead of /

## Changes

### Performance Optimizations
- **Entities source**: Cache routes once per collection, reducing N+1 RouteResolver calls
- **Blogging source**: Pre-compute date counts for timestamp-mode posts (O(n) instead of N filesystem reads)
- **Posts source**: Move route checks to do_collect() with caching

### Bug Fixes
- **Catchall routes**: Add detection for `/:entity_name/:slug` patterns in entities source
- **Homepage prefix**: Add `skip_language_prefix` option to prevent `/en/` appearing for homepage
- **Blog exclusion**: Add blog-level `sitemap_exclude` setting support

### Files Changed
- `lib/phoenix_kit/sitemap/sources/entities.ex`
- `lib/phoenix_kit/sitemap/sources/blogging.ex`
- `lib/phoenix_kit/sitemap/sources/posts.ex`
- `lib/phoenix_kit/sitemap/sources/static.ex`

## Test Plan
- [x] Pre-commit checks passed (format, credo, dialyzer)
- [x] Manual testing: entities with catchall routes now appear in sitemap
- [x] Manual testing: homepage shows as `/` without language prefix
- [x] Sitemap generation is faster due to reduced RouteResolver calls