### PR TITLE
Fix email sender to use Settings Database

### DIFF
--- a/lib/phoenix_kit/users/auth/user_notifier.ex
+++ b/lib/phoenix_kit/users/auth/user_notifier.ex
@@ -55,18 +55,38 @@ defmodule PhoenixKit.Users.Auth.UserNotifier do
   end
 
   # Get the from email address from configuration or use a default
+  # Priority: Settings Database > Config file > Default
   defp get_from_email do
-    case PhoenixKit.Config.get(:from_email) do
-      {:ok, email} -> email
-      :not_found -> "noreply@localhost"
+    # Priority 1: Settings Database (runtime)
+    case PhoenixKit.Settings.get_setting("from_email") do
+      nil ->
+        # Priority 2: Config file (compile-time, fallback)
+        case PhoenixKit.Config.get(:from_email) do
+          {:ok, email} -> email
+          # Priority 3: Default
+          _ -> "noreply@localhost"
+        end
+
+      email ->
+        email
     end
   end
 
   # Get the from name from configuration or use a default
+  # Priority: Settings Database > Config file > Default
   defp get_from_name do
-    case PhoenixKit.Config.get(:from_name) do
-      {:ok, name} -> name
-      :not_found -> "PhoenixKit"
+    # Priority 1: Settings Database (runtime)
+    case PhoenixKit.Settings.get_setting("from_name") do
+      nil ->
+        # Priority 2: Config file (compile-time, fallback)
+        case PhoenixKit.Config.get(:from_name) do
+          {:ok, name} -> name
+          # Priority 3: Default
+          _ -> "PhoenixKit"
+        end
+
+      name ->
+        name
     end
   end
 

--- a/lib/phoenix_kit_web/live/modules/emails/template_editor.ex
+++ b/lib/phoenix_kit_web/live/modules/emails/template_editor.ex
@@ -479,10 +479,21 @@ defmodule PhoenixKitWeb.Live.Modules.Emails.TemplateEditor do
     errors
   end
 
+  # Get the from email address from configuration or use a default
+  # Priority: Settings Database > Config file > Default
   defp get_from_email do
-    case PhoenixKit.Config.get(:from_email) do
-      {:ok, email} -> email
-      :not_found -> "noreply@localhost"
+    # Priority 1: Settings Database (runtime)
+    case PhoenixKit.Settings.get_setting("from_email") do
+      nil ->
+        # Priority 2: Config file (compile-time, fallback)
+        case PhoenixKit.Config.get(:from_email) do
+          {:ok, email} -> email
+          # Priority 3: Default
+          _ -> "noreply@localhost"
+        end
+
+      email ->
+        email
     end
   end
 


### PR DESCRIPTION
## Summary
- Fix `from_email`/`from_name` to use Settings Database as primary source instead of compile-time Config only

## Problem
UserNotifier and TemplateEditor were using only compile-time Config for sender address, ignoring runtime Settings Database values. This caused confirmation emails to be sent from `noreply@localhost` instead of the configured sender (e.g., `marketing@hydroforce.ee`), resulting in AWS SES rejection.

## Solution
Updated both modules to use priority chain:
1. **Settings Database** (runtime) - primary source
2. **Config file** (compile-time) - fallback
3. **Default value** - last resort

## Files Changed
- `lib/phoenix_kit/users/auth/user_notifier.ex` - confirmation, password reset, email update notifications
- `lib/phoenix_kit_web/live/modules/emails/template_editor.ex` - template preview

## Test Plan
- [x] `mix format` passed
- [x] `mix quality` passed (credo, dialyzer)
- [x] Manual test: confirmation email now sends from correct address