### PR TITLE
Add V40 migration for UUIDv7 columns on all legacy tables

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,22 @@
 This is a web application written using the Phoenix web framework.
 
+## 🚧 IN-PROGRESS: UUID Migration (V40)
+
+> **DELETE THIS SECTION** after the UUID migration is fully complete and merged to main.
+
+**TL;DR**: V40 adds UUIDv7 columns to all 33 legacy bigserial tables. Non-breaking change.
+
+**Key points:**
+- Migration: `lib/phoenix_kit/migrations/postgres/v40.ex`
+- Helper: `lib/phoenix_kit/uuid.ex` (dual integer/UUID lookups with prefix support)
+- All schemas have `field :uuid, Ecto.UUID`
+- User schema generates UUID in Elixir; others use DB DEFAULT
+- Docs: `guides/uuid_migration.md`
+
+**DO NOT**: Remove UUID DEFAULT, change to UUIDv4, or modify foreign keys.
+
+---
+
 ## Project guidelines
 
 - Use `mix precommit` alias when you are done with all changes and fix any pending issues

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,46 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## 🚧 IN-PROGRESS: UUID Migration (V40)
+
+> **DELETE THIS SECTION** after the UUID migration is fully complete and merged to main.
+
+### Summary
+
+V40 adds UUIDv7 columns to all 33 legacy tables that use bigserial primary keys. This is a **non-breaking, graceful migration** that allows parent apps to gradually adopt UUIDs.
+
+### What's Been Done
+
+- ✅ Created V40 migration (`lib/phoenix_kit/migrations/postgres/v40.ex`)
+- ✅ Added `field :uuid, Ecto.UUID` to all 33 schemas
+- ✅ Created `PhoenixKit.UUID` helper module with prefix support
+- ✅ User schema generates UUIDv7 in Elixir changeset
+- ✅ Other schemas rely on PostgreSQL DEFAULT (both work correctly)
+- ✅ Documentation at `guides/uuid_migration.md`
+
+### Key Design Decisions
+
+1. **UUIDv7 only** - Time-ordered for better index performance
+2. **Keep DEFAULT** - DB generates UUID if Ecto doesn't (backward compatible)
+3. **Dual-accessor pattern** - `PhoenixKit.UUID.get/2` accepts both integer and UUID
+4. **Non-breaking** - Integer IDs continue to work, FKs remain bigserial
+
+### Files Modified
+
+- `lib/phoenix_kit/migrations/postgres/v40.ex` - Main migration
+- `lib/phoenix_kit/uuid.ex` - Helper module
+- `lib/phoenix_kit/users/auth/user.ex` - UUIDv7 in registration changeset
+- 30+ schema files - Added `field :uuid, Ecto.UUID`
+- `guides/uuid_migration.md` - Documentation
+
+### DO NOT
+
+- Remove the UUID DEFAULT from the migration
+- Change UUIDv7 back to UUIDv4
+- Modify foreign keys (they stay as bigserial)
+
+---
+
 ## MCP Memory Knowledge Base
 
 ⚠️ **IMPORTANT**: Always start working with the project by studying data in the MCP memory storage. Use the command:

--- a/guides/uuid_migration.md
+++ b/guides/uuid_migration.md
@@ -1,0 +1,310 @@
+# UUID Migration Guide
+
+This guide explains PhoenixKit's graceful UUID migration strategy for transitioning from bigserial (incremental) to UUID primary keys.
+
+## Overview
+
+Starting with V40, PhoenixKit adds UUID columns to all legacy tables. This is a **non-breaking change** that allows parent applications to gradually transition from integer IDs to UUIDs at their own pace.
+
+All UUIDs are generated using **UUIDv7** (time-ordered UUIDs), which provides better index performance than random UUIDv4.
+
+## UUIDv7 Benefits
+
+UUIDv7 is a time-ordered UUID format defined in RFC 9562:
+
+- **Time-ordered**: First 48 bits contain Unix timestamp in milliseconds
+- **Better index performance**: Sequential ordering improves B-tree index locality
+- **Sortable by creation time**: Natural chronological ordering without extra columns
+- **Standard UUID format**: Compatible with existing UUID infrastructure
+
+Example UUIDv7: `019b5704-3680-7b95-9d82-ef16127f1fd2`
+
+## Migration Strategy
+
+### Phase 1: UUID Column Addition (V40) ✅ Current
+
+- Adds `uuid` column to all 33 legacy tables
+- Backfills existing records with generated UUIDv7 values
+- Creates unique indexes on UUID columns
+- Keeps DEFAULT for database-level inserts
+- **Non-breaking**: Existing integer IDs continue to work
+- **Zero downtime**: All operations are idempotent
+
+### Phase 2: Configuration Option (Future)
+
+- New installations can choose UUID-native mode
+- Existing installations continue with dual-column approach
+
+### Phase 3: UUID Default (2.0)
+
+- UUID becomes the default for new installations
+- Migration tooling provided for 1.x users
+
+## Tables Affected
+
+### Core Auth
+- `phoenix_kit_users`
+- `phoenix_kit_users_tokens`
+- `phoenix_kit_user_roles`
+- `phoenix_kit_user_role_assignments`
+
+### Settings & Referrals
+- `phoenix_kit_settings`
+- `phoenix_kit_referral_codes`
+- `phoenix_kit_referral_code_usage`
+
+### Email System
+- `phoenix_kit_email_logs`
+- `phoenix_kit_email_events`
+- `phoenix_kit_email_blocklist`
+- `phoenix_kit_email_templates`
+- `phoenix_kit_email_orphaned_events`
+- `phoenix_kit_email_metrics`
+
+### OAuth
+- `phoenix_kit_user_oauth_providers`
+
+### Entities
+- `phoenix_kit_entities`
+- `phoenix_kit_entity_data`
+
+### Audit
+- `phoenix_kit_audit_logs`
+
+### Billing
+- `phoenix_kit_currencies`
+- `phoenix_kit_billing_profiles`
+- `phoenix_kit_orders`
+- `phoenix_kit_invoices`
+- `phoenix_kit_transactions`
+- `phoenix_kit_payment_methods`
+- `phoenix_kit_subscription_plans`
+- `phoenix_kit_subscriptions`
+- `phoenix_kit_payment_provider_configs`
+- `phoenix_kit_webhook_events`
+
+### AI System
+- `phoenix_kit_ai_endpoints`
+- `phoenix_kit_ai_requests`
+- `phoenix_kit_ai_prompts`
+
+### DB Sync
+- `phoenix_kit_db_sync_connections`
+- `phoenix_kit_db_sync_transfers`
+
+### Admin
+- `phoenix_kit_admin_notes`
+
+## Using the UUID Helper Module
+
+PhoenixKit provides `PhoenixKit.UUID` for working with dual identifiers:
+
+### Looking Up Records
+
+```elixir
+# Automatic detection - works with both ID types
+user = PhoenixKit.UUID.get(User, "123")                    # integer lookup
+user = PhoenixKit.UUID.get(User, "019b5704-3680-7b95-...")  # UUID lookup
+
+# Explicit lookups
+user = PhoenixKit.UUID.get_by_id(User, 123)
+user = PhoenixKit.UUID.get_by_uuid(User, "019b5704-3680-7b95-...")
+
+# With error raising
+user = PhoenixKit.UUID.get!(User, identifier)
+
+# With prefix for multi-tenant schemas
+user = PhoenixKit.UUID.get(User, "123", prefix: "tenant_abc")
+```
+
+### Parsing Identifiers
+
+```elixir
+PhoenixKit.UUID.parse_identifier("123")
+# => {:integer, 123}
+
+PhoenixKit.UUID.parse_identifier("019b5704-3680-7b95-9d82-ef16127f1fd2")
+# => {:uuid, "019b5704-3680-7b95-9d82-ef16127f1fd2"}
+
+PhoenixKit.UUID.parse_identifier("invalid")
+# => :invalid
+```
+
+### Generating UUIDs
+
+```elixir
+uuid = PhoenixKit.UUID.generate()
+# => "019b5704-3680-7b95-9d82-ef16127f1fd2"  (UUIDv7)
+```
+
+### Working with Records
+
+```elixir
+# Get preferred identifier (UUID if available, else ID)
+identifier = PhoenixKit.UUID.preferred_identifier(user)
+
+# Extract specific identifiers
+uuid = PhoenixKit.UUID.extract_uuid(user)
+id = PhoenixKit.UUID.extract_id(user)
+
+# Check identifier type
+PhoenixKit.UUID.uuid?("019b5704-...")       # => true
+PhoenixKit.UUID.integer_id?(123)            # => true
+```
+
+## Transitioning Your Application
+
+### Step 1: Update PhoenixKit
+
+```elixir
+# mix.exs
+def deps do
+  [{:phoenix_kit, "~> 1.8"}]
+end
+```
+
+### Step 2: Run Migrations
+
+```bash
+mix ecto.migrate
+```
+
+### Step 3: Update URLs (Optional)
+
+Start using UUIDs in user-facing URLs for security:
+
+```elixir
+# Before (enumerable integer IDs)
+"/users/123"
+
+# After (non-enumerable UUIDs)
+"/users/019b5704-3680-7b95-9d82-ef16127f1fd2"
+```
+
+### Step 4: Update Controllers/LiveViews
+
+```elixir
+# Before
+def show(conn, %{"id" => id}) do
+  user = Repo.get!(User, id)
+  # ...
+end
+
+# After (supports both ID types)
+def show(conn, %{"id" => identifier}) do
+  user = PhoenixKit.UUID.get!(User, identifier)
+  # ...
+end
+```
+
+### Step 5: Update API Responses (Optional)
+
+Include UUIDs in API responses:
+
+```elixir
+def render("user.json", %{user: user}) do
+  %{
+    id: user.id,           # Keep for backward compatibility
+    uuid: user.uuid,       # Add UUID
+    email: user.email
+  }
+end
+```
+
+## Why UUIDs?
+
+### Security Benefits
+
+- **Non-enumerable**: UUIDs can't be guessed or iterated
+- **No information leakage**: Don't reveal record counts
+- **Distributed-friendly**: No central ID coordination needed
+
+### Technical Benefits (UUIDv7)
+
+- **Time-sortable**: UUIDv7 maintains insertion order naturally
+- **Better index performance**: Sequential ordering reduces index fragmentation
+- **Merge-friendly**: No conflicts when syncing databases
+- **Future-proof**: Industry standard for modern applications
+
+## FAQ
+
+### Will my existing code break?
+
+No. Integer IDs continue to work exactly as before. The UUID column is additive.
+
+### Do I need to update my foreign keys?
+
+Not in Phase 1. Foreign keys still use integer IDs internally. The UUID column is for external reference.
+
+### Can I use UUIDs in URLs immediately?
+
+Yes! After running the V40 migration, all records have UUIDs. Use `PhoenixKit.UUID.get/2` for lookups.
+
+### What about performance?
+
+- UUID columns add ~16 bytes per row
+- Unique indexes are created for efficient lookups
+- UUIDv7 provides better index locality than random UUIDs
+- Integer foreign keys remain for join performance
+
+### How do I generate UUIDs for new records?
+
+New user records automatically get UUIDs via the `registration_changeset`. The database also has a DEFAULT that generates UUIDv7 for any direct SQL inserts.
+
+For other schemas, add UUID generation to your changesets:
+
+```elixir
+|> maybe_generate_uuid()
+
+defp maybe_generate_uuid(changeset) do
+  case get_field(changeset, :uuid) do
+    nil -> put_change(changeset, :uuid, UUIDv7.generate())
+    _ -> changeset
+  end
+end
+```
+
+Or use `PhoenixKit.UUID.generate()`:
+
+```elixir
+defp maybe_generate_uuid(changeset) do
+  case get_field(changeset, :uuid) do
+    nil -> put_change(changeset, :uuid, PhoenixKit.UUID.generate())
+    _ -> changeset
+  end
+end
+```
+
+### What's the difference between UUIDv4 and UUIDv7?
+
+| Feature | UUIDv4 | UUIDv7 |
+|---------|--------|--------|
+| Generation | Random | Time-ordered |
+| Index performance | Poor (random distribution) | Good (sequential) |
+| Sortable by time | No | Yes |
+| Format | `xxxxxxxx-xxxx-4xxx-...` | `xxxxxxxx-xxxx-7xxx-...` |
+
+PhoenixKit uses UUIDv7 exclusively for better performance.
+
+## Multi-Tenant Support
+
+For multi-tenant applications using PostgreSQL schema prefixes:
+
+```elixir
+# Lookup with prefix
+user = PhoenixKit.UUID.get(User, "123", prefix: "tenant_abc")
+
+# All lookup functions support prefix
+user = PhoenixKit.UUID.get_by_id(User, 123, prefix: "tenant_abc")
+user = PhoenixKit.UUID.get_by_uuid(User, uuid, prefix: "tenant_abc")
+```
+
+## Rollback
+
+If needed, the V40 migration can be rolled back:
+
+```bash
+mix ecto.rollback
+```
+
+This removes all UUID columns and indexes, restoring the schema to V39 state.

--- a/lib/phoenix_kit/ai/endpoint.ex
+++ b/lib/phoenix_kit/ai/endpoint.ex
@@ -95,6 +95,7 @@ defmodule PhoenixKit.AI.Endpoint do
            ]}
 
   schema "phoenix_kit_ai_endpoints" do
+    field :uuid, Ecto.UUID
     # Identity
     field :name, :string
     field :description, :string

--- a/lib/phoenix_kit/ai/prompt.ex
+++ b/lib/phoenix_kit/ai/prompt.ex
@@ -88,6 +88,7 @@ defmodule PhoenixKit.AI.Prompt do
            ]}
 
   schema "phoenix_kit_ai_prompts" do
+    field :uuid, Ecto.UUID
     # Identity
     field :name, :string
     field :slug, :string

--- a/lib/phoenix_kit/ai/request.ex
+++ b/lib/phoenix_kit/ai/request.ex
@@ -97,6 +97,7 @@ defmodule PhoenixKit.AI.Request do
            ]}
 
   schema "phoenix_kit_ai_requests" do
+    field :uuid, Ecto.UUID
     # New endpoint system fields
     field :endpoint_name, :string
 

--- a/lib/phoenix_kit/audit_log/entry.ex
+++ b/lib/phoenix_kit/audit_log/entry.ex
@@ -42,6 +42,7 @@ defmodule PhoenixKit.AuditLog.Entry do
   ]
 
   schema "phoenix_kit_audit_logs" do
+    field :uuid, Ecto.UUID
     field :target_user_id, :integer
     field :admin_user_id, :integer
     field :action, :string

--- a/lib/phoenix_kit/billing/billing_profile.ex
+++ b/lib/phoenix_kit/billing/billing_profile.ex
@@ -65,6 +65,7 @@ defmodule PhoenixKit.Billing.BillingProfile do
   @valid_types ~w(individual company)
 
   schema "phoenix_kit_billing_profiles" do
+    field :uuid, Ecto.UUID
     field :type, :string, default: "individual"
     field :is_default, :boolean, default: false
     field :name, :string

--- a/lib/phoenix_kit/billing/currency.ex
+++ b/lib/phoenix_kit/billing/currency.ex
@@ -35,6 +35,7 @@ defmodule PhoenixKit.Billing.Currency do
   @primary_key {:id, :id, autogenerate: true}
 
   schema "phoenix_kit_currencies" do
+    field :uuid, Ecto.UUID
     field :code, :string
     field :name, :string
     field :symbol, :string

--- a/lib/phoenix_kit/billing/invoice.ex
+++ b/lib/phoenix_kit/billing/invoice.ex
@@ -66,6 +66,7 @@ defmodule PhoenixKit.Billing.Invoice do
   @valid_statuses ~w(draft sent paid void overdue)
 
   schema "phoenix_kit_invoices" do
+    field :uuid, Ecto.UUID
     field :invoice_number, :string
     field :status, :string, default: "draft"
 

--- a/lib/phoenix_kit/billing/order.ex
+++ b/lib/phoenix_kit/billing/order.ex
@@ -89,6 +89,7 @@ defmodule PhoenixKit.Billing.Order do
   @valid_payment_methods ~w(bank stripe paypal razorpay)
 
   schema "phoenix_kit_orders" do
+    field :uuid, Ecto.UUID
     field :order_number, :string
     field :status, :string, default: "draft"
     field :payment_method, :string

--- a/lib/phoenix_kit/billing/payment_method.ex
+++ b/lib/phoenix_kit/billing/payment_method.ex
@@ -34,6 +34,7 @@ defmodule PhoenixKit.Billing.PaymentMethod do
   @statuses ~w(active expired removed failed)
 
   schema "phoenix_kit_payment_methods" do
+    field :uuid, Ecto.UUID
     field :provider, :string
     field :provider_payment_method_id, :string
     field :provider_customer_id, :string

--- a/lib/phoenix_kit/billing/subscription.ex
+++ b/lib/phoenix_kit/billing/subscription.ex
@@ -46,6 +46,7 @@ defmodule PhoenixKit.Billing.Subscription do
   @statuses ~w(trialing active past_due paused cancelled)
 
   schema "phoenix_kit_subscriptions" do
+    field :uuid, Ecto.UUID
     field :status, :string, default: "active"
 
     # Billing period

--- a/lib/phoenix_kit/billing/subscription_plan.ex
+++ b/lib/phoenix_kit/billing/subscription_plan.ex
@@ -43,6 +43,7 @@ defmodule PhoenixKit.Billing.SubscriptionPlan do
   @intervals ~w(day week month year)
 
   schema "phoenix_kit_subscription_plans" do
+    field :uuid, Ecto.UUID
     field :name, :string
     field :slug, :string
     field :description, :string

--- a/lib/phoenix_kit/billing/transaction.ex
+++ b/lib/phoenix_kit/billing/transaction.ex
@@ -23,6 +23,7 @@ defmodule PhoenixKit.Billing.Transaction do
   @payment_methods ~w(bank stripe paypal razorpay)
 
   schema "phoenix_kit_transactions" do
+    field :uuid, Ecto.UUID
     field :transaction_number, :string
     field :amount, :decimal
     field :currency, :string, default: "EUR"

--- a/lib/phoenix_kit/billing/webhook_event.ex
+++ b/lib/phoenix_kit/billing/webhook_event.ex
@@ -26,6 +26,7 @@ defmodule PhoenixKit.Billing.WebhookEvent do
   import Ecto.Changeset
 
   schema "phoenix_kit_webhook_events" do
+    field :uuid, Ecto.UUID
     field :provider, :string
     field :event_id, :string
     field :event_type, :string

--- a/lib/phoenix_kit/db_sync/connection.ex
+++ b/lib/phoenix_kit/db_sync/connection.ex
@@ -67,6 +67,7 @@ defmodule PhoenixKit.DBSync.Connection do
   @valid_conflict_strategies ~w(skip overwrite merge append)
 
   schema "phoenix_kit_db_sync_connections" do
+    field :uuid, Ecto.UUID
     field :name, :string
     field :direction, :string
     field :site_url, :string

--- a/lib/phoenix_kit/db_sync/transfer.ex
+++ b/lib/phoenix_kit/db_sync/transfer.ex
@@ -73,6 +73,7 @@ defmodule PhoenixKit.DBSync.Transfer do
   @valid_conflict_strategies ~w(skip overwrite merge append)
 
   schema "phoenix_kit_db_sync_transfers" do
+    field :uuid, Ecto.UUID
     field :direction, :string
     field :session_code, :string
     field :remote_site_url, :string

--- a/lib/phoenix_kit/emails/event.ex
+++ b/lib/phoenix_kit/emails/event.ex
@@ -68,6 +68,7 @@ defmodule PhoenixKit.Emails.Event do
   @primary_key {:id, :id, autogenerate: true}
 
   schema "phoenix_kit_email_events" do
+    field :uuid, Ecto.UUID
     field :event_type, :string
     field :event_data, :map, default: %{}
     field :occurred_at, :utc_datetime_usec

--- a/lib/phoenix_kit/emails/log.ex
+++ b/lib/phoenix_kit/emails/log.ex
@@ -174,6 +174,7 @@ defmodule PhoenixKit.Emails.Log do
   @primary_key {:id, :id, autogenerate: true}
 
   schema "phoenix_kit_email_logs" do
+    field :uuid, Ecto.UUID
     field :message_id, :string
     field :aws_message_id, :string
     field :to, :string

--- a/lib/phoenix_kit/emails/rate_limiter.ex
+++ b/lib/phoenix_kit/emails/rate_limiter.ex
@@ -12,6 +12,7 @@ defmodule PhoenixKit.Emails.EmailBlocklist do
 
   @primary_key {:id, :id, autogenerate: true}
   schema "phoenix_kit_email_blocklist" do
+    field :uuid, Ecto.UUID
     field :email, :string
     field :reason, :string
     field :expires_at, :utc_datetime_usec

--- a/lib/phoenix_kit/emails/template.ex
+++ b/lib/phoenix_kit/emails/template.ex
@@ -114,6 +114,7 @@ defmodule PhoenixKit.Emails.Template do
   ]
 
   schema "phoenix_kit_email_templates" do
+    field :uuid, Ecto.UUID
     field :name, :string
     field :slug, :string
     field :display_name, :string

--- a/lib/phoenix_kit/entities/entities.ex
+++ b/lib/phoenix_kit/entities/entities.ex
@@ -114,6 +114,7 @@ defmodule PhoenixKit.Entities do
            ]}
 
   schema "phoenix_kit_entities" do
+    field :uuid, Ecto.UUID
     field :name, :string
     field :display_name, :string
     field :display_name_plural, :string

--- a/lib/phoenix_kit/entities/entity_data.ex
+++ b/lib/phoenix_kit/entities/entity_data.ex
@@ -92,6 +92,7 @@ defmodule PhoenixKit.Entities.EntityData do
            ]}
 
   schema "phoenix_kit_entity_data" do
+    field :uuid, Ecto.UUID
     field :title, :string
     field :slug, :string
     field :status, :string, default: "published"

--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -279,11 +279,21 @@ defmodule PhoenixKit.Migrations.Postgres do
   - Usage tracking (count and last used timestamp)
   - Sorting and organization support
 
-  ### V39 - Admin Notes System ⚡ LATEST
+  ### V39 - Admin Notes System
   - Phoenix_kit_admin_notes for internal admin notes about users
   - Admin-to-admin communication about user accounts
   - Author tracking for accountability
   - Any admin can view/edit/delete any note
+
+  ### V40 - UUID Column Addition ⚡ LATEST
+  - Adds `uuid` column to all 33 legacy tables using bigserial PKs
+  - Non-breaking: keeps existing bigserial primary keys intact
+  - Backfills existing records with generated UUIDs
+  - Creates unique indexes on uuid columns
+  - Enables gradual transition to UUID-based lookups
+  - Phase 1 of graceful UUID migration strategy for library consumers
+  - Optional module aware: skips tables that don't exist
+  - Batched updates for large tables to avoid lock contention
 
   ## Migration Paths
 
@@ -343,7 +353,7 @@ defmodule PhoenixKit.Migrations.Postgres do
   use Ecto.Migration
 
   @initial_version 1
-  @current_version 39
+  @current_version 40
   @default_prefix "public"
 
   @doc false

--- a/lib/phoenix_kit/migrations/postgres/v40.ex
+++ b/lib/phoenix_kit/migrations/postgres/v40.ex
@@ -1,0 +1,375 @@
+defmodule PhoenixKit.Migrations.Postgres.V40 do
+  @moduledoc """
+  PhoenixKit V40 Migration: UUID Column Addition for Legacy Tables
+
+  This migration adds UUID columns to all legacy tables that currently use
+  bigserial primary keys. This is Phase 1 of the graceful UUID migration
+  strategy, designed to be completely non-breaking for existing installations.
+
+  ## Strategy
+
+  This migration is designed to work with PhoenixKit as a library dependency:
+  - **Non-breaking**: Only adds new columns, doesn't change existing PKs
+  - **Backward compatible**: Existing code using integer IDs continues to work
+  - **Forward compatible**: New code can start using UUIDs immediately
+  - **Optional module aware**: Skips tables that don't exist (disabled modules)
+
+  ## Changes
+
+  For each of the 33 legacy tables:
+  1. Adds a `uuid` column (UUID type, using UUIDv7 for time-ordering)
+  2. Backfills existing records with generated UUIDv7 values
+  3. Creates a unique index on the uuid column
+  4. Sets the column to NOT NULL after backfill
+  5. Keeps DEFAULT for database-level inserts (Ecto changesets override with UUIDv7)
+
+  ## UUIDv7
+
+  This migration uses UUIDv7 (time-ordered UUIDs) which provide:
+  - Time-based ordering (first 48 bits are Unix timestamp in milliseconds)
+  - Better index locality than random UUIDs
+  - Sortable by creation time
+  - Compatible with standard UUID format
+
+  A PostgreSQL function `uuid_generate_v7()` is created to generate UUIDv7
+  values at the database level.
+
+  ## Tables Affected
+
+  ### Core Auth (V01)
+  - phoenix_kit_users
+  - phoenix_kit_users_tokens
+  - phoenix_kit_user_roles
+  - phoenix_kit_user_role_assignments
+
+  ### Settings & Referrals (V03-V04)
+  - phoenix_kit_settings
+  - phoenix_kit_referral_codes
+  - phoenix_kit_referral_code_usage
+
+  ### Email System (V07, V09, V15, V22)
+  - phoenix_kit_email_logs
+  - phoenix_kit_email_events
+  - phoenix_kit_email_blocklist
+  - phoenix_kit_email_templates
+  - phoenix_kit_email_orphaned_events
+  - phoenix_kit_email_metrics
+
+  ### OAuth (V16)
+  - phoenix_kit_user_oauth_providers
+
+  ### Entities (V17)
+  - phoenix_kit_entities
+  - phoenix_kit_entity_data
+
+  ### Audit (V22)
+  - phoenix_kit_audit_logs
+
+  ### Billing (V31, V33)
+  - phoenix_kit_currencies
+  - phoenix_kit_billing_profiles
+  - phoenix_kit_orders
+  - phoenix_kit_invoices
+  - phoenix_kit_transactions
+  - phoenix_kit_payment_methods
+  - phoenix_kit_subscription_plans
+  - phoenix_kit_subscriptions
+  - phoenix_kit_payment_provider_configs
+  - phoenix_kit_webhook_events
+
+  ### AI System (V32, V34, V38)
+  - phoenix_kit_ai_endpoints
+  - phoenix_kit_ai_requests
+  - phoenix_kit_ai_prompts
+
+  ### DB Sync (V37)
+  - phoenix_kit_db_sync_connections
+  - phoenix_kit_db_sync_transfers
+
+  ### Admin Notes (V39)
+  - phoenix_kit_admin_notes
+
+  ## Performance Considerations
+
+  - Uses batched updates for large tables to avoid long locks
+  - Checks table existence before migration (for optional modules)
+  - UUIDv7 provides better index performance than random UUIDs
+
+  ## Usage
+
+      # Migrate up
+      PhoenixKit.Migrations.Postgres.up(prefix: "public", version: 40)
+
+      # Rollback
+      PhoenixKit.Migrations.Postgres.down(prefix: "public", version: 39)
+  """
+  use Ecto.Migration
+
+  @tables_to_migrate [
+    # Core Auth (V01)
+    :phoenix_kit_users,
+    :phoenix_kit_users_tokens,
+    :phoenix_kit_user_roles,
+    :phoenix_kit_user_role_assignments,
+    # Settings & Referrals (V03-V04)
+    :phoenix_kit_settings,
+    :phoenix_kit_referral_codes,
+    :phoenix_kit_referral_code_usage,
+    # Email System (V07, V09, V15, V22)
+    :phoenix_kit_email_logs,
+    :phoenix_kit_email_events,
+    :phoenix_kit_email_blocklist,
+    :phoenix_kit_email_templates,
+    :phoenix_kit_email_orphaned_events,
+    :phoenix_kit_email_metrics,
+    # OAuth (V16)
+    :phoenix_kit_user_oauth_providers,
+    # Entities (V17)
+    :phoenix_kit_entities,
+    :phoenix_kit_entity_data,
+    # Audit (V22)
+    :phoenix_kit_audit_logs,
+    # Billing (V31, V33)
+    :phoenix_kit_currencies,
+    :phoenix_kit_billing_profiles,
+    :phoenix_kit_orders,
+    :phoenix_kit_invoices,
+    :phoenix_kit_transactions,
+    :phoenix_kit_payment_methods,
+    :phoenix_kit_subscription_plans,
+    :phoenix_kit_subscriptions,
+    :phoenix_kit_payment_provider_configs,
+    :phoenix_kit_webhook_events,
+    # AI System (V32, V34, V38)
+    :phoenix_kit_ai_endpoints,
+    :phoenix_kit_ai_requests,
+    :phoenix_kit_ai_prompts,
+    # DB Sync (V37)
+    :phoenix_kit_db_sync_connections,
+    :phoenix_kit_db_sync_transfers,
+    # Admin Notes (V39)
+    :phoenix_kit_admin_notes
+  ]
+
+  # Tables that may have large amounts of data and need batched updates
+  @large_tables [
+    :phoenix_kit_users,
+    :phoenix_kit_users_tokens,
+    :phoenix_kit_email_logs,
+    :phoenix_kit_email_events,
+    :phoenix_kit_audit_logs,
+    :phoenix_kit_entity_data,
+    :phoenix_kit_ai_requests
+  ]
+
+  # Batch size for large table updates
+  @batch_size 10_000
+
+  @doc """
+  Run the V40 migration to add UUID columns to all legacy tables.
+  """
+  def up(%{prefix: prefix} = opts) do
+    escaped_prefix = Map.get(opts, :escaped_prefix, prefix)
+
+    # Step 1: Ensure pgcrypto extension exists
+    execute("CREATE EXTENSION IF NOT EXISTS pgcrypto")
+
+    # Step 2: Create UUIDv7 generation function if it doesn't exist
+    # UUIDv7 format: timestamp (48 bits) + version (4 bits) + random (12 bits) + variant (2 bits) + random (62 bits)
+    execute("""
+    CREATE OR REPLACE FUNCTION uuid_generate_v7()
+    RETURNS uuid AS $$
+    DECLARE
+      unix_ts_ms bytea;
+      uuid_bytes bytea;
+    BEGIN
+      -- Get current timestamp in milliseconds
+      unix_ts_ms := substring(int8send(floor(extract(epoch FROM clock_timestamp()) * 1000)::bigint) FROM 3);
+
+      -- Build UUIDv7: 6 bytes timestamp + 2 bytes random (with version) + 8 bytes random (with variant)
+      uuid_bytes := unix_ts_ms || gen_random_bytes(10);
+
+      -- Set version 7 (0111xxxx in byte 7)
+      uuid_bytes := set_byte(uuid_bytes, 6, (get_byte(uuid_bytes, 6) & 15) | 112);
+
+      -- Set variant (10xxxxxx in byte 9)
+      uuid_bytes := set_byte(uuid_bytes, 8, (get_byte(uuid_bytes, 8) & 63) | 128);
+
+      RETURN encode(uuid_bytes, 'hex')::uuid;
+    END
+    $$ LANGUAGE plpgsql VOLATILE;
+    """)
+
+    # Step 3: Process each table
+    for table <- @tables_to_migrate do
+      add_uuid_column_to_table(table, prefix, escaped_prefix)
+    end
+
+    # Step 4: Update version comment
+    execute("COMMENT ON TABLE #{prefix_table_name("phoenix_kit", prefix)} IS '40'")
+  end
+
+  @doc """
+  Rollback the V40 migration by removing UUID columns.
+  """
+  def down(%{prefix: prefix} = opts) do
+    escaped_prefix = Map.get(opts, :escaped_prefix, prefix)
+
+    # Remove UUID columns from all tables (in reverse order)
+    for table <- Enum.reverse(@tables_to_migrate) do
+      remove_uuid_column_from_table(table, prefix, escaped_prefix)
+    end
+
+    # Update version comment
+    execute("COMMENT ON TABLE #{prefix_table_name("phoenix_kit", prefix)} IS '39'")
+  end
+
+  # Add UUID column to a single table with all safety checks
+  defp add_uuid_column_to_table(table, prefix, escaped_prefix) do
+    table_name = prefix_table_name(Atom.to_string(table), prefix)
+
+    # Check if table exists (for optional modules that might not be enabled)
+    if table_exists?(table, escaped_prefix) do
+      # Check if uuid column already exists (idempotency)
+      unless column_exists?(table, :uuid, escaped_prefix) do
+        # Step 1: Add UUID column with UUIDv7 default
+        # The default ensures database-level inserts work correctly.
+        # Ecto changesets will generate UUIDv7 in Elixir, which takes precedence.
+        execute("""
+        ALTER TABLE #{table_name}
+        ADD COLUMN uuid UUID DEFAULT uuid_generate_v7()
+        """)
+
+        # Step 2: Backfill existing records with UUIDv7
+        # Use batched updates for large tables to avoid long locks
+        if table in @large_tables do
+          backfill_uuids_batched(table_name)
+        else
+          # Small tables can be updated in one go
+          execute("""
+          UPDATE #{table_name}
+          SET uuid = uuid_generate_v7()
+          WHERE uuid IS NULL
+          """)
+        end
+
+        # Step 3: Create unique index
+        execute("""
+        CREATE UNIQUE INDEX IF NOT EXISTS #{table}_uuid_idx
+        ON #{table_name}(uuid)
+        """)
+
+        # Step 4: Set NOT NULL constraint after backfill
+        execute("""
+        ALTER TABLE #{table_name}
+        ALTER COLUMN uuid SET NOT NULL
+        """)
+
+        # Note: We KEEP the DEFAULT so database-level inserts continue to work.
+        # This is important for backward compatibility with code that doesn't
+        # explicitly set the uuid field. Ecto changesets will generate UUIDv7
+        # in Elixir, which takes precedence over the default.
+      end
+    end
+  end
+
+  # Backfill UUIDs in batches to avoid long locks on large tables
+  defp backfill_uuids_batched(table_name) do
+    # Use a loop to update in batches
+    # This is done via a DO block to handle it in a single migration step
+    execute("""
+    DO $$
+    DECLARE
+      batch_count INTEGER := 0;
+      updated_rows INTEGER;
+    BEGIN
+      LOOP
+        UPDATE #{table_name}
+        SET uuid = uuid_generate_v7()
+        WHERE id IN (
+          SELECT id FROM #{table_name}
+          WHERE uuid IS NULL
+          LIMIT #{@batch_size}
+        );
+
+        GET DIAGNOSTICS updated_rows = ROW_COUNT;
+        batch_count := batch_count + 1;
+
+        -- Exit when no more rows to update
+        EXIT WHEN updated_rows = 0;
+
+        -- Small delay between batches to reduce lock contention
+        PERFORM pg_sleep(0.01);
+      END LOOP;
+    END $$;
+    """)
+  end
+
+  # Remove UUID column from a single table
+  defp remove_uuid_column_from_table(table, prefix, escaped_prefix) do
+    table_name = prefix_table_name(Atom.to_string(table), prefix)
+
+    if table_exists?(table, escaped_prefix) and column_exists?(table, :uuid, escaped_prefix) do
+      # Drop index first (handle nil prefix properly)
+      index_name = prefix_index_name(table, prefix)
+
+      execute("""
+      DROP INDEX IF EXISTS #{index_name}
+      """)
+
+      # Drop column
+      execute("""
+      ALTER TABLE #{table_name}
+      DROP COLUMN IF EXISTS uuid
+      """)
+    end
+  end
+
+  # Helper to build prefixed index name, handling nil prefix
+  defp prefix_index_name(table, nil), do: "#{table}_uuid_idx"
+  defp prefix_index_name(table, "public"), do: "public.#{table}_uuid_idx"
+  defp prefix_index_name(table, prefix), do: "#{prefix}.#{table}_uuid_idx"
+
+  # Check if a table exists in the database
+  defp table_exists?(table, escaped_prefix) do
+    table_name = Atom.to_string(table)
+
+    query = """
+    SELECT EXISTS (
+      SELECT FROM information_schema.tables
+      WHERE table_name = '#{table_name}'
+      AND table_schema = '#{escaped_prefix}'
+    )
+    """
+
+    case repo().query(query, [], log: false) do
+      {:ok, %{rows: [[true]]}} -> true
+      _ -> false
+    end
+  end
+
+  # Check if a column exists in a table
+  defp column_exists?(table, column, escaped_prefix) do
+    table_name = Atom.to_string(table)
+    column_name = Atom.to_string(column)
+
+    query = """
+    SELECT EXISTS (
+      SELECT FROM information_schema.columns
+      WHERE table_name = '#{table_name}'
+      AND column_name = '#{column_name}'
+      AND table_schema = '#{escaped_prefix}'
+    )
+    """
+
+    case repo().query(query, [], log: false) do
+      {:ok, %{rows: [[true]]}} -> true
+      _ -> false
+    end
+  end
+
+  # Helper to build prefixed table name
+  defp prefix_table_name(table_name, nil), do: table_name
+  defp prefix_table_name(table_name, "public"), do: "public.#{table_name}"
+  defp prefix_table_name(table_name, prefix), do: "#{prefix}.#{table_name}"
+end

--- a/lib/phoenix_kit/referral_codes/referral_code_usage.ex
+++ b/lib/phoenix_kit/referral_codes/referral_code_usage.ex
@@ -37,6 +37,7 @@ defmodule PhoenixKit.ReferralCodeUsage do
   @primary_key {:id, :id, autogenerate: true}
 
   schema "phoenix_kit_referral_code_usage" do
+    field :uuid, Ecto.UUID
     field :used_by, :integer
     field :date_used, :utc_datetime_usec
 

--- a/lib/phoenix_kit/referral_codes/referral_codes.ex
+++ b/lib/phoenix_kit/referral_codes/referral_codes.ex
@@ -74,6 +74,7 @@ defmodule PhoenixKit.ReferralCodes do
   @primary_key {:id, :id, autogenerate: true}
 
   schema "phoenix_kit_referral_codes" do
+    field :uuid, Ecto.UUID
     field :code, :string
     field :description, :string
     field :status, :boolean, default: true

--- a/lib/phoenix_kit/settings/setting.ex
+++ b/lib/phoenix_kit/settings/setting.ex
@@ -83,6 +83,7 @@ defmodule PhoenixKit.Settings.Setting do
   @primary_key {:id, :id, autogenerate: true}
 
   schema "phoenix_kit_settings" do
+    field :uuid, Ecto.UUID
     field :key, :string
     field :value, :string
     field :value_json, :map

--- a/lib/phoenix_kit/users/admin_note.ex
+++ b/lib/phoenix_kit/users/admin_note.ex
@@ -33,6 +33,7 @@ defmodule PhoenixKit.Users.AdminNote do
         }
 
   schema "phoenix_kit_admin_notes" do
+    field :uuid, Ecto.UUID
     belongs_to :user, PhoenixKit.Users.Auth.User
     belongs_to :author, PhoenixKit.Users.Auth.User
 

--- a/lib/phoenix_kit/users/auth/user.ex
+++ b/lib/phoenix_kit/users/auth/user.ex
@@ -31,6 +31,7 @@ defmodule PhoenixKit.Users.Auth.User do
 
   @type t :: %__MODULE__{
           id: integer() | nil,
+          uuid: Ecto.UUID.t() | nil,
           email: String.t(),
           username: String.t() | nil,
           password: String.t() | nil,
@@ -51,6 +52,7 @@ defmodule PhoenixKit.Users.Auth.User do
         }
 
   schema "phoenix_kit_users" do
+    field :uuid, Ecto.UUID
     field :email, :string
     field :username, :string
     field :password, :string, virtual: true, redact: true
@@ -116,6 +118,15 @@ defmodule PhoenixKit.Users.Auth.User do
     |> validate_registration_fields()
     |> maybe_generate_username_from_email()
     |> set_default_active_status()
+    |> maybe_generate_uuid()
+  end
+
+  # Generate UUIDv7 for new records if not already set
+  defp maybe_generate_uuid(changeset) do
+    case get_field(changeset, :uuid) do
+      nil -> put_change(changeset, :uuid, UUIDv7.generate())
+      _ -> changeset
+    end
   end
 
   defp validate_email(changeset, opts) do

--- a/lib/phoenix_kit/users/auth/user_token.ex
+++ b/lib/phoenix_kit/users/auth/user_token.ex
@@ -38,6 +38,7 @@ defmodule PhoenixKit.Users.Auth.UserToken do
   @magic_link_validity_in_minutes 15
 
   schema "phoenix_kit_users_tokens" do
+    field :uuid, Ecto.UUID
     field :token, :binary
     field :context, :string
     field :sent_to, :string

--- a/lib/phoenix_kit/users/oauth_provider.ex
+++ b/lib/phoenix_kit/users/oauth_provider.ex
@@ -14,6 +14,7 @@ defmodule PhoenixKit.Users.OAuthProvider do
   @supported_providers ~w(google apple github facebook twitter microsoft)
 
   schema "phoenix_kit_user_oauth_providers" do
+    field :uuid, Ecto.UUID
     belongs_to :user, User, foreign_key: :user_id
 
     field :provider, :string

--- a/lib/phoenix_kit/users/role.ex
+++ b/lib/phoenix_kit/users/role.ex
@@ -30,6 +30,7 @@ defmodule PhoenixKit.Users.Role do
 
   @type t :: %__MODULE__{
           id: integer() | nil,
+          uuid: Ecto.UUID.t() | nil,
           name: String.t(),
           description: String.t() | nil,
           is_system_role: boolean(),
@@ -44,6 +45,7 @@ defmodule PhoenixKit.Users.Role do
   }
 
   schema "phoenix_kit_user_roles" do
+    field :uuid, Ecto.UUID
     field :name, :string
     field :description, :string
     field :is_system_role, :boolean, default: false

--- a/lib/phoenix_kit/users/role_assignment.ex
+++ b/lib/phoenix_kit/users/role_assignment.ex
@@ -24,6 +24,7 @@ defmodule PhoenixKit.Users.RoleAssignment do
 
   @type t :: %__MODULE__{
           id: integer() | nil,
+          uuid: Ecto.UUID.t() | nil,
           user_id: integer(),
           role_id: integer(),
           assigned_by: integer() | nil,
@@ -32,6 +33,7 @@ defmodule PhoenixKit.Users.RoleAssignment do
         }
 
   schema "phoenix_kit_user_role_assignments" do
+    field :uuid, Ecto.UUID
     belongs_to :user, PhoenixKit.Users.Auth.User
     belongs_to :role, PhoenixKit.Users.Role
     belongs_to :assigned_by_user, PhoenixKit.Users.Auth.User, foreign_key: :assigned_by

--- a/lib/phoenix_kit/uuid.ex
+++ b/lib/phoenix_kit/uuid.ex
@@ -1,0 +1,379 @@
+defmodule PhoenixKit.UUID do
+  @moduledoc """
+  UUID utilities for PhoenixKit's graceful UUID migration.
+
+  This module provides helper functions for working with dual ID systems
+  (bigserial + UUID) during the transition period. It enables parent
+  applications to gradually migrate from integer IDs to UUIDs.
+
+  ## Background
+
+  PhoenixKit V40 adds UUID columns to all legacy tables that previously
+  used bigserial primary keys. This module provides utilities to:
+
+  - Look up records by either integer ID or UUID
+  - Generate UUIDv7 values for new records
+  - Validate UUID formats
+  - Help with the transition from integer to UUID-based lookups
+
+  ## UUIDv7
+
+  This module generates UUIDv7 (time-ordered UUIDs) which provide:
+  - Time-based ordering (first 48 bits are Unix timestamp in milliseconds)
+  - Better index locality than random UUIDs (UUIDv4)
+  - Sortable by creation time
+  - Compatible with standard UUID format
+
+  ## Usage
+
+  ### Looking up records by ID or UUID
+
+      # Automatically detects ID type
+      PhoenixKit.UUID.get(User, "123")                    # integer lookup
+      PhoenixKit.UUID.get(User, "019b5704-3680-7b95-...")  # UUID lookup
+
+      # Explicit lookups
+      PhoenixKit.UUID.get_by_id(User, 123)
+      PhoenixKit.UUID.get_by_uuid(User, "019b5704-3680-7b95-...")
+
+      # With prefix for multi-tenant schemas
+      PhoenixKit.UUID.get(User, "123", prefix: "tenant_123")
+
+  ### Generating UUIDs
+
+      PhoenixKit.UUID.generate()  # Returns a new UUIDv7 string
+
+  ### Parsing identifiers
+
+      PhoenixKit.UUID.parse_identifier("123")
+      # => {:integer, 123}
+
+      PhoenixKit.UUID.parse_identifier("019b5704-3680-7b95-9d82-ef16127f1fd2")
+      # => {:uuid, "019b5704-3680-7b95-9d82-ef16127f1fd2"}
+
+  ## Migration Strategy
+
+  This module is part of PhoenixKit's graceful UUID migration strategy:
+
+  1. **V40**: UUID columns added to all legacy tables (non-breaking)
+  2. **Transition**: Parent apps can use UUIDs in URLs/APIs while
+     internal FKs continue using bigserial
+  3. **Future**: UUID becomes the primary identifier
+
+  ## Best Practices
+
+  - Use `get/2` for user-facing lookups (URLs, API params)
+  - Use `get_by_id/2` for internal operations where you know the ID type
+  - Always generate UUIDs for new records using schema changesets
+  - Prefer UUIDs in URLs for security (non-enumerable)
+  """
+
+  alias PhoenixKit.RepoHelper
+
+  @uuid_regex ~r/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+  @doc """
+  Generates a new UUIDv7 string.
+
+  UUIDv7 is a time-ordered UUID where the first 48 bits are a Unix timestamp
+  in milliseconds, providing natural chronological ordering.
+
+  ## Examples
+
+      iex> PhoenixKit.UUID.generate()
+      "019b5704-3680-7b95-9d82-ef16127f1fd2"
+  """
+  @spec generate() :: String.t()
+  def generate do
+    UUIDv7.generate()
+  end
+
+  @doc """
+  Gets a record by either integer ID or UUID string.
+
+  Automatically detects the identifier type and performs the appropriate lookup.
+  Returns `nil` if the record is not found.
+
+  ## Parameters
+
+  - `schema` - The Ecto schema module
+  - `identifier` - Either an integer ID, string integer, or UUID string
+  - `opts` - Optional keyword list:
+    - `:prefix` - Schema prefix for multi-tenant databases
+    - `:repo` - Override the repository to use
+
+  ## Examples
+
+      iex> PhoenixKit.UUID.get(User, 123)
+      %User{id: 123, uuid: "..."}
+
+      iex> PhoenixKit.UUID.get(User, "123")
+      %User{id: 123, uuid: "..."}
+
+      iex> PhoenixKit.UUID.get(User, "019b5704-3680-7b95-9d82-ef16127f1fd2")
+      %User{id: 123, uuid: "019b5704-3680-7b95-9d82-ef16127f1fd2"}
+
+      iex> PhoenixKit.UUID.get(User, "nonexistent")
+      nil
+
+      # With prefix for multi-tenant schemas
+      iex> PhoenixKit.UUID.get(User, "123", prefix: "tenant_abc")
+      %User{id: 123, uuid: "..."}
+  """
+  @spec get(module(), integer() | String.t(), keyword()) :: struct() | nil
+  def get(schema, identifier, opts \\ []) do
+    case parse_identifier(identifier) do
+      {:integer, id} -> get_by_id(schema, id, opts)
+      {:uuid, uuid} -> get_by_uuid(schema, uuid, opts)
+      :invalid -> nil
+    end
+  end
+
+  @doc """
+  Gets a record by either integer ID or UUID string, raising if not found.
+
+  ## Examples
+
+      iex> PhoenixKit.UUID.get!(User, "019b5704-3680-7b95-9d82-ef16127f1fd2")
+      %User{uuid: "019b5704-3680-7b95-9d82-ef16127f1fd2"}
+
+      iex> PhoenixKit.UUID.get!(User, "nonexistent")
+      ** (Ecto.NoResultsError)
+  """
+  @spec get!(module(), integer() | String.t(), keyword()) :: struct()
+  def get!(schema, identifier, opts \\ []) do
+    case get(schema, identifier, opts) do
+      nil -> raise Ecto.NoResultsError, queryable: schema
+      record -> record
+    end
+  end
+
+  @doc """
+  Gets a record by its integer ID.
+
+  ## Options
+
+  - `:prefix` - Schema prefix for multi-tenant databases
+  - `:repo` - Override the repository to use
+
+  ## Examples
+
+      iex> PhoenixKit.UUID.get_by_id(User, 123)
+      %User{id: 123}
+
+      iex> PhoenixKit.UUID.get_by_id(User, 999999)
+      nil
+
+      iex> PhoenixKit.UUID.get_by_id(User, 123, prefix: "tenant_abc")
+      %User{id: 123}
+  """
+  @spec get_by_id(module(), integer() | String.t(), keyword()) :: struct() | nil
+  def get_by_id(schema, id, opts \\ [])
+
+  def get_by_id(schema, id, opts) when is_integer(id) do
+    repo = Keyword.get(opts, :repo, RepoHelper.repo())
+    query_opts = build_query_opts(opts)
+    repo.get(schema, id, query_opts)
+  end
+
+  def get_by_id(schema, id, opts) when is_binary(id) do
+    case Integer.parse(id) do
+      {int_id, ""} -> get_by_id(schema, int_id, opts)
+      _ -> nil
+    end
+  end
+
+  @doc """
+  Gets a record by its UUID.
+
+  ## Options
+
+  - `:prefix` - Schema prefix for multi-tenant databases
+  - `:repo` - Override the repository to use
+
+  ## Examples
+
+      iex> PhoenixKit.UUID.get_by_uuid(User, "019b5704-3680-7b95-9d82-ef16127f1fd2")
+      %User{uuid: "019b5704-3680-7b95-9d82-ef16127f1fd2"}
+
+      iex> PhoenixKit.UUID.get_by_uuid(User, "nonexistent-uuid")
+      nil
+
+      iex> PhoenixKit.UUID.get_by_uuid(User, "019b5704-...", prefix: "tenant_abc")
+      %User{uuid: "019b5704-..."}
+  """
+  @spec get_by_uuid(module(), String.t(), keyword()) :: struct() | nil
+  def get_by_uuid(schema, uuid, opts \\ [])
+
+  def get_by_uuid(schema, uuid, opts) when is_binary(uuid) do
+    if valid_uuid?(uuid) do
+      repo = Keyword.get(opts, :repo, RepoHelper.repo())
+      query_opts = build_query_opts(opts)
+      repo.get_by(schema, [uuid: uuid], query_opts)
+    else
+      nil
+    end
+  end
+
+  @doc """
+  Parses an identifier and returns its type.
+
+  ## Examples
+
+      iex> PhoenixKit.UUID.parse_identifier(123)
+      {:integer, 123}
+
+      iex> PhoenixKit.UUID.parse_identifier("123")
+      {:integer, 123}
+
+      iex> PhoenixKit.UUID.parse_identifier("019b5704-3680-7b95-9d82-ef16127f1fd2")
+      {:uuid, "019b5704-3680-7b95-9d82-ef16127f1fd2"}
+
+      iex> PhoenixKit.UUID.parse_identifier("invalid")
+      :invalid
+  """
+  @spec parse_identifier(integer() | String.t()) ::
+          {:integer, integer()} | {:uuid, String.t()} | :invalid
+  def parse_identifier(id) when is_integer(id), do: {:integer, id}
+
+  def parse_identifier(id) when is_binary(id) do
+    cond do
+      valid_uuid?(id) ->
+        {:uuid, id}
+
+      integer_string?(id) ->
+        {int_id, ""} = Integer.parse(id)
+        {:integer, int_id}
+
+      true ->
+        :invalid
+    end
+  end
+
+  def parse_identifier(_), do: :invalid
+
+  @doc """
+  Checks if a string is a valid UUID format.
+
+  Works with both UUIDv4 and UUIDv7 formats.
+
+  ## Examples
+
+      iex> PhoenixKit.UUID.valid_uuid?("019b5704-3680-7b95-9d82-ef16127f1fd2")
+      true
+
+      iex> PhoenixKit.UUID.valid_uuid?("not-a-uuid")
+      false
+  """
+  @spec valid_uuid?(String.t()) :: boolean()
+  def valid_uuid?(string) when is_binary(string) do
+    Regex.match?(@uuid_regex, string)
+  end
+
+  def valid_uuid?(_), do: false
+
+  @doc """
+  Checks if an identifier is a UUID (vs integer).
+
+  ## Examples
+
+      iex> PhoenixKit.UUID.uuid?("019b5704-3680-7b95-9d82-ef16127f1fd2")
+      true
+
+      iex> PhoenixKit.UUID.uuid?("123")
+      false
+
+      iex> PhoenixKit.UUID.uuid?(123)
+      false
+  """
+  @spec uuid?(any()) :: boolean()
+  def uuid?(identifier) do
+    case parse_identifier(identifier) do
+      {:uuid, _} -> true
+      _ -> false
+    end
+  end
+
+  @doc """
+  Checks if an identifier is an integer ID (vs UUID).
+
+  ## Examples
+
+      iex> PhoenixKit.UUID.integer_id?(123)
+      true
+
+      iex> PhoenixKit.UUID.integer_id?("123")
+      true
+
+      iex> PhoenixKit.UUID.integer_id?("019b5704-3680-7b95-9d82-ef16127f1fd2")
+      false
+  """
+  @spec integer_id?(any()) :: boolean()
+  def integer_id?(identifier) do
+    case parse_identifier(identifier) do
+      {:integer, _} -> true
+      _ -> false
+    end
+  end
+
+  @doc """
+  Extracts the UUID from a record, returning nil if not present.
+
+  ## Examples
+
+      iex> PhoenixKit.UUID.extract_uuid(%User{uuid: "019b5704-..."})
+      "019b5704-..."
+
+      iex> PhoenixKit.UUID.extract_uuid(%User{uuid: nil})
+      nil
+  """
+  @spec extract_uuid(struct()) :: String.t() | nil
+  def extract_uuid(%{uuid: uuid}), do: uuid
+  def extract_uuid(_), do: nil
+
+  @doc """
+  Extracts the integer ID from a record.
+
+  ## Examples
+
+      iex> PhoenixKit.UUID.extract_id(%User{id: 123})
+      123
+  """
+  @spec extract_id(struct()) :: integer() | nil
+  def extract_id(%{id: id}), do: id
+  def extract_id(_), do: nil
+
+  @doc """
+  Returns the preferred identifier for a record.
+
+  Prefers UUID if available, falls back to integer ID.
+
+  ## Examples
+
+      iex> PhoenixKit.UUID.preferred_identifier(%User{id: 123, uuid: "019b5704-..."})
+      "019b5704-..."
+
+      iex> PhoenixKit.UUID.preferred_identifier(%User{id: 123, uuid: nil})
+      123
+  """
+  @spec preferred_identifier(struct()) :: String.t() | integer() | nil
+  def preferred_identifier(%{uuid: uuid}) when is_binary(uuid), do: uuid
+  def preferred_identifier(%{id: id}), do: id
+  def preferred_identifier(_), do: nil
+
+  # Private helpers
+
+  defp integer_string?(string) do
+    case Integer.parse(string) do
+      {_, ""} -> true
+      _ -> false
+    end
+  end
+
+  # Build query options from keyword list, filtering to Ecto-supported options
+  defp build_query_opts(opts) do
+    opts
+    |> Keyword.take([:prefix])
+    |> Enum.reject(fn {_k, v} -> is_nil(v) end)
+  end
+end


### PR DESCRIPTION
## Summary

  - Adds UUID columns (using UUIDv7) to all 33 legacy tables that currently use bigserial primary keys
  - Creates PostgreSQL `uuid_generate_v7()` function for time-ordered UUID generation
  - Adds `PhoenixKit.UUID` helper module for dual-identifier lookups (integer ID or UUID)
  - Includes comprehensive documentation in `guides/uuid_migration.md`

  ## Key Design Decisions

  - **Non-breaking**: Only adds new columns, existing integer IDs continue to work
  - **UUIDv7 only**: Time-ordered UUIDs for better index performance than random UUIDv4
  - **DB DEFAULT preserved**: Database-level inserts automatically get UUIDs
  - **Batched updates**: Large tables use batched backfill to minimize lock contention
  - **Multi-tenant support**: All lookup functions support `:prefix` option

  ## Tables Affected (33 total)

  Core Auth, Settings, Referrals, Email System, OAuth, Entities, Audit, Billing, AI System, DB Sync, Admin Notes

  ## Test plan

  - [ ] Run migration on test database: `mix ecto.migrate`
  - [ ] Verify UUID columns exist on all 33 tables
  - [ ] Test new user registration generates UUIDv7
  - [ ] Test `PhoenixKit.UUID.get/2` with both integer and UUID identifiers
  - [ ] Verify rollback works: `mix ecto.rollback`