### PR TITLE
Add Legal Module Phase 1 (V43)

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -72,5 +72,15 @@
 
   # Blogging module type inference false positives
   # Dialyzer incorrectly infers create_post only returns {:error, ...} in certain contexts
-  ~r/lib\/phoenix_kit_web\/live\/modules\/blogging\/editor\.ex:839:.*pattern_match/
+  ~r/lib\/phoenix_kit_web\/live\/modules\/blogging\/editor\.ex:839:.*pattern_match/,
+
+  # Legal module - dynamic dispatch to Blogging module
+  # Dialyzer can't infer types through blogging_module() helper
+  ~r/lib\/modules\/legal\/legal\.ex:.*pattern_match/,
+  ~r/lib\/modules\/legal\/legal\.ex:.*pattern_match_cov/,
+
+  # ConsentLog schema - changeset type spec with empty struct
+  ~r/lib\/modules\/legal\/schemas\/consent_log\.ex:.*invalid_contract/,
+  ~r/lib\/modules\/legal\/schemas\/consent_log\.ex:.*no_return/,
+  ~r/lib\/modules\/legal\/schemas\/consent_log\.ex:.*call/
 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 1.7.16 - 2025-12-29
+
+### Legal Module - Phase 1
+- **New Legal module** for privacy compliance and legal page management
+- **Compliance framework selection** - Support for GDPR, CCPA, LGPD, PDPA, POPIA, and Generic frameworks
+- **Company information form** - Store company details for legal page generation
+- **DPO contact form** - Data Protection Officer contact information
+- **Legal page generation** - Generate pages from EEx templates:
+  - Privacy Policy, Terms of Service, Cookie Policy
+  - Data Retention Policy, CCPA Notice, Acceptable Use Policy, Do Not Sell
+- **Blogging integration** - Generated pages stored as blog posts in dedicated "legal" blog
+- **Consent logging schema** - Track user consent for cookies and data processing (V43 migration)
+- **Admin settings interface** - Manage legal settings at `/admin/settings/legal`
+- **Module organization** - Files structured in `lib/modules/legal/` following Storage module pattern
+
 ## 1.7.15 - 2025-12-29
 - Major AI Module enhancements: real-time PubSub updates across tabs, client-side TimeAgo hook for efficient time displays, reasoning/thinking parameters for AI endpoints, prompt tracking in request logs, and pagination with date filtering on admin pages.
 - Initial Job Module release with basic functionality

--- a/lib/modules/legal/legal.ex
+++ b/lib/modules/legal/legal.ex
@@ -1,0 +1,611 @@
+defmodule PhoenixKit.Modules.Legal do
+  @moduledoc """
+  Legal module for PhoenixKit - GDPR/CCPA compliant legal pages and consent management.
+
+  ## Phase 1: Legal Pages Generation
+  - Compliance framework selection (GDPR, CCPA, etc.)
+  - Company information management
+  - Legal page generation (Privacy Policy, Terms, Cookie Policy)
+  - Integration with Blogging module for page storage
+
+  ## Phase 2: Cookie Consent Widget (prepared infrastructure)
+  - Cookie consent banner
+  - Consent logging to phoenix_kit_consent_logs table
+  - Google Consent Mode v2 integration
+
+  ## Dependencies
+  - Blogging module must be enabled before Legal module
+
+  ## Usage
+
+      # Enable the module (requires Blogging to be enabled)
+      PhoenixKit.Modules.Legal.enable_system()
+
+      # Check if enabled
+      PhoenixKit.Modules.Legal.enabled?()
+
+      # Get configuration
+      PhoenixKit.Modules.Legal.get_config()
+
+      # Generate legal pages
+      PhoenixKit.Modules.Legal.generate_all_pages()
+  """
+
+  alias PhoenixKit.Modules.Legal.TemplateGenerator
+  alias PhoenixKit.Settings
+
+  @enabled_key "legal_enabled"
+  @module_name "legal"
+  @legal_blog_slug "legal"
+
+  # Compliance frameworks with required and optional pages
+  @frameworks %{
+    "gdpr" => %{
+      id: "gdpr",
+      name: "GDPR (European Union)",
+      description: "General Data Protection Regulation - strictest requirements, opt-in consent",
+      regions: ["EU", "EEA"],
+      consent_model: :opt_in,
+      required_pages: ["privacy-policy", "cookie-policy"],
+      optional_pages: ["terms-of-service", "data-retention-policy"]
+    },
+    "uk_gdpr" => %{
+      id: "uk_gdpr",
+      name: "UK GDPR (United Kingdom)",
+      description: "Post-Brexit UK version, similar to EU GDPR",
+      regions: ["UK"],
+      consent_model: :opt_in,
+      required_pages: ["privacy-policy", "cookie-policy"],
+      optional_pages: ["terms-of-service"]
+    },
+    "ccpa" => %{
+      id: "ccpa",
+      name: "CCPA/CPRA (California)",
+      description: "California Consumer Privacy Act - opt-out model, 'Do Not Sell' requirement",
+      regions: ["US-CA"],
+      consent_model: :opt_out,
+      required_pages: ["privacy-policy", "do-not-sell"],
+      optional_pages: ["terms-of-service", "ccpa-notice"]
+    },
+    "us_states" => %{
+      id: "us_states",
+      name: "US State Privacy Laws",
+      description: "Virginia, Colorado, Connecticut, Utah + 15 more states",
+      regions: ["US"],
+      consent_model: :opt_out,
+      required_pages: ["privacy-policy"],
+      optional_pages: ["terms-of-service", "do-not-sell"]
+    },
+    "lgpd" => %{
+      id: "lgpd",
+      name: "LGPD (Brazil)",
+      description: "Brazilian General Data Protection Law - opt-in consent",
+      regions: ["BR"],
+      consent_model: :opt_in,
+      required_pages: ["privacy-policy"],
+      optional_pages: ["terms-of-service", "cookie-policy"]
+    },
+    "pipeda" => %{
+      id: "pipeda",
+      name: "PIPEDA (Canada)",
+      description: "Personal Information Protection and Electronic Documents Act",
+      regions: ["CA"],
+      consent_model: :opt_in,
+      required_pages: ["privacy-policy"],
+      optional_pages: ["terms-of-service", "cookie-policy"]
+    },
+    "generic" => %{
+      id: "generic",
+      name: "Generic (Basic)",
+      description: "Basic privacy policy for other regions",
+      regions: ["*"],
+      consent_model: :notice,
+      required_pages: ["privacy-policy"],
+      optional_pages: ["terms-of-service", "cookie-policy"]
+    }
+  }
+
+  # Standard pages that can be generated
+  @page_types %{
+    "privacy-policy" => %{
+      slug: "privacy-policy",
+      title: "Privacy Policy",
+      template: "privacy_policy.eex",
+      description: "Information about data collection, usage, and user rights"
+    },
+    "cookie-policy" => %{
+      slug: "cookie-policy",
+      title: "Cookie Policy",
+      template: "cookie_policy.eex",
+      description: "Details about cookies and tracking technologies"
+    },
+    "terms-of-service" => %{
+      slug: "terms-of-service",
+      title: "Terms of Service",
+      template: "terms_of_service.eex",
+      description: "Terms and conditions for using the service"
+    },
+    "do-not-sell" => %{
+      slug: "do-not-sell",
+      title: "Do Not Sell My Personal Information",
+      template: "do_not_sell.eex",
+      description: "CCPA opt-out page for California residents"
+    },
+    "data-retention-policy" => %{
+      slug: "data-retention-policy",
+      title: "Data Retention Policy",
+      template: "data_retention_policy.eex",
+      description: "GDPR data retention periods"
+    },
+    "ccpa-notice" => %{
+      slug: "ccpa-notice",
+      title: "CCPA Notice at Collection",
+      template: "ccpa_notice.eex",
+      description: "California notice at point of data collection"
+    },
+    "acceptable-use" => %{
+      slug: "acceptable-use",
+      title: "Acceptable Use Policy",
+      template: "acceptable_use.eex",
+      description: "Rules for acceptable use of the service"
+    }
+  }
+
+  # ===================================
+  # SYSTEM MANAGEMENT
+  # ===================================
+
+  @doc """
+  Check if Legal module is enabled.
+  """
+  @spec enabled?() :: boolean()
+  def enabled? do
+    Settings.get_boolean_setting(@enabled_key, false)
+  end
+
+  @doc """
+  Enable the Legal module.
+
+  Requires Blogging module to be enabled first.
+  Creates the "legal" blog if it doesn't exist.
+
+  ## Returns
+  - `{:ok, :enabled}` - Successfully enabled
+  - `{:error, :blogging_required}` - Blogging module must be enabled first
+  """
+  @spec enable_system() :: {:ok, :enabled} | {:error, :blogging_required | term()}
+  def enable_system do
+    # Check Blogging dependency
+    if blogging_enabled?() do
+      case Settings.update_boolean_setting_with_module(@enabled_key, true, @module_name) do
+        {:ok, _} ->
+          # Ensure legal blog exists
+          ensure_legal_blog()
+          {:ok, :enabled}
+
+        error ->
+          error
+      end
+    else
+      {:error, :blogging_required}
+    end
+  end
+
+  @doc """
+  Disable the Legal module.
+  """
+  @spec disable_system() :: {:ok, term()} | {:error, term()}
+  def disable_system do
+    Settings.update_boolean_setting_with_module(@enabled_key, false, @module_name)
+  end
+
+  # ===================================
+  # CONFIGURATION
+  # ===================================
+
+  @doc """
+  Get the full configuration of the Legal module.
+
+  Returns a map with:
+  - enabled: boolean
+  - frameworks: list of selected framework IDs
+  - company_info: map with company details
+  - dpo_contact: map with DPO contact info
+  - generated_pages: list of generated page slugs
+  - consent_widget_enabled: boolean (Phase 2)
+  """
+  @spec get_config() :: map()
+  def get_config do
+    %{
+      enabled: enabled?(),
+      blogging_enabled: blogging_enabled?(),
+      frameworks: get_selected_frameworks(),
+      company_info: get_company_info(),
+      dpo_contact: get_dpo_contact(),
+      generated_pages: list_generated_pages(),
+      consent_widget_enabled: consent_widget_enabled?(),
+      cookie_banner_position: get_cookie_banner_position()
+    }
+  end
+
+  @doc """
+  Get available compliance frameworks.
+  """
+  @spec available_frameworks() :: map()
+  def available_frameworks, do: @frameworks
+
+  @doc """
+  Get available page types.
+  """
+  @spec available_page_types() :: map()
+  def available_page_types, do: @page_types
+
+  @doc """
+  Get selected compliance frameworks.
+  """
+  @spec get_selected_frameworks() :: list(String.t())
+  def get_selected_frameworks do
+    case Settings.get_json_setting("legal_frameworks", %{"items" => []}) do
+      %{"items" => items} when is_list(items) -> items
+      _ -> []
+    end
+  end
+
+  @doc """
+  Set compliance frameworks.
+
+  ## Parameters
+  - framework_ids: List of framework IDs to enable
+
+  ## Returns
+  - `{:ok, setting}` on success
+  - `{:error, reason}` on failure
+  """
+  @spec set_frameworks(list(String.t())) :: {:ok, term()} | {:error, term()}
+  def set_frameworks(framework_ids) when is_list(framework_ids) do
+    valid_ids = Enum.filter(framework_ids, &Map.has_key?(@frameworks, &1))
+
+    Settings.update_json_setting_with_module(
+      "legal_frameworks",
+      %{"items" => valid_ids},
+      @module_name
+    )
+  end
+
+  @doc """
+  Get company information.
+  """
+  @spec get_company_info() :: map()
+  def get_company_info do
+    default = %{
+      "name" => "",
+      "address_line1" => "",
+      "address_line2" => "",
+      "city" => "",
+      "state" => "",
+      "postal_code" => "",
+      "country" => "",
+      "website_url" => "",
+      "registration_number" => "",
+      "vat_number" => ""
+    }
+
+    Settings.get_json_setting("legal_company_info", default)
+  end
+
+  @doc """
+  Update company information.
+  """
+  @spec update_company_info(map()) :: {:ok, term()} | {:error, term()}
+  def update_company_info(params) when is_map(params) do
+    current = get_company_info()
+    merged = Map.merge(current, stringify_keys(params))
+    Settings.update_json_setting_with_module("legal_company_info", merged, @module_name)
+  end
+
+  @doc """
+  Get Data Protection Officer contact.
+  """
+  @spec get_dpo_contact() :: map()
+  def get_dpo_contact do
+    default = %{
+      "name" => "",
+      "email" => "",
+      "phone" => "",
+      "address" => ""
+    }
+
+    Settings.get_json_setting("legal_dpo_contact", default)
+  end
+
+  @doc """
+  Update DPO contact information.
+  """
+  @spec update_dpo_contact(map()) :: {:ok, term()} | {:error, term()}
+  def update_dpo_contact(params) when is_map(params) do
+    current = get_dpo_contact()
+    merged = Map.merge(current, stringify_keys(params))
+    Settings.update_json_setting_with_module("legal_dpo_contact", merged, @module_name)
+  end
+
+  # ===================================
+  # CONSENT WIDGET (Phase 2)
+  # ===================================
+
+  @doc """
+  Check if consent widget is enabled (Phase 2 feature).
+  """
+  @spec consent_widget_enabled?() :: boolean()
+  def consent_widget_enabled? do
+    Settings.get_boolean_setting("legal_consent_widget_enabled", false)
+  end
+
+  @doc """
+  Get cookie banner position.
+  """
+  @spec get_cookie_banner_position() :: String.t()
+  def get_cookie_banner_position do
+    Settings.get_setting("legal_cookie_banner_position", "bottom")
+  end
+
+  # ===================================
+  # PAGE GENERATION
+  # ===================================
+
+  @doc """
+  Generate a legal page from template.
+
+  ## Parameters
+  - page_type: Page type slug (e.g., "privacy-policy")
+  - opts: Keyword options
+    - :language - Language code (default: "en")
+    - :scope - User scope for audit trail
+
+  ## Returns
+  - `{:ok, post}` on success
+  - `{:error, reason}` on failure
+  """
+  @spec generate_page(String.t(), keyword()) :: {:ok, map()} | {:error, term()}
+  def generate_page(page_type, opts \\ []) do
+    language = Keyword.get(opts, :language, "en")
+    scope = Keyword.get(opts, :scope, nil)
+
+    with {:ok, page_config} <- get_page_config(page_type),
+         {:ok, content} <- render_template(page_config.template) do
+      create_or_update_legal_post(page_config, content, language, scope)
+    end
+  end
+
+  @doc """
+  Generate all required pages for selected frameworks.
+
+  ## Parameters
+  - opts: Keyword options
+    - :language - Language code (default: "en")
+    - :scope - User scope for audit trail
+    - :include_optional - Include optional pages (default: false)
+
+  ## Returns
+  - `{:ok, results}` - Map of page_type => result
+  """
+  @spec generate_all_pages(keyword()) :: {:ok, map()}
+  def generate_all_pages(opts \\ []) do
+    include_optional = Keyword.get(opts, :include_optional, false)
+    frameworks = get_selected_frameworks()
+
+    pages =
+      if include_optional do
+        get_all_pages_for_frameworks(frameworks)
+      else
+        get_required_pages_for_frameworks(frameworks)
+      end
+
+    results =
+      pages
+      |> Enum.map(fn page_type ->
+        {page_type, generate_page(page_type, opts)}
+      end)
+      |> Map.new()
+
+    {:ok, results}
+  end
+
+  @doc """
+  List generated legal pages.
+  """
+  @spec list_generated_pages() :: list(map())
+  def list_generated_pages do
+    if blogging_enabled?() do
+      posts = blogging_module().list_posts(@legal_blog_slug)
+
+      Enum.map(posts, fn post ->
+        %{
+          slug: post.slug,
+          path: post.path,
+          title: get_in(post, [:metadata, :title]) || post.slug,
+          status: get_in(post, [:metadata, :status]) || "draft",
+          updated_at: get_in(post, [:metadata, :updated_at])
+        }
+      end)
+    else
+      []
+    end
+  rescue
+    _ -> []
+  end
+
+  @doc """
+  Get pages required for given frameworks.
+  """
+  @spec get_required_pages_for_frameworks(list(String.t())) :: list(String.t())
+  def get_required_pages_for_frameworks(framework_ids) do
+    framework_ids
+    |> Enum.flat_map(fn id ->
+      case Map.get(@frameworks, id) do
+        nil -> []
+        framework -> framework.required_pages
+      end
+    end)
+    |> Enum.uniq()
+  end
+
+  @doc """
+  Get all pages (required + optional) for given frameworks.
+  """
+  @spec get_all_pages_for_frameworks(list(String.t())) :: list(String.t())
+  def get_all_pages_for_frameworks(framework_ids) do
+    framework_ids
+    |> Enum.flat_map(fn id ->
+      case Map.get(@frameworks, id) do
+        nil -> []
+        framework -> framework.required_pages ++ framework.optional_pages
+      end
+    end)
+    |> Enum.uniq()
+  end
+
+  # ===================================
+  # PRIVATE HELPERS
+  # ===================================
+
+  defp blogging_enabled? do
+    blogging_module().enabled?()
+  rescue
+    _ -> false
+  end
+
+  defp blogging_module do
+    PhoenixKitWeb.Live.Modules.Blogging
+  end
+
+  defp ensure_legal_blog do
+    # First check if legal blog already exists
+    case blogging_module().get_blog(@legal_blog_slug) do
+      {:ok, _existing_blog} ->
+        {:ok, :exists}
+
+      {:error, :not_found} ->
+        # Blog doesn't exist, create it
+        case blogging_module().add_blog("Legal", "slug", @legal_blog_slug) do
+          {:ok, _blog} -> {:ok, :created}
+          {:error, :already_exists} -> {:ok, :exists}
+          {:error, reason} -> {:error, reason}
+        end
+    end
+  rescue
+    e -> {:error, e}
+  end
+
+  defp get_page_config(page_type) do
+    case Map.get(@page_types, page_type) do
+      nil -> {:error, :unknown_page_type}
+      config -> {:ok, config}
+    end
+  end
+
+  defp render_template(template_name) do
+    context = build_template_context()
+    TemplateGenerator.render(template_name, context)
+  end
+
+  defp build_template_context do
+    company = get_company_info()
+    dpo = get_dpo_contact()
+    frameworks = get_selected_frameworks()
+
+    # Format full address from individual fields
+    company_address = format_company_address(company)
+
+    %{
+      company_name: company["name"] || "",
+      company_address: company_address,
+      company_country: get_country_name(company["country"]),
+      company_website: company["website_url"] || "",
+      registration_number: company["registration_number"] || "",
+      vat_number: company["vat_number"] || "",
+      dpo_name: dpo["name"] || "",
+      dpo_email: dpo["email"] || "",
+      dpo_phone: dpo["phone"] || "",
+      dpo_address: dpo["address"] || "",
+      frameworks: frameworks,
+      effective_date: Date.utc_today() |> Date.to_string()
+    }
+  end
+
+  defp format_company_address(company) do
+    [
+      company["address_line1"],
+      company["address_line2"],
+      [company["city"], company["state"]]
+      |> Enum.reject(&(&1 == "" or is_nil(&1)))
+      |> Enum.join(", "),
+      company["postal_code"],
+      get_country_name(company["country"])
+    ]
+    |> Enum.reject(&(&1 == "" or is_nil(&1)))
+    |> Enum.join("\n")
+  end
+
+  defp get_country_name(nil), do: ""
+  defp get_country_name(""), do: ""
+
+  defp get_country_name(country_code) do
+    case BeamLabCountries.get(country_code) do
+      nil -> country_code
+      country -> country.name
+    end
+  end
+
+  defp create_or_update_legal_post(page_config, content, _language, scope) do
+    # Build the full markdown content with title
+    full_content = "# #{page_config.title}\n\n#{content}"
+
+    # Check if post already exists
+    case blogging_module().read_post(@legal_blog_slug, page_config.slug) do
+      {:ok, existing_post} ->
+        # Update existing post
+        blogging_module().update_post(
+          @legal_blog_slug,
+          existing_post,
+          %{
+            "content" => full_content,
+            "status" => "draft"
+          },
+          scope: scope
+        )
+
+      {:error, :not_found} ->
+        # Create new post
+        blogging_module().create_post(@legal_blog_slug, %{
+          title: page_config.title,
+          slug: page_config.slug,
+          scope: scope
+        })
+        |> case do
+          {:ok, post} ->
+            # Update with content
+            blogging_module().update_post(
+              @legal_blog_slug,
+              post,
+              %{"content" => full_content, "status" => "draft"},
+              scope: scope
+            )
+
+          error ->
+            error
+        end
+
+      error ->
+        error
+    end
+  rescue
+    e -> {:error, e}
+  end
+
+  defp stringify_keys(map) when is_map(map) do
+    Map.new(map, fn
+      {k, v} when is_atom(k) -> {Atom.to_string(k), v}
+      {k, v} -> {k, v}
+    end)
+  end
+end

--- a/lib/modules/legal/schemas/consent_log.ex
+++ b/lib/modules/legal/schemas/consent_log.ex
@@ -1,0 +1,262 @@
+defmodule PhoenixKit.Modules.Legal.ConsentLog do
+  @moduledoc """
+  Schema for consent log entries.
+
+  Tracks user consent for cookies and data processing, supporting GDPR, CCPA,
+  and other privacy regulations.
+
+  ## Fields
+    * `user_id` - The ID of the logged-in user (nil for anonymous)
+    * `session_id` - Session identifier for anonymous tracking
+    * `consent_type` - Type of consent (necessary, analytics, marketing, preferences)
+    * `consent_given` - Whether consent was given
+    * `consent_version` - Version of privacy/cookie policy
+    * `ip_address` - IP address when consent was recorded
+    * `user_agent_hash` - SHA256 hash of user agent for fingerprinting
+    * `metadata` - Additional metadata about the consent
+
+  ## Consent Types
+    * `necessary` - Essential cookies (always required)
+    * `analytics` - Performance and analytics cookies
+    * `marketing` - Advertising and targeting cookies
+    * `preferences` - Functionality and preference cookies
+
+  ## Usage
+
+      # Log consent for anonymous user
+      ConsentLog.create(%{
+        session_id: "abc123",
+        consent_type: "analytics",
+        consent_given: true,
+        consent_version: "1.0",
+        ip_address: "192.168.1.1"
+      })
+
+      # Log consent for logged-in user
+      ConsentLog.create(%{
+        user_id: 123,
+        consent_type: "marketing",
+        consent_given: false
+      })
+
+      # Get current consent status
+      ConsentLog.get_consent_status(user_id: 123)
+      ConsentLog.get_consent_status(session_id: "abc123")
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+  import Ecto.Query, warn: false
+
+  @type t :: %__MODULE__{
+          id: integer() | nil,
+          uuid: Ecto.UUID.t() | nil,
+          user_id: integer() | nil,
+          session_id: String.t() | nil,
+          consent_type: String.t(),
+          consent_given: boolean(),
+          consent_version: String.t() | nil,
+          ip_address: String.t() | nil,
+          user_agent_hash: String.t() | nil,
+          metadata: map() | nil,
+          inserted_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+
+  @consent_types ["necessary", "analytics", "marketing", "preferences"]
+
+  schema "phoenix_kit_consent_logs" do
+    field :uuid, Ecto.UUID
+    field :user_id, :integer
+    field :session_id, :string
+    field :consent_type, :string
+    field :consent_given, :boolean, default: false
+    field :consent_version, :string
+    field :ip_address, :string
+    field :user_agent_hash, :string
+    field :metadata, :map, default: %{}
+
+    timestamps(type: :utc_datetime_usec)
+  end
+
+  @doc """
+  Returns valid consent types.
+  """
+  @spec consent_types() :: list(String.t())
+  def consent_types, do: @consent_types
+
+  @doc """
+  Creates a changeset for consent log entry.
+
+  ## Required Fields
+    * `:consent_type` - Type of consent
+
+  ## Optional Fields
+    * `:user_id` - User ID (for logged-in users)
+    * `:session_id` - Session ID (for anonymous users)
+    * `:consent_given` - Whether consent was given (default: false)
+    * `:consent_version` - Version of policy
+    * `:ip_address` - IP address
+    * `:user_agent_hash` - Hashed user agent
+    * `:metadata` - Additional metadata
+  """
+  @spec changeset(t(), map()) :: Ecto.Changeset.t()
+  def changeset(consent_log, attrs) do
+    consent_log
+    |> cast(attrs, [
+      :user_id,
+      :session_id,
+      :consent_type,
+      :consent_given,
+      :consent_version,
+      :ip_address,
+      :user_agent_hash,
+      :metadata
+    ])
+    |> validate_required([:consent_type])
+    |> validate_inclusion(:consent_type, @consent_types)
+    |> validate_user_or_session()
+    |> maybe_generate_uuid()
+  end
+
+  # Validate that either user_id or session_id is present
+  defp validate_user_or_session(changeset) do
+    user_id = get_field(changeset, :user_id)
+    session_id = get_field(changeset, :session_id)
+
+    if is_nil(user_id) and is_nil(session_id) do
+      add_error(changeset, :base, "Either user_id or session_id must be present")
+    else
+      changeset
+    end
+  end
+
+  # Generate UUIDv7 if not present
+  defp maybe_generate_uuid(changeset) do
+    if get_field(changeset, :uuid) do
+      changeset
+    else
+      put_change(changeset, :uuid, generate_uuidv7())
+    end
+  end
+
+  # Generate UUIDv7 (time-ordered)
+  defp generate_uuidv7 do
+    # Use Ecto.UUID.generate for now, replace with proper UUIDv7 if needed
+    Ecto.UUID.generate()
+  end
+
+  # ===================================
+  # CRUD OPERATIONS
+  # ===================================
+
+  @doc """
+  Create a new consent log entry.
+  """
+  @spec create(map()) :: {:ok, t()} | {:error, Ecto.Changeset.t()}
+  def create(attrs) do
+    %__MODULE__{}
+    |> changeset(attrs)
+    |> repo().insert()
+  end
+
+  @doc """
+  Get consent status for a user or session.
+
+  Returns a map of consent_type => consent_given for the most recent entries.
+
+  ## Options
+    * `:user_id` - Get consent for logged-in user
+    * `:session_id` - Get consent for anonymous session
+  """
+  @spec get_consent_status(keyword()) :: map()
+  def get_consent_status(opts) do
+    user_id = Keyword.get(opts, :user_id)
+    session_id = Keyword.get(opts, :session_id)
+
+    query =
+      from(c in __MODULE__,
+        select: %{consent_type: c.consent_type, consent_given: c.consent_given},
+        order_by: [desc: c.inserted_at]
+      )
+
+    query =
+      cond do
+        user_id -> where(query, [c], c.user_id == ^user_id)
+        session_id -> where(query, [c], c.session_id == ^session_id)
+        true -> query
+      end
+
+    query
+    |> repo().all()
+    |> Enum.uniq_by(& &1.consent_type)
+    |> Map.new(fn %{consent_type: type, consent_given: given} -> {type, given} end)
+  rescue
+    _ -> %{}
+  end
+
+  @doc """
+  Log consent for multiple types at once.
+
+  ## Parameters
+    * `consents` - Map of consent_type => consent_given
+    * `opts` - Options including :user_id, :session_id, :ip_address, etc.
+
+  ## Example
+
+      ConsentLog.log_consents(
+        %{"analytics" => true, "marketing" => false},
+        user_id: 123,
+        consent_version: "1.0"
+      )
+  """
+  @spec log_consents(map(), keyword()) :: {:ok, list(t())} | {:error, term()}
+  def log_consents(consents, opts) when is_map(consents) do
+    base_attrs = %{
+      user_id: Keyword.get(opts, :user_id),
+      session_id: Keyword.get(opts, :session_id),
+      consent_version: Keyword.get(opts, :consent_version),
+      ip_address: Keyword.get(opts, :ip_address),
+      user_agent_hash: Keyword.get(opts, :user_agent_hash),
+      metadata: Keyword.get(opts, :metadata, %{})
+    }
+
+    results =
+      Enum.map(consents, fn {consent_type, consent_given} ->
+        attrs =
+          Map.merge(base_attrs, %{
+            consent_type: consent_type,
+            consent_given: consent_given
+          })
+
+        create(attrs)
+      end)
+
+    errors = Enum.filter(results, &match?({:error, _}, &1))
+
+    if Enum.empty?(errors) do
+      {:ok, Enum.map(results, fn {:ok, log} -> log end)}
+    else
+      {:error, errors}
+    end
+  end
+
+  @doc """
+  Hash user agent string for privacy-focused storage.
+  """
+  @spec hash_user_agent(String.t()) :: String.t()
+  def hash_user_agent(user_agent) when is_binary(user_agent) do
+    :crypto.hash(:sha256, user_agent)
+    |> Base.encode16(case: :lower)
+  end
+
+  def hash_user_agent(_), do: nil
+
+  # ===================================
+  # PRIVATE HELPERS
+  # ===================================
+
+  defp repo do
+    PhoenixKit.RepoHelper.repo()
+  end
+end

--- a/lib/modules/legal/services/template_generator.ex
+++ b/lib/modules/legal/services/template_generator.ex
@@ -1,0 +1,186 @@
+defmodule PhoenixKit.Modules.Legal.TemplateGenerator do
+  @moduledoc """
+  Generates legal page content from EEx templates.
+
+  Templates are loaded from:
+  1. Parent application's `priv/legal_templates/` (for customization)
+  2. PhoenixKit's bundled templates in `priv/legal_templates/`
+
+  ## Template Variables
+
+  All templates receive these variables:
+    * `@company_name` - Company name
+    * `@company_address` - Company address
+    * `@company_country` - Company country
+    * `@company_website` - Company website URL
+    * `@registration_number` - Company registration number
+    * `@vat_number` - VAT number
+    * `@dpo_name` - Data Protection Officer name
+    * `@dpo_email` - DPO email
+    * `@dpo_phone` - DPO phone
+    * `@dpo_address` - DPO address
+    * `@frameworks` - List of selected framework IDs
+    * `@effective_date` - Current date in ISO format
+
+  ## Usage
+
+      context = %{
+        company_name: "Acme Corp",
+        company_address: "123 Main St",
+        effective_date: "2025-01-15"
+      }
+
+      {:ok, content} = TemplateGenerator.render("privacy_policy.eex", context)
+  """
+
+  require Logger
+
+  @templates_dir "legal_templates"
+
+  @doc """
+  Render a template with the given context.
+
+  ## Parameters
+    * `template_name` - Template filename (e.g., "privacy_policy.eex")
+    * `context` - Map of variables to pass to the template
+
+  ## Returns
+    * `{:ok, content}` - Rendered content
+    * `{:error, reason}` - Error reason
+  """
+  @spec render(String.t(), map()) :: {:ok, String.t()} | {:error, term()}
+  def render(template_name, context) when is_map(context) do
+    template_path = get_template_path(template_name)
+
+    if File.exists?(template_path) do
+      try do
+        # Convert context map to keyword list for EEx
+        assigns = Enum.map(context, fn {k, v} -> {to_atom(k), v} end)
+        content = EEx.eval_file(template_path, assigns: assigns)
+        {:ok, content}
+      rescue
+        e in EEx.SyntaxError ->
+          Logger.error("Template syntax error in #{template_name}: #{inspect(e)}")
+          {:error, {:syntax_error, e.message}}
+
+        e ->
+          Logger.error("Template rendering error in #{template_name}: #{inspect(e)}")
+          {:error, {:render_error, Exception.message(e)}}
+      end
+    else
+      Logger.warning("Template not found: #{template_path}")
+      {:error, :template_not_found}
+    end
+  end
+
+  @doc """
+  Get the full path to a template file.
+
+  Checks parent application first, then falls back to PhoenixKit templates.
+  """
+  @spec get_template_path(String.t()) :: String.t()
+  def get_template_path(template_name) do
+    # Try parent application first
+    case get_parent_template_path(template_name) do
+      {:ok, path} -> path
+      :error -> get_phoenix_kit_template_path(template_name)
+    end
+  end
+
+  @doc """
+  List all available templates.
+  """
+  @spec list_available_templates() :: list(String.t())
+  def list_available_templates do
+    phoenix_kit_templates = list_phoenix_kit_templates()
+    parent_templates = list_parent_templates()
+
+    (phoenix_kit_templates ++ parent_templates)
+    |> Enum.uniq()
+    |> Enum.sort()
+  end
+
+  @doc """
+  Check if a template exists.
+  """
+  @spec template_exists?(String.t()) :: boolean()
+  def template_exists?(template_name) do
+    get_template_path(template_name)
+    |> File.exists?()
+  end
+
+  # ===================================
+  # PRIVATE HELPERS
+  # ===================================
+
+  defp get_parent_template_path(template_name) do
+    case PhoenixKit.Config.get_parent_app() do
+      nil ->
+        :error
+
+      app ->
+        try do
+          priv_dir = Application.app_dir(app, "priv")
+          path = Path.join([priv_dir, @templates_dir, template_name])
+
+          if File.exists?(path) do
+            {:ok, path}
+          else
+            :error
+          end
+        rescue
+          _ -> :error
+        end
+    end
+  end
+
+  defp get_phoenix_kit_template_path(template_name) do
+    priv_dir = :code.priv_dir(:phoenix_kit) |> to_string()
+    Path.join([priv_dir, @templates_dir, template_name])
+  rescue
+    _ ->
+      # Fallback for development
+      Path.join(["priv", @templates_dir, template_name])
+  end
+
+  defp list_phoenix_kit_templates do
+    priv_dir = :code.priv_dir(:phoenix_kit) |> to_string()
+    templates_dir = Path.join(priv_dir, @templates_dir)
+
+    if File.dir?(templates_dir) do
+      templates_dir
+      |> File.ls!()
+      |> Enum.filter(&String.ends_with?(&1, ".eex"))
+    else
+      []
+    end
+  rescue
+    _ -> []
+  end
+
+  defp list_parent_templates do
+    case PhoenixKit.Config.get_parent_app() do
+      nil ->
+        []
+
+      app ->
+        try do
+          priv_dir = Application.app_dir(app, "priv")
+          templates_dir = Path.join(priv_dir, @templates_dir)
+
+          if File.dir?(templates_dir) do
+            templates_dir
+            |> File.ls!()
+            |> Enum.filter(&String.ends_with?(&1, ".eex"))
+          else
+            []
+          end
+        rescue
+          _ -> []
+        end
+    end
+  end
+
+  defp to_atom(key) when is_atom(key), do: key
+  defp to_atom(key) when is_binary(key), do: String.to_atom(key)
+end

--- a/lib/modules/legal/web/settings.ex
+++ b/lib/modules/legal/web/settings.ex
@@ -1,0 +1,229 @@
+defmodule PhoenixKitWeb.Live.Modules.Legal.Settings do
+  @moduledoc """
+  LiveView for Legal module settings and page generation.
+
+  Route: {prefix}/admin/settings/legal
+
+  Sections:
+  1. Module enable/disable (with Blogging dependency check)
+  2. Compliance framework selection
+  3. Company information form
+  4. DPO contact form
+  5. Page generation controls
+  6. Generated pages list
+  """
+  use PhoenixKitWeb, :live_view
+  use Gettext, backend: PhoenixKitWeb.Gettext
+
+  alias PhoenixKit.Billing.CountryData
+  alias PhoenixKit.Modules.Legal
+  alias PhoenixKit.Settings
+  alias PhoenixKit.Utils.Routes
+
+  @impl true
+  def mount(_params, _session, socket) do
+    config = Legal.get_config()
+
+    socket =
+      socket
+      |> assign(:project_title, Settings.get_setting("project_title", "PhoenixKit"))
+      |> assign(:page_title, gettext("Legal Settings"))
+      |> assign(
+        :current_path,
+        Routes.path("/admin/settings/legal", locale: socket.assigns[:current_locale_base])
+      )
+      |> assign(:blogging_enabled, config.blogging_enabled)
+      |> assign(:legal_enabled, config.enabled)
+      |> assign(:available_frameworks, Legal.available_frameworks())
+      |> assign(:available_page_types, Legal.available_page_types())
+      |> assign(:selected_frameworks, config.frameworks)
+      |> assign(:company_info, config.company_info)
+      |> assign(:countries, CountryData.countries_for_select())
+      |> assign(
+        :subdivision_label,
+        CountryData.get_subdivision_label(config.company_info["country"])
+      )
+      |> assign(:dpo_contact, config.dpo_contact)
+      |> assign(:generated_pages, config.generated_pages)
+      |> assign(:generating, false)
+
+    {:ok, socket}
+  end
+
+  @impl true
+  def handle_params(_params, _uri, socket), do: {:noreply, socket}
+
+  @impl true
+  def handle_event("toggle_legal", _params, socket) do
+    if socket.assigns.legal_enabled do
+      case Legal.disable_system() do
+        {:ok, _} ->
+          {:noreply,
+           socket
+           |> assign(:legal_enabled, false)
+           |> put_flash(:info, gettext("Legal module disabled"))}
+
+        {:error, _} ->
+          {:noreply, put_flash(socket, :error, gettext("Failed to disable Legal module"))}
+      end
+    else
+      case Legal.enable_system() do
+        {:ok, _} ->
+          {:noreply,
+           socket
+           |> assign(:legal_enabled, true)
+           |> put_flash(:info, gettext("Legal module enabled"))}
+
+        {:error, :blogging_required} ->
+          {:noreply, put_flash(socket, :error, gettext("Please enable Blogging module first"))}
+
+        {:error, _} ->
+          {:noreply, put_flash(socket, :error, gettext("Failed to enable Legal module"))}
+      end
+    end
+  end
+
+  @impl true
+  def handle_event("toggle_framework", %{"id" => framework_id}, socket) do
+    current = socket.assigns.selected_frameworks
+
+    updated =
+      if framework_id in current do
+        List.delete(current, framework_id)
+      else
+        [framework_id | current]
+      end
+
+    case Legal.set_frameworks(updated) do
+      {:ok, _} ->
+        {:noreply, assign(socket, :selected_frameworks, updated)}
+
+      {:error, _} ->
+        {:noreply, put_flash(socket, :error, gettext("Failed to save frameworks"))}
+    end
+  end
+
+  @impl true
+  def handle_event("save_company_info", params, socket) do
+    company_info = build_company_info(params)
+
+    case Legal.update_company_info(company_info) do
+      {:ok, _} ->
+        {:noreply,
+         socket
+         |> assign(:company_info, company_info)
+         |> assign(:subdivision_label, CountryData.get_subdivision_label(company_info["country"]))
+         |> put_flash(:info, gettext("Company information saved"))}
+
+      {:error, _} ->
+        {:noreply, put_flash(socket, :error, gettext("Failed to save company information"))}
+    end
+  end
+
+  @impl true
+  def handle_event("update_country", %{"company_country" => country_code}, socket) do
+    {:noreply,
+     assign(socket, :subdivision_label, CountryData.get_subdivision_label(country_code))}
+  end
+
+  @impl true
+  def handle_event("save_dpo_contact", params, socket) do
+    dpo_contact = %{
+      "name" => params["dpo_name"] || "",
+      "email" => params["dpo_email"] || "",
+      "phone" => params["dpo_phone"] || "",
+      "address" => params["dpo_address"] || ""
+    }
+
+    case Legal.update_dpo_contact(dpo_contact) do
+      {:ok, _} ->
+        {:noreply,
+         socket
+         |> assign(:dpo_contact, dpo_contact)
+         |> put_flash(:info, gettext("DPO contact saved"))}
+
+      {:error, _} ->
+        {:noreply, put_flash(socket, :error, gettext("Failed to save DPO contact"))}
+    end
+  end
+
+  @impl true
+  def handle_event("generate_page", %{"page_type" => page_type}, socket) do
+    socket = assign(socket, :generating, true)
+
+    case Legal.generate_page(page_type, scope: socket.assigns[:current_scope]) do
+      {:ok, _post} ->
+        {:noreply,
+         socket
+         |> assign(:generating, false)
+         |> assign(:generated_pages, Legal.list_generated_pages())
+         |> put_flash(:info, gettext("Page generated successfully"))}
+
+      {:error, reason} ->
+        {:noreply,
+         socket
+         |> assign(:generating, false)
+         |> put_flash(
+           :error,
+           gettext("Failed to generate page: %{reason}", reason: inspect(reason))
+         )}
+    end
+  end
+
+  @impl true
+  def handle_event("generate_all_pages", _params, socket) do
+    socket = assign(socket, :generating, true)
+
+    {:ok, results} = Legal.generate_all_pages(scope: socket.assigns[:current_scope])
+
+    success_count =
+      results
+      |> Enum.count(fn {_, result} -> match?({:ok, _}, result) end)
+
+    {:noreply,
+     socket
+     |> assign(:generating, false)
+     |> assign(:generated_pages, Legal.list_generated_pages())
+     |> put_flash(:info, gettext("Generated %{count} pages", count: success_count))}
+  end
+
+  # Helper to get edit URL for a legal page
+  defp get_edit_url(page_slug, generated_pages) do
+    case Enum.find(generated_pages, fn p -> p.slug == page_slug end) do
+      nil ->
+        Routes.path("/admin/blogging/legal")
+
+      page ->
+        Routes.path("/admin/blogging/legal/edit?path=#{URI.encode(page.path)}")
+    end
+  end
+
+  # Helper to check if a page is generated
+  defp page_generated?(page_slug, generated_pages) do
+    Enum.any?(generated_pages, fn p -> p.slug == page_slug end)
+  end
+
+  # Helper to get page status
+  defp get_page_status(page_slug, generated_pages) do
+    case Enum.find(generated_pages, fn p -> p.slug == page_slug end) do
+      nil -> nil
+      page -> page.status
+    end
+  end
+
+  # Helper to build company info map from params
+  defp build_company_info(params) do
+    %{
+      "name" => params["company_name"] || "",
+      "address_line1" => params["company_address_line1"] || "",
+      "address_line2" => params["company_address_line2"] || "",
+      "city" => params["company_city"] || "",
+      "state" => params["company_state"] || "",
+      "postal_code" => params["company_postal_code"] || "",
+      "country" => params["company_country"] || "",
+      "website_url" => params["company_website"] || "",
+      "registration_number" => params["registration_number"] || "",
+      "vat_number" => params["vat_number"] || ""
+    }
+  end
+end

--- a/lib/modules/legal/web/settings.html.heex
+++ b/lib/modules/legal/web/settings.html.heex
@@ -1,0 +1,497 @@
+<PhoenixKitWeb.Components.LayoutWrapper.app_layout
+  flash={@flash}
+  phoenix_kit_current_scope={assigns[:phoenix_kit_current_scope]}
+  page_title={@page_title}
+  current_path={@current_path}
+  project_title={@project_title}
+  current_locale={@current_locale}
+>
+  <div class="container flex flex-col mx-auto px-4 py-6">
+    <%!-- Header Section --%>
+    <header class="w-full relative mb-6">
+      <%!-- Back Button (Left aligned) --%>
+      <.link
+        navigate={PhoenixKit.Utils.Routes.path("/admin/settings", locale: @current_locale_base)}
+        class="btn btn-outline btn-primary btn-sm absolute left-0 top-0 -mb-12"
+      >
+        <.icon name="hero-arrow-left" class="w-4 h-4" /> Back to Settings
+      </.link>
+
+      <%!-- Title Section --%>
+      <div class="text-center">
+        <h1 class="text-4xl font-bold text-base-content mb-3">{gettext("Legal Settings")}</h1>
+        <p class="text-lg text-base-content">
+          {gettext(
+            "Configure compliance frameworks, company information, and generate legal pages."
+          )}
+        </p>
+      </div>
+    </header>
+
+    <div class="max-w-4xl mx-auto space-y-6">
+      <%!-- Module Toggle --%>
+      <div class="flex items-center justify-between bg-base-200 p-4 rounded-lg">
+        <div>
+          <h2 class="font-semibold">{gettext("Legal Module")}</h2>
+          <p class="text-sm text-base-content/60">
+            {gettext("Enable or disable the Legal module")}
+          </p>
+        </div>
+        <div class="form-control">
+          <label class="label cursor-pointer gap-4">
+            <input
+              type="checkbox"
+              class="toggle toggle-primary"
+              checked={@legal_enabled}
+              phx-click="toggle_legal"
+              disabled={not @blogging_enabled}
+            />
+          </label>
+        </div>
+      </div>
+
+      <%!-- Blogging Dependency Warning --%>
+      <%= if not @blogging_enabled do %>
+        <div class="alert alert-warning">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            class="stroke-current shrink-0 h-6 w-6"
+            fill="none"
+            viewBox="0 0 24 24"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+            />
+          </svg>
+          <span>
+            {gettext("Blogging module is required for Legal pages. Please enable Blogging first.")}
+          </span>
+          <.link
+            navigate={PhoenixKit.Utils.Routes.path("/admin/settings/blogging")}
+            class="btn btn-sm"
+          >
+            {gettext("Enable Blogging")}
+          </.link>
+        </div>
+      <% end %>
+
+      <%= if @legal_enabled do %>
+        <%!-- Section 1: Compliance Frameworks --%>
+        <div class="card bg-base-100 shadow">
+          <div class="card-body">
+            <h2 class="card-title">{gettext("Compliance Frameworks")}</h2>
+            <p class="text-sm text-base-content/60 mb-4">
+              {gettext("Select the privacy regulations your application must comply with.")}
+            </p>
+
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <%= for {id, framework} <- @available_frameworks do %>
+                <label class={"flex items-start gap-3 p-4 border rounded-lg cursor-pointer hover:bg-base-200 transition-colors #{if id in @selected_frameworks, do: "border-primary bg-primary/5", else: "border-base-300"}"}>
+                  <input
+                    type="checkbox"
+                    class="checkbox checkbox-primary checkbox-sm mt-0.5 shrink-0"
+                    checked={id in @selected_frameworks}
+                    phx-click="toggle_framework"
+                    phx-value-id={id}
+                  />
+                  <div class="min-w-0 flex-1">
+                    <div class="font-medium text-sm">{framework.name}</div>
+                    <div class="text-xs text-base-content/60 mt-1">
+                      {framework.description}
+                    </div>
+                  </div>
+                </label>
+              <% end %>
+            </div>
+          </div>
+        </div>
+
+        <%!-- Section 2: Company Information --%>
+        <div class="card bg-base-100 shadow">
+          <div class="card-body">
+            <h2 class="card-title">{gettext("Company Information")}</h2>
+            <p class="text-sm text-base-content/60 mb-4">
+              {gettext("This information will appear in your legal documents.")}
+            </p>
+
+            <form phx-submit="save_company_info">
+              <div class="space-y-4">
+                <%!-- Company Name & Website row --%>
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <div class="form-control">
+                    <label class="label">
+                      <span class="label-text">{gettext("Company Name")}</span>
+                    </label>
+                    <input
+                      type="text"
+                      name="company_name"
+                      value={@company_info["name"]}
+                      class="input input-bordered"
+                      placeholder="Acme Corp"
+                    />
+                  </div>
+
+                  <div class="form-control">
+                    <label class="label">
+                      <span class="label-text">{gettext("Website URL")}</span>
+                    </label>
+                    <input
+                      type="url"
+                      name="company_website"
+                      value={@company_info["website_url"]}
+                      class="input input-bordered"
+                      placeholder="https://example.com"
+                    />
+                  </div>
+                </div>
+
+                <%!-- Address Line 1 --%>
+                <div class="form-control">
+                  <label class="label">
+                    <span class="label-text">{gettext("Address Line 1")}</span>
+                  </label>
+                  <input
+                    type="text"
+                    name="company_address_line1"
+                    value={@company_info["address_line1"]}
+                    class="input input-bordered"
+                    placeholder="123 Business Street"
+                  />
+                </div>
+
+                <%!-- Address Line 2 --%>
+                <div class="form-control">
+                  <label class="label">
+                    <span class="label-text">{gettext("Address Line 2")}</span>
+                  </label>
+                  <input
+                    type="text"
+                    name="company_address_line2"
+                    value={@company_info["address_line2"]}
+                    class="input input-bordered"
+                    placeholder={gettext("Suite, Floor, Building (optional)")}
+                  />
+                </div>
+
+                <%!-- City + State row --%>
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <div class="form-control">
+                    <label class="label">
+                      <span class="label-text">{gettext("City")}</span>
+                    </label>
+                    <input
+                      type="text"
+                      name="company_city"
+                      value={@company_info["city"]}
+                      class="input input-bordered"
+                      placeholder="Tallinn"
+                    />
+                  </div>
+
+                  <div class="form-control">
+                    <label class="label">
+                      <span class="label-text">{@subdivision_label}</span>
+                    </label>
+                    <input
+                      type="text"
+                      name="company_state"
+                      value={@company_info["state"]}
+                      class="input input-bordered"
+                      placeholder={gettext("(optional)")}
+                    />
+                  </div>
+                </div>
+
+                <%!-- Postal Code + Country row --%>
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <div class="form-control">
+                    <label class="label">
+                      <span class="label-text">{gettext("Postal Code")}</span>
+                    </label>
+                    <input
+                      type="text"
+                      name="company_postal_code"
+                      value={@company_info["postal_code"]}
+                      class="input input-bordered font-mono"
+                      placeholder="10115"
+                    />
+                  </div>
+
+                  <div class="form-control">
+                    <label class="label">
+                      <span class="label-text">{gettext("Country")}</span>
+                    </label>
+                    <select
+                      name="company_country"
+                      class="select select-bordered"
+                      phx-change="update_country"
+                    >
+                      <option value="">{gettext("Select country...")}</option>
+                      <%= for {name, code} <- @countries do %>
+                        <option value={code} selected={@company_info["country"] == code}>
+                          {name}
+                        </option>
+                      <% end %>
+                    </select>
+                  </div>
+                </div>
+
+                <%!-- Registration Number + VAT row --%>
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <div class="form-control">
+                    <label class="label">
+                      <span class="label-text">{gettext("Registration Number")}</span>
+                    </label>
+                    <input
+                      type="text"
+                      name="registration_number"
+                      value={@company_info["registration_number"]}
+                      class="input input-bordered"
+                    />
+                  </div>
+
+                  <div class="form-control">
+                    <label class="label">
+                      <span class="label-text">{gettext("VAT Number")}</span>
+                    </label>
+                    <input
+                      type="text"
+                      name="vat_number"
+                      value={@company_info["vat_number"]}
+                      class="input input-bordered"
+                      placeholder="EE123456789"
+                    />
+                  </div>
+                </div>
+              </div>
+
+              <div class="card-actions justify-end mt-4">
+                <button type="submit" class="btn btn-primary">
+                  {gettext("Save Company Info")}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+
+        <%!-- Section 3: DPO Contact --%>
+        <div class="card bg-base-100 shadow">
+          <div class="card-body">
+            <h2 class="card-title">{gettext("Data Protection Officer (DPO)")}</h2>
+            <p class="text-sm text-base-content/60 mb-4">
+              {gettext("Required for GDPR compliance. Leave empty if not applicable.")}
+            </p>
+
+            <form phx-submit="save_dpo_contact">
+              <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div class="form-control">
+                  <label class="label">
+                    <span class="label-text">{gettext("DPO Name")}</span>
+                  </label>
+                  <input
+                    type="text"
+                    name="dpo_name"
+                    value={@dpo_contact["name"]}
+                    class="input input-bordered"
+                  />
+                </div>
+
+                <div class="form-control">
+                  <label class="label">
+                    <span class="label-text">{gettext("DPO Email")}</span>
+                  </label>
+                  <input
+                    type="email"
+                    name="dpo_email"
+                    value={@dpo_contact["email"]}
+                    class="input input-bordered"
+                    placeholder="dpo@example.com"
+                  />
+                </div>
+
+                <div class="form-control">
+                  <label class="label">
+                    <span class="label-text">{gettext("DPO Phone")}</span>
+                  </label>
+                  <input
+                    type="tel"
+                    name="dpo_phone"
+                    value={@dpo_contact["phone"]}
+                    class="input input-bordered"
+                  />
+                </div>
+
+                <div class="form-control">
+                  <label class="label">
+                    <span class="label-text">{gettext("DPO Address")}</span>
+                  </label>
+                  <input
+                    type="text"
+                    name="dpo_address"
+                    value={@dpo_contact["address"]}
+                    class="input input-bordered"
+                  />
+                </div>
+              </div>
+
+              <div class="card-actions justify-end mt-4">
+                <button type="submit" class="btn btn-primary">
+                  {gettext("Save DPO Contact")}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+
+        <%!-- Section 4: Page Generation --%>
+        <div class="card bg-base-100 shadow">
+          <div class="card-body">
+            <div class="flex items-center justify-between">
+              <div>
+                <h2 class="card-title">{gettext("Legal Pages")}</h2>
+                <p class="text-sm text-base-content/60">
+                  {gettext("Generate legal pages based on selected frameworks.")}
+                </p>
+              </div>
+              <button
+                phx-click="generate_all_pages"
+                class="btn btn-primary"
+                disabled={@generating or Enum.empty?(@selected_frameworks)}
+              >
+                <%= if @generating do %>
+                  <span class="loading loading-spinner loading-sm"></span>
+                <% end %>
+                {gettext("Generate All Required Pages")}
+              </button>
+            </div>
+
+            <div class="divider"></div>
+
+            <%= if Enum.empty?(@selected_frameworks) do %>
+              <div class="alert alert-info">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  class="stroke-current shrink-0 w-6 h-6"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                  >
+                  </path>
+                </svg>
+                <span>
+                  {gettext("Select compliance frameworks above to see required pages.")}
+                </span>
+              </div>
+            <% else %>
+              <div class="overflow-x-auto">
+                <table class="table">
+                  <thead>
+                    <tr>
+                      <th>{gettext("Page")}</th>
+                      <th>{gettext("Required By")}</th>
+                      <th>{gettext("Status")}</th>
+                      <th class="text-right">{gettext("Actions")}</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <%= for {page_type, page_config} <- @available_page_types do %>
+                      <% required_by =
+                        Enum.filter(@selected_frameworks, fn fw_id ->
+                          fw = @available_frameworks[fw_id]
+                          fw && page_type in (fw.required_pages ++ fw.optional_pages)
+                        end) %>
+                      <%= if not Enum.empty?(required_by) do %>
+                        <tr>
+                          <td>
+                            <div class="font-medium">{page_config.title}</div>
+                            <div class="text-xs text-base-content/60">
+                              {page_config.description}
+                            </div>
+                          </td>
+                          <td>
+                            <div class="flex flex-wrap gap-1">
+                              <%= for fw_id <- required_by do %>
+                                <% fw = @available_frameworks[fw_id] %>
+                                <span class={"badge badge-sm #{if page_type in fw.required_pages, do: "badge-primary", else: "badge-ghost"}"}>
+                                  {fw_id}
+                                </span>
+                              <% end %>
+                            </div>
+                          </td>
+                          <td>
+                            <%= if page_generated?(page_type, @generated_pages) do %>
+                              <% status = get_page_status(page_type, @generated_pages) %>
+                              <span class={"badge #{if status == "published", do: "badge-success", else: "badge-warning"}"}>
+                                {status}
+                              </span>
+                            <% else %>
+                              <span class="badge badge-ghost">{gettext("Not generated")}</span>
+                            <% end %>
+                          </td>
+                          <td class="text-right">
+                            <div class="flex justify-end gap-2">
+                              <%= if page_generated?(page_type, @generated_pages) do %>
+                                <.link
+                                  navigate={get_edit_url(page_type, @generated_pages)}
+                                  class="btn btn-sm btn-ghost"
+                                >
+                                  {gettext("Edit")}
+                                </.link>
+                              <% end %>
+                              <button
+                                phx-click="generate_page"
+                                phx-value-page_type={page_type}
+                                class="btn btn-sm btn-outline"
+                                disabled={@generating}
+                              >
+                                {if page_generated?(page_type, @generated_pages),
+                                  do: gettext("Regenerate"),
+                                  else: gettext("Generate")}
+                              </button>
+                            </div>
+                          </td>
+                        </tr>
+                      <% end %>
+                    <% end %>
+                  </tbody>
+                </table>
+              </div>
+
+              <div class="alert alert-warning mt-4">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  class="stroke-current shrink-0 h-6 w-6"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+                  />
+                </svg>
+                <div>
+                  <h3 class="font-bold">{gettext("Legal Review Required")}</h3>
+                  <div class="text-sm">
+                    {gettext(
+                      "Generated pages are drafts. Have them reviewed by a legal professional before publishing."
+                    )}
+                  </div>
+                </div>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</PhoenixKitWeb.Components.LayoutWrapper.app_layout>

--- a/lib/phoenix_kit/billing/country_data.ex
+++ b/lib/phoenix_kit/billing/country_data.ex
@@ -248,6 +248,33 @@ defmodule PhoenixKit.Billing.CountryData do
   end
 
   @doc """
+  Get the subdivision label for a country.
+
+  Returns appropriate label like "State", "Province", "Region", etc.
+  based on what the country uses for administrative divisions.
+
+  ## Examples
+
+      iex> CountryData.get_subdivision_label("US")
+      "State"
+
+      iex> CountryData.get_subdivision_label("CA")
+      "Province"
+
+      iex> CountryData.get_subdivision_label("EE")
+      "County"
+  """
+  def get_subdivision_label(nil), do: "State/Province"
+  def get_subdivision_label(""), do: "State/Province"
+
+  def get_subdivision_label(alpha2) when is_binary(alpha2) do
+    case BeamLabCountries.get(alpha2) do
+      nil -> "State/Province"
+      country -> country.subdivision_type || "State/Province"
+    end
+  end
+
+  @doc """
   Get list of EU countries for select dropdown.
   """
   def eu_countries_for_select do

--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -292,7 +292,7 @@ defmodule PhoenixKit.Migrations.Postgres do
   - Creates unique indexes on uuid columns
   - Enables gradual transition to UUID-based lookups
 
-  ### V41 - AI Prompt Tracking & Reasoning Parameters ⚡ LATEST
+  ### V41 - AI Prompt Tracking & Reasoning Parameters
   - Adds `prompt_id` and `prompt_name` to phoenix_kit_ai_requests
   - Tracks which prompt template was used for AI completions
   - Denormalized prompt_name preserved for historical display
@@ -303,7 +303,7 @@ defmodule PhoenixKit.Migrations.Postgres do
     - `reasoning_max_tokens` (integer) - Hard cap on thinking tokens (1024-32000)
     - `reasoning_exclude` (boolean) - Hide reasoning from response
 
-  ### V42 - Universal Scheduled Jobs System ⚡ LATEST
+  ### V42 - Universal Scheduled Jobs System
   - Phoenix_kit_scheduled_jobs for polymorphic scheduled task management
   - Behaviour-based handler pattern for extensibility
   - Priority-based job execution ordering
@@ -311,6 +311,15 @@ defmodule PhoenixKit.Migrations.Postgres do
   - Status management: pending, executed, failed, cancelled
   - Replaces single-purpose PublishScheduledPostsJob with generic processor
   - Supports any schedulable resource (posts, emails, notifications, etc.)
+
+  ### V43 - Legal Module ⚡ LATEST
+  - Phoenix_kit_consent_logs for user consent tracking (GDPR/CCPA compliance)
+  - Supports logged-in users and anonymous visitors via session_id
+  - Consent types: necessary, analytics, marketing, preferences
+  - Settings seeds for legal module configuration:
+    - legal_enabled, legal_frameworks, legal_company_info
+    - legal_dpo_contact, legal_consent_widget_enabled
+    - legal_cookie_banner_position
 
   ## Migration Paths
 
@@ -370,7 +379,7 @@ defmodule PhoenixKit.Migrations.Postgres do
   use Ecto.Migration
 
   @initial_version 1
-  @current_version 42
+  @current_version 43
   @default_prefix "public"
 
   @doc false

--- a/lib/phoenix_kit/migrations/postgres/v43.ex
+++ b/lib/phoenix_kit/migrations/postgres/v43.ex
@@ -1,0 +1,208 @@
+defmodule PhoenixKit.Migrations.Postgres.V43 do
+  @moduledoc """
+  PhoenixKit V43 Migration: Legal Module
+
+  This migration introduces the Legal module infrastructure for GDPR/CCPA compliance,
+  including consent tracking and legal page management.
+
+  ## Changes
+
+  ### Phase 1: Settings Seeds
+  - legal_enabled: Module enable/disable toggle
+  - legal_frameworks: Selected compliance frameworks (JSON array)
+  - legal_company_info: Company information for legal pages (JSON)
+  - legal_dpo_contact: Data Protection Officer contact (JSON)
+
+  ### Phase 2 Prep: Consent Logs Table
+  - phoenix_kit_consent_logs: User consent tracking for cookie banners
+  - Supports both logged-in users and anonymous visitors
+  - Tracks consent type, version, and user fingerprint
+
+  ### Consent Widget Settings (Phase 2)
+  - legal_consent_widget_enabled: Cookie consent banner toggle
+  - legal_cookie_banner_position: Banner position (bottom, top, etc.)
+
+  ## PostgreSQL Support
+  - JSONB storage for flexible metadata
+  - Optimized indexes for consent queries
+  - Supports prefix for schema isolation
+
+  ## Usage
+
+      # Migrate up
+      PhoenixKit.Migrations.Postgres.up(prefix: "public", version: 43)
+
+      # Rollback
+      PhoenixKit.Migrations.Postgres.down(prefix: "public", version: 42)
+  """
+  use Ecto.Migration
+
+  @doc """
+  Run the V43 migration to add the Legal module infrastructure.
+  """
+  def up(%{prefix: prefix} = _opts) do
+    # ===================================
+    # 1. CONSENT LOGS TABLE (Phase 2 prep)
+    # ===================================
+    create_if_not_exists table(:phoenix_kit_consent_logs, prefix: prefix) do
+      # User identification
+      add :user_id, :bigint, null: true
+      add :session_id, :string, size: 64, null: true
+
+      # Consent details
+      add :consent_type, :string, size: 30, null: false
+      add :consent_given, :boolean, null: false, default: false
+      add :consent_version, :string, size: 20, null: true
+
+      # Fingerprinting for anonymous tracking
+      add :ip_address, :string, size: 45, null: true
+      add :user_agent_hash, :string, size: 64, null: true
+
+      # Additional data
+      add :metadata, :map, null: true, default: %{}
+
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    # Indexes for consent logs
+    create_if_not_exists index(:phoenix_kit_consent_logs, [:user_id],
+                           name: :phoenix_kit_consent_logs_user_id_idx,
+                           prefix: prefix
+                         )
+
+    create_if_not_exists index(:phoenix_kit_consent_logs, [:session_id],
+                           name: :phoenix_kit_consent_logs_session_id_idx,
+                           prefix: prefix
+                         )
+
+    create_if_not_exists index(:phoenix_kit_consent_logs, [:consent_type],
+                           name: :phoenix_kit_consent_logs_type_idx,
+                           prefix: prefix
+                         )
+
+    create_if_not_exists index(:phoenix_kit_consent_logs, [:inserted_at],
+                           name: :phoenix_kit_consent_logs_inserted_at_idx,
+                           prefix: prefix
+                         )
+
+    # Composite index for user consent lookup
+    create_if_not_exists index(:phoenix_kit_consent_logs, [:user_id, :consent_type],
+                           name: :phoenix_kit_consent_logs_user_type_idx,
+                           prefix: prefix
+                         )
+
+    # Composite index for session consent lookup
+    create_if_not_exists index(:phoenix_kit_consent_logs, [:session_id, :consent_type],
+                           name: :phoenix_kit_consent_logs_session_type_idx,
+                           prefix: prefix
+                         )
+
+    # ===================================
+    # 2. SETTINGS SEEDS
+    # ===================================
+    # Boolean settings use 'value' column (string)
+    execute """
+    INSERT INTO #{prefix_table_name("phoenix_kit_settings", prefix)} (key, value, module, date_added, date_updated)
+    VALUES
+      ('legal_enabled', 'false', 'legal', NOW(), NOW()),
+      ('legal_consent_widget_enabled', 'false', 'legal', NOW(), NOW()),
+      ('legal_cookie_banner_position', 'bottom', 'legal', NOW(), NOW())
+    ON CONFLICT (key) DO NOTHING
+    """
+
+    # JSON settings use 'value_json' column (jsonb)
+    execute """
+    INSERT INTO #{prefix_table_name("phoenix_kit_settings", prefix)} (key, value_json, module, date_added, date_updated)
+    VALUES
+      ('legal_frameworks', '{"items": []}'::jsonb, 'legal', NOW(), NOW()),
+      ('legal_company_info', '{}'::jsonb, 'legal', NOW(), NOW()),
+      ('legal_dpo_contact', '{}'::jsonb, 'legal', NOW(), NOW())
+    ON CONFLICT (key) DO NOTHING
+    """
+
+    # ===================================
+    # 3. TABLE COMMENTS
+    # ===================================
+    execute """
+    COMMENT ON TABLE #{prefix_table_name("phoenix_kit_consent_logs", prefix)} IS
+    'User consent tracking for GDPR/CCPA compliance cookie banners'
+    """
+
+    execute """
+    COMMENT ON COLUMN #{prefix_table_name("phoenix_kit_consent_logs", prefix)}.consent_type IS
+    'Type of consent: necessary, analytics, marketing, preferences'
+    """
+
+    execute """
+    COMMENT ON COLUMN #{prefix_table_name("phoenix_kit_consent_logs", prefix)}.consent_version IS
+    'Version of privacy/cookie policy when consent was given'
+    """
+
+    execute """
+    COMMENT ON COLUMN #{prefix_table_name("phoenix_kit_consent_logs", prefix)}.user_agent_hash IS
+    'SHA256 hash of user agent for anonymous tracking without storing full UA string'
+    """
+
+    # Update version
+    execute "COMMENT ON TABLE #{prefix_table_name("phoenix_kit", prefix)} IS '43'"
+  end
+
+  @doc """
+  Rollback the V43 migration.
+  """
+  def down(%{prefix: prefix} = _opts) do
+    # Drop indexes first
+    drop_if_exists index(:phoenix_kit_consent_logs, [:session_id, :consent_type],
+                     name: :phoenix_kit_consent_logs_session_type_idx,
+                     prefix: prefix
+                   )
+
+    drop_if_exists index(:phoenix_kit_consent_logs, [:user_id, :consent_type],
+                     name: :phoenix_kit_consent_logs_user_type_idx,
+                     prefix: prefix
+                   )
+
+    drop_if_exists index(:phoenix_kit_consent_logs, [:inserted_at],
+                     name: :phoenix_kit_consent_logs_inserted_at_idx,
+                     prefix: prefix
+                   )
+
+    drop_if_exists index(:phoenix_kit_consent_logs, [:consent_type],
+                     name: :phoenix_kit_consent_logs_type_idx,
+                     prefix: prefix
+                   )
+
+    drop_if_exists index(:phoenix_kit_consent_logs, [:session_id],
+                     name: :phoenix_kit_consent_logs_session_id_idx,
+                     prefix: prefix
+                   )
+
+    drop_if_exists index(:phoenix_kit_consent_logs, [:user_id],
+                     name: :phoenix_kit_consent_logs_user_id_idx,
+                     prefix: prefix
+                   )
+
+    # Drop table
+    drop_if_exists table(:phoenix_kit_consent_logs, prefix: prefix)
+
+    # Remove settings
+    execute """
+    DELETE FROM #{prefix_table_name("phoenix_kit_settings", prefix)}
+    WHERE key IN (
+      'legal_enabled',
+      'legal_frameworks',
+      'legal_company_info',
+      'legal_dpo_contact',
+      'legal_consent_widget_enabled',
+      'legal_cookie_banner_position'
+    )
+    """
+
+    # Update version
+    execute "COMMENT ON TABLE #{prefix_table_name("phoenix_kit", prefix)} IS '42'"
+  end
+
+  defp prefix_table_name(table_name, nil), do: table_name
+  defp prefix_table_name(table_name, "public"), do: "public.#{table_name}"
+  defp prefix_table_name(table_name, prefix), do: "#{prefix}.#{table_name}"
+end

--- a/lib/phoenix_kit_web/components/layout_wrapper.ex
+++ b/lib/phoenix_kit_web/components/layout_wrapper.ex
@@ -843,6 +843,16 @@ defmodule PhoenixKitWeb.Components.LayoutWrapper do
                           />
                         <% end %>
 
+                        <%= if PhoenixKit.Modules.Legal.enabled?() do %>
+                          <.admin_nav_item
+                            href={Routes.locale_aware_path(assigns, "/admin/settings/legal")}
+                            icon="legal"
+                            label={gettext("Legal")}
+                            current_path={@current_path || ""}
+                            nested={true}
+                          />
+                        <% end %>
+
                         <%= if SEO.module_enabled?() do %>
                           <.admin_nav_item
                             href={Routes.locale_aware_path(assigns, "/admin/settings/seo")}

--- a/lib/phoenix_kit_web/integration.ex
+++ b/lib/phoenix_kit_web/integration.ex
@@ -380,6 +380,7 @@ defmodule PhoenixKitWeb.Integration do
           live "/admin/settings/referral-codes", Live.Modules.ReferralCodes, :index
           live "/admin/settings/email-tracking", Live.Modules.Emails.EmailTracking, :index
           live "/admin/settings/languages", Live.Modules.Languages, :index
+          live "/admin/settings/legal", Live.Modules.Legal.Settings, :index
 
           live "/admin/settings/maintenance",
                Live.Modules.Maintenance.Settings,
@@ -588,6 +589,7 @@ defmodule PhoenixKitWeb.Integration do
           live "/admin/settings/referral-codes", Live.Modules.ReferralCodes, :index
           live "/admin/settings/emails", Live.Modules.Emails.Settings, :index
           live "/admin/settings/languages", Live.Modules.Languages, :index
+          live "/admin/settings/legal", Live.Modules.Legal.Settings, :index
 
           live "/admin/settings/maintenance",
                Live.Modules.Maintenance.Settings,

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule PhoenixKit.MixProject do
   use Mix.Project
 
-  @version "1.7.15"
+  @version "1.7.16"
   @description "PhoenixKit is a starter kit for building modern web applications with Elixir and Phoenix"
   @source_url "https://github.com/BeamLabEU/phoenix_kit"
 

--- a/priv/legal_templates/acceptable_use.eex
+++ b/priv/legal_templates/acceptable_use.eex
@@ -1,0 +1,163 @@
+<%!-- Acceptable Use Policy Template --%>
+<%!-- Variables: company_name, company_address, company_country, company_website, dpo_name, dpo_email, frameworks, effective_date --%>
+
+> **DRAFT DOCUMENT - LEGAL REVIEW REQUIRED**
+>
+> This document was auto-generated based on your selected compliance frameworks.
+> It provides a basic template that meets minimum requirements but MUST be reviewed
+> and customized by a qualified legal professional before publication.
+>
+> Last generated: <%= @effective_date %>
+
+---
+
+**Effective Date:** <%= @effective_date %>
+
+## 1. Introduction
+
+This Acceptable Use Policy ("Policy") governs your use of the services, websites, and applications (collectively, "Services") provided by <%= @company_name %> ("we," "our," or "us")<%= if @company_website != "", do: " at #{@company_website}", else: "" %>.
+
+By accessing or using our Services, you agree to comply with this Policy. If you do not agree, you must not use our Services.
+
+## 2. Scope
+
+This Policy applies to all users of our Services, including:
+- Registered account holders
+- Visitors to our websites
+- API users and developers
+- Any person or entity accessing our Services
+
+## 3. Acceptable Use
+
+You agree to use our Services only for lawful purposes and in accordance with this Policy. You may:
+
+- Use the Services for their intended purpose
+- Create and manage legitimate user accounts
+- Share content you have the right to distribute
+- Communicate respectfully with other users and our team
+- Report violations or security vulnerabilities responsibly
+
+## 4. Prohibited Activities
+
+You must NOT use our Services to:
+
+### 4.1 Illegal Activities
+- Violate any applicable laws, regulations, or third-party rights
+- Engage in fraud, money laundering, or terrorist financing
+- Distribute illegal content or materials
+- Facilitate or promote illegal activities
+
+### 4.2 Harmful Content
+- Upload, transmit, or distribute malware, viruses, or malicious code
+- Distribute spam, phishing attempts, or deceptive content
+- Post content that is defamatory, obscene, or threatening
+- Share content that exploits or harms minors
+- Distribute hate speech or content promoting discrimination
+
+### 4.3 Security Violations
+- Attempt unauthorized access to systems or accounts
+- Interfere with or disrupt the Services or networks
+- Circumvent security measures or access controls
+- Engage in denial-of-service attacks or similar activities
+- Scrape, harvest, or collect user data without authorization
+
+### 4.4 Intellectual Property Violations
+- Infringe copyrights, trademarks, or other intellectual property rights
+- Remove or alter proprietary notices or labels
+- Use the Services to pirate or distribute unauthorized content
+
+### 4.5 Abusive Behavior
+- Harass, threaten, or intimidate other users
+- Impersonate others or misrepresent your identity
+- Stalk or invade the privacy of other users
+- Engage in bullying or targeted attacks
+
+### 4.6 System Abuse
+- Create multiple accounts to evade restrictions
+- Use automated tools without authorization
+- Overload systems with excessive requests
+- Exploit bugs or vulnerabilities (except through responsible disclosure)
+
+## 5. Content Standards
+
+When creating or sharing content through our Services, you must ensure it:
+
+- Is accurate and not misleading
+- Does not violate third-party rights
+- Complies with applicable laws
+- Is appropriate for the intended audience
+- Does not contain personal data of others without consent
+
+## 6. Account Responsibilities
+
+If you have an account with us, you are responsible for:
+
+- Maintaining the security of your login credentials
+- All activities occurring under your account
+- Promptly reporting any unauthorized access
+- Keeping your account information accurate and up-to-date
+- Complying with any age restrictions
+
+## 7. Monitoring and Enforcement
+
+We reserve the right to:
+
+- Monitor use of the Services for policy compliance
+- Investigate suspected violations
+- Remove or disable access to violating content
+- Suspend or terminate accounts for policy violations
+- Report illegal activities to law enforcement
+- Take legal action against violators
+
+## 8. Reporting Violations
+
+If you become aware of any violation of this Policy, please report it to:
+
+<%= if @dpo_email != "" do %>**Email:** <%= @dpo_email %><% end %>
+<%= if @company_address != "" do %>**Mail:** <%= @company_address %><% end %>
+
+We take all reports seriously and will investigate promptly.
+
+## 9. Consequences of Violations
+
+Violations of this Policy may result in:
+
+- Warning or notice of violation
+- Temporary suspension of access
+- Permanent termination of account
+- Removal of content
+- Legal action
+- Reporting to law enforcement
+
+The severity of the consequence will depend on the nature and frequency of the violation.
+
+## 10. No Waiver
+
+Our failure to enforce any provision of this Policy does not constitute a waiver of our right to enforce it in the future.
+
+## 11. Changes to This Policy
+
+We may update this Policy from time to time. We will notify you of significant changes by:
+- Posting the updated Policy on our website
+- Sending notification to registered users
+- Updating the "Effective Date" at the top
+
+Your continued use of the Services after changes become effective constitutes acceptance of the updated Policy.
+
+## 12. Relationship with Other Policies
+
+This Policy is supplementary to our:
+- Terms of Service
+- Privacy Policy
+- Cookie Policy
+
+In case of conflict, the Terms of Service shall prevail.
+
+## 13. Contact Information
+
+For questions about this Acceptable Use Policy, please contact:
+
+**<%= @company_name %>**
+<%= if @company_address != "" do %><%= @company_address %><% end %>
+<%= if @dpo_email != "" do %>Email: <%= @dpo_email %><% end %>
+<%= if @company_website != "" do %>Website: <%= @company_website %><% end %>

--- a/priv/legal_templates/ccpa_notice.eex
+++ b/priv/legal_templates/ccpa_notice.eex
@@ -1,0 +1,134 @@
+<%!-- CCPA Notice at Collection Template --%>
+<%!-- Variables: company_name, company_address, company_country, company_website, dpo_name, dpo_email, frameworks, effective_date --%>
+
+> **DRAFT DOCUMENT - LEGAL REVIEW REQUIRED**
+>
+> This document was auto-generated based on your selected compliance frameworks.
+> It provides a basic template that meets minimum requirements but MUST be reviewed
+> and customized by a qualified legal professional before publication.
+>
+> Last generated: <%= @effective_date %>
+
+---
+
+**Effective Date:** <%= @effective_date %>
+
+# Notice at Collection of Personal Information
+
+## California Consumer Privacy Act (CCPA) / California Privacy Rights Act (CPRA)
+
+This Notice at Collection is provided pursuant to the California Consumer Privacy Act of 2018 (CCPA), as amended by the California Privacy Rights Act of 2020 (CPRA), and describes <%= @company_name %>'s practices regarding the collection and use of personal information.
+
+## Categories of Personal Information We Collect
+
+At or before the point of collection, we may collect the following categories of personal information:
+
+| Category | Examples | Collected |
+|----------|----------|-----------|
+| **Identifiers** | Name, email address, phone number, IP address, account name | Yes |
+| **Customer Records** | Billing address, payment information, purchase history | Yes |
+| **Commercial Information** | Products purchased, services used, transaction history | Yes |
+| **Internet Activity** | Browsing history, search history, interaction with website | Yes |
+| **Geolocation Data** | General location based on IP address | Yes |
+| **Professional Information** | Job title, company name (if provided) | Yes |
+| **Inferences** | Preferences, characteristics, behavior patterns | Yes |
+| **Sensitive Personal Information** | Account login credentials | Yes |
+
+## Purposes for Collection and Use
+
+We collect and use personal information for the following business purposes:
+
+1. **Providing Services**
+   - Processing transactions and orders
+   - Managing your account
+   - Providing customer support
+
+2. **Communications**
+   - Sending service-related notifications
+   - Marketing communications (with consent)
+   - Responding to inquiries
+
+3. **Improvement and Analytics**
+   - Improving our products and services
+   - Understanding usage patterns
+   - Conducting research and analytics
+
+4. **Security and Compliance**
+   - Detecting and preventing fraud
+   - Maintaining security
+   - Complying with legal obligations
+
+## Retention of Personal Information
+
+Personal information is retained for as long as necessary to fulfill the purposes for which it was collected, typically:
+
+- Account information: Duration of account relationship plus 3 years
+- Transaction records: 7 years for tax and legal compliance
+- Marketing preferences: Until withdrawal of consent
+- Website analytics: 26 months
+
+## Your California Privacy Rights
+
+As a California resident, you have the following rights:
+
+### Right to Know
+You may request information about:
+- Categories of personal information collected
+- Sources of personal information
+- Business purposes for collection
+- Categories of third parties with whom we share information
+- Specific pieces of personal information collected about you
+
+### Right to Delete
+You may request deletion of your personal information, subject to certain exceptions.
+
+### Right to Correct
+You may request correction of inaccurate personal information.
+
+### Right to Opt-Out
+You may opt out of:
+- The sale of your personal information
+- Sharing of your personal information for cross-context behavioral advertising
+
+### Right to Limit Use of Sensitive Personal Information
+You may limit the use and disclosure of sensitive personal information.
+
+### Right to Non-Discrimination
+You will not receive discriminatory treatment for exercising your privacy rights.
+
+## How to Exercise Your Rights
+
+To exercise your California privacy rights:
+
+1. **Online:** Visit our "Do Not Sell My Personal Information" page
+2. **Email:** Contact us at <%= if @dpo_email != "", do: @dpo_email, else: "privacy@[your-domain].com" %>
+<%= if @company_address != "" do %>3. **Mail:** <%= @company_address %><% end %>
+
+We will verify your identity before fulfilling your request. You may designate an authorized agent to make requests on your behalf.
+
+## Sale and Sharing of Personal Information
+
+<%= @company_name %> does not "sell" personal information in the traditional sense. However, certain sharing activities (such as with advertising partners) may be considered a "sale" or "sharing" under the CCPA/CPRA.
+
+**Categories potentially sold/shared in the preceding 12 months:**
+- Internet activity and browsing history (with advertising partners)
+- Identifiers (with analytics providers)
+
+To opt out of the sale/sharing of your personal information, visit our "Do Not Sell My Personal Information" page.
+
+## Sensitive Personal Information
+
+We collect sensitive personal information (account credentials) solely for providing our services. We do not use or disclose sensitive personal information for purposes beyond those permitted by the CPRA.
+
+## Financial Incentives
+
+We do not offer financial incentives for the collection, sale, or deletion of personal information.
+
+## Contact Us
+
+For questions about this Notice or our privacy practices:
+
+**<%= @company_name %>**
+<%= if @company_address != "" do %><%= @company_address %><% end %>
+<%= if @dpo_email != "" do %>Email: <%= @dpo_email %><% end %>
+<%= if @company_website != "" do %>Website: <%= @company_website %><% end %>

--- a/priv/legal_templates/cookie_policy.eex
+++ b/priv/legal_templates/cookie_policy.eex
@@ -1,0 +1,122 @@
+<%!-- Cookie Policy Template --%>
+<%!-- Variables: company_name, company_address, company_website, dpo_email, frameworks, effective_date --%>
+
+> **DRAFT DOCUMENT - LEGAL REVIEW REQUIRED**
+>
+> This document was auto-generated based on your selected compliance frameworks.
+> It provides a basic template that meets minimum requirements but MUST be reviewed
+> and customized by a qualified legal professional before publication.
+>
+> Last generated: <%= @effective_date %>
+
+---
+
+**Effective Date:** <%= @effective_date %>
+
+## 1. What Are Cookies
+
+Cookies are small text files that are stored on your device (computer, tablet, or mobile) when you visit a website. They are widely used to make websites work more efficiently and provide information to website owners.
+
+## 2. Company Information
+
+**<%= @company_name %>**
+<%= if @company_address != "" do %><%= @company_address %><% end %>
+<%= if @company_website != "" do %>Website: <%= @company_website %><% end %>
+
+## 3. Types of Cookies We Use
+
+### 3.1 Strictly Necessary Cookies
+
+These cookies are essential for the website to function properly. They enable core functionality such as security, network management, and account access. You cannot opt out of these cookies.
+
+| Cookie Name | Purpose | Duration |
+|-------------|---------|----------|
+| session_id | User session management | Session |
+| csrf_token | Security - prevents cross-site request forgery | Session |
+| remember_token | Persistent login functionality | 14 days |
+
+### 3.2 Performance/Analytics Cookies
+
+These cookies help us understand how visitors interact with our website by collecting and reporting information anonymously.
+
+| Cookie Name | Purpose | Duration |
+|-------------|---------|----------|
+| _ga | Google Analytics - distinguishes users | 2 years |
+| _gid | Google Analytics - distinguishes users | 24 hours |
+| _gat | Google Analytics - throttles request rate | 1 minute |
+
+### 3.3 Functionality/Preference Cookies
+
+These cookies enable enhanced functionality and personalization, such as remembering your preferences and settings.
+
+| Cookie Name | Purpose | Duration |
+|-------------|---------|----------|
+| language | Remembers language preference | 1 year |
+| theme | Remembers theme preference | 1 year |
+| timezone | Remembers timezone setting | 1 year |
+
+### 3.4 Marketing/Targeting Cookies
+
+These cookies are used to track visitors across websites for advertising purposes. They help display relevant and personalized ads.
+
+| Cookie Name | Purpose | Duration |
+|-------------|---------|----------|
+| _fbp | Facebook Pixel - tracks conversions | 3 months |
+| _gcl_au | Google Ads - conversion tracking | 3 months |
+
+## 4. How to Manage Cookies
+
+<%= if "gdpr" in @frameworks or "uk_gdpr" in @frameworks do %>
+### Cookie Consent (GDPR)
+
+Under GDPR, we request your consent before setting non-essential cookies. When you first visit our website, you will see a cookie consent banner that allows you to:
+
+- Accept all cookies
+- Reject non-essential cookies
+- Customize your cookie preferences by category
+
+You can change your cookie preferences at any time by clicking on "Cookie Settings" in the footer of our website.
+<% end %>
+
+<%= if "ccpa" in @frameworks do %>
+### Opt-Out Rights (CCPA)
+
+California residents have the right to opt out of cookies used for the "sale" of personal information. Please visit our "Do Not Sell My Personal Information" page to exercise this right.
+<% end %>
+
+### Browser Settings
+
+You can also control and manage cookies through your browser settings. Most browsers allow you to:
+
+- View cookies stored on your device
+- Delete all or specific cookies
+- Block third-party cookies
+- Block all cookies
+- Clear cookies when you close your browser
+
+Please note that blocking or deleting cookies may impact your experience on our website and limit certain functionality.
+
+**Browser-specific instructions:**
+- [Chrome](https://support.google.com/chrome/answer/95647)
+- [Firefox](https://support.mozilla.org/en-US/kb/cookies-information-websites-store-on-your-computer)
+- [Safari](https://support.apple.com/guide/safari/manage-cookies-sfri11471/mac)
+- [Edge](https://support.microsoft.com/en-us/microsoft-edge/delete-cookies-in-microsoft-edge-63947406-40ac-c3b8-57b9-2a946a29ae09)
+
+## 5. Third-Party Cookies
+
+Some cookies are placed by third-party services that appear on our pages. We do not control the setting of these cookies. Please check the third party's website for more information about their cookies and how to manage them.
+
+## 6. Do Not Track Signals
+
+Some browsers have a "Do Not Track" feature that signals to websites that you do not want your online activities tracked. Our website <%= if "ccpa" in @frameworks, do: "honors", else: "currently does not respond to" %> Do Not Track signals.
+
+## 7. Updates to This Policy
+
+We may update this Cookie Policy from time to time to reflect changes in our practices or for legal, operational, or regulatory reasons. We encourage you to review this page periodically.
+
+## 8. Contact Us
+
+If you have questions about our use of cookies, please contact us at:
+
+**<%= @company_name %>**
+<%= if @dpo_email != "" do %>Email: <%= @dpo_email %><% end %>

--- a/priv/legal_templates/data_retention_policy.eex
+++ b/priv/legal_templates/data_retention_policy.eex
@@ -1,0 +1,126 @@
+<%!-- Data Retention Policy Template --%>
+<%!-- Variables: company_name, company_address, company_country, company_website, dpo_name, dpo_email, frameworks, effective_date --%>
+
+> **DRAFT DOCUMENT - LEGAL REVIEW REQUIRED**
+>
+> This document was auto-generated based on your selected compliance frameworks.
+> It provides a basic template that meets minimum requirements but MUST be reviewed
+> and customized by a qualified legal professional before publication.
+>
+> Last generated: <%= @effective_date %>
+
+---
+
+**Effective Date:** <%= @effective_date %>
+
+## 1. Introduction
+
+This Data Retention Policy outlines how <%= @company_name %> ("we," "our," or "us") retains, manages, and disposes of personal data in compliance with applicable data protection laws<%= if "gdpr" in @frameworks, do: ", including the General Data Protection Regulation (GDPR)", else: "" %>.
+
+## 2. Purpose
+
+The purpose of this policy is to:
+- Ensure personal data is not kept longer than necessary
+- Comply with legal and regulatory requirements
+- Protect the rights of data subjects
+- Establish clear procedures for data retention and deletion
+
+## 3. Scope
+
+This policy applies to all personal data processed by <%= @company_name %>, regardless of the format or medium in which it is stored.
+
+<%= if @dpo_name != "" or @dpo_email != "" do %>
+## 4. Responsible Party
+
+**Data Protection Officer:**
+<%= if @dpo_name != "" do %>- **Name:** <%= @dpo_name %><% end %>
+<%= if @dpo_email != "" do %>- **Email:** <%= @dpo_email %><% end %>
+<%= if @dpo_phone != "" do %>- **Phone:** <%= @dpo_phone %><% end %>
+<% end %>
+
+## 5. Retention Periods
+
+The following table outlines our standard retention periods for different categories of personal data:
+
+| Data Category | Retention Period | Legal Basis |
+|---------------|------------------|-------------|
+| **Account Information** | Duration of account + 3 years | Contractual necessity, legal obligations |
+| **Transaction Records** | 7 years from transaction date | Tax and accounting regulations |
+| **Communication Records** | 3 years from last contact | Legitimate interest, legal claims |
+| **Marketing Preferences** | Until consent withdrawal + 30 days | Consent |
+| **Website Analytics** | 26 months | Legitimate interest |
+| **Access Logs** | 12 months | Security, legal compliance |
+| **Backup Data** | 90 days after source deletion | Business continuity |
+| **Job Applications** | 6 months (unsuccessful), duration of employment + 7 years (successful) | Legal obligations, legitimate interest |
+| **Contract Documents** | Duration of contract + 10 years | Legal claims |
+| **Support Tickets** | 3 years from resolution | Service improvement, legal claims |
+
+*Note: These periods may vary based on specific legal requirements in your jurisdiction.*
+
+## 6. Retention Principles
+
+<%= if "gdpr" in @frameworks or "uk_gdpr" in @frameworks do %>
+### 6.1 GDPR Principles
+
+In accordance with GDPR Article 5(1)(e), personal data shall be:
+
+- Kept in a form which permits identification of data subjects for no longer than is necessary
+- Processed in a manner that ensures appropriate security
+- Subject to periodic review to assess the necessity of retention
+<% end %>
+
+### 6.2 General Principles
+
+- **Necessity:** Data is retained only as long as required for its original purpose
+- **Accuracy:** Retained data is kept accurate and up-to-date
+- **Security:** Appropriate security measures protect retained data
+- **Accountability:** Clear records document retention decisions
+
+## 7. Data Disposal
+
+When the retention period expires, personal data will be:
+
+### 7.1 Electronic Data
+- Securely deleted using industry-standard methods
+- Removed from all backup systems within the backup retention cycle
+- Anonymized where full deletion is not feasible
+
+### 7.2 Physical Records
+- Shredded using cross-cut shredders
+- Disposed of through certified destruction services
+- Documented with destruction certificates where applicable
+
+## 8. Exceptions to Standard Retention
+
+Data may be retained beyond standard periods when:
+- Required by law or regulatory authority
+- Needed for ongoing legal proceedings
+- Subject to a legal hold notice
+- Necessary for legitimate business purposes (documented)
+
+## 9. Data Subject Rights
+
+<%= if "gdpr" in @frameworks or "uk_gdpr" in @frameworks do %>
+Data subjects may request:
+- Information about how long their data will be stored
+- Erasure of their personal data ("right to be forgotten")
+- Restriction of processing during retention review
+
+To exercise these rights, contact: <%= if @dpo_email != "", do: @dpo_email, else: "our Data Protection Officer" %>
+<% end %>
+
+## 10. Review and Updates
+
+This policy is reviewed annually and updated as necessary to reflect:
+- Changes in legal requirements
+- Business process changes
+- Technological developments
+- Lessons learned from data protection incidents
+
+## 11. Contact Information
+
+For questions about this Data Retention Policy, please contact:
+
+**<%= @company_name %>**
+<%= if @company_address != "" do %><%= @company_address %><% end %>
+<%= if @dpo_email != "" do %>Email: <%= @dpo_email %><% end %>

--- a/priv/legal_templates/do_not_sell.eex
+++ b/priv/legal_templates/do_not_sell.eex
@@ -1,0 +1,111 @@
+<%!-- Do Not Sell My Personal Information Template (CCPA) --%>
+<%!-- Variables: company_name, company_address, company_website, dpo_email, effective_date --%>
+
+> **DRAFT DOCUMENT - LEGAL REVIEW REQUIRED**
+>
+> This document was auto-generated for CCPA/CPRA compliance.
+> It MUST be reviewed and customized by a qualified legal professional
+> before publication.
+>
+> Last generated: <%= @effective_date %>
+
+---
+
+**Effective Date:** <%= @effective_date %>
+
+## Your California Privacy Rights
+
+The California Consumer Privacy Act (CCPA) and California Privacy Rights Act (CPRA) give California residents the right to opt out of the "sale" or "sharing" of their personal information.
+
+## What Does "Sale" Mean Under CCPA?
+
+Under CCPA, a "sale" is broadly defined as sharing, disclosing, or making available personal information to a third party in exchange for monetary or other valuable consideration. This can include:
+
+- Sharing data with advertising partners
+- Using third-party analytics that share data
+- Allowing cookies that track you across websites
+
+## Do We Sell Your Personal Information?
+
+<%= @company_name %> <%= "[does/does not]" %> sell personal information as defined by the CCPA. However, we may share your information with third parties for advertising and analytics purposes, which may be considered a "sale" under CCPA.
+
+### Categories of Information We May Share
+
+| Category | Examples | Third Parties |
+|----------|----------|---------------|
+| Identifiers | IP address, cookie IDs | Analytics, Advertising |
+| Internet Activity | Browsing history, search queries | Analytics |
+| Geolocation | General location data | Analytics, Advertising |
+
+## How to Opt Out
+
+You can opt out of the sale or sharing of your personal information using any of the following methods:
+
+### 1. Online Request
+
+Click the button below to submit your opt-out request:
+
+**[Do Not Sell My Personal Information]**
+
+### 2. Email Request
+
+Send an email to: <%= if @dpo_email != "", do: @dpo_email, else: "[privacy@yourcompany.com]" %>
+
+Include:
+- Subject line: "CCPA Opt-Out Request"
+- Your name and email address associated with your account
+- A statement that you wish to opt out of the sale of your personal information
+
+### 3. Browser Settings
+
+You can enable Global Privacy Control (GPC) in your browser. We honor GPC signals as a valid opt-out request.
+
+Browsers that support GPC:
+- Firefox (with extension)
+- Brave
+- DuckDuckGo
+
+## What Happens After You Opt Out
+
+Once you submit an opt-out request:
+
+1. **Immediate Effect:** We will stop selling your personal information to third parties within 15 business days
+2. **Existing Data:** We will instruct third parties to stop using any previously shared data
+3. **Cookies:** Non-essential tracking cookies will be disabled
+4. **Account Impact:** Your account and service access will not be affected
+
+## Verification
+
+To protect your privacy, we may need to verify your identity before processing your request. We may ask for:
+- Email verification
+- Account credentials
+- Additional identifying information
+
+## Authorized Agents
+
+You may designate an authorized agent to submit requests on your behalf. The agent must provide:
+- Written authorization signed by you
+- Proof of the agent's identity
+- Proof of your identity
+
+## Your Other CCPA Rights
+
+In addition to opting out, you have the right to:
+
+- **Know:** Request information about the personal data we collect, use, and disclose
+- **Delete:** Request deletion of your personal information
+- **Correct:** Request correction of inaccurate personal information
+- **Limit Use:** Limit use of sensitive personal information
+- **Non-Discrimination:** Not receive discriminatory treatment for exercising your rights
+
+## Contact Us
+
+For questions about this page or to exercise your rights, contact us at:
+
+**<%= @company_name %>**
+<%= if @company_address != "" do %><%= @company_address %><% end %>
+<%= if @dpo_email != "" do %>Email: <%= @dpo_email %><% end %>
+
+---
+
+**Last updated:** <%= @effective_date %>

--- a/priv/legal_templates/privacy_policy.eex
+++ b/priv/legal_templates/privacy_policy.eex
@@ -1,0 +1,173 @@
+<%!-- Privacy Policy Template --%>
+<%!-- Variables: company_name, company_address, company_country, company_website, dpo_name, dpo_email, frameworks, effective_date --%>
+
+> **DRAFT DOCUMENT - LEGAL REVIEW REQUIRED**
+>
+> This document was auto-generated based on your selected compliance frameworks.
+> It provides a basic template that meets minimum requirements but MUST be reviewed
+> and customized by a qualified legal professional before publication.
+>
+> Last generated: <%= @effective_date %>
+
+---
+
+**Effective Date:** <%= @effective_date %>
+
+## 1. Introduction
+
+<%= @company_name %> ("we," "our," or "us") is committed to protecting your privacy. This Privacy Policy explains how we collect, use, disclose, and safeguard your information when you visit our website<%= if @company_website != "", do: " at #{@company_website}", else: "" %> or use our services.
+
+## 2. Company Information
+
+**<%= @company_name %>**
+<%= if @company_address != "" do %>
+<%= @company_address %>
+<% end %>
+<%= if @company_country != "" do %>
+<%= @company_country %>
+<% end %>
+<%= if @registration_number != "" do %>
+Registration Number: <%= @registration_number %>
+<% end %>
+<%= if @vat_number != "" do %>
+VAT Number: <%= @vat_number %>
+<% end %>
+
+<%= if @dpo_name != "" or @dpo_email != "" do %>
+## 3. Data Protection Officer
+
+For any data protection inquiries, please contact our Data Protection Officer:
+
+<%= if @dpo_name != "" do %>- **Name:** <%= @dpo_name %><% end %>
+<%= if @dpo_email != "" do %>- **Email:** <%= @dpo_email %><% end %>
+<%= if @dpo_phone != "" do %>- **Phone:** <%= @dpo_phone %><% end %>
+<%= if @dpo_address != "" do %>- **Address:** <%= @dpo_address %><% end %>
+<% end %>
+
+## 4. Information We Collect
+
+### 4.1 Information You Provide
+
+We may collect personal information that you voluntarily provide to us when you:
+- Register for an account
+- Subscribe to our newsletter
+- Contact us with inquiries
+- Make a purchase
+- Participate in surveys or promotions
+
+This information may include:
+- Name and contact information (email, phone number)
+- Account credentials
+- Billing and payment information
+- Communication preferences
+- Any other information you choose to provide
+
+### 4.2 Automatically Collected Information
+
+When you access our services, we automatically collect certain information, including:
+- IP address
+- Browser type and version
+- Operating system
+- Device information
+- Access times and dates
+- Pages viewed and links clicked
+- Referring URL
+
+### 4.3 Cookies and Tracking Technologies
+
+We use cookies and similar tracking technologies to collect information about your browsing activities. For more details, please see our Cookie Policy.
+
+## 5. How We Use Your Information
+
+We use the information we collect to:
+- Provide, maintain, and improve our services
+- Process transactions and send related information
+- Send promotional communications (with your consent)
+- Respond to your comments, questions, and requests
+- Monitor and analyze trends, usage, and activities
+- Detect, investigate, and prevent security incidents
+- Comply with legal obligations
+
+<%= if "gdpr" in @frameworks or "uk_gdpr" in @frameworks do %>
+## 6. Legal Basis for Processing (GDPR)
+
+Under the General Data Protection Regulation, we process your personal data based on the following legal grounds:
+
+- **Consent (Article 6(1)(a)):** Where you have given explicit consent for specific purposes
+- **Contract Performance (Article 6(1)(b)):** Where processing is necessary to fulfill our contractual obligations
+- **Legal Obligation (Article 6(1)(c)):** Where we must comply with legal requirements
+- **Legitimate Interests (Article 6(1)(f)):** Where we have legitimate business interests that don't override your rights
+<% end %>
+
+## 7. Data Sharing and Disclosure
+
+We may share your information with:
+- **Service Providers:** Third parties that perform services on our behalf
+- **Business Partners:** With your consent, for joint marketing activities
+- **Legal Authorities:** When required by law or to protect our rights
+- **Business Transfers:** In connection with mergers, acquisitions, or asset sales
+
+We do not sell your personal information to third parties.
+
+<%= if "gdpr" in @frameworks or "uk_gdpr" in @frameworks or "lgpd" in @frameworks or "pipeda" in @frameworks do %>
+## 8. Your Rights
+
+You have the following rights regarding your personal data:
+
+<%= if "gdpr" in @frameworks or "uk_gdpr" in @frameworks do %>
+### GDPR Rights (EU/EEA/UK residents)
+
+- **Right to Access:** Request a copy of your personal data
+- **Right to Rectification:** Request correction of inaccurate data
+- **Right to Erasure:** Request deletion of your data ("right to be forgotten")
+- **Right to Restrict Processing:** Request limitation of how we use your data
+- **Right to Data Portability:** Receive your data in a structured, machine-readable format
+- **Right to Object:** Object to processing based on legitimate interests
+- **Rights Related to Automated Decision-Making:** Not be subject to decisions based solely on automated processing
+
+To exercise these rights, contact our Data Protection Officer at <%= @dpo_email %>.
+<% end %>
+<% end %>
+
+<%= if "ccpa" in @frameworks or "us_states" in @frameworks do %>
+### CCPA/CPRA Rights (California residents)
+
+Under the California Consumer Privacy Act and California Privacy Rights Act, you have the right to:
+
+- **Know:** Request information about the personal data we collect, use, and disclose
+- **Delete:** Request deletion of your personal information
+- **Correct:** Request correction of inaccurate personal information
+- **Opt-Out:** Opt out of the sale or sharing of your personal information
+- **Limit Use:** Limit the use and disclosure of sensitive personal information
+- **Non-Discrimination:** Not receive discriminatory treatment for exercising your rights
+
+To exercise these rights, please visit our "Do Not Sell My Personal Information" page or contact us.
+<% end %>
+
+## 9. Data Security
+
+We implement appropriate technical and organizational measures to protect your personal information against unauthorized access, alteration, disclosure, or destruction. However, no method of transmission over the Internet or electronic storage is 100% secure.
+
+## 10. Data Retention
+
+We retain your personal information only for as long as necessary to fulfill the purposes for which it was collected, comply with legal obligations, resolve disputes, and enforce our agreements.
+
+## 11. International Data Transfers
+
+Your information may be transferred to and processed in countries other than your country of residence. We ensure appropriate safeguards are in place to protect your data in accordance with this Privacy Policy.
+
+## 12. Children's Privacy
+
+Our services are not intended for children under 16 years of age. We do not knowingly collect personal information from children under 16.
+
+## 13. Changes to This Policy
+
+We may update this Privacy Policy from time to time. We will notify you of any changes by posting the new Privacy Policy on this page and updating the "Effective Date" at the top.
+
+## 14. Contact Us
+
+If you have questions about this Privacy Policy or our privacy practices, please contact us at:
+
+**<%= @company_name %>**
+<%= if @company_address != "" do %><%= @company_address %><% end %>
+<%= if @dpo_email != "" do %>Email: <%= @dpo_email %><% end %>

--- a/priv/legal_templates/terms_of_service.eex
+++ b/priv/legal_templates/terms_of_service.eex
@@ -1,0 +1,161 @@
+<%!-- Terms of Service Template --%>
+<%!-- Variables: company_name, company_address, company_country, company_website, dpo_email, effective_date --%>
+
+> **DRAFT DOCUMENT - LEGAL REVIEW REQUIRED**
+>
+> This document was auto-generated and provides a basic template.
+> It MUST be reviewed and customized by a qualified legal professional
+> before publication to ensure compliance with applicable laws.
+>
+> Last generated: <%= @effective_date %>
+
+---
+
+**Effective Date:** <%= @effective_date %>
+
+## 1. Agreement to Terms
+
+By accessing or using the services provided by <%= @company_name %> ("we," "our," or "us")<%= if @company_website != "", do: " at #{@company_website}", else: "" %>, you agree to be bound by these Terms of Service ("Terms"). If you do not agree to these Terms, please do not use our services.
+
+## 2. Company Information
+
+**<%= @company_name %>**
+<%= if @company_address != "" do %><%= @company_address %><% end %>
+<%= if @company_country != "" do %><%= @company_country %><% end %>
+<%= if @registration_number != "" do %>Registration Number: <%= @registration_number %><% end %>
+<%= if @vat_number != "" do %>VAT Number: <%= @vat_number %><% end %>
+
+## 3. Eligibility
+
+You must be at least 18 years old (or the age of majority in your jurisdiction) to use our services. By using our services, you represent and warrant that you meet this requirement.
+
+## 4. Account Registration
+
+### 4.1 Account Creation
+
+When creating an account, you agree to:
+- Provide accurate, current, and complete information
+- Maintain and promptly update your account information
+- Keep your password confidential and secure
+- Notify us immediately of any unauthorized access to your account
+- Accept responsibility for all activities that occur under your account
+
+### 4.2 Account Termination
+
+We reserve the right to suspend or terminate your account at any time for any reason, including if we reasonably believe that you have violated these Terms.
+
+## 5. Acceptable Use
+
+### 5.1 Permitted Use
+
+You may use our services only for lawful purposes and in accordance with these Terms.
+
+### 5.2 Prohibited Activities
+
+You agree NOT to:
+- Violate any applicable laws, regulations, or third-party rights
+- Use the services for any illegal or unauthorized purpose
+- Transmit any viruses, malware, or other malicious code
+- Attempt to gain unauthorized access to our systems or networks
+- Interfere with or disrupt the integrity or performance of our services
+- Collect or harvest user data without consent
+- Impersonate any person or entity
+- Engage in any activity that could damage our reputation
+- Use automated means to access our services without permission
+- Reverse engineer, decompile, or disassemble any aspect of our services
+
+## 6. Intellectual Property
+
+### 6.1 Our Rights
+
+All content, features, and functionality of our services, including but not limited to text, graphics, logos, icons, images, audio, video, software, and code, are owned by or licensed to <%= @company_name %> and are protected by copyright, trademark, and other intellectual property laws.
+
+### 6.2 Limited License
+
+We grant you a limited, non-exclusive, non-transferable, revocable license to access and use our services for your personal, non-commercial use, subject to these Terms.
+
+### 6.3 Your Content
+
+You retain ownership of any content you submit to our services. By submitting content, you grant us a worldwide, royalty-free, sublicensable license to use, reproduce, modify, and display such content in connection with our services.
+
+## 7. Payment Terms
+
+### 7.1 Fees
+
+Certain features of our services may require payment. All fees are stated in the applicable currency and are exclusive of taxes unless otherwise noted.
+
+### 7.2 Payment Processing
+
+Payments are processed through third-party payment processors. By making a payment, you agree to the payment processor's terms and conditions.
+
+### 7.3 Refunds
+
+Refund policies vary by service. Please refer to the specific terms for the service you are purchasing.
+
+## 8. Disclaimer of Warranties
+
+OUR SERVICES ARE PROVIDED "AS IS" AND "AS AVAILABLE" WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT.
+
+We do not warrant that:
+- Our services will be uninterrupted, error-free, or secure
+- Any defects will be corrected
+- Our services will meet your requirements
+- Any results or outcomes will be achieved
+
+## 9. Limitation of Liability
+
+TO THE FULLEST EXTENT PERMITTED BY LAW, <%= String.upcase(@company_name) %> SHALL NOT BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES, INCLUDING BUT NOT LIMITED TO LOSS OF PROFITS, DATA, USE, GOODWILL, OR OTHER INTANGIBLE LOSSES, RESULTING FROM:
+
+- Your use or inability to use our services
+- Any unauthorized access to or use of our servers
+- Any interruption or cessation of transmission to or from our services
+- Any bugs, viruses, or other harmful code transmitted through our services
+- Any errors or omissions in any content
+
+## 10. Indemnification
+
+You agree to indemnify, defend, and hold harmless <%= @company_name %> and its officers, directors, employees, agents, and affiliates from any claims, damages, losses, liabilities, and expenses (including attorneys' fees) arising from:
+
+- Your use of our services
+- Your violation of these Terms
+- Your violation of any third-party rights
+- Your content submitted to our services
+
+## 11. Governing Law and Dispute Resolution
+
+### 11.1 Governing Law
+
+These Terms shall be governed by and construed in accordance with the laws of <%= if @company_country != "", do: @company_country, else: "[Your Jurisdiction]" %>, without regard to its conflict of law provisions.
+
+### 11.2 Dispute Resolution
+
+Any disputes arising from these Terms or your use of our services shall be resolved through:
+
+1. **Informal Negotiation:** First, by contacting us to attempt resolution
+2. **Mediation:** If negotiation fails, through mediation
+3. **Arbitration/Litigation:** As a last resort, through binding arbitration or litigation in the courts of <%= if @company_country != "", do: @company_country, else: "[Your Jurisdiction]" %>
+
+## 12. Changes to Terms
+
+We reserve the right to modify these Terms at any time. We will notify you of material changes by:
+- Posting the updated Terms on our website
+- Updating the "Effective Date" at the top
+- Sending you an email notification (for significant changes)
+
+Your continued use of our services after changes constitutes acceptance of the modified Terms.
+
+## 13. Severability
+
+If any provision of these Terms is found to be unenforceable or invalid, that provision shall be limited or eliminated to the minimum extent necessary, and the remaining provisions shall remain in full force and effect.
+
+## 14. Entire Agreement
+
+These Terms, together with our Privacy Policy and any other agreements expressly incorporated by reference, constitute the entire agreement between you and <%= @company_name %> regarding your use of our services.
+
+## 15. Contact Us
+
+If you have any questions about these Terms, please contact us at:
+
+**<%= @company_name %>**
+<%= if @company_address != "" do %><%= @company_address %><% end %>
+<%= if @dpo_email != "" do %>Email: <%= @dpo_email %><% end %>


### PR DESCRIPTION
## Summary

Add Legal Module Phase 1 for GDPR/CCPA compliance with consent logging and legal page generation.

## Changes

### V43 Migration
- Add `phoenix_kit_consent_logs` table for user consent tracking
- Add legal settings seeds (legal_enabled, consent_widget_enabled, etc.)

### Legal Module (`lib/modules/legal/`)
- `PhoenixKit.Modules.Legal` - Main context with config, enable/disable
- `ConsentLog` schema - User consent records with analytics
- `TemplateGenerator` - EEx-based legal page generation
- Settings LiveView at `/admin/settings/legal`

### EEx Templates (`priv/legal_templates/`)
- Privacy Policy, Terms of Service, Cookie Policy
- CCPA Notice, Do Not Sell, Data Retention Policy
- Acceptable Use Policy

### Integration
- Admin sidebar navigation for Legal settings
- Blogging module integration for legal page storage
- `get_blog/1` and `check_slug_availability/3` helpers

### Other
- `get_subdivision_label/1` in CountryData for address forms
- Version 1.7.16

## Test Plan
- [x] `mix compile` passes
- [x] `mix quality` passes (format, credo, dialyzer)
- [x] Test app updated with V41→V42→V43 migrations
- [x] `phoenix_kit_consent_logs` table created
- [x] Legal settings seeds inserted