### PR TITLE
Add V89 migration, status_badge component, and table_row_menu inline mode

### DIFF
--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -529,7 +529,18 @@ defmodule PhoenixKit.Migrations.Postgres do
   - Replaces unique index with partial index (slug-mode only, WHERE slug IS NOT NULL)
   - Adds unique index on `(group_uuid, post_date, post_time)` for timestamp-mode posts
 
-  ### V87 - Add Catalogue tables ⚡ LATEST
+  ### V89 - Catalogue pricing ⚡ LATEST
+  - Renames `price` to `base_price` in `phoenix_kit_cat_items`
+  - Adds `markup_percentage` decimal column to `phoenix_kit_cat_catalogues`
+
+  ### V88 - Publishing schema V2
+  - Restructures posts/versions/contents for publishing module
+  - Adds `active_version_uuid`, `trashed_at` to posts
+  - Adds `published_at` to versions
+  - Data migration from legacy columns
+  - Drops legacy post columns: `scheduled_at`, `status`, `published_at`, `primary_language`, `data`
+
+  ### V87 - Add Catalogue tables
   - Creates `phoenix_kit_cat_manufacturers` — manufacturer directory
   - Creates `phoenix_kit_cat_suppliers` — supplier directory
   - Creates `phoenix_kit_cat_manufacturer_suppliers` — many-to-many join with unique constraint
@@ -667,7 +678,7 @@ defmodule PhoenixKit.Migrations.Postgres do
   use Ecto.Migration
 
   @initial_version 1
-  @current_version 88
+  @current_version 89
   @default_prefix "public"
 
   @doc false

--- a/lib/phoenix_kit/migrations/postgres/v89.ex
+++ b/lib/phoenix_kit/migrations/postgres/v89.ex
@@ -1,0 +1,87 @@
+defmodule PhoenixKit.Migrations.Postgres.V89 do
+  @moduledoc """
+  V89: Catalogue pricing — rename price to base_price, add markup_percentage.
+
+  Changes:
+  - Rename `price` to `base_price` in `phoenix_kit_cat_items`
+  - Add `markup_percentage` decimal column to `phoenix_kit_cat_catalogues`
+  """
+
+  use Ecto.Migration
+
+  def up(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+    schema = if prefix == "public", do: "public", else: prefix
+
+    execute("""
+    DO $$
+    BEGIN
+      -- Rename price to base_price in items
+      IF EXISTS (
+        SELECT FROM information_schema.columns
+        WHERE table_schema = '#{schema}'
+          AND table_name = 'phoenix_kit_cat_items'
+          AND column_name = 'price'
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_cat_items
+          RENAME COLUMN price TO base_price;
+      END IF;
+
+      -- Add markup_percentage to catalogues
+      IF EXISTS (
+        SELECT FROM information_schema.tables
+        WHERE table_schema = '#{schema}' AND table_name = 'phoenix_kit_cat_catalogues'
+      ) AND NOT EXISTS (
+        SELECT FROM information_schema.columns
+        WHERE table_schema = '#{schema}'
+          AND table_name = 'phoenix_kit_cat_catalogues'
+          AND column_name = 'markup_percentage'
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_cat_catalogues
+          ADD COLUMN markup_percentage DECIMAL(7, 2) NOT NULL DEFAULT 0;
+      END IF;
+    END $$;
+    """)
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '89'")
+  end
+
+  def down(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+    schema = if prefix == "public", do: "public", else: prefix
+
+    execute("""
+    DO $$
+    BEGIN
+      -- Rename base_price back to price in items
+      IF EXISTS (
+        SELECT FROM information_schema.columns
+        WHERE table_schema = '#{schema}'
+          AND table_name = 'phoenix_kit_cat_items'
+          AND column_name = 'base_price'
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_cat_items
+          RENAME COLUMN base_price TO price;
+      END IF;
+
+      -- Drop markup_percentage from catalogues
+      IF EXISTS (
+        SELECT FROM information_schema.columns
+        WHERE table_schema = '#{schema}'
+          AND table_name = 'phoenix_kit_cat_catalogues'
+          AND column_name = 'markup_percentage'
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_cat_catalogues
+          DROP COLUMN markup_percentage;
+      END IF;
+    END $$;
+    """)
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '88'")
+  end
+
+  defp prefix_str("public"), do: "public."
+  defp prefix_str(prefix), do: "#{prefix}."
+end

--- a/lib/phoenix_kit_web/components/core/badge.ex
+++ b/lib/phoenix_kit_web/components/core/badge.ex
@@ -253,6 +253,47 @@ defmodule PhoenixKitWeb.Components.Core.Badge do
   defp enabled_class(true), do: "badge-success"
   defp enabled_class(false), do: "badge-neutral"
 
+  @doc """
+  Renders a generic status badge from a status string.
+
+  Maps common status values to appropriate badge colors. Covers statuses used
+  across PhoenixKit modules (catalogue items, entities, users, etc.).
+
+  ## Attributes
+
+  - `status` - Status string (required)
+  - `size` - Badge size (default: :sm)
+  - `class` - Additional CSS classes
+
+  ## Examples
+
+      <.status_badge status="active" />
+      <.status_badge status="deleted" size={:xs} />
+      <.status_badge status="discontinued" class="ml-2" />
+  """
+  attr :status, :string, required: true
+  attr :size, :atom, default: :sm, values: [:xs, :sm, :md, :lg]
+  attr :class, :string, default: ""
+
+  def status_badge(assigns) do
+    ~H"""
+    <span class={["badge", status_class(@status), size_class(@size), @class]}>
+      {String.capitalize(@status)}
+    </span>
+    """
+  end
+
+  defp status_class("active"), do: "badge-success"
+  defp status_class("inactive"), do: "badge-ghost"
+  defp status_class("archived"), do: "badge-warning"
+  defp status_class("deleted"), do: "badge-error"
+  defp status_class("discontinued"), do: "badge-warning"
+  defp status_class("draft"), do: "badge-warning"
+  defp status_class("published"), do: "badge-success"
+  defp status_class("pending"), do: "badge-info"
+  defp status_class("suspended"), do: "badge-error"
+  defp status_class(_), do: "badge-ghost"
+
   # Size classes — h-auto allows badge to expand when text wraps on mobile
   defp size_class(:xs), do: "badge-xs h-auto"
   defp size_class(:sm), do: "badge-sm h-auto"

--- a/lib/phoenix_kit_web/components/core/table_default.ex
+++ b/lib/phoenix_kit_web/components/core/table_default.ex
@@ -79,6 +79,7 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
   attr :variant, :string, default: "default", values: ["default", "zebra", "pin-rows", "pin-cols"]
   attr :size, :string, default: "md", values: ["xs", "sm", "md", "lg"]
   attr :toggleable, :boolean, default: false
+  attr :show_toggle, :boolean, default: true
   attr :items, :list, default: []
   attr :card_title, :any, default: nil
   attr :card_fields, :any, default: nil
@@ -122,8 +123,8 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
   defp table_default_with_cards(assigns) do
     ~H"""
     <div id={@id} phx-hook="TableCardView" data-storage-key={@storage_key || @id} class="relative">
-      <%!-- Toggle buttons — only if toggleable, only desktop --%>
-      <div :if={@toggleable} class="hidden md:flex justify-end mb-2">
+      <%!-- Toggle buttons — only if toggleable and show_toggle, only desktop --%>
+      <div :if={@toggleable && @show_toggle} class="hidden md:flex justify-end mb-2">
         <div class="join">
           <button
             type="button"

--- a/lib/phoenix_kit_web/components/core/table_default.ex
+++ b/lib/phoenix_kit_web/components/core/table_default.ex
@@ -83,6 +83,7 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
   attr :card_title, :any, default: nil
   attr :card_fields, :any, default: nil
   attr :storage_key, :string, default: nil
+  attr :wrapper_class, :string, default: "rounded-lg shadow-md overflow-x-auto overflow-y-clip"
   attr :rest, :global
 
   slot :inner_block, required: true
@@ -102,7 +103,7 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
 
   defp table_default_classic(assigns) do
     ~H"""
-    <div class="rounded-lg shadow-md overflow-x-auto overflow-y-clip">
+    <div class={@wrapper_class}>
       <table
         class={[
           "table",
@@ -144,7 +145,7 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
       </div>
       <%!-- Table: hidden on mobile always, shown on desktop (JS controls md: classes) --%>
       <div data-table-view="" class="hidden md:block">
-        <div class="rounded-lg shadow-md overflow-x-auto overflow-y-clip">
+        <div class={@wrapper_class}>
           <table
             class={[
               "table",

--- a/lib/phoenix_kit_web/components/core/table_row_menu.ex
+++ b/lib/phoenix_kit_web/components/core/table_row_menu.ex
@@ -59,6 +59,10 @@ defmodule PhoenixKitWeb.Components.Core.TableRowMenu do
 
   * `id` - Unique element ID (required). Used by the JS hook.
   * `label` - Accessible label for the trigger button (optional, default: "Actions")
+  * `mode` - Display mode (optional, default: "dropdown"):
+    - `"dropdown"` — always show the ⋮ dropdown menu (original behavior)
+    - `"inline"` — always show actions as inline buttons (no dropdown)
+    - `"auto"` — inline buttons on `md+` screens, dropdown on mobile
   * `class` - Additional CSS classes for the wrapper (optional)
 
   ## Slots
@@ -68,9 +72,53 @@ defmodule PhoenixKitWeb.Components.Core.TableRowMenu do
   """
   attr :id, :string, required: true
   attr :label, :string, default: "Actions"
+  attr :mode, :string, default: "dropdown", values: ["dropdown", "inline", "auto"]
   attr :class, :string, default: nil
 
   slot :inner_block, required: true
+
+  def table_row_menu(%{mode: "inline"} = assigns) do
+    ~H"""
+    <div class={["inline-flex flex-nowrap items-center gap-0.5 row-menu-inline", @class]} role="group" aria-label={@label}>
+      {render_slot(@inner_block)}
+    </div>
+    """
+  end
+
+  def table_row_menu(%{mode: "auto"} = assigns) do
+    ~H"""
+    <%!-- Inline buttons: visible on md+ --%>
+    <div class={["hidden md:inline-flex flex-nowrap items-center gap-0.5 row-menu-inline", @class]} role="group" aria-label={@label}>
+      {render_slot(@inner_block)}
+    </div>
+    <%!-- Dropdown menu: visible on mobile only --%>
+    <div
+      id={@id}
+      phx-hook="RowMenu"
+      class={["relative inline-block md:hidden", @class]}
+      data-row-menu-wrapper
+    >
+      <button
+        type="button"
+        data-row-menu-trigger
+        aria-label={@label}
+        aria-expanded="false"
+        aria-haspopup="menu"
+        class="btn btn-xs btn-ghost btn-circle"
+      >
+        <.icon name="hero-ellipsis-vertical" class="w-4 h-4" />
+      </button>
+      <ul
+        data-row-menu-content
+        role="menu"
+        class="hidden fixed z-[9999] min-w-[10rem] rounded-box bg-base-100 border border-base-200 shadow-xl p-1 focus:outline-none"
+        tabindex="-1"
+      >
+        {render_slot(@inner_block)}
+      </ul>
+    </div>
+    """
+  end
 
   def table_row_menu(assigns) do
     ~H"""

--- a/priv/static/assets/phoenix_kit.js
+++ b/priv/static/assets/phoenix_kit.js
@@ -1458,8 +1458,26 @@ if (typeof window.Chart === "undefined") {
           var mode = btn.dataset.viewAction;
           localStorage.setItem(self.storageKey, mode);
           self.applyMode(mode);
+          // Notify other TableCardView instances sharing the same key
+          window.dispatchEvent(new CustomEvent("phx:table-view-change", {
+            detail: { key: self.storageKey, mode: mode }
+          }));
         });
       });
+
+      // Listen for view changes from other instances with the same key
+      this._onViewChange = function(e) {
+        if (e.detail.key === self.storageKey) {
+          self.applyMode(e.detail.mode);
+        }
+      };
+      window.addEventListener("phx:table-view-change", this._onViewChange);
+    },
+
+    destroyed() {
+      if (this._onViewChange) {
+        window.removeEventListener("phx:table-view-change", this._onViewChange);
+      }
     },
 
     applyMode(mode) {


### PR DESCRIPTION
  ## Summary

  Core additions to support the phoenix_kit_catalogue release.

  ### V89 Migration
  - Rename `price` → `base_price` in `phoenix_kit_cat_items`
  - Add `markup_percentage` DECIMAL(7,2) NOT NULL DEFAULT 0 to
  `phoenix_kit_cat_catalogues`
  - Bump `@current_version` to 89

  ### status_badge component (badge.ex)
  - New generic `status_badge/1` mapping common status strings to badge colors
  - Covers: active, inactive, archived, deleted, discontinued, draft, published, pending,
   suspended

  ### table_row_menu inline mode (table_row_menu.ex)
  - New `mode` attr: `"dropdown"` (default), `"inline"`, `"auto"`
  - `"auto"` renders inline buttons on md+ screens, dropdown on mobile
  - Uses `.row-menu-inline` CSS class — requires companion CSS in parent app
  - Fully backwards compatible — default behavior unchanged

  ### table_default enhancements (table_default.ex)
  - `wrapper_class` attr to override default overflow/shadow wrapper
  - `show_toggle` attr to hide per-table toggle button (for external global toggles)

  ### TableCardView JS sync (phoenix_kit.js)
  - Instances sharing the same `storage_key` sync via `phx:table-view-change` custom
  event
  - Proper `destroyed()` cleanup for event listener