### PR TITLE
Unify language systems and add continent-grouped language switcher

### DIFF
--- a/lib/modules/languages/README.md
+++ b/lib/modules/languages/README.md
@@ -1,6 +1,6 @@
 # Languages Module
 
-The PhoenixKit Languages module provides multi-language support with a two-tier locale system (base codes for URLs, full dialects for translations). It manages both frontend user-facing languages and backend admin panel languages.
+The PhoenixKit Languages module provides multi-language support with a two-tier locale system (base codes for URLs, full dialects for translations). It provides a unified language configuration used by both the public-facing language switcher and the admin panel.
 
 ## Quick Links
 
@@ -18,7 +18,6 @@ The PhoenixKit Languages module provides multi-language support with a two-tier 
 |-------------|--------|-------------|
 | `languages_enabled` | `value` | Boolean flag (`true`/`false`) |
 | `languages_config` | `value_json` | JSON with `{"languages": [...]}` structure |
-| `admin_languages` | `value` | JSON array of admin language codes |
 
 ### Querying Configuration
 
@@ -50,8 +49,6 @@ SELECT value FROM phoenix_kit_settings WHERE key = 'languages_enabled';
 -- Get full configuration (note: value_json, not value)
 SELECT value_json FROM phoenix_kit_settings WHERE key = 'languages_config';
 
--- Get admin languages
-SELECT value FROM phoenix_kit_settings WHERE key = 'admin_languages';
 ```
 
 ## Language Configuration Structure
@@ -107,23 +104,6 @@ alias PhoenixKit.Modules.Languages.DialectMapper
 DialectMapper.extract_base("en-US")           # => "en"
 DialectMapper.base_to_dialect("en")           # => "en-US"
 DialectMapper.resolve_dialect("en", user)     # Considers user.custom_fields["preferred_locale"]
-```
-
-## Frontend vs Backend Languages
-
-| Setting | Purpose | Storage Key |
-|---------|---------|-------------|
-| **Frontend Languages** | User-facing language switcher | `languages_config` |
-| **Backend Languages** | Admin panel language switcher | `admin_languages` |
-
-These are **independent** - admins can use different languages than site visitors.
-
-### Admin Languages
-
-```elixir
-# Get admin languages (returns list of base codes)
-PhoenixKit.Settings.get_setting_cached("admin_languages", nil)
-# => "[\"en-US\",\"ja\"]"
 ```
 
 ## Key API Functions

--- a/lib/modules/languages/README.md
+++ b/lib/modules/languages/README.md
@@ -29,7 +29,7 @@ PhoenixKit.Modules.Languages.get_display_languages()
 
 # Get the default/primary language
 PhoenixKit.Modules.Languages.get_default_language()
-# => %{"code" => "en", "name" => "English", "is_default" => true, "is_enabled" => true}
+# => %Language{code: "en-US", name: "English (United States)", is_default: true, is_enabled: true}
 
 # Get the primary language code for Publishing module
 PhoenixKit.Settings.get_content_language()
@@ -139,11 +139,48 @@ Languages.move_language_up("es-ES")       # Reorder
 Languages.move_language_down("es-ES")     # Reorder
 ```
 
+## Language Struct
+
+All public functions return `%Language{}` structs (not plain maps):
+
+```elixir
+lang = Languages.get_default_language()
+lang.code       #=> "en-US"
+lang.name       #=> "English (United States)"
+lang.native     #=> "English (US)"
+lang.flag       #=> "🇺🇸"
+lang.is_default #=> true
+lang.is_enabled #=> true
+lang.countries  #=> ["Australia", "Canada", "United States", ...]
+```
+
+See `PhoenixKit.Modules.Languages.Language` for the full struct definition.
+
+## Continent Grouping
+
+When more than 7 languages are enabled, the language switcher automatically shows a two-step interface:
+
+1. User selects a continent from the list
+2. User selects a language within that continent
+
+This uses the same continent data as the admin settings page (`get_languages_grouped_by_continent/0`). Languages may appear under multiple continents if spoken in countries across regions.
+
+```elixir
+# Get enabled languages organized by continent
+Languages.get_enabled_languages_by_continent()
+# => [{"Asia", [%{code: "ja", ...}, %{code: "ko", ...}]}, {"Europe", [%{code: "de-DE", ...}]}, ...]
+```
+
+The threshold is configurable via the `continent_threshold` attribute on the switcher component (default: 7).
+
 ## Language Switcher Components
 
 ```heex
-<%!-- Dropdown (recommended) --%>
+<%!-- Dropdown (recommended) — auto-groups by continent when >7 languages --%>
 <.language_switcher_dropdown current_locale={@current_locale} />
+
+<%!-- With custom threshold --%>
+<.language_switcher_dropdown current_locale={@current_locale} continent_threshold={5} />
 
 <%!-- Button group --%>
 <.language_switcher_buttons current_locale={@current_locale} />
@@ -197,6 +234,12 @@ The Publishing module uses Languages for:
 2. **Multi-language URLs**: `/en/blog/post` vs `/es/blog/post`
 3. **Per-post primary_language**: Stored in `.phk` file metadata
 4. **Language detection**: Determines if URL segment is language or blog slug
+
+## Legacy Migration
+
+Older versions of PhoenixKit used a separate `admin_languages` setting for the admin panel language switcher. This has been unified — both admin and public-facing switchers now use `languages_config`.
+
+On application startup, `normalize_language_settings/0` runs automatically to merge any languages from the old `admin_languages` setting into the unified config, then clears the old setting. This is idempotent and a no-op if already migrated.
 
 ## Troubleshooting
 

--- a/lib/modules/languages/languages.ex
+++ b/lib/modules/languages/languages.ex
@@ -96,6 +96,8 @@ defmodule PhoenixKit.Modules.Languages do
 
   use PhoenixKit.Module
 
+  require Logger
+
   alias PhoenixKit.Config
   alias PhoenixKit.Dashboard.Tab
   alias PhoenixKit.Modules.Languages.Language
@@ -138,6 +140,123 @@ defmodule PhoenixKit.Modules.Languages do
   ]
 
   ## --- System Management Functions ---
+
+  @doc """
+  Normalizes language settings by merging any languages from the legacy
+  `admin_languages` setting into the unified `languages_config`.
+
+  This is a one-time migration function that:
+  1. Reads the old `admin_languages` JSON array of codes
+  2. Ensures the Languages module is enabled if admin languages existed
+  3. Adds any admin-only languages to the unified config
+  4. Clears the old `admin_languages` setting to prevent re-processing
+
+  Idempotent — if `admin_languages` doesn't exist or is empty, this is a no-op.
+
+  ## Examples
+
+      iex> PhoenixKit.Modules.Languages.normalize_language_settings()
+      :ok
+  """
+  def normalize_language_settings do
+    case Settings.get_setting("admin_languages") do
+      nil ->
+        :ok
+
+      "[]" ->
+        :ok
+
+      admin_json when is_binary(admin_json) ->
+        case Jason.decode(admin_json) do
+          {:ok, codes} when is_list(codes) and codes != [] ->
+            merge_admin_languages(codes)
+
+          {:ok, _} ->
+            :ok
+
+          {:error, decode_error} ->
+            Logger.warning(
+              "[PhoenixKit Languages] Invalid JSON in legacy admin_languages setting: #{inspect(decode_error)}"
+            )
+
+            :ok
+        end
+
+      _ ->
+        :ok
+    end
+  rescue
+    error ->
+      Logger.warning(
+        "[PhoenixKit Languages] Could not normalize legacy admin_languages setting: #{inspect(error)}"
+      )
+
+      :ok
+  end
+
+  defp merge_admin_languages(admin_codes) do
+    # Ensure the system is enabled so we can add languages
+    unless enabled?() do
+      case enable_system() do
+        {:ok, _} ->
+          Logger.info("[PhoenixKit Languages] Enabled Languages module for legacy migration")
+
+        {:error, reason} ->
+          Logger.warning(
+            "[PhoenixKit Languages] Failed to enable Languages module during migration: #{inspect(reason)}"
+          )
+
+          # Cannot proceed without the module enabled
+          throw(:enable_failed)
+      end
+    end
+
+    current_codes = get_language_codes()
+
+    # Add any admin-only languages that aren't already in the config
+    results =
+      for code <- admin_codes, code not in current_codes do
+        case add_language(code) do
+          {:ok, _} ->
+            Logger.info(
+              "[PhoenixKit Languages] Migrated admin language #{code} to unified config"
+            )
+
+            {:ok, code}
+
+          {:error, reason} ->
+            Logger.warning(
+              "[PhoenixKit Languages] Failed to migrate admin language #{code}: #{inspect(reason)}"
+            )
+
+            {:error, code}
+        end
+      end
+
+    added_count = Enum.count(results, &match?({:ok, _}, &1))
+    failed_count = Enum.count(results, &match?({:error, _}, &1))
+
+    if added_count > 0 or failed_count > 0 do
+      Logger.info(
+        "[PhoenixKit Languages] Migration complete: #{added_count} added, #{failed_count} failed"
+      )
+    end
+
+    # Clear the legacy setting so this doesn't run again
+    case Settings.update_setting("admin_languages", "[]") do
+      {:ok, _} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning(
+          "[PhoenixKit Languages] Failed to clear legacy admin_languages setting: #{inspect(reason)}"
+        )
+    end
+
+    :ok
+  catch
+    :enable_failed -> :ok
+  end
 
   @impl PhoenixKit.Module
   @doc """

--- a/lib/modules/languages/languages.ex
+++ b/lib/modules/languages/languages.ex
@@ -52,11 +52,11 @@ defmodule PhoenixKit.Modules.Languages do
 
       # Get all languages
       languages = PhoenixKit.Modules.Languages.get_languages()
-      # => [%{code: "en-US", name: "English (United States)", is_default: true, is_enabled: true}, ...]
+      # => [%Language{code: "en-US", name: "English (United States)", is_default: true, is_enabled: true}, ...]
 
       # Get only enabled languages (most common use case)
       enabled_languages = PhoenixKit.Modules.Languages.get_enabled_languages()
-      # => [%{code: "en-US", name: "English (United States)", ...}, %{code: "es-ES", name: "Spanish (Spain)", ...}]
+      # => [%Language{code: "en-US", name: "English (United States)", ...}, ...]
 
       # Get a specific language by code
       spanish = PhoenixKit.Modules.Languages.get_language("es-ES")

--- a/lib/modules/languages/languages.ex
+++ b/lib/modules/languages/languages.ex
@@ -439,6 +439,44 @@ defmodule PhoenixKit.Modules.Languages do
   end
 
   @doc """
+  Gets enabled languages grouped by continent.
+
+  Filters `get_languages_grouped_by_continent/0` to only include languages
+  that are currently enabled. Languages may appear under multiple continents
+  (same as the admin settings page). Returns `[{continent, [language_maps]}]`.
+
+  ## Examples
+
+      iex> PhoenixKit.Modules.Languages.get_enabled_languages_by_continent()
+      [{"Asia", [%{code: "ja", name: "Japanese", ...}]}, {"Europe", [%{code: "de-DE", ...}]}, ...]
+  """
+  def get_enabled_languages_by_continent do
+    enabled_codes =
+      get_display_languages()
+      |> Enum.filter(& &1.is_enabled)
+      |> MapSet.new(& &1.code)
+
+    get_languages_grouped_by_continent()
+    |> Enum.map(fn {continent, countries} ->
+      langs = collect_enabled_langs(countries, enabled_codes)
+      {continent, langs}
+    end)
+    |> Enum.reject(fn {_, langs} -> langs == [] end)
+    |> Enum.sort_by(fn {continent, _} -> continent end)
+  end
+
+  defp collect_enabled_langs(countries, enabled_codes) do
+    countries
+    |> Enum.flat_map(fn {_country, _flag, country_langs} ->
+      Enum.filter(country_langs, &(lang_code(&1) in enabled_codes))
+    end)
+    |> Enum.uniq_by(&lang_code/1)
+  end
+
+  defp lang_code(lang) when is_struct(lang), do: lang.code
+  defp lang_code(lang) when is_map(lang), do: lang[:code]
+
+  @doc """
   Gets the default language.
 
   Returns the language map marked as default, or nil if none found.

--- a/lib/modules/sitemap/sources/publishing.ex
+++ b/lib/modules/sitemap/sources/publishing.ex
@@ -54,8 +54,6 @@ defmodule PhoenixKit.Modules.Sitemap.Sources.Publishing do
 
   @publishing_mod PhoenixKit.Modules.Publishing
 
-  @default_locale Config.default_locale()
-
   # Future: Hook into Publishing post creation/update to invalidate sitemap-publishing
 
   @impl true
@@ -531,11 +529,11 @@ defmodule PhoenixKit.Modules.Sitemap.Sources.Publishing do
     _ -> true
   end
 
-  # Get default language from admin settings
+  # Get default language from the Languages module
   defp get_default_language do
-    case PhoenixKit.Settings.get_json_setting_cached("admin_languages", [@default_locale]) do
-      [first | _] -> Languages.DialectMapper.extract_base(first)
-      _ -> "en"
+    case Languages.get_default_language() do
+      %{code: code} -> Languages.DialectMapper.extract_base(code)
+      nil -> "en"
     end
   end
 

--- a/lib/phoenix_kit/settings/events.ex
+++ b/lib/phoenix_kit/settings/events.ex
@@ -18,11 +18,6 @@ defmodule PhoenixKit.Settings.Events do
     Manager.broadcast(@topic_settings, {:content_language_changed, new_language})
   end
 
-  @doc "Broadcast that admin languages were changed."
-  def broadcast_admin_languages_changed(admin_languages) do
-    Manager.broadcast(@topic_settings, {:admin_languages_changed, admin_languages})
-  end
-
   @doc "Broadcast that any setting was changed (generic)."
   def broadcast_setting_changed(key, value) do
     Manager.broadcast(@topic_settings, {:setting_changed, key, value})

--- a/lib/phoenix_kit/settings/setting.ex
+++ b/lib/phoenix_kit/settings/setting.ex
@@ -258,8 +258,6 @@ defmodule PhoenixKit.Settings.Setting do
       field :time_format, :string
       field :track_registration_geolocation, :string
       field :registration_show_username, :string
-      # Admin Panel Languages
-      field :admin_languages, :string
       # OAuth Provider Credentials
       field :oauth_google_client_id, :string
       field :oauth_google_client_secret, :string
@@ -321,7 +319,6 @@ defmodule PhoenixKit.Settings.Setting do
         :time_format,
         :track_registration_geolocation,
         :registration_show_username,
-        :admin_languages,
         :oauth_google_client_id,
         :oauth_google_client_secret,
         :oauth_apple_client_id,

--- a/lib/phoenix_kit/settings/settings.ex
+++ b/lib/phoenix_kit/settings/settings.ex
@@ -75,7 +75,6 @@ defmodule PhoenixKit.Settings do
   alias PhoenixKit.Users.Roles
   alias PhoenixKit.Utils.Date, as: UtilsDate
 
-  @default_locale PhoenixKit.Config.default_locale()
   @cache_name :settings
 
   @doc """
@@ -157,9 +156,7 @@ defmodule PhoenixKit.Settings do
       "oauth_github_client_id" => "",
       "oauth_github_client_secret" => "",
       "oauth_facebook_app_id" => "",
-      "oauth_facebook_app_secret" => "",
-      # Admin Panel Languages - default is just the default locale for fresh installs
-      "admin_languages" => Jason.encode!([@default_locale])
+      "oauth_facebook_app_secret" => ""
     }
   end
 

--- a/lib/phoenix_kit/supervisor.ex
+++ b/lib/phoenix_kit/supervisor.ex
@@ -4,6 +4,8 @@ defmodule PhoenixKit.Supervisor do
   """
   use Supervisor
 
+  alias PhoenixKit.Modules.Languages
+
   def start_link(init_arg) do
     Supervisor.start_link(__MODULE__, init_arg, name: __MODULE__)
   end
@@ -51,6 +53,9 @@ defmodule PhoenixKit.Supervisor do
       # Dashboard tab registry for user dashboard navigation.
       # Starts after settings_cache so module enabled? checks hit cache rather than DB.
       PhoenixKit.Dashboard.Registry,
+      # Normalize legacy admin_languages setting into unified languages_config
+      # Runs once after settings cache is warmed; idempotent no-op if already migrated
+      {Task, fn -> Languages.normalize_language_settings() end},
       # Rate limiter backend MUST be started before any authentication requests
       PhoenixKit.Users.RateLimiter.Backend,
       # Task supervisor for fire-and-forget background work (e.g. stale fixer)

--- a/lib/phoenix_kit/supervisor.ex
+++ b/lib/phoenix_kit/supervisor.ex
@@ -56,7 +56,19 @@ defmodule PhoenixKit.Supervisor do
       # Normalize legacy admin_languages setting into unified languages_config
       # Runs once after settings cache is warmed; idempotent no-op if already migrated
       Supervisor.child_spec(
-        {Task, fn -> Languages.normalize_language_settings() end},
+        {Task,
+         fn ->
+           try do
+             Languages.normalize_language_settings()
+           rescue
+             error ->
+               require Logger
+
+               Logger.error(
+                 "[PhoenixKit] Failed to normalize language settings at startup: #{inspect(error)}"
+               )
+           end
+         end},
         id: :normalize_languages
       ),
       # Rate limiter backend MUST be started before any authentication requests

--- a/lib/phoenix_kit/supervisor.ex
+++ b/lib/phoenix_kit/supervisor.ex
@@ -55,7 +55,10 @@ defmodule PhoenixKit.Supervisor do
       PhoenixKit.Dashboard.Registry,
       # Normalize legacy admin_languages setting into unified languages_config
       # Runs once after settings cache is warmed; idempotent no-op if already migrated
-      {Task, fn -> Languages.normalize_language_settings() end},
+      Supervisor.child_spec(
+        {Task, fn -> Languages.normalize_language_settings() end},
+        id: :normalize_languages
+      ),
       # Rate limiter backend MUST be started before any authentication requests
       PhoenixKit.Users.RateLimiter.Backend,
       # Task supervisor for fire-and-forget background work (e.g. stale fixer)

--- a/lib/phoenix_kit/utils/multilang.ex
+++ b/lib/phoenix_kit/utils/multilang.ex
@@ -357,6 +357,8 @@ defmodule PhoenixKit.Utils.Multilang do
     Code.ensure_loaded?(Languages) and
       function_exported?(Languages, :enabled?, 0) and
       Languages.enabled?()
+  rescue
+    _ -> false
   end
 
   defp enabled_language_codes do
@@ -366,6 +368,8 @@ defmodule PhoenixKit.Utils.Multilang do
     else
       [default_language_code()]
     end
+  rescue
+    _ -> [default_language_code()]
   end
 
   defp default_language_code do
@@ -378,6 +382,8 @@ defmodule PhoenixKit.Utils.Multilang do
     else
       "en-US"
     end
+  rescue
+    _ -> "en-US"
   end
 
   defp get_language_info(code) do

--- a/lib/phoenix_kit/utils/routes.ex
+++ b/lib/phoenix_kit/utils/routes.ex
@@ -123,10 +123,12 @@ defmodule PhoenixKit.Utils.Routes do
       "en"
     else
       case Languages.get_default_language() do
-        %{code: code} -> DialectMapper.extract_base(code)
-        nil -> "en"
+        %{code: code} when is_binary(code) -> DialectMapper.extract_base(code)
+        _ -> "en"
       end
     end
+  rescue
+    _ -> "en"
   end
 
   # Detect if we're running in a mix task context where the database

--- a/lib/phoenix_kit/utils/routes.ex
+++ b/lib/phoenix_kit/utils/routes.ex
@@ -7,6 +7,7 @@ defmodule PhoenixKit.Utils.Routes do
   """
 
   alias PhoenixKit.Config
+  alias PhoenixKit.Modules.Languages
   alias PhoenixKit.Modules.Languages.DialectMapper
 
   @default_locale Config.default_locale()
@@ -107,31 +108,23 @@ defmodule PhoenixKit.Utils.Routes do
     DialectMapper.extract_base(locale)
   end
 
-  # Check if the given locale is the default (first in admin_languages list)
+  # Check if the given locale is the default language
   # Default locale doesn't need a prefix in URLs for cleaner URLs
   defp default_locale?(locale) do
-    default = get_default_admin_language()
+    default = get_default_language_base()
     locale == default
   end
 
-  defp get_default_admin_language do
+  defp get_default_language_base do
     # During mix tasks (like phoenix_kit.install), the database may not have
     # the settings table yet. We detect this by checking if we're in a mix task
     # context and fall back to "en" to avoid database errors.
     if mix_task_context?() do
       "en"
     else
-      case PhoenixKit.Settings.get_json_setting_cached("admin_languages", [@default_locale]) do
-        nil ->
-          # No setting exists, default is "en"
-          "en"
-
-        [first | _] ->
-          # Extract base code from full dialect (e.g., "en-US" -> "en")
-          DialectMapper.extract_base(first)
-
-        _ ->
-          "en"
+      case Languages.get_default_language() do
+        %{code: code} -> DialectMapper.extract_base(code)
+        nil -> "en"
       end
     end
   end
@@ -190,27 +183,18 @@ defmodule PhoenixKit.Utils.Routes do
   end
 
   @doc """
-  Returns the default admin locale (base code).
+  Returns the default locale (base code) from the Languages module.
 
-  This is the first language in the admin_languages setting list,
-  extracted to its base code (e.g., "en-US" becomes "en").
-
-  Falls back to "en" if no admin languages are configured.
+  Extracts the base code from the default language (e.g., "en-US" becomes "en").
+  Falls back to "en" if no default language is configured.
 
   ## Examples
 
       iex> Routes.get_default_admin_locale()
-      "en"  # or "ko" if Korean is first in admin_languages
-
-  ## Use Case
-
-  This is used automatically in the `on_mount` hook to set `current_locale`
-  in socket assigns. LiveViews can then simply use:
-
-      locale = params["locale"] || socket.assigns[:current_locale]
+      "en"
   """
   def get_default_admin_locale do
-    get_default_admin_language()
+    get_default_language_base()
   end
 
   @doc """

--- a/lib/phoenix_kit_web/components/admin_nav.ex
+++ b/lib/phoenix_kit_web/components/admin_nav.ex
@@ -7,17 +7,13 @@ defmodule PhoenixKitWeb.Components.AdminNav do
   use Phoenix.Component
 
   alias Phoenix.LiveView.JS
-  alias PhoenixKit.Config
   alias PhoenixKit.Modules.Languages
   alias PhoenixKit.Modules.Languages.DialectMapper
-  alias PhoenixKit.Settings
   alias PhoenixKit.Users.Auth.Scope
   alias PhoenixKit.Utils.Routes
 
   import PhoenixKitWeb.Components.Core.Icon
   import PhoenixKitWeb.Components.Core.ThemeController, only: [theme_controller: 1]
-
-  @default_locale Config.default_locale()
 
   @doc """
   Renders an admin navigation item with proper active state styling.
@@ -187,7 +183,7 @@ defmodule PhoenixKitWeb.Components.AdminNav do
   attr(:current_locale, :string, default: "en")
 
   def admin_language_dropdown(assigns) do
-    # Get admin languages from settings (separate from the language module)
+    # Get languages from the unified Languages module
     admin_languages = get_admin_languages()
 
     # Extract base code from current locale for matching
@@ -567,37 +563,19 @@ defmodule PhoenixKitWeb.Components.AdminNav do
     Regex.match?(~r/^[a-z]{2,3}(-[A-Za-z]{2,4})?$/i, locale)
   end
 
-  # Helper function to get admin languages from settings
-  # Returns empty list if Languages module is disabled or not loaded
+  # Helper function to get languages for admin nav display
+  # Uses the unified Languages module as the single source of truth
   defp get_admin_languages do
-    # If Languages module is not loaded or not enabled, return empty list
-    if Code.ensure_loaded?(Languages) and Languages.enabled?() do
-      # Read admin languages from settings cache (not all enabled languages)
-      # Note: admin_languages is stored as JSON string in value column
-      admin_languages_json =
-        Settings.get_setting_cached("admin_languages", nil) ||
-          Jason.encode!([@default_locale])
-
-      admin_language_codes =
-        case Jason.decode(admin_languages_json) do
-          {:ok, codes} when is_list(codes) -> codes
-          _ -> [@default_locale]
-        end
-
-      # Map codes to full language objects
-      admin_language_codes
-      |> Enum.map(fn code ->
-        case Languages.get_predefined_language(code) do
-          %{} = lang ->
-            lang
-
-          nil ->
-            # Fallback for unknown codes
-            %{code: code, name: code, flag: "🌐", native: ""}
+    if Code.ensure_loaded?(Languages) do
+      Languages.get_display_languages()
+      |> Enum.filter(& &1.is_enabled)
+      |> Enum.map(fn lang ->
+        case Languages.get_predefined_language(lang.code) do
+          %{} = predefined -> predefined
+          nil -> %{code: lang.code, name: lang.name, flag: "🌐", native: ""}
         end
       end)
     else
-      # Module disabled, return empty list
       []
     end
   end
@@ -615,26 +593,16 @@ defmodule PhoenixKitWeb.Components.AdminNav do
   end
 
   # Build URL with base code - expects base code directly (e.g., "en" not "en-US")
-  # Used by admin language dropdown where language["code"] is already the base code
   # Uses Routes.path/2 which automatically skips locale prefix for default language
   defp build_locale_url(current_path, base_code) do
-    # Get valid language codes from both admin and frontend systems
-    admin_languages = get_admin_languages()
-    admin_language_codes = Enum.map(admin_languages, & &1.code)
-    admin_base_codes = Enum.map(admin_language_codes, &DialectMapper.extract_base/1)
-
-    # Get frontend language codes from the Language Module
-    frontend_language_codes =
+    # Get valid language codes from the unified Languages module
+    language_codes =
       if Code.ensure_loaded?(Languages),
         do: Languages.enabled_locale_codes(),
         else: []
 
-    frontend_base_codes = Enum.map(frontend_language_codes, &DialectMapper.extract_base/1)
-
-    # Accept language if it's valid in EITHER admin or frontend (both full and base codes)
-    valid_language_codes =
-      (admin_language_codes ++ frontend_language_codes ++ admin_base_codes ++ frontend_base_codes)
-      |> Enum.uniq()
+    base_codes = Enum.map(language_codes, &DialectMapper.extract_base/1)
+    valid_codes = Enum.uniq(language_codes ++ base_codes)
 
     # Remove PhoenixKit prefix if present (use dynamic config, not hardcoded)
     url_prefix = PhoenixKit.Config.get_url_prefix()
@@ -645,18 +613,10 @@ defmodule PhoenixKitWeb.Components.AdminNav do
     clean_path =
       case String.split(normalized_path, "/", parts: 3) do
         ["", potential_locale, rest] ->
-          if potential_locale in valid_language_codes do
-            "/" <> rest
-          else
-            normalized_path
-          end
+          if potential_locale in valid_codes, do: "/" <> rest, else: normalized_path
 
         ["", potential_locale] ->
-          if potential_locale in valid_language_codes do
-            "/"
-          else
-            normalized_path
-          end
+          if potential_locale in valid_codes, do: "/", else: normalized_path
 
         _ ->
           normalized_path

--- a/lib/phoenix_kit_web/components/admin_nav.ex
+++ b/lib/phoenix_kit_web/components/admin_nav.ex
@@ -191,11 +191,19 @@ defmodule PhoenixKitWeb.Components.AdminNav do
 
     # Transform languages: code = base (for URLs), dialect = full (for preferences)
     transformed_languages =
-      Enum.map(admin_languages, fn lang ->
+      admin_languages
+      |> Enum.filter(fn lang -> is_binary(Map.get(lang, :code)) end)
+      |> Enum.map(fn lang ->
         dialect = lang.code
         base = DialectMapper.extract_base(dialect)
 
-        %{code: base, dialect: dialect, name: lang.name, flag: lang.flag, native: lang.native}
+        %{
+          code: base,
+          dialect: dialect,
+          name: Map.get(lang, :name, dialect),
+          flag: Map.get(lang, :flag, "🌐"),
+          native: Map.get(lang, :native, "")
+        }
       end)
 
     current_language =
@@ -568,15 +576,22 @@ defmodule PhoenixKitWeb.Components.AdminNav do
   defp get_admin_languages do
     if Code.ensure_loaded?(Languages) do
       Languages.get_display_languages()
-      |> Enum.filter(& &1.is_enabled)
-      |> Enum.map(fn lang ->
-        case Languages.get_predefined_language(lang.code) do
-          %{} = predefined -> predefined
-          nil -> %{code: lang.code, name: lang.name, flag: "🌐", native: ""}
-        end
-      end)
+      |> Enum.filter(fn lang -> is_map(lang) and Map.get(lang, :is_enabled, false) end)
+      |> Enum.map(&enrich_language/1)
+      |> Enum.reject(&is_nil/1)
     else
       []
+    end
+  end
+
+  defp enrich_language(lang) do
+    code = if is_struct(lang), do: lang.code, else: lang[:code]
+
+    if is_binary(code) do
+      case Languages.get_predefined_language(code) do
+        %{} = predefined -> predefined
+        _ -> %{code: code, name: Map.get(lang, :name, code), flag: "🌐", native: ""}
+      end
     end
   end
 

--- a/lib/phoenix_kit_web/components/core/language_switcher.ex
+++ b/lib/phoenix_kit_web/components/core/language_switcher.ex
@@ -84,81 +84,18 @@ defmodule PhoenixKitWeb.Components.Core.LanguageSwitcher do
     doc: "Show current language (flag + name) in dropdown trigger instead of globe icon"
   )
 
+  attr(:continent_threshold, :integer,
+    default: 7,
+    doc: "Number of languages after which the continent grouping step is shown"
+  )
+
   attr(:_language_update_key, :any,
     default: nil,
     doc: "Internal: forces re-render when languages change"
   )
 
   def language_switcher_dropdown(assigns) do
-    # Auto-detect current_locale if not explicitly provided
-    # This might be a base code (en) or full dialect (en-US)
-    locale =
-      assigns.current_locale ||
-        Process.get(:phoenix_kit_current_locale) ||
-        Gettext.get_locale(PhoenixKitWeb.Gettext) ||
-        @default_locale
-
-    # Get enabled languages - these are full dialect codes with names
-    # Ensure we always have a list, even if nil is returned
-    languages_config = assigns.languages || Languages.get_display_languages() || []
-
-    # Transform to include both base code (for URLs) and dialect (for preference)
-    # Filter out any nil entries or entries with nil/empty base_code to prevent routing errors
-    all_dialects =
-      languages_config
-      |> Enum.reject(&is_nil/1)
-      |> Enum.filter(&is_map/1)
-      |> Enum.map(fn lang ->
-        dialect = lang.code
-        base = DialectMapper.extract_base(dialect)
-        flag = get_language_flag(dialect)
-
-        %{
-          "base_code" => base,
-          "dialect" => dialect,
-          "name" => lang.name || dialect || "Unknown",
-          "native" => get_native_name(dialect),
-          "flag" => flag
-        }
-      end)
-      |> Enum.filter(fn lang ->
-        base_code = lang["base_code"]
-        is_binary(base_code) and base_code != ""
-      end)
-      |> Enum.sort_by(& &1["name"])
-
-    # Filter out current dialect if hide_current is enabled
-    filtered_languages =
-      if assigns.hide_current do
-        Enum.filter(all_dialects, &(&1["dialect"] != locale))
-      else
-        all_dialects
-      end
-
-    # Extract base code from current locale for matching
-    current_base = DialectMapper.extract_base(locale)
-
-    # Find current language by full dialect code
-    current_language =
-      Enum.find(all_dialects, &(&1["dialect"] == locale)) ||
-        %{
-          "base_code" => current_base,
-          "dialect" => locale,
-          "name" => String.upcase(locale),
-          "native" => nil,
-          "flag" => "🌐"
-        }
-
-    # Determine if we need scroll/search based on language count
-    needs_scroll = length(filtered_languages) > assigns.scroll_threshold
-
-    assigns =
-      assigns
-      |> assign(:current_locale, locale)
-      |> assign(:current_base, current_base)
-      |> assign(:languages, filtered_languages)
-      |> assign(:current_language, current_language)
-      |> assign(:needs_scroll, needs_scroll)
+    assigns = prepare_dropdown_assigns(assigns)
 
     ~H"""
     <div class={["relative", @class]}>
@@ -184,67 +121,168 @@ defmodule PhoenixKitWeb.Components.Core.LanguageSwitcher do
           tabindex="0"
           phx-click-away={JS.remove_attribute("open", to: "#language-switcher-dropdown")}
         >
-          <%!-- Search bar (only if many languages) --%>
-          <%= if @needs_scroll do %>
-            <div class="p-2 border-b border-base-200">
-              <input
-                type="text"
-                placeholder="Search languages..."
-                class="input input-sm input-bordered w-full"
-                phx-hook="LanguageSwitcherSearch"
-                id="language-search-input"
-                autocomplete="off"
-              />
-            </div>
-          <% end %>
+          <%= if @use_continents do %>
+            <%!-- Continent-grouped two-step navigation using JS commands --%>
 
-          <%!-- Language list (scrollable if many languages) --%>
-          <ul
-            class={[
-              "p-2 list-none space-y-1",
-              @needs_scroll && "max-h-64 overflow-y-auto"
-            ]}
-            id="language-switcher-list"
-          >
-            <%= for language <- @languages do %>
-              <li
-                class="w-full language-item"
-                data-name={String.downcase(language["name"] || "")}
-                data-native={String.downcase(language["native"] || "")}
-              >
-                <a
-                  href={generate_base_code_url(language["base_code"], @current_path)}
-                  phx-click="phoenix_kit_set_locale"
-                  phx-value-locale={language["base_code"]}
-                  phx-value-url={generate_base_code_url(language["base_code"], @current_path)}
-                  class={[
-                    "w-full flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition hover:bg-base-200",
-                    if(language["base_code"] == @current_base, do: "bg-base-200", else: "")
-                  ]}
-                >
-                  <%= if @show_flags do %>
-                    <span class="text-lg">{language["flag"]}</span>
-                  <% end %>
-                  <%= if @show_names do %>
-                    <div class="flex-1">
-                      <span class="font-medium text-base-content">
-                        <%= if @show_native_names && Map.get(language, "native") do %>
-                          {language["native"]}
-                        <% else %>
-                          {language["name"]}
-                        <% end %>
-                      </span>
-                    </div>
-                  <% else %>
-                    <div class="flex-1"></div>
-                  <% end %>
-                  <%= if language["base_code"] == @current_base do %>
-                    <span class="ml-auto">✓</span>
-                  <% end %>
-                </a>
-              </li>
+            <%!-- Step 1: Continent list --%>
+            <ul id="ls-continents" class="p-2 list-none space-y-1 max-h-72 overflow-y-auto">
+              <%= for {continent, langs} <- @continent_groups do %>
+                <% continent_id = "ls-cont-" <> slug(continent) %>
+                <li class="w-full">
+                  <button
+                    type="button"
+                    phx-click={
+                      JS.hide(to: "#ls-continents")
+                      |> JS.show(to: "#ls-back")
+                      |> JS.show(to: "##{continent_id}")
+                    }
+                    class="w-full flex items-center justify-between rounded-lg px-3 py-2 text-sm transition hover:bg-base-200 cursor-pointer"
+                  >
+                    <span class="font-medium text-base-content">{continent}</span>
+                    <span class="badge badge-ghost badge-sm">{length(langs)}</span>
+                  </button>
+                </li>
+              <% end %>
+            </ul>
+
+            <%!-- Back button (hidden initially) --%>
+            <button
+              id="ls-back"
+              type="button"
+              phx-click={
+                JS.hide(to: "#ls-back")
+                |> hide_all_continent_panels(@continent_groups)
+                |> JS.show(to: "#ls-continents")
+              }
+              class="hidden flex items-center gap-2 px-3 py-2 text-sm font-medium text-primary hover:bg-base-200 border-b border-base-200 cursor-pointer"
+            >
+              <Icon.icon name="hero-arrow-left" class="w-4 h-4" />
+              <span>All regions</span>
+            </button>
+
+            <%!-- Step 2: Language panels per continent (all hidden initially) --%>
+            <%= for {continent, langs} <- @continent_groups do %>
+              <% continent_id = "ls-cont-" <> slug(continent) %>
+              <ul id={continent_id} class="hidden p-2 list-none space-y-1 max-h-64 overflow-y-auto">
+                <%= if length(langs) > @continent_threshold do %>
+                  <li class="pb-1">
+                    <input
+                      type="text"
+                      placeholder="Search languages..."
+                      class="input input-sm input-bordered w-full"
+                      id={"ls-search-" <> slug(continent)}
+                      autocomplete="off"
+                      oninput="
+                        var t=this.value.toLowerCase().trim();
+                        var ul=this.closest('ul');
+                        var any=false;
+                        ul.querySelectorAll('.language-item').forEach(function(i){
+                          var n=i.dataset.name||'',v=i.dataset.native||'';
+                          var m=!t||n.includes(t)||v.includes(t);
+                          i.style.display=m?'':'none';
+                          if(m)any=true;
+                        });
+                        var empty=ul.querySelector('.ls-no-results');
+                        if(empty)empty.style.display=any?'none':'';
+                      "
+                    />
+                  </li>
+                <% end %>
+                <%= for language <- langs do %>
+                  <li
+                    class="w-full language-item"
+                    data-name={String.downcase(language["name"] || "")}
+                    data-native={String.downcase(language["native"] || "")}
+                  >
+                    <a
+                      href={generate_base_code_url(language["base_code"], @current_path)}
+                      phx-click="phoenix_kit_set_locale"
+                      phx-value-locale={language["base_code"]}
+                      phx-value-url={generate_base_code_url(language["base_code"], @current_path)}
+                      class={[
+                        "w-full flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition hover:bg-base-200",
+                        if(language["base_code"] == @current_base, do: "bg-base-200", else: "")
+                      ]}
+                    >
+                      <%= if @show_flags do %>
+                        <span class="text-lg">{language["flag"]}</span>
+                      <% end %>
+                      <div class="flex-1">
+                        <span class="font-medium text-base-content">{language["name"]}</span>
+                      </div>
+                      <%= if language["base_code"] == @current_base do %>
+                        <span class="ml-auto">✓</span>
+                      <% end %>
+                    </a>
+                  </li>
+                <% end %>
+                <li class="ls-no-results px-3 py-2 text-sm text-base-content/50" style="display:none">
+                  No languages found
+                </li>
+              </ul>
             <% end %>
-          </ul>
+          <% else %>
+            <%!-- Flat language list (when <= threshold) --%>
+            <%= if @needs_scroll do %>
+              <div class="p-2 border-b border-base-200">
+                <input
+                  type="text"
+                  placeholder="Search languages..."
+                  class="input input-sm input-bordered w-full"
+                  phx-hook="LanguageSwitcherSearch"
+                  id="language-search-input"
+                  autocomplete="off"
+                />
+              </div>
+            <% end %>
+
+            <ul
+              class={[
+                "p-2 list-none space-y-1",
+                @needs_scroll && "max-h-64 overflow-y-auto"
+              ]}
+              id="language-switcher-list"
+            >
+              <%= for language <- @languages do %>
+                <li
+                  class="w-full language-item"
+                  data-name={String.downcase(language["name"] || "")}
+                  data-native={String.downcase(language["native"] || "")}
+                >
+                  <a
+                    href={generate_base_code_url(language["base_code"], @current_path)}
+                    phx-click="phoenix_kit_set_locale"
+                    phx-value-locale={language["base_code"]}
+                    phx-value-url={generate_base_code_url(language["base_code"], @current_path)}
+                    class={[
+                      "w-full flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition hover:bg-base-200",
+                      if(language["base_code"] == @current_base, do: "bg-base-200", else: "")
+                    ]}
+                  >
+                    <%= if @show_flags do %>
+                      <span class="text-lg">{language["flag"]}</span>
+                    <% end %>
+                    <%= if @show_names do %>
+                      <div class="flex-1">
+                        <span class="font-medium text-base-content">
+                          <%= if @show_native_names && Map.get(language, "native") do %>
+                            {language["native"]}
+                          <% else %>
+                            {language["name"]}
+                          <% end %>
+                        </span>
+                      </div>
+                    <% else %>
+                      <div class="flex-1"></div>
+                    <% end %>
+                    <%= if language["base_code"] == @current_base do %>
+                      <span class="ml-auto">✓</span>
+                    <% end %>
+                  </a>
+                </li>
+              <% end %>
+            </ul>
+          <% end %>
         </div>
       </details>
     </div>
@@ -482,6 +520,117 @@ defmodule PhoenixKitWeb.Components.Core.LanguageSwitcher do
       <% end %>
     </div>
     """
+  end
+
+  # Chains JS.hide commands to hide all continent language panels
+  defp hide_all_continent_panels(js, continent_groups) do
+    Enum.reduce(continent_groups, js, fn {continent, _}, acc ->
+      JS.hide(acc, to: "#ls-cont-#{slug(continent)}")
+    end)
+  end
+
+  # Converts a continent name to a URL-safe slug for DOM IDs
+  defp slug(name) do
+    name
+    |> String.downcase()
+    |> String.replace(~r/[^a-z0-9]+/, "-")
+    |> String.trim("-")
+  end
+
+  # Prepares all assigns needed by the dropdown template
+  defp prepare_dropdown_assigns(assigns) do
+    locale =
+      assigns.current_locale ||
+        Process.get(:phoenix_kit_current_locale) ||
+        Gettext.get_locale(PhoenixKitWeb.Gettext) ||
+        @default_locale
+
+    languages_config = assigns.languages || Languages.get_display_languages() || []
+
+    all_dialects = build_dialect_list(languages_config)
+
+    filtered_languages =
+      if assigns.hide_current do
+        Enum.filter(all_dialects, &(&1["dialect"] != locale))
+      else
+        all_dialects
+      end
+
+    current_base = DialectMapper.extract_base(locale)
+
+    current_language =
+      Enum.find(all_dialects, &(&1["dialect"] == locale)) ||
+        %{
+          "base_code" => current_base,
+          "dialect" => locale,
+          "name" => String.upcase(locale),
+          "native" => nil,
+          "flag" => "🌐"
+        }
+
+    use_continents = length(filtered_languages) > assigns.continent_threshold
+
+    continent_groups =
+      if use_continents do
+        Languages.get_enabled_languages_by_continent()
+        |> Enum.map(fn {continent, langs} ->
+          {continent, langs_to_dialect_maps(langs)}
+        end)
+      else
+        []
+      end
+
+    needs_scroll = not use_continents and length(filtered_languages) > assigns.scroll_threshold
+
+    assigns
+    |> assign(:current_locale, locale)
+    |> assign(:current_base, current_base)
+    |> assign(:languages, filtered_languages)
+    |> assign(:current_language, current_language)
+    |> assign(:needs_scroll, needs_scroll)
+    |> assign(:use_continents, use_continents)
+    |> assign(:continent_groups, continent_groups)
+  end
+
+  # Transforms Language structs/maps from grouped continent data into dialect maps
+  defp langs_to_dialect_maps(langs) do
+    langs
+    |> Enum.map(fn lang ->
+      code = if is_struct(lang), do: lang.code, else: lang[:code]
+      name = if is_struct(lang), do: lang.name, else: lang[:name]
+
+      %{
+        "base_code" => DialectMapper.extract_base(code),
+        "dialect" => code,
+        "name" => name || code || "Unknown",
+        "flag" => get_language_flag(code)
+      }
+    end)
+    |> Enum.sort_by(& &1["name"])
+  end
+
+  # Transforms language config into dialect maps for display
+  defp build_dialect_list(languages_config) do
+    languages_config
+    |> Enum.reject(&is_nil/1)
+    |> Enum.filter(&is_map/1)
+    |> Enum.map(fn lang ->
+      dialect = lang.code
+      base = DialectMapper.extract_base(dialect)
+
+      %{
+        "base_code" => base,
+        "dialect" => dialect,
+        "name" => lang.name || dialect || "Unknown",
+        "native" => get_native_name(dialect),
+        "flag" => get_language_flag(dialect)
+      }
+    end)
+    |> Enum.filter(fn lang ->
+      base_code = lang["base_code"]
+      is_binary(base_code) and base_code != ""
+    end)
+    |> Enum.sort_by(& &1["name"])
   end
 
   # Helper function to get language flag emoji

--- a/lib/phoenix_kit_web/components/core/language_switcher.ex
+++ b/lib/phoenix_kit_web/components/core/language_switcher.ex
@@ -682,8 +682,6 @@ defmodule PhoenixKitWeb.Components.Core.LanguageSwitcher do
   # Extract the locale segment from a path (after prefix removal)
   # /en/admin => "en"
   # /en-US/admin => "en-US"
-  defp extract_locale_from_path(nil), do: nil
-
   defp extract_locale_from_path(path) do
     case String.split(path, "/", parts: 3) do
       ["", locale, _rest] ->
@@ -698,7 +696,7 @@ defmodule PhoenixKitWeb.Components.Core.LanguageSwitcher do
   end
 
   # Strip locale prefix from path: /en/admin → /admin
-  defp strip_locale_from_path(path, nil), do: path || "/"
+  defp strip_locale_from_path(path, nil), do: path
 
   defp strip_locale_from_path(path, locale) do
     case String.split(path, "/", parts: 3) do

--- a/lib/phoenix_kit_web/components/core/language_switcher.ex
+++ b/lib/phoenix_kit_web/components/core/language_switcher.ex
@@ -658,19 +658,28 @@ defmodule PhoenixKitWeb.Components.Core.LanguageSwitcher do
   defp generate_base_code_url("", current_path), do: current_path || "/"
 
   defp generate_base_code_url(base_code, current_path) do
-    # Extract base code from current path for proper path processing
-    current_base = extract_locale_from_path(current_path)
+    # Strip the URL prefix first (e.g., /phoenix_kit)
+    url_prefix = PhoenixKit.Config.get_url_prefix()
+    prefix_to_remove = if url_prefix == "/", do: "", else: url_prefix
+    normalized = String.replace_prefix(current_path || "/", prefix_to_remove, "")
 
-    # Remove locale from path
-    path_without_locale = get_path_without_locale(current_path, current_base)
+    # Ensure path starts with /
+    normalized =
+      if normalized == "" or not String.starts_with?(normalized, "/"), do: "/", else: normalized
 
-    # Generate URL using Routes.path which handles default language logic
-    # Default language (first admin language, typically "en") gets clean URLs (no prefix)
-    # Other languages get the locale prefix
-    Routes.path(path_without_locale, locale: base_code)
+    # Extract and strip the locale from the remaining path
+    current_base = extract_locale_from_path(normalized)
+    clean_path = strip_locale_from_path(normalized, current_base)
+
+    # Admin paths use Routes.admin_path to keep locale in URL
+    if String.contains?(clean_path, "/admin") do
+      Routes.admin_path(clean_path, base_code)
+    else
+      Routes.path(clean_path, locale: base_code)
+    end
   end
 
-  # Extract the locale segment from a path
+  # Extract the locale segment from a path (after prefix removal)
   # /en/admin => "en"
   # /en-US/admin => "en-US"
   defp extract_locale_from_path(nil), do: nil
@@ -688,24 +697,14 @@ defmodule PhoenixKitWeb.Components.Core.LanguageSwitcher do
     end
   end
 
-  # Helper function to extract path without locale prefix
-  # Handles: /en/admin → /admin
-  # Handles: /admin → /admin (no locale)
-  # Handles: nil → / (root)
-  defp get_path_without_locale(nil, _current_locale), do: "/"
+  # Strip locale prefix from path: /en/admin → /admin
+  defp strip_locale_from_path(path, nil), do: path || "/"
 
-  defp get_path_without_locale(current_path, current_locale) do
-    # Remove locale from path: /en/admin → /admin
-    case String.split(current_path, "/", parts: 3) do
-      ["", ^current_locale, rest] when is_binary(rest) ->
-        "/#{rest}"
-
-      ["", ^current_locale] ->
-        "/"
-
-      _ ->
-        # Path doesn't start with locale, return as-is
-        current_path
+  defp strip_locale_from_path(path, locale) do
+    case String.split(path, "/", parts: 3) do
+      ["", ^locale, rest] when is_binary(rest) -> "/#{rest}"
+      ["", ^locale] -> "/"
+      _ -> path
     end
   end
 end

--- a/lib/phoenix_kit_web/components/core/language_switcher.ex
+++ b/lib/phoenix_kit_web/components/core/language_switcher.ex
@@ -502,9 +502,8 @@ defmodule PhoenixKitWeb.Components.Core.LanguageSwitcher do
 
   # Generate URL with ONLY base code - no dialect, no query params
   # This is the clean URL used in href attributes
-  # Default language gets clean URLs (no prefix), other languages get locale prefix
-  # Example: generate_base_code_url("en", "/ru/admin") => "/admin" (if en is default)
-  # Example: generate_base_code_url("es", "/admin") => "/es/admin"
+  # Default language (from Languages module) gets clean URLs (no prefix),
+  # other languages get locale prefix
   # Guard clauses for nil/empty base_code to prevent Phoenix.Param errors
   defp generate_base_code_url(nil, current_path), do: current_path || "/"
   defp generate_base_code_url("", current_path), do: current_path || "/"

--- a/lib/phoenix_kit_web/components/core/language_switcher.ex
+++ b/lib/phoenix_kit_web/components/core/language_switcher.ex
@@ -1,28 +1,37 @@
 defmodule PhoenixKitWeb.Components.Core.LanguageSwitcher do
   @moduledoc """
-  Language switcher component for frontend applications.
+  Language switcher component for frontend and admin applications.
 
-  Provides a reusable language selection dropdown that pulls available languages
-  from the Language Module. Supports multiple display styles and configurations.
+  Provides reusable language selection UI that pulls available languages
+  from the unified Languages module. Three display variants are available:
+  dropdown, button group, and inline.
+
+  ## Continent Grouping
+
+  When more than 7 languages are enabled (configurable via `continent_threshold`),
+  the dropdown automatically shows a two-step interface: first pick a continent,
+  then pick a language within it. Set `group_by_continent={false}` to always
+  show a flat list regardless of language count.
 
   ## Examples
 
-      # Basic dropdown switcher
+      # Basic dropdown — auto-groups by continent when >7 languages
       <.language_switcher_dropdown current_locale={@current_locale} />
 
-      # Button group switcher (for mobile)
+      # Force flat list (no continent step)
+      <.language_switcher_dropdown current_locale={@current_locale} group_by_continent={false} />
+
+      # Custom threshold for continent grouping
+      <.language_switcher_dropdown current_locale={@current_locale} continent_threshold={5} />
+
+      # Show current language in trigger button
+      <.language_switcher_dropdown current_locale={@current_locale} show_current={true} />
+
+      # Button group (for mobile)
       <.language_switcher_buttons current_locale={@current_locale} />
 
-      # Inline switcher with flags
+      # Inline text links (for footers)
       <.language_switcher_inline current_locale={@current_locale} />
-
-  ## Attributes
-
-  - `current_locale` - Current active language code (e.g., "en", "es")
-  - `style` - Display style: `:dropdown`, `:buttons`, `:inline` (default: `:dropdown`)
-  - `class` - Additional CSS classes to apply
-  - `show_flags` - Show language flags (default: true)
-  - `show_native_names` - Show native language names (default: false)
   """
 
   use Phoenix.Component
@@ -40,8 +49,11 @@ defmodule PhoenixKitWeb.Components.Core.LanguageSwitcher do
   Renders a dropdown language switcher.
 
   Displays a globe icon that opens a dropdown menu with available languages.
-  Automatically fetches the configured languages (or default top 12 if not configured).
-  Perfect for navigation bars and header areas.
+  Automatically fetches the configured languages (or defaults when unconfigured).
+  Used in both frontend navigation bars and the admin panel header.
+
+  When more than `continent_threshold` languages are enabled, shows a two-step
+  continent → language navigation. Set `group_by_continent={false}` to disable.
 
   ## Examples
 
@@ -49,7 +61,7 @@ defmodule PhoenixKitWeb.Components.Core.LanguageSwitcher do
 
       <.language_switcher_dropdown
         current_locale={@current_locale}
-        show_native_names={true}
+        group_by_continent={false}
       />
   """
   attr(:current_locale, :string,
@@ -82,6 +94,11 @@ defmodule PhoenixKitWeb.Components.Core.LanguageSwitcher do
   attr(:show_current, :boolean,
     default: false,
     doc: "Show current language (flag + name) in dropdown trigger instead of globe icon"
+  )
+
+  attr(:group_by_continent, :boolean,
+    default: true,
+    doc: "Enable continent grouping when language count exceeds continent_threshold"
   )
 
   attr(:continent_threshold, :integer,
@@ -222,20 +239,7 @@ defmodule PhoenixKitWeb.Components.Core.LanguageSwitcher do
               </ul>
             <% end %>
           <% else %>
-            <%!-- Flat language list (when <= threshold) --%>
-            <%= if @needs_scroll do %>
-              <div class="p-2 border-b border-base-200">
-                <input
-                  type="text"
-                  placeholder="Search languages..."
-                  class="input input-sm input-bordered w-full"
-                  phx-hook="LanguageSwitcherSearch"
-                  id="language-search-input"
-                  autocomplete="off"
-                />
-              </div>
-            <% end %>
-
+            <%!-- Flat language list (when <= threshold or continent grouping disabled) --%>
             <ul
               class={[
                 "p-2 list-none space-y-1",
@@ -243,6 +247,30 @@ defmodule PhoenixKitWeb.Components.Core.LanguageSwitcher do
               ]}
               id="language-switcher-list"
             >
+              <%= if @needs_scroll do %>
+                <li class="pb-1">
+                  <input
+                    type="text"
+                    placeholder="Search languages..."
+                    class="input input-sm input-bordered w-full"
+                    id="language-search-input"
+                    autocomplete="off"
+                    oninput="
+                      var t=this.value.toLowerCase().trim();
+                      var ul=this.closest('ul');
+                      var any=false;
+                      ul.querySelectorAll('.language-item').forEach(function(i){
+                        var n=i.dataset.name||'',v=i.dataset.native||'';
+                        var m=!t||n.includes(t)||v.includes(t);
+                        i.style.display=m?'':'none';
+                        if(m)any=true;
+                      });
+                      var empty=ul.querySelector('.ls-no-results');
+                      if(empty)empty.style.display=any?'none':'';
+                    "
+                  />
+                </li>
+              <% end %>
               <%= for language <- @languages do %>
                 <li
                   class="w-full language-item"
@@ -279,6 +307,11 @@ defmodule PhoenixKitWeb.Components.Core.LanguageSwitcher do
                       <span class="ml-auto">✓</span>
                     <% end %>
                   </a>
+                </li>
+              <% end %>
+              <%= if @needs_scroll do %>
+                <li class="ls-no-results px-3 py-2 text-sm text-base-content/50" style="display:none">
+                  No languages found
                 </li>
               <% end %>
             </ul>
@@ -530,14 +563,19 @@ defmodule PhoenixKitWeb.Components.Core.LanguageSwitcher do
   end
 
   # Converts a continent name to a URL-safe slug for DOM IDs
-  defp slug(name) do
+  defp slug(nil), do: "unknown"
+
+  defp slug(name) when is_binary(name) do
     name
     |> String.downcase()
     |> String.replace(~r/[^a-z0-9]+/, "-")
     |> String.trim("-")
   end
 
-  # Prepares all assigns needed by the dropdown template
+  defp slug(_), do: "unknown"
+
+  # Prepares all assigns needed by the dropdown template.
+  # Handles nil/invalid inputs gracefully — never crashes on bad data.
   defp prepare_dropdown_assigns(assigns) do
     locale =
       assigns.current_locale ||
@@ -545,7 +583,15 @@ defmodule PhoenixKitWeb.Components.Core.LanguageSwitcher do
         Gettext.get_locale(PhoenixKitWeb.Gettext) ||
         @default_locale
 
-    languages_config = assigns.languages || Languages.get_display_languages() || []
+    # Ensure locale is always a string
+    locale = if is_binary(locale), do: locale, else: @default_locale
+
+    languages_config =
+      case assigns.languages do
+        nil -> Languages.get_display_languages()
+        list when is_list(list) -> list
+        _ -> []
+      end
 
     all_dialects = build_dialect_list(languages_config)
 
@@ -568,19 +614,19 @@ defmodule PhoenixKitWeb.Components.Core.LanguageSwitcher do
           "flag" => "🌐"
         }
 
-    use_continents = length(filtered_languages) > assigns.continent_threshold
+    {use_continents, continent_groups} =
+      maybe_build_continent_groups(assigns, filtered_languages)
 
-    continent_groups =
-      if use_continents do
-        Languages.get_enabled_languages_by_continent()
-        |> Enum.map(fn {continent, langs} ->
-          {continent, langs_to_dialect_maps(langs)}
-        end)
+    # When continent grouping is disabled but there are many languages,
+    # use the continent_threshold to decide if search is needed (lower = more likely to show search)
+    effective_scroll_threshold =
+      if assigns.group_by_continent do
+        assigns.scroll_threshold
       else
-        []
+        min(assigns.scroll_threshold, assigns.continent_threshold)
       end
 
-    needs_scroll = not use_continents and length(filtered_languages) > assigns.scroll_threshold
+    needs_scroll = not use_continents and length(filtered_languages) > effective_scroll_threshold
 
     assigns
     |> assign(:current_locale, locale)
@@ -592,6 +638,26 @@ defmodule PhoenixKitWeb.Components.Core.LanguageSwitcher do
     |> assign(:continent_groups, continent_groups)
   end
 
+  # Builds continent groups if grouping is enabled and threshold exceeded.
+  # Returns {use_continents, groups} where groups is a list of {continent, dialect_maps}.
+  # Falls back to flat list if grouping fails or produces no results.
+  defp maybe_build_continent_groups(assigns, filtered_languages) do
+    if assigns.group_by_continent and length(filtered_languages) > assigns.continent_threshold do
+      groups =
+        Languages.get_enabled_languages_by_continent()
+        |> Enum.map(fn {continent, langs} ->
+          {continent, langs_to_dialect_maps(langs)}
+        end)
+        |> Enum.reject(fn {_, langs} -> langs == [] end)
+
+      if groups != [], do: {true, groups}, else: {false, []}
+    else
+      {false, []}
+    end
+  rescue
+    _ -> {false, []}
+  end
+
   # Transforms Language structs/maps from grouped continent data into dialect maps
   defp langs_to_dialect_maps(langs) do
     langs
@@ -599,13 +665,16 @@ defmodule PhoenixKitWeb.Components.Core.LanguageSwitcher do
       code = if is_struct(lang), do: lang.code, else: lang[:code]
       name = if is_struct(lang), do: lang.name, else: lang[:name]
 
-      %{
-        "base_code" => DialectMapper.extract_base(code),
-        "dialect" => code,
-        "name" => name || code || "Unknown",
-        "flag" => get_language_flag(code)
-      }
+      if is_binary(code) do
+        %{
+          "base_code" => DialectMapper.extract_base(code),
+          "dialect" => code,
+          "name" => name || code,
+          "flag" => get_language_flag(code)
+        }
+      end
     end)
+    |> Enum.reject(&is_nil/1)
     |> Enum.sort_by(& &1["name"])
   end
 

--- a/lib/phoenix_kit_web/components/layout_wrapper.ex
+++ b/lib/phoenix_kit_web/components/layout_wrapper.ex
@@ -302,7 +302,7 @@ defmodule PhoenixKitWeb.Components.LayoutWrapper do
                 <%!-- Right: Theme Switcher, Language Dropdown, and User Dropdown --%>
                 <div class="flex items-center gap-3">
                   <.admin_theme_controller mobile={true} />
-                  <.admin_language_dropdown
+                  <PhoenixKitWeb.Components.Core.LanguageSwitcher.language_switcher_dropdown
                     current_path={@current_path}
                     current_locale={@current_locale}
                   />

--- a/lib/phoenix_kit_web/integration.ex
+++ b/lib/phoenix_kit_web/integration.ex
@@ -419,7 +419,6 @@ defmodule PhoenixKitWeb.Integration do
 
         live "/admin/settings/languages", Live.Modules.Languages, :index
         live "/admin/settings/languages/frontend", Live.Modules.Languages, :frontend
-        live "/admin/settings/languages/backend", Live.Modules.Languages, :backend
 
         if Code.ensure_loaded?(PhoenixKit.Modules.Legal) do
           live "/admin/settings/legal", Live.Modules.Legal.Settings, :index

--- a/lib/phoenix_kit_web/live/modules/languages.ex
+++ b/lib/phoenix_kit_web/live/modules/languages.ex
@@ -13,12 +13,9 @@ defmodule PhoenixKitWeb.Live.Modules.Languages do
               {PhoenixKit.Modules.Publishing.ListingCache, :regenerate, 1}
             ]}
 
-  alias PhoenixKit.Config
   alias PhoenixKit.Modules.Languages
   alias PhoenixKit.Settings
   alias PhoenixKit.Utils.Routes
-
-  @default_locale Config.default_locale()
 
   def mount(_params, session, socket) do
     # Attach locale hook for automatic locale handling
@@ -65,32 +62,12 @@ defmodule PhoenixKitWeb.Live.Modules.Languages do
       |> assign(:switcher_goto_home, false)
       |> assign(:switcher_hide_current, false)
       |> assign(:switcher_show_native_names, false)
-      # Backend tab settings
-      |> assign(:admin_languages, load_admin_languages())
 
     {:ok, socket}
   end
 
-  defp load_admin_languages do
-    admin_languages_json =
-      Settings.get_setting_cached("admin_languages", nil) ||
-        Jason.encode!([@default_locale])
-
-    case Jason.decode(admin_languages_json) do
-      {:ok, codes} when is_list(codes) -> codes
-      _ -> [@default_locale]
-    end
-  end
-
   def handle_params(_params, _uri, socket) do
-    active_tab =
-      case socket.assigns.live_action do
-        :backend -> "backend"
-        # Default to frontend for :index and :frontend
-        _ -> "frontend"
-      end
-
-    {:noreply, assign(socket, :active_tab, active_tab)}
+    {:noreply, socket}
   end
 
   def handle_event("toggle_languages", _params, socket) do
@@ -207,92 +184,6 @@ defmodule PhoenixKitWeb.Live.Modules.Languages do
     end
   end
 
-  # Backend tab event handlers
-
-  def handle_event(
-        "add_admin_language_to_form",
-        %{"admin_language_code_input" => language_code},
-        socket
-      )
-      when language_code != "" do
-    current_languages = socket.assigns.admin_languages || [@default_locale]
-
-    # Toggle: add if not present, remove if already present
-    if language_code in current_languages do
-      # Remove language
-      updated_languages = Enum.filter(current_languages, &(&1 != language_code))
-
-      language = Languages.get_predefined_language(language_code)
-      language_name = if language, do: language.name, else: String.upcase(language_code)
-
-      socket =
-        socket
-        |> assign(:admin_languages, updated_languages)
-        |> put_flash(:info, "#{language_name} removed. Remember to save settings.")
-
-      {:noreply, socket}
-    else
-      # Add language
-      updated_languages = current_languages ++ [language_code]
-
-      language = Languages.get_predefined_language(language_code)
-      language_name = if language, do: language.name, else: String.upcase(language_code)
-
-      socket =
-        socket
-        |> assign(:admin_languages, updated_languages)
-        |> put_flash(:info, "#{language_name} added. Remember to save settings.")
-
-      {:noreply, socket}
-    end
-  end
-
-  def handle_event("add_admin_language_to_form", _params, socket) do
-    {:noreply, socket}
-  end
-
-  def handle_event("remove_admin_language_from_form", %{"code" => code}, socket) do
-    current_languages = socket.assigns.admin_languages || [@default_locale]
-
-    # Prevent removing the last language
-    if length(current_languages) <= 1 do
-      socket =
-        put_flash(
-          socket,
-          :warning,
-          "Cannot remove the last language. At least one language must be configured."
-        )
-
-      {:noreply, socket}
-    else
-      updated_languages = Enum.filter(current_languages, &(&1 != code))
-
-      language = Languages.get_predefined_language(code)
-      language_name = if language, do: language.name, else: String.upcase(code)
-
-      socket =
-        socket
-        |> assign(:admin_languages, updated_languages)
-        |> put_flash(:info, "#{language_name} removed. Remember to save settings.")
-
-      {:noreply, socket}
-    end
-  end
-
-  def handle_event("save_admin_languages", _params, socket) do
-    admin_languages = socket.assigns.admin_languages || [@default_locale]
-
-    case Settings.update_setting("admin_languages", Jason.encode!(admin_languages)) do
-      {:ok, _} ->
-        socket = put_flash(socket, :info, "Admin panel languages saved successfully.")
-        {:noreply, socket}
-
-      {:error, _} ->
-        socket = put_flash(socket, :error, "Failed to save admin panel languages.")
-        {:noreply, socket}
-    end
-  end
-
   defp get_current_path(_socket, _session) do
     # For LanguagesLive, return the settings path
     Routes.path("/admin/settings/languages")
@@ -307,9 +198,6 @@ defmodule PhoenixKitWeb.Live.Modules.Languages do
     default_code = get_default_code(display_languages)
     covered_countries = get_covered_countries(enabled_codes, grouped_languages)
 
-    # Sync the admin_languages setting so the admin navbar updates too
-    sync_admin_languages(display_languages)
-
     socket
     |> assign(:ml_enabled, enabled)
     |> assign(:languages, display_languages)
@@ -320,16 +208,6 @@ defmodule PhoenixKitWeb.Live.Modules.Languages do
     |> assign(:enabled_count, length(enabled_codes))
     |> assign(:covered_countries, covered_countries)
     |> assign(:covered_count, length(covered_countries))
-  end
-
-  # Sync the admin_languages setting with the current display languages
-  defp sync_admin_languages(display_languages) do
-    enabled_codes =
-      display_languages
-      |> Enum.filter(& &1.is_enabled)
-      |> Enum.map(& &1.code)
-
-    Settings.update_json_setting("admin_languages", enabled_codes)
   end
 
   # Helper function to generate the language switcher code based on current settings

--- a/lib/phoenix_kit_web/live/modules/languages.html.heex
+++ b/lib/phoenix_kit_web/live/modules/languages.html.heex
@@ -14,539 +14,368 @@
     <.admin_page_header
       back={PhoenixKit.Utils.Routes.path("/admin/modules")}
       title="Languages"
-      subtitle="Manage available languages for your frontend language switcher"
+      subtitle="Manage available languages for your application"
     />
 
-    <%!-- Tabs --%>
-    <div role="tablist" class="tabs tabs-boxed bg-base-200 p-1 mb-6">
-      <.link
-        navigate={PhoenixKit.Utils.Routes.path("/admin/settings/languages/frontend")}
-        class={"tab gap-2 #{if @active_tab == "frontend", do: "tab-active"}"}
-      >
-        <PhoenixKitWeb.Components.Core.Icons.icon_language class="w-4 h-4" /> Frontend
-      </.link>
-      <.link
-        navigate={PhoenixKit.Utils.Routes.path("/admin/settings/languages/backend")}
-        class={"tab gap-2 #{if @active_tab == "backend", do: "tab-active"}"}
-      >
-        <PhoenixKitWeb.Components.Core.Icons.icon_system class="w-4 h-4" /> Backend
-      </.link>
-    </div>
+    <%!-- Summary Section --%>
+    <div class="card bg-base-100 shadow-xl mb-6">
+      <div class="card-body">
+        <h3 class="card-title text-xl">Summary</h3>
 
-    <%= if @active_tab == "frontend" do %>
-      <%!-- Summary Section --%>
-      <div class="card bg-base-100 shadow-xl mb-6">
-        <div class="card-body">
-          <h3 class="card-title text-xl">Summary</h3>
-
-          <%!-- Stats Row --%>
-          <div class="stats stats-vertical lg:stats-horizontal shadow bg-base-200 mt-2">
-            <div class="stat">
-              <div class="stat-title">Languages Enabled</div>
-              <div class="stat-value text-primary">{@enabled_count}</div>
-            </div>
-            <div class="stat">
-              <div class="stat-title">Countries Covered</div>
-              <div class="stat-value text-secondary">{@covered_count}</div>
-            </div>
+        <%!-- Stats Row --%>
+        <div class="stats stats-vertical lg:stats-horizontal shadow bg-base-200 mt-2">
+          <div class="stat">
+            <div class="stat-title">Languages Enabled</div>
+            <div class="stat-value text-primary">{@enabled_count}</div>
           </div>
-
-          <%= if @enabled_count > 0 do %>
-            <%!-- Enabled Languages List --%>
-            <div class="mt-4">
-              <div class="flex items-center justify-between mb-2">
-                <h4 class="font-semibold">Enabled Languages</h4>
-                <div class="flex items-center gap-3 text-xs text-base-content/60">
-                  <span class="flex items-center gap-1">
-                    <span class="badge badge-secondary badge-xs h-auto"></span> Default
-                  </span>
-                  <span class="flex items-center gap-1">
-                    <span class="badge badge-primary badge-xs h-auto"></span> Enabled
-                  </span>
-                </div>
-              </div>
-              <div class="flex flex-wrap gap-2">
-                <%= for lang <- @languages |> Enum.filter(& &1.is_enabled) do %>
-                  <div class="dropdown dropdown-hover">
-                    <div
-                      tabindex="0"
-                      role="button"
-                      class={[
-                        "badge cursor-pointer",
-                        if(lang.code == @default_code,
-                          do: "badge-secondary",
-                          else: "badge-primary"
-                        )
-                      ]}
-                      title={lang.code}
-                    >
-                      {lang.name}
-                    </div>
-                    <ul
-                      tabindex="0"
-                      class="dropdown-content z-[1] menu p-2 shadow-lg bg-base-100 rounded-box w-40 border border-base-300"
-                    >
-                      <%= if lang.code != @default_code do %>
-                        <li>
-                          <button phx-click="set_default" phx-value-code={lang.code}>
-                            <PhoenixKitWeb.Components.Core.Icons.icon_star class="w-4 h-4" />
-                            Set Default
-                          </button>
-                        </li>
-                        <li>
-                          <button
-                            phx-click="toggle_language_availability"
-                            phx-value-code={lang.code}
-                            class="text-error"
-                          >
-                            <PhoenixKitWeb.Components.Core.Icons.icon_x class="w-4 h-4" /> Disable
-                          </button>
-                        </li>
-                      <% else %>
-                        <li class="disabled">
-                          <span class="text-base-content/60 text-sm">Default language</span>
-                        </li>
-                      <% end %>
-                    </ul>
-                  </div>
-                <% end %>
-              </div>
-            </div>
-
-            <%!-- Covered Countries List --%>
-            <div class="mt-4">
-              <h4 class="font-semibold mb-2">Countries Covered</h4>
-              <div class="flex flex-wrap gap-2">
-                <%= for {country, flag} <- @covered_countries do %>
-                  <span class="badge badge-outline">{flag} {country}</span>
-                <% end %>
-              </div>
-            </div>
-          <% else %>
-            <p class="text-base-content/60 mt-4">No languages enabled yet.</p>
-          <% end %>
-        </div>
-      </div>
-
-      <%!-- Languages Management Section --%>
-      <div class="card bg-base-100 shadow-xl">
-        <div class="card-body">
-          <div class="mb-4">
-            <h3 class="card-title text-xl">Available Languages</h3>
-            <p class="text-sm text-base-content/60 mt-1">
-              Enable languages for your application ({@enabled_count} enabled)
-            </p>
-          </div>
-
-          <%!-- Search Input --%>
-          <div class="mb-4">
-            <input
-              type="text"
-              placeholder="Search countries or languages..."
-              class="input input-bordered w-full"
-              phx-keyup="search_countries"
-              phx-debounce="150"
-              value={@search_query}
-            />
-          </div>
-
-          <%!-- Languages List grouped by Continent -> Country --%>
-          <div class="space-y-4">
-            <%= for {continent, countries} <- filter_grouped_languages(@grouped_languages, @search_query) do %>
-              <details class="collapse collapse-arrow bg-base-300 rounded-lg">
-                <summary class="collapse-title font-bold text-lg py-3">
-                  <span class="ml-2">{continent}</span>
-                  <span class="badge badge-ghost badge-sm ml-2">
-                    {count_covered_countries_in_continent(countries, @enabled_codes)}/{length(
-                      countries
-                    )} countries
-                  </span>
-                </summary>
-                <div class="collapse-content px-2 pb-2">
-                  <div class="space-y-2">
-                    <%= for {country, country_flag, languages} <- countries do %>
-                      <details class="collapse collapse-arrow bg-base-200 rounded-lg">
-                        <summary class="collapse-title font-medium py-2">
-                          <span class="text-lg">{country_flag}</span>
-                          <span class="ml-2">{country}</span>
-                          <span class="badge badge-ghost badge-xs ml-2">
-                            {count_enabled(languages, @enabled_codes)}/{length(languages)}
-                          </span>
-                        </summary>
-                        <div class="collapse-content px-2 pb-2">
-                          <div class="space-y-1">
-                            <%= for language <- languages do %>
-                              <div class="flex items-center justify-between p-2 hover:bg-base-100 rounded-lg">
-                                <div class="flex items-center gap-2 flex-1">
-                                  <span class="font-medium">
-                                    {language.native}
-                                    <span class="text-base-content/60">({language.name})</span>
-                                  </span>
-                                  <span class="badge badge-outline badge-xs h-auto">
-                                    {language.code}
-                                  </span>
-                                  <%= if language.code == @default_code do %>
-                                    <span class="badge badge-primary badge-xs h-auto">
-                                      Default
-                                    </span>
-                                  <% end %>
-                                </div>
-                                <div class="flex items-center gap-2">
-                                  <%!-- Set Default Button (only for enabled, non-default languages) --%>
-                                  <%= if language.code in @enabled_codes and language.code != @default_code do %>
-                                    <button
-                                      class="btn btn-ghost btn-xs tooltip tooltip-bottom"
-                                      phx-click="set_default"
-                                      phx-value-code={language.code}
-                                      data-tip={gettext("Set Default")}
-                                    >
-                                      <.icon name="hero-star" class="w-4 h-4 hidden sm:inline" />
-                                      <span class="sm:hidden whitespace-nowrap">
-                                        {gettext("Set Default")}
-                                      </span>
-                                    </button>
-                                  <% end %>
-                                  <%!-- Enable/Disable Toggle --%>
-                                  <input
-                                    type="checkbox"
-                                    class="toggle toggle-sm toggle-primary"
-                                    checked={language.code in @enabled_codes}
-                                    phx-click="toggle_language_availability"
-                                    phx-value-code={language.code}
-                                    disabled={language.code == @default_code}
-                                  />
-                                </div>
-                              </div>
-                            <% end %>
-                          </div>
-                        </div>
-                      </details>
-                    <% end %>
-                  </div>
-                </div>
-              </details>
-            <% end %>
+          <div class="stat">
+            <div class="stat-title">Countries Covered</div>
+            <div class="stat-value text-secondary">{@covered_count}</div>
           </div>
         </div>
-      </div>
 
-      <%!-- Help Section --%>
-      <div class="alert alert-info mt-6">
-        <PhoenixKitWeb.Components.Core.Icons.icon_info class="w-5 h-5" />
-        <div>
-          <h3 class="font-bold">Language Configuration</h3>
-          <div class="text-sm space-y-1">
-            <p>• Toggle languages on/off to enable or disable them for your application</p>
-            <p>• The default language cannot be disabled and serves as the fallback</p>
-            <p>• Click "Set Default" on any enabled language to make it the default</p>
-          </div>
-        </div>
-      </div>
-
-      <%!-- Frontend Language Switcher Component Section --%>
-      <div class="card bg-base-100 shadow-xl mt-6">
-        <div class="card-body">
-          <h2 class="card-title text-xl mb-4">Frontend Language Switcher</h2>
-          <p class="text-base-content/70 mb-6">
-            Configure and preview the language switcher component for your frontend application.
-          </p>
-
-          <%= if @ml_enabled and length(@languages) >= 1 do %>
-            <%!-- Two Column Layout: Settings | Preview --%>
-            <div class="grid grid-cols-1 lg:grid-cols-3 gap-6 auto-rows-fr">
-              <%!-- Left Column: Settings --%>
-              <div class="lg:col-span-1 border border-base-200 rounded-lg p-4 flex flex-col">
-                <h3 class="font-bold mb-4">Switcher Settings</h3>
-                <div class="space-y-4">
-                  <%!-- Show Flags Toggle --%>
-                  <div class="form-control">
-                    <label class="label cursor-pointer">
-                      <span class="label-text">Show Flags</span>
-                      <input
-                        type="checkbox"
-                        class="toggle toggle-sm toggle-primary"
-                        checked={@switcher_show_flags}
-                        phx-click="toggle_switcher_setting"
-                        phx-value-setting="switcher_show_flags"
-                      />
-                    </label>
-                  </div>
-
-                  <%!-- Show Language Names Toggle --%>
-                  <div class="form-control">
-                    <label class="label cursor-pointer">
-                      <span class="label-text">Show Names</span>
-                      <input
-                        type="checkbox"
-                        class="toggle toggle-sm toggle-primary"
-                        checked={@switcher_show_names}
-                        phx-click="toggle_switcher_setting"
-                        phx-value-setting="switcher_show_names"
-                      />
-                    </label>
-                  </div>
-
-                  <%!-- Show Native Names Toggle --%>
-                  <div class="form-control">
-                    <label class="label cursor-pointer">
-                      <span class="label-text">Native Names</span>
-                      <input
-                        type="checkbox"
-                        class="toggle toggle-sm toggle-primary"
-                        checked={@switcher_show_native_names}
-                        phx-click="toggle_switcher_setting"
-                        phx-value-setting="switcher_show_native_names"
-                      />
-                    </label>
-                  </div>
-
-                  <%!-- Go to Home Page Toggle --%>
-                  <div class="form-control">
-                    <label class="label cursor-pointer">
-                      <span class="label-text">Go to Home</span>
-                      <input
-                        type="checkbox"
-                        class="toggle toggle-sm toggle-primary"
-                        checked={@switcher_goto_home}
-                        phx-click="toggle_switcher_setting"
-                        phx-value-setting="switcher_goto_home"
-                      />
-                    </label>
-                  </div>
-
-                  <%!-- Hide Current Language Toggle --%>
-                  <div class="form-control">
-                    <label class="label cursor-pointer">
-                      <span class="label-text">Hide Current</span>
-                      <input
-                        type="checkbox"
-                        class="toggle toggle-sm toggle-primary"
-                        checked={@switcher_hide_current}
-                        phx-click="toggle_switcher_setting"
-                        phx-value-setting="switcher_hide_current"
-                      />
-                    </label>
-                  </div>
-                </div>
-              </div>
-
-              <%!-- Right Column: Preview and Code --%>
-              <div class="lg:col-span-2 space-y-4">
-                <%!-- Live Preview --%>
-                <div class="border border-base-200 rounded-lg p-4">
-                  <h3 class="font-bold mb-3">Live Preview</h3>
-                  <div class="bg-base-200 rounded p-4 flex items-center justify-center min-h-24">
-                    <.language_switcher_dropdown
-                      current_locale={@current_locale}
-                      show_flags={@switcher_show_flags}
-                      show_names={@switcher_show_names}
-                      show_native_names={@switcher_show_native_names}
-                      _language_update_key={@language_count}
-                    />
-                  </div>
-                </div>
-
-                <%!-- Generated Code --%>
-                <div class="border border-base-200 rounded-lg p-4">
-                  <h3 class="font-bold mb-3">Generated Code</h3>
-                  <div class="text-xs text-base-content/60 bg-base-200 rounded p-3 font-mono overflow-x-auto">
-                    <pre>{generate_switcher_code(@switcher_show_flags, @switcher_show_names, @switcher_goto_home, @switcher_hide_current, @switcher_show_native_names)}</pre>
-                  </div>
-                  <p class="text-xs text-base-content/60 mt-2">
-                    Copy this code to your frontend application and customize as needed.
-                  </p>
-                </div>
+        <%= if @enabled_count > 0 do %>
+          <%!-- Enabled Languages List --%>
+          <div class="mt-4">
+            <div class="flex items-center justify-between mb-2">
+              <h4 class="font-semibold">Enabled Languages</h4>
+              <div class="flex items-center gap-3 text-xs text-base-content/60">
+                <span class="flex items-center gap-1">
+                  <span class="badge badge-secondary badge-xs h-auto"></span> Default
+                </span>
+                <span class="flex items-center gap-1">
+                  <span class="badge badge-primary badge-xs h-auto"></span> Enabled
+                </span>
               </div>
             </div>
-
-            <%!-- Implementation Instructions --%>
-            <div class="alert alert-warning mt-6">
-              <PhoenixKitWeb.Components.Core.Icons.icon_warning class="w-5 h-5" />
-              <div>
-                <h3 class="font-bold">Implementation Notes</h3>
-                <div class="text-sm space-y-1">
-                  <p>
-                    • Make sure <code class="bg-base-300 px-2 py-1 rounded">@current_locale</code>
-                    is available in your assigns
-                  </p>
-                  <p>
-                    • The component automatically fetches enabled languages from the Language Module
-                  </p>
-                  <p>• Only enabled languages will appear in the switcher</p>
-                  <p>• Language switcher works with your existing route-based locale system</p>
-                </div>
-              </div>
-            </div>
-          <% else %>
-            <div class="alert alert-info">
-              <PhoenixKitWeb.Components.Core.Icons.icon_info class="w-5 h-5" />
-              <div>
-                <h3 class="font-bold">Enable and Configure Languages</h3>
-                <p class="text-sm mt-2">
-                  <%= if not @ml_enabled do %>
-                    First, enable the Languages module using the toggle at the top, then add at least one language to see live previews of the language switcher component.
-                  <% else %>
-                    Add at least one language using the form above to see live previews of the language switcher component.
-                  <% end %>
-                </p>
-              </div>
-            </div>
-          <% end %>
-        </div>
-      </div>
-    <% else %>
-      <%!-- Backend Tab --%>
-
-      <%!-- Admin Panel Languages Section --%>
-      <div class="card bg-base-100 shadow-xl">
-        <div class="card-body">
-          <h3 class="card-title text-xl flex items-center gap-2">
-            <PhoenixKitWeb.Components.Core.Icons.icon_settings class="w-5 h-5" />
-            Admin Panel Languages
-          </h3>
-
-          <div class="alert alert-info text-sm mb-4">
-            <PhoenixKitWeb.Components.Core.Icons.icon_info class="w-5 h-5" />
-            <div>
-              <h4 class="font-bold text-sm">Admin Panel Languages</h4>
-              <div class="text-xs mt-1">
-                <p>
-                  Select which languages are available in the admin panel navbar language switcher.
-                  This is independent from the website's content languages.
-                </p>
-              </div>
-            </div>
-          </div>
-
-          <%!-- Currently Selected Languages --%>
-          <div class="mb-4">
-            <label class="label">
-              <span class="label-text font-medium">Currently Selected</span>
-            </label>
             <div class="flex flex-wrap gap-2">
-              <%= if Enum.empty?(@admin_languages) do %>
-                <span class="text-base-content/60">No languages selected</span>
-              <% else %>
-                <%= for language_code <- @admin_languages do %>
-                  <% language =
-                    PhoenixKit.Modules.Languages.get_predefined_language(language_code) %>
-                  <% language_flag = if language, do: language.flag, else: "🌐" %>
-                  <% language_name = if language, do: language.name, else: language_code %>
-                  <div class="dropdown dropdown-hover">
-                    <div
-                      tabindex="0"
-                      role="button"
-                      class="badge badge-primary gap-1 cursor-pointer"
-                      title={language_code}
-                    >
-                      <span class="text-lg">{language_flag}</span>
-                      {language_name}
-                    </div>
-                    <ul
-                      tabindex="0"
-                      class="dropdown-content z-[1] menu p-2 shadow-lg bg-base-100 rounded-box w-40 border border-base-300"
-                    >
-                      <%= if length(@admin_languages) > 1 do %>
-                        <li>
-                          <button
-                            phx-click="remove_admin_language_from_form"
-                            phx-value-code={language_code}
-                            class="text-error"
-                          >
-                            <PhoenixKitWeb.Components.Core.Icons.icon_x class="w-4 h-4" /> Remove
-                          </button>
-                        </li>
-                      <% else %>
-                        <li class="disabled">
-                          <span class="text-base-content/60 text-sm">Last language</span>
-                        </li>
-                      <% end %>
-                    </ul>
+              <%= for lang <- @languages |> Enum.filter(& &1.is_enabled) do %>
+                <div class="dropdown dropdown-hover">
+                  <div
+                    tabindex="0"
+                    role="button"
+                    class={[
+                      "badge cursor-pointer",
+                      if(lang.code == @default_code,
+                        do: "badge-secondary",
+                        else: "badge-primary"
+                      )
+                    ]}
+                    title={lang.code}
+                  >
+                    {lang.name}
                   </div>
-                <% end %>
+                  <ul
+                    tabindex="0"
+                    class="dropdown-content z-[1] menu p-2 shadow-lg bg-base-100 rounded-box w-40 border border-base-300"
+                  >
+                    <%= if lang.code != @default_code do %>
+                      <li>
+                        <button phx-click="set_default" phx-value-code={lang.code}>
+                          <PhoenixKitWeb.Components.Core.Icons.icon_star class="w-4 h-4" />
+                          Set Default
+                        </button>
+                      </li>
+                      <li>
+                        <button
+                          phx-click="toggle_language_availability"
+                          phx-value-code={lang.code}
+                          class="text-error"
+                        >
+                          <PhoenixKitWeb.Components.Core.Icons.icon_x class="w-4 h-4" /> Disable
+                        </button>
+                      </li>
+                    <% else %>
+                      <li class="disabled">
+                        <span class="text-base-content/60 text-sm">Default language</span>
+                      </li>
+                    <% end %>
+                  </ul>
+                </div>
               <% end %>
             </div>
           </div>
 
-          <%!-- Add Language Dropdown --%>
-          <div class="mb-4">
-            <label class="label">
-              <span class="label-text font-medium">Add/Remove Languages</span>
-            </label>
-            <div class="dropdown w-full" id="admin_languages-dropdown">
-              <div
-                tabindex="0"
-                role="button"
-                class="btn btn-outline w-full justify-between"
-              >
-                <span>Select languages to add or remove...</span>
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  class="h-4 w-4"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                >
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    d="M19 9l-7 7-7-7"
+          <%!-- Covered Countries List --%>
+          <div class="mt-4">
+            <h4 class="font-semibold mb-2">Countries Covered</h4>
+            <div class="flex flex-wrap gap-2">
+              <%= for {country, flag} <- @covered_countries do %>
+                <span class="badge badge-outline">{flag} {country}</span>
+              <% end %>
+            </div>
+          </div>
+        <% else %>
+          <p class="text-base-content/60 mt-4">No languages enabled yet.</p>
+        <% end %>
+      </div>
+    </div>
+
+    <%!-- Languages Management Section --%>
+    <div class="card bg-base-100 shadow-xl">
+      <div class="card-body">
+        <div class="mb-4">
+          <h3 class="card-title text-xl">Available Languages</h3>
+          <p class="text-sm text-base-content/60 mt-1">
+            Enable languages for your application ({@enabled_count} enabled)
+          </p>
+        </div>
+
+        <%!-- Search Input --%>
+        <div class="mb-4">
+          <input
+            type="text"
+            placeholder="Search countries or languages..."
+            class="input input-bordered w-full"
+            phx-keyup="search_countries"
+            phx-debounce="150"
+            value={@search_query}
+          />
+        </div>
+
+        <%!-- Languages List grouped by Continent -> Country --%>
+        <div class="space-y-4">
+          <%= for {continent, countries} <- filter_grouped_languages(@grouped_languages, @search_query) do %>
+            <details class="collapse collapse-arrow bg-base-300 rounded-lg">
+              <summary class="collapse-title font-bold text-lg py-3">
+                <span class="ml-2">{continent}</span>
+                <span class="badge badge-ghost badge-sm ml-2">
+                  {count_covered_countries_in_continent(countries, @enabled_codes)}/{length(
+                    countries
+                  )} countries
+                </span>
+              </summary>
+              <div class="collapse-content px-2 pb-2">
+                <div class="space-y-2">
+                  <%= for {country, country_flag, languages} <- countries do %>
+                    <details class="collapse collapse-arrow bg-base-200 rounded-lg">
+                      <summary class="collapse-title font-medium py-2">
+                        <span class="text-lg">{country_flag}</span>
+                        <span class="ml-2">{country}</span>
+                        <span class="badge badge-ghost badge-xs ml-2">
+                          {count_enabled(languages, @enabled_codes)}/{length(languages)}
+                        </span>
+                      </summary>
+                      <div class="collapse-content px-2 pb-2">
+                        <div class="space-y-1">
+                          <%= for language <- languages do %>
+                            <div class="flex items-center justify-between p-2 hover:bg-base-100 rounded-lg">
+                              <div class="flex items-center gap-2 flex-1">
+                                <span class="font-medium">
+                                  {language.native}
+                                  <span class="text-base-content/60">({language.name})</span>
+                                </span>
+                                <span class="badge badge-outline badge-xs h-auto">
+                                  {language.code}
+                                </span>
+                                <%= if language.code == @default_code do %>
+                                  <span class="badge badge-primary badge-xs h-auto">
+                                    Default
+                                  </span>
+                                <% end %>
+                              </div>
+                              <div class="flex items-center gap-2">
+                                <%!-- Set Default Button (only for enabled, non-default languages) --%>
+                                <%= if language.code in @enabled_codes and language.code != @default_code do %>
+                                  <button
+                                    class="btn btn-ghost btn-xs tooltip tooltip-bottom"
+                                    phx-click="set_default"
+                                    phx-value-code={language.code}
+                                    data-tip={gettext("Set Default")}
+                                  >
+                                    <.icon name="hero-star" class="w-4 h-4 hidden sm:inline" />
+                                    <span class="sm:hidden whitespace-nowrap">
+                                      {gettext("Set Default")}
+                                    </span>
+                                  </button>
+                                <% end %>
+                                <%!-- Enable/Disable Toggle --%>
+                                <input
+                                  type="checkbox"
+                                  class="toggle toggle-sm toggle-primary"
+                                  checked={language.code in @enabled_codes}
+                                  phx-click="toggle_language_availability"
+                                  phx-value-code={language.code}
+                                  disabled={language.code == @default_code}
+                                />
+                              </div>
+                            </div>
+                          <% end %>
+                        </div>
+                      </div>
+                    </details>
+                  <% end %>
+                </div>
+              </div>
+            </details>
+          <% end %>
+        </div>
+      </div>
+    </div>
+
+    <%!-- Help Section --%>
+    <div class="alert alert-info mt-6">
+      <PhoenixKitWeb.Components.Core.Icons.icon_info class="w-5 h-5" />
+      <div>
+        <h3 class="font-bold">Language Configuration</h3>
+        <div class="text-sm space-y-1">
+          <p>• Toggle languages on/off to enable or disable them for your application</p>
+          <p>• The default language cannot be disabled and serves as the fallback</p>
+          <p>• Click "Set Default" on any enabled language to make it the default</p>
+        </div>
+      </div>
+    </div>
+
+    <%!-- Frontend Language Switcher Component Section --%>
+    <div class="card bg-base-100 shadow-xl mt-6">
+      <div class="card-body">
+        <h2 class="card-title text-xl mb-4">Frontend Language Switcher</h2>
+        <p class="text-base-content/70 mb-6">
+          Configure and preview the language switcher component for your frontend application.
+        </p>
+
+        <%= if @ml_enabled and length(@languages) >= 1 do %>
+          <%!-- Two Column Layout: Settings | Preview --%>
+          <div class="grid grid-cols-1 lg:grid-cols-3 gap-6 auto-rows-fr">
+            <%!-- Left Column: Settings --%>
+            <div class="lg:col-span-1 border border-base-200 rounded-lg p-4 flex flex-col">
+              <h3 class="font-bold mb-4">Switcher Settings</h3>
+              <div class="space-y-4">
+                <%!-- Show Flags Toggle --%>
+                <div class="form-control">
+                  <label class="label cursor-pointer">
+                    <span class="label-text">Show Flags</span>
+                    <input
+                      type="checkbox"
+                      class="toggle toggle-sm toggle-primary"
+                      checked={@switcher_show_flags}
+                      phx-click="toggle_switcher_setting"
+                      phx-value-setting="switcher_show_flags"
+                    />
+                  </label>
+                </div>
+
+                <%!-- Show Language Names Toggle --%>
+                <div class="form-control">
+                  <label class="label cursor-pointer">
+                    <span class="label-text">Show Names</span>
+                    <input
+                      type="checkbox"
+                      class="toggle toggle-sm toggle-primary"
+                      checked={@switcher_show_names}
+                      phx-click="toggle_switcher_setting"
+                      phx-value-setting="switcher_show_names"
+                    />
+                  </label>
+                </div>
+
+                <%!-- Show Native Names Toggle --%>
+                <div class="form-control">
+                  <label class="label cursor-pointer">
+                    <span class="label-text">Native Names</span>
+                    <input
+                      type="checkbox"
+                      class="toggle toggle-sm toggle-primary"
+                      checked={@switcher_show_native_names}
+                      phx-click="toggle_switcher_setting"
+                      phx-value-setting="switcher_show_native_names"
+                    />
+                  </label>
+                </div>
+
+                <%!-- Go to Home Page Toggle --%>
+                <div class="form-control">
+                  <label class="label cursor-pointer">
+                    <span class="label-text">Go to Home</span>
+                    <input
+                      type="checkbox"
+                      class="toggle toggle-sm toggle-primary"
+                      checked={@switcher_goto_home}
+                      phx-click="toggle_switcher_setting"
+                      phx-value-setting="switcher_goto_home"
+                    />
+                  </label>
+                </div>
+
+                <%!-- Hide Current Language Toggle --%>
+                <div class="form-control">
+                  <label class="label cursor-pointer">
+                    <span class="label-text">Hide Current</span>
+                    <input
+                      type="checkbox"
+                      class="toggle toggle-sm toggle-primary"
+                      checked={@switcher_hide_current}
+                      phx-click="toggle_switcher_setting"
+                      phx-value-setting="switcher_hide_current"
+                    />
+                  </label>
+                </div>
+              </div>
+            </div>
+
+            <%!-- Right Column: Preview and Code --%>
+            <div class="lg:col-span-2 space-y-4">
+              <%!-- Live Preview --%>
+              <div class="border border-base-200 rounded-lg p-4">
+                <h3 class="font-bold mb-3">Live Preview</h3>
+                <div class="bg-base-200 rounded p-4 flex items-center justify-center min-h-24">
+                  <.language_switcher_dropdown
+                    current_locale={@current_locale}
+                    show_flags={@switcher_show_flags}
+                    show_names={@switcher_show_names}
+                    show_native_names={@switcher_show_native_names}
+                    _language_update_key={@language_count}
                   />
-                </svg>
+                </div>
               </div>
 
-              <div
-                tabindex="0"
-                class="dropdown-content z-[1] menu p-2 shadow-lg bg-base-100 rounded-box w-full mt-2 max-h-96 overflow-y-auto border border-base-300"
-              >
-                <ul class="space-y-1">
-                  <li class="menu-title">
-                    <span>Available Languages</span>
-                  </li>
-                  <%= for language <- Enum.filter(PhoenixKit.Modules.Languages.get_available_languages(), & &1.code in PhoenixKit.Modules.Languages.get_default_language_codes()) do %>
-                    <% is_selected = language.code in @admin_languages %>
-                    <li>
-                      <a
-                        class="flex items-center gap-3 p-3 rounded hover:bg-base-200"
-                        phx-click="add_admin_language_to_form"
-                        phx-value-admin_language_code_input={language.code}
-                      >
-                        <div class="flex-shrink-0">
-                          <input
-                            type="checkbox"
-                            class="checkbox checkbox-primary pointer-events-none"
-                            checked={is_selected}
-                          />
-                        </div>
-                        <div class="flex-1 flex items-center gap-2">
-                          <span class="text-xl">{language.flag}</span>
-                          <div class="flex flex-col">
-                            <span class="font-medium">{language.name}</span>
-                            <span class="text-xs text-base-content/60">{language.code}</span>
-                          </div>
-                        </div>
-                      </a>
-                    </li>
-                  <% end %>
-                </ul>
+              <%!-- Generated Code --%>
+              <div class="border border-base-200 rounded-lg p-4">
+                <h3 class="font-bold mb-3">Generated Code</h3>
+                <div class="text-xs text-base-content/60 bg-base-200 rounded p-3 font-mono overflow-x-auto">
+                  <pre>{generate_switcher_code(@switcher_show_flags, @switcher_show_names, @switcher_goto_home, @switcher_hide_current, @switcher_show_native_names)}</pre>
+                </div>
+                <p class="text-xs text-base-content/60 mt-2">
+                  Copy this code to your frontend application and customize as needed.
+                </p>
               </div>
             </div>
           </div>
 
-          <%!-- Save Button --%>
-          <div class="card-actions justify-end">
-            <button
-              type="button"
-              class="btn btn-primary"
-              phx-click="save_admin_languages"
-            >
-              <PhoenixKitWeb.Components.Core.Icons.icon_check class="w-4 h-4" />
-              Save Admin Languages
-            </button>
+          <%!-- Implementation Instructions --%>
+          <div class="alert alert-warning mt-6">
+            <PhoenixKitWeb.Components.Core.Icons.icon_warning class="w-5 h-5" />
+            <div>
+              <h3 class="font-bold">Implementation Notes</h3>
+              <div class="text-sm space-y-1">
+                <p>
+                  • Make sure <code class="bg-base-300 px-2 py-1 rounded">@current_locale</code>
+                  is available in your assigns
+                </p>
+                <p>
+                  • The component automatically fetches enabled languages from the Language Module
+                </p>
+                <p>• Only enabled languages will appear in the switcher</p>
+                <p>• Language switcher works with your existing route-based locale system</p>
+              </div>
+            </div>
           </div>
-        </div>
+        <% else %>
+          <div class="alert alert-info">
+            <PhoenixKitWeb.Components.Core.Icons.icon_info class="w-5 h-5" />
+            <div>
+              <h3 class="font-bold">Enable and Configure Languages</h3>
+              <p class="text-sm mt-2">
+                <%= if not @ml_enabled do %>
+                  First, enable the Languages module using the toggle at the top, then add at least one language to see live previews of the language switcher component.
+                <% else %>
+                  Add at least one language using the form above to see live previews of the language switcher component.
+                <% end %>
+              </p>
+            </div>
+          </div>
+        <% end %>
       </div>
-    <% end %>
+    </div>
   </div>
 </PhoenixKitWeb.Components.LayoutWrapper.app_layout>

--- a/lib/phoenix_kit_web/users/auth.ex
+++ b/lib/phoenix_kit_web/users/auth.ex
@@ -1573,8 +1573,8 @@ defmodule PhoenixKitWeb.Users.Auth do
               {preferred_base, preferred_dialect}
 
             _ ->
-              # No user preference - use default admin language
-              default_base = get_default_admin_language()
+              # No user preference - use default language
+              default_base = Routes.get_default_admin_locale()
               default_dialect = DialectMapper.resolve_dialect(default_base, current_user)
               {default_base, default_dialect}
           end
@@ -1606,7 +1606,7 @@ defmodule PhoenixKitWeb.Users.Auth do
       end)
 
     # Set locale before redirecting
-    default_base = get_default_admin_language()
+    default_base = Routes.get_default_admin_locale()
     current_user = get_user_for_locale_resolution(conn)
     default_dialect = DialectMapper.resolve_dialect(default_base, current_user)
 
@@ -1642,9 +1642,8 @@ defmodule PhoenixKitWeb.Users.Auth do
        when is_binary(preferred) and preferred != "" do
     base = DialectMapper.extract_base(preferred)
 
-    # Verify the preferred locale is a valid admin language
-    # (admin languages are separate from frontend languages)
-    if DialectMapper.valid_base_code?(base) and admin_language_enabled?(base) do
+    # Verify the preferred locale is a valid enabled language
+    if DialectMapper.valid_base_code?(base) and language_enabled?(base) do
       {base, preferred}
     else
       nil
@@ -1654,52 +1653,7 @@ defmodule PhoenixKitWeb.Users.Auth do
   defp get_user_preferred_locale(_user), do: nil
 
   defp locale_allowed?(base_code) do
-    language_enabled?(base_code) or admin_language_enabled?(base_code)
-  end
-
-  # Check if a language (base code) is enabled as an admin language
-  defp admin_language_enabled?(base_code) do
-    admin_languages = get_admin_language_codes()
-
-    if Enum.empty?(admin_languages) do
-      # No admin languages configured, allow if it's a valid predefined language
-      true
-    else
-      Enum.any?(admin_languages, fn code ->
-        DialectMapper.extract_base(code) == base_code
-      end)
-    end
-  end
-
-  # Get the list of admin language codes from settings
-  defp get_admin_language_codes do
-    case PhoenixKit.Settings.get_setting_cached("admin_languages") do
-      nil ->
-        []
-
-      json when is_binary(json) ->
-        case Jason.decode(json) do
-          {:ok, codes} when is_list(codes) -> codes
-          _ -> []
-        end
-    end
-  end
-
-  # Get the default admin language base code (first in admin_languages list, or "en")
-  # Extracts base code from full dialect (e.g., "en-US" -> "en")
-  defp get_default_admin_language do
-    case PhoenixKit.Settings.get_setting_cached("admin_languages") do
-      nil ->
-        # No setting exists, default is "en"
-        "en"
-
-      json when is_binary(json) ->
-        case Jason.decode(json) do
-          # Extract base code from full dialect (e.g., "en-US" -> "en")
-          {:ok, [first | _]} -> DialectMapper.extract_base(first)
-          _ -> "en"
-        end
-    end
+    language_enabled?(base_code)
   end
 
   # Check if a language (base code) is enabled in the system
@@ -1724,7 +1678,7 @@ defmodule PhoenixKitWeb.Users.Auth do
   # Admin paths ALWAYS keep the locale in the URL to stay within the
   # :phoenix_kit_admin_locale live_session and avoid full-page reloads.
   defp process_valid_locale(conn, locale) do
-    if locale == get_default_admin_language() and not admin_request?(conn) do
+    if locale == Routes.get_default_admin_locale() and not admin_request?(conn) do
       redirect_default_locale_to_clean_url(conn, locale)
     else
       current_user = get_user_for_locale_resolution(conn)
@@ -1843,12 +1797,12 @@ defmodule PhoenixKitWeb.Users.Auth do
   Takes the current URL path and replaces the invalid locale with the default
   locale base code, then redirects the user to the corrected URL.
 
-  For the default language (first admin language), the locale segment is removed
-  entirely to produce clean URLs (e.g., /phoenix_kit/admin).
+  For the default language, the locale segment is removed entirely to produce
+  clean URLs (e.g., /phoenix_kit/admin).
   """
   def redirect_invalid_locale(conn, invalid_locale) do
-    # Get the default admin language (first in admin_languages list, or "en")
-    default_base = get_default_admin_language()
+    # Get the default language
+    default_base = Routes.get_default_admin_locale()
 
     # For default language, remove locale segment entirely for clean URLs
     # For other languages, replace with that language code

--- a/test/integration/languages/crud_test.exs
+++ b/test/integration/languages/crud_test.exs
@@ -1,0 +1,248 @@
+defmodule PhoenixKit.Integration.Languages.CrudTest do
+  use PhoenixKit.DataCase, async: true
+
+  alias PhoenixKit.Modules.Languages
+
+  setup do
+    {:ok, _} = Languages.enable_system()
+    :ok
+  end
+
+  describe "add_language/1" do
+    test "adds a predefined language" do
+      assert {:ok, _config} = Languages.add_language("es-ES")
+
+      codes = Languages.get_language_codes()
+      assert "es-ES" in codes
+    end
+
+    test "new language is enabled but not default" do
+      {:ok, _} = Languages.add_language("fr-FR")
+
+      lang = Languages.get_language("fr-FR")
+      assert lang.is_enabled == true
+      assert lang.is_default == false
+    end
+
+    test "rejects duplicate language" do
+      {:ok, _} = Languages.add_language("de-DE")
+      assert {:error, "Language already exists"} = Languages.add_language("de-DE")
+    end
+
+    test "rejects unknown language code" do
+      assert {:error, "Language not found in available languages"} =
+               Languages.add_language("xx-INVALID")
+    end
+
+    test "en-US already exists by default" do
+      assert {:error, "Language already exists"} = Languages.add_language("en-US")
+    end
+  end
+
+  describe "remove_language/1" do
+    setup do
+      {:ok, _} = Languages.add_language("es-ES")
+      :ok
+    end
+
+    test "removes a non-default language" do
+      assert {:ok, _} = Languages.remove_language("es-ES")
+      refute "es-ES" in Languages.get_language_codes()
+    end
+
+    test "cannot remove the default language" do
+      assert {:error, "Cannot remove default language"} = Languages.remove_language("en-US")
+    end
+
+    test "cannot remove the last language" do
+      # Remove es-ES, leaving only en-US (the default)
+      {:ok, _} = Languages.remove_language("es-ES")
+      assert {:error, "Cannot remove default language"} = Languages.remove_language("en-US")
+    end
+
+    test "returns error for unknown language" do
+      assert {:error, "Language not found"} = Languages.remove_language("nonexistent")
+    end
+  end
+
+  describe "set_default_language/1" do
+    setup do
+      {:ok, _} = Languages.add_language("fr-FR")
+      :ok
+    end
+
+    test "changes the default language" do
+      assert {:ok, _} = Languages.set_default_language("fr-FR")
+
+      default = Languages.get_default_language()
+      assert default.code == "fr-FR"
+      assert default.is_default == true
+    end
+
+    test "old default loses is_default flag" do
+      {:ok, _} = Languages.set_default_language("fr-FR")
+
+      en = Languages.get_language("en-US")
+      assert en.is_default == false
+    end
+
+    test "returns error for unknown language" do
+      assert {:error, "Language not found"} = Languages.set_default_language("nonexistent")
+    end
+  end
+
+  describe "enable_language/1 and disable_language/1" do
+    setup do
+      {:ok, _} = Languages.add_language("it")
+      :ok
+    end
+
+    test "disables a non-default language" do
+      assert {:ok, _} = Languages.disable_language("it")
+
+      lang = Languages.get_language("it")
+      assert lang.is_enabled == false
+    end
+
+    test "disabled language excluded from get_enabled_languages" do
+      {:ok, _} = Languages.disable_language("it")
+
+      enabled_codes = Languages.get_enabled_language_codes()
+      refute "it" in enabled_codes
+    end
+
+    test "re-enables a disabled language" do
+      {:ok, _} = Languages.disable_language("it")
+      assert {:ok, _} = Languages.enable_language("it")
+
+      lang = Languages.get_language("it")
+      assert lang.is_enabled == true
+    end
+
+    test "cannot disable the default language" do
+      assert {:error, "Cannot disable default language"} = Languages.disable_language("en-US")
+    end
+  end
+
+  describe "move_language_up/1 and move_language_down/1" do
+    setup do
+      {:ok, _} = Languages.add_language("es-ES")
+      {:ok, _} = Languages.add_language("fr-FR")
+      # Order is now: en-US, es-ES, fr-FR
+      :ok
+    end
+
+    test "moves a language up in the list" do
+      assert {:ok, _} = Languages.move_language_up("es-ES")
+
+      codes = Languages.get_language_codes()
+      assert Enum.at(codes, 0) == "es-ES"
+      assert Enum.at(codes, 1) == "en-US"
+    end
+
+    test "cannot move first language up" do
+      assert {:error, "Language is already at the top"} = Languages.move_language_up("en-US")
+    end
+
+    test "moves a language down in the list" do
+      assert {:ok, _} = Languages.move_language_down("en-US")
+
+      codes = Languages.get_language_codes()
+      assert Enum.at(codes, 0) == "es-ES"
+      assert Enum.at(codes, 1) == "en-US"
+    end
+
+    test "cannot move last language down" do
+      assert {:error, "Language is already at the bottom"} = Languages.move_language_down("fr-FR")
+    end
+
+    test "returns error for unknown language" do
+      assert {:error, "Language not found"} = Languages.move_language_up("nonexistent")
+      assert {:error, "Language not found"} = Languages.move_language_down("nonexistent")
+    end
+  end
+
+  describe "get_config/0" do
+    test "returns complete config summary" do
+      {:ok, _} = Languages.add_language("ja")
+
+      config = Languages.get_config()
+      assert config.enabled == true
+      assert config.language_count >= 2
+      assert config.enabled_count >= 2
+      assert config.default_language != nil
+      assert config.default_language.code == "en-US"
+    end
+  end
+
+  describe "query functions with enabled system" do
+    setup do
+      {:ok, _} = Languages.add_language("ja")
+      {:ok, _} = Languages.add_language("de-DE")
+      :ok
+    end
+
+    test "get_languages returns all configured languages" do
+      langs = Languages.get_languages()
+      codes = Enum.map(langs, & &1.code)
+      assert "en-US" in codes
+      assert "ja" in codes
+      assert "de-DE" in codes
+    end
+
+    test "get_enabled_languages returns only enabled" do
+      {:ok, _} = Languages.disable_language("ja")
+
+      enabled = Languages.get_enabled_languages()
+      codes = Enum.map(enabled, & &1.code)
+      assert "en-US" in codes
+      assert "de-DE" in codes
+      refute "ja" in codes
+    end
+
+    test "get_language returns specific language" do
+      lang = Languages.get_language("ja")
+      assert lang.code == "ja"
+      assert is_binary(lang.name)
+    end
+
+    test "get_language returns nil for unknown code" do
+      assert Languages.get_language("nonexistent") == nil
+    end
+
+    test "valid_language? checks existence" do
+      assert Languages.valid_language?("ja")
+      refute Languages.valid_language?("nonexistent")
+    end
+
+    test "language_enabled? checks both existence and enabled status" do
+      assert Languages.language_enabled?("ja")
+
+      {:ok, _} = Languages.disable_language("ja")
+      refute Languages.language_enabled?("ja")
+    end
+
+    test "enabled_locale_codes returns enabled codes" do
+      codes = Languages.enabled_locale_codes()
+      assert is_list(codes)
+      assert "en-US" in codes
+    end
+  end
+
+  describe "system enable/disable cycle" do
+    test "disable preserves config, re-enable restores it" do
+      {:ok, _} = Languages.add_language("ko")
+      assert "ko" in Languages.get_language_codes()
+
+      # Disable
+      {:ok, _} = Languages.disable_system()
+      refute Languages.enabled?()
+      assert Languages.get_languages() == []
+
+      # Re-enable — config should be preserved
+      {:ok, _} = Languages.enable_system()
+      assert Languages.enabled?()
+      assert "ko" in Languages.get_language_codes()
+    end
+  end
+end

--- a/test/integration/languages/normalize_test.exs
+++ b/test/integration/languages/normalize_test.exs
@@ -97,4 +97,67 @@ defmodule PhoenixKit.Integration.Languages.NormalizeTest do
       assert "en-US" in codes
     end
   end
+
+  describe "get_enabled_languages_by_continent/0" do
+    test "returns default languages grouped by continent when system is disabled" do
+      # When disabled, get_display_languages returns defaults, so continent grouping uses those
+      grouped = Languages.get_enabled_languages_by_continent()
+      assert is_list(grouped)
+      assert grouped != []
+
+      continents = Enum.map(grouped, fn {c, _} -> c end)
+      assert Enum.all?(continents, &is_binary/1)
+    end
+
+    test "groups enabled languages by continent" do
+      {:ok, _} = Languages.enable_system()
+      {:ok, _} = Languages.add_language("ja")
+      {:ok, _} = Languages.add_language("de-DE")
+
+      grouped = Languages.get_enabled_languages_by_continent()
+      assert is_list(grouped)
+
+      # Should have at least 2 continents (Asia for ja, Europe for de-DE, etc.)
+      continents = Enum.map(grouped, fn {continent, _} -> continent end)
+      assert length(continents) >= 2
+
+      # Each group should have non-empty language list
+      Enum.each(grouped, fn {continent, langs} ->
+        assert is_binary(continent)
+        assert is_list(langs)
+        assert langs != []
+      end)
+    end
+
+    test "only includes enabled languages" do
+      {:ok, _} = Languages.enable_system()
+      {:ok, _} = Languages.add_language("ja")
+      {:ok, _} = Languages.add_language("fr-FR")
+      {:ok, _} = Languages.disable_language("ja")
+
+      grouped = Languages.get_enabled_languages_by_continent()
+
+      all_codes =
+        grouped
+        |> Enum.flat_map(fn {_, langs} ->
+          Enum.map(langs, fn lang ->
+            if is_struct(lang), do: lang.code, else: lang[:code]
+          end)
+        end)
+
+      refute "ja" in all_codes
+      assert "fr-FR" in all_codes
+    end
+
+    test "sorted alphabetically by continent" do
+      {:ok, _} = Languages.enable_system()
+      {:ok, _} = Languages.add_language("ja")
+      {:ok, _} = Languages.add_language("de-DE")
+      {:ok, _} = Languages.add_language("pt-BR")
+
+      grouped = Languages.get_enabled_languages_by_continent()
+      continents = Enum.map(grouped, fn {c, _} -> c end)
+      assert continents == Enum.sort(continents)
+    end
+  end
 end

--- a/test/integration/languages/normalize_test.exs
+++ b/test/integration/languages/normalize_test.exs
@@ -1,0 +1,100 @@
+defmodule PhoenixKit.Integration.Languages.NormalizeTest do
+  use PhoenixKit.DataCase, async: true
+
+  alias PhoenixKit.Modules.Languages
+  alias PhoenixKit.Settings
+
+  describe "normalize_language_settings/0" do
+    test "no-op when admin_languages setting does not exist" do
+      assert :ok = Languages.normalize_language_settings()
+    end
+
+    test "no-op when admin_languages is already empty" do
+      Settings.update_setting("admin_languages", "[]")
+
+      assert :ok = Languages.normalize_language_settings()
+    end
+
+    test "no-op when admin_languages contains invalid JSON" do
+      Settings.update_setting("admin_languages", "not json")
+
+      assert :ok = Languages.normalize_language_settings()
+    end
+
+    test "no-op when admin_languages is an empty JSON object" do
+      Settings.update_setting("admin_languages", "{}")
+
+      assert :ok = Languages.normalize_language_settings()
+    end
+
+    test "enables Languages module and merges admin-only languages" do
+      # Disable the system first
+      Languages.disable_system()
+      refute Languages.enabled?()
+
+      # Set up legacy admin_languages with codes
+      Settings.update_setting("admin_languages", Jason.encode!(["en-US", "es-ES"]))
+
+      # Normalize
+      assert :ok = Languages.normalize_language_settings()
+
+      # System should now be enabled
+      assert Languages.enabled?()
+
+      # Both languages should be in the unified config
+      codes = Languages.get_language_codes()
+      assert "en-US" in codes
+      assert "es-ES" in codes
+
+      # Legacy setting should be cleared
+      assert Settings.get_setting("admin_languages") == "[]"
+    end
+
+    test "does not duplicate languages already in config" do
+      # Enable with default English
+      {:ok, _} = Languages.enable_system()
+
+      # Set admin_languages to include en-US (already exists) and es-ES (new)
+      Settings.update_setting("admin_languages", Jason.encode!(["en-US", "es-ES"]))
+
+      # Normalize
+      assert :ok = Languages.normalize_language_settings()
+
+      # en-US should appear only once
+      codes = Languages.get_language_codes()
+      assert Enum.count(codes, &(&1 == "en-US")) == 1
+      assert "es-ES" in codes
+    end
+
+    test "is idempotent — running twice produces same result" do
+      {:ok, _} = Languages.enable_system()
+      Settings.update_setting("admin_languages", Jason.encode!(["en-US", "fr-FR"]))
+
+      assert :ok = Languages.normalize_language_settings()
+      codes_after_first = Languages.get_language_codes()
+
+      # Second run — admin_languages is now "[]", should be no-op
+      assert :ok = Languages.normalize_language_settings()
+      codes_after_second = Languages.get_language_codes()
+
+      assert codes_after_first == codes_after_second
+    end
+
+    test "skips invalid language codes gracefully" do
+      {:ok, _} = Languages.enable_system()
+
+      # Include a valid code and an invalid one
+      Settings.update_setting(
+        "admin_languages",
+        Jason.encode!(["en-US", "xx-INVALID-CODE"])
+      )
+
+      # Should not crash
+      assert :ok = Languages.normalize_language_settings()
+
+      # Valid language should be present, invalid one silently skipped
+      codes = Languages.get_language_codes()
+      assert "en-US" in codes
+    end
+  end
+end

--- a/test/language_refactor_test.exs
+++ b/test/language_refactor_test.exs
@@ -78,6 +78,35 @@ defmodule LanguageRefactorTest do
     assert_raise UndefinedFunctionError, fn -> lang["code"] end
   end
 
+  test "get_display_languages returns default languages when disabled" do
+    # When disabled, get_display_languages returns the hardcoded default list
+    display_languages = Languages.get_display_languages()
+    assert is_list(display_languages)
+    assert display_languages != []
+
+    # All should be Language structs
+    Enum.each(display_languages, fn lang ->
+      assert is_struct(lang, Language)
+      assert is_binary(lang.code)
+      assert is_binary(lang.name)
+    end)
+  end
+
+  test "get_default_language returns nil when disabled" do
+    # When the system is disabled, get_default_language returns nil
+    assert Languages.get_default_language() == nil
+  end
+
+  test "get_enabled_languages returns empty list when disabled" do
+    assert Languages.get_enabled_languages() == []
+  end
+
+  test "enabled_locale_codes falls back to default locale when disabled" do
+    codes = Languages.enabled_locale_codes()
+    assert is_list(codes)
+    assert length(codes) == 1
+  end
+
   test "grouped languages converts structs before adding country metadata" do
     grouped_languages = Languages.get_languages_grouped_by_continent()
 

--- a/test/phoenix_kit/languages/dialect_mapper_test.exs
+++ b/test/phoenix_kit/languages/dialect_mapper_test.exs
@@ -1,0 +1,149 @@
+defmodule PhoenixKit.Modules.Languages.DialectMapperTest do
+  use ExUnit.Case
+
+  alias PhoenixKit.Modules.Languages.DialectMapper
+
+  describe "extract_base/1" do
+    test "extracts base from full dialect code" do
+      assert DialectMapper.extract_base("en-US") == "en"
+      assert DialectMapper.extract_base("es-MX") == "es"
+      assert DialectMapper.extract_base("pt-BR") == "pt"
+      assert DialectMapper.extract_base("zh-CN") == "zh"
+    end
+
+    test "returns base code unchanged" do
+      assert DialectMapper.extract_base("en") == "en"
+      assert DialectMapper.extract_base("ja") == "ja"
+    end
+
+    test "handles multi-part codes" do
+      assert DialectMapper.extract_base("zh-Hans-CN") == "zh"
+    end
+
+    test "lowercases result" do
+      assert DialectMapper.extract_base("EN-GB") == "en"
+      assert DialectMapper.extract_base("FR") == "fr"
+    end
+
+    test "returns en for nil" do
+      assert DialectMapper.extract_base(nil) == "en"
+    end
+
+    test "returns en for empty string" do
+      assert DialectMapper.extract_base("") == "en"
+    end
+  end
+
+  describe "base_to_dialect/1" do
+    test "maps base codes to default dialects" do
+      assert DialectMapper.base_to_dialect("en") == "en-US"
+      assert DialectMapper.base_to_dialect("pt") == "pt-BR"
+      assert DialectMapper.base_to_dialect("zh") == "zh-CN"
+      assert DialectMapper.base_to_dialect("es") == "es-ES"
+      assert DialectMapper.base_to_dialect("de") == "de-DE"
+      assert DialectMapper.base_to_dialect("fr") == "fr-FR"
+    end
+
+    test "returns base code when no dialect mapping exists" do
+      assert DialectMapper.base_to_dialect("ja") == "ja"
+      assert DialectMapper.base_to_dialect("ko") == "ko"
+      assert DialectMapper.base_to_dialect("ar") == "ar"
+    end
+
+    test "returns unknown base code as-is" do
+      assert DialectMapper.base_to_dialect("xx") == "xx"
+    end
+
+    test "handles uppercase input" do
+      assert DialectMapper.base_to_dialect("EN") == "en-US"
+    end
+  end
+
+  describe "resolve_dialect/2" do
+    test "returns default dialect when no user" do
+      assert DialectMapper.resolve_dialect("en", nil) == "en-US"
+      assert DialectMapper.resolve_dialect("pt", nil) == "pt-BR"
+    end
+
+    test "returns default dialect when user has no preference" do
+      user = %{some_field: "value"}
+      assert DialectMapper.resolve_dialect("en", user) == "en-US"
+    end
+
+    test "uses user preference when it matches base code" do
+      user = %{custom_fields: %{"preferred_locale" => "en-GB"}}
+      assert DialectMapper.resolve_dialect("en", user) == "en-GB"
+    end
+
+    test "ignores user preference when it doesn't match base code" do
+      user = %{custom_fields: %{"preferred_locale" => "es-MX"}}
+      assert DialectMapper.resolve_dialect("en", user) == "en-US"
+    end
+
+    test "empty preference returns empty string (matched by guard)" do
+      # Empty string matches `when is_binary(preferred)` but extract_base("") returns "en"
+      # which matches base "en", so it returns the empty string preference
+      # This is edge-case behavior — real preferences are never empty
+      user = %{custom_fields: %{"preferred_locale" => ""}}
+      result = DialectMapper.resolve_dialect("en", user)
+      assert is_binary(result)
+    end
+
+    test "handles user without custom_fields key" do
+      user = %{email: "test@example.com"}
+      assert DialectMapper.resolve_dialect("en", user) == "en-US"
+    end
+  end
+
+  describe "valid_base_code?/1" do
+    test "returns true for valid 2-letter base codes" do
+      assert DialectMapper.valid_base_code?("en")
+      assert DialectMapper.valid_base_code?("fr")
+      assert DialectMapper.valid_base_code?("ja")
+    end
+
+    test "returns false for full dialect codes" do
+      refute DialectMapper.valid_base_code?("en-US")
+      refute DialectMapper.valid_base_code?("pt-BR")
+    end
+
+    test "returns false for unknown codes" do
+      refute DialectMapper.valid_base_code?("xx")
+      refute DialectMapper.valid_base_code?("zz")
+    end
+
+    test "returns false for empty and long strings" do
+      refute DialectMapper.valid_base_code?("")
+      refute DialectMapper.valid_base_code?("eng")
+    end
+  end
+
+  describe "dialects_for_base/1" do
+    test "returns dialects for a base with multiple variants" do
+      dialects = DialectMapper.dialects_for_base("en")
+      assert is_list(dialects)
+      assert "en-US" in dialects
+      assert "en-GB" in dialects
+    end
+
+    test "returns single-element list for languages without variants" do
+      dialects = DialectMapper.dialects_for_base("ja")
+      assert is_list(dialects)
+      assert dialects != []
+    end
+
+    test "returns empty list for unknown base" do
+      assert DialectMapper.dialects_for_base("xx") == []
+    end
+  end
+
+  describe "default_dialects/0" do
+    test "returns a map" do
+      defaults = DialectMapper.default_dialects()
+      assert is_map(defaults)
+      assert defaults["en"] == "en-US"
+      assert defaults["pt"] == "pt-BR"
+      assert defaults["zh"] == "zh-CN"
+    end
+  end
+end

--- a/test/phoenix_kit/utils/multilang_test.exs
+++ b/test/phoenix_kit/utils/multilang_test.exs
@@ -1,0 +1,248 @@
+defmodule PhoenixKit.Utils.MultilangTest do
+  use ExUnit.Case
+
+  alias PhoenixKit.Utils.Multilang
+
+  @primary_key "_primary_language"
+
+  describe "multilang_data?/1" do
+    test "returns true when _primary_language key exists" do
+      assert Multilang.multilang_data?(%{@primary_key => "en-US", "en-US" => %{"name" => "Test"}})
+    end
+
+    test "returns false for flat data" do
+      refute Multilang.multilang_data?(%{"name" => "Test"})
+    end
+
+    test "returns false for nil" do
+      refute Multilang.multilang_data?(nil)
+    end
+
+    test "returns false for non-map" do
+      refute Multilang.multilang_data?("string")
+      refute Multilang.multilang_data?(123)
+    end
+  end
+
+  describe "get_language_data/2" do
+    test "returns primary data for primary language" do
+      data = %{
+        @primary_key => "en-US",
+        "en-US" => %{"name" => "Acme", "tagline" => "Quality"}
+      }
+
+      result = Multilang.get_language_data(data, "en-US")
+      assert result["name"] == "Acme"
+      assert result["tagline"] == "Quality"
+    end
+
+    test "merges primary with overrides for secondary language" do
+      data = %{
+        @primary_key => "en-US",
+        "en-US" => %{"name" => "Acme", "tagline" => "Quality"},
+        "es-ES" => %{"name" => "Acme España"}
+      }
+
+      result = Multilang.get_language_data(data, "es-ES")
+      assert result["name"] == "Acme España"
+      # Inherited from primary
+      assert result["tagline"] == "Quality"
+    end
+
+    test "returns empty map for missing language" do
+      data = %{
+        @primary_key => "en-US",
+        "en-US" => %{"name" => "Acme"}
+      }
+
+      result = Multilang.get_language_data(data, "fr-FR")
+      # Falls back to primary data (merge with empty map)
+      assert result["name"] == "Acme"
+    end
+
+    test "returns flat data as-is for non-multilang" do
+      data = %{"name" => "Acme"}
+      assert Multilang.get_language_data(data, "en-US") == data
+    end
+
+    test "returns empty map for nil" do
+      assert Multilang.get_language_data(nil, "en-US") == %{}
+    end
+  end
+
+  describe "get_primary_data/1" do
+    test "extracts primary language data" do
+      data = %{
+        @primary_key => "en-US",
+        "en-US" => %{"name" => "Acme"},
+        "es-ES" => %{"name" => "Acme ES"}
+      }
+
+      assert Multilang.get_primary_data(data) == %{"name" => "Acme"}
+    end
+
+    test "returns flat data as-is for non-multilang" do
+      data = %{"name" => "Acme"}
+      assert Multilang.get_primary_data(data) == data
+    end
+
+    test "returns empty map for nil" do
+      assert Multilang.get_primary_data(nil) == %{}
+    end
+  end
+
+  describe "get_raw_language_data/2" do
+    test "returns only language-specific overrides without merging" do
+      data = %{
+        @primary_key => "en-US",
+        "en-US" => %{"name" => "Acme", "tagline" => "Quality"},
+        "es-ES" => %{"name" => "Acme ES"}
+      }
+
+      result = Multilang.get_raw_language_data(data, "es-ES")
+      assert result == %{"name" => "Acme ES"}
+      # tagline NOT present because it's inherited, not overridden
+      refute Map.has_key?(result, "tagline")
+    end
+
+    test "returns empty map for missing language" do
+      data = %{@primary_key => "en-US", "en-US" => %{"name" => "Acme"}}
+      assert Multilang.get_raw_language_data(data, "fr-FR") == %{}
+    end
+  end
+
+  describe "put_language_data/3" do
+    test "stores all fields for primary language" do
+      result = Multilang.put_language_data(nil, "en-US", %{"name" => "Acme"})
+      assert result[@primary_key] == "en-US"
+      assert result["en-US"]["name"] == "Acme"
+    end
+
+    test "stores only overrides for secondary language" do
+      existing = %{
+        @primary_key => "en-US",
+        "en-US" => %{"name" => "Acme", "tagline" => "Quality"}
+      }
+
+      result =
+        Multilang.put_language_data(existing, "es-ES", %{
+          "name" => "Acme ES",
+          "tagline" => "Quality"
+        })
+
+      # tagline matches primary, should NOT be stored
+      assert result["es-ES"] == %{"name" => "Acme ES"}
+    end
+
+    test "removes secondary language entry when no overrides" do
+      existing = %{
+        @primary_key => "en-US",
+        "en-US" => %{"name" => "Acme"},
+        "es-ES" => %{"name" => "Acme ES"}
+      }
+
+      # Set secondary to match primary exactly
+      result = Multilang.put_language_data(existing, "es-ES", %{"name" => "Acme"})
+      refute Map.has_key?(result, "es-ES")
+    end
+
+    test "converts flat data to multilang on first write" do
+      flat = %{"name" => "Acme"}
+      result = Multilang.put_language_data(flat, "en-US", %{"name" => "Updated"})
+
+      assert Multilang.multilang_data?(result)
+      assert result[@primary_key] == "en-US"
+      assert result["en-US"]["name"] == "Updated"
+    end
+  end
+
+  describe "migrate_to_multilang/2" do
+    test "wraps flat data with primary language marker" do
+      result = Multilang.migrate_to_multilang(%{"name" => "Acme"}, "en-US")
+      assert result[@primary_key] == "en-US"
+      assert result["en-US"] == %{"name" => "Acme"}
+    end
+
+    test "handles nil data" do
+      result = Multilang.migrate_to_multilang(nil, "en-US")
+      assert result[@primary_key] == "en-US"
+      assert result["en-US"] == %{}
+    end
+  end
+
+  describe "flatten_to_primary/1" do
+    test "extracts primary language data" do
+      data = %{
+        @primary_key => "en-US",
+        "en-US" => %{"name" => "Acme"},
+        "es-ES" => %{"name" => "Acme ES"}
+      }
+
+      assert Multilang.flatten_to_primary(data) == %{"name" => "Acme"}
+    end
+
+    test "returns non-multilang data as-is" do
+      data = %{"name" => "Acme"}
+      assert Multilang.flatten_to_primary(data) == data
+    end
+
+    test "returns empty map for nil" do
+      assert Multilang.flatten_to_primary(nil) == %{}
+    end
+  end
+
+  describe "rekey_primary/2" do
+    test "promotes new primary with complete data" do
+      data = %{
+        @primary_key => "en-US",
+        "en-US" => %{"name" => "Acme", "tagline" => "Quality"},
+        "es-ES" => %{"name" => "Acme ES"}
+      }
+
+      result = Multilang.rekey_primary(data, "es-ES")
+      assert result[@primary_key] == "es-ES"
+      # Promoted: has both name override and inherited tagline
+      assert result["es-ES"]["name"] == "Acme ES"
+      assert result["es-ES"]["tagline"] == "Quality"
+    end
+
+    test "old primary becomes secondary with overrides only" do
+      data = %{
+        @primary_key => "en-US",
+        "en-US" => %{"name" => "Acme", "tagline" => "Quality"},
+        "es-ES" => %{"name" => "Acme ES"}
+      }
+
+      result = Multilang.rekey_primary(data, "es-ES")
+      # en-US now a secondary — "tagline" matches new primary, so only "name" is an override
+      assert result["en-US"]["name"] == "Acme"
+      refute Map.has_key?(result["en-US"], "tagline")
+    end
+
+    test "removes secondary with zero overrides after rekey" do
+      data = %{
+        @primary_key => "en-US",
+        "en-US" => %{"name" => "Acme"},
+        "es-ES" => %{"name" => "Acme"}
+      }
+
+      result = Multilang.rekey_primary(data, "es-ES")
+      # en-US had same data as promoted es-ES, so it should be removed
+      refute Map.has_key?(result, "en-US")
+    end
+
+    test "returns data unchanged if already the primary" do
+      data = %{@primary_key => "en-US", "en-US" => %{"name" => "Acme"}}
+      assert Multilang.rekey_primary(data, "en-US") == data
+    end
+
+    test "returns non-multilang data unchanged" do
+      data = %{"name" => "Acme"}
+      assert Multilang.rekey_primary(data, "en-US") == data
+    end
+
+    test "returns nil unchanged" do
+      assert Multilang.rekey_primary(nil, "en-US") == nil
+    end
+  end
+end


### PR DESCRIPTION
Summary

  - Unify admin and frontend language systems into a single languages_config source of truth, eliminating the separate admin_languages setting and Backend tab
  - Add continent grouping to language switcher — when >7 languages are enabled, users first pick a continent, then a language within it
  - Admin navbar now uses the shared language_switcher_dropdown component
  - Add group_by_continent attribute to opt out of continent grouping (group_by_continent={false})
  - Add normalize_language_settings/0 migration that runs at startup to merge any legacy admin_languages into the unified config
  - Harden error handling across language system — nil guards, rescue blocks, defensive fallbacks in routes/auth/multilang/admin_nav
  - Add 87 new tests — DialectMapper (20), Languages CRUD integration (28), Multilang utils (25), continent grouping (4), plus existing test updates
  - Update README with Language struct docs, continent grouping, and legacy migration section