### PR TITLE
Remove deprecated select-bordered class for daisyUI 5 compatibility

### DIFF
--- a/lib/modules/customer_service/web/edit.html.heex
+++ b/lib/modules/customer_service/web/edit.html.heex
@@ -21,7 +21,7 @@
               <label class="label">
                 <span class="label-text font-medium">Customer</span>
               </label>
-              <select name="ticket[user_uuid]" class="select select-bordered w-full">
+              <select name="ticket[user_uuid]" class="select w-full">
                 <option value="">Current User (You)</option>
                 <%= for user <- @all_users do %>
                   <option value={user.uuid}>{user.email}</option>
@@ -85,7 +85,7 @@
               <label class="label">
                 <span class="label-text font-medium">Assigned To</span>
               </label>
-              <select name="ticket[assigned_to_uuid]" class="select select-bordered w-full">
+              <select name="ticket[assigned_to_uuid]" class="select w-full">
                 <option value="">Unassigned</option>
                 <%= for user <- @staff_users do %>
                   <option
@@ -103,7 +103,7 @@
               <label class="label">
                 <span class="label-text font-medium">Status</span>
               </label>
-              <select name="ticket[status]" class="select select-bordered w-full">
+              <select name="ticket[status]" class="select w-full">
                 <option value="open" selected={@form[:status].value == "open"}>Open</option>
                 <option value="in_progress" selected={@form[:status].value == "in_progress"}>
                   In Progress

--- a/lib/modules/customer_service/web/list.html.heex
+++ b/lib/modules/customer_service/web/list.html.heex
@@ -103,7 +103,7 @@
           />
         </div>
         <div class="w-full md:w-48">
-          <select name="filters[status]" class="select select-bordered w-full">
+          <select name="filters[status]" class="select w-full">
             <option value="">All Statuses</option>
             <option value="open" selected={@status_filter == "open"}>Open</option>
             <option value="in_progress" selected={@status_filter == "in_progress"}>
@@ -114,7 +114,7 @@
           </select>
         </div>
         <div class="w-full md:w-48">
-          <select name="filters[assigned_to]" class="select select-bordered w-full">
+          <select name="filters[assigned_to]" class="select w-full">
             <option value="">All Assigned</option>
             <option value="unassigned" selected={@assigned_to_filter == "unassigned"}>
               Unassigned

--- a/lib/modules/customer_service/web/new.html.heex
+++ b/lib/modules/customer_service/web/new.html.heex
@@ -47,7 +47,7 @@
         <select
           id="ticket_priority"
           name="ticket[priority]"
-          class="select select-bordered w-full max-w-xs"
+          class="select w-full max-w-xs"
         >
           <option
             value="low"

--- a/lib/modules/customer_service/web/settings.html.heex
+++ b/lib/modules/customer_service/web/settings.html.heex
@@ -54,7 +54,7 @@
               <span class="label-text font-medium">Tickets Per Page</span>
             </label>
             <select
-              class="select select-bordered w-full max-w-xs"
+              class="select w-full max-w-xs"
               phx-change="update_per_page"
               name="per_page"
             >

--- a/lib/modules/customer_service/web/user_list.html.heex
+++ b/lib/modules/customer_service/web/user_list.html.heex
@@ -20,7 +20,7 @@
     <div class="bg-base-200 rounded-lg p-4 mb-6">
       <form phx-change="filter" class="flex flex-col md:flex-row gap-4 items-center">
         <div class="w-full md:w-48">
-          <select name="filters[status]" class="select select-bordered w-full">
+          <select name="filters[status]" class="select w-full">
             <option value="">{gettext("All Statuses")}</option>
             <option value="open" selected={@status_filter == "open"}>{gettext("Open")}</option>
             <option value="in_progress" selected={@status_filter == "in_progress"}>

--- a/lib/modules/db/web/activity.html.heex
+++ b/lib/modules/db/web/activity.html.heex
@@ -51,7 +51,7 @@
           <select
             name="table"
             phx-change="filter_table"
-            class="select select-bordered select-sm w-56"
+            class="select select-sm w-56"
           >
             <option value="">All tables</option>
             <%= for table <- @tables do %>
@@ -66,7 +66,7 @@
           <select
             name="operation"
             phx-change="filter_operation"
-            class="select select-bordered select-sm w-56"
+            class="select select-sm w-56"
           >
             <option value="">All</option>
             <option value="INSERT" selected={@filter_operation == "INSERT"}>INSERT</option>

--- a/lib/modules/db/web/show.html.heex
+++ b/lib/modules/db/web/show.html.heex
@@ -36,7 +36,7 @@
           <.form for={%{}} phx-change="set_per_page" class="flex items-center gap-2">
             <span class="text-sm text-base-content/70">Show</span>
             <select
-              class="select select-bordered select-sm w-20"
+              class="select select-sm w-20"
               name="per_page"
             >
               <%= for option <- [10, 20, 50, 100, 200] do %>

--- a/lib/modules/sitemap/web/settings.html.heex
+++ b/lib/modules/sitemap/web/settings.html.heex
@@ -481,7 +481,7 @@
                   <span class="label-text font-medium">Display Style</span>
                 </label>
                 <select
-                  class="select select-bordered w-full"
+                  class="select w-full"
                   name="style"
                   disabled={!@config.html_enabled}
                 >
@@ -515,7 +515,7 @@
             <form phx-change="update_interval" class="flex items-center gap-4 mt-4">
               <span class="text-sm">Regenerate every</span>
               <select
-                class="select select-bordered select-sm"
+                class="select select-sm"
                 name="interval"
                 disabled={!@config.schedule_enabled}
               >

--- a/lib/modules/storage/web/bucket_form.html.heex
+++ b/lib/modules/storage/web/bucket_form.html.heex
@@ -45,7 +45,7 @@
               </label>
               <select
                 name="bucket[provider]"
-                class={"select select-bordered #{input_class(@changeset, :provider)}"}
+                class={"select #{input_class(@changeset, :provider)}"}
                 required
               >
                 <option value="">{gettext("Select provider...")}</option>
@@ -241,7 +241,7 @@
                 </label>
                 <select
                   name="bucket[access_type]"
-                  class="select select-bordered w-full"
+                  class="select w-full"
                 >
                   <option
                     value="public"

--- a/lib/modules/storage/web/dimension_form.html.heex
+++ b/lib/modules/storage/web/dimension_form.html.heex
@@ -176,7 +176,7 @@
 
               <select
                 name="dimension[format]"
-                class={"select select-bordered #{input_class(@changeset, :format)}"}
+                class={"select #{input_class(@changeset, :format)}"}
               >
                 <option value="">{gettext("Preserve original")}</option>
                 <%= if @dimension_type != "video" do %>

--- a/lib/phoenix_kit_web/components/core/aws_region_select.ex
+++ b/lib/phoenix_kit_web/components/core/aws_region_select.ex
@@ -73,7 +73,7 @@ defmodule PhoenixKitWeb.Components.Core.AWSRegionSelect do
               value={@value}
               phx-change={@phx_change}
               class={[
-                "select select-bordered w-full",
+                "select w-full",
                 "focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent",
                 "transition-colors duration-200",
                 if(@verified == :success, do: "border-success", else: ""),

--- a/lib/phoenix_kit_web/components/core/select.ex
+++ b/lib/phoenix_kit_web/components/core/select.ex
@@ -41,7 +41,7 @@ defmodule PhoenixKitWeb.Components.Core.Select do
         id={@id}
         name={@name}
         class={[
-          "select select-bordered w-full",
+          "select w-full",
           @errors != [] && "select-error"
         ]}
         multiple={@multiple}

--- a/lib/phoenix_kit_web/live/components/media_selector_modal.html.heex
+++ b/lib/phoenix_kit_web/live/components/media_selector_modal.html.heex
@@ -203,7 +203,7 @@
                   phx-change="filter_type"
                   phx-target={@myself}
                   name="filter"
-                  class="select select-bordered select-sm w-full"
+                  class="select select-sm w-full"
                 >
                   <option value="all" selected={@file_type_filter == :all}>All Files</option>
                   <option value="image" selected={@file_type_filter == :image}>

--- a/lib/phoenix_kit_web/live/modules/jobs/index.html.heex
+++ b/lib/phoenix_kit_web/live/modules/jobs/index.html.heex
@@ -81,7 +81,7 @@
               <label class="label py-1">
                 <span class="label-text text-xs">Queue</span>
               </label>
-              <select class="select select-bordered select-sm" name="queue">
+              <select class="select select-sm" name="queue">
                 <option value="all" selected={@filter_queue == "all"}>All Queues</option>
                 <%= for {queue, _count} <- @queue_stats do %>
                   <option value={queue} selected={@filter_queue == queue}>{queue}</option>
@@ -93,7 +93,7 @@
               <label class="label py-1">
                 <span class="label-text text-xs">State</span>
               </label>
-              <select class="select select-bordered select-sm" name="state">
+              <select class="select select-sm" name="state">
                 <option value="all" selected={@filter_state == "all"}>All States</option>
                 <option value="available" selected={@filter_state == "available"}>
                   available
@@ -123,7 +123,7 @@
               <label class="label py-1">
                 <span class="label-text text-xs">Worker</span>
               </label>
-              <select class="select select-bordered select-sm" name="worker">
+              <select class="select select-sm" name="worker">
                 <option value="all" selected={@filter_worker == "all"}>All Workers</option>
                 <%= for {worker, count} <- @worker_stats do %>
                   <option value={worker} selected={@filter_worker == worker}>

--- a/lib/phoenix_kit_web/live/settings.html.heex
+++ b/lib/phoenix_kit_web/live/settings.html.heex
@@ -129,7 +129,7 @@
               </label>
               <select
                 name="settings[week_start_day]"
-                class="select select-bordered w-full focus:select-primary"
+                class="select w-full focus:select-primary"
               >
                 <%= for {label, value} <- @setting_options["week_start_day"] do %>
                   <option value={value} selected={value == @settings["week_start_day"]}>
@@ -172,7 +172,7 @@
               </label>
               <select
                 name="settings[time_zone]"
-                class="select select-bordered w-full focus:select-primary"
+                class="select w-full focus:select-primary"
               >
                 <%= for {label, value} <- @setting_options["time_zone"] do %>
                   <option value={value} selected={value == @settings["time_zone"]}>
@@ -215,7 +215,7 @@
               </label>
               <select
                 name="settings[date_format]"
-                class="select select-bordered w-full focus:select-primary"
+                class="select w-full focus:select-primary"
               >
                 <%= for {label, value} <- @setting_options["date_format"] do %>
                   <option value={value} selected={value == @settings["date_format"]}>
@@ -258,7 +258,7 @@
               </label>
               <select
                 name="settings[time_format]"
-                class="select select-bordered w-full focus:select-primary"
+                class="select w-full focus:select-primary"
               >
                 <%= for {label, value} <- @setting_options["time_format"] do %>
                   <option value={value} selected={value == @settings["time_format"]}>

--- a/lib/phoenix_kit_web/live/settings/organization.html.heex
+++ b/lib/phoenix_kit_web/live/settings/organization.html.heex
@@ -48,7 +48,7 @@
               </label>
               <select
                 name="company_country"
-                class="select select-bordered"
+                class="select"
                 phx-change="country_changed"
                 required
               >

--- a/lib/phoenix_kit_web/live/settings/users.html.heex
+++ b/lib/phoenix_kit_web/live/settings/users.html.heex
@@ -194,7 +194,7 @@
               </label>
               <select
                 name="settings[new_user_default_role]"
-                class="select select-bordered w-full focus:select-primary"
+                class="select w-full focus:select-primary"
               >
                 <%= for {label, value} <- @setting_options["new_user_default_role"] do %>
                   <option value={value} selected={value == @settings["new_user_default_role"]}>
@@ -257,7 +257,7 @@
               </label>
               <select
                 name="settings[new_user_default_status]"
-                class="select select-bordered w-full focus:select-primary"
+                class="select w-full focus:select-primary"
               >
                 <%= for {label, value} <- @setting_options["new_user_default_status"] do %>
                   <option value={value} selected={value == @settings["new_user_default_status"]}>
@@ -533,7 +533,7 @@
                     </label>
                     <select
                       name="field[type]"
-                      class="select select-bordered"
+                      class="select"
                       required
                       phx-change="field_type_changed"
                     >

--- a/lib/phoenix_kit_web/live/users/media_selector.html.heex
+++ b/lib/phoenix_kit_web/live/users/media_selector.html.heex
@@ -110,7 +110,7 @@
             <select
               phx-change="filter_type"
               name="filter"
-              class="select select-bordered w-full"
+              class="select w-full"
             >
               <option value="all" selected={@file_type_filter == :all}>All Files</option>
               <option value="image" selected={@file_type_filter == :image}>Images Only</option>

--- a/lib/phoenix_kit_web/live/users/sessions.html.heex
+++ b/lib/phoenix_kit_web/live/users/sessions.html.heex
@@ -138,7 +138,7 @@
           <select
             phx-change="filter_by_user_status"
             name="status"
-            class="select select-bordered w-full max-w-xs"
+            class="select w-full max-w-xs"
           >
             <option value="all" selected={@filter_user_status == "all"}>All Users</option>
             <option value="active" selected={@filter_user_status == "active"}>

--- a/lib/phoenix_kit_web/live/users/users.html.heex
+++ b/lib/phoenix_kit_web/live/users/users.html.heex
@@ -99,7 +99,7 @@
             <span class="label-text">Filter by role</span>
           </label>
           <form phx-change="filter_by_role">
-            <select class="select select-bordered w-full" name="role" value={@filter_role}>
+            <select class="select w-full" name="role" value={@filter_role}>
               <option value="all">All Users</option>
               <option value="Owner">Owners Only</option>
               <option value="Admin">Admins Only</option>

--- a/lib/phoenix_kit_web/users/user_form.html.heex
+++ b/lib/phoenix_kit_web/users/user_form.html.heex
@@ -535,7 +535,7 @@
                   <% "select" -> %>
                     <select
                       name={"user[custom_fields][#{field_key}]"}
-                      class={"select select-bordered w-full #{if field_error, do: "select-error", else: ""}"}
+                      class={"select w-full #{if field_error, do: "select-error", else: ""}"}
                       required={field_def["required"]}
                     >
                       <option value="">Select an option</option>


### PR DESCRIPTION
daisyUI 5 applies borders by default on select elements, making select-bordered obsolete. The old class was causing content to render at the top of the select instead of being vertically centered.