### PR TITLE
Fix orphan files query: publishing_versions instead of posts.data

### DIFF
--- a/lib/modules/storage/storage.ex
+++ b/lib/modules/storage/storage.ex
@@ -748,11 +748,11 @@ defmodule PhoenixKit.Modules.Storage do
            f.uuid
          )
        )},
-      {"phoenix_kit_publishing_posts",
+      {"phoenix_kit_publishing_versions",
        dynamic(
          [f],
          fragment(
-           "NOT EXISTS (SELECT 1 FROM phoenix_kit_publishing_posts pp WHERE pp.data->>'featured_image' = ?::text)",
+           "NOT EXISTS (SELECT 1 FROM phoenix_kit_publishing_versions pv WHERE pv.data->>'featured_image_uuid' = ?::text)",
            f.uuid
          )
        )},


### PR DESCRIPTION
## Summary
- Fix 500 error on admin media page (`/admin/media`)
- Migration v88 moved `data` column from `phoenix_kit_publishing_posts` to `phoenix_kit_publishing_versions`, but the orphan files query in `storage.ex` still referenced the old `pp.data` column
- Updated query to use `phoenix_kit_publishing_versions pv` with correct field `featured_image_uuid`

## Test plan
- [ ] Navigate to `/admin/media` — page should load without errors
- [ ] Verify orphan file count is calculated correctly
- [ ] Test file cleanup (delete orphaned files) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)