### PR TITLE
Migrate select elements to daisyUI 5 label wrapper pattern

### DIFF
--- a/lib/modules/customer_service/web/edit.html.heex
+++ b/lib/modules/customer_service/web/edit.html.heex
@@ -21,12 +21,14 @@
               <label class="label">
                 <span class="label-text font-medium">Customer</span>
               </label>
-              <select name="ticket[user_uuid]" class="select w-full">
-                <option value="">Current User (You)</option>
-                <%= for user <- @all_users do %>
-                  <option value={user.uuid}>{user.email}</option>
-                <% end %>
-              </select>
+              <label class="select w-full">
+                <select name="ticket[user_uuid]">
+                  <option value="">Current User (You)</option>
+                  <%= for user <- @all_users do %>
+                    <option value={user.uuid}>{user.email}</option>
+                  <% end %>
+                </select>
+              </label>
               <label class="label">
                 <span class="label-text-alt text-base-content/50">
                   Select the customer this ticket is for
@@ -85,17 +87,19 @@
               <label class="label">
                 <span class="label-text font-medium">Assigned To</span>
               </label>
-              <select name="ticket[assigned_to_uuid]" class="select w-full">
-                <option value="">Unassigned</option>
-                <%= for user <- @staff_users do %>
-                  <option
-                    value={user.uuid}
-                    selected={to_string(@form[:assigned_to_uuid].value) == to_string(user.uuid)}
-                  >
-                    {user.email}
-                  </option>
-                <% end %>
-              </select>
+              <label class="select w-full">
+                <select name="ticket[assigned_to_uuid]">
+                  <option value="">Unassigned</option>
+                  <%= for user <- @staff_users do %>
+                    <option
+                      value={user.uuid}
+                      selected={to_string(@form[:assigned_to_uuid].value) == to_string(user.uuid)}
+                    >
+                      {user.email}
+                    </option>
+                  <% end %>
+                </select>
+              </label>
             </div>
 
             <%!-- Status (for edit) --%>
@@ -103,16 +107,20 @@
               <label class="label">
                 <span class="label-text font-medium">Status</span>
               </label>
-              <select name="ticket[status]" class="select w-full">
-                <option value="open" selected={@form[:status].value == "open"}>Open</option>
-                <option value="in_progress" selected={@form[:status].value == "in_progress"}>
-                  In Progress
-                </option>
-                <option value="resolved" selected={@form[:status].value == "resolved"}>
-                  Resolved
-                </option>
-                <option value="closed" selected={@form[:status].value == "closed"}>Closed</option>
-              </select>
+              <label class="select w-full">
+                <select name="ticket[status]">
+                  <option value="open" selected={@form[:status].value == "open"}>Open</option>
+                  <option value="in_progress" selected={@form[:status].value == "in_progress"}>
+                    In Progress
+                  </option>
+                  <option value="resolved" selected={@form[:status].value == "resolved"}>
+                    Resolved
+                  </option>
+                  <option value="closed" selected={@form[:status].value == "closed"}>
+                    Closed
+                  </option>
+                </select>
+              </label>
             </div>
           <% end %>
 

--- a/lib/modules/customer_service/web/list.html.heex
+++ b/lib/modules/customer_service/web/list.html.heex
@@ -103,23 +103,27 @@
           />
         </div>
         <div class="w-full md:w-48">
-          <select name="filters[status]" class="select w-full">
-            <option value="">All Statuses</option>
-            <option value="open" selected={@status_filter == "open"}>Open</option>
-            <option value="in_progress" selected={@status_filter == "in_progress"}>
-              In Progress
-            </option>
-            <option value="resolved" selected={@status_filter == "resolved"}>Resolved</option>
-            <option value="closed" selected={@status_filter == "closed"}>Closed</option>
-          </select>
+          <label class="select w-full">
+            <select name="filters[status]">
+              <option value="">All Statuses</option>
+              <option value="open" selected={@status_filter == "open"}>Open</option>
+              <option value="in_progress" selected={@status_filter == "in_progress"}>
+                In Progress
+              </option>
+              <option value="resolved" selected={@status_filter == "resolved"}>Resolved</option>
+              <option value="closed" selected={@status_filter == "closed"}>Closed</option>
+            </select>
+          </label>
         </div>
         <div class="w-full md:w-48">
-          <select name="filters[assigned_to]" class="select w-full">
-            <option value="">All Assigned</option>
-            <option value="unassigned" selected={@assigned_to_filter == "unassigned"}>
-              Unassigned
-            </option>
-          </select>
+          <label class="select w-full">
+            <select name="filters[assigned_to]">
+              <option value="">All Assigned</option>
+              <option value="unassigned" selected={@assigned_to_filter == "unassigned"}>
+                Unassigned
+              </option>
+            </select>
+          </label>
         </div>
         <button type="button" phx-click="clear_filters" class="btn btn-ghost">
           Clear

--- a/lib/modules/customer_service/web/new.html.heex
+++ b/lib/modules/customer_service/web/new.html.heex
@@ -44,27 +44,28 @@
         <label class="label" for="ticket_priority">
           <span class="label-text font-medium">{gettext("Priority")}</span>
         </label>
-        <select
-          id="ticket_priority"
-          name="ticket[priority]"
-          class="select w-full max-w-xs"
-        >
-          <option
-            value="low"
-            selected={@form[:priority].value == "low" || @form[:priority].value == nil}
+        <label class="select w-full max-w-xs">
+          <select
+            id="ticket_priority"
+            name="ticket[priority]"
           >
-            {gettext("Low")}
-          </option>
-          <option value="medium" selected={@form[:priority].value == "medium"}>
-            {gettext("Medium")}
-          </option>
-          <option value="high" selected={@form[:priority].value == "high"}>
-            {gettext("High")}
-          </option>
-          <option value="urgent" selected={@form[:priority].value == "urgent"}>
-            {gettext("Urgent")}
-          </option>
-        </select>
+            <option
+              value="low"
+              selected={@form[:priority].value == "low" || @form[:priority].value == nil}
+            >
+              {gettext("Low")}
+            </option>
+            <option value="medium" selected={@form[:priority].value == "medium"}>
+              {gettext("Medium")}
+            </option>
+            <option value="high" selected={@form[:priority].value == "high"}>
+              {gettext("High")}
+            </option>
+            <option value="urgent" selected={@form[:priority].value == "urgent"}>
+              {gettext("Urgent")}
+            </option>
+          </select>
+        </label>
       </div>
 
       <%!-- Description --%>

--- a/lib/modules/customer_service/web/settings.html.heex
+++ b/lib/modules/customer_service/web/settings.html.heex
@@ -53,16 +53,17 @@
             <label class="label">
               <span class="label-text font-medium">Tickets Per Page</span>
             </label>
-            <select
-              class="select w-full max-w-xs"
-              phx-change="update_per_page"
-              name="per_page"
-            >
-              <option value="10" selected={@per_page == 10}>10</option>
-              <option value="20" selected={@per_page == 20}>20</option>
-              <option value="50" selected={@per_page == 50}>50</option>
-              <option value="100" selected={@per_page == 100}>100</option>
-            </select>
+            <label class="select w-full max-w-xs">
+              <select
+                phx-change="update_per_page"
+                name="per_page"
+              >
+                <option value="10" selected={@per_page == 10}>10</option>
+                <option value="20" selected={@per_page == 20}>20</option>
+                <option value="50" selected={@per_page == 50}>50</option>
+                <option value="100" selected={@per_page == 100}>100</option>
+              </select>
+            </label>
           </div>
         </div>
       </div>

--- a/lib/modules/customer_service/web/user_list.html.heex
+++ b/lib/modules/customer_service/web/user_list.html.heex
@@ -20,19 +20,21 @@
     <div class="bg-base-200 rounded-lg p-4 mb-6">
       <form phx-change="filter" class="flex flex-col md:flex-row gap-4 items-center">
         <div class="w-full md:w-48">
-          <select name="filters[status]" class="select w-full">
-            <option value="">{gettext("All Statuses")}</option>
-            <option value="open" selected={@status_filter == "open"}>{gettext("Open")}</option>
-            <option value="in_progress" selected={@status_filter == "in_progress"}>
-              {gettext("In Progress")}
-            </option>
-            <option value="resolved" selected={@status_filter == "resolved"}>
-              {gettext("Resolved")}
-            </option>
-            <option value="closed" selected={@status_filter == "closed"}>
-              {gettext("Closed")}
-            </option>
-          </select>
+          <label class="select w-full">
+            <select name="filters[status]">
+              <option value="">{gettext("All Statuses")}</option>
+              <option value="open" selected={@status_filter == "open"}>{gettext("Open")}</option>
+              <option value="in_progress" selected={@status_filter == "in_progress"}>
+                {gettext("In Progress")}
+              </option>
+              <option value="resolved" selected={@status_filter == "resolved"}>
+                {gettext("Resolved")}
+              </option>
+              <option value="closed" selected={@status_filter == "closed"}>
+                {gettext("Closed")}
+              </option>
+            </select>
+          </label>
         </div>
 
         <%= if @status_filter do %>

--- a/lib/modules/db/web/activity.html.heex
+++ b/lib/modules/db/web/activity.html.heex
@@ -48,31 +48,33 @@
           <label class="label py-0">
             <span class="label-text text-xs">Table</span>
           </label>
-          <select
-            name="table"
-            phx-change="filter_table"
-            class="select select-sm w-56"
-          >
-            <option value="">All tables</option>
-            <%= for table <- @tables do %>
-              <option value={table} selected={@filter_table == table}>{table}</option>
-            <% end %>
-          </select>
+          <label class="select select-sm w-56">
+            <select
+              name="table"
+              phx-change="filter_table"
+            >
+              <option value="">All tables</option>
+              <%= for table <- @tables do %>
+                <option value={table} selected={@filter_table == table}>{table}</option>
+              <% end %>
+            </select>
+          </label>
         </div>
         <div class="form-control">
           <label class="label py-0">
             <span class="label-text text-xs">Operation</span>
           </label>
-          <select
-            name="operation"
-            phx-change="filter_operation"
-            class="select select-sm w-56"
-          >
-            <option value="">All</option>
-            <option value="INSERT" selected={@filter_operation == "INSERT"}>INSERT</option>
-            <option value="UPDATE" selected={@filter_operation == "UPDATE"}>UPDATE</option>
-            <option value="DELETE" selected={@filter_operation == "DELETE"}>DELETE</option>
-          </select>
+          <label class="select select-sm w-56">
+            <select
+              name="operation"
+              phx-change="filter_operation"
+            >
+              <option value="">All</option>
+              <option value="INSERT" selected={@filter_operation == "INSERT"}>INSERT</option>
+              <option value="UPDATE" selected={@filter_operation == "UPDATE"}>UPDATE</option>
+              <option value="DELETE" selected={@filter_operation == "DELETE"}>DELETE</option>
+            </select>
+          </label>
         </div>
       </div>
       <div class="flex-1"></div>

--- a/lib/modules/db/web/show.html.heex
+++ b/lib/modules/db/web/show.html.heex
@@ -35,14 +35,13 @@
           </span>
           <.form for={%{}} phx-change="set_per_page" class="flex items-center gap-2">
             <span class="text-sm text-base-content/70">Show</span>
-            <select
-              class="select select-sm w-20"
-              name="per_page"
-            >
-              <%= for option <- [10, 20, 50, 100, 200] do %>
-                <option value={option} selected={option == @per_page}>{option}</option>
-              <% end %>
-            </select>
+            <label class="select select-sm w-20">
+              <select name="per_page">
+                <%= for option <- [10, 20, 50, 100, 200] do %>
+                  <option value={option} selected={option == @per_page}>{option}</option>
+                <% end %>
+              </select>
+            </label>
             <span class="text-sm text-base-content/70">per page</span>
           </.form>
         </div>

--- a/lib/modules/sitemap/web/settings.html.heex
+++ b/lib/modules/sitemap/web/settings.html.heex
@@ -480,18 +480,19 @@
                 <label class="label">
                   <span class="label-text font-medium">Display Style</span>
                 </label>
-                <select
-                  class="select w-full"
-                  name="style"
-                  disabled={!@config.html_enabled}
-                >
-                  <option value="table" selected={@config.html_style in ["table", "grouped"]}>
-                    Table (Clean table layout)
-                  </option>
-                  <option value="minimal" selected={@config.html_style in ["minimal", "flat"]}>
-                    Minimal (Simple list)
-                  </option>
-                </select>
+                <label class="select w-full">
+                  <select
+                    name="style"
+                    disabled={!@config.html_enabled}
+                  >
+                    <option value="table" selected={@config.html_style in ["table", "grouped"]}>
+                      Table (Clean table layout)
+                    </option>
+                    <option value="minimal" selected={@config.html_style in ["minimal", "flat"]}>
+                      Minimal (Simple list)
+                    </option>
+                  </select>
+                </label>
               </form>
             </div>
           </div>
@@ -514,26 +515,31 @@
 
             <form phx-change="update_interval" class="flex items-center gap-4 mt-4">
               <span class="text-sm">Regenerate every</span>
-              <select
-                class="select select-sm"
-                name="interval"
-                disabled={!@config.schedule_enabled}
-              >
-                <option value="1" selected={@config.schedule_interval_hours == 1}>1 hour</option>
-                <option value="6" selected={@config.schedule_interval_hours == 6}>6 hours</option>
-                <option value="12" selected={@config.schedule_interval_hours == 12}>
-                  12 hours
-                </option>
-                <option value="24" selected={@config.schedule_interval_hours == 24}>
-                  24 hours
-                </option>
-                <option value="48" selected={@config.schedule_interval_hours == 48}>
-                  48 hours
-                </option>
-                <option value="168" selected={@config.schedule_interval_hours == 168}>
-                  Weekly
-                </option>
-              </select>
+              <label class="select select-sm">
+                <select
+                  name="interval"
+                  disabled={!@config.schedule_enabled}
+                >
+                  <option value="1" selected={@config.schedule_interval_hours == 1}>
+                    1 hour
+                  </option>
+                  <option value="6" selected={@config.schedule_interval_hours == 6}>
+                    6 hours
+                  </option>
+                  <option value="12" selected={@config.schedule_interval_hours == 12}>
+                    12 hours
+                  </option>
+                  <option value="24" selected={@config.schedule_interval_hours == 24}>
+                    24 hours
+                  </option>
+                  <option value="48" selected={@config.schedule_interval_hours == 48}>
+                    48 hours
+                  </option>
+                  <option value="168" selected={@config.schedule_interval_hours == 168}>
+                    Weekly
+                  </option>
+                </select>
+              </label>
             </form>
           </div>
         </div>

--- a/lib/modules/storage/web/bucket_form.html.heex
+++ b/lib/modules/storage/web/bucket_form.html.heex
@@ -43,37 +43,38 @@
                 <span class="label-text font-semibold">{gettext("Storage Provider")} *</span>
                 <span class="label-text-alt">{gettext("Type of storage service")}</span>
               </label>
-              <select
-                name="bucket[provider]"
-                class={"select #{input_class(@changeset, :provider)}"}
-                required
-              >
-                <option value="">{gettext("Select provider...")}</option>
-                <option
-                  value="local"
-                  selected={Ecto.Changeset.get_field(@changeset, :provider) == "local"}
+              <label class={"select #{input_class(@changeset, :provider)}"}>
+                <select
+                  name="bucket[provider]"
+                  required
                 >
-                  {gettext("Local Filesystem")}
-                </option>
-                <option
-                  value="s3"
-                  selected={Ecto.Changeset.get_field(@changeset, :provider) == "s3"}
-                >
-                  AWS S3
-                </option>
-                <option
-                  value="b2"
-                  selected={Ecto.Changeset.get_field(@changeset, :provider) == "b2"}
-                >
-                  Backblaze B2
-                </option>
-                <option
-                  value="r2"
-                  selected={Ecto.Changeset.get_field(@changeset, :provider) == "r2"}
-                >
-                  Cloudflare R2
-                </option>
-              </select>
+                  <option value="">{gettext("Select provider...")}</option>
+                  <option
+                    value="local"
+                    selected={Ecto.Changeset.get_field(@changeset, :provider) == "local"}
+                  >
+                    {gettext("Local Filesystem")}
+                  </option>
+                  <option
+                    value="s3"
+                    selected={Ecto.Changeset.get_field(@changeset, :provider) == "s3"}
+                  >
+                    AWS S3
+                  </option>
+                  <option
+                    value="b2"
+                    selected={Ecto.Changeset.get_field(@changeset, :provider) == "b2"}
+                  >
+                    Backblaze B2
+                  </option>
+                  <option
+                    value="r2"
+                    selected={Ecto.Changeset.get_field(@changeset, :provider) == "r2"}
+                  >
+                    Cloudflare R2
+                  </option>
+                </select>
+              </label>
             </div>
           <% else %>
             <%!-- Provider Display (read-only in edit mode) --%>
@@ -239,23 +240,22 @@
                   <span class="label-text font-semibold">{gettext("Access Type")}</span>
                   <span class="label-text-alt">{gettext("How files are served")}</span>
                 </label>
-                <select
-                  name="bucket[access_type]"
-                  class="select w-full"
-                >
-                  <option
-                    value="public"
-                    selected={Ecto.Changeset.get_field(@changeset, :access_type) == "public"}
-                  >
-                    {gettext("Public (redirect to bucket URL)")}
-                  </option>
-                  <option
-                    value="private"
-                    selected={Ecto.Changeset.get_field(@changeset, :access_type) == "private"}
-                  >
-                    {gettext("Private (proxy through server)")}
-                  </option>
-                </select>
+                <label class="select w-full">
+                  <select name="bucket[access_type]">
+                    <option
+                      value="public"
+                      selected={Ecto.Changeset.get_field(@changeset, :access_type) == "public"}
+                    >
+                      {gettext("Public (redirect to bucket URL)")}
+                    </option>
+                    <option
+                      value="private"
+                      selected={Ecto.Changeset.get_field(@changeset, :access_type) == "private"}
+                    >
+                      {gettext("Private (proxy through server)")}
+                    </option>
+                  </select>
+                </label>
                 <label class="label">
                   <span class="label-text-alt text-base-content/60">
                     {gettext(

--- a/lib/modules/storage/web/dimension_form.html.heex
+++ b/lib/modules/storage/web/dimension_form.html.heex
@@ -174,28 +174,27 @@
               <%!-- Get format value safely --%>
               <% format_value = get_field_value(@changeset, :format) %>
 
-              <select
-                name="dimension[format]"
-                class={"select #{input_class(@changeset, :format)}"}
-              >
-                <option value="">{gettext("Preserve original")}</option>
-                <%= if @dimension_type != "video" do %>
-                  <option value="jpg" selected={format_value == "jpg"}>
-                    JPEG
-                  </option>
-                  <option value="png" selected={format_value == "png"}>
-                    PNG
-                  </option>
-                  <option value="webp" selected={format_value == "webp"}>
-                    WebP
-                  </option>
-                <% end %>
-                <%= if @dimension_type == "video" do %>
-                  <option value="mp4" selected={format_value == "mp4"}>
-                    MP4
-                  </option>
-                <% end %>
-              </select>
+              <label class={"select #{input_class(@changeset, :format)}"}>
+                <select name="dimension[format]">
+                  <option value="">{gettext("Preserve original")}</option>
+                  <%= if @dimension_type != "video" do %>
+                    <option value="jpg" selected={format_value == "jpg"}>
+                      JPEG
+                    </option>
+                    <option value="png" selected={format_value == "png"}>
+                      PNG
+                    </option>
+                    <option value="webp" selected={format_value == "webp"}>
+                      WebP
+                    </option>
+                  <% end %>
+                  <%= if @dimension_type == "video" do %>
+                    <option value="mp4" selected={format_value == "mp4"}>
+                      MP4
+                    </option>
+                  <% end %>
+                </select>
+              </label>
               {render_error(@changeset, :format)}
             </div>
           </div>

--- a/lib/phoenix_kit_web/components/core/aws_region_select.ex
+++ b/lib/phoenix_kit_web/components/core/aws_region_select.ex
@@ -67,42 +67,42 @@ defmodule PhoenixKitWeb.Components.Core.AWSRegionSelect do
         <% else %>
           <%= if @regions_loaded and not Enum.empty?(@regions) do %>
             <%!-- Region dropdown (after loading regions) --%>
-            <select
-              id={@id}
-              name={@name}
-              value={@value}
-              phx-change={@phx_change}
-              class={[
-                "select w-full",
-                "focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent",
-                "transition-colors duration-200",
-                if(@verified == :success, do: "border-success", else: ""),
-                if(@verified == :error, do: "border-error", else: ""),
-                @class
-              ]}
-              disabled={@verifying}
-            >
-              <%!-- Empty option --%>
-              <option value="">Select a region (optional)</option>
+            <label class={[
+              "select w-full",
+              "focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent",
+              "transition-colors duration-200",
+              if(@verified == :success, do: "border-success", else: ""),
+              if(@verified == :error, do: "border-error", else: ""),
+              @class
+            ]}>
+              <select
+                id={@id}
+                name={@name}
+                value={@value}
+                phx-change={@phx_change}
+                disabled={@verifying}
+              >
+                <%!-- Empty option --%>
+                <option value="">Select a region (optional)</option>
 
-              <%!-- Show currently selected region first if not in list --%>
-              <%= if @value != "" and @value not in @regions do %>
-                <option value={@value} selected>
-                  {@value} (currently selected)
-                </option>
-              <% end %>
+                <%!-- Show currently selected region first if not in list --%>
+                <%= if @value != "" and @value not in @regions do %>
+                  <option value={@value} selected>
+                    {@value} (currently selected)
+                  </option>
+                <% end %>
 
-              <%!-- Region options from loaded list --%>
-              <%= for region <- @regions do %>
-                <option
-                  value={region}
-                  selected={region == @value}
-                  class="transition-colors duration-150 hover:bg-base-200"
-                >
-                  {region}
-                </option>
-              <% end %>
-            </select>
+                <%!-- Region options from loaded list --%>
+                <%= for region <- @regions do %>
+                  <option
+                    value={region}
+                    selected={region == @value}
+                  >
+                    {region}
+                  </option>
+                <% end %>
+              </select>
+            </label>
           <% else %>
             <%!-- Text input (default mode before loading regions) --%>
             <input

--- a/lib/phoenix_kit_web/components/core/select.ex
+++ b/lib/phoenix_kit_web/components/core/select.ex
@@ -37,19 +37,20 @@ defmodule PhoenixKitWeb.Components.Core.Select do
         {@label}
       </.label>
 
-      <select
-        id={@id}
-        name={@name}
-        class={[
-          "select w-full",
-          @errors != [] && "select-error"
-        ]}
-        multiple={@multiple}
-        {@rest}
-      >
-        <option :if={@prompt} value="">{@prompt}</option>
-        {Phoenix.HTML.Form.options_for_select(@options, @value)}
-      </select>
+      <label class={[
+        "select w-full",
+        @errors != [] && "select-error"
+      ]}>
+        <select
+          id={@id}
+          name={@name}
+          multiple={@multiple}
+          {@rest}
+        >
+          <option :if={@prompt} value="">{@prompt}</option>
+          {Phoenix.HTML.Form.options_for_select(@options, @value)}
+        </select>
+      </label>
 
       <.error :for={msg <- @errors}>{msg}</.error>
     </div>

--- a/lib/phoenix_kit_web/live/components/media_selector_modal.html.heex
+++ b/lib/phoenix_kit_web/live/components/media_selector_modal.html.heex
@@ -199,20 +199,21 @@
               </div>
               <%!-- Filter by Type --%>
               <div class="w-full md:w-40">
-                <select
-                  phx-change="filter_type"
-                  phx-target={@myself}
-                  name="filter"
-                  class="select select-sm w-full"
-                >
-                  <option value="all" selected={@file_type_filter == :all}>All Files</option>
-                  <option value="image" selected={@file_type_filter == :image}>
-                    Images Only
-                  </option>
-                  <option value="video" selected={@file_type_filter == :video}>
-                    Videos Only
-                  </option>
-                </select>
+                <label class="select select-sm w-full">
+                  <select
+                    phx-change="filter_type"
+                    phx-target={@myself}
+                    name="filter"
+                  >
+                    <option value="all" selected={@file_type_filter == :all}>All Files</option>
+                    <option value="image" selected={@file_type_filter == :image}>
+                      Images Only
+                    </option>
+                    <option value="video" selected={@file_type_filter == :video}>
+                      Videos Only
+                    </option>
+                  </select>
+                </label>
               </div>
             </div>
           </div>

--- a/lib/phoenix_kit_web/live/modules/jobs/index.html.heex
+++ b/lib/phoenix_kit_web/live/modules/jobs/index.html.heex
@@ -81,56 +81,62 @@
               <label class="label py-1">
                 <span class="label-text text-xs">Queue</span>
               </label>
-              <select class="select select-sm" name="queue">
-                <option value="all" selected={@filter_queue == "all"}>All Queues</option>
-                <%= for {queue, _count} <- @queue_stats do %>
-                  <option value={queue} selected={@filter_queue == queue}>{queue}</option>
-                <% end %>
-              </select>
+              <label class="select select-sm">
+                <select name="queue">
+                  <option value="all" selected={@filter_queue == "all"}>All Queues</option>
+                  <%= for {queue, _count} <- @queue_stats do %>
+                    <option value={queue} selected={@filter_queue == queue}>{queue}</option>
+                  <% end %>
+                </select>
+              </label>
             </form>
 
             <form phx-change="filter_state" class="form-control">
               <label class="label py-1">
                 <span class="label-text text-xs">State</span>
               </label>
-              <select class="select select-sm" name="state">
-                <option value="all" selected={@filter_state == "all"}>All States</option>
-                <option value="available" selected={@filter_state == "available"}>
-                  available
-                </option>
-                <option value="scheduled" selected={@filter_state == "scheduled"}>
-                  scheduled
-                </option>
-                <option value="executing" selected={@filter_state == "executing"}>
-                  executing
-                </option>
-                <option value="completed" selected={@filter_state == "completed"}>
-                  completed
-                </option>
-                <option value="retryable" selected={@filter_state == "retryable"}>
-                  retryable
-                </option>
-                <option value="discarded" selected={@filter_state == "discarded"}>
-                  discarded
-                </option>
-                <option value="cancelled" selected={@filter_state == "cancelled"}>
-                  cancelled
-                </option>
-              </select>
+              <label class="select select-sm">
+                <select name="state">
+                  <option value="all" selected={@filter_state == "all"}>All States</option>
+                  <option value="available" selected={@filter_state == "available"}>
+                    available
+                  </option>
+                  <option value="scheduled" selected={@filter_state == "scheduled"}>
+                    scheduled
+                  </option>
+                  <option value="executing" selected={@filter_state == "executing"}>
+                    executing
+                  </option>
+                  <option value="completed" selected={@filter_state == "completed"}>
+                    completed
+                  </option>
+                  <option value="retryable" selected={@filter_state == "retryable"}>
+                    retryable
+                  </option>
+                  <option value="discarded" selected={@filter_state == "discarded"}>
+                    discarded
+                  </option>
+                  <option value="cancelled" selected={@filter_state == "cancelled"}>
+                    cancelled
+                  </option>
+                </select>
+              </label>
             </form>
 
             <form phx-change="filter_worker" class="form-control">
               <label class="label py-1">
                 <span class="label-text text-xs">Worker</span>
               </label>
-              <select class="select select-sm" name="worker">
-                <option value="all" selected={@filter_worker == "all"}>All Workers</option>
-                <%= for {worker, count} <- @worker_stats do %>
-                  <option value={worker} selected={@filter_worker == worker}>
-                    {short_worker_name(worker)} ({count})
-                  </option>
-                <% end %>
-              </select>
+              <label class="select select-sm">
+                <select name="worker">
+                  <option value="all" selected={@filter_worker == "all"}>All Workers</option>
+                  <%= for {worker, count} <- @worker_stats do %>
+                    <option value={worker} selected={@filter_worker == worker}>
+                      {short_worker_name(worker)} ({count})
+                    </option>
+                  <% end %>
+                </select>
+              </label>
             </form>
 
             <div class="flex-1"></div>

--- a/lib/phoenix_kit_web/live/settings.html.heex
+++ b/lib/phoenix_kit_web/live/settings.html.heex
@@ -127,16 +127,15 @@
                   {gettext("First day of the week")}
                 </span>
               </label>
-              <select
-                name="settings[week_start_day]"
-                class="select w-full focus:select-primary"
-              >
-                <%= for {label, value} <- @setting_options["week_start_day"] do %>
-                  <option value={value} selected={value == @settings["week_start_day"]}>
-                    {label}
-                  </option>
-                <% end %>
-              </select>
+              <label class="select w-full focus:select-primary">
+                <select name="settings[week_start_day]">
+                  <%= for {label, value} <- @setting_options["week_start_day"] do %>
+                    <option value={value} selected={value == @settings["week_start_day"]}>
+                      {label}
+                    </option>
+                  <% end %>
+                </select>
+              </label>
               <div class="label">
                 <span class="label-text-alt text-xs text-base-content/50">
                   <%= if @settings["week_start_day"] != @saved_settings["week_start_day"] do %>
@@ -170,16 +169,15 @@
                   {gettext("System default timezone")}
                 </span>
               </label>
-              <select
-                name="settings[time_zone]"
-                class="select w-full focus:select-primary"
-              >
-                <%= for {label, value} <- @setting_options["time_zone"] do %>
-                  <option value={value} selected={value == @settings["time_zone"]}>
-                    {label}
-                  </option>
-                <% end %>
-              </select>
+              <label class="select w-full focus:select-primary">
+                <select name="settings[time_zone]">
+                  <%= for {label, value} <- @setting_options["time_zone"] do %>
+                    <option value={value} selected={value == @settings["time_zone"]}>
+                      {label}
+                    </option>
+                  <% end %>
+                </select>
+              </label>
               <div class="label">
                 <span class="label-text-alt text-xs text-base-content/50">
                   <%= if @settings["time_zone"] != @saved_settings["time_zone"] do %>
@@ -213,16 +211,15 @@
                   {gettext("How dates are displayed")}
                 </span>
               </label>
-              <select
-                name="settings[date_format]"
-                class="select w-full focus:select-primary"
-              >
-                <%= for {label, value} <- @setting_options["date_format"] do %>
-                  <option value={value} selected={value == @settings["date_format"]}>
-                    {label}
-                  </option>
-                <% end %>
-              </select>
+              <label class="select w-full focus:select-primary">
+                <select name="settings[date_format]">
+                  <%= for {label, value} <- @setting_options["date_format"] do %>
+                    <option value={value} selected={value == @settings["date_format"]}>
+                      {label}
+                    </option>
+                  <% end %>
+                </select>
+              </label>
               <div class="label">
                 <span class="label-text-alt text-xs text-base-content/50">
                   <%= if @settings["date_format"] != @saved_settings["date_format"] do %>
@@ -256,16 +253,15 @@
                   {gettext("How times are displayed")}
                 </span>
               </label>
-              <select
-                name="settings[time_format]"
-                class="select w-full focus:select-primary"
-              >
-                <%= for {label, value} <- @setting_options["time_format"] do %>
-                  <option value={value} selected={value == @settings["time_format"]}>
-                    {label}
-                  </option>
-                <% end %>
-              </select>
+              <label class="select w-full focus:select-primary">
+                <select name="settings[time_format]">
+                  <%= for {label, value} <- @setting_options["time_format"] do %>
+                    <option value={value} selected={value == @settings["time_format"]}>
+                      {label}
+                    </option>
+                  <% end %>
+                </select>
+              </label>
               <div class="label">
                 <span class="label-text-alt text-xs text-base-content/50">
                   <%= if @settings["time_format"] != @saved_settings["time_format"] do %>

--- a/lib/phoenix_kit_web/live/settings/organization.html.heex
+++ b/lib/phoenix_kit_web/live/settings/organization.html.heex
@@ -46,19 +46,20 @@
                   {gettext("Country")} <span class="text-error">*</span>
                 </span>
               </label>
-              <select
-                name="company_country"
-                class="select"
-                phx-change="country_changed"
-                required
-              >
-                <option value="">{gettext("Select country...")}</option>
-                <%= for {name, code} <- @countries do %>
-                  <option value={code} selected={@company_country == code}>
-                    {name}
-                  </option>
-                <% end %>
-              </select>
+              <label class="select">
+                <select
+                  name="company_country"
+                  phx-change="country_changed"
+                  required
+                >
+                  <option value="">{gettext("Select country...")}</option>
+                  <%= for {name, code} <- @countries do %>
+                    <option value={code} selected={@company_country == code}>
+                      {name}
+                    </option>
+                  <% end %>
+                </select>
+              </label>
             </div>
 
             <div class="divider">{gettext("Address")}</div>

--- a/lib/phoenix_kit_web/live/settings/users.html.heex
+++ b/lib/phoenix_kit_web/live/settings/users.html.heex
@@ -192,16 +192,15 @@
                   {gettext("Role assigned to new user registrations")}
                 </span>
               </label>
-              <select
-                name="settings[new_user_default_role]"
-                class="select w-full focus:select-primary"
-              >
-                <%= for {label, value} <- @setting_options["new_user_default_role"] do %>
-                  <option value={value} selected={value == @settings["new_user_default_role"]}>
-                    {label}
-                  </option>
-                <% end %>
-              </select>
+              <label class="select w-full focus:select-primary">
+                <select name="settings[new_user_default_role]">
+                  <%= for {label, value} <- @setting_options["new_user_default_role"] do %>
+                    <option value={value} selected={value == @settings["new_user_default_role"]}>
+                      {label}
+                    </option>
+                  <% end %>
+                </select>
+              </label>
               <div class="label">
                 <span class="label-text-alt text-xs text-base-content/50">
                   <%= if @settings["new_user_default_role"] != @saved_settings["new_user_default_role"] do %>
@@ -255,16 +254,15 @@
                   {gettext("Active status for new user registrations")}
                 </span>
               </label>
-              <select
-                name="settings[new_user_default_status]"
-                class="select w-full focus:select-primary"
-              >
-                <%= for {label, value} <- @setting_options["new_user_default_status"] do %>
-                  <option value={value} selected={value == @settings["new_user_default_status"]}>
-                    {label}
-                  </option>
-                <% end %>
-              </select>
+              <label class="select w-full focus:select-primary">
+                <select name="settings[new_user_default_status]">
+                  <%= for {label, value} <- @setting_options["new_user_default_status"] do %>
+                    <option value={value} selected={value == @settings["new_user_default_status"]}>
+                      {label}
+                    </option>
+                  <% end %>
+                </select>
+              </label>
               <div class="label">
                 <span class="label-text-alt text-xs text-base-content/50">
                   <%= if @settings["new_user_default_status"] != @saved_settings["new_user_default_status"] do %>
@@ -531,21 +529,22 @@
                     <label class="label">
                       <span class="label-text">{gettext("Type")} *</span>
                     </label>
-                    <select
-                      name="field[type]"
-                      class="select"
-                      required
-                      phx-change="field_type_changed"
-                    >
-                      <%= for type <- ~w(text textarea number boolean date email url uuid select radio checkbox) do %>
-                        <option
-                          value={type}
-                          selected={@field_form_type == type}
-                        >
-                          {String.capitalize(type)}
-                        </option>
-                      <% end %>
-                    </select>
+                    <label class="select">
+                      <select
+                        name="field[type]"
+                        required
+                        phx-change="field_type_changed"
+                      >
+                        <%= for type <- ~w(text textarea number boolean date email url uuid select radio checkbox) do %>
+                          <option
+                            value={type}
+                            selected={@field_form_type == type}
+                          >
+                            {String.capitalize(type)}
+                          </option>
+                        <% end %>
+                      </select>
+                    </label>
                   </div>
 
                   <%!-- Required Checkbox --%>

--- a/lib/phoenix_kit_web/live/users/media_selector.html.heex
+++ b/lib/phoenix_kit_web/live/users/media_selector.html.heex
@@ -107,15 +107,16 @@
 
           <%!-- Filter by Type --%>
           <div class="w-full md:w-48">
-            <select
-              phx-change="filter_type"
-              name="filter"
-              class="select w-full"
-            >
-              <option value="all" selected={@file_type_filter == :all}>All Files</option>
-              <option value="image" selected={@file_type_filter == :image}>Images Only</option>
-              <option value="video" selected={@file_type_filter == :video}>Videos Only</option>
-            </select>
+            <label class="select w-full">
+              <select
+                phx-change="filter_type"
+                name="filter"
+              >
+                <option value="all" selected={@file_type_filter == :all}>All Files</option>
+                <option value="image" selected={@file_type_filter == :image}>Images Only</option>
+                <option value="video" selected={@file_type_filter == :video}>Videos Only</option>
+              </select>
+            </label>
           </div>
         </div>
       </div>

--- a/lib/phoenix_kit_web/live/users/sessions.html.heex
+++ b/lib/phoenix_kit_web/live/users/sessions.html.heex
@@ -135,25 +135,26 @@
           <label class="label">
             <span class="label-text">Filter by User Status</span>
           </label>
-          <select
-            phx-change="filter_by_user_status"
-            name="status"
-            class="select w-full max-w-xs"
-          >
-            <option value="all" selected={@filter_user_status == "all"}>All Users</option>
-            <option value="active" selected={@filter_user_status == "active"}>
-              Active Users
-            </option>
-            <option value="inactive" selected={@filter_user_status == "inactive"}>
-              Inactive Users
-            </option>
-            <option value="confirmed" selected={@filter_user_status == "confirmed"}>
-              Confirmed Email
-            </option>
-            <option value="pending" selected={@filter_user_status == "pending"}>
-              Pending Email
-            </option>
-          </select>
+          <label class="select w-full max-w-xs">
+            <select
+              phx-change="filter_by_user_status"
+              name="status"
+            >
+              <option value="all" selected={@filter_user_status == "all"}>All Users</option>
+              <option value="active" selected={@filter_user_status == "active"}>
+                Active Users
+              </option>
+              <option value="inactive" selected={@filter_user_status == "inactive"}>
+                Inactive Users
+              </option>
+              <option value="confirmed" selected={@filter_user_status == "confirmed"}>
+                Confirmed Email
+              </option>
+              <option value="pending" selected={@filter_user_status == "pending"}>
+                Pending Email
+              </option>
+            </select>
+          </label>
         </div>
 
         <%!-- Refresh Button --%>

--- a/lib/phoenix_kit_web/live/users/users.html.heex
+++ b/lib/phoenix_kit_web/live/users/users.html.heex
@@ -99,12 +99,14 @@
             <span class="label-text">Filter by role</span>
           </label>
           <form phx-change="filter_by_role">
-            <select class="select w-full" name="role" value={@filter_role}>
-              <option value="all">All Users</option>
-              <option value="Owner">Owners Only</option>
-              <option value="Admin">Admins Only</option>
-              <option value="User">Regular Users</option>
-            </select>
+            <label class="select w-full">
+              <select name="role" value={@filter_role}>
+                <option value="all">All Users</option>
+                <option value="Owner">Owners Only</option>
+                <option value="Admin">Admins Only</option>
+                <option value="User">Regular Users</option>
+              </select>
+            </label>
           </form>
         </div>
 

--- a/lib/phoenix_kit_web/users/user_form.html.heex
+++ b/lib/phoenix_kit_web/users/user_form.html.heex
@@ -533,21 +533,22 @@
                       readonly
                     />
                   <% "select" -> %>
-                    <select
-                      name={"user[custom_fields][#{field_key}]"}
-                      class={"select w-full #{if field_error, do: "select-error", else: ""}"}
-                      required={field_def["required"]}
-                    >
-                      <option value="">Select an option</option>
-                      <%= for {option, index} <- Enum.with_index(field_def["options"] || []) do %>
-                        <option
-                          value={index}
-                          selected={to_string(field_value) == to_string(index)}
-                        >
-                          {option}
-                        </option>
-                      <% end %>
-                    </select>
+                    <label class={"select w-full #{if field_error, do: "select-error", else: ""}"}>
+                      <select
+                        name={"user[custom_fields][#{field_key}]"}
+                        required={field_def["required"]}
+                      >
+                        <option value="">Select an option</option>
+                        <%= for {option, index} <- Enum.with_index(field_def["options"] || []) do %>
+                          <option
+                            value={index}
+                            selected={to_string(field_value) == to_string(index)}
+                          >
+                            {option}
+                          </option>
+                        <% end %>
+                      </select>
+                    </label>
                   <% _default -> %>
                     <%!-- text, radio, checkbox, and other types default to text input --%>
                     <input


### PR DESCRIPTION
daisyUI 5 changed the select component to use a <label class="select"> wrapper instead of putting the class directly on <select>. This fixes selects rendering incorrectly on LiveView navigation (content pressed against top) while working correctly after a hard refresh.