### PR TITLE
Add V91 locations migration and JS hooks integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,6 +148,15 @@ Updates require: `mix.exs` (@version), `CHANGELOG.md`. Run `mix compile`, `mix t
 
 PR review files go in `dev_docs/pull_requests/{year}/{pr_number}-{slug}/` directory. Use `{AGENT}_REVIEW.md` naming (e.g., `CLAUDE_REVIEW.md`, `GEMINI_REVIEW.md`). See `dev_docs/pull_requests/README.md`.
 
+Severity levels for review findings:
+
+- `BUG - CRITICAL` — Will cause crashes, data loss, or security issues
+- `BUG - HIGH` — Incorrect behavior that affects users
+- `BUG - MEDIUM` — Edge cases, minor incorrect behavior
+- `IMPROVEMENT - HIGH` — Significant code quality or performance issue
+- `IMPROVEMENT - MEDIUM` — Better patterns or maintainability
+- `NITPICK` — Style, naming, minor suggestions
+
 ### Publishing commands
 
 - `mix hex.build`
@@ -283,6 +292,25 @@ CSS source discovery is **automatic at compile time**. The `:phoenix_kit_css_sou
 2. `app.css` must have `@import "./_phoenix_kit_sources.css";`
 
 After setup, adding or removing modules is zero-config — the compiler regenerates on each compilation.
+
+### JavaScript Hooks for External Modules
+
+PhoenixKit provides JS hooks (RowMenu, TableCardView, SortableGrid, etc.) in `priv/static/assets/phoenix_kit.js`. This file defines `window.PhoenixKitHooks` which the parent app spreads into LiveSocket:
+
+```javascript
+hooks: { ...window.PhoenixKitHooks, ...colocatedHooks }
+```
+
+**Parent app setup (handled by `mix phoenix_kit.install`):**
+1. `phoenix_kit.js` is copied to `priv/static/assets/vendor/`
+2. A `<script>` tag is added to the root layout **before** `app.js`:
+   ```html
+   <script src={~p"/assets/vendor/phoenix_kit.js"}></script>
+   ```
+
+**On update (`mix phoenix_kit.update`):** The JS file is automatically refreshed to keep hooks in sync.
+
+External modules register custom hooks via inline `<script>` tags on `window.PhoenixKitHooks`. See the hello_world template for examples.
 
 ### PhoenixKit Layout Guidelines
 

--- a/lib/mix/tasks/phoenix_kit.install.ex
+++ b/lib/mix/tasks/phoenix_kit.install.ex
@@ -55,6 +55,7 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
       DbConnectionCheck,
       DemoFiles,
       EndpointIntegration,
+      JsIntegration,
       LayoutConfig,
       MailerConfig,
       MigrationStrategy,
@@ -103,6 +104,7 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
       |> ObanConfig.add_oban_supervisor()
       |> LayoutConfig.add_layout_integration_configuration()
       |> CssIntegration.add_automatic_css_integration()
+      |> JsIntegration.add_js_integration()
       |> DemoFiles.copy_test_demo_files()
       |> RouterIntegration.add_router_integration(opts[:router_path])
       |> BrowserPipelineIntegration.add_integration_to_browser_pipeline()

--- a/lib/mix/tasks/phoenix_kit.update.ex
+++ b/lib/mix/tasks/phoenix_kit.update.ex
@@ -90,6 +90,7 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
       CssIntegration,
       DbConnectionCheck,
       IgniterHelpers,
+      JsIntegration,
       ObanConfig,
       RateLimiterConfig
     }
@@ -581,6 +582,9 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
 
       # Update CSS integration (enables daisyUI themes if disabled)
       update_css_integration()
+
+      # Update JS hooks file
+      JsIntegration.update_js_file()
 
       # Always rebuild assets unless explicitly skipped
       unless Keyword.get(opts, :skip_assets, false) do

--- a/lib/phoenix_kit/install/js_integration.ex
+++ b/lib/phoenix_kit/install/js_integration.ex
@@ -1,0 +1,189 @@
+defmodule PhoenixKit.Install.JsIntegration do
+  @moduledoc """
+  Handles automatic JavaScript hooks integration for PhoenixKit installation.
+
+  This module:
+  - Copies `phoenix_kit.js` to the parent app's `priv/static/assets/vendor/`
+  - Adds a `<script>` tag to the root layout so hooks are loaded before LiveSocket
+
+  The JS file defines `window.PhoenixKitHooks` which is spread into LiveSocket's
+  hooks object in app.js: `hooks: { ...window.PhoenixKitHooks, ...colocatedHooks }`
+  """
+
+  require Logger
+
+  @source_filename "phoenix_kit.js"
+  @script_marker "<!-- PhoenixKit JS Hooks -->"
+
+  @doc """
+  Copies phoenix_kit.js to the parent app's static vendor directory and
+  adds a script tag to the root layout.
+
+  Safe to run multiple times (idempotent).
+  """
+  def add_js_integration(igniter) do
+    igniter
+    |> copy_js_file()
+    |> add_script_tag_to_layout()
+  end
+
+  @doc """
+  Updates the JS file in the parent app's static vendor directory.
+  Called during `mix phoenix_kit.update` to keep hooks in sync.
+  """
+  def update_js_file do
+    case resolve_source_path() do
+      {:ok, source} ->
+        dest = dest_path()
+        File.mkdir_p(Path.dirname(dest))
+
+        case File.cp(source, dest) do
+          :ok ->
+            Logger.info("Updated #{@source_filename} in priv/static/assets/vendor/")
+            :ok
+
+          {:error, reason} ->
+            Logger.warning("Failed to update #{@source_filename}: #{inspect(reason)}")
+            {:error, reason}
+        end
+
+      {:error, :not_found} ->
+        Logger.warning("Could not find #{@source_filename} in PhoenixKit priv/static/assets/")
+        {:error, :not_found}
+    end
+  rescue
+    error ->
+      Logger.warning("Unexpected error updating #{@source_filename}: #{inspect(error)}")
+      {:error, :unexpected}
+  end
+
+  # ── Private ──────────────────────────────────────────────────────
+
+  defp copy_js_file(igniter) do
+    case resolve_source_path() do
+      {:ok, source} ->
+        dest = dest_path()
+        File.mkdir_p(Path.dirname(dest))
+
+        case File.cp(source, dest) do
+          :ok ->
+            Igniter.add_notice(
+              igniter,
+              "✅ Copied #{@source_filename} to priv/static/assets/vendor/"
+            )
+
+          {:error, reason} ->
+            Igniter.add_warning(
+              igniter,
+              "⚠️  Failed to copy #{@source_filename}: #{inspect(reason)}. " <>
+                "Please copy it manually from deps/phoenix_kit/priv/static/assets/#{@source_filename}"
+            )
+        end
+
+      {:error, :not_found} ->
+        Igniter.add_warning(
+          igniter,
+          "⚠️  Could not find #{@source_filename}. " <>
+            "Please copy it manually from the phoenix_kit package."
+        )
+    end
+  end
+
+  defp add_script_tag_to_layout(igniter) do
+    layout_paths = [
+      "lib/#{Mix.Phoenix.otp_app()}_web/components/layouts/root.html.heex",
+      "lib/#{Mix.Phoenix.otp_app()}_web/templates/layout/root.html.heex"
+    ]
+
+    case find_existing_file(layout_paths) do
+      {:ok, layout_path} ->
+        content = File.read!(layout_path)
+
+        cond do
+          String.contains?(content, @script_marker) ->
+            # Already integrated
+            igniter
+
+          String.contains?(content, "phoenix_kit.js") ->
+            # Already has a script tag (manually added)
+            igniter
+
+          true ->
+            inject_script_tag(igniter, layout_path, content)
+        end
+
+      {:error, :not_found} ->
+        Igniter.add_notice(
+          igniter,
+          """
+          ⚠️  Could not find root layout. Please add this before your app.js script tag:
+
+              #{@script_marker}
+              <script src="/assets/vendor/#{@source_filename}"></script>
+          """
+        )
+    end
+  end
+
+  defp inject_script_tag(igniter, layout_path, content) do
+    script_tag = """
+        #{@script_marker}
+        <script src={~p"/assets/vendor/#{@source_filename}"}></script>\
+    """
+
+    # Insert before the app.js script tag
+    updated =
+      String.replace(
+        content,
+        ~r{(\s*<script[^>]*src=[^>]*app\.js[^>]*>)},
+        "\n#{script_tag}\n\\1",
+        global: false
+      )
+
+    if updated != content do
+      File.write!(layout_path, updated)
+
+      Igniter.add_notice(
+        igniter,
+        "✅ Added PhoenixKit JS hooks script tag to #{layout_path}"
+      )
+    else
+      Igniter.add_warning(
+        igniter,
+        """
+        ⚠️  Could not automatically add script tag to #{layout_path}.
+        Please add this before your app.js script tag:
+
+            #{@script_marker}
+            <script src={~p"/assets/vendor/#{@source_filename}"}></script>
+        """
+      )
+    end
+  end
+
+  defp resolve_source_path do
+    # Try multiple possible locations
+    candidates = [
+      # Path dependency (development)
+      Path.join([File.cwd!(), "..", "phoenix_kit", "priv", "static", "assets", @source_filename]),
+      # Hex dependency
+      Path.join([:code.priv_dir(:phoenix_kit), "static", "assets", @source_filename])
+    ]
+
+    case Enum.find(candidates, &File.exists?/1) do
+      nil -> {:error, :not_found}
+      path -> {:ok, path}
+    end
+  end
+
+  defp dest_path do
+    Path.join([File.cwd!(), "priv", "static", "assets", "vendor", @source_filename])
+  end
+
+  defp find_existing_file(paths) do
+    case Enum.find(paths, &File.exists?/1) do
+      nil -> {:error, :not_found}
+      path -> {:ok, path}
+    end
+  end
+end

--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -529,7 +529,15 @@ defmodule PhoenixKit.Migrations.Postgres do
   - Replaces unique index with partial index (slug-mode only, WHERE slug IS NOT NULL)
   - Adds unique index on `(group_uuid, post_date, post_time)` for timestamp-mode posts
 
-  ### V89 - Catalogue pricing ⚡ LATEST
+  ### V91 - Locations tables ⚡ LATEST
+  - `phoenix_kit_location_types` for user-defined location categories
+  - `phoenix_kit_locations` for physical locations with type reference
+  - `phoenix_kit_location_type_assignments` for many-to-many join
+
+  ### V90 - Activity feed
+  - `phoenix_kit_activities` table for business-level action logging
+
+  ### V89 - Catalogue pricing
   - Renames `price` to `base_price` in `phoenix_kit_cat_items`
   - Adds `markup_percentage` decimal column to `phoenix_kit_cat_catalogues`
 
@@ -678,7 +686,7 @@ defmodule PhoenixKit.Migrations.Postgres do
   use Ecto.Migration
 
   @initial_version 1
-  @current_version 90
+  @current_version 91
   @default_prefix "public"
 
   @doc false

--- a/lib/phoenix_kit/migrations/postgres/v91.ex
+++ b/lib/phoenix_kit/migrations/postgres/v91.ex
@@ -1,0 +1,244 @@
+defmodule PhoenixKit.Migrations.Postgres.V91 do
+  @moduledoc """
+  V91: Add Locations tables.
+
+  Creates the three tables needed by the PhoenixKitLocations module:
+  - `phoenix_kit_location_types` — user-defined location categories (Showroom, Storage, etc.)
+  - `phoenix_kit_locations` — physical locations with full address, contact, features
+  - `phoenix_kit_location_type_assignments` — many-to-many join (a location can have multiple types)
+  """
+
+  use Ecto.Migration
+
+  def up(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+    schema = if prefix == "public", do: "public", else: prefix
+
+    # ── Location Types ─────────────────────────────────────────────
+    create_if_not_exists table(:phoenix_kit_location_types,
+                           primary_key: false,
+                           prefix: prefix
+                         ) do
+      add(:uuid, :uuid, primary_key: true, default: fragment("uuid_generate_v7()"))
+      add(:name, :string, null: false, size: 255)
+      add(:description, :text)
+      add(:status, :string, default: "active", size: 20)
+      add(:data, :map, default: %{})
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create_if_not_exists(index(:phoenix_kit_location_types, [:status], prefix: prefix))
+
+    # ── Locations ──────────────────────────────────────────────────
+    create_if_not_exists table(:phoenix_kit_locations,
+                           primary_key: false,
+                           prefix: prefix
+                         ) do
+      add(:uuid, :uuid, primary_key: true, default: fragment("uuid_generate_v7()"))
+      add(:name, :string, null: false, size: 255)
+      add(:description, :text)
+      add(:public_notes, :text)
+
+      # Address (international standard)
+      add(:address_line_1, :string, size: 500)
+      add(:address_line_2, :string, size: 500)
+      add(:city, :string, size: 255)
+      add(:state, :string, size: 255)
+      add(:postal_code, :string, size: 20)
+      add(:country, :string, size: 255)
+
+      # Contact
+      add(:phone, :string, size: 50)
+      add(:email, :string, size: 255)
+      add(:website, :string, size: 500)
+
+      # Internal
+      add(:notes, :text)
+      add(:status, :string, default: "active", size: 20)
+
+      # Features (JSONB with boolean flags)
+      add(:features, :map, default: %{})
+
+      # Multilang translations
+      add(:data, :map, default: %{})
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create_if_not_exists(index(:phoenix_kit_locations, [:status], prefix: prefix))
+
+    # ── Location ↔ Type join (many-to-many) ────────────────────────
+    create_if_not_exists table(:phoenix_kit_location_type_assignments,
+                           primary_key: false,
+                           prefix: prefix
+                         ) do
+      add(:uuid, :uuid, primary_key: true, default: fragment("uuid_generate_v7()"))
+
+      add(
+        :location_uuid,
+        references(:phoenix_kit_locations,
+          column: :uuid,
+          type: :uuid,
+          on_delete: :delete_all,
+          prefix: prefix
+        ),
+        null: false
+      )
+
+      add(
+        :location_type_uuid,
+        references(:phoenix_kit_location_types,
+          column: :uuid,
+          type: :uuid,
+          on_delete: :delete_all,
+          prefix: prefix
+        ),
+        null: false
+      )
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create_if_not_exists(
+      unique_index(
+        :phoenix_kit_location_type_assignments,
+        [:location_uuid, :location_type_uuid],
+        prefix: prefix
+      )
+    )
+
+    # ── Idempotent column additions (for existing V90 installs) ────
+    execute("""
+    DO $$
+    BEGIN
+      -- Drop old columns that were renamed/removed
+      IF EXISTS (
+        SELECT FROM information_schema.columns
+        WHERE table_schema = '#{schema}'
+          AND table_name = 'phoenix_kit_locations'
+          AND column_name = 'location_type_uuid'
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_locations DROP COLUMN location_type_uuid;
+      END IF;
+
+      IF EXISTS (
+        SELECT FROM information_schema.columns
+        WHERE table_schema = '#{schema}'
+          AND table_name = 'phoenix_kit_locations'
+          AND column_name = 'address'
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_locations RENAME COLUMN address TO address_line_1;
+      END IF;
+
+      -- Add new columns if missing
+      IF NOT EXISTS (
+        SELECT FROM information_schema.columns
+        WHERE table_schema = '#{schema}'
+          AND table_name = 'phoenix_kit_locations'
+          AND column_name = 'description'
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_locations ADD COLUMN description TEXT;
+      END IF;
+
+      IF NOT EXISTS (
+        SELECT FROM information_schema.columns
+        WHERE table_schema = '#{schema}'
+          AND table_name = 'phoenix_kit_locations'
+          AND column_name = 'public_notes'
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_locations ADD COLUMN public_notes TEXT;
+      END IF;
+
+      IF NOT EXISTS (
+        SELECT FROM information_schema.columns
+        WHERE table_schema = '#{schema}'
+          AND table_name = 'phoenix_kit_locations'
+          AND column_name = 'address_line_2'
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_locations ADD COLUMN address_line_2 VARCHAR(500);
+      END IF;
+
+      IF NOT EXISTS (
+        SELECT FROM information_schema.columns
+        WHERE table_schema = '#{schema}'
+          AND table_name = 'phoenix_kit_locations'
+          AND column_name = 'state'
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_locations ADD COLUMN state VARCHAR(255);
+      END IF;
+
+      IF NOT EXISTS (
+        SELECT FROM information_schema.columns
+        WHERE table_schema = '#{schema}'
+          AND table_name = 'phoenix_kit_locations'
+          AND column_name = 'postal_code'
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_locations ADD COLUMN postal_code VARCHAR(20);
+      END IF;
+
+      IF NOT EXISTS (
+        SELECT FROM information_schema.columns
+        WHERE table_schema = '#{schema}'
+          AND table_name = 'phoenix_kit_locations'
+          AND column_name = 'website'
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_locations ADD COLUMN website VARCHAR(500);
+      END IF;
+
+      IF NOT EXISTS (
+        SELECT FROM information_schema.columns
+        WHERE table_schema = '#{schema}'
+          AND table_name = 'phoenix_kit_locations'
+          AND column_name = 'features'
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_locations ADD COLUMN features JSONB NOT NULL DEFAULT '{}';
+      END IF;
+
+      -- Drop unique index on location_types.name if exists (names don't need to be unique)
+      IF EXISTS (
+        SELECT FROM pg_indexes
+        WHERE schemaname = '#{schema}'
+          AND tablename = 'phoenix_kit_location_types'
+          AND indexname = 'phoenix_kit_location_types_name_index'
+      ) THEN
+        DROP INDEX #{p}phoenix_kit_location_types_name_index;
+      END IF;
+
+      -- Fix address_line_1 type if it was created as text (from early V90)
+      IF EXISTS (
+        SELECT FROM information_schema.columns
+        WHERE table_schema = '#{schema}'
+          AND table_name = 'phoenix_kit_locations'
+          AND column_name = 'address_line_1'
+          AND data_type = 'text'
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_locations
+          ALTER COLUMN address_line_1 TYPE VARCHAR(500);
+      END IF;
+    END $$;
+    """)
+
+    # Index on location_uuid for type assignment lookups
+    create_if_not_exists(
+      index(:phoenix_kit_location_type_assignments, [:location_uuid], prefix: prefix)
+    )
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '91'")
+  end
+
+  def down(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    drop_if_exists(table(:phoenix_kit_location_type_assignments, prefix: prefix))
+    drop_if_exists(table(:phoenix_kit_locations, prefix: prefix))
+    drop_if_exists(table(:phoenix_kit_location_types, prefix: prefix))
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '90'")
+  end
+
+  defp prefix_str("public"), do: "public."
+  defp prefix_str(prefix), do: "#{prefix}."
+end


### PR DESCRIPTION
Migration V91:
- Creates phoenix_kit_location_types, phoenix_kit_locations, and phoenix_kit_location_type_assignments tables with UUIDv7, indexes, and FK cascades
- Idempotent column additions for upgrade scenarios

JS hooks integration:
- Add JsIntegration module that copies phoenix_kit.js to parent app's priv/static/assets/vendor/ and injects <script> tag in root layout
- Wire into install and update tasks so hooks (RowMenu, TableCardView, etc.) load automatically before LiveSocket

Docs:
- Add PR review severity levels to AGENTS.md
- Add JS hooks integration section to AGENTS.md