### PR TITLE
Add centralized Integrations system for external service connections

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -79,6 +79,17 @@
   # External optional modules guarded by Code.ensure_loaded? at runtime
   {"lib/modules/sitemap/sources/publishing.ex", :unknown_function},
   {"lib/phoenix_kit/dashboard/registry.ex", :unknown_function},
+  {"lib/phoenix_kit/install/css_integration.ex", :unknown_function},
+
+  # Integrations: Dialyzer infers boolean branches in cond/case are unreachable
+  # when provider auth_type covers all spec'd atoms. False positive — defensive code.
+  {"lib/phoenix_kit/integrations/integrations.ex", :pattern_match},
+  {"lib/phoenix_kit/scheduled_jobs/workers/process_scheduled_jobs_worker.ex", :unknown_function},
+
+  # ExUnit internal functions — false positives when test/support is compiled in MIX_ENV=test
+  # Dialyzer cannot resolve ExUnit private macros expanded at compile time
+  {"test/support/conn_case.ex", :unknown_function},
+  {"test/support/data_case.ex", :unknown_function},
 
   # Extracted module references — conditionally loaded via Code.ensure_loaded?
   # These modules live in separate packages (phoenix_kit_ecommerce, phoenix_kit_billing)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,6 +171,26 @@ Severity levels for review findings:
 - The migration system uses Oban-style versioned migrations (see `lib/phoenix_kit/migrations/postgres/`)
 
 
+## Integrations System
+
+Centralized management of external service connections (OAuth, API keys, bot tokens).
+
+**Architecture:**
+- `lib/phoenix_kit/integrations/integrations.ex` — Main context (CRUD, OAuth flow, credentials)
+- `lib/phoenix_kit/integrations/providers.ex` — Provider registry (Google, OpenRouter, etc.)
+- `lib/phoenix_kit/integrations/oauth.ex` — Generic OAuth 2.0 flow
+- `lib/phoenix_kit/integrations/events.ex` — PubSub events
+- `lib/phoenix_kit_web/live/settings/integrations.ex` — List page
+- `lib/phoenix_kit_web/live/settings/integration_form.ex` — Add/edit page
+- `lib/phoenix_kit_web/components/core/integration_picker.ex` — Reusable picker component
+
+**Storage:** Uses existing `phoenix_kit_settings` table with `value_json` JSONB. Keys follow `integration:{provider}:{name}` convention. Each connection is a JSON blob. Connections are referenced by their settings row UUID.
+
+**Module callbacks:** Modules declare `required_integrations/0` (e.g., `["google"]`) for the "Used by" display. Modules declare `integration_providers/0` to contribute custom provider definitions.
+
+**Plan:** `dev_docs/plans/integrations-system.md`
+
+
 ## Documentations
 
 Built-in Dashboard Features

--- a/dev_docs/plans/integrations-system.md
+++ b/dev_docs/plans/integrations-system.md
@@ -1,0 +1,656 @@
+# PhoenixKit Integrations System — Implementation Plan
+
+**Created:** 2026-04-01
+**Status:** Phases 1-4 implemented (2026-04-02)
+**Scope:** phoenix_kit (core), phoenix_kit_document_creator, phoenix_kit_ai
+
+---
+
+## Problem
+
+External service connections (OAuth accounts, API keys) are currently owned by individual modules. The document creator manages its own Google OAuth flow, token storage, and refresh logic. The AI module stores API keys per-endpoint in its own DB table.
+
+If a new module also needs Google (e.g., Google Calendar, Google Sheets), it would have to duplicate the entire OAuth flow. If a new module needs OpenRouter or another AI provider, it can't share the API key already configured in the AI module.
+
+## Solution
+
+A centralized **Integrations** system in phoenix_kit core that:
+
+1. Stores service credentials (OAuth tokens, API keys) using the existing Settings system (`value_json` JSONB column)
+2. Provides a shared OAuth flow (authorize, callback, token refresh) that any module can use
+3. Provides an "Integrations" tab in Admin Settings where admins connect/disconnect services
+4. Exposes a simple API (`PhoenixKit.Integrations`) for modules to read credentials
+
+## Design Decision: Settings, Not a New Table
+
+The existing `phoenix_kit_settings` table already supports this:
+
+- **`value_json` (JSONB)** — stores any shape of credentials as a map, no size limit
+- **`key` (string, unique)** — e.g., `"integration:google"`, `"integration:openrouter"`
+- **`module` (string)** — tag as `"integrations"` for organization
+- **Caching** — `get_json_setting_cached/2` with automatic invalidation on writes
+- **Already proven** — document creator already stores OAuth tokens this way
+
+**Why not a new table:**
+- Settings already does exactly what we need (key-value JSON with caching)
+- No migration needed for the storage layer
+- Consistent with how the rest of PhoenixKit stores configuration
+- The data shape varies wildly per provider (OAuth vs API key vs key+secret) — JSONB handles this naturally
+
+**Key convention:** All integration settings keys are prefixed with `"integration:"` (e.g., `"integration:google"`, `"integration:openrouter"`, `"integration:stripe"`).
+
+---
+
+## Data Shape Per Integration
+
+Every integration is a single JSON blob stored under a settings key. The shape varies by auth type, but all share common fields:
+
+### Common Fields (all integrations)
+
+```elixir
+%{
+  # Identity
+  "provider" => "google",                          # Provider slug
+  "auth_type" => "oauth2",                         # "oauth2" | "api_key" | "key_secret" | "bot_token" | "credentials"
+  "label" => "Google Workspace",                   # Display name (set by admin or auto)
+
+  # Status
+  "status" => "connected",                         # "connected" | "disconnected" | "error"
+  "connected_at" => "2026-03-15T10:30:00Z",        # ISO8601
+  "connected_by" => "user-uuid-here",              # Admin who connected it
+
+  # Connection identity (from the external service)
+  "external_account_id" => "user@company.com",     # Email, team ID, account ID, etc.
+  "external_account_name" => "Company Workspace",  # Human-readable name
+
+  # Service-specific metadata (varies per provider)
+  "metadata" => %{...}
+}
+```
+
+### OAuth 2.0 Integrations (Google, Microsoft, Slack, etc.)
+
+```elixir
+%{
+  # ... common fields ...
+  "auth_type" => "oauth2",
+
+  # App credentials (entered by admin in settings)
+  "client_id" => "123456.apps.googleusercontent.com",
+  "client_secret" => "GOCSPX-...",
+
+  # Tokens (obtained via OAuth flow)
+  "access_token" => "ya29.a0AfH6SMBx...",
+  "refresh_token" => "1//0gqUP8...",
+  "token_type" => "Bearer",
+  "expires_at" => "2026-03-15T11:30:00Z",          # Absolute expiry (computed from expires_in)
+  "token_obtained_at" => "2026-03-15T10:30:00Z",
+
+  # Scopes
+  "scopes" => "https://www.googleapis.com/auth/drive https://www.googleapis.com/auth/documents",
+
+  # Provider-specific metadata
+  "metadata" => %{
+    "connected_email" => "user@gmail.com"
+  }
+}
+```
+
+### API Key Integrations (OpenRouter, Stripe, SendGrid, etc.)
+
+```elixir
+%{
+  # ... common fields ...
+  "auth_type" => "api_key",
+
+  # The key itself
+  "api_key" => "sk-or-v1-abc123...",
+
+  # Optional provider-specific fields
+  "metadata" => %{
+    "organization_id" => "org-xxx",       # OpenAI org
+    "http_referer" => "https://myapp.com", # OpenRouter
+    "x_title" => "My App"                  # OpenRouter
+  }
+}
+```
+
+### Key Pair Integrations (AWS, Twilio, etc.)
+
+```elixir
+%{
+  # ... common fields ...
+  "auth_type" => "key_secret",
+
+  "access_key" => "AKIA...",
+  "secret_key" => "wJalr...",
+
+  "metadata" => %{
+    "region" => "us-east-1",
+    "account_id" => "123456789"
+  }
+}
+```
+
+### Bot Token Integrations (Telegram, Discord, etc.)
+
+```elixir
+%{
+  # ... common fields ...
+  "auth_type" => "bot_token",
+
+  # The bot token
+  "bot_token" => "123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11",
+
+  # Connection identity (populated after validation)
+  "external_account_id" => "123456",
+  "external_account_name" => "MyCompanyBot",
+
+  "metadata" => %{
+    "bot_username" => "@my_company_bot",
+    "webhook_url" => "https://myapp.com/webhooks/telegram"  # if using webhooks
+  }
+}
+```
+
+Telegram bots authenticate with a single token from BotFather. The token never expires (unless revoked). Validation is done by calling `getMe` on the Telegram Bot API. Discord bots follow a similar pattern with a bot token.
+
+### Custom Credentials (SMTP, databases, etc.)
+
+```elixir
+%{
+  # ... common fields ...
+  "auth_type" => "credentials",
+
+  # Freeform — shape defined by the provider definition
+  "credentials" => %{
+    "host" => "smtp.gmail.com",
+    "port" => 587,
+    "username" => "noreply@company.com",
+    "password" => "app-specific-password",
+    "encryption" => "starttls"
+  }
+}
+```
+
+---
+
+## Provider Definitions
+
+Providers are defined in code (not DB) as a registry of known integration types. This tells the UI what fields to show and how to handle auth.
+
+```elixir
+# lib/phoenix_kit/integrations/providers.ex
+
+# Each provider definition contains:
+%{
+  key: "google",
+  name: "Google Workspace",
+  description: "Google Docs, Drive, Calendar, Sheets, Gmail",
+  icon: "hero-cloud",                    # or a custom SVG/image path
+  auth_type: :oauth2,
+  oauth_config: %{
+    auth_url: "https://accounts.google.com/o/oauth2/v2/auth",
+    token_url: "https://oauth2.googleapis.com/token",
+    userinfo_url: "https://www.googleapis.com/oauth2/v2/userinfo",
+    default_scopes: "https://www.googleapis.com/auth/drive https://www.googleapis.com/auth/documents",
+    auth_params: %{access_type: "offline", prompt: "consent"}
+  },
+  setup_fields: [
+    %{key: "client_id", label: "Client ID", type: :text, required: true,
+      placeholder: "xxxxx.apps.googleusercontent.com",
+      help: "From Google Cloud Console → APIs & Services → Credentials"},
+    %{key: "client_secret", label: "Client Secret", type: :password, required: true,
+      placeholder: "GOCSPX-..."}
+  ],
+  # Which modules can use this integration
+  capabilities: [:google_docs, :google_drive, :google_calendar, :google_sheets]
+}
+```
+
+The provider registry is extensible — external modules can register additional providers via a callback in `PhoenixKit.Module`:
+
+```elixir
+# In a module like PhoenixKitDocumentCreator:
+@impl PhoenixKit.Module
+def integration_providers do
+  [
+    %{key: "google", ...}   # Can contribute provider definitions
+  ]
+end
+```
+
+Or more likely, core ships with common providers and modules just declare which ones they need. New providers are added to the registry as needed.
+
+**Example bot token provider:**
+
+```elixir
+%{
+  key: "telegram",
+  name: "Telegram Bot",
+  description: "Telegram Bot API for messaging, notifications, and commands",
+  icon: "hero-chat-bubble-left-right",
+  auth_type: :bot_token,
+  setup_fields: [
+    %{key: "bot_token", label: "Bot Token", type: :password, required: true,
+      placeholder: "123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11",
+      help: "From @BotFather on Telegram"}
+  ],
+  validation: %{
+    url: "https://api.telegram.org/bot{bot_token}/getMe",
+    method: :get,
+    success_path: ["ok"]   # check response.ok == true
+  },
+  capabilities: [:telegram_messaging, :telegram_webhooks]
+}
+```
+
+---
+
+## Context Module API
+
+### `PhoenixKit.Integrations`
+
+```elixir
+# === Reading credentials (used by consuming modules) ===
+
+# Get full integration data for a provider
+get_integration("google")
+# => {:ok, %{"provider" => "google", "access_token" => "ya29...", ...}}
+# => {:error, :not_configured}
+
+# Get just the credentials needed for API calls (provider-aware)
+get_credentials("google")
+# => {:ok, %{access_token: "ya29...", token_type: "Bearer"}}
+# => {:error, :not_configured}
+
+# Check if an integration is connected and has valid credentials
+connected?("google")
+# => true | false
+
+# === OAuth flow (used by the Integrations settings UI) ===
+
+# Build authorization URL for OAuth providers
+authorization_url("google", redirect_uri)
+# => {:ok, "https://accounts.google.com/o/oauth2/v2/auth?..."}
+
+# Exchange authorization code for tokens
+exchange_code("google", code, redirect_uri)
+# => {:ok, %{"access_token" => ..., "refresh_token" => ...}}
+
+# Refresh an expired access token
+refresh_access_token("google")
+# => {:ok, "new-access-token"}
+
+# Disconnect (remove tokens, keep client_id/secret)
+disconnect("google")
+# => :ok
+
+# === Setup (used by the Integrations settings UI) ===
+
+# Save app-level credentials (client_id/secret for OAuth, api_key for key-based)
+save_setup("google", %{"client_id" => "...", "client_secret" => "..."})
+save_setup("openrouter", %{"api_key" => "sk-or-..."})
+
+# === HTTP helper (used by consuming modules) ===
+
+# Make an authenticated request with automatic token refresh on 401
+authenticated_request("google", :get, url, opts)
+# => {:ok, %Req.Response{...}}
+# Automatically adds Bearer token, retries with refreshed token on 401
+
+# === Provider registry ===
+
+# List all known providers
+list_providers()
+# => [%{key: "google", name: "Google Workspace", ...}, ...]
+
+# List all configured integrations (connected or just setup)
+list_integrations()
+# => [%{"provider" => "google", "status" => "connected", ...}, ...]
+```
+
+---
+
+## Admin UI
+
+### New Settings Tab: "Integrations"
+
+Added as a core settings subtab in `admin_tabs.ex`, priority ~915 (after Organization, before Users or after Users):
+
+```
+Settings
+├── General
+├── Authorization
+├── Organization
+├── Users
+├── Integrations    ← NEW
+├── Media
+├── [module tabs...]
+```
+
+### Integrations Page Layout
+
+The page shows a card for each **known provider** (from the registry). Each card shows:
+
+**Disconnected state:**
+```
+┌─────────────────────────────────────────────┐
+│ 🔗 Google Workspace                         │
+│ Google Docs, Drive, Calendar, Sheets, Gmail  │
+│                                              │
+│ Client ID:     [________________________]    │
+│ Client Secret: [________________________]    │
+│                                              │
+│ [Save]                                       │
+│                                              │
+│ Status: Not connected                        │
+└─────────────────────────────────────────────┘
+```
+
+**After saving client credentials:**
+```
+┌─────────────────────────────────────────────┐
+│ 🔗 Google Workspace                         │
+│                                              │
+│ Client ID:     123456.apps.googleusercontent │
+│ Client Secret: ••••••••••••                  │
+│                                              │
+│ [Connect Google Account]                     │
+│                                              │
+│ Status: Credentials saved, not connected     │
+└─────────────────────────────────────────────┘
+```
+
+**Connected:**
+```
+┌─────────────────────────────────────────────┐
+│ ✓ Google Workspace                          │
+│ Connected as user@gmail.com                  │
+│ Connected on 2026-03-15                      │
+│                                              │
+│ Used by: Document Creator                    │
+│                                              │
+│ [Disconnect]  [Reconnect]                    │
+└─────────────────────────────────────────────┘
+```
+
+**API key providers (simpler):**
+```
+┌─────────────────────────────────────────────┐
+│ 🔗 OpenRouter                               │
+│ AI model access (100+ models)                │
+│                                              │
+│ API Key: [_______________________________]   │
+│                                              │
+│ [Save & Validate]                            │
+│                                              │
+│ Status: ✓ Connected (validated)              │
+│ Used by: AI                                  │
+└─────────────────────────────────────────────┘
+```
+
+### Which Providers Appear
+
+Only providers that are **relevant** to the current installation should appear. Options:
+
+- **Option A:** Show all providers from the registry (simple, but cluttered)
+- **Option B (preferred):** Show providers that at least one enabled module declares it needs, plus any already-configured providers
+
+Modules declare their integration needs via a new optional callback:
+
+```elixir
+@impl PhoenixKit.Module
+def required_integrations, do: ["google"]   # or ["openrouter"]
+```
+
+---
+
+## Scope of Module Changes
+
+### Changes to `PhoenixKit.Module` Behaviour
+
+Add two new optional callbacks (with defaults):
+
+```elixir
+@callback required_integrations() :: [String.t()]
+# Which integration providers this module needs. Used to show relevant
+# providers on the Integrations settings page.
+# Default: []
+
+@callback integration_providers() :: [map()]
+# Additional provider definitions this module contributes.
+# Most modules won't need this — core ships with common providers.
+# Default: []
+```
+
+### Migration: `phoenix_kit_document_creator`
+
+**Before:** Module manages its own Google OAuth flow in `GoogleDocsClient`, stores everything under `"document_creator_google_oauth"` settings key.
+
+**After:** Module reads Google credentials from `PhoenixKit.Integrations.get_credentials("google")` and uses `PhoenixKit.Integrations.authenticated_request("google", ...)` for API calls.
+
+**What moves to core:**
+- OAuth authorization URL generation
+- Code-to-token exchange
+- Token refresh logic
+- Token storage (now under `"integration:google"`)
+- The settings UI for client_id/secret + connect/disconnect
+
+**What stays in document_creator:**
+- Google Docs API calls (create, copy, replace text, etc.)
+- Google Drive API calls (list files, create folders, export PDF, etc.)
+- Folder configuration (folder paths/names — these are document-creator-specific, stored in their own settings key)
+- Variable substitution logic
+- All business logic
+
+**Specific file changes:**
+
+1. **`google_docs_client.ex`** — Remove:
+   - `@settings_key`, `settings_key/0`
+   - `get_credentials/0`, `save_credentials/1`
+   - `authorization_url/1`, `exchange_code/2`, `refresh_access_token/0`
+   - `get_client_credentials/0`
+   - `authenticated_request/3`, `retry_with_refreshed_token/3`
+
+   Replace with calls to:
+   - `PhoenixKit.Integrations.get_credentials("google")` for reading tokens
+   - `PhoenixKit.Integrations.authenticated_request("google", method, url, opts)` for API calls with auto-refresh
+
+   Keep folder config in a separate document-creator-specific settings key (e.g., `"document_creator_folders"`).
+
+2. **`google_oauth_settings_live.ex`** — Significant simplification:
+   - Remove all OAuth flow handling (connect, disconnect, credential saving)
+   - The settings page becomes **folder configuration only**
+   - OAuth connection moves to the core Integrations settings page
+   - Could add a link/notice: "Connect your Google account in Settings → Integrations"
+
+3. **`phoenix_kit_document_creator.ex`** — Add:
+   ```elixir
+   @impl PhoenixKit.Module
+   def required_integrations, do: ["google"]
+   ```
+
+### Migration: `phoenix_kit_ai`
+
+The endpoints themselves stay as-is — they define model, temperature, max_tokens, etc. What changes is where the **API key** comes from. Instead of each endpoint storing its own `api_key`, there's one OpenRouter API key configured in Settings → Integrations, and all endpoints use it.
+
+**Approach: Remove per-endpoint API key, use shared integration**
+
+1. **`endpoint.ex`** — Remove `api_key` field (or deprecate/ignore it):
+   - Remove `field(:api_key, :string)`
+   - Remove `validate_api_key_format/1` validation
+   - The `provider` field stays (still useful to know which provider an endpoint targets)
+   - `provider_settings` stays (http_referer, x_title are per-endpoint config, not credentials)
+
+2. **`openrouter_client.ex`** — Update credential resolution:
+   ```elixir
+   # Before: build_headers_from_endpoint(%{api_key: api_key, ...})
+   # After:
+   def build_headers_for_provider(provider, provider_settings) do
+     {:ok, %{"api_key" => api_key}} = PhoenixKit.Integrations.get_credentials(provider)
+     settings = provider_settings || %{}
+
+     opts =
+       []
+       |> maybe_add_opt(:http_referer, settings["http_referer"])
+       |> maybe_add_opt(:x_title, settings["x_title"])
+
+     build_headers(api_key, opts)
+   end
+   ```
+
+3. **`completion.ex`** — Update `chat_completion/3` and `embeddings/3`:
+   - Replace `OpenRouterClient.build_headers_from_endpoint(endpoint)` with
+     `OpenRouterClient.build_headers_for_provider(endpoint.provider, endpoint.provider_settings)`
+
+4. **`endpoint_form.ex`** — Remove the API key input field and validation UI:
+   - Remove the "API Key" text input
+   - Remove the "Validate API Key" button and async validation logic
+   - Model fetching uses `PhoenixKit.Integrations.get_credentials("openrouter")` for the key
+   - Add a notice/link: "Configure your OpenRouter API key in Settings → Integrations"
+   - If no integration is connected, show a warning instead of the form
+
+5. **`validate_api_key/1` in `openrouter_client.ex`** — Still exists but takes the key from integration:
+   ```elixir
+   # Used by the Integrations settings page during "Save & Validate"
+   def validate_api_key(api_key) when is_binary(api_key) do
+     # ... same validation logic, just called from a different place
+   end
+   ```
+
+6. **`phoenix_kit_ai.ex`** — Add:
+   ```elixir
+   @impl PhoenixKit.Module
+   def required_integrations, do: ["openrouter"]
+   ```
+
+7. **`validate_endpoint/1`** — Update to check integration instead of endpoint.api_key:
+   ```elixir
+   defp validate_endpoint(endpoint) do
+     cond do
+       endpoint.model == nil or endpoint.model == "" ->
+         {:error, "Endpoint has no model configured"}
+       not PhoenixKit.Integrations.connected?(endpoint.provider) ->
+         {:error, "No #{endpoint.provider} integration configured"}
+       endpoint.enabled == false ->
+         {:error, "Endpoint is disabled"}
+       true ->
+         {:ok, endpoint}
+     end
+   end
+   ```
+
+8. **DB migration** — Remove `api_key` column from `phoenix_kit_ai_endpoints` (or leave it and stop reading it, to avoid breaking existing data). No new columns needed.
+
+**What stays unchanged in the AI module:**
+- Endpoint CRUD (create, list, update, delete)
+- All generation parameters (temperature, max_tokens, top_p, etc.)
+- Model selection per endpoint
+- Provider settings (http_referer, x_title) per endpoint
+- Request logging and usage tracking
+- Prompt templates and variable substitution
+- The playground, usage dashboard, and all other admin pages
+
+---
+
+## Implementation Order
+
+### Phase 1: Core Foundation
+
+1. **`lib/phoenix_kit/integrations/integrations.ex`** — Context module with Settings-backed CRUD
+2. **`lib/phoenix_kit/integrations/providers.ex`** — Provider registry (start with Google + OpenRouter)
+3. **`lib/phoenix_kit/integrations/oauth.ex`** — Generic OAuth 2.0 flow (authorize, exchange, refresh)
+4. **Update `PhoenixKit.Module`** — Add `required_integrations/0` and `integration_providers/0` optional callbacks
+5. **`lib/phoenix_kit_web/live/settings/integrations.ex`** — Admin settings LiveView
+6. **Update `admin_tabs.ex`** — Register the Integrations subtab
+
+### Phase 2: Migrate Document Creator
+
+7. **Update `google_docs_client.ex`** — Replace OAuth/credential code with `PhoenixKit.Integrations` calls
+8. **Simplify `google_oauth_settings_live.ex`** — Remove OAuth UI, keep folder config only
+9. **Data migration** — Move existing `"document_creator_google_oauth"` credentials to `"integration:google"` (can be done in a mix task or on first access)
+10. **Update module definition** — Add `required_integrations/0`
+
+### Phase 3: Migrate AI Module
+
+11. **Remove `api_key` from endpoint schema** — Stop reading it; optionally drop column in migration
+12. **Update `openrouter_client.ex`** — Resolve API key from `PhoenixKit.Integrations.get_credentials("openrouter")`
+13. **Update `endpoint_form.ex`** — Remove API key input, add link to Integrations settings
+14. **Update `validate_endpoint/1`** — Check integration connection instead of endpoint.api_key
+15. **Update module definition** — Add `required_integrations/0`
+
+### Phase 4: Polish
+
+16. **"Used by" tracking** — Show which modules use each integration on the settings page (computed from `required_integrations/0`, no storage needed)
+17. **Connection health checks** — Periodic validation that tokens/keys still work (result stored in the integration's JSON blob as `last_validated_at` / `validation_status`)
+
+### Phase 5: Usage Logging (Future)
+
+18. **New table: `phoenix_kit_integration_logs`** — Track which module called which integration, when, success/failure, for audit and debugging
+19. **Usage dashboard** — UI showing integration activity over time
+
+---
+
+## File Structure
+
+```
+lib/phoenix_kit/integrations/
+├── integrations.ex          # Context module (public API)
+├── providers.ex             # Provider registry & definitions
+└── oauth.ex                 # Generic OAuth 2.0 flow
+
+lib/phoenix_kit_web/live/settings/
+├── integrations.ex          # LiveView for the Integrations settings tab
+└── integrations.html.heex   # Template
+```
+
+---
+
+## Settings Keys Used
+
+| Key | Content | Module |
+|-----|---------|--------|
+| `"integration:google"` | OAuth creds, tokens, metadata | `"integrations"` |
+| `"integration:openrouter"` | API key, metadata | `"integrations"` |
+| `"integration:anthropic"` | API key, metadata | `"integrations"` |
+| `"integration:openai"` | API key, metadata | `"integrations"` |
+| `"integration:stripe"` | API keys (test+live), metadata | `"integrations"` |
+| `"integration:aws"` | Access key + secret, region | `"integrations"` |
+| etc. | | |
+
+Old key `"document_creator_google_oauth"` is deprecated and migrated to `"integration:google"`.
+
+---
+
+## Security Note
+
+Currently, **all settings (including OAuth tokens and API keys) are stored as plaintext** in the database. This is an existing condition — the document creator already stores Google OAuth tokens this way, and user-login OAuth credentials (google client_id/secret) are stored as plaintext string settings.
+
+Adding encryption is out of scope for this plan but is a natural follow-up. The Integrations API provides a clean abstraction boundary — if encryption is added later, it only needs to change inside `PhoenixKit.Integrations` (encrypt on write, decrypt on read) without affecting any consuming modules.
+
+---
+
+## Research Summary
+
+### How Integration Platforms Do It
+
+Every major platform (n8n, Nango, Zapier) uses the **encrypted JSON blob** pattern:
+- One storage record per integration, credentials as JSON
+- Auth type discriminator tells the app how to interpret the blob
+- Application code defines field shapes, not the DB schema
+- Token refresh tracking in application layer
+
+Our approach matches this — we just use the existing Settings table instead of a dedicated credentials table, which is appropriate for our scale (app-wide integrations, not thousands of per-user connections).
+
+### Service Requirements That Informed the Design
+
+From researching 17+ services:
+- **OAuth tokens expire differently** (30min for HubSpot, 1hr for Google, never for Slack bots) → store `expires_at` and always handle refresh
+- **Some services need a per-connection base URL** (Salesforce `instance_url`, Mailgun region) → store in `metadata`
+- **Some return multiple tokens** (Slack: bot + user) → JSON blob handles arbitrary shapes
+- **API key services vary** (some need org_id, some need domain, some need region) → `metadata` map
+- **Setup credentials vs runtime credentials** are distinct (client_id/secret vs access_token) → both in same blob, distinguished by field names
+- **GitHub Apps use JWT, not refresh tokens** → `auth_type` field allows different refresh strategies
+
+All of these are handled by the flexible JSON blob approach without schema changes.

--- a/lib/phoenix_kit/dashboard/admin_tabs.ex
+++ b/lib/phoenix_kit/dashboard/admin_tabs.ex
@@ -261,6 +261,15 @@ defmodule PhoenixKit.Dashboard.AdminTabs do
         :admin_settings,
         "settings"
       ),
+      admin_subtab(
+        :admin_settings_integrations,
+        "Integrations",
+        "hero-link",
+        "integrations",
+        915,
+        :admin_settings,
+        "settings"
+      ),
       %Tab{
         id: :admin_settings_media,
         label: "Media",

--- a/lib/phoenix_kit/integrations/events.ex
+++ b/lib/phoenix_kit/integrations/events.ex
@@ -1,0 +1,82 @@
+defmodule PhoenixKit.Integrations.Events do
+  @moduledoc """
+  PubSub helpers for broadcasting integration changes in real-time.
+
+  Allows multiple admins viewing the Integrations settings page to see
+  changes immediately without page refresh. Also notifies other LiveViews
+  that depend on integration status (e.g., document creator, AI endpoints).
+
+  ## Topic
+
+  All events are broadcast on the `"phoenix_kit:integrations"` topic.
+
+  ## Events
+
+  - `{:integration_setup_saved, provider_key, data}` — setup credentials saved (client_id/secret, API key, etc.)
+  - `{:integration_connected, provider_key, data}` — OAuth flow completed, integration is now connected
+  - `{:integration_disconnected, provider_key}` — integration was disconnected
+  - `{:integration_validated, provider_key, :ok | {:error, reason}}` — health check completed
+
+  ## Usage
+
+      # Subscribe in a LiveView mount
+      if connected?(socket), do: PhoenixKit.Integrations.Events.subscribe()
+
+      # Handle events
+      def handle_info({:integration_connected, provider_key, _data}, socket) do
+        {:noreply, reload_data(socket)}
+      end
+  """
+
+  alias PhoenixKit.PubSub.Manager
+
+  @topic "phoenix_kit:integrations"
+
+  @doc "Subscribe to all integration change events."
+  @spec subscribe() :: :ok | {:error, term()}
+  def subscribe do
+    Manager.subscribe(@topic)
+  end
+
+  @doc "Broadcast that an integration's setup credentials were saved."
+  @spec broadcast_setup_saved(String.t(), map()) :: :ok
+  def broadcast_setup_saved(provider_key, data) do
+    broadcast({:integration_setup_saved, provider_key, data})
+  end
+
+  @doc "Broadcast that an OAuth integration was connected (tokens obtained)."
+  @spec broadcast_connected(String.t(), map()) :: :ok
+  def broadcast_connected(provider_key, data) do
+    broadcast({:integration_connected, provider_key, data})
+  end
+
+  @doc "Broadcast that an integration was disconnected (tokens removed)."
+  @spec broadcast_disconnected(String.t()) :: :ok
+  def broadcast_disconnected(provider_key) do
+    broadcast({:integration_disconnected, provider_key})
+  end
+
+  @doc "Broadcast that an integration's health check completed."
+  @spec broadcast_validated(String.t(), :ok | {:error, term()}) :: :ok
+  def broadcast_validated(provider_key, status) do
+    broadcast({:integration_validated, provider_key, status})
+  end
+
+  @doc "Broadcast that a new named connection was added for a provider."
+  @spec broadcast_connection_added(String.t(), String.t()) :: :ok
+  def broadcast_connection_added(provider_key, name) do
+    broadcast({:integration_connection_added, provider_key, name})
+  end
+
+  @doc "Broadcast that a named connection was removed from a provider."
+  @spec broadcast_connection_removed(String.t(), String.t()) :: :ok
+  def broadcast_connection_removed(provider_key, name) do
+    broadcast({:integration_connection_removed, provider_key, name})
+  end
+
+  defp broadcast(message) do
+    Manager.broadcast(@topic, message)
+  rescue
+    _ -> :ok
+  end
+end

--- a/lib/phoenix_kit/integrations/integrations.ex
+++ b/lib/phoenix_kit/integrations/integrations.ex
@@ -1,0 +1,768 @@
+defmodule PhoenixKit.Integrations do
+  @moduledoc """
+  Centralized management of external service integrations.
+
+  Stores credentials (OAuth tokens, API keys, bot tokens, etc.) using the
+  existing `PhoenixKit.Settings` system with `value_json` JSONB storage.
+  Each integration is a JSON blob under a key like `"integration:google"`.
+
+  ## Auth types supported
+
+  - `:oauth2` — Google, Microsoft, Slack, etc. (client_id/secret + access/refresh tokens)
+  - `:api_key` — OpenRouter, Stripe, SendGrid, etc. (single API key)
+  - `:key_secret` — AWS, Twilio, etc. (access key + secret key)
+  - `:bot_token` — Telegram, Discord, etc. (single bot token)
+  - `:credentials` — SMTP, databases, etc. (freeform credential map)
+
+  ## Usage
+
+      # Check if a provider is connected
+      PhoenixKit.Integrations.connected?("google")
+
+      # Get credentials for API calls
+      {:ok, creds} = PhoenixKit.Integrations.get_credentials("google")
+      # => %{"access_token" => "ya29...", "token_type" => "Bearer", ...}
+
+      # Make an authenticated request with auto-refresh on 401
+      {:ok, response} = PhoenixKit.Integrations.authenticated_request("google", :get, url)
+  """
+
+  require Logger
+
+  alias PhoenixKit.Integrations.Events
+  alias PhoenixKit.Integrations.OAuth
+  alias PhoenixKit.Integrations.Providers
+  alias PhoenixKit.Settings
+  alias PhoenixKit.Settings.Queries
+
+  @settings_module "integrations"
+
+  # ---------------------------------------------------------------------------
+  # Reading credentials
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Get the full integration data for a provider.
+
+  Returns the entire JSON blob including credentials, status, and metadata.
+  Automatically migrates legacy settings keys (e.g., `"document_creator_google_oauth"`)
+  on first access.
+  """
+  @spec get_integration(String.t()) ::
+          {:ok, map()} | {:error, :not_configured | :invalid_provider_key}
+  def get_integration(provider_key) when is_binary(provider_key) and provider_key != "" do
+    # Check if this looks like a UUID (used when endpoints store the settings UUID)
+    data =
+      if uuid?(provider_key) do
+        Settings.get_json_setting_by_uuid(provider_key)
+      else
+        Settings.get_json_setting(settings_key(provider_key), nil)
+      end
+
+    case data do
+      nil ->
+        # Try legacy migration
+        case maybe_migrate_legacy(provider_key) do
+          {:ok, data} -> {:ok, data}
+          _ -> {:error, :not_configured}
+        end
+
+      %{} = data ->
+        {:ok, data}
+    end
+  end
+
+  def get_integration(_), do: {:error, :invalid_provider_key}
+
+  @doc """
+  Get credentials for a provider, suitable for making API calls.
+
+  Returns the full integration data map. The caller extracts what it needs
+  based on the auth type (e.g., `"access_token"` for OAuth, `"api_key"` for API key).
+  """
+  @spec get_credentials(String.t()) :: {:ok, map()} | {:error, :not_configured | :deleted}
+  def get_credentials(provider_key) when is_binary(provider_key) and provider_key != "" do
+    is_uuid = uuid?(provider_key)
+
+    data =
+      if is_uuid do
+        Settings.get_json_setting_by_uuid(provider_key)
+      else
+        Settings.get_json_setting(settings_key(provider_key), nil)
+      end
+
+    case data do
+      %{} = data when map_size(data) > 0 ->
+        if has_credentials?(data), do: {:ok, data}, else: {:error, :not_configured}
+
+      _ ->
+        if is_uuid do
+          # UUID was provided but not found — the integration was deleted
+          {:error, :deleted}
+        else
+          # If checking a bare provider key, try to find any connected connection
+          {_provider, name} = parse_provider_name(provider_key)
+
+          if name == "default" do
+            find_first_connected(provider_key)
+          else
+            {:error, :not_configured}
+          end
+        end
+    end
+  end
+
+  def get_credentials(_), do: {:error, :not_configured}
+
+  @doc """
+  Check if an integration is connected and has valid credentials.
+  """
+  @spec connected?(String.t()) :: boolean()
+  def connected?(provider_key) when is_binary(provider_key) do
+    case get_credentials(provider_key) do
+      {:ok, _} ->
+        true
+
+      _ ->
+        # If checking a bare provider key (no name), check if ANY connection is connected
+        {_provider, name} = parse_provider_name(provider_key)
+
+        if name == "default" do
+          list_connections(provider_key)
+          |> Enum.any?(fn %{data: data} -> has_credentials?(data) end)
+        else
+          false
+        end
+    end
+  end
+
+  def connected?(_), do: false
+
+  # ---------------------------------------------------------------------------
+  # Setup (saving app-level credentials)
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Save setup credentials for a provider.
+
+  For OAuth providers, this saves client_id/client_secret.
+  For API key providers, this saves the api_key.
+  For bot token providers, this saves the bot_token.
+
+  Merges with existing data to preserve any previously obtained tokens.
+  Sets status to "disconnected" if no runtime credentials exist yet.
+  """
+  @spec save_setup(String.t(), map()) :: {:ok, map()} | {:error, term()}
+  def save_setup(provider_key, attrs) when is_binary(provider_key) and is_map(attrs) do
+    provider = Providers.get(provider_key)
+    existing = Settings.get_json_setting(settings_key(provider_key), %{})
+
+    data =
+      existing
+      |> Map.merge(attrs)
+      |> Map.put("provider", provider_key)
+      |> Map.put("auth_type", provider && Atom.to_string(provider.auth_type))
+      |> maybe_set_status(provider)
+      |> maybe_set_connected_at()
+
+    case save_integration(provider_key, data) do
+      {:ok, saved} = result ->
+        Events.broadcast_setup_saved(provider_key, saved)
+        result
+
+      error ->
+        error
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # OAuth flow
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Build the OAuth authorization URL for a provider.
+  """
+  @spec authorization_url(String.t(), String.t(), String.t() | nil) ::
+          {:ok, String.t()} | {:error, term()}
+  def authorization_url(provider_key, redirect_uri, extra_scopes \\ nil) do
+    with {:ok, provider} <- fetch_provider(provider_key),
+         {:ok, data} <- get_integration(provider_key) do
+      OAuth.authorization_url(provider.oauth_config, data, redirect_uri, extra_scopes)
+    end
+  end
+
+  @doc """
+  Exchange an OAuth authorization code for tokens and save them.
+  """
+  @spec exchange_code(String.t(), String.t(), String.t()) :: {:ok, map()} | {:error, term()}
+  def exchange_code(provider_key, code, redirect_uri) do
+    with {:ok, provider} <- fetch_provider(provider_key),
+         {:ok, data} <- get_integration(provider_key),
+         {:ok, token_data} <- OAuth.exchange_code(provider.oauth_config, data, code, redirect_uri) do
+      # Fetch userinfo if the provider supports it
+      userinfo = fetch_userinfo_safe(provider, token_data["access_token"])
+
+      updated =
+        data
+        |> Map.merge(token_data)
+        |> Map.put("status", "connected")
+        |> Map.put("connected_at", DateTime.utc_now() |> DateTime.to_iso8601())
+        |> Map.put(
+          "scopes",
+          provider.oauth_config[:default_scopes] || provider.oauth_config["default_scopes"]
+        )
+        |> maybe_set_userinfo(userinfo)
+
+      case save_integration(provider_key, updated) do
+        {:ok, saved} = result ->
+          Events.broadcast_connected(provider_key, saved)
+          result
+
+        error ->
+          error
+      end
+    end
+  end
+
+  @doc """
+  Refresh an expired OAuth access token and save the new one.
+  """
+  @spec refresh_access_token(String.t()) :: {:ok, String.t()} | {:error, term()}
+  def refresh_access_token(provider_key) do
+    with {:ok, provider} <- fetch_provider(provider_key),
+         {:ok, data} <- get_integration(provider_key),
+         {:ok, new_token, updated_fields} <-
+           OAuth.refresh_access_token(provider.oauth_config, data) do
+      updated = Map.merge(data, updated_fields)
+      save_integration(provider_key, updated)
+      {:ok, new_token}
+    end
+  end
+
+  @doc """
+  Disconnect an integration (remove tokens, keep setup credentials).
+
+  For OAuth: removes access_token, refresh_token, keeps client_id/client_secret.
+  For API key/bot token: removes the key entirely.
+  """
+  @spec disconnect(String.t()) :: :ok
+  def disconnect(provider_key) when is_binary(provider_key) do
+    case Settings.get_json_setting(settings_key(provider_key), nil) do
+      nil ->
+        :ok
+
+      data ->
+        auth_type = data["auth_type"]
+
+        cleaned =
+          case auth_type do
+            "oauth2" ->
+              data
+              |> Map.take(["provider", "auth_type", "client_id", "client_secret"])
+              |> Map.put("status", "disconnected")
+
+            "key_secret" ->
+              data
+              |> Map.take(["provider", "auth_type", "access_key", "secret_key"])
+              |> Map.put("status", "disconnected")
+
+            _ ->
+              data
+              |> Map.take(["provider", "auth_type"])
+              |> Map.put("status", "disconnected")
+          end
+
+        save_integration(provider_key, cleaned)
+        Events.broadcast_disconnected(provider_key)
+        :ok
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # HTTP helper with auto-refresh
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Make an authenticated HTTP request with automatic token refresh on 401.
+
+  For OAuth providers: adds Bearer token, retries with refreshed token on 401.
+  For API key providers: adds Bearer token from the api_key.
+  For bot token providers: returns credentials for the caller to use directly.
+
+  `opts` are passed through to `Req.request/1`.
+  """
+  @spec authenticated_request(String.t(), atom(), String.t(), keyword()) ::
+          {:ok, Req.Response.t()} | {:error, term()}
+  def authenticated_request(provider_key, method, url, opts \\ []) do
+    with {:ok, data} <- get_credentials(provider_key) do
+      token = resolve_bearer_token(data)
+      opts = put_auth_header(opts, token)
+
+      case do_request(method, url, opts) do
+        {:ok, %{status: 401}} = _unauthorized ->
+          retry_with_refreshed_token(provider_key, data, method, url, opts)
+
+        other ->
+          other
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Listing
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  List all configured integrations (those that have saved data).
+  """
+  @spec list_integrations() :: [map()]
+  def list_integrations do
+    Providers.all()
+    |> Enum.flat_map(fn provider ->
+      list_connections(provider.key)
+      |> Enum.map(fn %{data: data} -> data end)
+    end)
+  end
+
+  @doc """
+  List all known providers.
+  """
+  @spec list_providers() :: [map()]
+  def list_providers do
+    Providers.all()
+  end
+
+  @doc """
+  Returns the settings key for a provider connection.
+
+  Accepts `"google"` (returns default connection key) or
+  `"google:personal"` (returns named connection key).
+
+  ## Examples
+
+      iex> PhoenixKit.Integrations.settings_key("google")
+      "integration:google:default"
+
+      iex> PhoenixKit.Integrations.settings_key("google:personal")
+      "integration:google:personal"
+  """
+  @spec settings_key(String.t()) :: String.t()
+  def settings_key(provider_key) do
+    {provider, name} = parse_provider_name(provider_key)
+    "integration:#{provider}:#{name}"
+  end
+
+  @doc """
+  Lists all connections for a provider.
+
+  Returns a list of `%{uuid: uuid, name: name, data: data}` maps, with "default" first.
+  The `uuid` is the stable identifier for the settings row.
+  """
+  @spec list_connections(String.t()) :: [%{uuid: String.t(), name: String.t(), data: map()}]
+  def list_connections(provider_key) do
+    prefix = "integration:#{provider_key}:"
+
+    connections =
+      Settings.get_json_settings_by_prefix_with_uuid(prefix)
+      |> Enum.map(fn {uuid, key, data} ->
+        name = key |> String.replace_prefix(prefix, "")
+        %{uuid: uuid, name: name, data: data}
+      end)
+
+    # Also check for old non-named key (e.g., "integration:google" without ":default")
+    # and include it as "default" if no default connection exists yet
+    has_default = Enum.any?(connections, fn %{name: name} -> name == "default" end)
+
+    connections =
+      if has_default do
+        connections
+      else
+        old_key = "integration:#{provider_key}"
+
+        case Queries.get_setting_by_key(old_key) do
+          %{uuid: uuid, value_json: data} when is_map(data) and map_size(data) > 0 ->
+            [%{uuid: uuid, name: "default", data: data} | connections]
+
+          _ ->
+            connections
+        end
+      end
+
+    Enum.sort_by(connections, fn %{name: name} -> if name == "default", do: "0", else: name end)
+  end
+
+  @doc """
+  Adds a new named connection for a provider.
+
+  The name can be any string alphanumeric with hyphens (e.g., "company-drive").
+  """
+  @spec add_connection(String.t(), String.t()) :: {:ok, map()} | {:error, term()}
+  def add_connection(provider_key, name) when is_binary(provider_key) and is_binary(name) do
+    name = String.trim(name)
+
+    cond do
+      name == "" ->
+        {:error, :empty_name}
+
+      Settings.get_json_setting(settings_key("#{provider_key}:#{name}"), nil) != nil ->
+        {:error, :already_exists}
+
+      true ->
+        data = %{
+          "provider" => provider_key,
+          "name" => name,
+          "auth_type" => provider_auth_type(provider_key),
+          "status" => "disconnected"
+        }
+
+        save_integration("#{provider_key}:#{name}", data)
+        |> tap(fn
+          {:ok, _} -> Events.broadcast_connection_added(provider_key, name)
+          _ -> :ok
+        end)
+    end
+  end
+
+  @doc """
+  Removes a named connection. The "default" connection cannot be removed.
+  """
+  @spec remove_connection(String.t(), String.t()) :: :ok | {:error, term()}
+  def remove_connection(_provider_key, "default"), do: {:error, :cannot_remove_default}
+
+  def remove_connection(provider_key, name) when is_binary(provider_key) and is_binary(name) do
+    key = settings_key("#{provider_key}:#{name}")
+
+    case Settings.delete_setting(key) do
+      {:ok, _} ->
+        Events.broadcast_connection_removed(provider_key, name)
+        :ok
+
+      {:error, :not_found} ->
+        :ok
+
+      error ->
+        error
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Private
+  # ---------------------------------------------------------------------------
+
+  @uuid_pattern ~r/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+  defp uuid?(str), do: is_binary(str) and Regex.match?(@uuid_pattern, str)
+
+  defp find_first_connected(provider_key) do
+    list_connections(provider_key)
+    |> Enum.find_value({:error, :not_configured}, fn %{data: data} ->
+      if has_credentials?(data), do: {:ok, data}
+    end)
+  end
+
+  defp parse_provider_name(key) do
+    case String.split(key, ":", parts: 2) do
+      [provider, name] when name != "" -> {provider, name}
+      [provider] -> {provider, "default"}
+    end
+  end
+
+  defp provider_auth_type(provider_key) do
+    case Providers.get(provider_key) do
+      %{auth_type: auth_type} -> Atom.to_string(auth_type)
+      nil -> nil
+    end
+  end
+
+  defp save_integration(provider_key, data) do
+    case Settings.update_json_setting_with_module(
+           settings_key(provider_key),
+           data,
+           @settings_module
+         ) do
+      {:ok, _setting} ->
+        {:ok, data}
+
+      {:error, changeset} = error ->
+        Logger.error(
+          "[Integrations] Failed to save integration for #{provider_key}: #{inspect(changeset)}"
+        )
+
+        error
+    end
+  end
+
+  defp fetch_provider(provider_key) do
+    case Providers.get(provider_key) do
+      nil -> {:error, :unknown_provider}
+      provider -> {:ok, provider}
+    end
+  end
+
+  defp fetch_userinfo_safe(provider, access_token) do
+    if provider.oauth_config do
+      case OAuth.fetch_userinfo(provider.oauth_config, access_token) do
+        {:ok, info} -> info
+        _ -> %{}
+      end
+    else
+      %{}
+    end
+  end
+
+  defp maybe_set_userinfo(data, userinfo) do
+    metadata = Map.get(data, "metadata", %{})
+
+    updated_metadata =
+      metadata
+      |> maybe_put("connected_email", userinfo["email"])
+      |> maybe_put("name", userinfo["name"])
+      |> maybe_put("picture", userinfo["picture"])
+
+    data
+    |> Map.put("metadata", updated_metadata)
+    |> maybe_put("external_account_id", userinfo["email"])
+    |> maybe_put("external_account_name", userinfo["name"])
+    |> maybe_put("external_account_name", userinfo["name"])
+  end
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, _key, ""), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
+
+  defp maybe_set_status(data, nil), do: Map.put_new(data, "status", "disconnected")
+
+  defp maybe_set_status(data, provider) do
+    # If already validated as "connected" or "error", keep the status
+    # Only set status on initial save
+    if data["status"] in ["connected", "error"] do
+      data
+    else
+      has_creds =
+        case provider.auth_type do
+          :oauth2 -> has_token?(data)
+          :api_key -> present?(data["api_key"])
+          :bot_token -> present?(data["bot_token"])
+          :key_secret -> present?(data["access_key"])
+          :credentials -> has_custom_creds?(data)
+        end
+
+      cond do
+        # OAuth with tokens is connected (verified by the OAuth flow itself)
+        provider.auth_type == :oauth2 and has_creds -> Map.put(data, "status", "connected")
+        # Other types with credentials are "configured" until validated
+        has_creds -> Map.put(data, "status", "configured")
+        # No credentials at all
+        true -> Map.put(data, "status", "disconnected")
+      end
+    end
+  end
+
+  defp maybe_set_connected_at(data) do
+    if data["status"] == "connected" and is_nil(data["connected_at"]) do
+      Map.put(data, "connected_at", DateTime.utc_now() |> DateTime.to_iso8601())
+    else
+      data
+    end
+  end
+
+  defp has_credentials?(%{"status" => status}) when status in ["connected", "configured"],
+    do: true
+
+  defp has_credentials?(data),
+    do:
+      present?(data["access_token"]) or present?(data["api_key"]) or present?(data["bot_token"]) or
+        present?(data["access_key"]) or has_custom_creds?(data)
+
+  defp has_custom_creds?(%{"credentials" => creds}) when is_map(creds) and map_size(creds) > 0,
+    do: true
+
+  defp has_custom_creds?(_), do: false
+
+  defp present?(val), do: is_binary(val) and val != ""
+
+  defp has_token?(data), do: present?(data["access_token"])
+
+  defp resolve_bearer_token(data) do
+    data["access_token"] || data["api_key"] || data["bot_token"] || ""
+  end
+
+  defp put_auth_header(opts, token) do
+    headers =
+      opts
+      |> Keyword.get(:headers, [])
+      |> Enum.reject(fn {k, _} -> String.downcase(to_string(k)) == "authorization" end)
+
+    headers = [{"authorization", "Bearer #{token}"} | headers]
+    Keyword.put(opts, :headers, headers)
+  end
+
+  defp do_request(method, url, opts) do
+    Req.request([method: method, url: url] ++ opts)
+  end
+
+  defp retry_with_refreshed_token(provider_key, data, method, url, opts) do
+    if data["auth_type"] == "oauth2" and is_binary(data["refresh_token"]) and
+         data["refresh_token"] != "" do
+      case refresh_access_token(provider_key) do
+        {:ok, new_token} ->
+          opts = put_auth_header(opts, new_token)
+          do_request(method, url, opts)
+
+        {:error, reason} ->
+          Logger.warning(
+            "[Integrations] Token refresh failed for #{provider_key}: #{inspect(reason)}"
+          )
+
+          {:error, :token_refresh_failed}
+      end
+    else
+      Logger.warning("[Integrations] 401 for #{provider_key} but no refresh_token available")
+      {:error, :unauthorized}
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Legacy migration
+  # ---------------------------------------------------------------------------
+
+  # Map of legacy settings keys to provider keys.
+  # When a provider is accessed for the first time and has no data,
+  # we check if there's legacy data under old keys and migrate it.
+  @legacy_keys %{
+    "google" => "document_creator_google_oauth"
+  }
+
+  defp maybe_migrate_legacy(provider_key) do
+    {base_provider, _name} = parse_provider_name(provider_key)
+
+    # Check module-specific legacy key (e.g., "document_creator_google_oauth")
+    module_legacy_key = Map.get(@legacy_keys, base_provider)
+
+    # Also check old single-connection format (e.g., "integration:google")
+    old_format_key = "integration:#{base_provider}"
+
+    cond do
+      # Try module-specific legacy key first
+      module_legacy_key && has_legacy_data?(module_legacy_key) ->
+        do_migrate_legacy(base_provider, Settings.get_json_setting(module_legacy_key, %{}))
+
+      # Try old format without name
+      has_legacy_data?(old_format_key) ->
+        data = Settings.get_json_setting(old_format_key, %{})
+        save_integration(provider_key, data)
+
+      true ->
+        :skip
+    end
+  rescue
+    e ->
+      Logger.warning(
+        "[Integrations] Legacy migration failed for #{provider_key}: #{Exception.message(e)}"
+      )
+
+      :skip
+  end
+
+  defp has_legacy_data?(key) do
+    case Settings.get_json_setting(key, nil) do
+      data when is_map(data) and map_size(data) > 0 -> true
+      _ -> false
+    end
+  end
+
+  defp do_migrate_legacy("google", legacy_data) do
+    data = %{
+      "provider" => "google",
+      "auth_type" => "oauth2",
+      "client_id" => legacy_data["client_id"],
+      "client_secret" => legacy_data["client_secret"],
+      "access_token" => legacy_data["access_token"],
+      "refresh_token" => legacy_data["refresh_token"],
+      "token_type" => legacy_data["token_type"] || "Bearer",
+      "token_obtained_at" => legacy_data["token_obtained_at"],
+      "status" =>
+        if(is_binary(legacy_data["access_token"]) and legacy_data["access_token"] != "",
+          do: "connected",
+          else: "disconnected"
+        ),
+      "external_account_id" => legacy_data["connected_email"],
+      "metadata" => %{
+        "connected_email" => legacy_data["connected_email"]
+      }
+    }
+
+    # Compute expires_at from legacy expires_in if available
+    data =
+      with expires_in when is_integer(expires_in) <- legacy_data["expires_in"],
+           obtained_at when is_binary(obtained_at) <- legacy_data["token_obtained_at"],
+           {:ok, dt, _} <- DateTime.from_iso8601(obtained_at) do
+        Map.put(
+          data,
+          "expires_at",
+          dt |> DateTime.add(expires_in, :second) |> DateTime.to_iso8601()
+        )
+      else
+        _ -> data
+      end
+
+    # Set connected_at
+    data =
+      if data["status"] == "connected" do
+        Map.put(
+          data,
+          "connected_at",
+          legacy_data["token_obtained_at"] || DateTime.utc_now() |> DateTime.to_iso8601()
+        )
+      else
+        data
+      end
+
+    # Save the integration — if this fails, return :skip so caller gets :not_configured
+    case save_integration("google", data) do
+      {:ok, saved_data} ->
+        # Best-effort: move folder config to its own key
+        migrate_legacy_folders(legacy_data)
+
+        Logger.info(
+          "[Integrations] Migrated legacy 'document_creator_google_oauth' → 'integration:google'"
+        )
+
+        {:ok, saved_data}
+
+      {:error, reason} ->
+        Logger.warning("[Integrations] Legacy migration save failed: #{inspect(reason)}")
+        :skip
+    end
+  end
+
+  defp do_migrate_legacy(_provider_key, _legacy_data), do: :skip
+
+  defp migrate_legacy_folders(legacy_data) do
+    folder_fields = ~w(
+      folder_path_templates folder_name_templates
+      folder_path_documents folder_name_documents
+      folder_path_deleted folder_name_deleted
+      templates_folder_id documents_folder_id
+      deleted_templates_folder_id deleted_documents_folder_id
+    )
+
+    folder_data = Map.take(legacy_data, folder_fields)
+
+    if map_size(folder_data) > 0 do
+      case Settings.update_json_setting_with_module(
+             "document_creator_folders",
+             folder_data,
+             "document_creator"
+           ) do
+        {:ok, _} ->
+          :ok
+
+        {:error, reason} ->
+          Logger.warning(
+            "[Integrations] Legacy migration: failed to save folder config: #{inspect(reason)}"
+          )
+      end
+    end
+  end
+end

--- a/lib/phoenix_kit/integrations/oauth.ex
+++ b/lib/phoenix_kit/integrations/oauth.ex
@@ -1,0 +1,190 @@
+defmodule PhoenixKit.Integrations.OAuth do
+  @moduledoc """
+  Generic OAuth 2.0 flow for service integrations.
+
+  Handles authorization URL generation, code-to-token exchange,
+  token refresh, and userinfo fetching. Provider-specific details
+  (URLs, scopes, extra params) come from the provider definition
+  in `PhoenixKit.Integrations.Providers`.
+  """
+
+  require Logger
+
+  @doc """
+  Build the OAuth authorization URL for a provider.
+
+  Requires `client_id` to be present in the integration data and
+  the provider to have `oauth_config` with an `auth_url`.
+  """
+  @spec authorization_url(map(), map(), String.t(), String.t() | nil) ::
+          {:ok, String.t()} | {:error, atom()}
+  def authorization_url(oauth_config, integration_data, redirect_uri, extra_scopes \\ nil) do
+    client_id = integration_data["client_id"]
+
+    if is_binary(client_id) and client_id != "" do
+      scopes =
+        extra_scopes || oauth_config[:default_scopes] || oauth_config["default_scopes"] || ""
+
+      params =
+        %{
+          "client_id" => client_id,
+          "redirect_uri" => redirect_uri,
+          "response_type" => "code",
+          "scope" => scopes
+        }
+        |> Map.merge(oauth_config[:auth_params] || oauth_config["auth_params"] || %{})
+
+      url = "#{oauth_config[:auth_url] || oauth_config["auth_url"]}?#{URI.encode_query(params)}"
+      {:ok, url}
+    else
+      {:error, :client_id_not_configured}
+    end
+  end
+
+  @doc """
+  Exchange an authorization code for access and refresh tokens.
+  """
+  @spec exchange_code(map(), map(), String.t(), String.t()) ::
+          {:ok, map()} | {:error, term()}
+  def exchange_code(oauth_config, integration_data, code, redirect_uri) do
+    with {:ok, client_id, client_secret} <- validate_client_credentials(integration_data) do
+      token_url = oauth_config[:token_url] || oauth_config["token_url"]
+
+      token_url
+      |> post_token_request(
+        code: code,
+        client_id: client_id,
+        client_secret: client_secret,
+        redirect_uri: redirect_uri,
+        grant_type: "authorization_code"
+      )
+      |> handle_token_response(integration_data)
+    end
+  end
+
+  @doc """
+  Refresh an expired access token using the refresh token.
+  """
+  @spec refresh_access_token(map(), map()) :: {:ok, String.t(), map()} | {:error, term()}
+  def refresh_access_token(oauth_config, integration_data) do
+    refresh_token = integration_data["refresh_token"]
+
+    if is_binary(refresh_token) and refresh_token != "" do
+      with {:ok, client_id, client_secret} <- validate_client_credentials(integration_data) do
+        token_url = oauth_config[:token_url] || oauth_config["token_url"]
+
+        case post_token_request(token_url,
+               refresh_token: refresh_token,
+               client_id: client_id,
+               client_secret: client_secret,
+               grant_type: "refresh_token"
+             ) do
+          {:ok, %{status: 200, body: %{"access_token" => new_token} = body}} ->
+            updated_fields = %{
+              "access_token" => new_token,
+              "expires_at" => compute_expires_at(body["expires_in"]),
+              "token_obtained_at" => DateTime.utc_now() |> DateTime.to_iso8601()
+            }
+
+            {:ok, new_token, updated_fields}
+
+          {:ok, %{status: status}} ->
+            log_token_error("Token refresh failed", status)
+            {:error, {:refresh_failed, status}}
+
+          {:error, reason} ->
+            Logger.warning("[Integrations.OAuth] Token refresh error: #{inspect(reason)}")
+            {:error, reason}
+        end
+      end
+    else
+      {:error, :no_refresh_token}
+    end
+  end
+
+  @doc """
+  Fetch user info from the provider's userinfo endpoint.
+
+  Returns a map with at least `"email"` if available.
+  """
+  @spec fetch_userinfo(map(), String.t()) :: {:ok, map()} | {:error, term()}
+  def fetch_userinfo(oauth_config, access_token) do
+    userinfo_url = oauth_config[:userinfo_url] || oauth_config["userinfo_url"]
+
+    if is_binary(userinfo_url) and userinfo_url != "" do
+      case Req.get(userinfo_url, headers: [{"authorization", "Bearer #{access_token}"}]) do
+        {:ok, %{status: 200, body: body}} when is_map(body) ->
+          {:ok, body}
+
+        {:ok, %{status: status}} ->
+          Logger.warning("[Integrations.OAuth] Userinfo request returned status #{status}")
+          {:error, {:userinfo_failed, status}}
+
+        {:error, reason} ->
+          Logger.warning("[Integrations.OAuth] Userinfo request failed: #{inspect(reason)}")
+          {:error, reason}
+      end
+    else
+      {:ok, %{}}
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Helpers
+  # ---------------------------------------------------------------------------
+
+  defp compute_expires_at(nil), do: nil
+
+  defp compute_expires_at(expires_in) when is_integer(expires_in) do
+    DateTime.utc_now()
+    |> DateTime.add(expires_in, :second)
+    |> DateTime.to_iso8601()
+  end
+
+  defp compute_expires_at(_), do: nil
+
+  defp validate_client_credentials(data) do
+    client_id = data["client_id"]
+    client_secret = data["client_secret"]
+
+    if is_binary(client_id) and client_id != "" and
+         is_binary(client_secret) and client_secret != "" do
+      {:ok, client_id, client_secret}
+    else
+      {:error, :client_credentials_not_configured}
+    end
+  end
+
+  defp post_token_request(url, form_params) do
+    Req.post(url, form: form_params)
+  end
+
+  defp handle_token_response(
+         {:ok, %{status: 200, body: %{"access_token" => _} = body}},
+         integration_data
+       ) do
+    token_data = %{
+      "access_token" => body["access_token"],
+      "refresh_token" => body["refresh_token"] || integration_data["refresh_token"],
+      "token_type" => body["token_type"] || "Bearer",
+      "expires_at" => compute_expires_at(body["expires_in"]),
+      "token_obtained_at" => DateTime.utc_now() |> DateTime.to_iso8601()
+    }
+
+    {:ok, token_data}
+  end
+
+  defp handle_token_response({:ok, %{status: status}}, _integration_data) do
+    log_token_error("Token exchange failed", status)
+    {:error, {:token_exchange_failed, status}}
+  end
+
+  defp handle_token_response({:error, reason}, _integration_data) do
+    Logger.warning("[Integrations.OAuth] Token exchange error: #{inspect(reason)}")
+    {:error, reason}
+  end
+
+  defp log_token_error(message, status) do
+    Logger.warning("[Integrations.OAuth] #{message}: status=#{status}")
+  end
+end

--- a/lib/phoenix_kit/integrations/providers.ex
+++ b/lib/phoenix_kit/integrations/providers.ex
@@ -1,0 +1,282 @@
+defmodule PhoenixKit.Integrations.Providers do
+  @moduledoc """
+  Registry of known integration providers.
+
+  Each provider definition describes how to connect to an external service:
+  what auth type it uses, what fields the admin needs to fill in, and
+  how to validate the connection.
+
+  Providers are defined in code, not in the database. New providers are
+  added here as needed. External modules can also contribute providers
+  via the `integration_providers/0` callback on `PhoenixKit.Module`.
+  """
+
+  require Logger
+
+  alias PhoenixKit.ModuleRegistry
+
+  @type auth_type :: :oauth2 | :api_key | :key_secret | :bot_token | :credentials
+
+  @type setup_field :: %{
+          key: String.t(),
+          label: String.t(),
+          type: :text | :password | :textarea | :number | :select,
+          required: boolean(),
+          placeholder: String.t(),
+          help: String.t() | nil,
+          options: [%{value: String.t(), label: String.t()}] | nil
+        }
+
+  @type provider :: %{
+          key: String.t(),
+          name: String.t(),
+          description: String.t(),
+          icon: String.t(),
+          auth_type: auth_type(),
+          oauth_config: map() | nil,
+          setup_fields: [setup_field()],
+          capabilities: [atom()]
+        }
+
+  @doc """
+  Returns all known providers, including those contributed by external modules.
+  """
+  @spec all() :: [provider()]
+  def all do
+    builtin_providers() ++ external_providers()
+  end
+
+  @doc """
+  Look up a single provider by key.
+
+  Accepts both plain keys (`"google"`) and named keys (`"google:personal"`) —
+  the name is stripped before lookup since provider definitions are per-type.
+  """
+  @spec get(String.t()) :: provider() | nil
+  def get(key) when is_binary(key) do
+    # Strip name if present (e.g., "google:personal" -> "google")
+    base_key =
+      case String.split(key, ":", parts: 2) do
+        [base, _name] -> base
+        [base] -> base
+      end
+
+    Enum.find(all(), fn p -> p.key == base_key end)
+  end
+
+  # ---------------------------------------------------------------------------
+  # Built-in provider definitions
+  # ---------------------------------------------------------------------------
+
+  defp builtin_providers do
+    [
+      google(),
+      openrouter()
+    ]
+  end
+
+  defp google do
+    %{
+      key: "google",
+      name: "Google",
+      description: "Google Docs, Drive, Calendar, Sheets, Gmail",
+      icon: "hero-cloud",
+      auth_type: :oauth2,
+      oauth_config: %{
+        auth_url: "https://accounts.google.com/o/oauth2/v2/auth",
+        token_url: "https://oauth2.googleapis.com/token",
+        userinfo_url: "https://www.googleapis.com/oauth2/v2/userinfo",
+        default_scopes:
+          "openid email profile https://www.googleapis.com/auth/drive https://www.googleapis.com/auth/documents",
+        auth_params: %{"access_type" => "offline", "prompt" => "consent"}
+      },
+      setup_fields: [
+        %{
+          key: "client_id",
+          label: "Client ID",
+          type: :text,
+          required: true,
+          placeholder: "xxxxx.apps.googleusercontent.com",
+          help: "From Google Cloud Console → APIs & Services → Credentials",
+          options: nil
+        },
+        %{
+          key: "client_secret",
+          label: "Client Secret",
+          type: :password,
+          required: true,
+          placeholder: "GOCSPX-...",
+          help: nil,
+          options: nil
+        }
+      ],
+      capabilities: [:google_docs, :google_drive, :google_calendar, :google_sheets],
+      instructions: [
+        %{
+          title: "Create a Google Cloud project",
+          steps: [
+            {"Go to the [Google Cloud Console](https://console.cloud.google.com)", nil},
+            {"Create a new project or select an existing one", nil}
+          ]
+        },
+        %{
+          title: "Enable required APIs",
+          steps: [
+            {"Go to [APIs & Services → Library](https://console.cloud.google.com/apis/library)",
+             nil},
+            {"Search for **Google Drive API**, click it, then click **Enable**", nil},
+            {"Go back to the Library and search for **Google Docs API**, click it, then click **Enable**",
+             nil}
+          ],
+          note:
+            "Drive API handles file listing, creation, copying, and PDF export. Docs API is used for reading document content and substituting template variables."
+        },
+        %{
+          title: "Set up OAuth consent",
+          steps: [
+            {"Go to [Branding](https://console.cloud.google.com/auth/branding) in the sidebar — fill in the **App name** and **User support email**, then save",
+             nil},
+            {"Go to [Audience](https://console.cloud.google.com/auth/audience) — set user type to **External** (or Internal for Google Workspace)",
+             nil},
+            {"Still on Audience — while the app is in **Testing** status, add the Google account you will connect as a **Test user** (this must be the same account whose Drive will store your files)",
+             nil},
+            {"Go to [Data Access](https://console.cloud.google.com/auth/scopes) — click **Add or Remove Scopes** and add the Drive and Docs scopes. This step may not be required — the app requests the needed scopes at connect time regardless.",
+             nil}
+          ],
+          note:
+            "Navigate to the OAuth section using the search bar or the hamburger menu: search for \"OAuth\", or go to the sidebar: **APIs & Services → OAuth consent screen**. This opens a different section with its own sidebar."
+        },
+        %{
+          title: "Create an OAuth Client",
+          steps: [
+            {"Go to [APIs & Services → Credentials](https://console.cloud.google.com/apis/credentials)",
+             nil},
+            {"Click **Create Credentials → OAuth client ID**", nil},
+            {"Application type: **Web application** (do not select \"Desktop app\" — it won't support redirect URIs)",
+             nil},
+            {"Under **Authorized redirect URIs**, add: `{redirect_uri}`", nil},
+            {"Copy the **Client ID** and **Client Secret** into the form above", nil}
+          ]
+        },
+        %{
+          title: "Connect and authorize",
+          steps: [
+            {"Click **Save**, then **Connect Account**", nil},
+            {"Google will show an \"unverified app\" warning — click **Advanced → Go to (app name)** to proceed",
+             nil},
+            {"Grant access to Google Docs and Google Drive", nil},
+            {"You'll be redirected back here once connected", nil}
+          ]
+        }
+      ]
+    }
+  end
+
+  defp openrouter do
+    %{
+      key: "openrouter",
+      name: "OpenRouter",
+      description: "AI model access via OpenRouter (100+ models)",
+      icon: "hero-sparkles",
+      auth_type: :api_key,
+      oauth_config: nil,
+      validation: %{
+        url: "https://openrouter.ai/api/v1/auth/key",
+        method: :get,
+        auth_header: "Authorization",
+        auth_prefix: "Bearer "
+      },
+      setup_fields: [
+        %{
+          key: "api_key",
+          label: "API Key",
+          type: :password,
+          required: true,
+          placeholder: "sk-or-v1-...",
+          help: "From openrouter.ai/keys",
+          options: nil
+        }
+      ],
+      capabilities: [:ai_completions, :ai_embeddings],
+      instructions: [
+        %{
+          title: "Create an OpenRouter account",
+          steps: [
+            {"Go to [openrouter.ai](https://openrouter.ai) and sign up or log in", nil},
+            {"Navigate to [Keys](https://openrouter.ai/keys)", nil}
+          ]
+        },
+        %{
+          title: "Create an API key",
+          steps: [
+            {"Click **Create Key**", nil},
+            {"Give it a name (e.g., your app name)", nil},
+            {"Copy the key and paste it into the form above", nil}
+          ]
+        },
+        %{
+          title: "Add credits (optional)",
+          steps: [
+            {"Some models are free, but most require credits", nil},
+            {"Go to [Credits](https://openrouter.ai/credits) to add funds", nil}
+          ]
+        }
+      ]
+    }
+  end
+
+  # ---------------------------------------------------------------------------
+  # External module provider contributions
+  # ---------------------------------------------------------------------------
+
+  defp external_providers do
+    ModuleRegistry.all_modules()
+    |> Enum.flat_map(fn mod ->
+      if Code.ensure_loaded?(mod) and function_exported?(mod, :integration_providers, 0) do
+        try do
+          mod.integration_providers()
+        rescue
+          e ->
+            Logger.warning(
+              "[Integrations.Providers] #{inspect(mod)}.integration_providers/0 failed: #{Exception.message(e)}"
+            )
+
+            []
+        end
+      else
+        []
+      end
+    end)
+  end
+
+  @doc """
+  Returns a map of provider_key => [module_name] showing which modules use each integration.
+  """
+  @spec used_by_modules() :: %{String.t() => [String.t()]}
+  def used_by_modules do
+    ModuleRegistry.all_modules()
+    |> Enum.reduce(%{}, fn mod, acc ->
+      if Code.ensure_loaded?(mod) and function_exported?(mod, :required_integrations, 0) do
+        try do
+          integrations = mod.required_integrations()
+
+          module_name =
+            if function_exported?(mod, :module_name, 0), do: mod.module_name(), else: inspect(mod)
+
+          Enum.reduce(integrations, acc, fn key, inner_acc ->
+            Map.update(inner_acc, key, [module_name], &[module_name | &1])
+          end)
+        rescue
+          e ->
+            Logger.warning(
+              "[Integrations.Providers] #{inspect(mod)}.required_integrations/0 failed: #{Exception.message(e)}"
+            )
+
+            acc
+        end
+      else
+        acc
+      end
+    end)
+  end
+end

--- a/lib/phoenix_kit/module.ex
+++ b/lib/phoenix_kit/module.ex
@@ -80,6 +80,9 @@ defmodule PhoenixKit.Module do
   - `migration_module/0` - Module implementing versioned migrations (default: `nil`).
     When set, `mix phoenix_kit.update` will automatically run this module's migrations
     alongside the core PhoenixKit migrations.
+  - `required_integrations/0` - Integration provider keys this module needs (default: `[]`).
+    Used by the Integrations settings page to show relevant providers.
+  - `integration_providers/0` - Additional provider definitions this module contributes (default: `[]`).
   """
 
   @typedoc "Permission metadata for the module"
@@ -108,6 +111,8 @@ defmodule PhoenixKit.Module do
   @callback version() :: String.t()
   @callback migration_module() :: module() | nil
   @callback required_modules() :: [String.t()]
+  @callback required_integrations() :: [String.t()]
+  @callback integration_providers() :: [map()]
 
   @doc """
   Returns the OTP app name for Tailwind CSS source scanning.
@@ -135,6 +140,8 @@ defmodule PhoenixKit.Module do
     version: 0,
     migration_module: 0,
     required_modules: 0,
+    required_integrations: 0,
+    integration_providers: 0,
     css_sources: 0
   ]
 
@@ -179,6 +186,12 @@ defmodule PhoenixKit.Module do
       def required_modules, do: []
 
       @impl PhoenixKit.Module
+      def required_integrations, do: []
+
+      @impl PhoenixKit.Module
+      def integration_providers, do: []
+
+      @impl PhoenixKit.Module
       def css_sources, do: []
 
       defoverridable get_config: 0,
@@ -191,6 +204,8 @@ defmodule PhoenixKit.Module do
                      version: 0,
                      migration_module: 0,
                      required_modules: 0,
+                     required_integrations: 0,
+                     integration_providers: 0,
                      css_sources: 0
     end
   end

--- a/lib/phoenix_kit/settings/queries.ex
+++ b/lib/phoenix_kit/settings/queries.ex
@@ -28,6 +28,13 @@ defmodule PhoenixKit.Settings.Queries do
     repo().get_by(Setting, key: key)
   end
 
+  @doc """
+  Gets a setting record by UUID.
+  """
+  def get_setting_by_uuid(uuid) when is_binary(uuid) do
+    repo().get(Setting, uuid)
+  end
+
   # Multiple records queries
 
   @doc """
@@ -106,6 +113,33 @@ defmodule PhoenixKit.Settings.Queries do
       value = if setting.value_json, do: setting.value_json, else: setting.value
       {setting.key, value}
     end)
+  end
+
+  @doc """
+  Lists settings whose keys start with the given prefix.
+
+  ## Examples
+
+      iex> PhoenixKit.Settings.Queries.list_settings_by_key_prefix("integration:google:")
+      [%Setting{key: "integration:google:default", ...}, %Setting{key: "integration:google:personal", ...}]
+  """
+  def list_settings_by_key_prefix(prefix) when is_binary(prefix) do
+    like_pattern = prefix <> "%"
+
+    Setting
+    |> where([s], like(s.key, ^like_pattern))
+    |> order_by([s], s.key)
+    |> repo().all()
+  end
+
+  @doc """
+  Deletes a setting by key. Returns `{:ok, setting}` or `{:error, :not_found}`.
+  """
+  def delete_setting_by_key(key) when is_binary(key) do
+    case get_setting_by_key(key) do
+      nil -> {:error, :not_found}
+      setting -> repo().delete(setting)
+    end
   end
 
   # Write operations

--- a/lib/phoenix_kit/settings/settings.ex
+++ b/lib/phoenix_kit/settings/settings.ex
@@ -546,6 +546,58 @@ defmodule PhoenixKit.Settings do
   end
 
   @doc """
+  Lists all JSON settings whose keys start with the given prefix.
+
+  Returns a list of `{key, json_value}` tuples.
+  """
+  def get_json_settings_by_prefix(prefix) when is_binary(prefix) do
+    prefix
+    |> Queries.list_settings_by_key_prefix()
+    |> Enum.flat_map(fn setting ->
+      if setting.value_json, do: [{setting.key, setting.value_json}], else: []
+    end)
+  end
+
+  @doc """
+  Lists all JSON settings whose keys start with the given prefix,
+  including the setting UUID. Returns a list of `{uuid, key, json_value}` tuples.
+  """
+  def get_json_settings_by_prefix_with_uuid(prefix) when is_binary(prefix) do
+    prefix
+    |> Queries.list_settings_by_key_prefix()
+    |> Enum.flat_map(fn setting ->
+      if setting.value_json,
+        do: [{setting.uuid, setting.key, setting.value_json}],
+        else: []
+    end)
+  end
+
+  @doc """
+  Gets a JSON setting by its UUID. Returns the `value_json` map or the default.
+  """
+  def get_json_setting_by_uuid(uuid, default \\ nil) when is_binary(uuid) do
+    case Queries.get_setting_by_uuid(uuid) do
+      %Setting{value_json: value_json} when not is_nil(value_json) -> value_json
+      _ -> default
+    end
+  end
+
+  @doc """
+  Deletes a setting by key. Returns `{:ok, setting}` or `{:error, :not_found}`.
+  Also invalidates the cache for the key.
+  """
+  def delete_setting(key) when is_binary(key) do
+    result = Queries.delete_setting_by_key(key)
+
+    case result do
+      {:ok, _} -> PhoenixKit.Cache.invalidate(@cache_name, key)
+      _ -> :ok
+    end
+
+    result
+  end
+
+  @doc """
   Gets OAuth credentials for a specific provider.
 
   Returns a map with all credentials for the given provider.

--- a/lib/phoenix_kit_web.ex
+++ b/lib/phoenix_kit_web.ex
@@ -144,6 +144,7 @@ defmodule PhoenixKitWeb do
       import PhoenixKitWeb.Components.Core.DevNotice
       import PhoenixKitWeb.Components.Core.PhoenixKitGlobals
       import PhoenixKitWeb.Components.Core.NavTabs
+      import PhoenixKitWeb.Components.Core.IntegrationPicker
     end
   end
 

--- a/lib/phoenix_kit_web/components/core/integration_picker.ex
+++ b/lib/phoenix_kit_web/components/core/integration_picker.ex
@@ -1,0 +1,300 @@
+defmodule PhoenixKitWeb.Components.Core.IntegrationPicker do
+  @moduledoc """
+  Reusable integration connection picker component.
+
+  Displays integration connections as clickable cards in a modal or inline grid.
+  Supports single and multi-select modes, search, and provider filtering.
+
+  ## Examples
+
+      <%-- Single select, one provider --%>
+      <.integration_picker
+        id="google-picker"
+        connections={@all_connections}
+        selected={[@selected_uuid]}
+        provider="google"
+        on_select="select_integration"
+      />
+
+      <%-- Multi-select, all providers, with search --%>
+      <.integration_picker
+        id="multi-picker"
+        connections={@all_connections}
+        selected={@selected_uuids}
+        multiple={true}
+        searchable={true}
+        on_select="update_integrations"
+      />
+
+      <%-- Single select, all providers --%>
+      <.integration_picker
+        id="any-picker"
+        connections={@all_connections}
+        selected={[@selected_uuid]}
+        on_select="pick_integration"
+      />
+
+  The parent LiveView is responsible for loading connections via
+  `PhoenixKit.Integrations.list_connections/1` or building the list
+  from `PhoenixKit.Integrations.Providers.all/0`.
+
+  ## Events
+
+  The component sends the `on_select` event with:
+  - Single mode: `%{"uuid" => uuid}` when a card is clicked
+  - Multi mode: `%{"uuid" => uuid, "action" => "add" | "remove"}` when toggled
+  """
+
+  use Phoenix.Component
+  use Gettext, backend: PhoenixKitWeb.Gettext
+
+  import PhoenixKitWeb.Components.Core.Icon, only: [icon: 1]
+
+  @doc """
+  Renders an integration picker as a grid of cards.
+
+  ## Attributes
+
+  * `id` - Unique element ID (required)
+  * `connections` - List of connection maps from `Integrations.list_connections/1`.
+    Each map must have `:uuid`, `:name`, `:data` keys, and optionally `:provider`
+    (a provider definition map with `:name`, `:icon`, `:key`).
+  * `selected` - List of currently selected UUIDs (default: [])
+  * `provider` - Filter to only show connections for this provider key (optional)
+  * `multiple` - Allow multiple selection (default: false)
+  * `searchable` - Show search input (default: false, auto-enabled when > 6 connections)
+  * `compact` - Use compact card layout (default: false)
+  * `on_select` - Event name sent to parent on selection (required)
+  * `empty_url` - URL for "Add Integration" link shown when no connections exist (optional)
+  * `class` - Additional CSS classes for the wrapper (optional)
+  """
+  attr :id, :string, required: true
+  attr :connections, :list, required: true
+  attr :selected, :list, default: []
+  attr :provider, :string, default: nil
+  attr :multiple, :boolean, default: false
+  attr :searchable, :any, default: nil
+  attr :compact, :boolean, default: false
+  attr :on_select, :string, required: true
+  attr :empty_url, :string, default: nil
+  attr :class, :string, default: ""
+  attr :search, :string, default: ""
+
+  def integration_picker(assigns) do
+    connections =
+      assigns.connections
+      |> filter_by_provider(assigns.provider)
+      |> filter_by_search(assigns.search)
+
+    show_search =
+      case assigns.searchable do
+        nil -> length(assigns.connections) > 6
+        val -> val
+      end
+
+    selected = auto_select(assigns.selected || [], connections)
+    selected_set = MapSet.new(selected)
+    existing_uuids = MapSet.new(Enum.map(connections, & &1.uuid))
+
+    deleted_selections =
+      Enum.filter(selected, fn uuid ->
+        uuid && not MapSet.member?(existing_uuids, uuid)
+      end)
+
+    assigns =
+      assigns
+      |> assign(:filtered_connections, connections)
+      |> assign(:deleted_selections, deleted_selections)
+      |> assign(:show_search, show_search)
+      |> assign(:selected_set, selected_set)
+
+    ~H"""
+    <div id={@id} class={["integration-picker", @class]}>
+      <%!-- Search --%>
+      <div :if={@show_search} class="mb-3">
+        <input
+          type="text"
+          placeholder={gettext("Search integrations...")}
+          value={@search}
+          phx-keyup="integration_picker_search"
+          phx-value-picker-id={@id}
+          class="input input-bordered input-sm w-full"
+        />
+      </div>
+
+      <%!-- Connection cards grid --%>
+      <div
+        :if={@filtered_connections != []}
+        class={[
+          "grid gap-2",
+          if(@compact, do: "grid-cols-1", else: "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3")
+        ]}
+      >
+        <button
+          :for={conn <- @filtered_connections}
+          type="button"
+          phx-click={@on_select}
+          phx-value-uuid={conn.uuid}
+          phx-value-action={select_action(@multiple, conn.uuid, @selected_set)}
+          class={[
+            "card bg-base-100 border text-left transition-all cursor-pointer",
+            "hover:shadow-md hover:border-primary/50",
+            if(MapSet.member?(@selected_set, conn.uuid),
+              do: "border-primary ring-2 ring-primary/20",
+              else: "border-base-300"
+            )
+          ]}
+        >
+          <div class={["card-body", if(@compact, do: "p-3", else: "p-4")]}>
+            <div class="flex items-center gap-3">
+              <%!-- Provider icon --%>
+              <span
+                :if={is_map(conn[:provider]) && conn.provider[:icon]}
+                class="w-8 h-8 flex items-center justify-center bg-base-200 rounded-lg shrink-0"
+              >
+                <.icon name={conn.provider.icon} class="w-4 h-4" />
+              </span>
+
+              <div class="flex-1 min-w-0">
+                <%!-- Connection name --%>
+                <div class="flex items-center gap-2">
+                  <span class="font-medium truncate">
+                    {if conn.name == "default",
+                      do:
+                        if(is_map(conn[:provider]),
+                          do: conn.provider.name,
+                          else: conn.data["provider"] || gettext("Default")
+                        ),
+                      else: conn.name}
+                  </span>
+                  <span
+                    :if={conn.name != "default" && is_map(conn[:provider])}
+                    class="badge badge-ghost badge-xs shrink-0"
+                  >
+                    {conn.provider.name}
+                  </span>
+                </div>
+
+                <%!-- Account info --%>
+                <p
+                  :if={conn.data["external_account_id"]}
+                  class="text-xs text-base-content/60 truncate"
+                >
+                  {conn.data["external_account_id"]}
+                </p>
+              </div>
+
+              <%!-- Status + selection indicator --%>
+              <div class="flex items-center gap-2 shrink-0">
+                <span :if={conn.data["status"] == "connected"} class="badge badge-success badge-xs">
+                  {gettext("Connected")}
+                </span>
+                <span
+                  :if={conn.data["status"] != "connected"}
+                  class="badge badge-ghost badge-xs"
+                >
+                  {gettext("Not connected")}
+                </span>
+
+                <%!-- Selection check --%>
+                <span :if={MapSet.member?(@selected_set, conn.uuid)}>
+                  <.icon name="hero-check-circle-solid" class="w-5 h-5 text-primary" />
+                </span>
+              </div>
+            </div>
+          </div>
+        </button>
+      </div>
+
+      <%!-- Deleted integration cards --%>
+      <div
+        :for={deleted_uuid <- @deleted_selections}
+        class="card bg-error/5 border border-error/30 mt-2"
+      >
+        <div class={["card-body", if(@compact, do: "p-3", else: "p-4")]}>
+          <div class="flex items-center gap-3">
+            <div class="w-8 h-8 rounded-lg bg-error/10 flex items-center justify-center shrink-0">
+              <.icon name="hero-exclamation-triangle" class="w-4 h-4 text-error" />
+            </div>
+            <div class="flex-1 min-w-0">
+              <div class="flex items-center gap-2">
+                <span class="font-medium text-error">{gettext("Integration deleted")}</span>
+                <span class="badge badge-error badge-xs">{gettext("Missing")}</span>
+              </div>
+              <p class="text-xs text-base-content/50 truncate">
+                {gettext("The selected integration no longer exists. Please choose a different one.")}
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <%!-- Empty state --%>
+      <div
+        :if={@filtered_connections == [] and @deleted_selections == []}
+        class="text-center py-8 text-base-content/50"
+      >
+        <.icon name="hero-link" class="w-10 h-10 mx-auto mb-2 opacity-40" />
+        <%= if @search != "" do %>
+          <p class="text-sm">{gettext("No integrations match your search.")}</p>
+        <% else %>
+          <p class="text-sm">{gettext("No integrations configured.")}</p>
+          <a
+            :if={@empty_url}
+            href={@empty_url}
+            class="link link-primary text-sm"
+          >
+            {gettext("Add one in Settings → Integrations")}
+          </a>
+        <% end %>
+      </div>
+    </div>
+    """
+  end
+
+  defp filter_by_provider(connections, nil), do: connections
+
+  defp filter_by_provider(connections, provider) do
+    Enum.filter(connections, fn conn ->
+      key = conn_provider_key(conn)
+      key == provider or String.starts_with?(key, provider <> ":")
+    end)
+  end
+
+  defp conn_provider_key(conn) do
+    cond do
+      is_map(conn[:provider]) -> conn.provider.key
+      is_binary(conn[:provider_key]) -> conn.provider_key
+      true -> conn.data["provider"] || ""
+    end
+  end
+
+  defp filter_by_search(connections, ""), do: connections
+  defp filter_by_search(connections, nil), do: connections
+
+  defp filter_by_search(connections, search) do
+    q = String.downcase(search)
+
+    Enum.filter(connections, fn conn ->
+      name = String.downcase(conn.name || "")
+      account = String.downcase(conn.data["external_account_id"] || "")
+
+      provider_name =
+        if is_map(conn[:provider]),
+          do: String.downcase(conn.provider.name || ""),
+          else: String.downcase(conn.data["provider"] || "")
+
+      String.contains?(name, q) or String.contains?(account, q) or
+        String.contains?(provider_name, q)
+    end)
+  end
+
+  defp auto_select([], [single]), do: [single.uuid]
+  defp auto_select(selected, _connections), do: selected
+
+  defp select_action(true, uuid, selected_set) do
+    if MapSet.member?(selected_set, uuid), do: "remove", else: "add"
+  end
+
+  defp select_action(false, _uuid, _selected_set), do: "select"
+end

--- a/lib/phoenix_kit_web/components/core/table_row_menu.ex
+++ b/lib/phoenix_kit_web/components/core/table_row_menu.ex
@@ -80,7 +80,11 @@ defmodule PhoenixKitWeb.Components.Core.TableRowMenu do
   def table_row_menu(%{mode: "inline"} = assigns) do
     ~H"""
     <div
-      class={["inline-flex flex-nowrap items-center gap-0.5 row-menu-inline", @class]}
+      class={[
+        "inline-flex flex-nowrap items-center gap-0.5 row-menu-inline",
+        "[&>li]:list-none [&>li]:inline-flex",
+        @class
+      ]}
       role="group"
       aria-label={@label}
     >
@@ -90,42 +94,13 @@ defmodule PhoenixKitWeb.Components.Core.TableRowMenu do
   end
 
   def table_row_menu(%{mode: "auto"} = assigns) do
-    ~H"""
-    <%!-- Inline buttons: visible on md+ --%>
-    <div
-      class={["hidden md:inline-flex flex-nowrap items-center gap-0.5 row-menu-inline", @class]}
-      role="group"
-      aria-label={@label}
-    >
-      {render_slot(@inner_block)}
-    </div>
-    <%!-- Dropdown menu: visible on mobile only --%>
-    <div
-      id={@id}
-      phx-hook="RowMenu"
-      class={["relative inline-block md:hidden", @class]}
-      data-row-menu-wrapper
-    >
-      <button
-        type="button"
-        data-row-menu-trigger
-        aria-label={@label}
-        aria-expanded="false"
-        aria-haspopup="menu"
-        class="btn btn-xs btn-ghost btn-circle"
-      >
-        <.icon name="hero-ellipsis-vertical" class="w-4 h-4" />
-      </button>
-      <ul
-        data-row-menu-content
-        role="menu"
-        class="hidden fixed z-[9999] min-w-[10rem] rounded-box bg-base-100 border border-base-200 shadow-xl p-1 focus:outline-none"
-        tabindex="-1"
-      >
-        {render_slot(@inner_block)}
-      </ul>
-    </div>
-    """
+    # TODO: Auto mode is intended to show inline buttons when they fit and collapse
+    # to the ⋮ dropdown when they overflow. The RowMenuAuto JS hook exists in
+    # phoenix_kit.js but doesn't work reliably — DaisyUI table cells have minimum
+    # widths that prevent proper overflow detection. For now, auto mode falls through
+    # to the default dropdown-only behaviour. Fix requires a different approach
+    # (e.g., container queries or measuring before first paint).
+    table_row_menu(%{assigns | mode: "dropdown"})
   end
 
   def table_row_menu(assigns) do

--- a/lib/phoenix_kit_web/integration.ex
+++ b/lib/phoenix_kit_web/integration.ex
@@ -423,6 +423,9 @@ defmodule PhoenixKitWeb.Integration do
         live "/admin/settings/users", Live.Settings.Users, :index
         live "/admin/settings/authorization", Live.Settings.Authorization, :index
         live "/admin/settings/organization", Live.Settings.Organization, :index
+        live "/admin/settings/integrations", Live.Settings.Integrations, :index
+        live "/admin/settings/integrations/new", Live.Settings.IntegrationForm, :new
+        live "/admin/settings/integrations/:provider/:name", Live.Settings.IntegrationForm, :edit
         live "/admin/modules", Live.Modules, :index
 
         live "/admin/settings/languages", Live.Modules.Languages, :index

--- a/lib/phoenix_kit_web/live/settings/integration_form.ex
+++ b/lib/phoenix_kit_web/live/settings/integration_form.ex
@@ -1,0 +1,517 @@
+defmodule PhoenixKitWeb.Live.Settings.IntegrationForm do
+  @moduledoc """
+  Form page for adding or editing an integration connection.
+
+  - `:new` action — shows provider picker, then setup form with instructions
+  - `:edit` action — shows the setup form for an existing connection
+  """
+  use PhoenixKitWeb, :live_view
+  use Gettext, backend: PhoenixKitWeb.Gettext
+
+  require Logger
+
+  alias PhoenixKit.Integrations
+  alias PhoenixKit.Integrations.Events
+  alias PhoenixKit.Integrations.Providers
+  alias PhoenixKit.Settings
+  alias PhoenixKit.Utils.Routes
+
+  def mount(_params, _session, socket) do
+    if connected?(socket), do: Events.subscribe()
+
+    project_title = Settings.get_project_title()
+
+    socket =
+      socket
+      |> assign(:page_title, gettext("Add Integration"))
+      |> assign(:project_title, project_title)
+      |> assign(:current_path, Routes.path("/admin/settings/integrations"))
+      |> assign(:providers, Providers.all())
+      |> assign(:selected_provider, nil)
+      |> assign(:provider, nil)
+      |> assign(:name, nil)
+      |> assign(:data, %{})
+      |> assign(:success, nil)
+      |> assign(:error, nil)
+      |> assign(:new_name, "")
+      |> assign(:testing, false)
+
+    {:ok, socket}
+  end
+
+  def handle_params(params, url, socket) do
+    # Store the base redirect URI from the actual browser URL so that
+    # OAuth callbacks use the same origin Google will redirect to.
+    redirect_uri =
+      case URI.parse(url) do
+        %{scheme: scheme, authority: authority, path: path}
+        when is_binary(scheme) and is_binary(authority) ->
+          "#{scheme}://#{authority}#{path}"
+
+        _ ->
+          nil
+      end
+
+    socket = assign(socket, :redirect_uri, redirect_uri)
+    socket = apply_action(socket, socket.assigns.live_action, params)
+    {:noreply, socket}
+  end
+
+  defp apply_action(socket, :new, _params) do
+    socket
+    |> assign(:page_title, gettext("Add Integration"))
+    |> assign(:selected_provider, nil)
+    |> assign(:provider, nil)
+    |> assign(:name, nil)
+    |> assign(:data, %{})
+  end
+
+  defp apply_action(socket, :edit, %{"provider" => provider_key, "name" => name} = params) do
+    provider = Providers.get(provider_key)
+    full_key = "#{provider_key}:#{name}"
+
+    data =
+      case Integrations.get_integration(full_key) do
+        {:ok, d} -> d
+        _ -> %{}
+      end
+
+    socket =
+      socket
+      |> assign(:page_title, gettext("Edit Integration"))
+      |> assign(:selected_provider, provider_key)
+      |> assign(:provider, provider)
+      |> assign(:name, name)
+      |> assign(:data, data)
+
+    # Handle OAuth callback (code in query params).
+    # Only process during live WebSocket connection — during dead (static) render
+    # the internal URI may differ from the external URL (e.g. http vs https behind
+    # a reverse proxy), causing redirect_uri mismatch with Google's token endpoint.
+    if connected?(socket) do
+      case params do
+        %{"code" => code} when is_binary(code) and code != "" ->
+          handle_oauth_callback(full_key, code, socket)
+
+        _ ->
+          socket
+      end
+    else
+      socket
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Events — provider selection (new mode)
+  # ---------------------------------------------------------------------------
+
+  def handle_event("select_provider", %{"provider" => provider_key}, socket) do
+    provider = Providers.get(provider_key)
+
+    {:noreply,
+     socket
+     |> assign(:selected_provider, provider_key)
+     |> assign(:provider, provider)
+     |> assign(:new_name, "")}
+  end
+
+  def handle_event("back_to_providers", _params, socket) do
+    {:noreply,
+     socket
+     |> assign(:selected_provider, nil)
+     |> assign(:provider, nil)}
+  end
+
+  # ---------------------------------------------------------------------------
+  # Events — create new connection
+  # ---------------------------------------------------------------------------
+
+  def handle_event("create_connection", %{"name" => name} = params, socket) do
+    provider_key = socket.assigns.selected_provider
+    name = String.trim(name)
+
+    # Default to "default" if empty
+    name = if name == "", do: "default", else: name
+
+    case Integrations.add_connection(provider_key, name) do
+      {:ok, _} ->
+        save_and_redirect(provider_key, name, params, socket)
+
+      {:error, :already_exists} ->
+        save_and_redirect(provider_key, name, params, socket)
+
+      {:error, :empty_name} ->
+        {:noreply, assign(socket, :error, gettext("Please enter a connection name."))}
+
+      {:error, reason} ->
+        {:noreply, assign(socket, :error, "Failed: #{inspect(reason)}")}
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Events — save setup credentials (edit mode)
+  # ---------------------------------------------------------------------------
+
+  def handle_event("save_setup", params, socket) do
+    provider_key = socket.assigns.selected_provider
+    name = socket.assigns.name
+    save_setup_fields(provider_key, name, params, socket)
+  end
+
+  # ---------------------------------------------------------------------------
+  # Events — OAuth disconnect
+  # ---------------------------------------------------------------------------
+
+  def handle_event("disconnect_account", _params, socket) do
+    provider_key = socket.assigns.selected_provider
+    name = socket.assigns.name
+    full_key = "#{provider_key}:#{name}"
+
+    # Keep the setup credentials (client_id/secret) but remove tokens
+    Integrations.disconnect(full_key)
+
+    # Reload data
+    data =
+      case Integrations.get_integration(full_key) do
+        {:ok, d} -> d
+        _ -> %{}
+      end
+
+    {:noreply,
+     socket
+     |> assign(:data, data)
+     |> assign(:success, gettext("Account disconnected"))
+     |> assign(:error, nil)}
+  end
+
+  # ---------------------------------------------------------------------------
+  # Events — OAuth connect
+  # ---------------------------------------------------------------------------
+
+  def handle_event("connect_oauth", _params, socket) do
+    provider_key = socket.assigns.selected_provider
+    name = socket.assigns.name || "default"
+    full_key = "#{provider_key}:#{name}"
+
+    redirect_uri =
+      socket.assigns[:redirect_uri] ||
+        build_redirect_uri(socket, provider_key, name)
+
+    case Integrations.authorization_url(full_key, redirect_uri) do
+      {:ok, url} ->
+        {:noreply, redirect(socket, external: url)}
+
+      {:error, :client_id_not_configured} ->
+        {:noreply, assign(socket, :error, gettext("Please save your Client ID first"))}
+
+      {:error, _} ->
+        {:noreply, assign(socket, :error, gettext("Failed to build authorization URL"))}
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Events — Test connection
+  # ---------------------------------------------------------------------------
+
+  def handle_event("test_connection", _params, socket) do
+    send(self(), :do_test_connection)
+    {:noreply, assign(socket, :testing, true)}
+  end
+
+  def handle_event("dismiss", _params, socket) do
+    {:noreply, assign(socket, success: nil, error: nil)}
+  end
+
+  # ---------------------------------------------------------------------------
+  # Async handlers
+  # ---------------------------------------------------------------------------
+
+  def handle_info(:do_test_connection, socket) do
+    provider_key = socket.assigns.selected_provider
+    name = socket.assigns.name
+    full_key = "#{provider_key}:#{name}"
+    provider = socket.assigns.provider
+
+    result = run_connection_test(provider, full_key)
+    save_validation_result(full_key, result)
+    Events.broadcast_validated(full_key, result)
+
+    data =
+      case Integrations.get_integration(full_key) do
+        {:ok, d} -> d
+        _ -> socket.assigns.data
+      end
+
+    socket =
+      case result do
+        :ok ->
+          socket
+          |> assign(:data, data)
+          |> assign(:success, gettext("Connection verified"))
+          |> assign(:error, nil)
+
+        {:error, reason} ->
+          socket
+          |> assign(:data, data)
+          |> assign(:error, "#{gettext("Test failed")}: #{reason}")
+          |> assign(:success, nil)
+      end
+
+    {:noreply, assign(socket, :testing, false)}
+  end
+
+  # PubSub: reload data when integrations change
+  def handle_info({event, _, _}, socket)
+      when event in [
+             :integration_setup_saved,
+             :integration_connected,
+             :integration_connection_added,
+             :integration_validated
+           ],
+      do: {:noreply, reload_data(socket)}
+
+  def handle_info({event, _}, socket)
+      when event in [:integration_disconnected, :integration_connection_removed],
+      do: {:noreply, reload_data(socket)}
+
+  # ---------------------------------------------------------------------------
+  # Private
+  # ---------------------------------------------------------------------------
+
+  defp handle_oauth_callback(full_key, code, socket) do
+    # Use the actual browser URL as redirect_uri (must match what was sent to Google)
+    redirect_uri =
+      socket.assigns[:redirect_uri] ||
+        build_redirect_uri(socket, socket.assigns.selected_provider, socket.assigns.name)
+
+    case Integrations.exchange_code(full_key, code, redirect_uri) do
+      {:ok, _data} ->
+        # Redirect to clean URL (strip ?code=... params) to prevent re-exchange
+        clean_path =
+          Routes.path(
+            "/admin/settings/integrations/#{socket.assigns.selected_provider}/#{socket.assigns.name}"
+          )
+
+        push_navigate(socket, to: clean_path)
+
+      {:error, reason} ->
+        Logger.warning("[IntegrationForm] OAuth callback failed: #{inspect(reason)}")
+
+        # Redirect to clean URL to strip the dead ?code= from the URL
+        clean_path =
+          Routes.path(
+            "/admin/settings/integrations/#{socket.assigns.selected_provider}/#{socket.assigns.name}"
+          )
+
+        socket
+        |> put_flash(:error, gettext("Failed to connect. Please try again."))
+        |> push_navigate(to: clean_path)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Private
+  # ---------------------------------------------------------------------------
+
+  defp save_and_redirect(provider_key, name, params, socket) do
+    provider = Providers.get(provider_key)
+    full_key = "#{provider_key}:#{name}"
+
+    attrs =
+      if provider do
+        provider.setup_fields
+        |> Enum.reduce(%{}, fn field, acc ->
+          value = String.trim(params[field.key] || "")
+
+          Map.put(acc, field.key, value)
+        end)
+      else
+        %{}
+      end
+
+    Integrations.save_setup(full_key, attrs)
+
+    edit_path = Routes.path("/admin/settings/integrations/#{provider_key}/#{name}")
+
+    {:noreply, push_navigate(socket, to: edit_path)}
+  end
+
+  defp run_connection_test(provider, full_key) do
+    case {provider && provider.auth_type, Integrations.get_credentials(full_key)} do
+      {:api_key, {:ok, data}} -> test_api_key(provider, data)
+      {:bot_token, {:ok, data}} -> test_bot_token(data)
+      {_, {:error, _}} -> {:error, gettext("No credentials configured")}
+      _ -> :ok
+    end
+  rescue
+    e -> {:error, Exception.message(e)}
+  end
+
+  defp test_api_key(provider, data) do
+    if Map.has_key?(provider, :validation) and provider.validation != nil do
+      v = provider.validation
+      api_key = data["api_key"] || ""
+      headers = [{v.auth_header, "#{v.auth_prefix}#{api_key}"}]
+
+      case Req.get(v.url, headers: headers) do
+        {:ok, %{status: 200}} ->
+          :ok
+
+        {:ok, %{status: 401}} ->
+          {:error, gettext("Invalid API key")}
+
+        {:ok, %{status: 403}} ->
+          {:error, gettext("Access denied — check your API key permissions")}
+
+        {:ok, %{status: status}} ->
+          {:error, gettext("Service returned error %{status}", status: status)}
+
+        {:error, _} ->
+          {:error, gettext("Could not reach the service — check your internet connection")}
+      end
+    else
+      :ok
+    end
+  end
+
+  defp test_bot_token(data) do
+    token = data["bot_token"] || ""
+
+    case Req.get("https://api.telegram.org/bot#{token}/getMe") do
+      {:ok, %{status: 200, body: %{"ok" => true}}} ->
+        :ok
+
+      {:ok, %{status: 401}} ->
+        {:error, gettext("Invalid bot token")}
+
+      {:ok, %{status: _}} ->
+        {:error, gettext("Invalid bot token — check with @BotFather")}
+
+      {:error, _} ->
+        {:error, gettext("Could not reach Telegram — check your internet connection")}
+    end
+  end
+
+  defp save_validation_result(full_key, result) do
+    now = DateTime.utc_now() |> DateTime.to_iso8601()
+
+    case Integrations.get_integration(full_key) do
+      {:ok, data} ->
+        updated =
+          case result do
+            :ok ->
+              Map.merge(data, %{
+                "status" => "connected",
+                "last_validated_at" => now,
+                "validation_status" => "ok"
+              })
+
+            {:error, reason} ->
+              Map.merge(data, %{
+                "status" => "error",
+                "last_validated_at" => now,
+                "validation_status" => "error: #{reason}"
+              })
+          end
+
+        Integrations.save_setup(full_key, updated)
+
+      _ ->
+        :ok
+    end
+  end
+
+  defp save_setup_fields(provider_key, name, params, socket) do
+    provider = Providers.get(provider_key)
+    full_key = "#{provider_key}:#{name}"
+
+    attrs =
+      if provider do
+        provider.setup_fields
+        |> Enum.reduce(%{}, fn field, acc ->
+          value = String.trim(params[field.key] || "")
+
+          # For password fields, skip empty values to keep the existing credential
+          Map.put(acc, field.key, value)
+        end)
+      else
+        %{}
+      end
+
+    case Integrations.save_setup(full_key, attrs) do
+      {:ok, data} ->
+        {:noreply,
+         socket
+         |> assign(:name, name)
+         |> assign(:data, data)
+         |> assign(:success, gettext("Saved"))
+         |> assign(:error, nil)}
+
+      {:error, _} ->
+        {:noreply, assign(socket, :error, gettext("Failed to save"))}
+    end
+  end
+
+  defp reload_data(socket) do
+    if socket.assigns.name && socket.assigns.selected_provider do
+      full_key = "#{socket.assigns.selected_provider}:#{socket.assigns.name}"
+
+      data =
+        case Integrations.get_integration(full_key) do
+          {:ok, d} -> d
+          _ -> %{}
+        end
+
+      assign(socket, :data, data)
+    else
+      socket
+    end
+  end
+
+  defp build_redirect_uri(socket, provider_key, name) do
+    base = Settings.get_setting("site_url", "")
+    locale = socket.assigns[:current_locale_base]
+    path = Routes.path("/admin/settings/integrations/#{provider_key}/#{name}", locale: locale)
+
+    if base != "" do
+      "#{String.trim_trailing(base, "/")}#{path}"
+    else
+      "http://localhost:4000#{path}"
+    end
+  end
+
+  # Simple inline markdown: **bold**, [links](url), `code`, and {variables}
+  defp render_markdown_inline(text, vars) do
+    text
+    |> replace_vars(vars)
+    |> String.replace(~r/`(.+?)`/, "<code class=\"bg-base-300 px-1 rounded text-xs\">\\1</code>")
+    |> String.replace(~r/\*\*(.+?)\*\*/, "<strong>\\1</strong>")
+    |> String.replace(~r/\[(.+?)\]\((.+?)\)/, "<a href=\"\\2\" target=\"_blank\">\\1</a>")
+  end
+
+  defp replace_vars(text, vars) do
+    Enum.reduce(vars, text, fn {key, value}, acc ->
+      String.replace(acc, "{#{key}}", value || "")
+    end)
+  end
+
+  defp has_setup_credentials?(data, provider) do
+    Enum.all?(provider.setup_fields, fn field ->
+      if field.required do
+        val = data[field.key]
+        is_binary(val) and val != ""
+      else
+        true
+      end
+    end)
+  end
+
+  defp format_date(nil), do: ""
+
+  defp format_date(iso_string) when is_binary(iso_string) do
+    case DateTime.from_iso8601(iso_string) do
+      {:ok, dt, _} -> Calendar.strftime(dt, "%Y-%m-%d")
+      _ -> iso_string
+    end
+  end
+end

--- a/lib/phoenix_kit_web/live/settings/integration_form.html.heex
+++ b/lib/phoenix_kit_web/live/settings/integration_form.html.heex
@@ -1,0 +1,298 @@
+<PhoenixKitWeb.Components.LayoutWrapper.app_layout
+  flash={@flash}
+  phoenix_kit_current_scope={assigns[:phoenix_kit_current_scope]}
+  page_title={"#{@project_title} - #{@page_title}"}
+  current_path={@current_path}
+  project_title={@project_title}
+  current_locale={@current_locale}
+>
+  <div class="container mx-auto px-4 py-6 max-w-2xl">
+    <.admin_page_header
+      back={PhoenixKit.Utils.Routes.path("/admin/settings/integrations")}
+      title={@page_title}
+      subtitle={if @provider, do: @provider.name, else: gettext("Choose a service to connect")}
+    />
+
+    <%!-- Flash messages --%>
+    <div :if={@success} class="alert alert-success mb-4" phx-click="dismiss">
+      <span>{@success}</span>
+    </div>
+    <div :if={@error} class="alert alert-error mb-4" phx-click="dismiss">
+      <span>{@error}</span>
+    </div>
+
+    <%!-- Step 1: Provider picker (new mode, no provider selected yet) --%>
+    <div :if={@live_action == :new && @selected_provider == nil}>
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <button
+          :for={provider <- @providers}
+          phx-click="select_provider"
+          phx-value-provider={provider.key}
+          class="card bg-base-100 shadow-sm border border-base-300 hover:border-primary transition-colors cursor-pointer"
+        >
+          <div class="card-body p-4 flex-row items-center gap-3">
+            <span class="w-10 h-10 flex items-center justify-center bg-base-200 rounded-lg">
+              <.icon name={provider.icon} class="w-5 h-5" />
+            </span>
+            <div class="text-left">
+              <div class="font-semibold">{provider.name}</div>
+              <div class="text-xs text-base-content/60">{provider.description}</div>
+            </div>
+          </div>
+        </button>
+      </div>
+    </div>
+
+    <%!-- Step 2: Setup form (provider selected in new mode, or edit mode) --%>
+    <div :if={@provider != nil} class="space-y-6">
+      <%!-- Back to provider picker (new mode only) --%>
+      <button
+        :if={@live_action == :new && @name == nil}
+        phx-click="back_to_providers"
+        class="btn btn-ghost btn-sm -mt-2"
+      >
+        <.icon name="hero-arrow-left" class="w-4 h-4" />
+        {gettext("Choose a different service")}
+      </button>
+
+      <%!-- Provider info header with status --%>
+      <div class="flex items-center gap-3">
+        <span class="w-10 h-10 flex items-center justify-center bg-base-200 rounded-lg shrink-0">
+          <.icon name={@provider.icon} class="w-5 h-5" />
+        </span>
+        <div class="flex-1">
+          <div class="flex items-center gap-2">
+            <h2 class="text-lg font-semibold">{@provider.name}</h2>
+            <%= if @data["status"] == "connected" do %>
+              <span class="badge badge-success badge-sm gap-1">
+                <.icon name="hero-check-circle" class="w-3 h-3" />
+                {gettext("Connected")}
+              </span>
+            <% end %>
+            <%= if @data["status"] == "configured" do %>
+              <span class="badge badge-warning badge-sm">{gettext("Not tested")}</span>
+            <% end %>
+            <%= if @data["status"] == "error" do %>
+              <span class="badge badge-error badge-sm">{gettext("Error")}</span>
+            <% end %>
+            <%= if @data["status"] in ["disconnected", nil] do %>
+              <span class="badge badge-ghost badge-sm">{gettext("Not connected")}</span>
+            <% end %>
+          </div>
+          <p class="text-sm text-base-content/60">
+            {@provider.description}
+            <span :if={@data["external_account_id"]} class="ml-1">
+              — {@data["external_account_id"]}
+            </span>
+          </p>
+        </div>
+      </div>
+
+      <% credentials_saved = @name != nil && has_setup_credentials?(@data, @provider) %>
+
+      <%!-- Step 1: Credentials --%>
+      <div class="card bg-base-100 shadow-sm">
+        <div class="card-body">
+          <div class="flex items-center gap-2">
+            <span class={"badge badge-sm #{if credentials_saved, do: "badge-success", else: "badge-ghost"}"}>
+              {gettext("Step 1")}
+            </span>
+            <h3 class="card-title text-base">
+              {if @provider.auth_type == :oauth2,
+                do: gettext("API Credentials"),
+                else: gettext("Credentials")}
+            </h3>
+          </div>
+          <p :if={@provider.auth_type == :oauth2} class="text-sm text-base-content/60">
+            {gettext("Enter your API credentials from the developer console.")}
+          </p>
+
+          <form
+            phx-submit={if @name, do: "save_setup", else: "create_connection"}
+            class="space-y-4 mt-2"
+          >
+            <%!-- Connection name (new mode only) --%>
+            <div :if={@name == nil} class="form-control">
+              <label class="label">
+                <span class="label-text">{gettext("Connection Name")}</span>
+              </label>
+              <input
+                type="text"
+                name="name"
+                value={@new_name}
+                class="input input-bordered w-full"
+                placeholder={gettext("default")}
+              />
+            </div>
+
+            <%!-- Provider-specific fields --%>
+            <div :for={field <- @provider.setup_fields} class="form-control">
+              <label class="label">
+                <span class="label-text">
+                  {field.label}
+                  <span :if={field.required} class="text-error">*</span>
+                </span>
+              </label>
+              <input
+                type={if field.type == :password, do: "password", else: "text"}
+                name={field.key}
+                value={@data[field.key] || ""}
+                class="input input-bordered w-full"
+                placeholder={field.placeholder || ""}
+                required={field.required}
+              />
+              <label :if={field.help} class="label">
+                <span class="label-text-alt text-base-content/50">{field.help}</span>
+              </label>
+            </div>
+
+            <button type="submit" class="btn btn-primary btn-sm">
+              {gettext("Save Credentials")}
+            </button>
+          </form>
+        </div>
+      </div>
+
+      <%!-- Step 2: Connect Account (OAuth providers only) --%>
+      <div :if={@provider.auth_type == :oauth2 && @name != nil} class="card bg-base-100 shadow-sm">
+        <div class="card-body">
+          <div class="flex items-center gap-2">
+            <span class={"badge badge-sm #{if @data["status"] == "connected", do: "badge-success", else: "badge-ghost"}"}>
+              {gettext("Step 2")}
+            </span>
+            <h3 class="card-title text-base">{gettext("Connect Account")}</h3>
+          </div>
+
+          <% meta = @data["metadata"] || %{} %>
+          <%= if @data["status"] == "connected" do %>
+            <div class="flex items-center gap-3 mt-3">
+              <%!-- Avatar --%>
+              <%= if meta["picture"] do %>
+                <img
+                  src={meta["picture"]}
+                  class="w-10 h-10 rounded-full"
+                  referrerpolicy="no-referrer"
+                />
+              <% else %>
+                <div class="w-10 h-10 rounded-full bg-base-200 flex items-center justify-center">
+                  <.icon name="hero-user" class="w-5 h-5 text-base-content/40" />
+                </div>
+              <% end %>
+              <div>
+                <div class="flex items-center gap-2">
+                  <span :if={meta["name"]} class="font-medium">{meta["name"]}</span>
+                  <div class="badge badge-success badge-sm gap-1">
+                    <.icon name="hero-check-circle" class="w-3 h-3" />
+                    {gettext("Connected")}
+                  </div>
+                </div>
+                <span :if={@data["external_account_id"]} class="text-sm text-base-content/60">
+                  {@data["external_account_id"]}
+                </span>
+                <span :if={@data["connected_at"]} class="text-xs text-base-content/40 block">
+                  {gettext("Connected on")} {format_date(@data["connected_at"])}
+                </span>
+              </div>
+            </div>
+            <div class="flex gap-2 mt-3">
+              <button
+                type="button"
+                phx-click="disconnect_account"
+                class="btn btn-outline btn-error btn-sm"
+                data-confirm={gettext("Are you sure you want to disconnect this account?")}
+              >
+                <.icon name="hero-link-slash" class="w-4 h-4" />
+                {gettext("Disconnect Account")}
+              </button>
+            </div>
+          <% else %>
+            <p class="text-sm text-base-content/60 mt-1">
+              {gettext(
+                "Authorize access to your Google account. This will open a Google sign-in page where you choose which account to connect."
+              )}
+            </p>
+
+            <%= if credentials_saved do %>
+              <button
+                type="button"
+                phx-click="connect_oauth"
+                class="btn btn-accent btn-sm mt-3"
+              >
+                <.icon name="hero-link" class="w-4 h-4" />
+                {gettext("Connect Google Account")}
+              </button>
+            <% else %>
+              <p class="text-sm text-base-content/40 mt-2">
+                {gettext("Complete Step 1 first to enable account connection.")}
+              </p>
+            <% end %>
+          <% end %>
+        </div>
+      </div>
+
+      <%!-- Test Connection (non-OAuth providers) --%>
+      <div
+        :if={
+          @provider.auth_type != :oauth2 && @name != nil &&
+            @data["status"] in ["configured", "connected", "error"]
+        }
+        class="card bg-base-100 shadow-sm"
+      >
+        <div class="card-body">
+          <div class="flex items-center gap-2">
+            <span class={"badge badge-sm #{if @data["status"] == "connected", do: "badge-success", else: "badge-ghost"}"}>
+              {gettext("Step 2")}
+            </span>
+            <h3 class="card-title text-base">{gettext("Verify Connection")}</h3>
+          </div>
+          <p class="text-sm text-base-content/60 mt-1">
+            {gettext("Test that your credentials are valid and the service is reachable.")}
+          </p>
+          <button
+            type="button"
+            phx-click="test_connection"
+            class={"btn btn-primary btn-sm mt-3 #{if @testing, do: "loading"}"}
+            disabled={@testing}
+          >
+            <.icon :if={!@testing} name="hero-signal" class="w-4 h-4" />
+            {if @testing, do: gettext("Testing..."), else: gettext("Test Connection")}
+          </button>
+        </div>
+      </div>
+
+      <%!-- Setup instructions (from provider definition) --%>
+      <div :if={Map.get(@provider, :instructions, []) != []} class="card bg-base-200/50">
+        <div class="card-body text-sm text-base-content/70 space-y-4">
+          <h3 class="font-semibold text-base-content text-base">
+            {gettext("Setup Instructions")}
+          </h3>
+
+          <div :for={{section, idx} <- Enum.with_index(Map.get(@provider, :instructions, []))}>
+            <h4 class="font-semibold text-base-content">
+              {idx + 1}. {section.title}
+            </h4>
+            <p
+              :if={Map.get(section, :note)}
+              class="text-xs text-base-content/50 mt-1 ml-2 mb-2"
+            >
+              <span class="[&>strong]:font-semibold [&>strong]:text-base-content/70">
+                {Phoenix.HTML.raw(
+                  render_markdown_inline(section.note, %{"redirect_uri" => @redirect_uri || ""})
+                )}
+              </span>
+            </p>
+            <ol class="list-decimal list-inside space-y-1 mt-1 ml-2">
+              <li :for={{text, _detail} <- section.steps}>
+                <span class="[&>a]:link [&>a]:link-primary [&>strong]:font-semibold [&>strong]:text-base-content">
+                  {Phoenix.HTML.raw(
+                    render_markdown_inline(text, %{"redirect_uri" => @redirect_uri || ""})
+                  )}
+                </span>
+              </li>
+            </ol>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</PhoenixKitWeb.Components.LayoutWrapper.app_layout>

--- a/lib/phoenix_kit_web/live/settings/integrations.ex
+++ b/lib/phoenix_kit_web/live/settings/integrations.ex
@@ -1,0 +1,252 @@
+defmodule PhoenixKitWeb.Live.Settings.Integrations do
+  @moduledoc """
+  Integrations list page — shows all configured service connections.
+
+  Each connection is displayed as a card with status, connected account info,
+  and quick actions (disconnect, test). An "Add Integration" button links to
+  the form page for creating new connections.
+  """
+  use PhoenixKitWeb, :live_view
+  use Gettext, backend: PhoenixKitWeb.Gettext
+
+  require Logger
+
+  alias PhoenixKit.Integrations
+  alias PhoenixKit.Integrations.Events
+  alias PhoenixKit.Integrations.Providers
+  alias PhoenixKit.Settings
+  alias PhoenixKit.Utils.Routes
+
+  def mount(_params, _session, socket) do
+    if connected?(socket), do: Events.subscribe()
+
+    project_title = Settings.get_project_title()
+
+    socket =
+      socket
+      |> assign(:page_title, gettext("Integrations"))
+      |> assign(:project_title, project_title)
+      |> assign(:current_path, get_current_path(socket.assigns.current_locale_base))
+      |> load_connections()
+      |> assign(:validating, nil)
+
+    {:ok, socket}
+  end
+
+  def handle_params(_params, _url, socket) do
+    {:noreply, socket}
+  end
+
+  # ---------------------------------------------------------------------------
+  # Events
+  # ---------------------------------------------------------------------------
+
+  def handle_event("disconnect", %{"provider" => provider_key}, socket) do
+    Integrations.disconnect(provider_key)
+
+    {:noreply,
+     socket
+     |> put_flash(:info, gettext("Disconnected"))
+     |> load_connections()}
+  end
+
+  def handle_event("validate_connection", %{"provider" => provider_key}, socket) do
+    send(self(), {:do_validate, provider_key})
+    {:noreply, assign(socket, :validating, provider_key)}
+  end
+
+  def handle_event("remove_connection", %{"provider" => provider_key, "name" => name}, socket) do
+    case Integrations.remove_connection(provider_key, name) do
+      :ok ->
+        {:noreply,
+         socket
+         |> put_flash(:info, gettext("Connection removed"))
+         |> load_connections()}
+
+      {:error, :cannot_remove_default} ->
+        {:noreply, put_flash(socket, :error, gettext("Cannot remove the default connection"))}
+
+      {:error, _} ->
+        {:noreply, put_flash(socket, :error, gettext("Failed to remove connection"))}
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Async validation
+  # ---------------------------------------------------------------------------
+
+  def handle_info({:do_validate, provider_key}, socket) do
+    result = validate_connection(provider_key)
+
+    case Integrations.get_integration(provider_key) do
+      {:ok, data} ->
+        now = DateTime.utc_now() |> DateTime.to_iso8601()
+
+        updated =
+          case result do
+            :ok ->
+              Map.merge(data, %{
+                "last_validated_at" => now,
+                "validation_status" => "ok",
+                "status" => "connected"
+              })
+
+            {:error, reason} ->
+              Map.merge(data, %{
+                "last_validated_at" => now,
+                "validation_status" => "error: #{reason}",
+                "status" => "error"
+              })
+          end
+
+        Integrations.save_setup(provider_key, updated)
+
+      _ ->
+        :ok
+    end
+
+    Events.broadcast_validated(provider_key, result)
+
+    {:noreply,
+     socket
+     |> assign(:validating, nil)
+     |> load_connections()}
+  end
+
+  # ---------------------------------------------------------------------------
+  # PubSub handlers
+  # ---------------------------------------------------------------------------
+
+  def handle_info({:integration_setup_saved, _, _}, socket),
+    do: {:noreply, load_connections(socket)}
+
+  def handle_info({:integration_connected, _, _}, socket),
+    do: {:noreply, load_connections(socket)}
+
+  def handle_info({:integration_disconnected, _}, socket),
+    do: {:noreply, load_connections(socket)}
+
+  def handle_info({:integration_validated, _, _}, socket),
+    do: {:noreply, load_connections(socket)}
+
+  def handle_info({:integration_connection_added, _, _}, socket),
+    do: {:noreply, load_connections(socket)}
+
+  def handle_info({:integration_connection_removed, _, _}, socket),
+    do: {:noreply, load_connections(socket)}
+
+  # ---------------------------------------------------------------------------
+  # Private
+  # ---------------------------------------------------------------------------
+
+  defp load_connections(socket) do
+    used_by = Providers.used_by_modules()
+
+    connections =
+      Providers.all()
+      |> Enum.flat_map(fn provider ->
+        Integrations.list_connections(provider.key)
+        |> Enum.map(fn %{uuid: uuid, name: name, data: data} ->
+          full_key = "#{provider.key}:#{name}"
+
+          %{
+            provider: provider,
+            uuid: uuid,
+            name: name,
+            full_key: full_key,
+            data: data,
+            used_by: Map.get(used_by, provider.key, [])
+          }
+        end)
+      end)
+
+    assign(socket, :connections, connections)
+  end
+
+  defp validate_connection(provider_key) do
+    do_validate_connection(provider_key)
+  rescue
+    e ->
+      Logger.error(
+        "[Integrations] validate_connection crashed for #{provider_key}: #{Exception.message(e)}"
+      )
+
+      {:error, "Validation failed unexpectedly"}
+  end
+
+  defp do_validate_connection(provider_key) do
+    with {:ok, data} <- Integrations.get_credentials(provider_key),
+         provider when not is_nil(provider) <- Providers.get(provider_key) do
+      validate_by_auth_type(provider, data)
+    else
+      {:error, _} -> {:error, "Not configured"}
+      nil -> {:error, "Unknown provider"}
+    end
+  end
+
+  defp validate_by_auth_type(%{auth_type: :oauth2} = provider, data) do
+    token = data["access_token"]
+    config = provider.oauth_config || %{}
+    userinfo_url = config[:userinfo_url] || config["userinfo_url"]
+
+    cond do
+      not (is_binary(token) and token != "") -> {:error, "No access token"}
+      is_nil(userinfo_url) -> :ok
+      true -> check_http(userinfo_url, [{"authorization", "Bearer #{token}"}])
+    end
+  end
+
+  defp validate_by_auth_type(%{auth_type: :api_key} = provider, data) do
+    api_key = data["api_key"]
+
+    cond do
+      not (is_binary(api_key) and api_key != "") ->
+        {:error, "No API key configured"}
+
+      Map.has_key?(provider, :validation) and provider.validation != nil ->
+        # Use provider's validation endpoint to actually test the key
+        v = provider.validation
+        headers = [{v.auth_header, "#{v.auth_prefix}#{api_key}"}]
+        check_http(v.url, headers)
+
+      true ->
+        :ok
+    end
+  end
+
+  defp validate_by_auth_type(%{auth_type: :bot_token}, data) do
+    token = data["bot_token"]
+
+    if is_binary(token) and token != "" do
+      case Req.get("https://api.telegram.org/bot#{token}/getMe") do
+        {:ok, %{status: 200, body: %{"ok" => true}}} -> :ok
+        {:ok, %{status: status}} -> {:error, "HTTP #{status}"}
+        {:error, reason} -> {:error, inspect(reason)}
+      end
+    else
+      {:error, "No bot token configured"}
+    end
+  end
+
+  defp validate_by_auth_type(_, _data), do: :ok
+
+  defp check_http(url, headers) do
+    case Req.get(url, headers: headers) do
+      {:ok, %{status: 200}} -> :ok
+      {:ok, %{status: 401}} -> {:error, gettext("Invalid credentials")}
+      {:ok, %{status: 403}} -> {:error, gettext("Access denied")}
+      {:ok, %{status: status}} -> {:error, gettext("Service error %{status}", status: status)}
+      {:error, _reason} -> {:error, gettext("Could not reach the service")}
+    end
+  end
+
+  defp get_current_path(locale) do
+    Routes.path("/admin/settings/integrations", locale: locale)
+  end
+
+  defp integration_status_badge("connected"), do: {"badge-success", gettext("Connected")}
+  defp integration_status_badge("configured"), do: {"badge-warning", gettext("Not tested")}
+  defp integration_status_badge("disconnected"), do: {"badge-ghost", gettext("Not connected")}
+  defp integration_status_badge("error"), do: {"badge-error", gettext("Error")}
+  defp integration_status_badge(_), do: {"badge-ghost", gettext("Not configured")}
+end

--- a/lib/phoenix_kit_web/live/settings/integrations.html.heex
+++ b/lib/phoenix_kit_web/live/settings/integrations.html.heex
@@ -1,0 +1,239 @@
+<PhoenixKitWeb.Components.LayoutWrapper.app_layout
+  flash={@flash}
+  phoenix_kit_current_scope={assigns[:phoenix_kit_current_scope]}
+  page_title={"#{@project_title} - Integrations"}
+  current_path={@current_path}
+  project_title={@project_title}
+  current_locale={@current_locale}
+>
+  <div class="container mx-auto px-4 py-6">
+    <.admin_page_header
+      back={PhoenixKit.Utils.Routes.path("/admin/settings")}
+      title={gettext("Integrations")}
+      subtitle={gettext("Connect external services for use across modules")}
+    >
+      <:actions>
+        <.pk_link
+          navigate="/admin/settings/integrations/new"
+          class="btn btn-primary btn-sm"
+        >
+          <.icon name="hero-plus" class="w-4 h-4" />
+          {gettext("Add Integration")}
+        </.pk_link>
+      </:actions>
+    </.admin_page_header>
+
+    <%!-- Flash messages --%>
+    <%!-- Connections table --%>
+    <div :if={@connections != []}>
+      <.table_default
+        id="integrations-table"
+        toggleable
+        items={@connections}
+        card_title={fn conn -> conn.provider.name end}
+        card_fields={
+          fn conn ->
+            fields = [
+              %{
+                label: gettext("Status"),
+                value:
+                  if(@validating == conn.full_key,
+                    do: gettext("Testing..."),
+                    else: elem(integration_status_badge(conn.data["status"]), 1)
+                  )
+              }
+            ]
+
+            fields =
+              if conn.name != "default",
+                do: fields ++ [%{label: gettext("Name"), value: conn.name}],
+                else: fields
+
+            fields =
+              if conn.data["external_account_id"],
+                do:
+                  fields ++
+                    [%{label: gettext("Account"), value: conn.data["external_account_id"]}],
+                else: fields
+
+            fields =
+              if conn.used_by != [],
+                do:
+                  fields ++ [%{label: gettext("Used by"), value: Enum.join(conn.used_by, ", ")}],
+                else: fields
+
+            fields
+          end
+        }
+      >
+        <:card_header :let={conn}>
+          <div class="flex items-center gap-2">
+            <.icon name={conn.provider.icon} class="w-5 h-5" />
+            <span class="font-medium">{conn.provider.name}</span>
+            <span :if={conn.name != "default"} class="badge badge-ghost badge-xs">
+              {conn.name}
+            </span>
+          </div>
+        </:card_header>
+
+        <.table_default_header>
+          <.table_default_row>
+            <.table_default_header_cell>{gettext("Service")}</.table_default_header_cell>
+            <.table_default_header_cell>{gettext("Name")}</.table_default_header_cell>
+            <.table_default_header_cell>{gettext("Account")}</.table_default_header_cell>
+            <.table_default_header_cell>{gettext("Status")}</.table_default_header_cell>
+            <.table_default_header_cell>{gettext("Used by")}</.table_default_header_cell>
+            <.table_default_header_cell>{gettext("Actions")}</.table_default_header_cell>
+          </.table_default_row>
+        </.table_default_header>
+
+        <.table_default_body>
+          <.table_default_row :for={conn <- @connections}>
+            <.table_default_cell>
+              <div class="flex items-center gap-2">
+                <.icon name={conn.provider.icon} class="w-4 h-4 text-base-content/60" />
+                <span>{conn.provider.name}</span>
+              </div>
+            </.table_default_cell>
+            <.table_default_cell>
+              {if conn.name == "default", do: gettext("Default"), else: conn.name}
+            </.table_default_cell>
+            <.table_default_cell>
+              <span :if={conn.data["external_account_id"]} class="text-sm">
+                {conn.data["external_account_id"]}
+              </span>
+              <span :if={!conn.data["external_account_id"]} class="text-base-content/30">—</span>
+            </.table_default_cell>
+            <.table_default_cell>
+              <%= if @validating == conn.full_key do %>
+                <span class="badge badge-sm badge-info gap-1">
+                  <span class="loading loading-spinner loading-xs"></span>
+                  {gettext("Testing...")}
+                </span>
+              <% else %>
+                <% {badge_class, badge_text} = integration_status_badge(conn.data["status"]) %>
+                <div>
+                  <span class={"badge badge-sm #{badge_class}"}>{badge_text}</span>
+                  <span
+                    :if={conn.data["status"] == "error" && conn.data["validation_status"]}
+                    class="text-xs text-error block mt-0.5"
+                  >
+                    {conn.data["validation_status"]}
+                  </span>
+                </div>
+              <% end %>
+            </.table_default_cell>
+            <.table_default_cell>
+              <span :if={conn.used_by != []} class="text-sm text-base-content/60">
+                {Enum.join(conn.used_by, ", ")}
+              </span>
+              <span :if={conn.used_by == []} class="text-base-content/30">—</span>
+            </.table_default_cell>
+            <.table_default_cell>
+              <.table_row_menu
+                id={"integration-menu-#{String.replace(conn.full_key, ":", "-")}"}
+                mode="auto"
+                label={gettext("Actions")}
+              >
+                <.table_row_menu_link
+                  navigate={
+                    PhoenixKit.Utils.Routes.path(
+                      "/admin/settings/integrations/#{conn.provider.key}/#{conn.name}"
+                    )
+                  }
+                  icon="hero-pencil"
+                  label={gettext("Configure")}
+                />
+                <.table_row_menu_button
+                  :if={conn.data["status"] == "connected"}
+                  phx-click="validate_connection"
+                  phx-value-provider={conn.full_key}
+                  icon="hero-signal"
+                  label={gettext("Test Connection")}
+                />
+                <.table_row_menu_divider :if={conn.data["status"] == "connected"} />
+                <.table_row_menu_button
+                  :if={conn.data["status"] == "connected"}
+                  phx-click="disconnect"
+                  phx-value-provider={conn.full_key}
+                  icon="hero-link-slash"
+                  label={gettext("Disconnect")}
+                  variant="warning"
+                  data-confirm={gettext("Are you sure you want to disconnect?")}
+                />
+                <.table_row_menu_button
+                  :if={conn.name != "default"}
+                  phx-click="remove_connection"
+                  phx-value-provider={conn.provider.key}
+                  phx-value-name={conn.name}
+                  icon="hero-trash"
+                  label={gettext("Remove")}
+                  variant="error"
+                  data-confirm={
+                    gettext(
+                      "This integration may be in use by other parts of the system. Remove it permanently?"
+                    )
+                  }
+                />
+              </.table_row_menu>
+            </.table_default_cell>
+          </.table_default_row>
+        </.table_default_body>
+
+        <:card_actions :let={conn}>
+          <.table_row_menu
+            id={"integration-card-menu-#{String.replace(conn.full_key, ":", "-")}"}
+            mode="auto"
+            label={gettext("Actions")}
+          >
+            <.table_row_menu_link
+              navigate={
+                PhoenixKit.Utils.Routes.path(
+                  "/admin/settings/integrations/#{conn.provider.key}/#{conn.name}"
+                )
+              }
+              icon="hero-pencil"
+              label={gettext("Configure")}
+            />
+            <.table_row_menu_button
+              :if={conn.data["status"] == "connected"}
+              phx-click="disconnect"
+              phx-value-provider={conn.full_key}
+              icon="hero-link-slash"
+              label={gettext("Disconnect")}
+              variant="warning"
+              data-confirm={gettext("Disconnect?")}
+            />
+            <.table_row_menu_button
+              :if={conn.name != "default"}
+              phx-click="remove_connection"
+              phx-value-provider={conn.provider.key}
+              phx-value-name={conn.name}
+              icon="hero-trash"
+              label={gettext("Remove")}
+              variant="error"
+              data-confirm={
+                gettext(
+                  "This integration may be in use by other parts of the system. Remove it permanently?"
+                )
+              }
+            />
+          </.table_row_menu>
+        </:card_actions>
+      </.table_default>
+    </div>
+
+    <%!-- Empty state --%>
+    <div :if={@connections == []} class="text-center py-12">
+      <.icon name="hero-link" class="h-16 w-16 mx-auto text-base-content/40 mb-4" />
+      <h3 class="text-lg font-medium mb-2">{gettext("No integrations configured")}</h3>
+      <p class="text-base-content/70 mb-4">
+        {gettext("Connect external services like Google, OpenRouter, or Telegram.")}
+      </p>
+      <.pk_link navigate="/admin/settings/integrations/new" class="btn btn-primary btn-sm">
+        <.icon name="hero-plus" class="w-4 h-4" />
+        {gettext("Add Integration")}
+      </.pk_link>
+    </div>
+  </div>
+</PhoenixKitWeb.Components.LayoutWrapper.app_layout>

--- a/priv/static/assets/phoenix_kit.js
+++ b/priv/static/assets/phoenix_kit.js
@@ -1617,6 +1617,134 @@ if (typeof window.Chart === "undefined") {
 
 
   // ============================================================================
+  // 5b. ROW MENU AUTO HOOK
+  // ============================================================================
+  //
+  // Smart auto-collapsing row menu: shows inline buttons when they fit in the
+  // available space, collapses into a ⋮ dropdown when they overflow.
+  // Uses ResizeObserver for dynamic detection — no fixed breakpoints.
+  //
+  window.PhoenixKitHooks.RowMenuAuto = {
+    mounted() {
+      this.inlineEl = this.el.querySelector("[data-row-menu-inline]");
+      this.dropdownEl = this.el.querySelector("[data-row-menu-dropdown]");
+      this.trigger = this.el.querySelector("[data-row-menu-trigger]");
+      this.menu = this.el.querySelector("[data-row-menu-content]");
+      this.isOpen = false;
+
+      if (!this.inlineEl || !this.dropdownEl) return;
+
+      // Start with both hidden
+      this.inlineEl.classList.add("hidden");
+      this.dropdownEl.classList.add("hidden");
+
+      // Set up dropdown click handlers
+      this._onTriggerClick = (e) => {
+        e.stopPropagation();
+        this.isOpen ? this._closeMenu() : this._openMenu();
+      };
+      this._onOutsideClick = (e) => {
+        if (!this.el.contains(e.target)) this._closeMenu();
+      };
+      this._onKeydown = (e) => {
+        if (e.key === "Escape") {
+          this._closeMenu();
+          if (this.trigger) this.trigger.focus();
+        }
+      };
+      this._onMenuClick = () => { this._closeMenu(); };
+
+      if (this.trigger) this.trigger.addEventListener("click", this._onTriggerClick);
+      if (this.menu) this.menu.addEventListener("click", this._onMenuClick);
+
+      // Listen to window resize
+      this._onResize = () => this._check();
+      window.addEventListener("resize", this._onResize);
+
+      // Initial check
+      this._check();
+    },
+
+    updated() {
+      this._check();
+    },
+
+    _check() {
+      if (!this.inlineEl || !this.dropdownEl) return;
+
+      var table = this.el.closest("table");
+      var scrollContainer = table ? table.parentElement : null;
+      if (!table || !scrollContainer) {
+        // Not in a table — show dropdown as fallback
+        this.inlineEl.classList.add("hidden");
+        this.dropdownEl.classList.remove("hidden");
+        return;
+      }
+
+      // Step 1: show inline, hide dropdown
+      this.inlineEl.classList.remove("hidden");
+      this.dropdownEl.classList.add("hidden");
+
+      // Step 2: check if showing inline causes the table to overflow
+      if (table.scrollWidth > scrollContainer.clientWidth) {
+        // Overflows — switch to dropdown
+        this.inlineEl.classList.add("hidden");
+        this.dropdownEl.classList.remove("hidden");
+      }
+      // else: fits, keep inline showing
+    },
+
+    _openMenu() {
+      if (!this.menu || !this.trigger) return;
+
+      var triggerRect = this.trigger.getBoundingClientRect();
+      var vw = window.innerWidth;
+      var vh = window.innerHeight;
+      var gap = 4;
+
+      this.menu.classList.remove("hidden");
+      var menuWidth = this.menu.offsetWidth || 160;
+      var menuHeight = this.menu.offsetHeight || 200;
+
+      var left = triggerRect.right - menuWidth;
+      if (left < 8) left = triggerRect.left;
+      left = Math.max(8, Math.min(left, vw - menuWidth - 8));
+
+      var top = triggerRect.bottom + gap;
+      if (top + menuHeight > vh - 8 && triggerRect.top - menuHeight - gap > 8) {
+        top = triggerRect.top - menuHeight - gap;
+      }
+      top = Math.max(8, Math.min(top, vh - menuHeight - 8));
+
+      this.menu.style.top = top + "px";
+      this.menu.style.left = left + "px";
+
+      this.isOpen = true;
+      this.trigger.setAttribute("aria-expanded", "true");
+
+      document.addEventListener("click", this._onOutsideClick, true);
+      document.addEventListener("keydown", this._onKeydown);
+    },
+
+    _closeMenu() {
+      if (!this.isOpen || !this.menu) return;
+      this.menu.classList.add("hidden");
+      this.isOpen = false;
+      if (this.trigger) this.trigger.setAttribute("aria-expanded", "false");
+      document.removeEventListener("click", this._onOutsideClick, true);
+      document.removeEventListener("keydown", this._onKeydown);
+    },
+
+    destroyed() {
+      this._closeMenu();
+      if (this._onResize) window.removeEventListener("resize", this._onResize);
+      if (this.trigger) this.trigger.removeEventListener("click", this._onTriggerClick);
+      if (this.menu) this.menu.removeEventListener("click", this._onMenuClick);
+    }
+  };
+
+
+  // ============================================================================
   // 6. EMAIL CHARTS HOOK
   // ============================================================================
   //

--- a/test/integration/integrations_test.exs
+++ b/test/integration/integrations_test.exs
@@ -1,0 +1,525 @@
+defmodule PhoenixKit.Integration.IntegrationsTest do
+  use PhoenixKit.DataCase, async: true
+
+  alias PhoenixKit.Integrations
+  alias PhoenixKit.Settings
+
+  # ===========================================================================
+  # save_setup + get_credentials round-trip
+  # ===========================================================================
+
+  describe "save_setup/2 and get_credentials/1 for API key provider" do
+    test "saves and retrieves an API key" do
+      {:ok, data} = Integrations.save_setup("openrouter", %{"api_key" => "sk-or-test-key"})
+      assert data["provider"] == "openrouter"
+      assert data["auth_type"] == "api_key"
+      assert data["api_key"] == "sk-or-test-key"
+      assert data["status"] == "connected"
+
+      {:ok, creds} = Integrations.get_credentials("openrouter")
+      assert creds["api_key"] == "sk-or-test-key"
+    end
+
+    test "connected? returns true after saving API key" do
+      Integrations.save_setup("openrouter", %{"api_key" => "sk-or-test-key"})
+      assert Integrations.connected?("openrouter")
+    end
+
+    test "connected? returns false when no data exists" do
+      refute Integrations.connected?("openrouter")
+    end
+
+    test "merges with existing data on subsequent save" do
+      Integrations.save_setup("openrouter", %{"api_key" => "key-1"})
+      Integrations.save_setup("openrouter", %{"api_key" => "key-2"})
+
+      {:ok, creds} = Integrations.get_credentials("openrouter")
+      assert creds["api_key"] == "key-2"
+    end
+  end
+
+  describe "save_setup/2 for OAuth provider" do
+    test "saves client credentials with disconnected status" do
+      {:ok, data} =
+        Integrations.save_setup("google", %{
+          "client_id" => "test-client.apps.googleusercontent.com",
+          "client_secret" => "GOCSPX-test"
+        })
+
+      assert data["provider"] == "google"
+      assert data["auth_type"] == "oauth2"
+      assert data["client_id"] == "test-client.apps.googleusercontent.com"
+      assert data["client_secret"] == "GOCSPX-test"
+      assert data["status"] == "disconnected"
+    end
+
+    test "OAuth provider not connected until tokens present" do
+      Integrations.save_setup("google", %{
+        "client_id" => "test-client",
+        "client_secret" => "test-secret"
+      })
+
+      refute Integrations.connected?("google")
+    end
+  end
+
+  # ===========================================================================
+  # get_integration
+  # ===========================================================================
+
+  describe "get_integration/1" do
+    test "returns full data blob" do
+      Integrations.save_setup("openrouter", %{"api_key" => "test-key"})
+
+      {:ok, data} = Integrations.get_integration("openrouter")
+      assert data["provider"] == "openrouter"
+      assert data["api_key"] == "test-key"
+      assert data["auth_type"] == "api_key"
+      assert data["status"] == "connected"
+    end
+
+    test "returns error for unconfigured provider" do
+      assert {:error, :not_configured} = Integrations.get_integration("nonexistent")
+    end
+  end
+
+  # ===========================================================================
+  # disconnect
+  # ===========================================================================
+
+  describe "disconnect/1 for OAuth provider" do
+    test "removes tokens but keeps client credentials" do
+      # Simulate a connected OAuth provider
+      Settings.update_json_setting_with_module(
+        Integrations.settings_key("google"),
+        %{
+          "provider" => "google",
+          "auth_type" => "oauth2",
+          "client_id" => "my-client-id",
+          "client_secret" => "my-client-secret",
+          "access_token" => "ya29.active-token",
+          "refresh_token" => "1//refresh-token",
+          "status" => "connected",
+          "external_account_id" => "user@gmail.com"
+        },
+        "integrations"
+      )
+
+      assert Integrations.connected?("google")
+
+      :ok = Integrations.disconnect("google")
+
+      {:ok, data} = Integrations.get_integration("google")
+      assert data["client_id"] == "my-client-id"
+      assert data["client_secret"] == "my-client-secret"
+      assert data["status"] == "disconnected"
+      refute Map.has_key?(data, "access_token")
+      refute Map.has_key?(data, "refresh_token")
+      refute Map.has_key?(data, "external_account_id")
+    end
+  end
+
+  describe "disconnect/1 for API key provider" do
+    test "removes everything except provider and auth_type" do
+      Integrations.save_setup("openrouter", %{"api_key" => "sk-or-key"})
+      assert Integrations.connected?("openrouter")
+
+      :ok = Integrations.disconnect("openrouter")
+
+      {:ok, data} = Integrations.get_integration("openrouter")
+      assert data["provider"] == "openrouter"
+      assert data["auth_type"] == "api_key"
+      assert data["status"] == "disconnected"
+      refute Map.has_key?(data, "api_key")
+    end
+  end
+
+  describe "disconnect/1 for key_secret provider" do
+    test "preserves access_key and secret_key" do
+      Settings.update_json_setting_with_module(
+        Integrations.settings_key("aws"),
+        %{
+          "provider" => "aws",
+          "auth_type" => "key_secret",
+          "access_key" => "AKIATEST",
+          "secret_key" => "secret123",
+          "status" => "connected",
+          "metadata" => %{"region" => "us-east-1"}
+        },
+        "integrations"
+      )
+
+      :ok = Integrations.disconnect("aws")
+
+      {:ok, data} = Integrations.get_integration("aws")
+      assert data["access_key"] == "AKIATEST"
+      assert data["secret_key"] == "secret123"
+      assert data["status"] == "disconnected"
+      refute Map.has_key?(data, "metadata")
+    end
+  end
+
+  describe "disconnect/1 for nonexistent provider" do
+    test "returns ok" do
+      assert :ok = Integrations.disconnect("nonexistent")
+    end
+  end
+
+  # ===========================================================================
+  # get_credentials for all auth types
+  # ===========================================================================
+
+  describe "get_credentials/1 for different auth types" do
+    test "returns credentials for connected OAuth (access_token present)" do
+      Settings.update_json_setting_with_module(
+        Integrations.settings_key("google"),
+        %{
+          "provider" => "google",
+          "auth_type" => "oauth2",
+          "access_token" => "ya29.token",
+          "status" => "connected"
+        },
+        "integrations"
+      )
+
+      assert {:ok, creds} = Integrations.get_credentials("google")
+      assert creds["access_token"] == "ya29.token"
+    end
+
+    test "returns credentials for bot_token provider" do
+      Settings.update_json_setting_with_module(
+        Integrations.settings_key("telegram"),
+        %{
+          "provider" => "telegram",
+          "auth_type" => "bot_token",
+          "bot_token" => "123456:ABC-DEF",
+          "status" => "connected"
+        },
+        "integrations"
+      )
+
+      assert {:ok, creds} = Integrations.get_credentials("telegram")
+      assert creds["bot_token"] == "123456:ABC-DEF"
+    end
+
+    test "returns credentials for key_secret provider" do
+      Settings.update_json_setting_with_module(
+        Integrations.settings_key("aws"),
+        %{
+          "provider" => "aws",
+          "auth_type" => "key_secret",
+          "access_key" => "AKIATEST",
+          "secret_key" => "secret",
+          "status" => "connected"
+        },
+        "integrations"
+      )
+
+      assert {:ok, creds} = Integrations.get_credentials("aws")
+      assert creds["access_key"] == "AKIATEST"
+    end
+
+    test "returns credentials for custom credentials provider" do
+      Settings.update_json_setting_with_module(
+        Integrations.settings_key("smtp"),
+        %{
+          "provider" => "smtp",
+          "auth_type" => "credentials",
+          "credentials" => %{"host" => "smtp.test.com", "port" => 587},
+          "status" => "connected"
+        },
+        "integrations"
+      )
+
+      assert {:ok, creds} = Integrations.get_credentials("smtp")
+      assert creds["credentials"]["host"] == "smtp.test.com"
+    end
+
+    test "returns error when only setup creds exist (no tokens)" do
+      Settings.update_json_setting_with_module(
+        Integrations.settings_key("google"),
+        %{
+          "provider" => "google",
+          "auth_type" => "oauth2",
+          "client_id" => "my-id",
+          "client_secret" => "my-secret",
+          "status" => "disconnected"
+        },
+        "integrations"
+      )
+
+      assert {:error, :not_configured} = Integrations.get_credentials("google")
+    end
+  end
+
+  # ===========================================================================
+  # settings_key
+  # ===========================================================================
+
+  describe "settings_key/1" do
+    test "prefixes with integration: and default name" do
+      assert Integrations.settings_key("google") == "integration:google:default"
+      assert Integrations.settings_key("openrouter") == "integration:openrouter:default"
+    end
+
+    test "supports explicit name" do
+      assert Integrations.settings_key("google:personal") == "integration:google:personal"
+    end
+  end
+
+  # ===========================================================================
+  # list_integrations
+  # ===========================================================================
+
+  describe "list_integrations/0" do
+    test "returns empty list when nothing configured" do
+      assert Integrations.list_integrations() == []
+    end
+
+    test "returns configured integrations" do
+      Integrations.save_setup("openrouter", %{"api_key" => "key-1"})
+
+      integrations = Integrations.list_integrations()
+      assert length(integrations) == 1
+      assert hd(integrations)["provider"] == "openrouter"
+    end
+  end
+
+  # ===========================================================================
+  # Multi-connection support
+  # ===========================================================================
+
+  describe "add_connection/2" do
+    test "creates a new named connection" do
+      {:ok, data} = Integrations.add_connection("google", "personal")
+      assert data["provider"] == "google"
+      assert data["name"] == "personal"
+      assert data["status"] == "disconnected"
+    end
+
+    test "rejects empty name" do
+      assert {:error, :empty_name} = Integrations.add_connection("google", "")
+    end
+
+    test "rejects duplicate name" do
+      {:ok, _} = Integrations.add_connection("google", "work")
+      assert {:error, :already_exists} = Integrations.add_connection("google", "work")
+    end
+  end
+
+  describe "remove_connection/2" do
+    test "removes a named connection" do
+      Integrations.add_connection("google", "temp")
+      assert :ok = Integrations.remove_connection("google", "temp")
+    end
+
+    test "cannot remove default connection" do
+      assert {:error, :cannot_remove_default} =
+               Integrations.remove_connection("google", "default")
+    end
+
+    test "returns ok for nonexistent connection" do
+      assert :ok = Integrations.remove_connection("google", "nonexistent")
+    end
+  end
+
+  describe "list_connections/1" do
+    test "returns empty list when no connections" do
+      assert Integrations.list_connections("google") == []
+    end
+
+    test "returns connections with uuid, name, and data" do
+      Integrations.save_setup("openrouter", %{"api_key" => "test-key"})
+
+      connections = Integrations.list_connections("openrouter")
+      assert length(connections) == 1
+      [conn] = connections
+      assert conn.name == "default"
+      assert conn.uuid != nil
+      assert conn.data["api_key"] == "test-key"
+    end
+
+    test "returns multiple connections sorted with default first" do
+      Integrations.add_connection("google", "personal")
+      Integrations.add_connection("google", "work")
+      Integrations.save_setup("google", %{"client_id" => "default-id"})
+
+      connections = Integrations.list_connections("google")
+      names = Enum.map(connections, & &1.name)
+      assert hd(names) == "default"
+      assert "personal" in names
+      assert "work" in names
+    end
+  end
+
+  # ===========================================================================
+  # UUID-based lookups
+  # ===========================================================================
+
+  describe "get_credentials/1 with UUID" do
+    test "returns credentials when looking up by UUID" do
+      Integrations.save_setup("openrouter", %{"api_key" => "uuid-test-key"})
+
+      [%{uuid: uuid}] = Integrations.list_connections("openrouter")
+
+      assert {:ok, data} = Integrations.get_credentials(uuid)
+      assert data["api_key"] == "uuid-test-key"
+    end
+
+    test "returns :deleted for nonexistent UUID" do
+      fake_uuid = "019d0000-0000-7000-8000-000000000000"
+      assert {:error, :deleted} = Integrations.get_credentials(fake_uuid)
+    end
+  end
+
+  describe "connected?/1 with UUID" do
+    test "returns true for connected UUID" do
+      Integrations.save_setup("openrouter", %{"api_key" => "valid-key"})
+      [%{uuid: uuid}] = Integrations.list_connections("openrouter")
+      assert Integrations.connected?(uuid)
+    end
+
+    test "returns false for deleted UUID" do
+      fake_uuid = "019d0000-0000-7000-8000-000000000000"
+      refute Integrations.connected?(fake_uuid)
+    end
+  end
+
+  # ===========================================================================
+  # authorization_url
+  # ===========================================================================
+
+  describe "authorization_url/3" do
+    test "builds URL when client_id is saved" do
+      Integrations.save_setup("google", %{
+        "client_id" => "test-client-id",
+        "client_secret" => "test-secret"
+      })
+
+      {:ok, url} = Integrations.authorization_url("google", "http://localhost:4000/callback")
+      assert url =~ "accounts.google.com"
+      assert url =~ "client_id=test-client-id"
+      assert url =~ "response_type=code"
+    end
+
+    test "returns error when client_id not saved" do
+      Integrations.save_setup("google", %{"client_secret" => "only-secret"})
+
+      assert {:error, :client_id_not_configured} =
+               Integrations.authorization_url("google", "http://localhost/cb")
+    end
+
+    test "returns error for unknown provider" do
+      assert {:error, :unknown_provider} =
+               Integrations.authorization_url("nonexistent", "http://localhost/cb")
+    end
+  end
+
+  # ===========================================================================
+  # Legacy migration
+  # ===========================================================================
+
+  describe "legacy migration from document_creator_google_oauth" do
+    test "migrates on first access to integration:google" do
+      # Write legacy data
+      Settings.update_json_setting_with_module(
+        "document_creator_google_oauth",
+        %{
+          "client_id" => "legacy-client",
+          "client_secret" => "legacy-secret",
+          "access_token" => "ya29.legacy-token",
+          "refresh_token" => "1//legacy-refresh",
+          "token_type" => "Bearer",
+          "expires_in" => 3600,
+          "token_obtained_at" => "2026-03-15T10:00:00Z",
+          "connected_email" => "legacy@gmail.com",
+          "folder_path_templates" => "clients",
+          "folder_name_templates" => "templates",
+          "templates_folder_id" => "folder-id-123"
+        },
+        "document_creator"
+      )
+
+      # Access via Integrations — should trigger migration
+      {:ok, data} = Integrations.get_integration("google")
+
+      assert data["provider"] == "google"
+      assert data["auth_type"] == "oauth2"
+      assert data["client_id"] == "legacy-client"
+      assert data["client_secret"] == "legacy-secret"
+      assert data["access_token"] == "ya29.legacy-token"
+      assert data["refresh_token"] == "1//legacy-refresh"
+      assert data["status"] == "connected"
+      assert data["external_account_id"] == "legacy@gmail.com"
+      assert data["metadata"]["connected_email"] == "legacy@gmail.com"
+      assert data["expires_at"] != nil
+    end
+
+    test "migrates folder config to separate key" do
+      Settings.update_json_setting_with_module(
+        "document_creator_google_oauth",
+        %{
+          "client_id" => "c",
+          "client_secret" => "s",
+          "access_token" => "t",
+          "folder_path_templates" => "my/path",
+          "folder_name_templates" => "tpl",
+          "templates_folder_id" => "tid"
+        },
+        "document_creator"
+      )
+
+      # Trigger migration
+      Integrations.get_integration("google")
+
+      # Check folder config was moved
+      folder_data = Settings.get_json_setting("document_creator_folders", nil)
+      assert folder_data != nil
+      assert folder_data["folder_path_templates"] == "my/path"
+      assert folder_data["folder_name_templates"] == "tpl"
+      assert folder_data["templates_folder_id"] == "tid"
+    end
+
+    test "does not migrate when integration:google already exists" do
+      # Set up integration data directly
+      Integrations.save_setup("google", %{
+        "client_id" => "new-client",
+        "client_secret" => "new-secret"
+      })
+
+      # Also set up legacy data (should be ignored)
+      Settings.update_json_setting_with_module(
+        "document_creator_google_oauth",
+        %{
+          "client_id" => "old-client",
+          "access_token" => "old-token"
+        },
+        "document_creator"
+      )
+
+      {:ok, data} = Integrations.get_integration("google")
+      assert data["client_id"] == "new-client"
+    end
+  end
+
+  # ===========================================================================
+  # connected_at timestamp
+  # ===========================================================================
+
+  describe "connected_at tracking" do
+    test "sets connected_at when API key saved" do
+      {:ok, data} = Integrations.save_setup("openrouter", %{"api_key" => "key"})
+      assert data["connected_at"] != nil
+    end
+
+    test "does not set connected_at for OAuth setup (no tokens yet)" do
+      {:ok, data} =
+        Integrations.save_setup("google", %{
+          "client_id" => "id",
+          "client_secret" => "secret"
+        })
+
+      assert data["connected_at"] == nil
+    end
+  end
+end

--- a/test/phoenix_kit/integrations/integrations_test.exs
+++ b/test/phoenix_kit/integrations/integrations_test.exs
@@ -1,0 +1,41 @@
+defmodule PhoenixKit.Integrations.IntegrationsTest do
+  @moduledoc """
+  Unit tests for the Integrations context (no DB required).
+  See test/integration/integrations_test.exs for full DB integration tests.
+  """
+  use ExUnit.Case, async: true
+
+  alias PhoenixKit.Integrations
+
+  describe "settings_key/1" do
+    test "returns prefixed key with default name" do
+      assert Integrations.settings_key("google") == "integration:google:default"
+      assert Integrations.settings_key("openrouter") == "integration:openrouter:default"
+    end
+
+    test "returns prefixed key with explicit name" do
+      assert Integrations.settings_key("google:personal") == "integration:google:personal"
+
+      assert Integrations.settings_key("openrouter:secondary") ==
+               "integration:openrouter:secondary"
+    end
+  end
+
+  describe "settings_key/1 with names" do
+    test "supports names with spaces and special characters" do
+      assert Integrations.settings_key("google:My Company Drive") ==
+               "integration:google:My Company Drive"
+    end
+  end
+
+  describe "list_providers/0" do
+    test "returns a list of provider maps" do
+      providers = Integrations.list_providers()
+      assert is_list(providers)
+      assert length(providers) >= 2
+      keys = Enum.map(providers, & &1.key)
+      assert "google" in keys
+      assert "openrouter" in keys
+    end
+  end
+end

--- a/test/phoenix_kit/integrations/oauth_test.exs
+++ b/test/phoenix_kit/integrations/oauth_test.exs
@@ -1,0 +1,90 @@
+defmodule PhoenixKit.Integrations.OAuthTest do
+  use ExUnit.Case, async: true
+
+  alias PhoenixKit.Integrations.OAuth
+
+  @google_oauth_config %{
+    auth_url: "https://accounts.google.com/o/oauth2/v2/auth",
+    token_url: "https://oauth2.googleapis.com/token",
+    userinfo_url: "https://www.googleapis.com/oauth2/v2/userinfo",
+    default_scopes: "https://www.googleapis.com/auth/drive",
+    auth_params: %{"access_type" => "offline", "prompt" => "consent"}
+  }
+
+  describe "authorization_url/4" do
+    test "builds valid URL with client_id" do
+      data = %{"client_id" => "test-client-id"}
+      redirect = "http://localhost:4000/callback"
+
+      assert {:ok, url} = OAuth.authorization_url(@google_oauth_config, data, redirect)
+      assert url =~ "accounts.google.com"
+      assert url =~ "client_id=test-client-id"
+      assert url =~ URI.encode_www_form(redirect)
+      assert url =~ "response_type=code"
+      assert url =~ "access_type=offline"
+      assert url =~ "prompt=consent"
+    end
+
+    test "uses default scopes from oauth_config" do
+      data = %{"client_id" => "test-client-id"}
+      redirect = "http://localhost:4000/callback"
+
+      {:ok, url} = OAuth.authorization_url(@google_oauth_config, data, redirect)
+      assert url =~ URI.encode_www_form("https://www.googleapis.com/auth/drive")
+    end
+
+    test "overrides scopes with extra_scopes" do
+      data = %{"client_id" => "test-client-id"}
+      redirect = "http://localhost:4000/callback"
+      extra = "custom-scope"
+
+      {:ok, url} = OAuth.authorization_url(@google_oauth_config, data, redirect, extra)
+      assert url =~ "scope=custom-scope"
+      refute url =~ "auth%2Fdrive"
+    end
+
+    test "returns error when client_id is missing" do
+      data = %{}
+      redirect = "http://localhost:4000/callback"
+
+      assert {:error, :client_id_not_configured} =
+               OAuth.authorization_url(@google_oauth_config, data, redirect)
+    end
+
+    test "returns error when client_id is empty string" do
+      data = %{"client_id" => ""}
+      redirect = "http://localhost:4000/callback"
+
+      assert {:error, :client_id_not_configured} =
+               OAuth.authorization_url(@google_oauth_config, data, redirect)
+    end
+
+    test "works with string-keyed oauth_config" do
+      config = %{
+        "auth_url" => "https://example.com/auth",
+        "default_scopes" => "scope1",
+        "auth_params" => %{"foo" => "bar"}
+      }
+
+      data = %{"client_id" => "my-id"}
+      redirect = "http://localhost/cb"
+
+      {:ok, url} = OAuth.authorization_url(config, data, redirect)
+      assert url =~ "example.com/auth"
+      assert url =~ "scope=scope1"
+      assert url =~ "foo=bar"
+    end
+  end
+
+  describe "fetch_userinfo/2" do
+    test "returns empty map when userinfo_url is nil" do
+      config = %{userinfo_url: nil}
+      assert {:ok, %{}} = OAuth.fetch_userinfo(config, "some-token")
+    end
+
+    test "returns empty map when userinfo_url is empty" do
+      config = %{userinfo_url: ""}
+      assert {:ok, %{}} = OAuth.fetch_userinfo(config, "some-token")
+    end
+  end
+end

--- a/test/phoenix_kit/integrations/providers_test.exs
+++ b/test/phoenix_kit/integrations/providers_test.exs
@@ -1,0 +1,78 @@
+defmodule PhoenixKit.Integrations.ProvidersTest do
+  use ExUnit.Case, async: true
+
+  alias PhoenixKit.Integrations.Providers
+
+  describe "all/0" do
+    test "returns a list of provider maps" do
+      providers = Providers.all()
+      assert is_list(providers)
+      assert length(providers) >= 2
+    end
+
+    test "includes google provider" do
+      providers = Providers.all()
+      google = Enum.find(providers, &(&1.key == "google"))
+      assert google != nil
+      assert google.name == "Google"
+      assert google.auth_type == :oauth2
+      assert google.oauth_config != nil
+      assert google.oauth_config[:auth_url] =~ "accounts.google.com"
+      assert google.oauth_config[:token_url] =~ "oauth2.googleapis.com"
+      assert google.oauth_config[:userinfo_url] =~ "googleapis.com/oauth2"
+    end
+
+    test "includes openrouter provider" do
+      providers = Providers.all()
+      openrouter = Enum.find(providers, &(&1.key == "openrouter"))
+      assert openrouter != nil
+      assert openrouter.name == "OpenRouter"
+      assert openrouter.auth_type == :api_key
+      assert openrouter.oauth_config == nil
+    end
+
+    test "google has required setup fields" do
+      google = Providers.get("google")
+      field_keys = Enum.map(google.setup_fields, & &1.key)
+      assert "client_id" in field_keys
+      assert "client_secret" in field_keys
+    end
+
+    test "openrouter has required setup fields" do
+      openrouter = Providers.get("openrouter")
+      field_keys = Enum.map(openrouter.setup_fields, & &1.key)
+      assert "api_key" in field_keys
+    end
+
+    test "all providers have required keys" do
+      for provider <- Providers.all() do
+        assert is_binary(provider.key), "provider missing key"
+        assert is_binary(provider.name), "#{provider.key} missing name"
+        assert is_binary(provider.description), "#{provider.key} missing description"
+        assert is_binary(provider.icon), "#{provider.key} missing icon"
+        assert provider.auth_type in [:oauth2, :api_key, :key_secret, :bot_token, :credentials]
+        assert is_list(provider.setup_fields), "#{provider.key} missing setup_fields"
+        assert is_list(provider.capabilities), "#{provider.key} missing capabilities"
+      end
+    end
+  end
+
+  describe "get/1" do
+    test "returns provider for known key" do
+      assert %{key: "google"} = Providers.get("google")
+      assert %{key: "openrouter"} = Providers.get("openrouter")
+    end
+
+    test "returns nil for unknown key" do
+      assert Providers.get("nonexistent") == nil
+      assert Providers.get("") == nil
+    end
+  end
+
+  describe "used_by_modules/0" do
+    test "returns a map" do
+      result = Providers.used_by_modules()
+      assert is_map(result)
+    end
+  end
+end


### PR DESCRIPTION
Introduces PhoenixKit.Integrations — a centralized system for managing external service connections (OAuth, API keys, bot tokens). Replaces per-module credential management with a shared Settings-backed store.

Core:
- Integrations context with CRUD, OAuth flow, token refresh, authenticated requests
- Provider registry (Google, OpenRouter) with setup instructions
- Generic OAuth 2.0 module (authorize, exchange, refresh, userinfo)
- PubSub events for real-time updates across admin sessions
- Multi-connection support (multiple connections per provider, UUID-based references)
- Legacy migration from document_creator_google_oauth
- Integration picker component (card-based, single/multi select, searchable)
- Settings tab with list page and add/edit form pages
- Connection health checks with human-friendly error messages

Module behaviour:
- New optional callbacks: required_integrations/0, integration_providers/0