### PR TITLE
Add V94 migration for Document Creator sync and fix Google token refresh

### DIFF
--- a/lib/phoenix_kit/integrations/integrations.ex
+++ b/lib/phoenix_kit/integrations/integrations.ex
@@ -221,12 +221,13 @@ defmodule PhoenixKit.Integrations do
   """
   @spec refresh_access_token(String.t()) :: {:ok, String.t()} | {:error, term()}
   def refresh_access_token(provider_key) do
-    with {:ok, provider} <- fetch_provider(provider_key),
-         {:ok, data} <- get_integration(provider_key),
+    with {:ok, data} <- get_integration(provider_key),
+         {:ok, provider_lookup_key} <- resolve_provider_lookup_key(provider_key, data),
+         {:ok, provider} <- fetch_provider(provider_lookup_key),
          {:ok, new_token, updated_fields} <-
            OAuth.refresh_access_token(provider.oauth_config, data) do
       updated = Map.merge(data, updated_fields)
-      save_integration(provider_key, updated)
+      save_integration(resolve_storage_key(provider_key, data), updated)
       {:ok, new_token}
     end
   end
@@ -606,6 +607,23 @@ defmodule PhoenixKit.Integrations do
     case Providers.get(provider_key) do
       nil -> {:error, :unknown_provider}
       provider -> {:ok, provider}
+    end
+  end
+
+  defp resolve_provider_lookup_key(provider_key, data) do
+    case data["provider"] do
+      saved_provider when is_binary(saved_provider) and saved_provider != "" ->
+        {:ok, saved_provider}
+
+      _ ->
+        if uuid?(provider_key), do: {:error, :unknown_provider}, else: {:ok, provider_key}
+    end
+  end
+
+  defp resolve_storage_key(provider_key, data) do
+    case data["provider"] do
+      saved_provider when is_binary(saved_provider) and saved_provider != "" -> saved_provider
+      _ -> provider_key
     end
   end
 

--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -529,7 +529,12 @@ defmodule PhoenixKit.Migrations.Postgres do
   - Replaces unique index with partial index (slug-mode only, WHERE slug IS NOT NULL)
   - Adds unique index on `(group_uuid, post_date, post_time)` for timestamp-mode posts
 
-  ### V93 - Settings prefix index ⚡ LATEST
+  ### V94 - Document Creator local DB sync ⚡ LATEST
+  - Adds `google_doc_id` (VARCHAR(255)) to `phoenix_kit_doc_templates`, `phoenix_kit_doc_documents`, `phoenix_kit_doc_headers_footers`
+  - Adds `status` (VARCHAR(20), DEFAULT 'published') to `phoenix_kit_doc_documents`
+  - Partial unique indexes on `google_doc_id WHERE google_doc_id IS NOT NULL`
+
+  ### V93 - Settings prefix index
   - Adds `text_pattern_ops` B-tree index on `phoenix_kit_settings.key` for efficient LIKE prefix queries
   - Used by the integrations system for `LIKE 'integration:provider:%'` lookups
 
@@ -696,7 +701,7 @@ defmodule PhoenixKit.Migrations.Postgres do
   use Ecto.Migration
 
   @initial_version 1
-  @current_version 93
+  @current_version 94
   @default_prefix "public"
 
   @doc false

--- a/lib/phoenix_kit/migrations/postgres/v94.ex
+++ b/lib/phoenix_kit/migrations/postgres/v94.ex
@@ -1,0 +1,142 @@
+defmodule PhoenixKit.Migrations.Postgres.V94 do
+  @moduledoc """
+  V94: Add google_doc_id and status columns to Document Creator tables.
+
+  Adds columns needed for local DB mirroring of Google Drive file metadata:
+  - `google_doc_id` (VARCHAR(255)) on templates, documents, and headers_footers
+  - `status` (VARCHAR(20), DEFAULT 'published') on documents (templates already have it)
+  - Partial unique indexes on `google_doc_id WHERE google_doc_id IS NOT NULL`
+
+  All operations are idempotent.
+  """
+
+  use Ecto.Migration
+
+  def up(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+    schema = if prefix == "public", do: "public", else: prefix
+
+    # 1. Add google_doc_id to phoenix_kit_doc_templates
+    execute("""
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT FROM information_schema.columns
+        WHERE table_schema = '#{schema}'
+          AND table_name = 'phoenix_kit_doc_templates'
+          AND column_name = 'google_doc_id'
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_doc_templates
+          ADD COLUMN google_doc_id VARCHAR(255);
+      END IF;
+    END $$;
+    """)
+
+    # 2. Add google_doc_id to phoenix_kit_doc_documents
+    execute("""
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT FROM information_schema.columns
+        WHERE table_schema = '#{schema}'
+          AND table_name = 'phoenix_kit_doc_documents'
+          AND column_name = 'google_doc_id'
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_doc_documents
+          ADD COLUMN google_doc_id VARCHAR(255);
+      END IF;
+    END $$;
+    """)
+
+    # 3. Add status to phoenix_kit_doc_documents
+    execute("""
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT FROM information_schema.columns
+        WHERE table_schema = '#{schema}'
+          AND table_name = 'phoenix_kit_doc_documents'
+          AND column_name = 'status'
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_doc_documents
+          ADD COLUMN status VARCHAR(20) DEFAULT 'published';
+      END IF;
+    END $$;
+    """)
+
+    # 4. Add google_doc_id to phoenix_kit_doc_headers_footers
+    execute("""
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT FROM information_schema.columns
+        WHERE table_schema = '#{schema}'
+          AND table_name = 'phoenix_kit_doc_headers_footers'
+          AND column_name = 'google_doc_id'
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_doc_headers_footers
+          ADD COLUMN google_doc_id VARCHAR(255);
+      END IF;
+    END $$;
+    """)
+
+    # 5. Partial unique indexes on google_doc_id (only for non-null values)
+    execute("""
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT FROM pg_indexes
+        WHERE schemaname = '#{schema}'
+          AND tablename = 'phoenix_kit_doc_templates'
+          AND indexname = 'phoenix_kit_doc_templates_google_doc_id_unique_idx'
+      ) THEN
+        CREATE UNIQUE INDEX phoenix_kit_doc_templates_google_doc_id_unique_idx
+          ON #{p}phoenix_kit_doc_templates (google_doc_id)
+          WHERE google_doc_id IS NOT NULL;
+      END IF;
+    END $$;
+    """)
+
+    execute("""
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT FROM pg_indexes
+        WHERE schemaname = '#{schema}'
+          AND tablename = 'phoenix_kit_doc_documents'
+          AND indexname = 'phoenix_kit_doc_documents_google_doc_id_unique_idx'
+      ) THEN
+        CREATE UNIQUE INDEX phoenix_kit_doc_documents_google_doc_id_unique_idx
+          ON #{p}phoenix_kit_doc_documents (google_doc_id)
+          WHERE google_doc_id IS NOT NULL;
+      END IF;
+    END $$;
+    """)
+
+    # 6. Status index on documents
+    create_if_not_exists(index(:phoenix_kit_doc_documents, [:status], prefix: prefix))
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '94'")
+  end
+
+  def down(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    drop_if_exists(index(:phoenix_kit_doc_documents, [:status], prefix: prefix))
+
+    execute("DROP INDEX IF EXISTS #{p}phoenix_kit_doc_documents_google_doc_id_unique_idx")
+    execute("DROP INDEX IF EXISTS #{p}phoenix_kit_doc_templates_google_doc_id_unique_idx")
+
+    execute("ALTER TABLE #{p}phoenix_kit_doc_headers_footers DROP COLUMN IF EXISTS google_doc_id")
+    execute("ALTER TABLE #{p}phoenix_kit_doc_documents DROP COLUMN IF EXISTS status")
+    execute("ALTER TABLE #{p}phoenix_kit_doc_documents DROP COLUMN IF EXISTS google_doc_id")
+    execute("ALTER TABLE #{p}phoenix_kit_doc_templates DROP COLUMN IF EXISTS google_doc_id")
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '93'")
+  end
+
+  defp prefix_str("public"), do: "public."
+  defp prefix_str(prefix), do: "#{prefix}."
+end

--- a/lib/phoenix_kit/migrations/postgres/v94.ex
+++ b/lib/phoenix_kit/migrations/postgres/v94.ex
@@ -1,10 +1,12 @@
 defmodule PhoenixKit.Migrations.Postgres.V94 do
   @moduledoc """
-  V94: Add google_doc_id and status columns to Document Creator tables.
+  V94: Add Google Drive metadata columns to Document Creator tables.
 
   Adds columns needed for local DB mirroring of Google Drive file metadata:
   - `google_doc_id` (VARCHAR(255)) on templates, documents, and headers_footers
   - `status` (VARCHAR(20), DEFAULT 'published') on documents (templates already have it)
+  - `path` (VARCHAR(500)) on templates and documents for the accepted folder path
+  - `folder_id` (VARCHAR(255)) on templates and documents for the accepted parent folder
   - Partial unique indexes on `google_doc_id WHERE google_doc_id IS NOT NULL`
 
   All operations are idempotent.
@@ -65,7 +67,71 @@ defmodule PhoenixKit.Migrations.Postgres.V94 do
     END $$;
     """)
 
-    # 4. Add google_doc_id to phoenix_kit_doc_headers_footers
+    # 4. Add path to phoenix_kit_doc_templates
+    execute("""
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT FROM information_schema.columns
+        WHERE table_schema = '#{schema}'
+          AND table_name = 'phoenix_kit_doc_templates'
+          AND column_name = 'path'
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_doc_templates
+          ADD COLUMN path VARCHAR(500);
+      END IF;
+    END $$;
+    """)
+
+    # 5. Add folder_id to phoenix_kit_doc_templates
+    execute("""
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT FROM information_schema.columns
+        WHERE table_schema = '#{schema}'
+          AND table_name = 'phoenix_kit_doc_templates'
+          AND column_name = 'folder_id'
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_doc_templates
+          ADD COLUMN folder_id VARCHAR(255);
+      END IF;
+    END $$;
+    """)
+
+    # 6. Add path to phoenix_kit_doc_documents
+    execute("""
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT FROM information_schema.columns
+        WHERE table_schema = '#{schema}'
+          AND table_name = 'phoenix_kit_doc_documents'
+          AND column_name = 'path'
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_doc_documents
+          ADD COLUMN path VARCHAR(500);
+      END IF;
+    END $$;
+    """)
+
+    # 7. Add folder_id to phoenix_kit_doc_documents
+    execute("""
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT FROM information_schema.columns
+        WHERE table_schema = '#{schema}'
+          AND table_name = 'phoenix_kit_doc_documents'
+          AND column_name = 'folder_id'
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_doc_documents
+          ADD COLUMN folder_id VARCHAR(255);
+      END IF;
+    END $$;
+    """)
+
+    # 8. Add google_doc_id to phoenix_kit_doc_headers_footers
     execute("""
     DO $$
     BEGIN
@@ -81,7 +147,7 @@ defmodule PhoenixKit.Migrations.Postgres.V94 do
     END $$;
     """)
 
-    # 5. Partial unique indexes on google_doc_id (only for non-null values)
+    # 9. Partial unique indexes on google_doc_id (only for non-null values)
     execute("""
     DO $$
     BEGIN
@@ -114,7 +180,7 @@ defmodule PhoenixKit.Migrations.Postgres.V94 do
     END $$;
     """)
 
-    # 6. Status index on documents
+    # 10. Status index on documents
     create_if_not_exists(index(:phoenix_kit_doc_documents, [:status], prefix: prefix))
 
     execute("COMMENT ON TABLE #{p}phoenix_kit IS '94'")
@@ -130,8 +196,12 @@ defmodule PhoenixKit.Migrations.Postgres.V94 do
     execute("DROP INDEX IF EXISTS #{p}phoenix_kit_doc_templates_google_doc_id_unique_idx")
 
     execute("ALTER TABLE #{p}phoenix_kit_doc_headers_footers DROP COLUMN IF EXISTS google_doc_id")
+    execute("ALTER TABLE #{p}phoenix_kit_doc_documents DROP COLUMN IF EXISTS folder_id")
+    execute("ALTER TABLE #{p}phoenix_kit_doc_documents DROP COLUMN IF EXISTS path")
     execute("ALTER TABLE #{p}phoenix_kit_doc_documents DROP COLUMN IF EXISTS status")
     execute("ALTER TABLE #{p}phoenix_kit_doc_documents DROP COLUMN IF EXISTS google_doc_id")
+    execute("ALTER TABLE #{p}phoenix_kit_doc_templates DROP COLUMN IF EXISTS folder_id")
+    execute("ALTER TABLE #{p}phoenix_kit_doc_templates DROP COLUMN IF EXISTS path")
     execute("ALTER TABLE #{p}phoenix_kit_doc_templates DROP COLUMN IF EXISTS google_doc_id")
 
     execute("COMMENT ON TABLE #{p}phoenix_kit IS '93'")


### PR DESCRIPTION
## Summary

  - Add V94 migration with `google_doc_id`, `status`, `path`, and `folder_id` columns on
  Document Creator tables for local DB mirroring of Google Drive file metadata
  - Fix `refresh_access_token` to resolve provider key from stored integration data when
  called with a UUID, fixing `:unknown_provider` errors during token refresh
  - Add `resolve_provider_lookup_key/2` and `resolve_storage_key/2` helpers