### PR TITLE
Add V96 migration: catalogue_uuid on catalogue items

### DIFF
--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -529,7 +529,19 @@ defmodule PhoenixKit.Migrations.Postgres do
   - Replaces unique index with partial index (slug-mode only, WHERE slug IS NOT NULL)
   - Adds unique index on `(group_uuid, post_date, post_time)` for timestamp-mode posts
 
-  ### V94 - Document Creator local DB sync ⚡ LATEST
+  ### V96 - Catalogue items linked directly to catalogues ⚡ LATEST
+  - Adds nullable `catalogue_uuid` FK on `phoenix_kit_cat_items` so items can
+    belong to a catalogue independently of having a category
+  - Backfills existing items from their category's catalogue_uuid
+  - Pins any remaining orphans to the oldest non-deleted catalogue
+  - Adds indexes on `catalogue_uuid` and `(catalogue_uuid, status)`
+
+  ### V95 - Media folders and folder links
+  - Creates `phoenix_kit_media_folders` and `phoenix_kit_media_folder_links` tables
+  - Adds organizational folder hierarchy for media files (metadata-only;
+    storage buckets are unaware of them)
+
+  ### V94 - Document Creator local DB sync
   - Adds `google_doc_id` (VARCHAR(255)) to `phoenix_kit_doc_templates`, `phoenix_kit_doc_documents`, `phoenix_kit_doc_headers_footers`
   - Adds `status` (VARCHAR(20), DEFAULT 'published') to `phoenix_kit_doc_documents`
   - Partial unique indexes on `google_doc_id WHERE google_doc_id IS NOT NULL`
@@ -701,7 +713,7 @@ defmodule PhoenixKit.Migrations.Postgres do
   use Ecto.Migration
 
   @initial_version 1
-  @current_version 95
+  @current_version 96
   @default_prefix "public"
 
   @doc false

--- a/lib/phoenix_kit/migrations/postgres/v96.ex
+++ b/lib/phoenix_kit/migrations/postgres/v96.ex
@@ -1,0 +1,114 @@
+defmodule PhoenixKit.Migrations.Postgres.V96 do
+  @moduledoc """
+  V96: Attach catalogue items directly to a catalogue.
+
+  Adds a nullable `catalogue_uuid` FK on `phoenix_kit_cat_items` so items
+  can belong to a catalogue independently of having a category. This lets
+  "uncategorized" items (items with no category) still be scoped to a
+  catalogue instead of floating in a global pool.
+
+  - Adds `catalogue_uuid` column with a FK to `phoenix_kit_cat_catalogues`
+    (`on_delete: :nilify_all`) — in-app cascades handle soft-delete lifecycle
+  - Backfills existing items from their category's catalogue_uuid
+  - Pins any remaining orphans (items with no category at all) to the
+    oldest non-deleted catalogue so they stay visible in the UI
+  - Adds indexes on `catalogue_uuid` and `(catalogue_uuid, status)`
+
+  All operations are idempotent.
+  """
+
+  use Ecto.Migration
+
+  def up(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+    schema = if prefix == "public", do: "public", else: prefix
+
+    # 1. Add catalogue_uuid column (nullable FK, nilify on catalogue hard-delete)
+    execute("""
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT FROM information_schema.columns
+        WHERE table_schema = '#{schema}'
+          AND table_name = 'phoenix_kit_cat_items'
+          AND column_name = 'catalogue_uuid'
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_cat_items
+          ADD COLUMN catalogue_uuid uuid
+          REFERENCES #{p}phoenix_kit_cat_catalogues(uuid) ON DELETE SET NULL;
+      END IF;
+    END $$;
+    """)
+
+    # 2. Backfill catalogue_uuid from the item's category
+    execute("""
+    UPDATE #{p}phoenix_kit_cat_items AS i
+       SET catalogue_uuid = c.catalogue_uuid
+      FROM #{p}phoenix_kit_cat_categories AS c
+     WHERE i.category_uuid = c.uuid
+       AND i.catalogue_uuid IS NULL
+    """)
+
+    # 3. Backfill any remaining orphans (items with no category at all) into
+    # the oldest non-deleted catalogue. In the pre-v95 world these items
+    # showed up on every catalogue detail page as "global uncategorized";
+    # pinning them to the first active catalogue keeps them visible and
+    # behaves the same way in the common single-catalogue case.
+    #
+    # We filter out `status = 'deleted'` so we never land orphans inside a
+    # trashed catalogue (which would immediately soft-delete them via the
+    # normal cascade semantics). If no non-deleted catalogues exist, the
+    # subquery returns NULL and nothing is updated — the items stay orphaned
+    # until one does.
+    execute("""
+    UPDATE #{p}phoenix_kit_cat_items
+       SET catalogue_uuid = (
+         SELECT uuid FROM #{p}phoenix_kit_cat_catalogues
+          WHERE status <> 'deleted'
+          ORDER BY inserted_at ASC
+          LIMIT 1
+       )
+     WHERE catalogue_uuid IS NULL
+    """)
+
+    # 4. Index on catalogue_uuid for per-catalogue queries, plus a composite
+    # index on (catalogue_uuid, status) because every per-catalogue query
+    # (`item_count_for_catalogue`, `list_items_for_catalogue`,
+    # `item_counts_by_catalogue`, `search_items_in_catalogue`) filters on
+    # both columns. The composite lets the planner satisfy the filter
+    # without a separate status check.
+    create_if_not_exists(index(:phoenix_kit_cat_items, [:catalogue_uuid], prefix: prefix))
+
+    create_if_not_exists(
+      index(:phoenix_kit_cat_items, [:catalogue_uuid, :status], prefix: prefix)
+    )
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '96'")
+  end
+
+  @doc """
+  Rolls V96 back by dropping the `catalogue_uuid` column (and its indexes).
+
+  **Lossy rollback:** items that were created *after* V96 as uncategorized
+  (no category) have their catalogue linkage stored solely in
+  `catalogue_uuid`. Dropping the column means those items can no longer
+  be attributed to a catalogue — they'll become global orphans again
+  (their pre-V96 shape). Back up before rolling back in production.
+  """
+  def down(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    drop_if_exists(index(:phoenix_kit_cat_items, [:catalogue_uuid, :status], prefix: prefix))
+
+    drop_if_exists(index(:phoenix_kit_cat_items, [:catalogue_uuid], prefix: prefix))
+
+    execute("ALTER TABLE #{p}phoenix_kit_cat_items DROP COLUMN IF EXISTS catalogue_uuid")
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '95'")
+  end
+
+  defp prefix_str("public"), do: "public."
+  defp prefix_str(prefix), do: "#{prefix}."
+end


### PR DESCRIPTION
Adds a nullable `catalogue_uuid` FK on `phoenix_kit_cat_items` so items belong directly to a catalogue instead of transitively through their category. Backfills existing items from `category.catalogue_uuid`, then pins any truly uncategorized orphans to the oldest non-deleted catalogue (they used to show on every catalogue detail page as a global pool; pinning keeps them visible in the common single-catalogue case).

Creates indexes on `[:catalogue_uuid]` and `[:catalogue_uuid, :status]` (every per-catalogue read path filters on both). Down migration is documented as lossy for items created post-V96 as uncategorized.

(Originally authored as V95 before rebasing onto upstream/dev, which already had a V95 for the media folder system. Renumbered to V96.)