### PR TITLE
Align admin routing docs and tab-path conventions with implementation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -347,8 +347,10 @@ External modules register custom hooks via inline `<script>` tags on `window.Pho
 PhoenixKit uses its own layout wrapper component instead of the standard Phoenix `Layouts.app`:
 
 - **Always** begin PhoenixKit LiveView templates with `<PhoenixKitWeb.Components.LayoutWrapper.app_layout ...>` which wraps all inner content
-- Required attributes: `flash`, `page_title`, `url_path`, `project_title`, `phoenix_kit_current_scope`
-- Optional: `current_locale`, `current_locale_base`
+- Required attribute: `flash`
+- Recommended attributes: `page_title`, `current_path`, `project_title`, `phoenix_kit_current_scope`
+- Optional: `current_locale`
+- Pass the `@url_path` assign (set by PhoenixKit's on_mount hook) into the `current_path` attribute — the component attribute is named `current_path`, not `url_path`
 
 Example:
 
@@ -356,15 +358,16 @@ Example:
 <PhoenixKitWeb.Components.LayoutWrapper.app_layout
   flash={@flash}
   page_title={@page_title}
-  url_path={@url_path}
+  current_path={@url_path}
   project_title={@project_title}
   phoenix_kit_current_scope={@phoenix_kit_current_scope}
   current_locale={assigns[:current_locale]}
-  current_locale_base={assigns[:current_locale_base]}
 >
   <!-- Your content here -->
 </PhoenixKitWeb.Components.LayoutWrapper.app_layout>
 ```
+
+For the complete list of component attributes, see `lib/phoenix_kit_web/components/layout_wrapper.ex` — only `flash` is strictly required; everything else has sensible defaults.
 
 ### URL Prefix and Navigation
 

--- a/dev_docs/guides/2025-12-30-routing-architecture-guide.md
+++ b/dev_docs/guides/2025-12-30-routing-architecture-guide.md
@@ -1,5 +1,15 @@
 # Routing Architecture Guide
 
+> ⚠️ **Historical design exploration — do not use Strategy 1 as an implementation recipe.**
+>
+> This document captures the state of the PhoenixKit router as of 2025-12-30, plus three scaling strategies that were being considered at the time. **Only the "Current Solution" section below still reflects how the router works today.** The three "Scaling Strategies" were exploratory and **Strategy 1 in particular was not adopted** — the architecture instead went with a single, shared `live_session :phoenix_kit_admin` block into which external plugin modules inject their routes via `compile_external_admin_routes/1` (see `lib/phoenix_kit_web/integration.ex`). Plugin modules expose `admin_routes/0` / `admin_locale_routes/0` (see any `phoenix_kit_*/lib/*/routes.ex`) and those quoted blocks are spliced into the core live_session at compile time.
+>
+> **Following Strategy 1 today would reproduce a known bug class**: a sub-router declaring its own `live_session :billing_admin` (or similar) sits in a different session than `:phoenix_kit_admin`, so every `push_navigate` from another admin page tears down the WebSocket with `navigate event failed because you are redirecting across live_sessions. A full page reload will be performed instead`, and the admin layout (applied by `maybe_apply_plugin_layout/1` inside the `:phoenix_kit_ensure_admin` on_mount hook) never gets applied to those routes.
+>
+> **For current user-facing routing guidance, read `phoenix_kit/guides/custom-admin-pages.md` instead.** This file is kept for historical reference only.
+
+---
+
 This guide documents the PhoenixKit routing architecture, compile-time optimization strategies, and recommendations for scaling as new modules are added.
 
 ## Table of Contents

--- a/dev_docs/guides/2026-02-23-plugin-system-architecture-guide.md
+++ b/dev_docs/guides/2026-02-23-plugin-system-architecture-guide.md
@@ -99,7 +99,7 @@ defmodule PhoenixKitHelloWorld do
       id: :admin_hello_world,
       label: "Hello World",
       icon: "hero-hand-raised",
-      path: "/admin/hello-world",
+      path: "hello-world",
       priority: 640,
       level: :admin,
       permission: "hello_world",

--- a/dev_docs/guides/2026-02-24-module-system-guide.md
+++ b/dev_docs/guides/2026-02-24-module-system-guide.md
@@ -97,7 +97,7 @@ defmodule PhoenixKit.Modules.Analytics do
         id: :admin_analytics,
         label: "Analytics",
         icon: "hero-chart-bar",
-        path: "/admin/analytics",
+        path: "analytics",
         priority: 600,
         level: :admin,
         permission: "analytics",  # MUST match module_key
@@ -599,7 +599,7 @@ def settings_tabs do
       id: :admin_settings_analytics,
       label: "Analytics",
       icon: "hero-chart-bar",
-      path: "/admin/settings/analytics",
+      path: "analytics",
       priority: 910,
       level: :admin,
       parent: :admin_settings,          # Required for settings subtabs
@@ -747,24 +747,50 @@ inside the admin `live_session` with the admin layout applied.
 
 ### Custom route module
 
-For complex routing needs (non-LiveView routes, custom pipelines), implement `route_module/0`:
+The `live_view:` field on a tab handles most module routing — including routes with dynamic segments like `:id` or `:slug` (the `path` string is spliced verbatim into the generated `live` route by `tab_to_route/1` in `integration.ex`). For CRUD pages that shouldn't appear in the sidebar, add extra tabs with `visible: false` — `phoenix_kit_posts` and `phoenix_kit_catalogue` are good references.
+
+You need a **route module** (via `route_module/0`) when the tab-based approach isn't expressive enough for your **admin LiveView routing**. Specifically:
+
+- You want to declare many admin `live` routes without a corresponding `Tab` entry for each one
+- You need separate localized (`:_locale` suffix) and non-localized route variants with distinct `:as` aliases — `admin_tabs/0` can't split these
+- You want a hybrid: `admin_tabs/0` for sidebar structure plus a route module for supplementary LiveView routes — `phoenix_kit_ai` uses exactly this pattern
+
+> **The admin functions only accept `live` routes.** `admin_routes/0` and `admin_locale_routes/0` get spliced directly inside `live_session :phoenix_kit_admin do … end` by `compile_external_admin_routes/1` at `integration.ex:481`. Phoenix LiveView's `live_session` macro only permits `live` declarations in its body — controller routes (`get`, `post`, etc.), `forward`, and nested `scope`/`pipe_through` blocks raise at compile time when placed there. For **non-LiveView module routes** (controllers, APIs, `forward`, catch-all public pages), use `generate/1` or `public_routes/1` on the same route module instead — they splice into separate router locations. `phoenix_kit_sync` puts its `POST /sync/api/*` controllers and its WebSocket `forward` in `generate/1`; `phoenix_kit_publishing` puts its catch-all blog `GET /:group` controller in `public_routes/1`.
+
+Implement `route_module/0` returning a module that exports `admin_routes/0` and `admin_locale_routes/0`, each returning a quoted block of `live` routes:
 
 ```elixir
-def route_module, do: PhoenixKitAnalytics.Router
+# In your main module
+def route_module, do: PhoenixKitAnalytics.Routes
 ```
 
 ```elixir
-defmodule PhoenixKitAnalytics.Router do
-  defmacro phoenix_kit_admin_routes do
+defmodule PhoenixKitAnalytics.Routes do
+  def admin_locale_routes do
     quote do
-      live "/admin/analytics", PhoenixKitAnalytics.Web.Index, :index
-      live "/admin/analytics/:id", PhoenixKitAnalytics.Web.Show, :show
+      live "/admin/analytics", PhoenixKitAnalytics.Web.Index, :index,
+        as: :analytics_localized
+      live "/admin/analytics/:id", PhoenixKitAnalytics.Web.Show, :show,
+        as: :analytics_show_localized
+    end
+  end
+
+  def admin_routes do
+    quote do
+      live "/admin/analytics", PhoenixKitAnalytics.Web.Index, :index,
+        as: :analytics
+      live "/admin/analytics/:id", PhoenixKitAnalytics.Web.Show, :show,
+        as: :analytics_show
     end
   end
 end
 ```
 
-Routes are generated at compile time via `compile_plugin_admin_routes/0` in `integration.ex`. A recompile is required after adding a new external module.
+Both functions define the same routes — one for the localized scope (`/:locale` prefix) and one for the non-localized scope. Every route needs a unique `:as` name across both.
+
+At compile time, PhoenixKit's `compile_external_admin_routes/1` (in `lib/phoenix_kit_web/integration.ex`) splices these quoted blocks into the single shared `live_session :phoenix_kit_admin` block. **You do not declare your own `live_session` — PhoenixKit owns `:phoenix_kit_admin` and Phoenix LiveView raises on duplicate names anyway.** A recompile is required after adding a new external module (handled automatically by `__mix_recompile__?/0` in the host router).
+
+See `phoenix_kit_entities/lib/phoenix_kit_entities/routes.ex` and `phoenix_kit_publishing/lib/phoenix_kit_publishing/routes.ex` for real-world reference implementations, and `phoenix_kit/guides/custom-admin-pages.md` for the user-facing routing guide.
 
 ### Assigns available in admin LiveViews
 

--- a/guides/custom-admin-pages.md
+++ b/guides/custom-admin-pages.md
@@ -40,7 +40,7 @@ config :phoenix_kit, :admin_dashboard_tabs, [
     id: :admin_analytics,
     label: "Analytics",
     icon: "hero-chart-bar",
-    path: "/admin/analytics",
+    path: "analytics",
     permission: "dashboard",
     priority: 150,
     group: :admin_main,
@@ -53,66 +53,69 @@ config :phoenix_kit, :admin_dashboard_tabs, [
 
 ## Igniter Generator
 
-For automated setup, use the built-in Igniter task to generate admin pages:
+For automated setup, use the built-in Igniter task to generate admin pages. The task takes **one positional argument** — the display title — and everything else is optional flags:
 
 ```bash
-mix phoenix_kit.gen.admin_page Analytics Reports "Reports Dashboard" \
-  --url="/admin/analytics/reports" \
-  --icon="hero-chart-bar"
+mix phoenix_kit.gen.admin.page "Reports Dashboard"
 ```
+
+That minimal invocation creates a page titled "Reports Dashboard" in the default `General` category, with an auto-derived URL slug, using the default heroicon.
 
 ### Arguments
 
-| Argument | Description | Example |
-|----------|-------------|---------|
-| `category` | Category name for grouping | `Analytics` |
-| `page_name` | Module name (PascalCase) | `Reports` |
-| `page_title` | Display title | `"Reports Dashboard"` |
+| Argument | Required | Description | Example |
+|----------|----------|-------------|---------|
+| `title` | ✅ Yes | Display title for the page — must be under 100 characters | `"Reports Dashboard"` |
 
 ### Options
 
-| Option | Required | Default | Description |
-|--------|----------|---------|-------------|
-| `--url` | ✅ Yes | - | URL path (must start with `/`) |
-| `--icon` | No | `"hero-document-text"` | Heroicon name |
-| `--description` | No | - | Brief description |
-| `--category-icon` | No | `"hero-folder"` | Category icon |
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--url` | derived from title via `slugify/1` | URL path (must start with `/`) |
+| `--category` | `"General"` | Category name for grouping — first page in a category creates the parent tab |
+| `--icon` | `"hero-document-text"` | Heroicon name for the page tab |
+| `--permission` | `"dashboard"` | Permission key for the parent tab |
+| `--category-icon` | `"hero-folder"` | Heroicon name for the category parent tab |
+
+Short aliases also work: `-u` (url), `-c` (category), `-i` (icon), `-p` (permission), `-ci` (category-icon).
 
 ### What It Generates
 
 1. **LiveView module** at `lib/{app_name}_web/phoenix_kit/live/admin/{category}/{page}.ex`
-2. **Config entry** in `config/config.exs` for the admin category
-3. **Template-based** boilerplate code
+2. **`:admin_dashboard_tabs` entry** in `config/config.exs` — including the `live_view:` field so the route is auto-wired into PhoenixKit's `live_session :phoenix_kit_admin`
+3. **Parent tab** for the category if this is the first page in it; subsequent pages in the same category only add child tabs
 
 ### After Generation
 
-**Important:** You must add the route to your router manually:
+**You do not need to touch your router.** The generated config entry carries a `live_view:` field, which PhoenixKit compiles into its own `live_session :phoenix_kit_admin` at build time. Just restart your server (routes are generated at compile time, not hot-reloaded) and the page will show up in the admin sidebar.
 
-```elixir
-# lib/my_app_web/router.ex
-scope "/" do
-  pipe_through :browser
+> ⚠️ **Do not add a `live_session` block for the generated page in your `router.ex`.** Declaring a separate `live_session` — even one that uses `{PhoenixKitWeb.Users.Auth, :phoenix_kit_ensure_admin}` as its `on_mount` — puts the page in a different session than core admin, and every `push_navigate` from another admin page will tear down the socket with `navigate event failed because you are redirecting across live_sessions. A full page reload will be performed instead`. You also cannot declare a second `live_session :phoenix_kit_admin` block of your own — Phoenix raises at compile time on duplicate names. See [Do Not Hand-Register Admin Routes in Your Parent Router](#do-not-hand-register-admin-routes-in-your-parent-router) below.
 
-  live_session :phoenix_kit_admin_custom_categories,
-    on_mount: [{PhoenixKitWeb.Users.Auth, :phoenix_kit_ensure_admin}] do
-    live "/admin/analytics/reports", MyAppWeb.PhoenixKit.Live.Admin.Analytics.Reports, :index
-  end
-end
-```
-
-### Example: Create Analytics Dashboard
+### More Examples
 
 ```bash
-mix phoenix_kit.gen.admin_page Analytics Dashboard "Analytics Dashboard" \
-  --url="/admin/analytics" \
+# Put the page under a custom category
+mix phoenix_kit.gen.admin.page "User Management" --category="Users"
+
+# Custom icon
+mix phoenix_kit.gen.admin.page "Analytics" --icon="hero-chart-bar"
+
+# Full control — category, URL, and icons
+mix phoenix_kit.gen.admin.page "Reports" \
+  --url="/admin/analytics/reports" \
+  --category="Analytics" \
   --icon="hero-chart-bar" \
   --category-icon="hero-chart-bar"
 ```
 
-This generates:
-- Module: `MyAppWeb.PhoenixKit.Live.Admin.Analytics.Dashboard`
-- Route: `/admin/analytics`
-- File: `lib/my_app_web/phoenix_kit/live/admin/analytics/dashboard.ex`
+The last form generates:
+- Module: `MyAppWeb.PhoenixKit.Live.Admin.Analytics.Reports`
+- Route: `/admin/analytics/reports`
+- File: `lib/my_app_web/phoenix_kit/live/admin/analytics/reports.ex`
+- Parent tab: `Analytics` (created on first page in this category)
+- Child tab: `Reports` under `Analytics`
+
+Run `mix phoenix_kit.gen.admin.page --help` to see the built-in help.
 
 ---
 
@@ -174,7 +177,7 @@ config :phoenix_kit, :admin_dashboard_tabs, [
     id: :admin_analytics,                           # Unique atom ID
     label: "Analytics",                             # Display text
     icon: "hero-chart-bar",                         # Heroicon name
-    path: "/admin/analytics",                       # Route path
+    path: "analytics",                              # Route path (relative — see note below)
     permission: "dashboard",                        # Required permission key
     priority: 150,                                  # Sort order (lower = first)
     group: :admin_main,                             # Sidebar group
@@ -183,13 +186,20 @@ config :phoenix_kit, :admin_dashboard_tabs, [
 ]
 ```
 
+> **About the `path` field.** Tab paths are **relative by convention**. PhoenixKit's `Tab.resolve_path/2` (in `lib/phoenix_kit/dashboard/tab.ex`) prepends the context prefix automatically:
+> - `admin_tabs/0` tabs → `/admin/<path>`  (e.g. `"analytics"` → `/admin/analytics`)
+> - `settings_tabs/0` tabs → `/admin/settings/<path>`
+> - `user_dashboard_tabs/0` tabs → `/dashboard/<path>`
+>
+> Absolute paths (starting with `/`) pass through unchanged, and both forms are valid. The relative form is preferred because it's what every real plugin module uses (`phoenix_kit_emails`, `phoenix_kit_catalogue`, `phoenix_kit_entities`, etc.), it's shorter, and the same tab can be reused across contexts (admin vs settings) without hardcoding the prefix.
+
 ### Tab Options
 
 | Option | Type | Required | Description |
 |--------|------|----------|-------------|
 | `id` | atom | ✅ Yes | Unique identifier for the tab (prefix with `admin_` by convention) |
 | `label` | string | ✅ Yes | Display text in sidebar |
-| `path` | string | ⚠️ Usually | Route path (auto-generated from `live_view` if provided) |
+| `path` | string | ⚠️ Usually | Route path — **relative by convention** (e.g. `"analytics"`), resolved to `/admin/analytics` by `Tab.resolve_path/2`. Absolute paths work too but are discouraged |
 | `icon` | string | No | Heroicon name (e.g., "hero-chart-bar") |
 | `permission` | string | ⚠️ Recommended | Permission key for access control |
 | `priority` | integer | No | Sort order (default: 500, lower = higher in sidebar) |
@@ -201,15 +211,16 @@ config :phoenix_kit, :admin_dashboard_tabs, [
 | `subtab_display` | atom | No | `:when_active` or `:always` (default: :when_active) |
 | `highlight_with_subtabs` | boolean | No | Highlight parent when subtab is active |
 
-### Using `live_view` for Seamless Navigation
+### Using `live_view` is Required, Not Optional
 
-When you provide the `live_view` tuple, PhoenixKit automatically generates a route inside the shared admin `live_session`. This means:
+When you provide the `live_view` tuple, PhoenixKit generates the route inside its shared `live_session :phoenix_kit_admin`. You get:
 
-- ✅ No full page reload when navigating from other admin pages
-- ✅ Preserves live navigation state
-- ✅ Consistent with built-in PhoenixKit admin pages
+- ✅ The admin layout (sidebar + header) applied by the `:phoenix_kit_ensure_admin` on_mount hook
+- ✅ No full page reload when navigating from other admin pages — `push_navigate` stays on the same socket
+- ✅ Preserved LiveView state across admin pages
+- ✅ Consistent admin permission enforcement
 
-**If you omit `live_view`**, you must define the route manually in your router.
+**Omitting `live_view:` and declaring the route yourself in `router.ex` is not a supported alternative** — you will lose the admin layout entirely, and every click from another admin page will tear down the WebSocket. See [Do Not Hand-Register Admin Routes in Your Parent Router](#do-not-hand-register-admin-routes-in-your-parent-router) below for the full explanation.
 
 ---
 
@@ -230,7 +241,7 @@ PhoenixKit organizes admin tabs into groups for better organization:
   id: :blog_posts,
   label: "Blog Posts",
   icon: "hero-document-text",
-  path: "/admin/blog",
+  path: "blog",
   permission: "entities",
   group: :admin_content,  # <-- Groups under "Content"
   live_view: {MyAppWeb.BlogPostsLive, :index}
@@ -250,7 +261,7 @@ Use the `permission` option to restrict access:
   id: :admin_billing,
   label: "Billing",
   icon: "hero-credit-card",
-  path: "/admin/billing",
+  path: "billing",
   permission: "billing",  # Users need "billing" permission
   live_view: {MyAppWeb.BillingLive, :index}
 }
@@ -395,7 +406,7 @@ config :phoenix_kit, :admin_dashboard_tabs, [
     id: :admin_blog_posts,
     label: "Blog Posts",
     icon: "hero-document-text",
-    path: "/admin/blog",
+    path: "blog",
     permission: "entities",
     group: :admin_content,
     live_view: {MyAppWeb.AdminBlogPostsLive, :index}
@@ -405,22 +416,63 @@ config :phoenix_kit, :admin_dashboard_tabs, [
 
 ---
 
-## Manual Route Definition
+## Do Not Hand-Register Admin Routes in Your Parent Router
 
-If you don't use the `live_view` option, define routes manually:
+**Never** declare `live` routes for PhoenixKit admin LiveViews in your parent app's `router.ex`. Always go through the tab system (`live_view:` field) or a plugin route module. Hand-writing the route breaks two things:
+
+1. **The admin layout disappears.** The sidebar and header are applied by the `:phoenix_kit_ensure_admin` on_mount hook (`lib/phoenix_kit_web/users/auth.ex`), which calls `maybe_apply_plugin_layout/1`. That hook only runs inside PhoenixKit's `live_session :phoenix_kit_admin`. A route declared in your own router sits in a different (or unnamed) live_session and never gets the layout.
+2. **Cross-`live_session` navigation crashes the socket.** Phoenix LiveView refuses to `push_navigate` across live_session boundaries — the server logs `navigate event to <url> failed because you are redirecting across live_sessions. A full page reload will be performed instead`, the WebSocket is torn down, and the user gets a full page reload every time they click from another admin page into yours.
+
+**Note on `:phoenix_kit_ensure_admin`.** It is an **`on_mount` hook**, not a Plug. You cannot put it in a `pipe_through` list. It only functions when attached to a `live_session` block via `on_mount: [{PhoenixKitWeb.Users.Auth, :phoenix_kit_ensure_admin}]`.
+
+**Note on reusing the `live_session` name.** You cannot work around this by declaring a second `live_session :phoenix_kit_admin` block in your router — Phoenix LiveView raises at compile time (`attempting to redefine live_session :phoenix_kit_admin. live_session routes must be declared in a single named block`). There is exactly one `:phoenix_kit_admin` block, and PhoenixKit owns it.
+
+### The two supported ways to add an admin page
+
+Both patterns compile routes into the same shared `live_session :phoenix_kit_admin`. You get the admin layout, seamless navigation, and the admin permission check with either one. **Both support dynamic path segments** (`:id`, `:uuid`, `:slug`, etc.) — `tab_to_route/1` in `lib/phoenix_kit_web/integration.ex` splices the `path` string verbatim into a Phoenix `live` route, so anything Phoenix router accepts works here.
+
+**1. `live_view:` on a tab** — the lightweight pattern. Each tab generates exactly one route:
 
 ```elixir
-# lib/my_app_web/router.ex
-import PhoenixKitWeb.Integration
-
-scope "/", MyAppWeb do
-  pipe_through [:browser, :require_authenticated_user, :phoenix_kit_ensure_admin]
-
-  live "/admin/custom", CustomAdminLive
-end
+config :phoenix_kit, :admin_dashboard_tabs, [
+  %{
+    id: :admin_analytics,
+    label: "Analytics",
+    icon: "hero-chart-bar",
+    path: "analytics",
+    permission: "dashboard",
+    group: :admin_main,
+    live_view: {MyAppWeb.AdminAnalyticsLive, :index}
+  }
+]
 ```
 
-> **Note**: Manual routes won't get seamless LiveView navigation from other admin pages. Prefer the `live_view` option when possible.
+For CRUD pages that shouldn't appear in the sidebar (e.g. `analytics/:id/edit`, `analytics/new`), add additional tabs with `visible: false` and a `parent:` link — dynamic segments are fine in the `path` field:
+
+```elixir
+%{
+  id: :admin_analytics_edit,
+  label: "Edit Report",
+  path: "analytics/:id/edit",
+  parent: :admin_analytics,
+  visible: false,
+  live_view: {MyAppWeb.AdminAnalyticsFormLive, :edit}
+}
+```
+
+This is how `phoenix_kit_posts`, `phoenix_kit_catalogue`, `phoenix_kit_locations`, `phoenix_kit_emails`, and most other plugins wire their CRUD routes — see `phoenix_kit_posts/lib/phoenix_kit_posts.ex:213` and `phoenix_kit_catalogue/lib/phoenix_kit_catalogue.ex:198` for reference.
+
+**2. Plugin route module** — the flexible pattern. Extract your pages into a PhoenixKit plugin that exports `route_module/0`, returning a module with `admin_routes/0` and `admin_locale_routes/0`. Each function returns a quoted block of **`live` route declarations** that get spliced into `:phoenix_kit_admin` at compile time.
+
+> **These admin functions can only contain `live` routes.** `admin_routes/0` and `admin_locale_routes/0` are spliced directly inside Phoenix's `live_session :phoenix_kit_admin do … end` block (see `phoenix_kit/lib/phoenix_kit_web/integration.ex:481`), and Phoenix LiveView's `live_session` only permits `live` declarations inside its body — controllers (`get`, `post`, `put`, etc.), `forward`, nested `scope` blocks, and `pipe_through` all raise at compile time when placed there. Non-LiveView admin functionality isn't supported by this pattern. For non-LiveView module routes (controllers, API endpoints, forwards, catch-all public pages), use the **`generate/1`** or **`public_routes/1`** entry points on the same route module — they splice into separate router locations outside any `live_session`. `phoenix_kit_sync/lib/phoenix_kit_sync/routes.ex` is a good reference (`post "/sync/api/…"` and `forward "…/sync/websocket"` live in `generate/1`).
+
+Use the route-module `admin_routes/0` / `admin_locale_routes/0` pattern when:
+
+- You want many admin `live` routes without a `Tab` entry for each (e.g. admin routes that don't need a sidebar item)
+- You need **separate localized and non-localized variants** with distinct `:as` aliases — `admin_tabs/0` generates one route per tab and can't do this split
+- You want to mix both patterns in one module — `phoenix_kit_ai` is a good reference: it uses `admin_tabs/0` for sidebar structure plus a route module for supplementary CRUD form routes. See `phoenix_kit_ai/lib/phoenix_kit_ai/routes.ex`.
+
+Other reference implementations: `phoenix_kit_entities/lib/phoenix_kit_entities/routes.ex` (admin `live` routes + public form submission routes via `generate/1`), `phoenix_kit_publishing/lib/phoenix_kit_publishing/routes.ex` (admin `live` routes via `admin_locale_routes/0` + public controller routes via `public_routes/1`).
 
 ---
 

--- a/lib/phoenix_kit/config/config.ex
+++ b/lib/phoenix_kit/config/config.ex
@@ -54,14 +54,14 @@ defmodule PhoenixKit.Config do
           id: :orders,
           label: "My Orders",
           icon: "hero-shopping-bag",
-          path: "/dashboard/orders",
+          path: "orders",
           priority: 100
         },
         %{
           id: :notifications,
           label: "Notifications",
           icon: "hero-bell",
-          path: "/dashboard/notifications",
+          path: "notifications",
           priority: 200,
           badge: %{type: :count, value: 0, color: :error}
         }

--- a/lib/phoenix_kit/dashboard/ADMIN_README.md
+++ b/lib/phoenix_kit/dashboard/ADMIN_README.md
@@ -43,13 +43,15 @@ config :phoenix_kit, :admin_dashboard_tabs, [
     id: :admin_analytics,
     label: "Analytics",
     icon: "hero-chart-bar",
-    path: "/admin/analytics",
+    path: "analytics",
     permission: "dashboard",
     priority: 350,
     group: :admin_main
   }
 ]
 ```
+
+> **Tab paths are relative by convention.** `Tab.resolve_path/2` prepends the context prefix at render/compile time — `admin_tabs/0` tabs get `/admin/`, `settings_tabs/0` get `/admin/settings/`, `user_dashboard_tabs/0` get `/dashboard/`. So `path: "analytics"` in an `admin_tabs/0` entry resolves to `/admin/analytics`. Absolute paths (starting with `/`) pass through unchanged, but the relative form is preferred — it's what every real plugin module uses and it lets the same tab definition work across contexts without hardcoding the prefix.
 
 ### Adding Tabs with Seamless Navigation
 
@@ -63,7 +65,7 @@ config :phoenix_kit, :admin_dashboard_tabs, [
     id: :admin_analytics,
     label: "Analytics",
     icon: "hero-chart-bar",
-    path: "/admin/analytics",
+    path: "analytics",
     permission: "dashboard",
     priority: 350,
     group: :admin_main,
@@ -86,7 +88,7 @@ With `live_view` set, PhoenixKit:
 | `id` | atom | required | Unique identifier (prefix with `admin_` by convention) |
 | `label` | string | required | Display text in sidebar |
 | `icon` | string | nil | Heroicon name (e.g., `"hero-chart-bar"`) |
-| `path` | string | required | URL path without prefix (e.g., `"/admin/analytics"`) |
+| `path` | string | required | URL path — **relative by convention** (e.g., `"analytics"`, resolved to `/admin/analytics` by `Tab.resolve_path/2`). Absolute paths also work but are discouraged |
 | `priority` | integer | 500 | Sort order (lower = higher in sidebar) |
 | `level` | atom | `:admin` | Set automatically by config loader |
 | `permission` | string | nil | Permission key for access control (e.g., `"billing"`) |
@@ -120,7 +122,7 @@ PhoenixKit.Dashboard.register_admin_tabs(:my_app, [
     id: :admin_analytics,
     label: "Analytics",
     icon: "hero-chart-bar",
-    path: "/admin/analytics",
+    path: "analytics",
     permission: "dashboard",
     priority: 350,
     group: :admin_main
@@ -142,7 +144,7 @@ config :phoenix_kit, :admin_dashboard_tabs, [
     id: :admin_reports,
     label: "Reports",
     icon: "hero-document-chart-bar",
-    path: "/admin/reports",
+    path: "reports",
     permission: "dashboard",
     priority: 360,
     group: :admin_main,
@@ -153,7 +155,7 @@ config :phoenix_kit, :admin_dashboard_tabs, [
   %{
     id: :admin_reports_sales,
     label: "Sales",
-    path: "/admin/reports/sales",
+    path: "reports/sales",
     parent: :admin_reports,
     priority: 361,
     live_view: {MyAppWeb.ReportsSalesLive, :index}
@@ -161,7 +163,7 @@ config :phoenix_kit, :admin_dashboard_tabs, [
   %{
     id: :admin_reports_users,
     label: "Users",
-    path: "/admin/reports/users",
+    path: "reports/users",
     parent: :admin_reports,
     priority: 362,
     live_view: {MyAppWeb.ReportsUsersLive, :index}
@@ -186,7 +188,7 @@ PhoenixKit.Dashboard.register_admin_tabs(:my_app, [
     id: :admin_workspaces,
     label: "Workspaces",
     icon: "hero-squares-2x2",
-    path: "/admin/workspaces",
+    path: "workspaces",
     permission: "dashboard",
     priority: 400,
     group: :admin_main,
@@ -198,7 +200,7 @@ PhoenixKit.Dashboard.register_admin_tabs(:my_app, [
           id: :"admin_workspace_#{ws.slug}",
           label: ws.name,
           icon: "hero-square-2-stack",
-          path: "/admin/workspaces/#{ws.slug}",
+          path: "workspaces/#{ws.slug}",
           priority: 401 + idx,
           level: :admin,
           permission: "dashboard",
@@ -243,7 +245,7 @@ config :phoenix_kit, :admin_dashboard_tabs, [
     id: :admin_analytics,
     label: "Analytics",
     icon: "hero-chart-bar",
-    path: "/admin/analytics",
+    path: "analytics",
     permission: "analytics",   # Not a built-in key → auto-registered
     group: :admin_main,
     live_view: {MyAppWeb.AnalyticsLive, :index}
@@ -271,7 +273,7 @@ config :phoenix_kit, :admin_dashboard_tabs, [
     id: :admin_analytics,
     label: "Analytics",
     icon: "hero-chart-bar",
-    path: "/admin/analytics",
+    path: "analytics",
     permission: "analytics",
     priority: 350,
     group: :admin_main,
@@ -281,7 +283,7 @@ config :phoenix_kit, :admin_dashboard_tabs, [
   %{
     id: :admin_analytics_sales,
     label: "Sales",
-    path: "/admin/analytics/sales",
+    path: "analytics/sales",
     parent: :admin_analytics,
     priority: 351,
     live_view: {MyAppWeb.AnalyticsSalesLive, :index}
@@ -289,7 +291,7 @@ config :phoenix_kit, :admin_dashboard_tabs, [
   %{
     id: :admin_analytics_traffic,
     label: "Traffic",
-    path: "/admin/analytics/traffic",
+    path: "analytics/traffic",
     parent: :admin_analytics,
     priority: 352,
     live_view: {MyAppWeb.AnalyticsTrafficLive, :index}
@@ -303,7 +305,7 @@ If a subtab needs its own independent permission, it can set a `permission` fiel
 %{
   id: :admin_analytics_billing,
   label: "Billing Reports",
-  path: "/admin/analytics/billing",
+  path: "analytics/billing",
   parent: :admin_analytics,
   permission: "analytics_billing",   # Separate permission, auto-registered
   priority: 353
@@ -357,7 +359,7 @@ This means:
 - Each page does a lightweight MOUNT (expected behavior for different LiveView modules)
 - No full page reloads within the admin panel
 
-**Important**: Custom admin routes defined by the parent app WITHOUT `live_view` may be in a different `live_session`, which would cause a full page reload when navigating to them. Use `live_view` in your tab config to avoid this.
+**Important**: Hand-writing `live` routes for admin LiveViews in your parent router puts them in a different `live_session` than `:phoenix_kit_admin`, which causes two problems: (1) the admin layout is lost (the sidebar/header are applied by `:phoenix_kit_ensure_admin` which only runs inside `:phoenix_kit_admin`), and (2) navigating from another admin page tears down the WebSocket with `navigate event failed because you are redirecting across live_sessions. A full page reload will be performed instead`. You cannot work around this by redeclaring `live_session :phoenix_kit_admin` in your router — Phoenix raises on duplicate live_session names. **Always register custom pages via `live_view:` on a tab** so PhoenixKit compiles them into the shared admin live_session. See `phoenix_kit/guides/custom-admin-pages.md` for the authoritative reference.
 
 ### Tab Rendering Flow
 
@@ -454,7 +456,7 @@ config :phoenix_kit, :admin_dashboard_tabs, [
     id: :admin_analytics,
     label: "Analytics",
     icon: "hero-chart-bar",
-    path: "/admin/analytics",
+    path: "analytics",
     permission: "dashboard",
     priority: 150,
     group: :admin_main,
@@ -500,7 +502,7 @@ config :phoenix_kit, AdminDashboardCategories, [
 # New format (recommended)
 config :phoenix_kit, :admin_dashboard_tabs, [
   %{id: :admin_analytics, label: "Analytics", icon: "hero-chart-bar",
-    path: "/admin/analytics", permission: "dashboard", group: :admin_main}
+    path: "analytics", permission: "dashboard", group: :admin_main}
 ]
 ```
 

--- a/lib/phoenix_kit/dashboard/README.md
+++ b/lib/phoenix_kit/dashboard/README.md
@@ -82,14 +82,14 @@ config :phoenix_kit, :user_dashboard_tabs, [
     id: :orders,
     label: "My Orders",
     icon: "hero-shopping-bag",
-    path: "/dashboard/orders",
+    path: "orders",
     priority: 100
   },
   %{
     id: :notifications,
     label: "Notifications",
     icon: "hero-bell",
-    path: "/dashboard/notifications",
+    path: "notifications",
     priority: 200,
     badge: %{type: :count, value: 0, color: :error}
   }
@@ -105,7 +105,7 @@ PhoenixKit.Dashboard.register_tabs(:my_app, [
     id: :printers,
     label: "Printers",
     icon: "hero-cube",
-    path: "/dashboard/printers",
+    path: "printers",
     priority: 150,
     badge: %{
       type: :count,
@@ -145,7 +145,7 @@ PhoenixKit.Dashboard.clear_attention(:alerts)
 %{
   id: :orders,           # Required: Unique atom identifier
   label: "Orders",       # Required: Display text
-  path: "/dashboard/orders",  # Required: URL path
+  path: "orders",        # Required: URL path (relative — resolved to /dashboard/orders)
   icon: "hero-shopping-bag",  # Optional: Heroicon name
   priority: 100          # Optional: Sort order (default: 500)
 }
@@ -153,25 +153,30 @@ PhoenixKit.Dashboard.clear_attention(:alerts)
 
 ### Tab Path Format
 
-**Important:** Tab paths should be specified WITHOUT the PhoenixKit URL prefix.
+Tab paths are **relative by convention**. `Tab.resolve_path/2` (see `lib/phoenix_kit/dashboard/tab.ex`) prepends the context prefix at load time based on which callback returned the tab:
+
+- `user_dashboard_tabs/0` → prepends `/dashboard` (e.g. `"orders"` → `/dashboard/orders`)
+- `admin_tabs/0` → prepends `/admin` (e.g. `"analytics"` → `/admin/analytics`)
+- `settings_tabs/0` → prepends `/admin/settings` (e.g. `"billing"` → `/admin/settings/billing`)
+
+An empty `path: ""` resolves to the bare context root (e.g. `""` in a user_dashboard tab becomes `/dashboard`).
 
 ```elixir
-# ✅ CORRECT - relative path without prefix
+# ✅ PREFERRED — relative form
+path: "orders"                    # resolves to /dashboard/orders
+path: "orders/pending"            # resolves to /dashboard/orders/pending
+path: ""                          # resolves to /dashboard (context root)
+
+# ⚠️ ACCEPTED — absolute form (passes through resolver unchanged, but discouraged)
 path: "/dashboard/orders"
 
-# ❌ WRONG - don't include the phoenix_kit prefix
+# ❌ WRONG — never include the PhoenixKit URL prefix
 path: "/phoenix_kit/dashboard/orders"
 ```
 
-PhoenixKit automatically normalizes paths for matching:
-- Strips the configured URL prefix (default: `/phoenix_kit`)
-- Strips locale prefixes (e.g., `/en/dashboard/orders` → `/dashboard/orders`)
-- Handles trailing slashes consistently
+The relative form is preferred because it's what every real plugin module uses (`phoenix_kit_emails`, `phoenix_kit_catalogue`, `phoenix_kit_entities`, etc.), it's shorter, and the same tab definition can be reused across contexts without hardcoding the prefix.
 
-This means your tab will correctly highlight regardless of:
-- What URL prefix is configured
-- Whether the user has a locale in the URL
-- Whether there's a trailing slash
+Separately, PhoenixKit normalizes the **incoming request path** for matching — stripping the configured URL prefix (default `/phoenix_kit`), stripping locale prefixes (`/en/dashboard/orders` → `/dashboard/orders`), and handling trailing slashes. This means your tab highlights correctly regardless of URL prefix, locale, or trailing slash — that's a separate concern from the tab's stored `path` field.
 
 ### Full Options
 
@@ -180,7 +185,7 @@ This means your tab will correctly highlight regardless of:
   id: :printers,
   label: "Printers",
   icon: "hero-cube",
-  path: "/dashboard/printers",
+  path: "printers",
   priority: 150,
   group: :farm,          # Group ID for organization
   match: :prefix,        # :exact, :prefix, {:regex, ~r/.../}, or function
@@ -215,7 +220,7 @@ config :phoenix_kit, :user_dashboard_tab_groups, [
 Then assign tabs to groups:
 
 ```elixir
-%{id: :printers, label: "Printers", path: "/dashboard/printers", group: :farm}
+%{id: :printers, label: "Printers", path: "printers", group: :farm}
 ```
 
 ## Subtabs
@@ -231,7 +236,7 @@ config :phoenix_kit, :user_dashboard_tabs, [
     id: :orders,
     label: "Orders",
     icon: "hero-shopping-bag",
-    path: "/dashboard/orders",
+    path: "orders",
     priority: 100,
     subtab_display: :when_active  # Show subtabs only when parent is active
   },
@@ -239,21 +244,21 @@ config :phoenix_kit, :user_dashboard_tabs, [
   %{
     id: :pending_orders,
     label: "Pending",
-    path: "/dashboard/orders/pending",
+    path: "orders/pending",
     priority: 110,
     parent: :orders  # Links this tab to the parent
   },
   %{
     id: :completed_orders,
     label: "Completed",
-    path: "/dashboard/orders/completed",
+    path: "orders/completed",
     priority: 120,
     parent: :orders
   },
   %{
     id: :cancelled_orders,
     label: "Cancelled",
-    path: "/dashboard/orders/cancelled",
+    path: "orders/cancelled",
     priority: 130,
     parent: :orders
   }
@@ -272,7 +277,7 @@ config :phoenix_kit, :user_dashboard_tabs, [
 %{
   id: :settings,
   label: "Settings",
-  path: "/dashboard/settings",
+  path: "settings",
   subtab_display: :always
 }
 ```
@@ -285,14 +290,14 @@ When `redirect_to_first_subtab: true` is set on a parent tab, clicking the paren
 %{
   id: :orders,
   label: "Orders",
-  path: "/dashboard/orders",           # This path won't be used for navigation
+  path: "orders",                      # This path won't be used for navigation
   redirect_to_first_subtab: true,      # Clicking "Orders" goes to first subtab
   subtab_display: :when_active
 }
 
 # First subtab (priority 110) becomes the landing page
-%{id: :pending, label: "Pending", path: "/dashboard/orders/pending", parent: :orders, priority: 110}
-%{id: :completed, label: "Completed", path: "/dashboard/orders/completed", parent: :orders, priority: 120}
+%{id: :pending, label: "Pending", path: "orders/pending", parent: :orders, priority: 110}
+%{id: :completed, label: "Completed", path: "orders/completed", parent: :orders, priority: 120}
 ```
 
 With this config, clicking "Orders" navigates to `/dashboard/orders/pending`.
@@ -305,7 +310,7 @@ By default, when a subtab is active, only the subtab is highlighted (not the par
 %{
   id: :orders,
   label: "Orders",
-  path: "/dashboard/orders",
+  path: "orders",
   highlight_with_subtabs: true  # Also highlight parent when subtab is active (default: false)
 }
 ```
@@ -325,7 +330,7 @@ Set these on the **parent tab** to apply to all its subtabs, or on **individual 
 %{
   id: :orders,
   label: "Orders",
-  path: "/dashboard/orders",
+  path: "orders",
   subtab_display: :when_active,
   # Style options for subtabs (applied to children)
   subtab_indent: "pl-12",        # Tailwind padding-left class (default: "pl-4")
@@ -341,13 +346,13 @@ Individual subtabs can override the parent's styling:
 
 ```elixir
 # Parent with default styling
-%{id: :settings, label: "Settings", path: "/dashboard/settings", subtab_display: :always},
+%{id: :settings, label: "Settings", path: "settings", subtab_display: :always},
 
 # Subtab with custom styling (overrides parent)
 %{
   id: :advanced_settings,
   label: "Advanced",
-  path: "/dashboard/settings/advanced",
+  path: "settings/advanced",
   parent: :settings,
   subtab_indent: "pl-14",
   subtab_text_size: "text-xs font-medium"
@@ -419,9 +424,9 @@ Animations play when subtabs become visible (when navigating to parent or subtab
 ```elixir
 # Register parent and subtabs at runtime
 PhoenixKit.Dashboard.register_tabs(:my_app, [
-  %{id: :printers, label: "Printers", path: "/dashboard/printers", subtab_display: :when_active},
-  %{id: :active_printers, label: "Active", path: "/dashboard/printers/active", parent: :printers},
-  %{id: :idle_printers, label: "Idle", path: "/dashboard/printers/idle", parent: :printers}
+  %{id: :printers, label: "Printers", path: "printers", subtab_display: :when_active},
+  %{id: :active_printers, label: "Active", path: "printers/active", parent: :printers},
+  %{id: :idle_printers, label: "Idle", path: "printers/idle", parent: :printers}
 ])
 ```
 
@@ -472,15 +477,15 @@ The parent tab acts as a category header. Clicking it goes to the first subtab. 
 %{
   id: :history,
   label: "History",
-  path: "/dashboard/history",
+  path: "history",
   redirect_to_first_subtab: true,   # Click goes to /dashboard/history/timeline
   highlight_with_subtabs: true,     # Parent stays highlighted
   subtab_display: :when_active
 }
 
 # Subtabs
-%{id: :timeline, label: "Timeline", path: "/dashboard/history/timeline", parent: :history, priority: 100}
-%{id: :stats, label: "Stats", path: "/dashboard/history/stats", parent: :history, priority: 200}
+%{id: :timeline, label: "Timeline", path: "history/timeline", parent: :history, priority: 100}
+%{id: :stats, label: "Stats", path: "history/stats", parent: :history, priority: 200}
 ```
 
 **Pattern 2: Parent has its own content, subtabs are secondary**
@@ -492,15 +497,15 @@ The parent tab has its own page. Subtabs provide additional views. Only the acti
 %{
   id: :orders,
   label: "Orders",
-  path: "/dashboard/orders",
+  path: "orders",
   match: :exact,                    # Only highlight when exactly on /dashboard/orders
   highlight_with_subtabs: false,    # Don't highlight parent when on subtab
   subtab_display: :when_active
 }
 
 # Subtabs
-%{id: :pending, label: "Pending", path: "/dashboard/orders/pending", parent: :orders}
-%{id: :completed, label: "Completed", path: "/dashboard/orders/completed", parent: :orders}
+%{id: :pending, label: "Pending", path: "orders/pending", parent: :orders}
+%{id: :completed, label: "Completed", path: "orders/completed", parent: :orders}
 ```
 
 **Pattern 3: Always-visible subtabs (settings menu)**
@@ -511,13 +516,13 @@ Subtabs are always visible regardless of which is active.
 %{
   id: :settings,
   label: "Settings",
-  path: "/dashboard/settings",
+  path: "settings",
   subtab_display: :always,          # Always show subtabs
   redirect_to_first_subtab: true
 }
 
-%{id: :profile, label: "Profile", path: "/dashboard/settings/profile", parent: :settings}
-%{id: :security, label: "Security", path: "/dashboard/settings/security", parent: :settings}
+%{id: :profile, label: "Profile", path: "settings/profile", parent: :settings}
+%{id: :security, label: "Security", path: "settings/security", parent: :settings}
 ```
 
 #### How Options Interact
@@ -707,7 +712,7 @@ For badges that show different values per user, organization, or other context (
   id: :alerts,
   label: "Alerts",
   icon: "hero-bell-alert",
-  path: "/dashboard/alerts",
+  path: "alerts",
   badge: %{
     type: :count,
     color: :error,
@@ -723,7 +728,7 @@ For badges that show different values per user, organization, or other context (
 %{
   id: :printers,
   label: "Printers",
-  path: "/dashboard/printers",
+  path: "printers",
   badge: %{
     type: :count,
     context_key: :farm,
@@ -826,7 +831,7 @@ Use the `visible` field for non-permission conditional logic like feature flags 
 %{
   id: :beta_feature,
   label: "Beta Feature",
-  path: "/dashboard/beta",
+  path: "beta",
   visible: fn scope ->
     scope.user.features["beta_enabled"] == true
   end
@@ -1068,7 +1073,7 @@ config :phoenix_kit, :user_dashboard_tabs, [
     id: :printers,
     label: "Printers",
     icon: "hero-cube",
-    path: "/dashboard",
+    path: "",
     priority: 100,
     group: :farm,
     match: :exact,
@@ -1081,7 +1086,7 @@ config :phoenix_kit, :user_dashboard_tabs, [
     id: :history,
     label: "History",
     icon: "hero-chart-bar",
-    path: "/dashboard/history",
+    path: "history",
     priority: 200,
     group: :farm
   },
@@ -1089,7 +1094,7 @@ config :phoenix_kit, :user_dashboard_tabs, [
     id: :farm_settings,
     label: "Farm Settings",
     icon: "hero-cog-6-tooth",
-    path: "/dashboard/farm-settings",
+    path: "farm-settings",
     priority: 300,
     group: :farm,
     visible: fn scope -> scope.user.has_farm? end
@@ -1110,7 +1115,7 @@ config :phoenix_kit, :user_dashboard_tabs, [
     id: :orders,
     label: "Orders",
     icon: "hero-shopping-bag",
-    path: "/dashboard/orders",
+    path: "orders",
     priority: 100,
     badge: %{type: :count, value: 0}
   },
@@ -1118,14 +1123,14 @@ config :phoenix_kit, :user_dashboard_tabs, [
     id: :wishlist,
     label: "Wishlist",
     icon: "hero-heart",
-    path: "/dashboard/wishlist",
+    path: "wishlist",
     priority: 200
   },
   %{
     id: :reviews,
     label: "Reviews",
     icon: "hero-star",
-    path: "/dashboard/reviews",
+    path: "reviews",
     priority: 300,
     badge: %{type: :new}
   },
@@ -1133,7 +1138,7 @@ config :phoenix_kit, :user_dashboard_tabs, [
     id: :addresses,
     label: "Addresses",
     icon: "hero-map-pin",
-    path: "/dashboard/addresses",
+    path: "addresses",
     priority: 400
   }
 ]
@@ -1175,16 +1180,16 @@ The `tab_loader` option allows tabs to change based on the selected context:
 # In your context module
 def get_tabs_for_context(%{type: :personal}) do
   [
-    %{id: :overview, label: "Overview", path: "/dashboard", icon: "hero-home"},
-    %{id: :settings, label: "Settings", path: "/dashboard/settings", icon: "hero-cog-6-tooth"}
+    %{id: :overview, label: "Overview", path: "", icon: "hero-home"},
+    %{id: :settings, label: "Settings", path: "settings", icon: "hero-cog-6-tooth"}
   ]
 end
 
 def get_tabs_for_context(%{type: :team}) do
   [
-    %{id: :overview, label: "Overview", path: "/dashboard", icon: "hero-home"},
-    %{id: :projects, label: "Projects", path: "/dashboard/projects", icon: "hero-folder"},
-    %{id: :settings, label: "Settings", path: "/dashboard/settings", icon: "hero-cog-6-tooth"}
+    %{id: :overview, label: "Overview", path: "", icon: "hero-home"},
+    %{id: :projects, label: "Projects", path: "projects", icon: "hero-folder"},
+    %{id: :settings, label: "Settings", path: "settings", icon: "hero-cog-6-tooth"}
   ]
 end
 ```

--- a/lib/phoenix_kit/dashboard/dashboard.ex
+++ b/lib/phoenix_kit/dashboard/dashboard.ex
@@ -24,18 +24,22 @@ defmodule PhoenixKit.Dashboard do
           id: :orders,
           label: "My Orders",
           icon: "hero-shopping-bag",
-          path: "/dashboard/orders",
+          path: "orders",
           priority: 100
         },
         %{
           id: :notifications,
           label: "Notifications",
           icon: "hero-bell",
-          path: "/dashboard/notifications",
+          path: "notifications",
           priority: 200,
           badge: %{type: :count, value: 0, color: :error}
         }
       ]
+
+  > Tab paths are **relative by convention** — `Tab.resolve_path/2` prepends `/dashboard/`
+  > for `user_dashboard_tabs`, `/admin/` for `admin_tabs`, `/admin/settings/` for `settings_tabs`.
+  > Absolute paths (starting with `/`) also work but the relative form is preferred.
 
   ### 2. Register Tabs at Runtime (Optional)
 
@@ -45,7 +49,7 @@ defmodule PhoenixKit.Dashboard do
           id: :printers,
           label: "Printers",
           icon: "hero-cube",
-          path: "/dashboard/printers",
+          path: "printers",
           priority: 150,
           badge: %{
             type: :count,
@@ -77,7 +81,7 @@ defmodule PhoenixKit.Dashboard do
 
   Then assign tabs to groups:
 
-      %{id: :printers, label: "Printers", path: "/dashboard/printers", group: :farm}
+      %{id: :printers, label: "Printers", path: "printers", group: :farm}
 
   ## Conditional Visibility
 
@@ -87,7 +91,7 @@ defmodule PhoenixKit.Dashboard do
       %{
         id: :beta_feature,
         label: "Beta",
-        path: "/dashboard/beta",
+        path: "beta",
         visible: fn scope ->
           scope.user.features["beta_enabled"] == true
         end
@@ -100,7 +104,7 @@ defmodule PhoenixKit.Dashboard do
       %{
         id: :notifications,
         label: "Notifications",
-        path: "/dashboard/notifications",
+        path: "notifications",
         badge: %{
           type: :count,
           color: :error,
@@ -139,13 +143,13 @@ defmodule PhoenixKit.Dashboard do
 
       # Register multiple tabs
       PhoenixKit.Dashboard.register_tabs(:my_app, [
-        %{id: :orders, label: "Orders", path: "/dashboard/orders", icon: "hero-shopping-bag"},
-        %{id: :history, label: "History", path: "/dashboard/history", icon: "hero-clock"}
+        %{id: :orders, label: "Orders", path: "orders", icon: "hero-shopping-bag"},
+        %{id: :history, label: "History", path: "history", icon: "hero-clock"}
       ])
 
       # Register a single tab
       PhoenixKit.Dashboard.register_tabs(:my_app, [
-        Tab.new!(id: :custom, label: "Custom", path: "/dashboard/custom")
+        Tab.new!(id: :custom, label: "Custom", path: "custom")
       ])
   """
   @spec register_tabs(atom(), [map() | Tab.t()]) :: :ok | {:error, term()}
@@ -231,7 +235,7 @@ defmodule PhoenixKit.Dashboard do
   ## Examples
 
       PhoenixKit.Dashboard.register_admin_tabs(:my_app, [
-        %{id: :admin_analytics, label: "Analytics", path: "/admin/analytics",
+        %{id: :admin_analytics, label: "Analytics", path: "analytics",
           icon: "hero-chart-bar", permission: "dashboard"}
       ])
   """

--- a/lib/phoenix_kit/dashboard/registry.ex
+++ b/lib/phoenix_kit/dashboard/registry.ex
@@ -15,24 +15,28 @@ defmodule PhoenixKit.Dashboard.Registry do
           id: :orders,
           label: "Orders",
           icon: "hero-shopping-bag",
-          path: "/dashboard/orders",
+          path: "orders",
           priority: 100
         },
         %{
           id: :settings,
           label: "Settings",
           icon: "hero-cog-6-tooth",
-          path: "/dashboard/settings",
+          path: "settings",
           priority: 900
         }
       ]
+
+  > Tab paths are relative by convention — `Tab.resolve_path/2` prepends the context prefix
+  > (`/dashboard/`, `/admin/`, or `/admin/settings/`) at load time. Both relative and absolute
+  > forms are accepted but relative is preferred.
 
   ## Runtime Registration
 
   Parent applications can register tabs at runtime:
 
       PhoenixKit.Dashboard.Registry.register(:my_app, [
-        Tab.new!(id: :custom, label: "Custom", path: "/dashboard/custom", priority: 150)
+        Tab.new!(id: :custom, label: "Custom", path: "custom", priority: 150)
       ])
 
   ## Groups
@@ -47,7 +51,7 @@ defmodule PhoenixKit.Dashboard.Registry do
 
   Then assign tabs to groups:
 
-      %{id: :printers, label: "Printers", path: "/dashboard/printers", group: :farm}
+      %{id: :printers, label: "Printers", path: "printers", group: :farm}
 
   ## PubSub Integration
 
@@ -94,12 +98,12 @@ defmodule PhoenixKit.Dashboard.Registry do
   ## Examples
 
       Registry.register(:my_app, [
-        Tab.new!(id: :home, label: "Home", path: "/dashboard", icon: "hero-home"),
-        Tab.new!(id: :orders, label: "Orders", path: "/dashboard/orders")
+        Tab.new!(id: :home, label: "Home", path: "", icon: "hero-home"),
+        Tab.new!(id: :orders, label: "Orders", path: "orders")
       ])
 
       # Register a single tab
-      Registry.register(:my_app, Tab.new!(id: :settings, label: "Settings", path: "/dashboard/settings"))
+      Registry.register(:my_app, Tab.new!(id: :settings, label: "Settings", path: "settings"))
   """
   @spec register(atom(), Tab.t() | [Tab.t()]) :: :ok
   def register(namespace, %Tab{} = tab) do
@@ -118,8 +122,8 @@ defmodule PhoenixKit.Dashboard.Registry do
   ## Examples
 
       Registry.register_from_config(:my_app, [
-        %{id: :home, label: "Home", path: "/dashboard", icon: "hero-home"},
-        %{id: :orders, label: "Orders", path: "/dashboard/orders"}
+        %{id: :home, label: "Home", path: "", icon: "hero-home"},
+        %{id: :orders, label: "Orders", path: "orders"}
       ])
   """
   @spec register_from_config(atom(), [map()] | [keyword()]) :: :ok | {:error, term()}

--- a/lib/phoenix_kit/dashboard/tab.ex
+++ b/lib/phoenix_kit/dashboard/tab.ex
@@ -18,9 +18,15 @@ defmodule PhoenixKit.Dashboard.Tab do
         id: :orders,
         label: "My Orders",
         icon: "hero-shopping-bag",
-        path: "/dashboard/orders",
+        path: "orders",
         priority: 100
       }
+
+  > Tab paths are **relative by convention** — `Tab.resolve_path/2` prepends the context
+  > prefix (`/dashboard/` for `user_dashboard_tabs`, `/admin/` for `admin_tabs`,
+  > `/admin/settings/` for `settings_tabs`). Absolute paths (starting with `/`) pass through
+  > unchanged but the relative form is preferred. An empty `path: ""` resolves to the bare
+  > context root (e.g. `/dashboard`).
 
   ## With Badge
 
@@ -28,7 +34,7 @@ defmodule PhoenixKit.Dashboard.Tab do
         id: :notifications,
         label: "Notifications",
         icon: "hero-bell",
-        path: "/dashboard/notifications",
+        path: "notifications",
         badge: %Badge{type: :count, value: 5, color: :error}
       }
 
@@ -38,7 +44,7 @@ defmodule PhoenixKit.Dashboard.Tab do
         id: :printers,
         label: "Printers",
         icon: "hero-cube",
-        path: "/dashboard/printers",
+        path: "printers",
         badge: %Badge{
           type: :count,
           subscribe: {"farm:stats", fn msg -> msg.printing_count end}
@@ -54,7 +60,7 @@ defmodule PhoenixKit.Dashboard.Tab do
         id: :beta_feature,
         label: "Beta",
         icon: "hero-beaker",
-        path: "/dashboard/beta",
+        path: "beta",
         visible: fn scope -> scope.user.features["beta_enabled"] == true end
       }
 
@@ -67,7 +73,7 @@ defmodule PhoenixKit.Dashboard.Tab do
         id: :orders,
         label: "Orders",
         icon: "hero-shopping-bag",
-        path: "/dashboard/orders",
+        path: "orders",
         subtab_display: :when_active  # Show subtabs only when this tab is active
       }
 
@@ -75,14 +81,14 @@ defmodule PhoenixKit.Dashboard.Tab do
       %Tab{
         id: :pending_orders,
         label: "Pending",
-        path: "/dashboard/orders/pending",
+        path: "orders/pending",
         parent: :orders
       }
 
       %Tab{
         id: :completed_orders,
         label: "Completed",
-        path: "/dashboard/orders/completed",
+        path: "orders/completed",
         parent: :orders
       }
 

--- a/lib/phoenix_kit/jobs.ex
+++ b/lib/phoenix_kit/jobs.ex
@@ -186,7 +186,7 @@ defmodule PhoenixKit.Jobs do
         id: :admin_jobs,
         label: "Jobs",
         icon: "hero-queue-list",
-        path: "/admin/jobs",
+        path: "jobs",
         priority: 610,
         level: :admin,
         permission: "jobs",

--- a/lib/phoenix_kit_web/dashboard/tabs_initializer.ex
+++ b/lib/phoenix_kit_web/dashboard/tabs_initializer.ex
@@ -76,7 +76,7 @@ defmodule PhoenixKitWeb.Dashboard.TabsInitializer do
         %{
           id: :alerts,
           label: "Alerts",
-          path: "/dashboard/alerts",
+          path: "alerts",
           badge: %{
             type: :count,
             context_key: :farm,  # Must match selector key

--- a/lib/phoenix_kit_web/integration.ex
+++ b/lib/phoenix_kit_web/integration.ex
@@ -675,7 +675,7 @@ defmodule PhoenixKitWeb.Integration do
   # ## Tab config example
   #
   #     config :phoenix_kit, :admin_dashboard_tabs, [
-  #       %{id: :admin_analytics, label: "Analytics", path: "/admin/analytics",
+  #       %{id: :admin_analytics, label: "Analytics", path: "analytics",
   #         live_view: {MyAppWeb.AnalyticsLive, :index}, permission: "dashboard"}
   #     ]
   #

--- a/scripts/PHOENIXKIT_AWS_COMPATIBILITY.md
+++ b/scripts/PHOENIXKIT_AWS_COMPATIBILITY.md
@@ -294,7 +294,15 @@ end
 phoenix_kit_routes()  # PhoenixKit's default routes (our route takes precedence)
 ```
 
-**Why This Works:** Phoenix router matches routes in order - our route is defined BEFORE `phoenix_kit_routes()`, so it takes precedence.
+**Why This Works:** Phoenix router matches routes in order — our route is defined BEFORE `phoenix_kit_routes()`, so it takes precedence. The `:phoenix_kit_ensure_admin` on_mount hook ensures the auth check runs and applies the admin layout, so the page renders correctly with the sidebar.
+
+> ⚠️ **Known limitation: cross-session navigation forces a full page reload.** This override LiveView sits in `live_session :custom_aws_settings`, not PhoenixKit's `live_session :phoenix_kit_admin`. When a user clicks from another admin page (e.g. `/admin/users`) to this AWS settings page, Phoenix LiveView cannot `push_navigate` across live_session boundaries — the WebSocket is torn down and the browser performs a full HTTP page load. The Elixir log shows:
+>
+>     navigate event to "/admin/settings/aws" failed because you are redirecting across live_sessions. A full page reload will be performed instead
+>
+> This is a Phoenix LiveView constraint, not a PhoenixKit bug — see `lib/phoenix_live_view/channel.ex:1615` and `phoenix_kit/guides/custom-admin-pages.md`. **You cannot work around it by renaming your `live_session` to `:phoenix_kit_admin`** — Phoenix raises at compile time on duplicate `live_session` names.
+>
+> **If full page reloads on navigation to this page are acceptable** (e.g. this is a rarely-visited settings page reached by direct URL), this pattern is the cleanest available solution. **If they are not acceptable**, the only real fix is to upstream an override hook into PhoenixKit core so plugin modules can replace core routes inside the same `:phoenix_kit_admin` block.
 
 #### 4. Standalone Script: `scripts/setup_aws_infrastructure.exs`
 


### PR DESCRIPTION
- Rewrite custom-admin-pages.md with explicit anti-pattern section covering layout loss and cross-live_session navigation failure modes
- Correct claim that dynamic segments require a route module; tab_to_route/1 splices paths verbatim, so live_view: on a tab supports :id/:slug via visible: false hidden tabs (as real modules like posts/catalogue do)
- Correct claim that admin_routes/0 accepts controller/forward/scope; the quoted block is spliced inside live_session :phoenix_kit_admin which only permits live declarations — redirect non-LiveView routes to generate/1 or public_routes/1 with phoenix_kit_sync and phoenix_kit_publishing as refs
- Fix Mix task name (phoenix_kit.gen.admin.page) and argument shape in Igniter generator section to match actual parse_args/2 in the task
- Fix LayoutWrapper attr name from url_path to current_path in AGENTS.md and remove non-existent current_locale_base example
- Convert tab-path examples to the relative-form convention used by every real plugin across ADMIN_README.md, dashboard/README.md, tab.ex moduledoc, dashboard.ex, registry.ex, config.ex, tabs_initializer.ex, and the two dev_docs guides
- Convert the built-in jobs tab from absolute to relative path form for consistency with the rest of the ecosystem
- Add historical-exploration banner to 2025-12-30 routing-architecture guide so readers know Strategy 1 was not adopted
- Add cross-session caveat note to PHOENIXKIT_AWS_COMPATIBILITY.md explaining the full-page-reload limitation of the override pattern
- Fix Igniter generator After Generation section to stop teaching a separate-live_session pattern that recreates the known bug

Motivation: these docs were drifting ahead of the implementation and would have led module authors into the exact "parent-router hand-registration" bug class (layout loss + cross-live_session navigation crash) that we just finished warning against in every other file. Every claim here is now traceable to a file:line ref in integration.ex, auth.ex, tab.ex, or layout_wrapper.ex.