### PR TITLE
Add V100 staff tables and V101 projects tables migrations

### DIFF
--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -529,7 +529,24 @@ defmodule PhoenixKit.Migrations.Postgres do
   - Replaces unique index with partial index (slug-mode only, WHERE slug IS NOT NULL)
   - Adds unique index on `(group_uuid, post_date, post_time)` for timestamp-mode posts
 
-  ### V99 - Media file trash bucket ⚡ LATEST
+  ### V101 - Projects module tables ⚡ LATEST
+  - Creates `phoenix_kit_project_tasks` (reusable task library),
+    `phoenix_kit_project_task_dependencies` (template-level ordering),
+    `phoenix_kit_projects`, `phoenix_kit_project_assignments`
+    (task instances with polymorphic assignee), and
+    `phoenix_kit_project_dependencies` (per-project task ordering)
+  - Assignment FKs reference staff module tables (teams, departments, people)
+  - CHECK constraint enforces at-most-one assignee (team / department / person)
+    on both `phoenix_kit_project_tasks` and `phoenix_kit_project_assignments`
+
+  ### V100 - Staff module tables
+  - Creates `phoenix_kit_staff_departments`, `phoenix_kit_staff_teams`,
+    `phoenix_kit_staff_people` (FK to `phoenix_kit_users`), and
+    `phoenix_kit_staff_team_memberships` join table
+  - UUIDv7 PKs, cascading deletes dept → team → team_memberships, and
+    user → person → team_memberships
+
+  ### V99 - Media file trash bucket
   - Adds `trashed_at` (timestamptz) to `phoenix_kit_files` for soft-delete
   - Partial index on `trashed_at` for efficient trash queries
 
@@ -537,7 +554,7 @@ defmodule PhoenixKit.Migrations.Postgres do
   - Adds `alternative_formats` (`text[]`) to `phoenix_kit_storage_dimensions`
   - Enables multi-format variant generation (e.g., WebP + AVIF alongside JPEG)
 
-  ### V97 - Per-item markup override ⚡ LATEST
+  ### V97 - Per-item markup override
   - Adds nullable `markup_percentage DECIMAL(7, 2)` column on
     `phoenix_kit_cat_items`
   - `NULL` = inherit the catalogue's markup (existing behavior);
@@ -728,7 +745,7 @@ defmodule PhoenixKit.Migrations.Postgres do
   use Ecto.Migration
 
   @initial_version 1
-  @current_version 99
+  @current_version 101
   @default_prefix "public"
 
   @doc false

--- a/lib/phoenix_kit/migrations/postgres/v100.ex
+++ b/lib/phoenix_kit/migrations/postgres/v100.ex
@@ -1,0 +1,147 @@
+defmodule PhoenixKit.Migrations.Postgres.V100 do
+  @moduledoc """
+  V100: Staff module tables.
+
+  Creates four tables used by `phoenix_kit_staff`:
+
+  - `phoenix_kit_staff_departments` — top-level org units
+  - `phoenix_kit_staff_teams` — teams inside a department
+  - `phoenix_kit_staff_people` — staff profiles, each linked 1:1 to a
+    `phoenix_kit_users` row (required FK)
+  - `phoenix_kit_staff_team_memberships` — join table for team membership
+
+  UUIDv7 primary keys, `timestamptz` timestamps, cascading deletes
+  department → team → team_memberships; person deletion cascades to
+  team_memberships; user deletion cascades to the staff person profile.
+
+  Departments and teams are identified by UUID only — no slug columns.
+  A team's name must be unique within its department.
+  """
+
+  use Ecto.Migration
+
+  def up(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    execute("""
+    CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_staff_departments (
+      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      name VARCHAR(255) NOT NULL,
+      description TEXT,
+      inserted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+    """)
+
+    execute("""
+    CREATE UNIQUE INDEX IF NOT EXISTS phoenix_kit_staff_departments_name_index
+    ON #{p}phoenix_kit_staff_departments (lower(name))
+    """)
+
+    execute("""
+    CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_staff_teams (
+      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      department_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_staff_departments(uuid) ON DELETE CASCADE,
+      name VARCHAR(255) NOT NULL,
+      description TEXT,
+      inserted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+    """)
+
+    execute("""
+    CREATE UNIQUE INDEX IF NOT EXISTS phoenix_kit_staff_teams_department_name_index
+    ON #{p}phoenix_kit_staff_teams (department_uuid, lower(name))
+    """)
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS phoenix_kit_staff_teams_department_index
+    ON #{p}phoenix_kit_staff_teams (department_uuid)
+    """)
+
+    execute("""
+    CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_staff_people (
+      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      user_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_users(uuid) ON DELETE CASCADE,
+      primary_department_uuid UUID REFERENCES #{p}phoenix_kit_staff_departments(uuid) ON DELETE SET NULL,
+      status VARCHAR(20) NOT NULL DEFAULT 'active',
+      job_title VARCHAR(255),
+      employment_type VARCHAR(20),
+      employment_start_date DATE,
+      employment_end_date DATE,
+      work_location VARCHAR(255),
+      work_phone VARCHAR(50),
+      personal_phone VARCHAR(50),
+      bio TEXT,
+      skills TEXT,
+      notes TEXT,
+      date_of_birth DATE,
+      personal_email VARCHAR(255),
+      emergency_contact_name VARCHAR(255),
+      emergency_contact_phone VARCHAR(50),
+      emergency_contact_relationship VARCHAR(100),
+      inserted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+    """)
+
+    execute("""
+    CREATE UNIQUE INDEX IF NOT EXISTS phoenix_kit_staff_people_user_index
+    ON #{p}phoenix_kit_staff_people (user_uuid)
+    """)
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS phoenix_kit_staff_people_primary_department_index
+    ON #{p}phoenix_kit_staff_people (primary_department_uuid)
+    """)
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS phoenix_kit_staff_people_status_index
+    ON #{p}phoenix_kit_staff_people (status)
+    """)
+
+    execute("""
+    CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_staff_team_memberships (
+      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      team_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_staff_teams(uuid) ON DELETE CASCADE,
+      staff_person_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_staff_people(uuid) ON DELETE CASCADE,
+      inserted_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+    """)
+
+    execute("""
+    CREATE UNIQUE INDEX IF NOT EXISTS phoenix_kit_staff_team_memberships_team_person_index
+    ON #{p}phoenix_kit_staff_team_memberships (team_uuid, staff_person_uuid)
+    """)
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS phoenix_kit_staff_team_memberships_person_index
+    ON #{p}phoenix_kit_staff_team_memberships (staff_person_uuid)
+    """)
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '100'")
+  end
+
+  @doc """
+  Drops all four staff tables.
+
+  **Lossy rollback:** all staff data (departments, teams, people, and
+  their team memberships) is permanently destroyed. Back up before
+  rolling back in production.
+  """
+  def down(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    execute("DROP TABLE IF EXISTS #{p}phoenix_kit_staff_team_memberships")
+    execute("DROP TABLE IF EXISTS #{p}phoenix_kit_staff_people")
+    execute("DROP TABLE IF EXISTS #{p}phoenix_kit_staff_teams")
+    execute("DROP TABLE IF EXISTS #{p}phoenix_kit_staff_departments")
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '99'")
+  end
+
+  defp prefix_str("public"), do: "public."
+  defp prefix_str(prefix), do: "#{prefix}."
+end

--- a/lib/phoenix_kit/migrations/postgres/v101.ex
+++ b/lib/phoenix_kit/migrations/postgres/v101.ex
@@ -1,0 +1,197 @@
+defmodule PhoenixKit.Migrations.Postgres.V101 do
+  @moduledoc """
+  V101: Projects module tables.
+
+  Creates five tables used by `phoenix_kit_projects`:
+
+  - `phoenix_kit_project_tasks` — reusable task library with default
+    assignees and estimated duration
+  - `phoenix_kit_project_task_dependencies` — "task A must finish before
+    task B" links at the template (library) level
+  - `phoenix_kit_projects` — project containers with start mode
+    (immediate / scheduled)
+  - `phoenix_kit_project_assignments` — task instance in a project;
+    copies duration + description from template (editable independently)
+  - `phoenix_kit_project_dependencies` — per-project assignment-level
+    "A must finish before B" links
+
+  Each assignment and task template may have **at most one** assignee
+  (team, department, or person) — enforced by `CHECK (num_nonnulls(...) <= 1)`
+  on both tables.
+
+  Depends on V100 (staff tables) for the polymorphic assignee foreign keys.
+  """
+
+  use Ecto.Migration
+
+  def up(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    execute("""
+    CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_project_tasks (
+      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      title VARCHAR(255) NOT NULL,
+      description TEXT,
+      estimated_duration INTEGER,
+      estimated_duration_unit VARCHAR(20) DEFAULT 'hours',
+      default_assigned_team_uuid UUID REFERENCES #{p}phoenix_kit_staff_teams(uuid) ON DELETE SET NULL,
+      default_assigned_department_uuid UUID REFERENCES #{p}phoenix_kit_staff_departments(uuid) ON DELETE SET NULL,
+      default_assigned_person_uuid UUID REFERENCES #{p}phoenix_kit_staff_people(uuid) ON DELETE SET NULL,
+      inserted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      CONSTRAINT phoenix_kit_project_tasks_single_default_assignee
+        CHECK (num_nonnulls(default_assigned_team_uuid, default_assigned_department_uuid, default_assigned_person_uuid) <= 1)
+    )
+    """)
+
+    execute("""
+    CREATE UNIQUE INDEX IF NOT EXISTS phoenix_kit_project_tasks_title_index
+    ON #{p}phoenix_kit_project_tasks (lower(title))
+    """)
+
+    execute("""
+    CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_projects (
+      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      name VARCHAR(255) NOT NULL,
+      description TEXT,
+      status VARCHAR(20) NOT NULL DEFAULT 'active',
+      is_template BOOLEAN NOT NULL DEFAULT false,
+      counts_weekends BOOLEAN NOT NULL DEFAULT false,
+      start_mode VARCHAR(20) NOT NULL DEFAULT 'immediate',
+      scheduled_start_date DATE,
+      started_at TIMESTAMPTZ,
+      completed_at TIMESTAMPTZ,
+      inserted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+    """)
+
+    execute("""
+    CREATE UNIQUE INDEX IF NOT EXISTS phoenix_kit_projects_name_index
+    ON #{p}phoenix_kit_projects (lower(name))
+    """)
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS phoenix_kit_projects_status_index
+    ON #{p}phoenix_kit_projects (status)
+    """)
+
+    execute("""
+    CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_project_assignments (
+      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      project_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_projects(uuid) ON DELETE CASCADE,
+      task_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_project_tasks(uuid) ON DELETE CASCADE,
+      status VARCHAR(20) NOT NULL DEFAULT 'todo',
+      position INTEGER NOT NULL DEFAULT 0,
+      description TEXT,
+      estimated_duration INTEGER,
+      estimated_duration_unit VARCHAR(20),
+      assigned_team_uuid UUID REFERENCES #{p}phoenix_kit_staff_teams(uuid) ON DELETE SET NULL,
+      assigned_department_uuid UUID REFERENCES #{p}phoenix_kit_staff_departments(uuid) ON DELETE SET NULL,
+      assigned_person_uuid UUID REFERENCES #{p}phoenix_kit_staff_people(uuid) ON DELETE SET NULL,
+      counts_weekends BOOLEAN,
+      progress_pct INTEGER NOT NULL DEFAULT 0,
+      track_progress BOOLEAN NOT NULL DEFAULT false,
+      completed_by_uuid UUID REFERENCES #{p}phoenix_kit_users(uuid) ON DELETE SET NULL,
+      completed_at TIMESTAMPTZ,
+      inserted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      CONSTRAINT phoenix_kit_project_assignments_single_assignee
+        CHECK (num_nonnulls(assigned_team_uuid, assigned_department_uuid, assigned_person_uuid) <= 1)
+    )
+    """)
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS phoenix_kit_project_assignments_project_index
+    ON #{p}phoenix_kit_project_assignments (project_uuid)
+    """)
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS phoenix_kit_project_assignments_status_index
+    ON #{p}phoenix_kit_project_assignments (status)
+    """)
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS phoenix_kit_project_assignments_task_index
+    ON #{p}phoenix_kit_project_assignments (task_uuid)
+    """)
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS phoenix_kit_project_assignments_team_index
+    ON #{p}phoenix_kit_project_assignments (assigned_team_uuid)
+    WHERE assigned_team_uuid IS NOT NULL
+    """)
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS phoenix_kit_project_assignments_department_index
+    ON #{p}phoenix_kit_project_assignments (assigned_department_uuid)
+    WHERE assigned_department_uuid IS NOT NULL
+    """)
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS phoenix_kit_project_assignments_person_index
+    ON #{p}phoenix_kit_project_assignments (assigned_person_uuid)
+    WHERE assigned_person_uuid IS NOT NULL
+    """)
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS phoenix_kit_project_assignments_completed_by_index
+    ON #{p}phoenix_kit_project_assignments (completed_by_uuid)
+    WHERE completed_by_uuid IS NOT NULL
+    """)
+
+    execute("""
+    CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_project_dependencies (
+      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      assignment_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_project_assignments(uuid) ON DELETE CASCADE,
+      depends_on_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_project_assignments(uuid) ON DELETE CASCADE,
+      inserted_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+    """)
+
+    execute("""
+    CREATE UNIQUE INDEX IF NOT EXISTS phoenix_kit_project_dependencies_pair_index
+    ON #{p}phoenix_kit_project_dependencies (assignment_uuid, depends_on_uuid)
+    """)
+
+    # Reverse lookup: "which assignments depend on X?" (impact analysis when
+    # marking X done). The pair index above only helps forward lookups.
+    execute("""
+    CREATE INDEX IF NOT EXISTS phoenix_kit_project_dependencies_depends_on_index
+    ON #{p}phoenix_kit_project_dependencies (depends_on_uuid)
+    """)
+
+    execute("""
+    CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_project_task_dependencies (
+      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      task_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_project_tasks(uuid) ON DELETE CASCADE,
+      depends_on_task_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_project_tasks(uuid) ON DELETE CASCADE,
+      inserted_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+    """)
+
+    execute("""
+    CREATE UNIQUE INDEX IF NOT EXISTS phoenix_kit_project_task_deps_pair_index
+    ON #{p}phoenix_kit_project_task_dependencies (task_uuid, depends_on_task_uuid)
+    """)
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '101'")
+  end
+
+  def down(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    execute("DROP TABLE IF EXISTS #{p}phoenix_kit_project_task_dependencies")
+    execute("DROP TABLE IF EXISTS #{p}phoenix_kit_project_dependencies")
+    execute("DROP TABLE IF EXISTS #{p}phoenix_kit_project_assignments")
+    execute("DROP TABLE IF EXISTS #{p}phoenix_kit_projects")
+    execute("DROP TABLE IF EXISTS #{p}phoenix_kit_project_tasks")
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '100'")
+  end
+
+  defp prefix_str("public"), do: "public."
+  defp prefix_str(prefix), do: "#{prefix}."
+end


### PR DESCRIPTION
V100 creates the four staff tables (`phoenix_kit_staff_departments`, `phoenix_kit_staff_teams`, `phoenix_kit_staff_people`, `phoenix_kit_staff_team_memberships`) used by the new `phoenix_kit_staff` module — UUIDv7 PKs, cascading deletes dept → team → memberships and user → person → memberships.

V101 creates the five projects tables (`phoenix_kit_project_tasks`, `phoenix_kit_project_task_dependencies`, `phoenix_kit_projects`, `phoenix_kit_project_assignments`, `phoenix_kit_project_dependencies`) used by `phoenix_kit_projects`. Assignment/task templates carry a polymorphic assignee (team/department/person) and a `CHECK (num_nonnulls(...) <= 1)` constraint enforces at-most-one assignee on both tables. V101 depends on V100 for the assignee FKs.

Bumps @current_version 99 → 101 and extends the moduledoc changelog.