### PR TITLE
Add V102 smart catalogues migration and multilang debounce flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,6 +144,8 @@ ls lib/phoenix_kit/migrations/postgres/v*.ex | sed 's/.*\/v\([0-9]*\)\.ex/\1/' |
 
 Updates require: `mix.exs` (@version), `CHANGELOG.md`. Run `mix compile`, `mix test`, `mix format`, `mix credo --strict` before committing.
 
+> **CHANGELOG ownership:** entries in `CHANGELOG.md` are written by the project maintainer, not by agents. If you bump `@version` and the CHANGELOG hasn't caught up yet, that's intentional — flag the gap and stop. Do not auto-write entries.
+
 ### PR Reviews
 
 PR review files go in `dev_docs/pull_requests/{year}/{pr_number}-{slug}/` directory. Use `{AGENT}_REVIEW.md` naming (e.g., `CLAUDE_REVIEW.md`, `GEMINI_REVIEW.md`). See `dev_docs/pull_requests/README.md`.
@@ -200,6 +202,42 @@ Centralized management of external service connections (OAuth, API keys, bot tok
 
 **Plan:** `dev_docs/plans/integrations-system.md`
 
+
+## Core Form Components
+
+`PhoenixKitWeb.Components.Core.{Input, Select, Textarea, Checkbox}` are the canonical form primitives. Use them over raw `<input>`/`<select>`/`<textarea>` markup in new code — they handle `phx-feedback-for`, gettext-translated error display, label wiring, and daisyUI styling for you. The existing `lib/phoenix_kit_web/users/user_form.html.heex` is the canonical reference usage.
+
+- All four accept a `class` attr that merges onto the **styled element** itself (the `<input>` / daisyUI `<label class="select">` / `<textarea>` / `<input type="checkbox">`) — pass daisyUI modifiers here: `input-sm`, `select-primary`, `checkbox-accent`, or project-specific focus styles like `transition-colors focus:input-primary`.
+- `<.input>` additionally has a `wrapper_class` attr that goes to the outer `<div phx-feedback-for>` — this is the role the `class` attr used to play before the convention was aligned with the Phoenix 1.7 generator (`class` → input element). No in-tree caller used the old behavior, but external consumers who did should switch to `wrapper_class`.
+- FormField binding is preferred: `<.input field={@form[:email]} type="email" label="Email" />`. The component dispatches on `%Phoenix.HTML.FormField{}` to pull id / name / value / errors in one shot. The raw `name=` + `value=` form still works for cases where field names are dynamic (import wizards, custom field loops in user_form).
+
+## Multilang Form Components
+
+`PhoenixKitWeb.Components.MultilangForm` provides the form-level translation toolkit: `<.multilang_tabs>`, `<.multilang_fields_wrapper>`, `<.translatable_field>`, plus helpers `mount_multilang/1`, `handle_switch_language/2`, `merge_translatable_params/4`. Forms that edit translatable content `import PhoenixKitWeb.Components.MultilangForm` and call `mount_multilang(socket)` in `mount/3`.
+
+### Wrapper scope rule
+
+`<.multilang_fields_wrapper>` wraps translatable fields *only*. Everything else — pricing, classification, status, actions — renders as a sibling **outside** the wrapper. This is load-bearing: the wrapper's `id` includes `@current_lang`, so a language switch changes the ID and morphdom re-mounts everything inside. If you put non-translatable fields inside, they get re-mounted on every switch (churn + focus loss + lost input state). Keep the wrapper small — in practice, the name + description `<.translatable_field>` calls are all that belongs inside.
+
+### Language switching: client-side visibility + trailing debounce
+
+`mount_multilang/1` seeds the multilang assigns and attaches a `:handle_info` hook via `Phoenix.LiveView.attach_hook/4` that receives the debounced timer message. The flow:
+
+1. User clicks a language tab → `switch_lang_js/2` runs a composed `%JS{}`: pushes `"switch_language"` **and** immediately toggles `hidden` on the two sibling divs client-side — `add_class` on `[data-translatable=fields]`, `remove_class` on `[data-translatable=skeletons]`. The skeleton is visible at `t=0`, no round-trip delay.
+2. `handle_switch_language/2` cancels any pending timer, schedules a new `Process.send_after(self(), {:__multilang_apply_lang__, lang}, 150)`, stores the timer ref in the process dictionary (not socket assigns — avoids triggering phantom render+diff cycles), and returns the socket **unchanged**. The server does not touch the wrapper's class state — so nothing can fight the JS toggles on the client.
+3. Rapid clicks re-enter step 2 — timer is cancelled and rescheduled; the JS toggles are idempotent. Only the final click's lang reaches step 4.
+4. 150ms after the last click: the timer fires, the hook intercepts `{:__multilang_apply_lang__, lang}`, calls `handle_multilang_apply_lang/2` which sets `:current_lang = lang`, and returns `{:halt, socket}` so the consumer never sees the message.
+5. Wrapper re-renders with new lang in its ids (skeleton id, fields id, and the translatable inputs' `lang_data`). morphdom sees the id change and **replaces both sibling divs** — the new skeleton div is re-rendered with `class="hidden …"` (its default), the new fields div is re-rendered without `hidden` and with the new-language content. The skeleton is hidden again, the fields are back, and everything else on the form (outside the wrapper) is untouched.
+
+Why client-side and not server-driven: the skeleton has to appear **before** any round-trip to feel responsive. A server-driven visibility flag needs the `JS.push` to reach the server, the server to re-render, and the diff to arrive at the client — visible delay on slow connections, and on localhost the window is so brief you can barely perceive it. The client-side toggle shows the skeleton at `t=0`; the server only owns the final `current_lang` commit.
+
+The `attach_hook` approach means consumers **don't need a `handle_info` clause** — the library handles the timer message transparently. There's a graceful fallback for LiveComponent sockets (where `attach_hook` raises `ArgumentError`): rescue + return socket unchanged; those consumers can add the clause manually if they ever appear.
+
+The wrapper accepts a `switching_lang` attr and `mount_multilang/1` seeds `:switching_lang = false`, purely as a backwards-compat no-op — consumer templates that already pass `switching_lang={@switching_lang}` keep resolving. The wrapper doesn't read the value.
+
+### Translatable fields
+
+`<.translatable_field>` takes the raw changeset via `changeset={@changeset}` (not FormField) because its behavior changes with the active tab — primary-language input vs. secondary-language JSONB-backed input with different `name` attributes. When using `<.translatable_field>` alongside component-style inputs, a form LV keeps **both** `:changeset` (for translatable_field) and `:form = to_form(changeset)` (for `<.input>` / `<.select>`) in sync via a private helper called from mount / validate / save-error paths.
 
 ## Documentations
 

--- a/lib/mix/tasks/compile.phoenix_kit_css_sources.ex
+++ b/lib/mix/tasks/compile.phoenix_kit_css_sources.ex
@@ -49,7 +49,7 @@ defmodule Mix.Tasks.Compile.PhoenixKitCssSources do
         app_name = to_string(app_name)
 
         case find_dep_path(String.to_atom(app_name), deps) do
-          {:path, path} -> "@source \"../../#{path}\";"
+          {:path, path} -> source_for_path(path)
           :hex -> "@source \"../../deps/#{app_name}\";"
           :not_found -> "@source \"../../deps/#{app_name}\";"
         end
@@ -80,6 +80,13 @@ defmodule Mix.Tasks.Compile.PhoenixKitCssSources do
 
     {:ok, []}
   end
+
+  # Absolute paths are emitted verbatim — prepending `../../` would
+  # produce `@source "../..//abs/path";` which Tailwind can't resolve
+  # reliably. Relative paths stay relative to the generated file at
+  # `assets/css/_phoenix_kit_sources.css` (two levels up to project root).
+  defp source_for_path("/" <> _ = abs_path), do: "@source \"#{abs_path}\";"
+  defp source_for_path(path), do: "@source \"../../#{path}\";"
 
   defp find_dep_path(app_name, deps) do
     dep =

--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -529,7 +529,24 @@ defmodule PhoenixKit.Migrations.Postgres do
   - Replaces unique index with partial index (slug-mode only, WHERE slug IS NOT NULL)
   - Adds unique index on `(group_uuid, post_date, post_time)` for timestamp-mode posts
 
-  ### V101 - Projects module tables ⚡ LATEST
+  ### V102 - Catalogue discount + smart catalogues ⚡ LATEST
+  Two related catalogue features bundled together:
+  - **Discount**: `discount_percentage DECIMAL(7, 2) NOT NULL DEFAULT 0`
+    on `phoenix_kit_cat_catalogues` (whole-catalogue default) and
+    nullable `discount_percentage DECIMAL(7, 2)` on `phoenix_kit_cat_items`
+    (per-item override; `NULL` inherits, any value including `0` overrides).
+    Pricing chain: `base → markup → discount`; `sale_price` stays
+    "after markup, before discount" and new `final_price` lives on top.
+  - **Smart catalogues**: `kind VARCHAR(20) NOT NULL DEFAULT 'standard'`
+    on `phoenix_kit_cat_catalogues` (one of `'standard'` or `'smart'`).
+    Items in a smart catalogue reference *other* catalogues with a value
+    + unit; items also get nullable `default_value DECIMAL(12, 4)` and
+    `default_unit VARCHAR(20)` as a per-item fallback. New table
+    `phoenix_kit_cat_item_catalogue_rules` stores the item → referenced
+    catalogue pairs with nullable `value`/`unit` (inherit from item
+    defaults) and a `position INTEGER` for UI ordering.
+
+  ### V101 - Projects module tables
   - Creates `phoenix_kit_project_tasks` (reusable task library),
     `phoenix_kit_project_task_dependencies` (template-level ordering),
     `phoenix_kit_projects`, `phoenix_kit_project_assignments`
@@ -745,7 +762,7 @@ defmodule PhoenixKit.Migrations.Postgres do
   use Ecto.Migration
 
   @initial_version 1
-  @current_version 101
+  @current_version 102
   @default_prefix "public"
 
   @doc false

--- a/lib/phoenix_kit/migrations/postgres/v102.ex
+++ b/lib/phoenix_kit/migrations/postgres/v102.ex
@@ -1,0 +1,278 @@
+defmodule PhoenixKit.Migrations.Postgres.V102 do
+  @moduledoc """
+  V102: Catalogue discount + smart catalogues.
+
+  Two related catalogue features shipped together:
+
+  ## Discount
+
+  Mirrors the markup columns added in V89 (catalogue) and V97 (item override):
+
+  - `phoenix_kit_cat_catalogues.discount_percentage DECIMAL(7, 2)
+    NOT NULL DEFAULT 0` — the catalogue-wide default discount applied on
+    top of the post-markup sale price.
+  - `phoenix_kit_cat_items.discount_percentage DECIMAL(7, 2)` — nullable
+    per-item override. `NULL` = inherit the catalogue's discount; any set
+    value (including `0`) overrides the catalogue's discount for that item.
+
+  The pricing chain becomes `base → markup → discount`:
+
+      sale_price   = base_price * (1 + effective_markup   / 100)
+      final_price  = sale_price  * (1 -  effective_discount / 100)
+
+  ## Smart catalogues
+
+  A smart catalogue's items reference *other* catalogues with a value +
+  unit (e.g. a "Delivery" item says "5% of Kitchen, 3% of Plumbing, plus
+  $20 flat of Hardware"). Consumers do the math; this module stores the
+  user's intent.
+
+  - `phoenix_kit_cat_catalogues.kind VARCHAR(20) NOT NULL DEFAULT 'standard'`
+    — one of `'standard'` (existing behavior) or `'smart'` (items
+    reference other catalogues).
+  - `phoenix_kit_cat_items.default_value DECIMAL(12, 4)` and
+    `default_unit VARCHAR(20)` (both nullable) — per-item fallback that
+    applies when a rule row has NULL `value`/`unit`.
+  - New table `phoenix_kit_cat_item_catalogue_rules` storing one row per
+    (item, referenced_catalogue) pair, with nullable `value` + `unit`
+    (inherit from item defaults) and a `position INT` for UI ordering.
+    Unit vocabulary is open-ended VARCHAR; v1 uses `'percent'` and
+    `'flat'`. Self- and smart-to-smart references are intentionally
+    allowed — consumers handle cycles at math time.
+
+  All operations are idempotent.
+  """
+
+  use Ecto.Migration
+
+  def up(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+    schema = if prefix == "public", do: "public", else: prefix
+
+    # ── Discount columns ─────────────────────────────────────────
+    execute("""
+    DO $$
+    BEGIN
+      -- Catalogue-wide discount: NOT NULL with a 0 default so all
+      -- existing rows preserve today's "no discount" behavior.
+      IF EXISTS (
+        SELECT FROM information_schema.tables
+        WHERE table_schema = '#{schema}' AND table_name = 'phoenix_kit_cat_catalogues'
+      ) AND NOT EXISTS (
+        SELECT FROM information_schema.columns
+        WHERE table_schema = '#{schema}'
+          AND table_name = 'phoenix_kit_cat_catalogues'
+          AND column_name = 'discount_percentage'
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_cat_catalogues
+          ADD COLUMN discount_percentage DECIMAL(7, 2) NOT NULL DEFAULT 0;
+      END IF;
+
+      -- Per-item discount override: nullable with no default. NULL = inherit.
+      IF EXISTS (
+        SELECT FROM information_schema.tables
+        WHERE table_schema = '#{schema}' AND table_name = 'phoenix_kit_cat_items'
+      ) AND NOT EXISTS (
+        SELECT FROM information_schema.columns
+        WHERE table_schema = '#{schema}'
+          AND table_name = 'phoenix_kit_cat_items'
+          AND column_name = 'discount_percentage'
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_cat_items
+          ADD COLUMN discount_percentage DECIMAL(7, 2);
+      END IF;
+
+      -- Smart-catalogue `kind` flag on catalogues: standard (default) or smart.
+      IF EXISTS (
+        SELECT FROM information_schema.tables
+        WHERE table_schema = '#{schema}' AND table_name = 'phoenix_kit_cat_catalogues'
+      ) AND NOT EXISTS (
+        SELECT FROM information_schema.columns
+        WHERE table_schema = '#{schema}'
+          AND table_name = 'phoenix_kit_cat_catalogues'
+          AND column_name = 'kind'
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_cat_catalogues
+          ADD COLUMN kind VARCHAR(20) NOT NULL DEFAULT 'standard';
+      END IF;
+
+      -- Per-item default value + unit for smart rules.
+      IF EXISTS (
+        SELECT FROM information_schema.tables
+        WHERE table_schema = '#{schema}' AND table_name = 'phoenix_kit_cat_items'
+      ) AND NOT EXISTS (
+        SELECT FROM information_schema.columns
+        WHERE table_schema = '#{schema}'
+          AND table_name = 'phoenix_kit_cat_items'
+          AND column_name = 'default_value'
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_cat_items
+          ADD COLUMN default_value DECIMAL(12, 4);
+      END IF;
+
+      IF EXISTS (
+        SELECT FROM information_schema.tables
+        WHERE table_schema = '#{schema}' AND table_name = 'phoenix_kit_cat_items'
+      ) AND NOT EXISTS (
+        SELECT FROM information_schema.columns
+        WHERE table_schema = '#{schema}'
+          AND table_name = 'phoenix_kit_cat_items'
+          AND column_name = 'default_unit'
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_cat_items
+          ADD COLUMN default_unit VARCHAR(20);
+      END IF;
+    END $$;
+    """)
+
+    # ── Smart rules table ───────────────────────────────────────
+    execute("""
+    CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_cat_item_catalogue_rules (
+      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      item_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_cat_items(uuid) ON DELETE CASCADE,
+      referenced_catalogue_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_cat_catalogues(uuid) ON DELETE CASCADE,
+      value DECIMAL(12, 4),
+      unit VARCHAR(20),
+      position INTEGER NOT NULL DEFAULT 0,
+      inserted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+    """)
+
+    execute("""
+    CREATE UNIQUE INDEX IF NOT EXISTS phoenix_kit_cat_item_catalogue_rules_pair_index
+    ON #{p}phoenix_kit_cat_item_catalogue_rules (item_uuid, referenced_catalogue_uuid)
+    """)
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS phoenix_kit_cat_item_catalogue_rules_item_index
+    ON #{p}phoenix_kit_cat_item_catalogue_rules (item_uuid)
+    """)
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS phoenix_kit_cat_item_catalogue_rules_referenced_index
+    ON #{p}phoenix_kit_cat_item_catalogue_rules (referenced_catalogue_uuid)
+    """)
+
+    # ── Data-integrity constraints ─────────────────────────────
+    # `kind` is a closed vocabulary at the DB layer (Ecto validates it
+    # too, but raw INSERTs from import scripts / IEx must also be
+    # blocked). `unit` stays open per the smart-catalogue moduledoc —
+    # consumers can introduce new units without a migration.
+    execute("""
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT FROM pg_constraint
+        WHERE conname = 'phoenix_kit_cat_catalogues_kind_check'
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_cat_catalogues
+          ADD CONSTRAINT phoenix_kit_cat_catalogues_kind_check
+          CHECK (kind IN ('standard', 'smart'));
+      END IF;
+
+      IF NOT EXISTS (
+        SELECT FROM pg_constraint
+        WHERE conname = 'phoenix_kit_cat_catalogues_discount_pct_check'
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_cat_catalogues
+          ADD CONSTRAINT phoenix_kit_cat_catalogues_discount_pct_check
+          CHECK (discount_percentage >= 0 AND discount_percentage <= 100);
+      END IF;
+
+      IF NOT EXISTS (
+        SELECT FROM pg_constraint
+        WHERE conname = 'phoenix_kit_cat_items_discount_pct_check'
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_cat_items
+          ADD CONSTRAINT phoenix_kit_cat_items_discount_pct_check
+          CHECK (discount_percentage IS NULL OR
+                 (discount_percentage >= 0 AND discount_percentage <= 100));
+      END IF;
+
+      IF NOT EXISTS (
+        SELECT FROM pg_constraint
+        WHERE conname = 'phoenix_kit_cat_items_default_value_check'
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_cat_items
+          ADD CONSTRAINT phoenix_kit_cat_items_default_value_check
+          CHECK (default_value IS NULL OR default_value >= 0);
+      END IF;
+
+      IF NOT EXISTS (
+        SELECT FROM pg_constraint
+        WHERE conname = 'phoenix_kit_cat_item_catalogue_rules_value_check'
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_cat_item_catalogue_rules
+          ADD CONSTRAINT phoenix_kit_cat_item_catalogue_rules_value_check
+          CHECK (value IS NULL OR value >= 0);
+      END IF;
+    END $$;
+    """)
+
+    # Partial index: smart catalogues are typically <1% of total
+    # catalogues but the smart-item edit form filters by them on every
+    # mount. A standard b-tree on `kind` would be wasteful; this scoped
+    # index covers the only query that filters by kind.
+    execute("""
+    CREATE INDEX IF NOT EXISTS phoenix_kit_cat_catalogues_kind_smart_index
+    ON #{p}phoenix_kit_cat_catalogues (uuid)
+    WHERE kind = 'smart'
+    """)
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '102'")
+  end
+
+  @doc """
+  Rolls V102 back: drops the rules table and both sets of added columns
+  (discount + smart-catalogue).
+
+  **Lossy rollback:** all discount values, smart-catalogue rules, item
+  defaults, and the `kind` distinction are lost. Back up before rolling
+  back in production.
+  """
+  def down(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    # Partial index + CHECK constraints first; PG drops them implicitly with
+    # DROP COLUMN, but being explicit keeps `down` reversible and idempotent.
+    execute("DROP INDEX IF EXISTS #{p}phoenix_kit_cat_catalogues_kind_smart_index")
+
+    execute("""
+    ALTER TABLE #{p}phoenix_kit_cat_item_catalogue_rules
+      DROP CONSTRAINT IF EXISTS phoenix_kit_cat_item_catalogue_rules_value_check
+    """)
+
+    execute("DROP TABLE IF EXISTS #{p}phoenix_kit_cat_item_catalogue_rules")
+
+    execute("""
+    ALTER TABLE #{p}phoenix_kit_cat_items
+      DROP CONSTRAINT IF EXISTS phoenix_kit_cat_items_default_value_check,
+      DROP CONSTRAINT IF EXISTS phoenix_kit_cat_items_discount_pct_check
+    """)
+
+    execute("ALTER TABLE #{p}phoenix_kit_cat_items DROP COLUMN IF EXISTS default_unit")
+    execute("ALTER TABLE #{p}phoenix_kit_cat_items DROP COLUMN IF EXISTS default_value")
+
+    execute("""
+    ALTER TABLE #{p}phoenix_kit_cat_catalogues
+      DROP CONSTRAINT IF EXISTS phoenix_kit_cat_catalogues_kind_check,
+      DROP CONSTRAINT IF EXISTS phoenix_kit_cat_catalogues_discount_pct_check
+    """)
+
+    execute("ALTER TABLE #{p}phoenix_kit_cat_catalogues DROP COLUMN IF EXISTS kind")
+
+    execute("ALTER TABLE #{p}phoenix_kit_cat_items DROP COLUMN IF EXISTS discount_percentage")
+
+    execute(
+      "ALTER TABLE #{p}phoenix_kit_cat_catalogues DROP COLUMN IF EXISTS discount_percentage"
+    )
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '101'")
+  end
+
+  defp prefix_str("public"), do: "public."
+  defp prefix_str(prefix), do: "#{prefix}."
+end

--- a/lib/phoenix_kit_web/components/core/checkbox.ex
+++ b/lib/phoenix_kit_web/components/core/checkbox.ex
@@ -18,6 +18,11 @@ defmodule PhoenixKitWeb.Components.Core.Checkbox do
   attr :errors, :list, default: []
   attr :checked, :boolean, default: false
 
+  attr :class, :any,
+    default: nil,
+    doc:
+      "extra classes merged onto the `<input type=\"checkbox\">` (e.g. `checkbox-sm`, `checkbox-accent`)"
+
   attr :rest, :global, include: ~w(readonly required)
 
   slot :inner_block
@@ -44,7 +49,7 @@ defmodule PhoenixKitWeb.Components.Core.Checkbox do
           name={@name}
           value="true"
           checked={@checked}
-          class="checkbox checkbox-primary"
+          class={["checkbox checkbox-primary", @class]}
           {@rest}
         />
 

--- a/lib/phoenix_kit_web/components/core/input.ex
+++ b/lib/phoenix_kit_web/components/core/input.ex
@@ -39,7 +39,14 @@ defmodule PhoenixKitWeb.Components.Core.Input do
     values:
       ~w(color date datetime-local email file hidden month number password range search tel text time url week)
 
-  attr :class, :string, default: nil
+  attr :class, :any,
+    default: nil,
+    doc:
+      "extra classes merged onto the `<input>` element — use this for daisyUI modifiers like `input-sm`, `input-primary`, or project-specific focus styles. Matches the Phoenix 1.7 generator convention."
+
+  attr :wrapper_class, :any,
+    default: nil,
+    doc: "extra classes for the outer `<div phx-feedback-for>` wrapper"
 
   attr :field, Phoenix.HTML.FormField,
     doc: "a form field struct retrieved from the form, for example: @form[:email]"
@@ -68,7 +75,7 @@ defmodule PhoenixKitWeb.Components.Core.Input do
 
   def input(assigns) do
     ~H"""
-    <div phx-feedback-for={@name} class={@class}>
+    <div phx-feedback-for={@name} class={@wrapper_class}>
       <label :if={@label && @label != ""} class="label mb-2" for={@id}>
         <span :if={@icon != []} class="label-text flex items-center">
           {render_slot(@icon)}
@@ -83,7 +90,8 @@ defmodule PhoenixKitWeb.Components.Core.Input do
         value={Phoenix.HTML.Form.normalize_value(@type, @value)}
         class={[
           "input w-full transition-colors focus:input-primary",
-          @errors != [] && "input-error"
+          @errors != [] && "input-error",
+          @class
         ]}
         {@rest}
       />

--- a/lib/phoenix_kit_web/components/core/select.ex
+++ b/lib/phoenix_kit_web/components/core/select.ex
@@ -19,6 +19,11 @@ defmodule PhoenixKitWeb.Components.Core.Select do
 
   attr :errors, :list, default: []
 
+  attr :class, :any,
+    default: nil,
+    doc:
+      "extra classes merged onto the daisyUI `<label class=\"select\">` wrapper — use this for daisyUI modifiers like `select-sm`, `select-primary`, or project-specific focus styles like `transition-colors focus-within:select-primary`"
+
   attr :rest, :global,
     include: ~w(autocomplete cols maxlength disabled placeholder readonly required rows)
 
@@ -39,7 +44,8 @@ defmodule PhoenixKitWeb.Components.Core.Select do
 
       <label class={[
         "select w-full",
-        @errors != [] && "select-error"
+        @errors != [] && "select-error",
+        @class
       ]}>
         <select
           id={@id}

--- a/lib/phoenix_kit_web/components/core/textarea.ex
+++ b/lib/phoenix_kit_web/components/core/textarea.ex
@@ -16,6 +16,11 @@ defmodule PhoenixKitWeb.Components.Core.Textarea do
 
   attr :errors, :list, default: []
 
+  attr :class, :any,
+    default: nil,
+    doc:
+      "extra classes merged onto the `<textarea>` element (e.g. `textarea-sm`, `min-h-[12rem]`)"
+
   attr :rest, :global,
     include: ~w(autocomplete cols maxlength disabled placeholder readonly required rows)
 
@@ -39,7 +44,8 @@ defmodule PhoenixKitWeb.Components.Core.Textarea do
         name={@name}
         class={[
           "textarea textarea-bordered min-h-[6rem] w-full focus:input-primary",
-          @errors != [] && "textarea-error"
+          @errors != [] && "textarea-error",
+          @class
         ]}
         {@rest}
       ><%= Phoenix.HTML.Form.normalize_value("textarea", @value) %></textarea>

--- a/lib/phoenix_kit_web/components/multilang_form.ex
+++ b/lib/phoenix_kit_web/components/multilang_form.ex
@@ -102,8 +102,11 @@ defmodule PhoenixKitWeb.Components.MultilangForm do
   @doc """
   Adds multilang assigns to the socket. Call from `mount/3`.
 
-  Adds: `:multilang_enabled`, `:primary_language`, `:current_lang`, `:language_tabs`,
-  `:show_multilang_tabs`
+  Adds: `:multilang_enabled`, `:primary_language`, `:current_lang`,
+  `:language_tabs`, `:show_multilang_tabs`, `:switching_lang` (no-op
+  compat assign — kept because consumer templates pass it through to
+  the wrapper). Also attaches an internal `:handle_info` hook that
+  receives the debounced language-switch timer message.
   """
   def mount_multilang(socket) do
     multilang_enabled = multilang_enabled?()
@@ -111,13 +114,51 @@ defmodule PhoenixKitWeb.Components.MultilangForm do
 
     language_tabs = if(multilang_enabled, do: safe_build_language_tabs(), else: [])
 
-    Phoenix.Component.assign(socket,
+    socket
+    |> Phoenix.Component.assign(
       multilang_enabled: multilang_enabled,
       primary_language: primary_language,
       current_lang: primary_language,
       language_tabs: language_tabs,
-      show_multilang_tabs: multilang_enabled and length(language_tabs) > 1
+      show_multilang_tabs: multilang_enabled and length(language_tabs) > 1,
+      # Kept for backwards compat with consumer templates that still pass
+      # `switching_lang={@switching_lang}` to `<.multilang_fields_wrapper>`.
+      # The wrapper no longer reads it — visibility is client-side JS.
+      switching_lang: false
     )
+    |> attach_multilang_hook()
+  end
+
+  # Attaches a `:handle_info` hook that intercepts the internal
+  # `{:__multilang_apply_lang__, lang}` message. The hook lives on the
+  # consumer's socket but is invisible to them — no `handle_info/2`
+  # clause needed. Returning `{:halt, socket}` prevents the message
+  # from reaching the consumer's own handle_info (and suppresses the
+  # "unhandled message" warning). Other messages pass through with
+  # `{:cont, socket}`.
+  #
+  # `attach_hook/4` is idempotent-by-name within a process — re-running
+  # `mount_multilang/1` (e.g. across reconnects) with the same hook id
+  # simply replaces the prior callback, so we don't need a guard.
+  defp attach_multilang_hook(socket) do
+    Phoenix.LiveView.attach_hook(
+      socket,
+      :__phoenix_kit_multilang_apply_lang__,
+      :handle_info,
+      fn
+        {:__multilang_apply_lang__, lang_code}, socket ->
+          {:halt, handle_multilang_apply_lang(socket, lang_code)}
+
+        _msg, socket ->
+          {:cont, socket}
+      end
+    )
+  rescue
+    # `attach_hook/4` only works on LiveView sockets, not LiveComponent
+    # sockets. Multilang consumers are all `Phoenix.LiveView` today, but
+    # if someone wires it into a component in the future, fall back
+    # silently — they'll need to add the `handle_info` themselves.
+    ArgumentError -> socket
   end
 
   @doc """
@@ -153,14 +194,71 @@ defmodule PhoenixKitWeb.Components.MultilangForm do
   @doc """
   Handles the `"switch_language"` event. Call from `handle_event/3`.
 
-  Returns the updated socket with the new `current_lang`.
+  Returns a socket that **defers** applying `:current_lang` via a short
+  trailing debounce (150 ms). Rapid click-through (EN → JA → FR → DE)
+  keeps rescheduling the timer; only the last click actually updates
+  `:current_lang` and triggers a content re-render. Without this, every
+  intermediate event caused its own server render and the client
+  briefly flashed each language's content before landing on the final
+  one.
+
+  Nothing to do on the consumer's end — `mount_multilang/1` attaches a
+  `:handle_info` hook via `Phoenix.LiveView.attach_hook/4` that
+  intercepts the internal `{:__multilang_apply_lang__, lang}` message
+  and applies the language transparently. Calling code never sees the
+  message.
+
   Ignores unknown language codes.
   """
+  @multilang_debounce_ms 150
+  # The timer ref lives in `socket.private` (not `socket.assigns`) so
+  # that storing it doesn't trigger a render+diff cycle that would fight
+  # the client-side skeleton/fields visibility toggles. Private state
+  # is per-socket — visible only inside the LV process — and survives
+  # the LV's lifecycle the same way assigns do, but with zero diff cost.
+  @multilang_timer_private_key :__phoenix_kit_multilang_timer__
+
   def handle_switch_language(socket, lang_code) do
     if lang_code in safe_enabled_languages() do
-      Phoenix.Component.assign(socket, :current_lang, lang_code)
+      socket = cancel_multilang_timer(socket)
+
+      timer_ref =
+        Process.send_after(
+          self(),
+          {:__multilang_apply_lang__, lang_code},
+          @multilang_debounce_ms
+        )
+
+      # Skeleton/fields visibility is driven entirely by
+      # `switch_lang_js/2`'s client-side class toggles. The server just
+      # holds off applying the new `current_lang` until the debounce
+      # fires, which is what causes the final morphdom swap that
+      # restores the fields (with new-lang content) and hides the
+      # skeleton again.
+      Phoenix.LiveView.put_private(socket, @multilang_timer_private_key, timer_ref)
     else
       socket
+    end
+  end
+
+  @doc """
+  Applies a debounced language change. Call from `handle_info/2` when
+  `{:__multilang_apply_lang__, lang_code}` is received.
+  """
+  def handle_multilang_apply_lang(socket, lang_code) do
+    socket
+    |> Phoenix.LiveView.put_private(@multilang_timer_private_key, nil)
+    |> Phoenix.Component.assign(:current_lang, lang_code)
+  end
+
+  defp cancel_multilang_timer(socket) do
+    case Map.get(socket.private, @multilang_timer_private_key) do
+      ref when is_reference(ref) ->
+        Process.cancel_timer(ref)
+        Phoenix.LiveView.put_private(socket, @multilang_timer_private_key, nil)
+
+      _ ->
+        socket
     end
   end
 
@@ -546,6 +644,12 @@ defmodule PhoenixKitWeb.Components.MultilangForm do
   """
   attr :multilang_enabled, :boolean, required: true
   attr :current_lang, :string, required: true
+
+  attr :switching_lang, :boolean,
+    default: false,
+    doc:
+      "accepted for backwards compatibility but no longer used — skeleton/fields visibility is client-side via `switch_lang_js/2`."
+
   attr :skeleton_class, :string, default: "card-body pt-4"
   attr :fields_class, :string, default: nil
   slot :skeleton
@@ -553,8 +657,11 @@ defmodule PhoenixKitWeb.Components.MultilangForm do
 
   def multilang_fields_wrapper(assigns) do
     ~H"""
-    <%!-- Skeleton placeholders (shown instantly on tab click).
-         IDs include current_lang so morphdom treats them as new elements. --%>
+    <%!-- Skeleton placeholders (shown instantly on tab click via JS).
+         IDs include current_lang so that when the debounce fires and
+         current_lang changes, morphdom treats these as new elements
+         and replaces them — which resets the skeleton back to `hidden`
+         and inserts the fields with new-language content. --%>
     <div
       :if={@multilang_enabled}
       id={"translatable-skeletons-#{@current_lang}"}
@@ -802,14 +909,32 @@ defmodule PhoenixKitWeb.Components.MultilangForm do
   @doc """
   Returns a `Phoenix.LiveView.JS` command that switches languages.
 
-  Pushes the `"switch_language"` event, hides current field content,
-  and shows skeleton placeholders for instant visual feedback.
+  Toggles skeleton/fields visibility **client-side, instantly** (hides
+  `[data-translatable=fields]`, reveals `[data-translatable=skeletons]`)
+  and pushes `"switch_language"` to the server. The server side holds
+  the class state untouched — `handle_switch_language/2` just schedules
+  a 150 ms debounced timer that eventually updates `:current_lang`,
+  which changes the wrapper div ids and makes morphdom replace both
+  divs with their new-language versions (skeleton back to `hidden`,
+  fields visible with new content). Nothing on the server renders
+  `hidden` on the fields or removes `hidden` from the skeleton, so the
+  JS toggles never fight a server diff.
 
-  Returns a no-op when `lang_code == current_lang` to prevent skeleton ghosts.
+  Returns a no-op when `lang_code == current_lang` — clicking the
+  already-active tab doesn't push and doesn't flash the skeleton.
   """
   def switch_lang_js(lang_code, current_lang) do
     if lang_code == current_lang do
-      %JS{}
+      # Same-lang click during an in-flight debounce: we need to cancel
+      # the pending server timer (which would otherwise still fire and
+      # flip to the wrong lang) AND revert the skeleton/fields toggles
+      # on the client (so the UI doesn't sit stuck in skeleton-visible
+      # state after the no-op server render). Pushing with the current
+      # lang hits `handle_switch_language/2`'s `cancel_multilang_timer`
+      # and reschedules a no-op `current_lang` set.
+      JS.push("switch_language", value: %{lang: lang_code})
+      |> JS.remove_class("hidden", to: "[data-translatable=fields]")
+      |> JS.add_class("hidden", to: "[data-translatable=skeletons]")
     else
       JS.push("switch_language", value: %{lang: lang_code})
       |> JS.add_class("hidden", to: "[data-translatable=fields]")

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule PhoenixKit.MixProject do
   use Mix.Project
 
-  @version "1.7.98"
+  @version "1.7.99"
   @description "A foundation for building Elixir Phoenix apps — SaaS, social networks, ERP systems, marketplaces, and more"
   @source_url "https://github.com/BeamLabEU/phoenix_kit"
 
@@ -21,7 +21,13 @@ defmodule PhoenixKit.MixProject do
       # Documentation
       docs: docs(),
 
-      # Testing
+      # Testing — Elixir 1.19's `mix test` uses these filters to pick
+      # which files to load as tests. Without them, `test/support/*.ex`
+      # files are flagged as orphaned and never run through the test
+      # loader, which leaves `test_helper.exs` looking up modules that
+      # were compiled but not loaded.
+      test_load_filters: [~r/_test\.exs$/],
+      test_ignore_filters: [~r{^test/support/}],
       test_coverage: [tool: ExCoveralls],
 
       # Aliases for development

--- a/test/phoenix_kit_web/components/multilang_form_test.exs
+++ b/test/phoenix_kit_web/components/multilang_form_test.exs
@@ -616,12 +616,50 @@ defmodule PhoenixKitWeb.Components.MultilangFormTest do
   # ── switch_lang_js ──────────────────────────────────────────
 
   describe "switch_lang_js/2" do
-    test "no-op for same language" do
-      assert switch_lang_js("en", "en") == %Phoenix.LiveView.JS{}
+    test "same-lang click pushes to cancel any pending debounce + reverts skeleton toggles" do
+      js = switch_lang_js("en", "en")
+      refute js == %Phoenix.LiveView.JS{}
+
+      ops = js.ops
+      assert Enum.any?(ops, fn op -> match?(["push", %{event: "switch_language"}], op) end)
+      # Same-lang must REVERT the skeleton/fields visibility (remove hidden
+      # from fields, add hidden to skeleton) so a stuck skeleton clears when
+      # the user re-clicks the active tab during an in-flight debounce.
+      assert Enum.any?(ops, fn op ->
+               match?(
+                 ["remove_class", %{names: ["hidden"], to: "[data-translatable=fields]"}],
+                 op
+               )
+             end)
+
+      assert Enum.any?(ops, fn op ->
+               match?(
+                 ["add_class", %{names: ["hidden"], to: "[data-translatable=skeletons]"}],
+                 op
+               )
+             end)
     end
 
-    test "returns JS commands for different language" do
-      refute switch_lang_js("fr", "en") == %Phoenix.LiveView.JS{}
+    test "different-lang click hides fields and shows skeleton client-side" do
+      js = switch_lang_js("fr", "en")
+      refute js == %Phoenix.LiveView.JS{}
+
+      ops = js.ops
+      assert Enum.any?(ops, fn op -> match?(["push", %{event: "switch_language"}], op) end)
+      # Add hidden on fields (hide them) and remove hidden from skeleton (show it).
+      assert Enum.any?(ops, fn op ->
+               match?(
+                 ["add_class", %{names: ["hidden"], to: "[data-translatable=fields]"}],
+                 op
+               )
+             end)
+
+      assert Enum.any?(ops, fn op ->
+               match?(
+                 ["remove_class", %{names: ["hidden"], to: "[data-translatable=skeletons]"}],
+                 op
+               )
+             end)
     end
   end
 
@@ -679,6 +717,100 @@ defmodule PhoenixKitWeb.Components.MultilangFormTest do
 
       refute Map.has_key?(result, "data")
       assert result["name"] == "Test"
+    end
+  end
+
+  # ── handle_switch_language / handle_multilang_apply_lang ────
+  #
+  # Exercises the debounced timer flow: schedule → cancel → reschedule
+  # → apply. The timer ref now lives in `socket.private` (not the
+  # process dictionary) so we assert against that.
+
+  describe "handle_switch_language/2 and handle_multilang_apply_lang/2" do
+    @timer_key :__phoenix_kit_multilang_timer__
+
+    setup do
+      socket = %Phoenix.LiveView.Socket{
+        assigns: %{current_lang: "en", __changed__: %{}},
+        private: %{}
+      }
+
+      # Drain any leftover timer messages from previous tests in this
+      # process so a stray send doesn't leak across cases.
+      drain()
+
+      %{socket: socket}
+    end
+
+    test "ignores unknown language codes (no timer scheduled)", %{socket: socket} do
+      result = handle_switch_language(socket, "klingon-XX")
+
+      refute is_reference(Map.get(result.private, @timer_key))
+      assert drain() == []
+    end
+
+    test "schedules a deferred apply message and stores the ref in private", %{socket: socket} do
+      socket2 = handle_switch_language(socket, "en")
+      ref = Map.get(socket2.private, @timer_key)
+
+      # If the multilang config doesn't recognize "en" (no Languages
+      # module configured in the test env), no timer is scheduled and
+      # there's nothing to assert on the apply path. Otherwise, verify
+      # the ref shape and that the message arrives within the window.
+      if is_reference(ref) do
+        assert_receive {:__multilang_apply_lang__, "en"}, 500
+      end
+    end
+
+    test "rapid resubscribe cancels the previous timer", %{socket: socket} do
+      socket2 = handle_switch_language(socket, "en")
+      ref1 = Map.get(socket2.private, @timer_key)
+
+      socket3 = handle_switch_language(socket2, "en")
+      ref2 = Map.get(socket3.private, @timer_key)
+
+      # Skip the assertion if no timer was scheduled (lang not in
+      # enabled_languages in this env).
+      if is_reference(ref1) and is_reference(ref2) do
+        refute ref1 == ref2
+        # First ref should be cancelled; only the second ref's message
+        # should arrive.
+        messages = receive_all(200)
+        assert length(messages) <= 1
+      end
+    end
+
+    test "handle_multilang_apply_lang assigns current_lang and clears the private timer", %{
+      socket: socket
+    } do
+      # Pretend a timer was previously scheduled.
+      ref = Process.send_after(self(), :__noop__, 5_000)
+      socket = Phoenix.LiveView.put_private(socket, @timer_key, ref)
+
+      result = handle_multilang_apply_lang(socket, "fr")
+
+      assert result.assigns.current_lang == "fr"
+      assert is_nil(Map.get(result.private, @timer_key))
+
+      # Cleanup: drain the noop and don't leave a dangling timer running.
+      Process.cancel_timer(ref)
+      drain()
+    end
+
+    defp drain do
+      receive_all(0)
+    end
+
+    defp receive_all(timeout) do
+      receive_all([], timeout)
+    end
+
+    defp receive_all(acc, timeout) do
+      receive do
+        msg -> receive_all([msg | acc], timeout)
+      after
+        timeout -> Enum.reverse(acc)
+      end
     end
   end
 end


### PR DESCRIPTION
- V102: `kind` + `discount_percentage` on catalogues, `discount_percentage` + `default_value` / `default_unit` on items, new `phoenix_kit_cat_item_catalogue_rules` table with CHECK constraints, UNIQUE (item_uuid, referenced_catalogue_uuid), and ON DELETE CASCADE on both FKs. Idempotent up/down; partial index on `kind='smart'`.
- MultilangForm: trailing-debounce `attach_hook/4` + client-side skeleton toggle via composed JS. Rapid language-tab clicks no longer flash stale content or re-mount non-translatable fields.
- Core form components (input/select/textarea/checkbox): realign `class` attr so it merges onto the styled element (input / daisyUI select wrapper / textarea / checkbox). `<.input>` gains `wrapper_class` for the outer `phx-feedback-for` div — matches the Phoenix 1.7 generator convention.
- AGENTS.md: document the Core Form Components and Multilang Form Components sections, including the wrapper-scope rule and why language switching is client-side-first.
- Bump to 1.7.99 and add test_load_filters / test_ignore_filters for Elixir 1.19 mix test hygiene.