### PR TITLE
Fix settings batch save when site_icon_file_uuid or default_tab_title is empty

### DIFF
--- a/lib/phoenix_kit/settings/setting.ex
+++ b/lib/phoenix_kit/settings/setting.ex
@@ -68,6 +68,8 @@ defmodule PhoenixKit.Settings.Setting do
     "sqs_polling_interval_ms",
     # General
     "site_url",
+    "site_icon_file_uuid",
+    "default_tab_title",
     # OAuth Provider Credentials
     "oauth_google_client_id",
     "oauth_google_client_secret",

--- a/lib/phoenix_kit/settings/settings.ex
+++ b/lib/phoenix_kit/settings/settings.ex
@@ -112,6 +112,9 @@ defmodule PhoenixKit.Settings do
       "time_format" => "H:i",
       "track_registration_geolocation" => "false",
       "registration_show_username" => "true",
+      # General branding
+      "site_icon_file_uuid" => "",
+      "default_tab_title" => "",
       # Auth Page Branding
       "auth_logo_file_uuid" => "",
       "auth_background_image_file_uuid" => "",


### PR DESCRIPTION
## Summary

Fixes a batch settings save failure on the General Settings form (\`/phoenix_kit/admin/settings\`) caused by two new form fields missing from the optional-settings list.

**Symptom:**
\`\`\`
[error] Settings batch update error: Failed to save settings:
default_tab_title (must provide either value or value_json)
\`\`\`
Submitting the form with an empty \"Default Tab Title\" or without a chosen site icon rolled back the whole batch — including the site icon selection — because \`validate_value_exclusivity\` rejects new records that have both \`value = \"\"\` and \`value_json = nil\`.

**Fix:**
- Add \`site_icon_file_uuid\` and \`default_tab_title\` to \`@optional_settings\` in \`lib/phoenix_kit/settings/setting.ex\` (same treatment as \`site_url\`, \`auth_logo_file_uuid\`, etc.).
- Add matching empty-string defaults to \`get_defaults/0\` in \`lib/phoenix_kit/settings/settings.ex\` so the fields are emitted consistently.

## Test plan

- [x] \`mix compile\` / pre-commit checks pass (Credo + Dialyzer)
- [ ] Open General Settings on a fresh DB (no prior \`phoenix_kit_settings\` rows for these keys)
- [ ] Leave \"Default Tab Title\" empty and save → batch succeeds
- [ ] Pick a site icon and save → icon persists, no rollback
- [ ] Existing settings (project_title, site_url, etc.) still save correctly