### PR TITLE
Add V103 nested categories migration and folder-scoped media picker

### DIFF
--- a/lib/modules/storage/schemas/file.ex
+++ b/lib/modules/storage/schemas/file.ex
@@ -206,7 +206,7 @@ defmodule PhoenixKit.Modules.Storage.File do
       :size,
       :user_uuid
     ])
-    |> validate_inclusion(:file_type, ["image", "video", "document", "archive"])
+    |> validate_inclusion(:file_type, ["image", "video", "audio", "document", "archive", "other"])
     |> validate_inclusion(:status, ["processing", "active", "failed", "trashed"])
     |> validate_number(:size, greater_than: 0)
     |> validate_number(:width, greater_than: 0)

--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -529,7 +529,13 @@ defmodule PhoenixKit.Migrations.Postgres do
   - Replaces unique index with partial index (slug-mode only, WHERE slug IS NOT NULL)
   - Adds unique index on `(group_uuid, post_date, post_time)` for timestamp-mode posts
 
-  ### V102 - Catalogue discount + smart catalogues ⚡ LATEST
+  ### V103 - Nested categories ⚡ LATEST
+  - Adds nullable self-FK `parent_uuid` on `phoenix_kit_cat_categories`
+    to support arbitrary-depth category trees. Existing rows become
+    roots (NULL parent). Adds a b-tree index on `(parent_uuid)` for the
+    "list children" query.
+
+  ### V102 - Catalogue discount + smart catalogues
   Two related catalogue features bundled together:
   - **Discount**: `discount_percentage DECIMAL(7, 2) NOT NULL DEFAULT 0`
     on `phoenix_kit_cat_catalogues` (whole-catalogue default) and
@@ -762,7 +768,7 @@ defmodule PhoenixKit.Migrations.Postgres do
   use Ecto.Migration
 
   @initial_version 1
-  @current_version 102
+  @current_version 103
   @default_prefix "public"
 
   @doc false

--- a/lib/phoenix_kit/migrations/postgres/v103.ex
+++ b/lib/phoenix_kit/migrations/postgres/v103.ex
@@ -1,0 +1,71 @@
+defmodule PhoenixKit.Migrations.Postgres.V103 do
+  @moduledoc """
+  V103: Nested categories.
+
+  Adds a nullable self-referential `parent_uuid` column on
+  `phoenix_kit_cat_categories`, turning the previously flat one-level
+  taxonomy into an arbitrary-depth tree. Existing rows stay
+  `parent_uuid = NULL` and become roots — no backfill needed.
+
+  The column is nullable (roots have no parent) with no `ON DELETE`
+  cascade: parent/child linkage is managed by the context layer, which
+  runs subtree-walking cascades inside a transaction. A DB-level cascade
+  would bypass the soft-delete machinery and the activity log.
+
+  A plain b-tree index on `(parent_uuid)` covers the "list children"
+  query used when rendering the tree. The existing index on
+  `(catalogue_uuid)` still covers "list all categories in a catalogue".
+  """
+
+  use Ecto.Migration
+
+  def up(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+    schema = if prefix == "public", do: "public", else: prefix
+
+    execute("""
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT FROM information_schema.columns
+        WHERE table_schema = '#{schema}'
+          AND table_name = 'phoenix_kit_cat_categories'
+          AND column_name = 'parent_uuid'
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_cat_categories
+          ADD COLUMN parent_uuid UUID
+          REFERENCES #{p}phoenix_kit_cat_categories(uuid);
+      END IF;
+    END $$;
+    """)
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS phoenix_kit_cat_categories_parent_index
+    ON #{p}phoenix_kit_cat_categories (parent_uuid)
+    """)
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '103'")
+  end
+
+  @doc """
+  Rolls V103 back by dropping the parent index and column.
+
+  **Lossy rollback:** the tree collapses — every category becomes a
+  root and all parent linkage is lost. Back up before rolling back in
+  production.
+  """
+  def down(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    execute("DROP INDEX IF EXISTS #{p}phoenix_kit_cat_categories_parent_index")
+
+    execute("ALTER TABLE #{p}phoenix_kit_cat_categories DROP COLUMN IF EXISTS parent_uuid")
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '102'")
+  end
+
+  defp prefix_str("public"), do: "public."
+  defp prefix_str(prefix), do: "#{prefix}."
+end

--- a/lib/phoenix_kit_web/live/components/media_selector_modal.ex
+++ b/lib/phoenix_kit_web/live/components/media_selector_modal.ex
@@ -33,13 +33,30 @@ defmodule PhoenixKitWeb.Live.Components.MediaSelectorModal do
         # Handle the selected file UUIDs
         {:noreply, socket |> assign(:gallery_uuids, file_uuids)}
       end
+
+  ## Attrs
+
+    * `show` — boolean, controls modal visibility
+    * `mode` — `:single` or `:multiple`
+    * `selected_uuids` — list of already-selected file UUIDs
+    * `phoenix_kit_current_user` — required for uploads to attribute the file
+    * `file_type_filter` — `:all` (default), `:image`, or `:video`
+    * `user_uuid` — when set, restricts the library to files owned by
+      that user; nil (default) shows the full library
+    * `scope_folder_id` — when set, restricts both the browse query
+      and the post-upload home folder to this folder UUID. Plugins
+      scoping the picker to a single domain object (e.g. a catalogue
+      item) pass this after lazy-creating their folder; files already
+      living elsewhere get a `FolderLink` into the scope folder on
+      re-upload rather than being moved out from under their original
+      owner. `nil` (default) = no scope, legacy full-library behaviour.
   """
   use PhoenixKitWeb, :live_component
 
   require Logger
 
   alias PhoenixKit.Modules.Storage
-  alias PhoenixKit.Modules.Storage.{File, FileInstance, URLSigner}
+  alias PhoenixKit.Modules.Storage.{File, FileInstance, FolderLink, URLSigner}
   alias PhoenixKit.Users.Auth
 
   import Ecto.Query
@@ -63,6 +80,11 @@ defmodule PhoenixKitWeb.Live.Components.MediaSelectorModal do
       |> assign(assigns)
       |> assign(:has_buckets, has_buckets)
       |> assign_new(:user_uuid, fn -> nil end)
+      # When set, restricts both the browse query and the post-upload
+      # home folder to this folder UUID. Plugins scoping the picker to
+      # a single domain object (e.g. a catalogue item) pass this
+      # after lazy-creating their folder.
+      |> assign_new(:scope_folder_id, fn -> nil end)
       |> assign_new(:file_type_filter, fn -> :all end)
       |> assign_new(:search_query, fn -> "" end)
       |> assign_new(:current_page, fn -> 1 end)
@@ -323,10 +345,12 @@ defmodule PhoenixKitWeb.Live.Components.MediaSelectorModal do
            ) do
         {:ok, file, :duplicate} ->
           Logger.info("Duplicate file uploaded: #{file.uuid}")
+          _ = maybe_set_folder(file, socket.assigns[:scope_folder_id])
           {:ok, file.uuid}
 
         {:ok, file} ->
           Logger.info("New file uploaded: #{file.uuid}")
+          _ = maybe_set_folder(file, socket.assigns[:scope_folder_id])
           {:ok, file.uuid}
 
         {:error, reason} ->
@@ -339,35 +363,49 @@ defmodule PhoenixKitWeb.Live.Components.MediaSelectorModal do
     end
   end
 
+  # When the picker is scoped to a folder, ensure the file is visible
+  # in that folder. Three cases:
+  # - Same folder (or already linked): no-op.
+  # - File has no home yet: adopt as home (set folder_uuid).
+  # - File has a different home: add a `FolderLink` so the file
+  #   appears in both folders without being yanked from its current
+  #   owner. Callers doing per-object isolation (catalogue items)
+  #   rely on this so uploading the same file to two items leaves
+  #   both with their own reference.
+  defp maybe_set_folder(_file, nil), do: :noop
+
+  defp maybe_set_folder(%File{folder_uuid: current}, new) when current == new,
+    do: :already_in_folder
+
+  defp maybe_set_folder(%File{folder_uuid: nil} = file, folder_uuid) do
+    repo = PhoenixKit.Config.get_repo()
+
+    file
+    |> Ecto.Changeset.change(%{folder_uuid: folder_uuid})
+    |> repo.update()
+  end
+
+  defp maybe_set_folder(%File{uuid: file_uuid}, folder_uuid) do
+    repo = PhoenixKit.Config.get_repo()
+
+    # `:nothing` + the (folder_uuid, file_uuid) unique index makes this
+    # idempotent — re-uploading the same file to the same linked folder
+    # is a no-op rather than an error.
+    %FolderLink{}
+    |> FolderLink.changeset(%{folder_uuid: folder_uuid, file_uuid: file_uuid})
+    |> repo.insert(on_conflict: :nothing, conflict_target: [:folder_uuid, :file_uuid])
+  end
+
   defp load_files(socket, page) do
     repo = PhoenixKit.Config.get_repo()
     per_page = socket.assigns.per_page
-    filter = socket.assigns.file_type_filter
-    search = socket.assigns.search_query
-
-    query = from(f in File, order_by: [desc: f.inserted_at])
 
     query =
-      if socket.assigns[:user_uuid] do
-        where(query, [f], f.user_uuid == ^socket.assigns.user_uuid)
-      else
-        query
-      end
-
-    query =
-      case filter do
-        :image -> where(query, [f], f.file_type == "image")
-        :video -> where(query, [f], f.file_type == "video")
-        :all -> query
-      end
-
-    query =
-      if search != "" do
-        search_pattern = "%#{search}%"
-        where(query, [f], ilike(f.original_file_name, ^search_pattern))
-      else
-        query
-      end
+      from(f in File, order_by: [desc: f.inserted_at])
+      |> scope_files_by_user(socket.assigns[:user_uuid])
+      |> scope_files_by_folder(socket.assigns[:scope_folder_id])
+      |> scope_files_by_type(socket.assigns.file_type_filter)
+      |> scope_files_by_search(socket.assigns.search_query)
 
     total_count = repo.aggregate(query, :count, :uuid)
     offset = (page - 1) * per_page
@@ -408,6 +446,45 @@ defmodule PhoenixKitWeb.Live.Components.MediaSelectorModal do
 
     {files_with_urls, total_count}
   end
+
+  # Scope helpers for load_files/2. Each one returns the query
+  # unchanged when the scope isn't set, otherwise narrows it. Keeps
+  # load_files readable and lets credo stop yelling about cyclomatic
+  # complexity on the combined set of scope branches.
+
+  defp scope_files_by_user(query, nil), do: query
+
+  defp scope_files_by_user(query, user_uuid),
+    do: where(query, [f], f.user_uuid == ^user_uuid)
+
+  # Scope to a specific folder when the caller provides one. Without
+  # a scope, the picker shows the full user library (legacy behavior).
+  # Files that are `FolderLink`-attached to the scope folder are
+  # included too, so per-object pickers still see files that live in
+  # another object's folder but are also shared with this one.
+  defp scope_files_by_folder(query, nil), do: query
+
+  defp scope_files_by_folder(query, folder_uuid) do
+    linked_subq =
+      from(fl in FolderLink,
+        where: fl.folder_uuid == ^folder_uuid,
+        select: fl.file_uuid
+      )
+
+    where(query, [f], f.folder_uuid == ^folder_uuid or f.uuid in subquery(linked_subq))
+  end
+
+  defp scope_files_by_type(query, :image), do: where(query, [f], f.file_type == "image")
+  defp scope_files_by_type(query, :video), do: where(query, [f], f.file_type == "video")
+  defp scope_files_by_type(query, _), do: query
+
+  defp scope_files_by_search(query, ""), do: query
+
+  defp scope_files_by_search(query, search) when is_binary(search) do
+    where(query, [f], ilike(f.original_file_name, ^"%#{search}%"))
+  end
+
+  defp scope_files_by_search(query, _), do: query
 
   defp generate_urls_from_instances(instances, file_uuid) do
     Enum.reduce(instances, %{}, fn instance, acc ->


### PR DESCRIPTION
- V103 migration: nullable self-FK `parent_uuid` on `phoenix_kit_cat_categories` plus a b-tree index for the "list children" query. Idempotent + reversible.
- `PhoenixKit.Modules.Storage.File` changeset: widen the `file_type` allowlist to include `"audio"` and `"other"` so non-image/video uploads from catalogue-style plugins bucket cleanly.
- `MediaSelectorModal`: new `scope_folder_id` attr that filters the browse query (folder + FolderLink subquery) and drives post-upload home folder selection via `maybe_set_folder/2`. Plugins pass this after lazy-creating a per-object folder so picker state stays isolated while shared files still reuse via `FolderLink`.
- Refactor `load_files/2` into composable `scope_files_by_*` helpers (fixes cyclomatic complexity regression credo flagged after the scope branch was added) and expand the moduledoc to enumerate every attr for consuming plugins.