### PR TITLE
Add phoenix_kit_favicon component for parent-owned head

### DIFF
--- a/lib/phoenix_kit_web/components/core/phoenix_kit_favicon.ex
+++ b/lib/phoenix_kit_web/components/core/phoenix_kit_favicon.ex
@@ -1,0 +1,45 @@
+defmodule PhoenixKitWeb.Components.Core.PhoenixKitFavicon do
+  @moduledoc """
+  Renders a `<link rel="icon">` tag driven by the PhoenixKit `site_icon_file_uuid`
+  setting.
+
+  Parent applications should include this component inside their root layout's
+  `<head>` so the site icon uploaded via PhoenixKit Settings actually reaches
+  the browser tab. PhoenixKit's standalone admin layout already includes it.
+
+  If the setting is empty, the component renders nothing so the parent app's
+  static favicon keeps working.
+
+  ## Usage
+
+      <head>
+        ...
+        <PhoenixKitWeb.Components.Core.PhoenixKitFavicon.phoenix_kit_favicon />
+      </head>
+  """
+
+  use Phoenix.Component
+
+  alias PhoenixKit.Modules.Storage.URLSigner
+  alias PhoenixKit.Settings
+
+  attr :variant, :string,
+    default: "thumbnail",
+    doc: "Storage variant name to serve as favicon (defaults to `thumbnail`)"
+
+  attr :type, :string,
+    default: "image/png",
+    doc: "MIME type emitted on the <link> tag"
+
+  def phoenix_kit_favicon(assigns) do
+    site_icon_uuid = Settings.get_setting_cached("site_icon_file_uuid", "")
+
+    assigns = assign(assigns, :site_icon_uuid, site_icon_uuid)
+
+    ~H"""
+    <%= if @site_icon_uuid != "" do %>
+      <link rel="icon" type={@type} href={URLSigner.signed_url(@site_icon_uuid, @variant)} />
+    <% end %>
+    """
+  end
+end

--- a/lib/phoenix_kit_web/components/layout_wrapper.ex
+++ b/lib/phoenix_kit_web/components/layout_wrapper.ex
@@ -37,6 +37,7 @@ defmodule PhoenixKitWeb.Components.LayoutWrapper do
 
   import PhoenixKitWeb.Components.Core.Flash, only: [flash_group: 1]
 
+  import PhoenixKitWeb.Components.Core.PhoenixKitFavicon
   import PhoenixKitWeb.Components.Core.PhoenixKitGlobals
   import PhoenixKitWeb.Components.AdminNav
   import PhoenixKitWeb.Components.Dashboard.AdminSidebar, only: [admin_sidebar: 1]
@@ -253,8 +254,9 @@ defmodule PhoenixKitWeb.Components.LayoutWrapper do
 
             ~H"""
             <%!-- PhoenixKit Admin Layout --%>
-            <%!-- Globals needed here for render_admin_with_parent path where parent layout may not set them --%>
+            <%!-- Globals + favicon needed here for render_admin_with_parent path where parent layout may not set them --%>
             <.phoenix_kit_globals />
+            <.phoenix_kit_favicon />
             <style data-phoenix-kit-themes>
               <%= HTML.raw(ThemeConfig.custom_theme_css()) %>
             </style>
@@ -689,14 +691,7 @@ defmodule PhoenixKitWeb.Components.LayoutWrapper do
         }>
           {assigns[:page_title] || "Admin"}
         </.live_title>
-        <% site_icon_uuid = PhoenixKit.Settings.get_setting_cached("site_icon_file_uuid", "") %>
-        <%= if site_icon_uuid != "" do %>
-          <link
-            rel="icon"
-            type="image/png"
-            href={PhoenixKit.Modules.Storage.URLSigner.signed_url(site_icon_uuid, "thumbnail")}
-          />
-        <% end %>
+        <.phoenix_kit_favicon />
         <%= if assigns[:seo_no_index] do %>
           <meta name="robots" content="noindex,nofollow" />
           <meta name="googlebot" content="noindex,nofollow" />


### PR DESCRIPTION
## Summary

Until now the `site_icon_file_uuid` setting (introduced in 1.7.97) only reached the browser tab in PhoenixKit standalone mode — `render_admin_only_layout` injected `<link rel="icon">` inline, but `render_admin_with_parent` and fully public parent-owned layouts had no way to pick up the uploaded favicon. So in production setups where the parent application owns `<head>`, the icon was saved correctly but never rendered.

## Changes

- Extract favicon markup into a new reusable component: `PhoenixKitWeb.Components.Core.PhoenixKitFavicon`. It reads `site_icon_file_uuid` from Settings via `get_setting_cached/2`, signs a storage URL through `Modules.Storage.URLSigner`, and renders nothing when the setting is empty so existing static favicons keep working.
- Parent applications can now include `<PhoenixKitWeb.Components.Core.PhoenixKitFavicon.phoenix_kit_favicon />` in their `root.html.heex` `<head>` to get the uploaded icon.
- Replace the inline favicon code in `render_admin_only_layout` with the new component (no behaviour change in standalone).
- Invoke the component next to `<.phoenix_kit_globals />` in `render_admin_with_parent`, so PhoenixKit admin pages rendered inside a parent layout still pick up the uploaded icon even before the parent app adopts the helper in its own `<head>`.

## Test plan

- [x] `mix compile --warnings-as-errors` — clean
- [x] `mix credo --strict` on changed files — clean
- [x] Manual: verified favicon renders on a parent-app admin page after uploading a site icon in Settings