### PR TITLE
Add V105 CRM tables migration + MediaBrowser PDF fix

### DIFF
--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -529,7 +529,17 @@ defmodule PhoenixKit.Migrations.Postgres do
   - Replaces unique index with partial index (slug-mode only, WHERE slug IS NOT NULL)
   - Adds unique index on `(group_uuid, post_date, post_time)` for timestamp-mode posts
 
-  ### V104 - Per-user notifications table ⚡ LATEST
+  ### V105 - CRM tables ⚡ LATEST
+  Two tables for the upcoming `phoenix_kit_crm` plugin:
+  - **phoenix_kit_crm_role_settings**: tracks which user roles are opted into
+    the CRM module (`enabled BOOLEAN NOT NULL DEFAULT false`; FK to
+    `phoenix_kit_user_roles(uuid)` ON DELETE CASCADE).
+  - **phoenix_kit_crm_user_role_view**: per-user, per-scope view preferences
+    (column selection, ordering, filters) for CRM tables. `scope` is a string
+    like `"role:<uuid>"` or `"companies"`. Unique on `(user_uuid, scope)`;
+    indexed on `(user_uuid)` for fast per-user lookups.
+
+  ### V104 - Per-user notifications table
   - Creates `phoenix_kit_notifications` with UUID v7 PK and FKs to
     `phoenix_kit_activities` and `phoenix_kit_users` (both ON DELETE CASCADE)
   - `seen_at` and `dismissed_at` tracked per-row so dropping one or the
@@ -538,8 +548,8 @@ defmodule PhoenixKit.Migrations.Postgres do
     per activity per recipient (fan-out writes stay safe against retries)
   - Partial index on `(recipient_uuid, inserted_at DESC) WHERE dismissed_at
     IS NULL` — covers the main "my undismissed inbox, newest first" query
-    
-  ### V103 - Nested categories ⚡ LATEST
+
+  ### V103 - Nested categories
   - Adds nullable self-FK `parent_uuid` on `phoenix_kit_cat_categories`
     to support arbitrary-depth category trees. Existing rows become
     roots (NULL parent). Adds a b-tree index on `(parent_uuid)` for the
@@ -778,7 +788,7 @@ defmodule PhoenixKit.Migrations.Postgres do
   use Ecto.Migration
 
   @initial_version 1
-  @current_version 104
+  @current_version 105
   @default_prefix "public"
 
   @doc false

--- a/lib/phoenix_kit/migrations/postgres/v105.ex
+++ b/lib/phoenix_kit/migrations/postgres/v105.ex
@@ -1,0 +1,87 @@
+defmodule PhoenixKit.Migrations.Postgres.V105 do
+  @moduledoc """
+  V105: CRM tables.
+
+  Two tables supporting the upcoming `phoenix_kit_crm` plugin:
+
+  ## phoenix_kit_crm_role_settings
+
+  Tracks which user roles have opted into the CRM module. One row per
+  role; the FK cascades on role deletion so no orphan cleanup is needed.
+
+  - `role_uuid UUID PRIMARY KEY` — FK → `phoenix_kit_user_roles(uuid)` ON DELETE CASCADE
+  - `enabled BOOLEAN NOT NULL DEFAULT false` — opt-in flag; false by default
+    so existing roles are unaffected until an admin explicitly enables CRM.
+  - `inserted_at`, `updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()`
+
+  ## phoenix_kit_crm_user_role_view
+
+  Per-user, per-scope view preferences for CRM tables (column selection,
+  ordering, active filters). One row per (user, scope) pair; scope values
+  are strings like `"role:<uuid>"` or `"companies"`.
+
+  - `uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7()`
+  - `user_uuid UUID NOT NULL` — FK → `phoenix_kit_users(uuid)` ON DELETE CASCADE
+  - `scope VARCHAR(100) NOT NULL` — e.g. `"role:<uuid>"`, `"companies"`
+  - `view_config JSONB NOT NULL DEFAULT '{}'` — arbitrary UI preferences blob
+  - `inserted_at`, `updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()`
+  - `UNIQUE (user_uuid, scope)` — one preference row per user/scope pair
+  - Index on `(user_uuid)` for per-user lookups
+
+  All operations are idempotent.
+  """
+
+  use Ecto.Migration
+
+  def up(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    execute("""
+    CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_crm_role_settings (
+      role_uuid UUID PRIMARY KEY REFERENCES #{p}phoenix_kit_user_roles(uuid) ON DELETE CASCADE,
+      enabled BOOLEAN NOT NULL DEFAULT false,
+      inserted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+    """)
+
+    execute("""
+    CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_crm_user_role_view (
+      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      user_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_users(uuid) ON DELETE CASCADE,
+      scope VARCHAR(100) NOT NULL,
+      view_config JSONB NOT NULL DEFAULT '{}',
+      inserted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      CONSTRAINT phoenix_kit_crm_user_role_view_user_scope_uniq UNIQUE (user_uuid, scope)
+    )
+    """)
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS idx_crm_user_role_view_user
+    ON #{p}phoenix_kit_crm_user_role_view (user_uuid)
+    """)
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '105'")
+  end
+
+  @doc """
+  Rolls V105 back by dropping both CRM tables in reverse creation order.
+
+  **Lossy rollback:** all role CRM opt-in settings and user view preferences
+  are lost. Back up before rolling back in production.
+  """
+  def down(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    execute("DROP TABLE IF EXISTS #{p}phoenix_kit_crm_user_role_view CASCADE")
+    execute("DROP TABLE IF EXISTS #{p}phoenix_kit_crm_role_settings CASCADE")
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '104'")
+  end
+
+  defp prefix_str("public"), do: "public."
+  defp prefix_str(prefix), do: "#{prefix}."
+end

--- a/lib/phoenix_kit_web/components/media_browser.ex
+++ b/lib/phoenix_kit_web/components/media_browser.ex
@@ -1718,7 +1718,10 @@ defmodule PhoenixKitWeb.Components.MediaBrowser do
     cond do
       String.starts_with?(mime_type, "image/") -> "image"
       String.starts_with?(mime_type, "video/") -> "video"
-      mime_type == "application/pdf" -> "pdf"
+      # PDFs fall under "document" because the File schema's allowlist is
+      # ["image", "video", "document", "archive"] — returning "pdf" here made
+      # every PDF upload fail the changeset validation silently.
+      mime_type == "application/pdf" -> "document"
       true -> "document"
     end
   end


### PR DESCRIPTION
## Summary

Two independent changes bundled in one PR:

1. **V105 migration — CRM tables** for the upcoming `phoenix_kit_crm` plugin.
2. **Fix application/pdf upload in MediaBrowser** — silent changeset-validation failure that prevented PDFs from ever reaching a bucket.

## Changes

### V105 — CRM tables (`lib/phoenix_kit/migrations/postgres/v105.ex`)

Two tables for the `phoenix_kit_crm` module:

- **`phoenix_kit_crm_role_settings`** — one row per role, tracks which user roles are opted into the CRM module. FK `role_uuid` → `phoenix_kit_user_roles(uuid)` ON DELETE CASCADE. `enabled BOOLEAN NOT NULL DEFAULT false` so existing roles stay unaffected until explicitly enabled.
- **`phoenix_kit_crm_user_role_view`** — per-user, per-scope view preferences (column selection, ordering, filters) for CRM tables. `scope` is a string like `"role:<uuid>"` or `"companies"`. Unique on `(user_uuid, scope)`; indexed on `(user_uuid)`. UUIDv7 PK. FK `user_uuid` → `phoenix_kit_users(uuid)` ON DELETE CASCADE.

Idempotent (`CREATE TABLE/INDEX IF NOT EXISTS`) and reversible (`down/1` drops both tables + index, resets version comment to `'104'` so rollback lands on V104 notifications cleanly).

`@current_version` bumped `104 → 105`; moduledoc entries added for V105 (⚡ LATEST) and V104 (Per-user notifications).

### MediaBrowser PDF fix (`lib/phoenix_kit_web/components/media_browser.ex`)

`determine_file_type/1` returned `"pdf"` for `application/pdf`, but the `File` changeset validates `file_type` against `["image", "video", "audio", "document", "archive", "other"]` — so every PDF upload silently failed validation and never reached any bucket. Mapping `application/pdf` → `"document"` fixes it; matches how form-upload integrations already classify PDFs.

## Test Plan

- [x] `mix precommit` (compile, format, credo --strict, dialyzer) — green
- [x] Migration renumber verified: `V105` module / `v105.ex` / `@current_version 105` / `up` writes `'105'` / `down` writes `'104'` (lands on upstream's V104 notifications)
- [x] `uuid_generate_v7()` used (project convention)
- [x] PDF upload tested manually via MediaBrowser admin page — file reaches bucket and appears in grid