### PR TITLE
Add V106 migration: split phoenix_kit_projects name uniqueness for templates vs projects

### DIFF
--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -788,7 +788,7 @@ defmodule PhoenixKit.Migrations.Postgres do
   use Ecto.Migration
 
   @initial_version 1
-  @current_version 105
+  @current_version 106
   @default_prefix "public"
 
   @doc false

--- a/lib/phoenix_kit/migrations/postgres/v106.ex
+++ b/lib/phoenix_kit/migrations/postgres/v106.ex
@@ -1,0 +1,84 @@
+defmodule PhoenixKit.Migrations.Postgres.V106 do
+  @moduledoc """
+  V106: Split `phoenix_kit_projects.name` uniqueness across templates and
+  real projects.
+
+  V101 created a single global unique index
+  (`phoenix_kit_projects_name_index`) on `lower(name)` over the
+  `phoenix_kit_projects` table. Templates and real projects share that
+  table — distinguished only by the `is_template` boolean — so they
+  also shared one name namespace, which made
+  `Projects.create_project_from_template/2` collide whenever a real
+  project should reuse the source template's name (the common,
+  expected case).
+
+  This migration replaces that single index with two partial unique
+  indexes — one per `is_template` value — so a template "Onboarding"
+  and a real project "Onboarding" can coexist freely.
+
+  ## Indexes
+
+  - `phoenix_kit_projects_name_template_index`
+    `UNIQUE (lower(name)) WHERE is_template = true`
+  - `phoenix_kit_projects_name_project_index`
+    `UNIQUE (lower(name)) WHERE is_template = false`
+
+  Both are idempotent (`CREATE INDEX IF NOT EXISTS` / `DROP INDEX IF
+  EXISTS`).
+
+  Schema-side change only. The Ecto changeset's `unique_constraint(:name,
+  name: :phoenix_kit_projects_name_index, ...)` reference is updated in
+  the same release of `phoenix_kit_projects` to point at whichever
+  partial index applies (the `is_template` value at validate time
+  selects the correct constraint name).
+  """
+
+  use Ecto.Migration
+
+  def up(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    execute("DROP INDEX IF EXISTS #{p}phoenix_kit_projects_name_index")
+
+    execute("""
+    CREATE UNIQUE INDEX IF NOT EXISTS phoenix_kit_projects_name_template_index
+    ON #{p}phoenix_kit_projects (lower(name))
+    WHERE is_template = true
+    """)
+
+    execute("""
+    CREATE UNIQUE INDEX IF NOT EXISTS phoenix_kit_projects_name_project_index
+    ON #{p}phoenix_kit_projects (lower(name))
+    WHERE is_template = false
+    """)
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '105'")
+  end
+
+  @doc """
+  Reverts to V101's single global unique index.
+
+  **Lossy rollback:** if the post-V106 state has both a template and a
+  real project with the same name, recreating the single
+  `phoenix_kit_projects_name_index` will fail with a uniqueness
+  violation. Resolve duplicates before rolling back in production.
+  """
+  def down(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    execute("DROP INDEX IF EXISTS #{p}phoenix_kit_projects_name_project_index")
+    execute("DROP INDEX IF EXISTS #{p}phoenix_kit_projects_name_template_index")
+
+    execute("""
+    CREATE UNIQUE INDEX IF NOT EXISTS phoenix_kit_projects_name_index
+    ON #{p}phoenix_kit_projects (lower(name))
+    """)
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '104'")
+  end
+
+  defp prefix_str("public"), do: "public."
+  defp prefix_str(prefix), do: "#{prefix}."
+end


### PR DESCRIPTION
## Summary

Splits V101's single global unique index on `phoenix_kit_projects (lower(name))`
into two partial indexes:

- `phoenix_kit_projects_name_template_index` — `WHERE is_template = true`
- `phoenix_kit_projects_name_project_index` — `WHERE is_template = false`

Templates and real projects share the `phoenix_kit_projects` table, distinguished
only by the `is_template` boolean. Under V101 they also shared a single name
namespace, which made `Projects.create_project_from_template/2` collide whenever
a real project should reuse the source template's name (the common, expected
case).

After this migration a template "Onboarding" and a real project "Onboarding"
can coexist. Both indexes are idempotent (`CREATE INDEX IF NOT EXISTS` /
`DROP INDEX IF EXISTS`).

## Why V106 (not V105)

PR #507 (`feat/v104-crm-tables`) already claims V105. V106 sits alongside it
without collision.

## Dependency

The corresponding `phoenix_kit_projects` changeset update — re-pointing
`unique_constraint(:name, ...)` at whichever partial index applies based on
`is_template` at validate time — depends on this migration landing first.
Without it the new constraint names don't exist and inserts fail.

## Rollback

`down/1` recreates V101's single global index. **Lossy if** the post-V106 state
has a template and a real project sharing the same name — the recreation will
fail with a uniqueness violation. Resolve duplicates before rolling back in
production.

## Test plan

- [x] `mix compile` clean
- [ ] Migration up/down both succeed on a fresh DB