### PR TITLE
Add V108 + drag-and-drop core + PR #506 review follow-up

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -649,3 +649,38 @@ config :phoenix_kit,
   route_modules: [PhoenixKitEntities.Routes]
 ```
 
+
+## TODOs
+
+Workspace-tracked items that aren't ready for inline `# TODO`
+comments in `lib/` (per the playbook, those should be resolved or
+moved here).
+
+### Component test coverage for `phoenix_kit_web/components/core/`
+
+There are no tests under `test/phoenix_kit_web/components/core/` —
+the directory doesn't exist. Several components in
+`lib/phoenix_kit_web/components/core/` are now non-trivial and would
+benefit from `Phoenix.LiveViewTest`-style render-and-assert
+coverage:
+
+- `<.draggable_list>` — recently grew a `:draggable` attr that
+  conditionally hides the SortableJS hook + `cursor-grab` styling.
+  Both branches need at least one rendered-HTML assertion.
+- `<.table_default>` — recently grew `:on_reorder` / `:reorder_scope`
+  / `:reorder_group` / `:item_id` attrs that wire the card-view
+  container as a sortable target. With- and without-DnD branches
+  need rendered-HTML assertions to pin `phx-hook="SortableGrid"`,
+  `data-sortable-*`, `data-id`, `class="sortable-item"`, and the
+  drag-handle footer row.
+- `<.input>`, `<.select>`, `<.textarea>`, `<.checkbox>` — the
+  canonical form primitives; surveyed for inline error rendering,
+  daisyUI variant classes, and the FormField vs raw `name=`/`value=`
+  dispatch.
+- `<.flash>`, `<.modal>` (if either's complexity has grown).
+
+Surfaced 2026-05-02 by the C12 triage during the V108 / DnD core
+work. Treated as out of scope for that PR (a single fixture in an
+empty test dir is awkward); fold into a future component-coverage
+sweep.
+

--- a/dev_docs/pull_requests/2026/506-dynamic-children-locale/FOLLOW_UP.md
+++ b/dev_docs/pull_requests/2026/506-dynamic-children-locale/FOLLOW_UP.md
@@ -1,0 +1,58 @@
+# Follow-up Items for PR #506 (Support arity-2 dynamic_children callback with locale)
+
+PR #506 extended `Tab.dynamic_children_fn` from `(scope -> [tab])` to
+also accept `(scope, locale -> [tab])`. Merged 2026-04-24. The
+CLAUDE_REVIEW.md verdict was APPROVE with two NITPICKs; both are
+closed in this batch.
+
+## Fixed (Batch 1 — 2026-05-02)
+
+- ~~**Test coverage half-tautological**~~ — the original
+  `"invoke_dynamic_children/3 dispatch"` describe block defined two
+  anonymous functions and called them with `.(%{})` and
+  `.(%{}, "en-US")`, asserting the counters incremented. As the
+  reviewer noted, that tested Elixir's function-call semantics, not
+  the sidebar's dispatch.
+
+  Fix: added a `@doc false` test-only delegate
+  `AdminSidebar.__invoke_dynamic_children_for_test__/3` that calls
+  the private `invoke_dynamic_children/3` so the test exercises the
+  actual dispatcher. Rewrote the describe block with four
+  assertion-pinned tests:
+
+  - arity-1 callback receives only the scope (`assert_received`
+    confirms the scope reaches the function),
+  - arity-2 callback receives both scope and locale,
+  - arity-2 callback handles a nil locale,
+  - the callback's return value is propagated to the caller.
+
+  Files: `lib/phoenix_kit_web/components/dashboard/admin_sidebar.ex`,
+  `test/phoenix_kit_web/components/admin_sidebar_dynamic_children_test.exs`.
+
+- ~~**Add `@typedoc` to `dynamic_children_fn`**~~ —
+  `lib/phoenix_kit/dashboard/tab.ex:120` had an inline `#` comment
+  that wasn't picked up by ExDoc / `h Tab`. Replaced with a
+  `@typedoc` block covering the two arities, the explicit-locale
+  rationale, and the `nil` semantic.
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `lib/phoenix_kit/dashboard/tab.ex` | Inline `#` comment on `dynamic_children_fn` promoted to `@typedoc` |
+| `lib/phoenix_kit_web/components/dashboard/admin_sidebar.ex` | Added `@doc false` `__invoke_dynamic_children_for_test__/3` delegate |
+| `test/phoenix_kit_web/components/admin_sidebar_dynamic_children_test.exs` | Rewrote the dispatch describe block with four assertion-pinned tests via the new delegate |
+
+## Verification
+
+- `mix format --check-formatted` clean
+- `mix compile --warnings-as-errors` clean
+- `mix credo --strict` (over the touched files): 116 mods/funs, 0
+  issues
+- `mix test test/phoenix_kit_web/components/admin_sidebar_dynamic_children_test.exs`:
+  **6 tests, 0 failures** (2 from the original `dynamic_children_fn
+  type` describe + 4 new dispatch tests)
+
+## Open
+
+None.

--- a/lib/phoenix_kit/dashboard/tab.ex
+++ b/lib/phoenix_kit/dashboard/tab.ex
@@ -112,11 +112,21 @@ defmodule PhoenixKit.Dashboard.Tab do
 
   @type level :: :user | :admin | :all
 
-  # `dynamic_children` may have arity 1 (receives scope) or arity 2 (receives scope
-  # and the current locale). The 2-arity variant lets modules render locale-aware
-  # children (e.g. translated tab labels) without having to fall back on
-  # `Gettext.get_locale/1` at render time. The sidebar dispatches on arity; both
-  # forms are supported for backwards compatibility.
+  @typedoc """
+  Callback that produces a parent tab's children at render time.
+
+  Two arities are supported and dispatched on at the sidebar layer:
+
+  - **Arity 1** — `(scope -> [tab])`. The original contract; most modules
+    use this form.
+  - **Arity 2** — `(scope, locale -> [tab])`. Receives the current locale
+    (or `nil` outside a localised request) so callbacks can render
+    locale-aware children (e.g. translated tab labels) without falling
+    back on `Gettext.get_locale/1` at render time. The locale is passed
+    explicitly so plugins don't depend on Gettext process state.
+
+  `nil` means "no dynamic children"; the parent tab renders alone.
+  """
   @type dynamic_children_fn ::
           (map() -> [t()])
           | (map(), String.t() | nil -> [t()])

--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -797,7 +797,7 @@ defmodule PhoenixKit.Migrations.Postgres do
   use Ecto.Migration
 
   @initial_version 1
-  @current_version 107
+  @current_version 108
   @default_prefix "public"
 
   @doc false

--- a/lib/phoenix_kit/migrations/postgres/v108.ex
+++ b/lib/phoenix_kit/migrations/postgres/v108.ex
@@ -1,0 +1,87 @@
+defmodule PhoenixKit.Migrations.Postgres.V108 do
+  @moduledoc """
+  V108: Add `position` columns for drag-and-drop reordering on three
+  list surfaces.
+
+  Three independent admin lists previously sat in insertion order
+  (latest first or alphabetical) with no user-driven order:
+
+  - `phoenix_kit_entities` — the entity-definitions list at
+    `/admin/entities`
+  - `phoenix_kit_cat_catalogues` — the catalogues index at
+    `/admin/catalogue`
+  - `phoenix_kit_cat_items` — items shown on a catalogue's detail page
+    and inside categories
+
+  Categories and smart-catalogue rules already carry their own
+  `position` columns (V87 and V102 respectively), so they're untouched
+  here. The `phoenix_kit_entity_data` table got its `position` column
+  in V81 along with a `(entity_uuid, position)` composite index for
+  the manual-sort query, so it's also already covered.
+
+  ## Up
+
+  Adds a nullable `position integer` to each of the three tables with a
+  default of `0`. New rows get `0`; the LV reorder handlers re-index
+  the visible group to `1..N` on the first user drag, so the default is
+  only ever observed transiently.
+
+  No indexes on the three new `position` columns themselves — entity /
+  catalogue / item-per-catalogue lists are small (≤ a few hundred
+  rows) and have other indexed scope filters; a position-only btree
+  would burn write amplification for no real read win.
+
+  ## Down
+
+  Drops the three columns. Lossy — any user-set ordering is discarded.
+  """
+
+  use Ecto.Migration
+
+  def up(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    execute("""
+    ALTER TABLE #{p}phoenix_kit_entities
+    ADD COLUMN IF NOT EXISTS position integer DEFAULT 0
+    """)
+
+    execute("""
+    ALTER TABLE #{p}phoenix_kit_cat_catalogues
+    ADD COLUMN IF NOT EXISTS position integer DEFAULT 0
+    """)
+
+    execute("""
+    ALTER TABLE #{p}phoenix_kit_cat_items
+    ADD COLUMN IF NOT EXISTS position integer DEFAULT 0
+    """)
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '108'")
+  end
+
+  def down(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    execute("""
+    ALTER TABLE #{p}phoenix_kit_cat_items
+    DROP COLUMN IF EXISTS position
+    """)
+
+    execute("""
+    ALTER TABLE #{p}phoenix_kit_cat_catalogues
+    DROP COLUMN IF EXISTS position
+    """)
+
+    execute("""
+    ALTER TABLE #{p}phoenix_kit_entities
+    DROP COLUMN IF EXISTS position
+    """)
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '107'")
+  end
+
+  defp prefix_str("public"), do: "public."
+  defp prefix_str(prefix), do: "#{prefix}."
+end

--- a/lib/phoenix_kit_web/components/core/draggable_list.ex
+++ b/lib/phoenix_kit_web/components/core/draggable_list.ex
@@ -76,6 +76,11 @@ defmodule PhoenixKitWeb.Components.Core.DraggableList do
   attr :item_class, :string, default: "", doc: "Additional CSS classes for each item wrapper"
   attr :hide_source, :boolean, default: false, doc: "Hide source element on drag start"
 
+  attr :draggable, :boolean,
+    default: true,
+    doc:
+      "When false, the container renders without the SortableGrid hook and items skip the grab-cursor styling — useful when the list is too short to reorder (length <= 1)"
+
   slot :item, required: true, doc: "Slot to render each item, receives the item as let"
   slot :add_button, doc: "Optional slot for add button at end of container"
 
@@ -99,17 +104,20 @@ defmodule PhoenixKitWeb.Components.Core.DraggableList do
     ~H"""
     <div
       id={@id}
-      data-sortable="true"
-      data-sortable-event={@on_reorder}
-      data-sortable-items=".sortable-item"
-      data-sortable-hide-source={to_string(@hide_source)}
-      phx-hook="SortableGrid"
+      data-sortable={if @draggable, do: "true"}
+      data-sortable-event={if @draggable, do: @on_reorder}
+      data-sortable-items={if @draggable, do: ".sortable-item"}
+      data-sortable-hide-source={if @draggable, do: to_string(@hide_source)}
+      phx-hook={if @draggable, do: "SortableGrid"}
       class={@container_class}
     >
       <%= for item <- @items do %>
         <div
-          class={["sortable-item cursor-grab active:cursor-grabbing", @item_class]}
-          data-id={@item_id_fn.(item)}
+          class={[
+            @draggable && "sortable-item cursor-grab active:cursor-grabbing",
+            @item_class
+          ]}
+          data-id={if @draggable, do: @item_id_fn.(item)}
         >
           {render_slot(@item, item)}
         </div>

--- a/lib/phoenix_kit_web/components/core/table_default.ex
+++ b/lib/phoenix_kit_web/components/core/table_default.ex
@@ -52,6 +52,7 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
   """
 
   use Phoenix.Component
+  use Gettext, backend: PhoenixKitWeb.Gettext
 
   import PhoenixKitWeb.Components.Core.Icon, only: [icon: 1]
 
@@ -93,6 +94,25 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
   attr :card_fields, :any, default: nil
   attr :storage_key, :string, default: nil
   attr :wrapper_class, :string, default: "rounded-lg shadow-md overflow-x-auto overflow-y-clip"
+
+  attr :on_reorder, :string,
+    default: nil,
+    doc:
+      "When set, the card-view container becomes a SortableGrid hook target. The table-view's tbody is owned by the inner_block — wire that side separately."
+
+  attr :reorder_scope, :map,
+    default: %{},
+    doc: "Map of scope values exposed on the card-view container as data-sortable-scope-* attrs"
+
+  attr :reorder_group, :string,
+    default: nil,
+    doc: "SortableJS group name for cross-container drag (must match the table-view side)"
+
+  attr :item_id, :any,
+    default: nil,
+    doc:
+      "1-arity function returning the data-id for a card. Defaults to `& &1.uuid`. Required when on_reorder is set."
+
   attr :rest, :global
 
   slot :inner_block, required: true
@@ -135,6 +155,14 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
   end
 
   defp table_default_with_cards(assigns) do
+    item_id_fn = assigns[:item_id] || fn item -> Map.get(item, :uuid) end
+    reorder_scope_attrs = build_sortable_scope_attrs(assigns[:reorder_scope] || %{})
+
+    assigns =
+      assigns
+      |> assign(:item_id_fn, item_id_fn)
+      |> assign(:reorder_scope_attrs, reorder_scope_attrs)
+
     ~H"""
     <div id={@id} phx-hook="TableCardView" data-storage-key={@storage_key || @id} class="relative">
       <%!-- Toolbar row: title (left) + actions and view toggle (right) --%>
@@ -189,8 +217,26 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
         </div>
       </div>
       <%!-- Cards: always shown on mobile, hidden on desktop (JS controls md: classes) --%>
-      <div data-card-view="" class="md:hidden grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-        <div :for={item <- @items} class="card card-sm bg-base-200 shadow-sm">
+      <div
+        id={if @on_reorder, do: "#{@id}-cards"}
+        data-card-view=""
+        class="md:hidden grid gap-4 md:grid-cols-2 lg:grid-cols-3"
+        data-sortable={if @on_reorder, do: "true"}
+        data-sortable-event={@on_reorder}
+        data-sortable-items={if @on_reorder, do: ".sortable-item"}
+        data-sortable-hide-source="false"
+        data-sortable-group={@reorder_group}
+        phx-hook={if @on_reorder, do: "SortableGrid"}
+        {@reorder_scope_attrs}
+      >
+        <div
+          :for={item <- @items}
+          class={[
+            "card card-sm bg-base-200 shadow-sm",
+            @on_reorder && "sortable-item cursor-grab active:cursor-grabbing"
+          ]}
+          data-id={if @on_reorder, do: @item_id_fn.(item)}
+        >
           <div class="card-body gap-3 flex flex-col">
             <%!-- Custom header (slot) or plain title string --%>
             <div :if={@card_header != []}>
@@ -206,12 +252,26 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
                 <div>{field.value}</div>
               <% end %>
             </div>
-            <%!-- Actions: pinned to bottom --%>
+            <%!-- Footer row: drag handle (bottom-left, when sortable) +
+                 actions (bottom-right, when present). Always rendered
+                 if either is present so the alignment is consistent. --%>
             <div
-              :if={@card_actions != []}
-              class="card-actions justify-end pt-1 border-t border-base-200 mt-auto"
+              :if={@on_reorder || @card_actions != []}
+              class="card-actions flex items-center justify-between pt-1 border-t border-base-200 mt-auto"
             >
-              {render_slot(@card_actions, item)}
+              <div
+                :if={@on_reorder}
+                class="text-base-content/30 hover:text-base-content/70 cursor-grab active:cursor-grabbing select-none"
+                title={gettext("Drag to reorder")}
+              >
+                <.icon name="hero-bars-3" class="w-4 h-4" />
+              </div>
+              <%!-- Spacer when sortable but no actions, so the handle
+                   stays left and we don't collapse the row. --%>
+              <span :if={@on_reorder && @card_actions == []}></span>
+              <div :if={@card_actions != []} class="flex gap-2 ml-auto">
+                {render_slot(@card_actions, item)}
+              </div>
             </div>
           </div>
         </div>
@@ -219,6 +279,24 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
     </div>
     """
   end
+
+  # Translates a `%{key => value}` map into a list of
+  # `{"data-sortable-scope-key" => value}` tuples so the SortableGrid
+  # hook can read them off the container as extra payload. nil/blank
+  # values become "" so the parser side can detect "uncategorized" /
+  # "no scope" without ambiguity.
+  defp build_sortable_scope_attrs(scope) when is_map(scope) do
+    Enum.flat_map(scope, fn {key, value} ->
+      attr_name = "data-sortable-scope-" <> sortable_scope_dash(to_string(key))
+      [{attr_name, sortable_scope_value(value)}]
+    end)
+  end
+
+  defp sortable_scope_value(nil), do: ""
+  defp sortable_scope_value(v) when is_binary(v), do: v
+  defp sortable_scope_value(v), do: to_string(v)
+
+  defp sortable_scope_dash(name), do: name |> String.replace("_", "-") |> String.downcase()
 
   @doc """
   Renders a table header section.

--- a/lib/phoenix_kit_web/components/dashboard/admin_sidebar.ex
+++ b/lib/phoenix_kit_web/components/dashboard/admin_sidebar.ex
@@ -271,6 +271,16 @@ defmodule PhoenixKitWeb.Components.Dashboard.AdminSidebar do
   defp invoke_dynamic_children(fun, scope, _locale) when is_function(fun, 1),
     do: fun.(scope)
 
+  @doc false
+  # Test-only public delegate. The internal dispatch helper is `defp` because
+  # it shouldn't be part of the runtime API; this `@doc false` wrapper lets
+  # the unit suite exercise the actual arity dispatch (rather than just
+  # re-asserting Elixir's call semantics on anonymous functions). Not
+  # recommended for runtime callers — the contract is `dynamic_children_fn`,
+  # not this wrapper.
+  def __invoke_dynamic_children_for_test__(fun, scope, locale),
+    do: invoke_dynamic_children(fun, scope, locale)
+
   # Recursively checks if any descendant (children, grandchildren, etc.) is active.
   # Includes depth limit and cycle detection for safety with parent-app-registered tabs.
   defp any_descendant_active?(parent_id, all_tabs, depth \\ 0, visited \\ %{})

--- a/priv/static/assets/phoenix_kit.js
+++ b/priv/static/assets/phoenix_kit.js
@@ -226,12 +226,35 @@ if (typeof window.Chart === "undefined") {
         var container = this.el;
         var eventName = container.dataset.sortableEvent || "reorder_items";
         var hideSource = container.dataset.sortableHideSource === "true";
+        var groupName = container.dataset.sortableGroup;
 
         injectStyles();
 
         this._itemCount = container.querySelectorAll(".sortable-item[data-id]").length;
 
-        this.sortable = window.Sortable.create(container, {
+        // Helper: read all data-sortable-scope-* attrs off an element and
+        // turn them into a `{key: value}` map. dataset already gives
+        // camelCase keys; we just strip the "sortableScope" prefix and
+        // lowercase the first letter.
+        var readScope = function(el) {
+          var out = {};
+          for (var key in el.dataset) {
+            if (key.indexOf("sortableScope") === 0 && key.length > "sortableScope".length) {
+              var fieldName = key.substring("sortableScope".length);
+              fieldName = fieldName.charAt(0).toLowerCase() + fieldName.slice(1);
+              out[fieldName] = el.dataset[key];
+            }
+          }
+          return out;
+        };
+
+        // SortableJS `group` controls which sortables can exchange items.
+        // - String form: simple shared group (any matching name accepts/donates).
+        // - Object form: {name, pull: true, put: true} when consumer needs
+        //   explicit cross-container behavior. We keep it as a plain string
+        //   here; the default pull/put = true is what cross-container DnD
+        //   needs.
+        var sortableOpts = {
           animation: 150,
           draggable: ".sortable-item",
           filter: ".sortable-ignore",
@@ -242,21 +265,70 @@ if (typeof window.Chart === "undefined") {
           dragClass: "sortable-drag",
           onStart: function() {
             if (hideSource) {
-              // Hide the fallback clone that SortableJS places at the initial position on body
               setTimeout(function() {
                 var fallback = document.querySelector("body > .sortable-fallback");
                 if (fallback) fallback.style.display = "none";
               }, 0);
             }
           },
+          // onEnd assumes the hook has exclusive control over the
+          // .sortable-item nodes inside its container — i.e. the LV
+          // owns this DOM subtree. If a third-party script ever
+          // injects nodes with `class="sortable-item" data-id=...`
+          // alongside ours, those IDs will be picked up by the
+          // querySelectorAll below; the LV handler should then
+          // reject unknown IDs at the server side. Trust your own DOM.
+          //
+          // The whole body is wrapped in try/catch so a single bad
+          // dataset value (e.g. corrupt JSON in a custom scope attr,
+          // or a missing source container after a fast unmount) flashes
+          // a console error instead of leaving SortableJS in a half-
+          // initialized state with the LV unable to reorder again.
           onEnd: function(evt) {
-            var items = container.querySelectorAll(".sortable-item[data-id]");
-            var orderedIds = Array.from(items).map(function(el) {
-              return el.dataset.id;
-            });
-            self.pushEvent(eventName, { ordered_ids: orderedIds });
+            try {
+              var fromContainer = evt.from;
+              var toContainer = evt.to;
+              var crossContainer = fromContainer !== toContainer;
+
+              // The destination container's items reflect the new ordering;
+              // the source's lost one but its remaining order is preserved
+              // by SortableJS, so we don't need a server reorder there.
+              var destItems = toContainer.querySelectorAll(".sortable-item[data-id]");
+              var orderedIds = Array.from(destItems).map(function(el) {
+                return el.dataset.id;
+              });
+
+              var payload = { ordered_ids: orderedIds };
+              var destScope = readScope(toContainer);
+              for (var k in destScope) payload[k] = destScope[k];
+
+              if (crossContainer) {
+                payload.moved_id = evt.item.dataset.id;
+                var fromScope = readScope(fromContainer);
+                for (var k2 in fromScope) {
+                  // Capitalize first letter so `categoryUuid` becomes
+                  // `fromCategoryUuid` (camelCase preserved).
+                  var capped = k2.charAt(0).toUpperCase() + k2.slice(1);
+                  payload["from" + capped] = fromScope[k2];
+                }
+                // Use the destination's event name so the LV handler is
+                // co-located with the table the item ended up in.
+                var destEvent = toContainer.dataset.sortableEvent || eventName;
+                self.pushEvent(destEvent, payload);
+              } else {
+                self.pushEvent(eventName, payload);
+              }
+            } catch (err) {
+              console.error("PhoenixKitHooks.SortableGrid.onEnd failed:", err);
+            }
           }
-        });
+        };
+
+        if (groupName) {
+          sortableOpts.group = groupName;
+        }
+
+        this.sortable = window.Sortable.create(container, sortableOpts);
       }
     };
   })();
@@ -1538,6 +1610,7 @@ if (typeof window.Chart === "undefined") {
       var key = this.el.dataset.storageKey || (this.el.id + "-view");
       var saved = localStorage.getItem(key) || "table";
       this.storageKey = key;
+      this.currentMode = saved;
       this.applyMode(saved);
 
       var self = this;
@@ -1545,6 +1618,7 @@ if (typeof window.Chart === "undefined") {
         btn.addEventListener("click", function() {
           var mode = btn.dataset.viewAction;
           localStorage.setItem(self.storageKey, mode);
+          self.currentMode = mode;
           self.applyMode(mode);
           // Notify other TableCardView instances sharing the same key
           window.dispatchEvent(new CustomEvent("phx:table-view-change", {
@@ -1556,10 +1630,22 @@ if (typeof window.Chart === "undefined") {
       // Listen for view changes from other instances with the same key
       this._onViewChange = function(e) {
         if (e.detail.key === self.storageKey) {
+          self.currentMode = e.detail.mode;
           self.applyMode(e.detail.mode);
         }
       };
       window.addEventListener("phx:table-view-change", this._onViewChange);
+    },
+
+    updated() {
+      // The LV re-render may have reset the inner divs' class attrs back
+      // to their template defaults (e.g. tableEl class="hidden md:block",
+      // cardEl class="md:hidden ..."). Re-apply the user's chosen mode so
+      // a SortableJS drop or any other LV-driven update doesn't snap the
+      // view back to the default.
+      if (this.currentMode) {
+        this.applyMode(this.currentMode);
+      }
     },
 
     destroyed() {

--- a/test/phoenix_kit_web/components/admin_sidebar_dynamic_children_test.exs
+++ b/test/phoenix_kit_web/components/admin_sidebar_dynamic_children_test.exs
@@ -1,18 +1,15 @@
 defmodule PhoenixKitWeb.Components.Dashboard.AdminSidebarDynamicChildrenTest do
   @moduledoc """
-  Unit tests for the arity-dispatching `expand_dynamic_children/3` helper in
-  `PhoenixKitWeb.Components.Dashboard.AdminSidebar`. The helper itself is private,
-  so we exercise it through `admin_sidebar/1` via Phoenix.LiveView.Rendered
-  APIs — but to keep the tests fast and DB-free, we rely on a thin public
-  wrapper test-helper: `invoke_dynamic_children_for_test/3`.
-
-  If that wrapper doesn't exist, we fall back to asserting the arity dispatch
-  via `Function.info/1` contracts baked into `Tab.dynamic_children_fn`.
+  Unit tests for the arity-dispatching `dynamic_children` callback handling in
+  `PhoenixKitWeb.Components.Dashboard.AdminSidebar`. The internal helper
+  `invoke_dynamic_children/3` is private, so the suite reaches it via the
+  `@doc false` test-only delegate `__invoke_dynamic_children_for_test__/3`.
   """
 
   use ExUnit.Case, async: true
 
   alias PhoenixKit.Dashboard.Tab
+  alias PhoenixKitWeb.Components.Dashboard.AdminSidebar
 
   describe "dynamic_children_fn type" do
     test "arity-1 function is a valid dynamic_children_fn" do
@@ -50,37 +47,60 @@ defmodule PhoenixKitWeb.Components.Dashboard.AdminSidebarDynamicChildrenTest do
     end
   end
 
-  # The arity-dispatch logic is a private helper in AdminSidebar; we invoke it
-  # via a reflection-style call so regressions are caught without depending on
-  # any LiveView rendering infrastructure in tests.
-  describe "invoke_dynamic_children/3 dispatch" do
-    setup do
-      # Walk the AdminSidebar module to grab the private helper via :erlang.apply
-      # on the compiled module. We can't call private funs directly, but we can
-      # verify via the public admin_sidebar render path that arity-2 functions
-      # receive the locale argument by using a recording function.
-      {:ok, arity_1_calls: :counters.new(1, []), arity_2_calls: :counters.new(1, [])}
+  describe "invoke_dynamic_children/3 dispatch (via __invoke_dynamic_children_for_test__/3)" do
+    test "arity-1 callback receives only the scope" do
+      parent = self()
+
+      fun = fn scope ->
+        send(parent, {:called_with, :arity_1, scope})
+        []
+      end
+
+      assert AdminSidebar.__invoke_dynamic_children_for_test__(fun, %{user: :alice}, "en-US") ==
+               []
+
+      assert_received {:called_with, :arity_1, %{user: :alice}}
     end
 
-    test "documents the expected dispatch contract", ctx do
-      # This test documents the behaviour contract rather than reaching into
-      # the private helper. Integration coverage for the actual dispatch sits
-      # in the sibling test that renders the sidebar component.
-      arity_1 = fn _scope ->
-        :counters.add(ctx.arity_1_calls, 1, 1)
+    test "arity-2 callback receives both scope and locale" do
+      parent = self()
+
+      fun = fn scope, locale ->
+        send(parent, {:called_with, :arity_2, scope, locale})
         []
       end
 
-      arity_2 = fn _scope, _locale ->
-        :counters.add(ctx.arity_2_calls, 1, 1)
+      assert AdminSidebar.__invoke_dynamic_children_for_test__(fun, %{user: :bob}, "ja-JP") == []
+      assert_received {:called_with, :arity_2, %{user: :bob}, "ja-JP"}
+    end
+
+    test "arity-2 callback handles a nil locale gracefully" do
+      parent = self()
+
+      fun = fn _scope, locale ->
+        send(parent, {:locale_received, locale})
         []
       end
 
-      arity_1.(%{})
-      arity_2.(%{}, "en-US")
+      AdminSidebar.__invoke_dynamic_children_for_test__(fun, %{}, nil)
+      assert_received {:locale_received, nil}
+    end
 
-      assert :counters.get(ctx.arity_1_calls, 1) == 1
-      assert :counters.get(ctx.arity_2_calls, 1) == 1
+    test "callback's return value is propagated" do
+      tab =
+        Tab.new!(
+          id: :child_one,
+          label: "Child",
+          path: "child",
+          priority: 1,
+          level: :admin
+        )
+
+      arity_1 = fn _scope -> [tab] end
+      arity_2 = fn _scope, _locale -> [tab] end
+
+      assert AdminSidebar.__invoke_dynamic_children_for_test__(arity_1, %{}, "en") == [tab]
+      assert AdminSidebar.__invoke_dynamic_children_for_test__(arity_2, %{}, "en") == [tab]
     end
   end
 end


### PR DESCRIPTION
## Summary

Four commits on top of \`upstream/dev\` (\`d3b06b13\`):

- **V108 migration** — `position integer DEFAULT 0` on three list
  surfaces (`phoenix_kit_entities`, `phoenix_kit_cat_catalogues`,
  `phoenix_kit_cat_items`) so admin lists can persist user-driven
  order. Pure schema add; no backfill, no indexes (lists are small).
- **Drag-and-drop core infrastructure** — `<.draggable_list>` gained
  a `:draggable` boolean attr (default `true`) so callers can
  disable DnD without duplicating card markup. `<.table_default>`
  gained four sortable attrs (`:on_reorder`, `:reorder_scope`,
  `:reorder_group`, `:item_id`) that wire the card-view container as
  a `SortableGrid` hook target. `phoenix_kit.js` gained
  cross-container drop detection + scope passing (via
  `data-sortable-scope-*` attrs and `data-sortable-group`) plus an
  `updated()` callback on `TableCardView` so the user's chosen
  view-mode survives LV re-renders. Consumers in this batch:
  `phoenix_kit_entities` (records DnD) and the in-flight
  `phoenix_kit_catalogue` work (catalogues / categories / items DnD,
  including cross-category item moves).
- **AGENTS.md TODOs section** — surfaces the component-test
  coverage gap C12 triage flagged: there are no tests under
  `test/phoenix_kit_web/components/core/`. Inventoried for a future
  coverage sweep (`<.draggable_list>`, `<.table_default>`, the form
  primitives, possibly `<.flash>` / `<.modal>`).
- **PR #506 review follow-up** — closes the two NITPICKs from
  Claude's review of the merged arity-2 `dynamic_children` work.

### PR follow-up(s)

- **PR #506** — \`3d4bf2f1\` "PR #506 review follow-up — close the
  two NITPICKs". The merged arity-2 `dynamic_children` work
  shipped with a half-tautological dispatch test (anonymous fn
  invoked via `.()`, asserting Elixir's call semantics rather than
  the sidebar's actual dispatcher) and an inline `#` comment on
  `dynamic_children_fn` that ExDoc didn't pick up.

  Fix: added a \`@doc false\` test-only delegate
  \`AdminSidebar.__invoke_dynamic_children_for_test__/3\` that
  calls the private \`invoke_dynamic_children/3\`. Rewrote the
  describe block with four assertion-pinned tests covering arity-1,
  arity-2, nil locale, and return-value propagation. Replaced the
  inline comment on \`dynamic_children_fn\` with a proper
  \`@typedoc\`. FOLLOW_UP.md filed under
  \`dev_docs/pull_requests/2026/506-dynamic-children-locale/\`.

### Quality sweep

The big work, structured by commit.

#### V108 migration (\`38b696cd\`)

\`lib/phoenix_kit/migrations/postgres/v108.ex\` adds nullable
\`position integer\` (default 0) to three tables — the
entity-definitions list, the catalogues index, and the catalogue
items list. Idempotent (\`ADD COLUMN IF NOT EXISTS\` matches the
project pattern from V107 and earlier). \`down/1\` drops the
columns and reverts the \`COMMENT ON TABLE phoenix_kit IS\` marker
from \`'108'\` back to \`'107'\`.

No indexes on the new \`position\` columns. The lists are small
(≤ a few hundred rows in practice) and have other indexed scope
filters; a position-only btree would burn write amplification for
no real read win. \`phoenix_kit_entity_data\` already got both
\`position\` and the \`(entity_uuid, position)\` composite index
in V81, so it's untouched here.

\`@current_version\` bumped from 107 → 108 in
\`lib/phoenix_kit/migrations/postgres.ex\`.

#### DnD core infra (\`b27e647e\`)

Three additive changes to the core DnD primitives so consumer
modules wire reorder UIs without forking the hook or the components.

**\`SortableGrid\` hook** (\`priv/static/assets/phoenix_kit.js\`):

- Reads \`data-sortable-group\` and passes it to SortableJS as the
  \`group\` config. Tables sharing a group name can exchange items
  via cross-container drag (catalogue's \"items move between
  categories\" use case). When unset, single-container reorder
  only — behavior unchanged.
- On \`onEnd\`, detects cross-container drops via
  \`evt.from !== evt.to\`. Cross-container payloads carry
  \`moved_id\` plus the source container's scope attrs prefixed
  with \`from*\`, alongside the destination's regular scope attrs.
  Push routes through the destination's \`data-sortable-event\` so
  the LV handler is co-located with the table the item ended up
  in.
- A \`readScope/1\` helper translates \`data-sortable-scope-*\`
  attrs (camelCase via DOMStringMap) into a \`{key: value}\` map.
  The prefix-length check ensures a bare \`data-sortable-scope\`
  attr can't masquerade as scope data.
- The \`onEnd\` body is wrapped in try/catch (a single bad dataset
  value, e.g. corrupt scope or missing source container after a
  fast unmount, logs to \`console.error\` instead of leaving
  SortableJS half-initialized).
- Leading docstring spells out the \"trust your own DOM\"
  assumption — if a third-party script injects sortable-item
  nodes, the LV handler should reject unknown IDs server-side.

**\`TableCardView\` hook** (\`priv/static/assets/phoenix_kit.js\`):

Added \`updated()\` callback that re-applies the user's saved view
mode after every LV-driven render. Without it, morphdom resets the
runtime \`md:hidden\` class toggles back to template defaults on
each diff (e.g. a SortableJS drop fires a reorder event, the LV
re-renders, and the card view snaps back to the table view). The
hook now caches \`currentMode\` on mount + every toggle/event and
replays it in \`updated()\`.

**\`<.draggable_list>\`** (\`components/core/draggable_list.ex\`):

New \`:draggable\` boolean attr (default \`true\`). When false,
the container renders without \`phx-hook=\"SortableGrid\"\` and
items skip the \`cursor-grab\` styling — useful when a list is too
short to reorder (length ≤ 1) so the affordance doesn't lie.
Default \`true\` keeps every existing caller unchanged.

**\`<.table_default>\`** (\`components/core/table_default.ex\`):

Four new attrs — \`:on_reorder\`, \`:reorder_scope\`,
\`:reorder_group\`, \`:item_id\` — wire the card-view container
as a \`SortableGrid\` hook target when set. Each rendered card
gets \`class=\"sortable-item cursor-grab active:cursor-grabbing\"\`
+ \`data-id={item_id_fn.(item)}\` so a user toggled into card view
(mobile or desktop click) gets the same DnD experience as the
table view. \`:item_id\` defaults to \`& Map.get(&1, :uuid)\` so
the conventional schema shape works zero-config.

A footer row joins the card-actions slot when sortable: drag-handle
icon (\`hero-bars-3\` with cursor-grab styling,
\`gettext(\"Drag to reorder\")\` tooltip) bottom-left, action
buttons bottom-right. \`use Gettext, backend: PhoenixKitWeb.Gettext\`
added to match the convention in \`flash.ex\` / \`input.ex\` /
\`integration_picker.ex\`.

A private \`build_sortable_scope_attrs/1\` helper translates a
\`%{key => value}\` scope map into
\`[{\"data-sortable-scope-key\" => value}, ...]\` tuples, spread
via \`{@reorder_scope_attrs}\` in HEEX (Phoenix's
\`attributes_escape/1\` applies, so untrusted-input callers
don't introduce an XSS path).

#### AGENTS.md TODOs section (\`af35b067\`)

C12 triage on the V108 + DnD work surfaced that there are no tests
under \`test/phoenix_kit_web/components/core/\` — the directory
doesn't exist. Several components there have grown to non-trivial
attr surfaces that warrant rendered-HTML coverage, but landing a
single fixture in an empty test dir alongside a feature PR muddles
the diff.

Recorded the gap as a TODOs section at the bottom of \`AGENTS.md\`
so a future component-coverage sweep has the inventory ready
(\`<.draggable_list>\` :draggable branches, \`<.table_default>\`
:on_reorder / :reorder_scope / :reorder_group / :item_id branches,
the form primitives, plus \`<.flash>\` / \`<.modal>\` if their
complexity has grown).

#### Triage outcome (C12 + C12.5 deep dive)

Three Explore agents ran against the diff. Most findings turned
out to be agent overreach:

- Agent #1 \"CRITICAL — SQL injection in V108 prefix\" — \*\*false
  alarm\*\*. The pattern is consistent with all 107 prior
  migrations; \`prefix\` is host-app-controlled at migration time,
  not user input.
- Agent #1 \"BUG-MEDIUM — data-id leakage when draggable=false\" —
  \*\*false alarm\*\*. HEEX omits \`nil\` attrs.
- Agent #1 \"IMPROVEMENT-HIGH — XSS via reorder_scope\" — \*\*false
  alarm\*\*. Phoenix HEEX \`{@list_of_tuples}\` spread routes
  through \`attributes_escape/1\` which escapes values.
- Agent #2 \"BUG-MEDIUM — Missing V108 test\" — \*\*false alarm\*\*.
  Per V107's docstring, schema-only changes are implicitly verified
  by \`test_helper.exs\` running all migrations on boot; only
  backfill logic gets a dedicated test, and V108 has none.
- Agent #2 \"BUG-MEDIUM — Missing component attr tests\" — \*\*out
  of scope\*\*; landing a single fixture in an empty test dir is
  awkward. Surfaced via the new AGENTS.md TODOs section.

Real findings, all closed in this batch:

- Agent #1 BUG-HIGH \"JS try/catch on onEnd\" — wrapped onEnd, errors
  now log to \`console.error\`.
- Agent #1 IMPROVEMENT-MEDIUM \"DOM trust assumption\" — added
  docstring at the hook.
- Agent #2 NITPICK \"gettext for 'Drag to reorder'\" — added
  \`use Gettext\` to \`<.table_default>\`, wrapped the title.

## Companion PR

The downstream consumer is the in-flight
[\`mdon/phoenix_kit_entities\`](https://github.com/BeamLabEU/phoenix_kit_entities/pull/11)
work which adds DnD to the entity definitions list and the
DataNavigator records list. Until this core PR merges + a release
cuts, the entities suite fails on \`column phoenix_kit_entities.
position does not exist\` because the local schema has the
\`:position\` field but the Hex-pinned core's migration chain stops
at V107.

## Verification

- \`mix format --check-formatted\` clean
- \`mix compile --warnings-as-errors\` clean
- \`mix credo --strict\` clean (whole tree, 7564 mods/funs, 0
  issues — 0 net change vs pre-PR; the one pre-existing format
  violation in \`integrations/providers.ex\` is intentionally
  left out of this diff)
- \`mix test test/phoenix_kit_web/components/admin_sidebar_dynamic_children_test.exs\`:
  6 tests, 0 failures (2 from the original \`dynamic_children_fn
  type\` describe block + 4 new dispatch tests via the
  \`__invoke_dynamic_children_for_test__/3\` delegate)
- V108 round-tripped locally via
  \`phoenix_kit_parent\`'s migration runner: up adds the three
  columns, down drops them, marker comment flips both directions.

## Test plan

- [x] \`mix format --check-formatted\` clean
- [x] \`mix compile --warnings-as-errors\` clean
- [x] \`mix credo --strict\` clean
- [x] \`mix test\` for the touched test file passes (6/6)
- [x] V108 up + down round-trip verified
- [x] PR #506 FOLLOW_UP.md filed and committed
- [x] Companion entities PR #11 verifies the new attrs end-to-end
      via a parent app running V108 locally