### PR TITLE
Add ensure_current/2 helper + V110 language column on doc templates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,7 @@ end
 
 - `test/support/test_repo.ex` — `PhoenixKit.Test.Repo` (Ecto repo for tests)
 - `test/support/data_case.ex` — `PhoenixKit.DataCase` (sandbox setup, `:integration` tag)
-- `test/support/postgres/migrations/` — Migration wrapper calling `PhoenixKit.Migrations.up()`
+- `test/test_helper.exs` — calls `PhoenixKit.Migration.ensure_current/2` to apply all versioned migrations on every boot. **Do not** swap in `Ecto.Migrator.run(repo, [{0, PhoenixKit.Migration}], :up, all: true)` — that pattern silently goes stale (see `PhoenixKit.Migration.ensure_current/2` moduledoc for the staleness trap)
 - `config/test.exs` — DB config, sandbox pool, repo wiring
 
 ### Code Search

--- a/lib/phoenix_kit/migration.ex
+++ b/lib/phoenix_kit/migration.ex
@@ -185,12 +185,111 @@ defmodule PhoenixKit.Migration do
     migrator().migrated_version(opts)
   end
 
+  @doc """
+  Idempotently brings `repo` up to the latest PhoenixKit migration version.
+
+  Designed for test helpers and re-runnable boot paths where the
+  database is long-lived but the calling process restarts on every
+  invocation.
+
+  ## Why this exists
+
+  The natural-looking pattern
+
+      Ecto.Migrator.run(repo, [{0, PhoenixKit.Migration}], :up, all: true)
+
+  is broken for re-runnable contexts: `Ecto.Migrator` records "version
+  0 applied" in `schema_migrations` after the first call and filters
+  `{0, PhoenixKit.Migration}` out of pending on every subsequent call.
+  `PhoenixKit.Migration.up/1` is never re-invoked, so newly-shipped
+  Vxxx migrations don't get applied even though PhoenixKit's own marker
+  (the comment on the `phoenix_kit` table) is itself idempotent.
+
+  `ensure_current/2` works around that by passing a fresh wall-clock
+  version (`:os.system_time(:microsecond)`) to `Ecto.Migrator.up/4` on
+  every call. Ecto sees a "new" migration each time and invokes the
+  inner runner; PhoenixKit's marker then short-circuits if there's
+  nothing new to apply. The `schema_migrations` table accumulates one
+  row per call — cosmetic noise acceptable for the test-DB use case.
+  Microsecond precision keeps the collision and clock-skew windows
+  small enough that an NTP correction would have to rewind the clock
+  by µs at exactly the wrong moment to hide a newly-shipped migration.
+
+  For one-shot production migrations, prefer the documented
+  `mix ecto.migrate` path with a hand-rolled migration that calls
+  `PhoenixKit.Migration.up/1` directly.
+
+  ## Options
+
+  Forwarded verbatim to `Ecto.Migrator.up/4` and through to
+  `PhoenixKit.Migration.up/1`. Common values:
+
+    * `:log` — Ecto-level migration log (`:info` default; `false` to
+      silence)
+    * `:prefix` — runs PhoenixKit's tables under a non-default schema
+
+  ## Example
+
+      # In test/test_helper.exs
+      PhoenixKit.Migration.ensure_current(MyApp.Test.Repo, log: false)
+  """
+  @spec ensure_current(Ecto.Repo.t(), keyword()) :: :ok
+  def ensure_current(repo, opts \\ []) do
+    # Microsecond precision (rather than millisecond) shrinks the
+    # collision and clock-skew windows by 1000x. Two concurrent calls
+    # within the same microsecond would still collide, but in practice
+    # `ensure_current/2` runs once per `mix test` invocation. Bigint-
+    # safe (Postgres `bigint` covers ~9 quintillion microseconds, ~292
+    # years).
+    Ecto.Migrator.up(
+      repo,
+      :os.system_time(:microsecond),
+      PhoenixKit.Migration.Runner,
+      opts
+    )
+
+    :ok
+  end
+
   defp migrator do
     case repo().__adapter__() do
       Ecto.Adapters.Postgres -> PhoenixKit.Migrations.Postgres
       Ecto.Adapters.SQLite3 -> PhoenixKit.Migrations.SQLite
       Ecto.Adapters.MyXQL -> PhoenixKit.Migrations.MyXQL
       _ -> Keyword.fetch!(repo().config(), :phoenix_kit_migrator)
+    end
+  end
+end
+
+defmodule PhoenixKit.Migration.Runner do
+  @moduledoc false
+  # Static `Ecto.Migration` wrapper consumed by
+  # `PhoenixKit.Migration.ensure_current/2`. Lives at module scope (not
+  # an anonymous one defined per call) so `Ecto.Migrator.up/4` can
+  # resolve `up/0` and `down/0` against a known module name.
+  #
+  # `prefix/0` is imported by `use Ecto.Migration` and reads the
+  # current migration's prefix from the runner's process state. When
+  # `ensure_current/2` is called with `prefix: "auth"`, Ecto.Migrator
+  # propagates that into the runner context; without forwarding it
+  # back into `PhoenixKit.Migration.up/1` here, the inner migrator
+  # would default to `"public"` and silently apply the migrations to
+  # the wrong schema.
+
+  use Ecto.Migration
+
+  def up, do: PhoenixKit.Migration.up(runner_opts())
+  def down, do: PhoenixKit.Migration.down(runner_opts())
+
+  # `prefix/0` returns nil when no `:prefix` opt was passed to
+  # `Ecto.Migrator.up/4`. Forwarding `prefix: nil` to PhoenixKit's
+  # migrator would override the `"public"` default in `with_defaults/2`
+  # and crash inside `String.replace/4`. Only thread `:prefix` when it's
+  # actually set.
+  defp runner_opts do
+    case prefix() do
+      nil -> []
+      p -> [prefix: p]
     end
   end
 end

--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -529,7 +529,17 @@ defmodule PhoenixKit.Migrations.Postgres do
   - Replaces unique index with partial index (slug-mode only, WHERE slug IS NOT NULL)
   - Adds unique index on `(group_uuid, post_date, post_time)` for timestamp-mode posts
 
-  ### V109 - Rename Customer Service module to Customer Support ⚡ LATEST
+  ### V110 - Add `language` to Document Creator templates ⚡ LATEST
+  - Adds nullable `language VARCHAR(10)` to `phoenix_kit_doc_templates` so
+    each template can be tagged with a single locale (full code, e.g.
+    `en-US`, `et-EE`). Parent apps read it back via the public listing
+    API to fill template variables in the matching language.
+  - Documents intentionally do not get a language column — they inherit
+    from `template_uuid → templates.language`.
+  - Existing rows survive without a backfill; the form pre-selects the
+    project's primary language when creating new templates.
+
+  ### V109 - Rename Customer Service module to Customer Support
   - Renames 7 settings keys from `customer_service_*` → `customer_support_*`
   - Renames `auto_granted_perm:customer_service` → `auto_granted_perm:customer_support`
   - Updates `phoenix_kit_role_permissions.module_key` from `customer_service` → `customer_support`
@@ -813,7 +823,7 @@ defmodule PhoenixKit.Migrations.Postgres do
   use Ecto.Migration
 
   @initial_version 1
-  @current_version 109
+  @current_version 110
   @default_prefix "public"
 
   @doc false

--- a/lib/phoenix_kit/migrations/postgres/v110.ex
+++ b/lib/phoenix_kit/migrations/postgres/v110.ex
@@ -1,0 +1,58 @@
+defmodule PhoenixKit.Migrations.Postgres.V110 do
+  @moduledoc """
+  V110: Add `language` column to `phoenix_kit_doc_templates`.
+
+  Each Document Creator template represents a single Google Doc, which is
+  inherently single-language (translations live in separate templates).
+  Storing the locale on the template lets parent apps fill template variables
+  in the matching language regardless of the admin's UI locale.
+
+  - `language` (VARCHAR(10), nullable) — full locale code (`"en-US"`,
+    `"et-EE"`, `"ja"`, etc.) sourced from `PhoenixKit.Modules.Languages`.
+    Nullable so existing rows survive without a backfill; the form
+    pre-selects the project's primary language for new templates and
+    callers can update the value at any time.
+
+  Documents intentionally do not get a language column — they inherit
+  language from `template_uuid → templates.language`.
+
+  All operations are idempotent.
+  """
+
+  use Ecto.Migration
+
+  def up(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+    schema = if prefix == "public", do: "public", else: prefix
+
+    execute("""
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT FROM information_schema.columns
+        WHERE table_schema = '#{schema}'
+          AND table_name = 'phoenix_kit_doc_templates'
+          AND column_name = 'language'
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_doc_templates
+          ADD COLUMN language VARCHAR(10);
+      END IF;
+    END $$;
+    """)
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '110'")
+  end
+
+  def down(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    execute("ALTER TABLE #{p}phoenix_kit_doc_templates DROP COLUMN IF EXISTS language")
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '109'")
+  end
+
+  defp prefix_str("public"), do: "public."
+  defp prefix_str(prefix), do: "#{prefix}."
+end

--- a/test/phoenix_kit/migration_test.exs
+++ b/test/phoenix_kit/migration_test.exs
@@ -1,0 +1,57 @@
+defmodule PhoenixKit.MigrationTest do
+  @moduledoc """
+  Tests for `PhoenixKit.Migration.ensure_current/2` and its private
+  `Runner` wrapper.
+
+  ## Why these tests are spec-shape, not runtime
+
+  `ensure_current/2` calls `Ecto.Migrator.up/4`, which spawns a
+  migration runner in a separate process and acquires its own DB
+  connection. That conflicts with the Ecto sandbox's per-test isolation
+  — the spawned process can't see the test's checked-out connection,
+  the migration times out trying to acquire one, and the test fails
+  with a `DBConnection.ConnectionError` that has nothing to do with the
+  helper's actual behaviour.
+
+  Other migration tests in this repo follow the same convention (see
+  `test/phoenix_kit/migrations/v107_test.exs` `@moduledoc`): the schema
+  change itself is "verified at boot" — if `ensure_current/2` doesn't
+  work, the test_helper's call to it on every boot would fail and the
+  whole test suite wouldn't start. Migration *logic* gets tested
+  separately via direct SQL.
+
+  Below, we pin module shape (Runner has `up/0` + `down/0`,
+  `ensure_current/2` is exported) and the freshness of the synthetic
+  version. Real-world idempotency is empirically demonstrated by
+  consuming modules' `test_helper.exs` calls succeeding on every boot.
+  """
+
+  use ExUnit.Case, async: true
+
+  # `function_exported?/3` flakes across async test suites because of
+  # module-load ordering. `Module.__info__(:functions)` membership is
+  # deterministic and identical in cost. See workspace memory
+  # `feedback_test_coverage_blind_spots.md`.
+  defp exports?(module, fun, arity) do
+    Code.ensure_loaded!(module)
+    {fun, arity} in module.__info__(:functions)
+  end
+
+  describe "PhoenixKit.Migration.Runner" do
+    test "exports up/0 and down/0 (Ecto.Migrator's up/4 + down/4 contract)" do
+      assert exports?(PhoenixKit.Migration.Runner, :up, 0)
+      assert exports?(PhoenixKit.Migration.Runner, :down, 0)
+    end
+
+    test "is a real `Ecto.Migration` module" do
+      # `use Ecto.Migration` adds the `__migration__/0` reflection.
+      assert exports?(PhoenixKit.Migration.Runner, :__migration__, 0)
+    end
+  end
+
+  describe "ensure_current/2" do
+    test "is exported with arity 2" do
+      assert exports?(PhoenixKit.Migration, :ensure_current, 2)
+    end
+  end
+end

--- a/test/support/postgres/migrations/20260316000000_add_phoenix_kit.exs
+++ b/test/support/postgres/migrations/20260316000000_add_phoenix_kit.exs
@@ -1,7 +1,0 @@
-defmodule PhoenixKit.Test.Repo.Migrations.AddPhoenixKit do
-  use Ecto.Migration
-
-  def up, do: PhoenixKit.Migrations.up()
-
-  def down, do: PhoenixKit.Migrations.down()
-end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -35,8 +35,13 @@ repo_available =
     try do
       {:ok, _} = PhoenixKit.Test.Repo.start_link()
 
-      migrations_path = Path.join([__DIR__, "support", "postgres", "migrations"])
-      Ecto.Migrator.run(PhoenixKit.Test.Repo, migrations_path, :up, all: true, log: false)
+      # Use `ensure_current/2` — it picks up newly-shipped Vxxx
+      # migrations on every boot. The previous fixed-version
+      # migration-file approach was vulnerable to the
+      # outer-Ecto-tracking staleness trap; see
+      # `PhoenixKit.Migration.ensure_current/2` moduledoc for the bug
+      # story.
+      PhoenixKit.Migration.ensure_current(PhoenixKit.Test.Repo, log: false)
 
       Ecto.Adapters.SQL.Sandbox.mode(PhoenixKit.Test.Repo, :manual)
       true


### PR DESCRIPTION
## Summary

Two changes bundled here:

1. **`PhoenixKit.Migration.ensure_current/2`** — re-runnable analog of
   `mix ecto.migrate` for test helpers and any boot path that runs against
   a long-lived DB. Fixes a latent staleness bug where the documented
   canonical pattern stops applying newly-shipped Vxxx migrations after
   the first boot.

2. **V110 — `language` column on `phoenix_kit_doc_templates`** — adds a
   nullable `VARCHAR(10)` column so Document Creator templates can be
   tagged with a single locale (full code, e.g. `en-US`, `et-EE`). Parent
   apps will read this back via the public listing API to fill template
   variables in the matching language regardless of the admin's UI
   locale. Resolves the design ask in
   `BeamLabEU/phoenix_kit_document_creator#13`.

---

## (1) ensure_current/2 — the bug

The pattern shipped in `dev_docs/migration_cleanup.md` and copied into
every consuming module's `test_helper.exs`:

```elixir
Ecto.Migrator.run(repo, [{0, PhoenixKit.Migration}], :up, all: true)
```

is idempotent at the **outer** layer — Ecto.Migrator records "version 0
applied" in `schema_migrations` after the first call and filters
`{0, PhoenixKit.Migration}` out of pending on every subsequent boot.
`PhoenixKit.Migration.up/1` is never re-invoked, so newly-shipped Vxxx
migrations never apply even though PhoenixKit's own marker (the comment
on the `phoenix_kit` table) is itself idempotent.

Symptom: `column ... does not exist` after `mix deps.update phoenix_kit`
pulls in new migrations but the test DB stays at the old marker. The
two layers of idempotency cancel each other out.

Verified empirically — core's own `phoenix_kit_test` was at marker 107
even though Hex 1.7.103 ships V108 + V109. The original wrapper at
`test/support/postgres/migrations/20260316000000_add_phoenix_kit.exs`
hadn't re-run since first DB creation.

### The fix

`ensure_current/2` passes a fresh wall-clock version
(`:os.system_time(:microsecond)`) to `Ecto.Migrator.up/4` on every
call. Ecto sees a "new" migration each time and invokes the inner
runner; PhoenixKit's marker short-circuits internally if there's
nothing new to apply. Microsecond precision keeps the collision /
clock-skew window vanishingly small.

```elixir
# In test/test_helper.exs
PhoenixKit.Migration.ensure_current(MyApp.Test.Repo, log: false)
```

Forwards `:prefix` from the Ecto.Migration runner context via the
internal `Runner` module's `runner_opts/0` so callers passing
`prefix: "auth"` aren't silently routed to `"public"`.

The `schema_migrations` table accumulates one row per call (with a
microsecond-precision timestamp as the version) — cosmetic noise
acceptable for the test-DB use case.

---

## (2) V110 — `language` on document templates

Document Creator templates are inherently single-language (one Google
Doc = one language; translations live in separate templates). Today
parent apps fall back to either a global hardcoded value or the admin's
session locale when filling template variables — both wrong, since an
Estonian-language template should always be filled with Estonian
values regardless of which UI locale the admin happens to use.

V110 adds:

```sql
ALTER TABLE phoenix_kit_doc_templates ADD COLUMN language VARCHAR(10);
```

- **Nullable**, so existing rows survive without a backfill. The form
  in `phoenix_kit_document_creator` will pre-select the project's
  primary language (sourced from `PhoenixKit.Modules.Languages`) when
  creating new templates and let users change it from the admin UI.
- **Full locale codes** (`en-US`, `et-EE`, `ja`) — matches what
  `Languages.get_enabled_languages/0` returns, lossless. Consumers
  that want bare base codes can derive them via
  `DialectMapper.dialect_to_base/1`.
- **Templates only.** Documents inherit language from
  `template_uuid → templates.language` — they don't get their own
  column.

Schema/API changes in `phoenix_kit_document_creator` will land
separately on that repo.

---

## What's NOT changed

- Production migrations via `mix ecto.migrate` /
  `mix phoenix_kit.update` continue to work the same way; V110 is just
  the next versioned migration in line.
- Existing consumer modules' `test_helper.exs` files are untouched.
  They can migrate to `ensure_current/2` at their own pace; the old
  pattern still works (just with the latent staleness bug). Workspace
  `dev_docs/migration_cleanup.md` documents the cutover.

## Test plan

- [x] `mix format --check-formatted` clean
- [x] `mix credo --strict` — 7313 mods, no issues
- [x] `mix dialyzer` — 0 errors
- [x] `mix test` — 1049 tests; 3 pre-existing V107 failures verified on stock `dev` (stale-DB drift unrelated to this PR)
- [x] Empirical: marker advanced from 107 → 109 on the first test run after the change, confirming new migrations actually apply
- [x] V110 applied via `mix phoenix_kit.update` against `phoenix_kit_parent_dev`; column exists, nullable, `VARCHAR(10)`, marker advanced to 110
- [x] Browser-verified end-to-end through `phoenix_kit_parent` admin pages (catalogue list, smart catalogue detail, item edit form, search, paged list with 311 items) — 0 console errors
- [x] Phase 2 quality review applied — 4 fixes (CRITICAL prefix-loss bug + HIGH clock-skew hardening + spec/test cleanup)

## Followup

`dev_docs/migration_cleanup.md` and `dev_docs/quality_sweep.md` updates
land alongside (in the workspace, not this repo). Consumer modules
adopting `ensure_current/2` come as separate PRs — first is
`phoenix_kit_catalogue` (companion to this PR, paired merge).