### PR TITLE
Fix admin permissions for external plugin LiveViews

### DIFF
--- a/lib/phoenix_kit/module_registry.ex
+++ b/lib/phoenix_kit/module_registry.ex
@@ -32,6 +32,8 @@ defmodule PhoenixKit.ModuleRegistry do
       ModuleRegistry.all_permission_metadata() # Collect permission metadata
       ModuleRegistry.feature_enabled_checks()  # Build {mod, :enabled?} map
       ModuleRegistry.get_by_key("tickets")   # Find module by key
+      ModuleRegistry.get_module_key_for_namespace("PhoenixKitTickets")
+                                             # Resolve top-level namespace → key
   """
 
   use GenServer
@@ -178,6 +180,25 @@ defmodule PhoenixKit.ModuleRegistry do
   def get_by_key(key) when is_binary(key) do
     Enum.find(all_modules(), fn mod ->
       safe_call(mod, :module_key, nil) == key
+    end)
+  end
+
+  @doc """
+  Find a registered module's key by matching a top-level Elixir namespace.
+
+  Used by the admin permission layer to resolve a plugin LiveView's namespace
+  (e.g. `"PhoenixKitEntities"` from `PhoenixKitEntities.Web.Entities`) to the
+  plugin's permission key (e.g. `"entities"`).
+
+  Returns the key string or `nil` when no registered module matches.
+  """
+  @spec get_module_key_for_namespace(String.t()) :: String.t() | nil
+  def get_module_key_for_namespace(top_namespace) when is_binary(top_namespace) do
+    Enum.find_value(all_modules(), fn mod ->
+      case Module.split(mod) do
+        [^top_namespace | _] -> safe_call(mod, :module_key, nil)
+        _ -> nil
+      end
     end)
   end
 

--- a/lib/phoenix_kit/module_registry.ex
+++ b/lib/phoenix_kit/module_registry.ex
@@ -195,8 +195,10 @@ defmodule PhoenixKit.ModuleRegistry do
   @spec get_module_key_for_namespace(String.t()) :: String.t() | nil
   def get_module_key_for_namespace(top_namespace) when is_binary(top_namespace) do
     Enum.find_value(all_modules(), fn mod ->
-      case Module.split(mod) do
-        [^top_namespace | _] -> safe_call(mod, :module_key, nil)
+      with [^top_namespace] <- Module.split(mod),
+           key when is_binary(key) <- safe_call(mod, :module_key, nil) do
+        key
+      else
         _ -> nil
       end
     end)

--- a/lib/phoenix_kit_web/users/auth.ex
+++ b/lib/phoenix_kit_web/users/auth.ex
@@ -40,6 +40,7 @@ defmodule PhoenixKitWeb.Users.Auth do
 
   alias Phoenix.LiveView
   alias PhoenixKit.Admin.Events
+  alias PhoenixKit.ModuleRegistry
   alias PhoenixKit.Modules.Languages
   alias PhoenixKit.Modules.Languages.DialectMapper
   alias PhoenixKit.Modules.Maintenance
@@ -1146,7 +1147,8 @@ defmodule PhoenixKitWeb.Users.Auth do
     PhoenixKitWeb.Live.Modules.Jobs.Index => "jobs"
   }
 
-  defp permission_key_for_admin_view(view_module) do
+  @doc false
+  def permission_key_for_admin_view(view_module) do
     case Map.get(@admin_view_permissions, view_module) do
       nil ->
         infer_permission_from_custom_tabs(view_module) ||
@@ -1164,14 +1166,16 @@ defmodule PhoenixKitWeb.Users.Auth do
     |> Map.get(view_module)
   end
 
-  # Infer permission key from PhoenixKit.Modules.<Name>.Web.* namespace
+  # Infer permission key from `PhoenixKit.Modules.<Name>.Web.*` (core) or from a
+  # registered external plugin's top-level namespace
+  # (`PhoenixKitEntities.*`, `PhoenixKitBilling.*`, …) via `ModuleRegistry`.
   defp infer_permission_key_from_module(view_module) do
     case Module.split(view_module) do
       ["PhoenixKit", "Modules", module_name | _rest] ->
         Macro.underscore(module_name)
 
-      _ ->
-        nil
+      [top | _rest] ->
+        ModuleRegistry.get_module_key_for_namespace(top)
     end
   end
 

--- a/test/phoenix_kit/module_registry_test.exs
+++ b/test/phoenix_kit/module_registry_test.exs
@@ -141,6 +141,14 @@ defmodule PhoenixKit.ModuleRegistryTest do
     test "returns nil for an unknown namespace" do
       assert ModuleRegistry.get_module_key_for_namespace("NotARegisteredModule") == nil
     end
+
+    test "does not match modules whose path only starts with the namespace" do
+      # Internal modules like PhoenixKit.Modules.<X> have Module.split starting
+      # with "PhoenixKit", but a query for "PhoenixKit" must NOT resolve to one
+      # of them — only exact top-level segments (PhoenixKitEntities,
+      # PhoenixKitBilling, …) qualify.
+      assert ModuleRegistry.get_module_key_for_namespace("PhoenixKit") == nil
+    end
   end
 
   describe "all_admin_tabs/0" do

--- a/test/phoenix_kit/module_registry_test.exs
+++ b/test/phoenix_kit/module_registry_test.exs
@@ -115,6 +115,34 @@ defmodule PhoenixKit.ModuleRegistryTest do
     end
   end
 
+  describe "get_module_key_for_namespace/1" do
+    # Module.create/3 with an explicit top-level name — `defmodule X` inside a
+    # test would get auto-nested under PhoenixKit.ModuleRegistryTest.
+    setup do
+      Module.create(
+        PhoenixKitNamespaceFixture,
+        quote do
+          def module_key, do: "namespace_fixture"
+        end,
+        Macro.Env.location(__ENV__)
+      )
+
+      :ok
+    end
+
+    test "resolves a registered module's top-level namespace to its key" do
+      ModuleRegistry.register(PhoenixKitNamespaceFixture)
+      on_exit(fn -> ModuleRegistry.unregister(PhoenixKitNamespaceFixture) end)
+
+      assert ModuleRegistry.get_module_key_for_namespace("PhoenixKitNamespaceFixture") ==
+               "namespace_fixture"
+    end
+
+    test "returns nil for an unknown namespace" do
+      assert ModuleRegistry.get_module_key_for_namespace("NotARegisteredModule") == nil
+    end
+  end
+
   describe "all_admin_tabs/0" do
     test "returns a list of Tab structs" do
       tabs = ModuleRegistry.all_admin_tabs()

--- a/test/phoenix_kit_web/users/auth_test.exs
+++ b/test/phoenix_kit_web/users/auth_test.exs
@@ -1,0 +1,59 @@
+defmodule PhoenixKitWeb.Users.AuthTest do
+  use ExUnit.Case, async: false
+
+  alias PhoenixKit.ModuleRegistry
+  alias PhoenixKitWeb.Users.Auth
+
+  # `permission_key_for_admin_view/1` is exposed as `@doc false def` so this
+  # test can exercise the static map, the custom-tabs lookup, the
+  # `PhoenixKit.Modules.*` namespace branch, and the registered-plugin
+  # branch added for external modules (PhoenixKitEntities, PhoenixKitBilling, …).
+
+  # Fixture module created with an explicit top-level name. `defmodule X` inside
+  # a test gets auto-nested under the test module's namespace, which would make
+  # `Module.split/1` return the wrong head segment — Module.create/3 dodges that.
+  setup_all do
+    Module.create(
+      PhoenixKitFakePluginFixture,
+      quote do
+        def module_key, do: "fake_plugin"
+      end,
+      Macro.Env.location(__ENV__)
+    )
+
+    :ok
+  end
+
+  describe "permission_key_for_admin_view/1" do
+    test "returns key from static @admin_view_permissions map" do
+      assert Auth.permission_key_for_admin_view(PhoenixKitWeb.Live.Dashboard) ==
+               "dashboard"
+
+      assert Auth.permission_key_for_admin_view(PhoenixKitWeb.Live.Users.Users) ==
+               "users"
+    end
+
+    test "infers key from PhoenixKit.Modules.<Name>.Web.* namespace" do
+      assert Auth.permission_key_for_admin_view(PhoenixKit.Modules.Tickets.Web.Index) ==
+               "tickets"
+
+      assert Auth.permission_key_for_admin_view(PhoenixKit.Modules.NewsLetters.Web.Show) ==
+               "news_letters"
+    end
+
+    test "resolves external plugin namespace via ModuleRegistry" do
+      ModuleRegistry.register(PhoenixKitFakePluginFixture)
+      on_exit(fn -> ModuleRegistry.unregister(PhoenixKitFakePluginFixture) end)
+
+      assert Auth.permission_key_for_admin_view(PhoenixKitFakePluginFixture.Web.Index) ==
+               "fake_plugin"
+
+      assert Auth.permission_key_for_admin_view(PhoenixKitFakePluginFixture.Web.Edit.Form) ==
+               "fake_plugin"
+    end
+
+    test "returns nil for unknown views (preserves fail-closed default)" do
+      assert Auth.permission_key_for_admin_view(SomeRandomUnregisteredModule) == nil
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Custom roles granted plugin permission keys (e.g. `entities`, `billing`, `ai`) were denied access to those plugins' admin pages — even when the role explicitly had the permission and the module was enabled — because `PhoenixKitWeb.Users.Auth.infer_permission_key_from_module/1` only resolved the core `PhoenixKit.Modules.*` namespace.

For an external plugin LiveView like `PhoenixKitEntities.Web.Entities`, all three resolution fallbacks in `permission_key_for_admin_view/1` (static map, custom-tabs map, namespace inference) returned `nil`. The fail-closed branch in `enforce_admin_view_permission/2` then redirected every non-system role with "You do not have permission to access this section.", regardless of the role's actual permissions.

The fix adds a registry-backed fourth option: when the LiveView's top-level namespace doesn't match `PhoenixKit.Modules`, ask `PhoenixKit.ModuleRegistry` whether any registered module starts with that namespace, and return its declared `module_key/0`. Owner/Admin behaviour and the fail-closed default for genuinely unknown views are preserved.

## Changes

### `lib/phoenix_kit/module_registry.ex`
- Add `get_module_key_for_namespace/1` — symmetric with the existing `get_by_key/1`. Iterates `all_modules/0`, matches on `Module.split(mod)` head, returns the module's `module_key/0` via the existing `safe_call/3`. No new state, no caching layer.
- Reference it in the moduledoc Query API list.

### `lib/phoenix_kit_web/users/auth.ex`
- `infer_permission_key_from_module/1` gets a new `[top | _rest]` clause that calls `ModuleRegistry.get_module_key_for_namespace(top)`.
- The previous `_ -> nil` fallback is removed: `Module.split/1` always returns a non-empty list of binaries, so it was unreachable (Dialyzer flags this on strict).
- `permission_key_for_admin_view/1` is exposed as `@doc false def` (was `defp`) so unit tests can reach it without LiveView mounting machinery.
- `alias PhoenixKit.ModuleRegistry` added.

### Tests
- New `test/phoenix_kit_web/users/auth_test.exs` (4 cases): static-map hit, `PhoenixKit.Modules.*` namespace, registered-plugin namespace, unknown view → nil.
- New describe block in `test/phoenix_kit/module_registry_test.exs` for `get_module_key_for_namespace/1` (3 cases). Uses `Module.create/3` with explicit top-level fixture names to avoid `defmodule X` getting auto-nested under the test module's namespace.

### Tightening (second commit, post-internal-review)

Initial implementation used `[^top_namespace | _]` which matched any registered module whose `Module.split` path *starts with* the segment, not just modules whose top-level *is* the segment. Live repro on a parent app: `get_module_key_for_namespace("PhoenixKit") => "db"` because `PhoenixKit.Modules.DB` happens to be the first registered module beginning with `"PhoenixKit"`.

Today this is masked by `infer_permission_from_custom_tabs/1` for every existing `PhoenixKit.<X>.Web.*` admin view, so no user-visible regression exists. But it's a footgun for any future `PhoenixKit.*` view that doesn't register a tab.

Fix: tightened to `[^top_namespace]` (exact, single segment) and narrowed `safe_call`'s return via `is_binary/1` so `@spec` is truthful even if a misbehaving plugin returns a non-string `module_key/0`. Added regression test pinning `get_module_key_for_namespace("PhoenixKit") == nil`.

## Affected scope

Every plugin shipping its own admin UI under a top-level `PhoenixKit<Name>` namespace was unreachable for custom roles. Verified plugins in our deps tree: `PhoenixKitEntities`, `PhoenixKitCRM`, `PhoenixKitStaff`, `PhoenixKitProjects`, `PhoenixKitBilling`, `PhoenixKitCatalogue`, `PhoenixKitDocumentCreator`, `PhoenixKitLocations`, `PhoenixKitEcommerce`. After the fix, any registered module is auto-resolved by namespace.

## Test Plan

- [x] `mix format`
- [x] `mix credo --strict` — 0 issues on the changed files
- [x] `mix dialyzer` — 0 new warnings
- [x] `mix test test/phoenix_kit_web/users/auth_test.exs test/phoenix_kit/module_registry_test.exs` — 45 tests, 0 failures (DB optional; integration tests excluded automatically)
- [x] Pre-commit hook passed end-to-end (compile + docs + format + credo + dialyzer)
- [x] Live verification on a parent app via Tidewave: external plugin views now resolve to their module key (`PhoenixKitEntities.Web.Entities → "entities"`, `PhoenixKitAI.Web.Index → "ai"`, etc.); static map (`Dashboard → "dashboard"`, `Users → "users"`) and `PhoenixKit.Modules.*` namespace (`Languages → "languages"`) preserved; genuinely unknown views still return `nil` (fail-closed)
