### PR TITLE
Add gettext support for Dashboard sidebar labels

### DIFF
--- a/dev_docs/instructions/2026-05-08-per-module-i18n-procedure.md
+++ b/dev_docs/instructions/2026-05-08-per-module-i18n-procedure.md
@@ -340,6 +340,34 @@ curl -sS -H "Authorization: Bearer $TOKEN" -H "Accept: application/vnd.github+js
 
 The user keeps unpushed commits on local `main` for development. Pushing `main` to origin would expose them. Always work via a feature branch cherry-picked from `origin/main`.
 
+### Gotcha 10: `System.cmd("psql", …)` crashes with `:enoent` when psql isn't installed
+
+**Symptom:** `mix test` aborts before running any test with `(ErlangError) Erlang error: :enoent` raised from `:erlang.open_port/2`.
+
+**Diagnosis:** the package's `test/test_helper.exs` runs a DB-existence probe via `System.cmd("psql", ["-lqt"], …)` to decide whether to include `:integration` tests. `System.cmd/3` does not catch `:enoent` from a missing executable — it raises an ErlangError. Containers without the `postgresql-client` package on PATH (most CI images, by default) hit this immediately.
+
+**Fix:** wrap the `System.cmd` call in `try/rescue`, returning `:try_connect` (or whatever the file's "fall back to TCP probe" branch is) on any error:
+
+```elixir
+db_check =
+  try do
+    case System.cmd("psql", ["-lqt"], stderr_to_stdout: true) do
+      {output, 0} ->
+        # … existing parse-output logic …
+        if exists, do: :exists, else: :not_found
+
+      _ ->
+        :try_connect
+    end
+  rescue
+    _ -> :try_connect
+  end
+```
+
+**When to apply:** every package that has `System.cmd("psql", …)` (or any other system binary call) without an existing rescue clause in `test_helper.exs`. Found and fixed on `phoenix_kit_customer_support` (PR [#3](https://github.com/BeamLabEU/phoenix_kit_customer_support/pull/3)). Newsletters did not have this — its `test_helper.exs` was a bare `ExUnit.start()` before the i18n migration.
+
+If your module's `test_helper.exs` already has a different DB-probe shape, audit it for the same class of bug — any `System.cmd`-style call without `try/rescue` is a CI crash waiting to happen on a slim container.
+
 ---
 
 ## PR body skeleton

--- a/dev_docs/instructions/2026-05-08-per-module-i18n-procedure.md
+++ b/dev_docs/instructions/2026-05-08-per-module-i18n-procedure.md
@@ -368,6 +368,59 @@ db_check =
 
 If your module's `test_helper.exs` already has a different DB-probe shape, audit it for the same class of bug — any `System.cmd`-style call without `try/rescue` is a CI crash waiting to happen on a slim container.
 
+### Gotcha 11: Module reads `mix.exs` from the working tree, but the commit shape is what matters
+
+When verifying that `mix.exs` is clean (no `path:` override) before pushing, a reviewer or follow-up agent might `Read` the working tree file and see `path: "/tmp/pk-pr/i18n", override: true` — and panic that the path leaked into the commit. It didn't. The committed snapshot is clean; the working tree retains the local dev override (uncommitted).
+
+**Verification rule:** always check the committed form via `git show <sha>:mix.exs`, not by reading the file from the working tree. The two diverge by design under the established workflow.
+
+### Gotcha 12: Skip-worktree may already be lifted (`H` not `S`)
+
+The playbook's step 1 (lift `skip-worktree` on `mix.exs`) is a precaution. Several packages had already-`H` (normal) status — the lift was a no-op. If `git ls-files -t mix.exs` returns `H` rather than `S`, skip step 1 and proceed to step 2.
+
+### Gotcha 13: Dynamic-label tabs do NOT receive `gettext_backend:`
+
+If a module builds `%Tab{label: …}` with a **runtime** value rather than a static string (e.g. `label: role.name` for a per-role admin tab, or `label: project.title` for a per-project tab), do **not** add `gettext_backend:`. There is no static msgid for gettext to look up — the runtime string would be passed to `Gettext.dgettext/3` which would fail to find it in the catalogue and return the raw string anyway, just with an unnecessary call per render.
+
+The "every `%Tab{}`" rule in the public guide implicitly applies to **static-label** tabs (admin nav, settings nav, fixed sidebar items). Dynamic-label tabs (built from DB rows, user input, etc.) keep their raw `label: <value>` and stay untouched.
+
+Found on `phoenix_kit_crm`'s `sidebar_bootstrap.ex` (`role_tab/1` builds tabs from CRM role names).
+
+### Gotcha 14: `use PhoenixKitWeb, :live_view` files are off-limits for the migration
+
+If a module's LiveView file begins with `use PhoenixKitWeb, :live_view` (or `:controller`), that file is **deliberately part of the host app's web layer dependency chain**. The host's web module injects Gettext, router helpers, and other compile-time macros at the host-app level. The package can't override that with its own backend without breaking host apps.
+
+**Rule:** if a file does NOT have a direct `use Gettext, backend: ...` declaration of its own, but uses `PhoenixKitWeb.Gettext` only via `use PhoenixKitWeb, :live_view`, leave it alone. Migrating it would break runtime translations.
+
+Found on `phoenix_kit_crm/web/settings_live.ex`. Confirmed correct by reviewer.
+
+### Gotcha 15: Body-string `PhoenixKitWeb.Gettext` references in `lib/.../web/*` are out of scope
+
+Several modules (notably `phoenix_kit_billing` with 23 files, `phoenix_kit_ecommerce` with `shop_web.ex`, `phoenix_kit_legal` with calls in `legal.ex`) have **pre-existing** `use Gettext, backend: PhoenixKitWeb.Gettext` declarations or `Gettext.gettext(PhoenixKitWeb.Gettext, …)` calls in their LiveView/controller body code. These translate **page body strings** (form labels, button text, table headers) — not Tab labels.
+
+The per-module-i18n migration is **scoped to sidebar Tab labels only**. Body-string i18n is a separate, much larger sweep:
+
+- Replace every `use Gettext, backend: PhoenixKitWeb.Gettext` with `use Gettext, backend: PhoenixKit<X>.Gettext`
+- Run `mix gettext.extract` to discover all body-string msgids (often hundreds per module)
+- Produce translations in `ru` / `et` (or leave empty for graceful fallback)
+
+**Document body-string tech debt in the PR description** as out-of-scope, with the file count. Don't mix it into the tab-label PR — keep the diff focused. CRM was the exception: it had `gettext()` wrappers ON Tab labels themselves, so the wrapper-strip + backend-swap was bundled with the tab migration; for purely-body-string modules (billing, ecommerce, legal) the body-string sweep stays a separate PR.
+
+### Gotcha 16: Tab count vs. unique msgid count
+
+A module can have N `Tab.new!` sites but only M unique msgid values (M ≤ N), because the same label often appears across `admin_tabs/0`, `settings_tabs/0`, and `user_dashboard_tabs/0` (e.g. "Newsletters" parent in admin, "Newsletters" settings root, "Newsletters" user dashboard root — all the same msgid).
+
+Count msgids by reading the file's distinct `label:` values, not by counting `Tab.new!` sites. The `.pot` and `.po` files should have M entries, not N.
+
+Reported counts from the rollout:
+- `newsletters`: 9 sites → 9 msgids (no repeats)
+- `customer_support`: 4 sites → 3 msgids ("Customer Support" repeats)
+- `emails`: 10 sites → 8 msgids ("Emails" repeats)
+- `billing`: 13 sites → 11 msgids ("Billing" repeats)
+- `ecommerce`: 10 sites → 9 msgids ("E-Commerce" repeats)
+- `legal`: 1 site → 1 msgid
+- `crm`: 4 sites → 3 msgids ("CRM" repeats)
+
 ---
 
 ## PR body skeleton

--- a/dev_docs/instructions/2026-05-08-per-module-i18n-procedure.md
+++ b/dev_docs/instructions/2026-05-08-per-module-i18n-procedure.md
@@ -1,0 +1,361 @@
+# Per-Module i18n Migration — Operational Procedure
+
+**Audience:** an agent or developer applying the per-module Gettext pattern from [`guides/per-module-i18n.md`](../../guides/per-module-i18n.md) to one specific `phoenix_kit_<x>` package.
+
+**When to use:** the public guide tells you *what to build*. This document tells you *how to actually get there with this repo's git/build/test workflow* — including every grabbed-foot we hit on the Newsletters pilot ([`BeamLabEU/phoenix_kit_newsletters#12`](https://github.com/BeamLabEU/phoenix_kit_newsletters/pull/12)).
+
+Read the public guide first. Then come back here. Then start.
+
+---
+
+## Up-front context the agent must know
+
+| Fact | Why it matters |
+|---|---|
+| `phoenix_kit` core ships the new API in [PR #522](https://github.com/BeamLabEU/phoenix_kit/pull/522). Until that PR merges and a Hex release goes out, `Tab.localized_label/1` does not exist on any version of `phoenix_kit` you can pull from Hex. | Drives the **path-dep workflow** for local development and the **conditional CI skip** in `test_helper.exs`. |
+| The `phoenix_kit` PR-522 branch is checked out as a git worktree at `/tmp/pk-pr/i18n` on this machine. That checkout is the **only local source** of the new API. | Local `phoenix_kit_<x>` package's `mix.exs` `path:` override must point at `/tmp/pk-pr/i18n`, **not** `/app` (which is the user's working tree on a different branch). |
+| Each `phoenix_kit_<x>` package follows the **fork-based** PR workflow: `timujinne/<repo>` is the user's fork, `BeamLabEU/<repo>` is the upstream. Newsletters' upstream branch is `main` (not `dev`). | PR target = `BeamLabEU/<repo>:main`, head = `timujinne:feature/per-module-i18n`. |
+| The package's local `mix.exs` typically has the `path: "/app", override: true` line cached as **`skip-worktree`** (`git update-index --skip-worktree mix.exs`). | If you don't lift `skip-worktree` first, `git add mix.exs` silently does nothing AND `git diff` shows no diff even when content differs. See [Gotcha 1](#gotcha-1-skip-worktree-on-mixexs). |
+| Local `main` may be **N commits ahead of `origin/main`** with prior unpushed work that has nothing to do with you. | Don't push `main` directly. Branch from `origin/main` and cherry-pick your commit, so the PR contains only your work. |
+
+---
+
+## End-to-end procedure
+
+### 0. Pre-flight
+
+```bash
+# Confirm core PR-522 worktree exists and has the new API
+test -d /tmp/pk-pr/i18n && \
+  grep -q 'localized_label' /tmp/pk-pr/i18n/lib/phoenix_kit/dashboard/tab.ex && \
+  echo "OK"
+
+# Module repo
+cd /root/projects/phoenix_kit_<x>
+git fetch origin
+git fetch upstream     # if it exists; some forks only have origin
+git branch -vv          # note any local commits ahead of origin/main
+```
+
+### 1. Lift `skip-worktree` on `mix.exs`
+
+```bash
+cd /root/projects/phoenix_kit_<x>
+git ls-files -t mix.exs
+# If the leading char is 'S', it's skip-worktree. Lift it:
+git update-index --no-skip-worktree mix.exs
+```
+
+If you skip this step, every edit you make to `mix.exs` is **invisible to git** — `git add` returns *"paths matched … exist outside of your sparse-checkout definition"* (a misleading error — the issue is `skip-worktree`, not sparse), and `git diff` shows zero changes despite the file being different. Verify with `git hash-object mix.exs` ≠ `git ls-files -s mix.exs | cut -d' ' -f2` if you're unsure.
+
+### 2. Reset `mix.exs` to a clean baseline before editing
+
+The committed `mix.exs` shape and the user's local `mix.exs` shape can diverge significantly under `skip-worktree` (the user maintains a stripped-down local form for development convenience). Don't trust the working copy. Reset:
+
+```bash
+git checkout HEAD -- mix.exs
+```
+
+Then make **only** the three targeted edits:
+
+1. `extra_applications: [:logger]` → `extra_applications: [:logger, :gettext]`
+2. Add `{:gettext, "~> 1.0"}` to `deps`
+3. Add `priv` to `package files:` (was `~w(lib .formatter.exs mix.exs README.md CHANGELOG.md LICENSE)` → `~w(lib priv .formatter.exs mix.exs README.md CHANGELOG.md LICENSE)`)
+
+Do **not** touch `phoenix_kit` dep constraint. Most packages already have `~> 1.7` which admits any future release.
+
+### 3. Add the local `path:` override (uncommitted, just for dev)
+
+```bash
+sed -i 's|{:phoenix_kit, "~> 1.7"}|{:phoenix_kit, "~> 1.7", path: "/tmp/pk-pr/i18n", override: true}|' mix.exs
+```
+
+This is your local-only override. Per the package's CLAUDE-level conventions, the `path:` line is **never committed**. It only exists so `mix deps.compile phoenix_kit --force` pulls the new API from `/tmp/pk-pr/i18n` while you develop and run tests.
+
+### 4. Build the i18n wiring
+
+Follow the public guide:
+
+- `lib/phoenix_kit/<x>/gettext.ex` — `use Gettext.Backend, otp_app: :phoenix_kit_<x>`
+- `lib/phoenix_kit/<x>/<x>.ex` — every `Tab.new!`, `%Tab{}`, `Tab.divider/1`, `Tab.group_header/1` carries `gettext_backend: PhoenixKit.<X>.Gettext`. `gettext_domain:` is optional (defaults to `"default"`).
+- `priv/gettext/default.pot` — manually maintained list of every msgid that appears as a `label:` (or `tooltip:`) on a Tab/Group registration. **`mix gettext.extract` will NOT find these** because they're plain strings, not `dgettext` macro calls.
+- `priv/gettext/{en,ru,et}/LC_MESSAGES/default.po` — same set of msgids in each. `en/default.po` has `msgstr` equal to `msgid`; `ru` and `et` are filled with translations.
+
+### 5. Conditional CI skip + smoke test
+
+```elixir
+# test/test_helper.exs
+require Logger
+
+if Code.ensure_loaded?(PhoenixKit.Dashboard.Tab) and
+     function_exported?(PhoenixKit.Dashboard.Tab, :localized_label, 1) do
+  ExUnit.start()
+else
+  Logger.info(
+    "[test_helper] PhoenixKit.Dashboard.Tab.localized_label/1 not available — " <>
+      "i18n tests excluded. They will run automatically once `phoenix_kit` is " <>
+      "upgraded to a release that ships the gettext_backend API."
+  )
+
+  ExUnit.start(exclude: [:requires_phoenix_kit_i18n_api])
+end
+```
+
+Smoke test in `test/phoenix_kit/<x>/i18n_test.exs`:
+
+```elixir
+defmodule PhoenixKit.<X>.I18nTest do
+  use ExUnit.Case, async: false
+
+  @moduletag :requires_phoenix_kit_i18n_api
+
+  alias PhoenixKit.Dashboard.Tab
+  alias PhoenixKit.<X>.Gettext, as: <X>Gettext
+
+  setup do
+    original = Gettext.get_locale(<X>Gettext)
+    on_exit(fn -> Gettext.put_locale(<X>Gettext, original) end)
+    :ok
+  end
+
+  test "every admin tab carries the module's own gettext backend" do
+    for tab <- PhoenixKit.<X>.admin_tabs() do
+      assert tab.gettext_backend == <X>Gettext
+      assert tab.gettext_domain == "default"
+    end
+  end
+
+  test "ru locale resolves the parent tab to the expected translation" do
+    Gettext.put_locale(<X>Gettext, "ru")
+    [parent | _] = PhoenixKit.<X>.admin_tabs()
+    assert Tab.localized_label(parent) == "<TRANSLATED>"
+  end
+
+  test "unknown locale falls back to the raw msgid" do
+    Gettext.put_locale(<X>Gettext, "zz")
+    [parent | _] = PhoenixKit.<X>.admin_tabs()
+    assert Tab.localized_label(parent) == parent.label
+  end
+end
+```
+
+### 6. Local verification (with API)
+
+```bash
+mix deps.get
+mix deps.compile phoenix_kit --force
+mix test test/phoenix_kit/<x>/i18n_test.exs
+```
+
+Expect: all assertions pass. If `Tab.localized_label/1 is undefined` — `path:` line is wrong (typo, missed `override: true`, or worktree path doesn't have the new API). Re-check Step 0.
+
+If `mix.exs`-related `_build` artifacts give "not owner" errors during compile, blow them away: `rm -rf _build/dev/lib/phoenix_kit_<x>` and retry.
+
+### 7. Local verification (graceful degradation simulation)
+
+Skip this on the first attempt; do it before opening the PR to confirm CI will pass:
+
+```bash
+# Temporarily restore clean dep
+sed -i 's|, path: "/tmp/pk-pr/i18n", override: true||' mix.exs
+mix deps.compile phoenix_kit --force
+mix test test/phoenix_kit/<x>/i18n_test.exs
+# Expect: 4 tests, 0 failures, 4 excluded (helper detected missing API → skip kicked in)
+```
+
+Then re-add the path override for committing prep.
+
+### 8. Bump `@version` and write CHANGELOG
+
+For every owned `phoenix_kit_<x>` package, the team is the maintainer — so unlike `phoenix_kit` core, **you do bump version and write the CHANGELOG entry**:
+
+```elixir
+# mix.exs
+@version "0.1.<n+1>"
+```
+
+```markdown
+# CHANGELOG.md
+## 0.1.<n+1> - YYYY-MM-DD
+
+### Added
+- Per-module Gettext backend (`PhoenixKit.<X>.Gettext`) with `en`/`ru`/`et` catalogues for all admin sidebar tab labels. Requires `phoenix_kit` release that ships the `gettext_backend` Tab API ([BeamLabEU/phoenix_kit#522](https://github.com/BeamLabEU/phoenix_kit/pull/522)); on older releases tabs render raw English (graceful degradation).
+```
+
+### 9. Stage and commit on `main`
+
+Switch `mix.exs` to **clean form** (no `path:`) before committing. Then:
+
+```bash
+# Make sure the path override is gone from the file you're about to commit
+grep -n 'path:.*pk-pr' mix.exs && echo "STILL HAS PATH OVERRIDE — fix"
+
+git add \
+  mix.exs mix.lock \
+  lib/phoenix_kit/<x>/gettext.ex \
+  lib/phoenix_kit/<x>/<x>.ex \
+  priv/gettext/ \
+  test/test_helper.exs \
+  test/phoenix_kit/<x>/i18n_test.exs \
+  CHANGELOG.md
+
+git commit -m '...' # see Newsletters PR #12 for tone — descriptive, links PR #522
+```
+
+If pre-commit hooks fail on dialyzer or anything else, **investigate** before disabling. The Newsletters pilot pre-commit hooks were stable; if your module's pre-commit catches something, it's likely a real signal.
+
+### 10. Branch from `origin/main` and cherry-pick
+
+Local `main` may be ahead of `origin/main` with unrelated commits the user has stashed locally. Don't push them. Cherry-pick only your one commit onto a clean feature branch:
+
+```bash
+COMMIT=$(git rev-parse HEAD)
+
+git branch feature/per-module-i18n origin/main
+git checkout feature/per-module-i18n
+git cherry-pick $COMMIT
+```
+
+Expect a conflict on `mix.lock` because of how `gettext` resolves between the user's local main state and `origin/main`. Resolve by:
+
+```bash
+git checkout HEAD -- mix.lock      # take feature-branch base's mix.lock
+mix deps.get                        # let mix re-add gettext entry against the base
+git add mix.lock
+GIT_EDITOR=true git cherry-pick --continue
+```
+
+If `mix.lock` ends up identical to the base after `mix deps.get` (because the new dep was already a transitive of `phoenix_kit`), git will silently drop it from the commit — that's fine.
+
+### 11. Push the feature branch
+
+```bash
+git push -u origin feature/per-module-i18n
+```
+
+### 12. Open the PR via API
+
+```bash
+TOKEN=$(awk '/^github.com:/,0' ~/.config/gh/hosts.yml | awk '/^[[:space:]]*oauth_token:/{print $2; exit}')
+
+PAYLOAD=$(python3 -c "
+import json
+print(json.dumps({
+  'title': 'Add per-module Gettext backend for sidebar tab labels',
+  'head': 'timujinne:feature/per-module-i18n',
+  'base': 'main',
+  'body': open('/tmp/pr-body.md').read(),
+  'maintainer_can_modify': True,
+  'draft': False
+}))")
+
+curl -sS -X POST \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Accept: application/vnd.github+json" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  https://api.github.com/repos/BeamLabEU/phoenix_kit_<x>/pulls \
+  -d "$PAYLOAD"
+```
+
+Body skeleton lives at the bottom of this document.
+
+### 13. After PR creation
+
+- Restore the local `path:` override in `mix.exs` (uncommitted) so subsequent local development still picks up `/tmp/pk-pr/i18n`'s new API.
+- Reapply `git update-index --skip-worktree mix.exs` if the user wants `mix.exs` to stay invisible to git going forward.
+
+---
+
+## Gotchas (full list, with diagnosis)
+
+### Gotcha 1: `skip-worktree` on mix.exs
+
+**Symptom:** `git add mix.exs` errors with *"paths and/or pathspecs matched paths that exist outside of your sparse-checkout definition"*. `git diff` shows zero diff. `md5sum` of the file ≠ what's at HEAD.
+
+**Diagnosis:** `git ls-files -t mix.exs` shows `S mix.exs`. The file is marked skip-worktree.
+
+**Fix:** `git update-index --no-skip-worktree mix.exs`. Now stage normally.
+
+**Why it's there:** the user keeps a `path: "/app", override: true` line locally for dev that they don't want git to see. Once your committed mix.exs is clean (no path), the user can re-skip-worktree it after your PR.
+
+### Gotcha 2: Sparse-checkout error is misleading
+
+The `git add mix.exs` error message says "sparse-checkout". `git sparse-checkout list` returns "*this worktree is not sparse*". The actual cause is skip-worktree (gotcha 1). Don't go down the sparse-checkout rabbit hole.
+
+### Gotcha 3: `mix gettext.extract` doesn't see `Tab.new!(label: "…")`
+
+These are plain strings, not `dgettext` macro calls. The extractor silently produces an empty `.pot`. **Maintain `priv/gettext/default.pot` manually** — list every msgid by hand. Add a header comment in the file documenting that.
+
+### Gotcha 4: `priv` missing from `mix.exs` `package files:`
+
+If `package files:` is `~w(lib .formatter.exs mix.exs README.md CHANGELOG.md LICENSE)` (no `priv`), the `.po` files are silently omitted from the Hex tarball. Consumers who install from Hex get a backend with no catalogue → all locales return raw msgids.
+
+**Verification:** `mix hex.build && tar -tzf phoenix_kit_<x>-*.tar | grep priv/gettext` should list every `.pot`/`.po`. If it's empty, `priv` is missing.
+
+### Gotcha 5: `function_exported?` returns `false` for unloaded modules
+
+`if function_exported?(PhoenixKit.Dashboard.Tab, :localized_label, 1)` returns `false` if the `Tab` module hasn't been loaded yet — and at `test_helper.exs` start time it hasn't been. Symptom: i18n tests get excluded **even when the API is available**.
+
+**Fix:** wrap with `Code.ensure_loaded?/1` first:
+
+```elixir
+if Code.ensure_loaded?(PhoenixKit.Dashboard.Tab) and
+     function_exported?(PhoenixKit.Dashboard.Tab, :localized_label, 1) do
+```
+
+### Gotcha 6: `_build/` artifacts owned by `root`
+
+If past `mix compile` runs were done as root, you may hit *"could not touch … not owner"* on subsequent `mix` invocations as `node`. Fix:
+
+```bash
+rm -rf _build/dev/lib/phoenix_kit_<x>
+mix compile
+```
+
+The `+` ACL bit on the file usually means group-writable, so deletion via `rm -f` works for `node` even on root-owned files in this repo's layout.
+
+### Gotcha 7: Cherry-pick conflicts on `mix.lock`
+
+When you cherry-pick your commit from local `main` onto a fresh `feature/...` branch from `origin/main`, `mix.lock` will conflict if the user's local main has different deps than origin's. Resolve by taking the base's `mix.lock` and re-running `mix deps.get`:
+
+```bash
+git checkout HEAD -- mix.lock
+mix deps.get
+git add mix.lock
+GIT_EDITOR=true git cherry-pick --continue
+```
+
+`GIT_EDITOR=true` keeps the cherry-pick non-interactive (otherwise it tries to open `$EDITOR`).
+
+### Gotcha 8: `gh` CLI is not installed
+
+The container has no `gh` binary. Use `curl` against the GitHub REST API with the token from `~/.config/gh/hosts.yml`:
+
+```bash
+TOKEN=$(awk '/^github.com:/,0' ~/.config/gh/hosts.yml | awk '/^[[:space:]]*oauth_token:/{print $2; exit}')
+curl -sS -H "Authorization: Bearer $TOKEN" -H "Accept: application/vnd.github+json" ...
+```
+
+### Gotcha 9: Don't push local `main`
+
+The user keeps unpushed commits on local `main` for development. Pushing `main` to origin would expose them. Always work via a feature branch cherry-picked from `origin/main`.
+
+---
+
+## PR body skeleton
+
+Copy the [Newsletters PR #12 body](https://github.com/BeamLabEU/phoenix_kit_newsletters/pull/12) and substitute:
+
+- Module name (`Newsletters` → `<X>`)
+- Hex package name (`phoenix_kit_newsletters` → `phoenix_kit_<x>`)
+- Number of `Tab.new!` sites
+- The translation table (msgid / ru / et)
+- The version line in the rollout note
+
+Keep the **Behaviour matrix** table and the **Out of scope** section verbatim — they're load-bearing for reviewer expectations.
+
+---
+
+## When this document goes stale
+
+After PR #522 merges and `phoenix_kit` ships a Hex release with the API, the conditional CI skip becomes a defensive guard rather than a critical workaround. The `path:` override workflow goes away (replace with the actual Hex constraint). Update this document to reflect that — or delete it once all `phoenix_kit_<x>` packages have been migrated.

--- a/dev_docs/instructions/README.md
+++ b/dev_docs/instructions/README.md
@@ -13,3 +13,4 @@ Task-specific instructions written for AI agents or developers to execute a defi
 | File | What It Covers |
 |------|---------------|
 | `2026-02-16-uuid-parameter-rename-instructions.md` | Instructions for renaming UUID parameters to the `_uuid` suffix convention and adding hard errors on integer inputs — produced after PR #340 completed the schema migration |
+| `2026-05-08-per-module-i18n-procedure.md` | End-to-end operational procedure for applying the per-module Gettext pattern (companion to `guides/per-module-i18n.md`) — covers the path-dep workflow, every git/build gotcha hit on the Newsletters pilot, and the PR creation sequence. Use when migrating a new `phoenix_kit_<x>` package |

--- a/guides/README.md
+++ b/guides/README.md
@@ -72,6 +72,10 @@ Understanding the .phk publishing file format.
 
 Using the draggable list component for sortable UIs.
 
+#### [Per-Module i18n with Gettext](per-module-i18n.md)
+
+Translate sidebar tab labels, group labels, and tooltips inside your PhoenixKit module. Each module ships its own Gettext backend and `.po` files; tabs render localized labels at request time. Required for every module that exposes UI on `phoenix_kit ~> 1.8`.
+
 ---
 
 ## Guide Purpose

--- a/guides/per-module-i18n.md
+++ b/guides/per-module-i18n.md
@@ -2,7 +2,7 @@
 
 **Translate sidebar tab labels, group labels, and tooltips inside your PhoenixKit module.**
 
-This guide shows how each PhoenixKit module owns its own Gettext backend, ships its own `.po` files, and registers admin/settings/dashboard tabs with `gettext_backend:` so labels translate at render time according to the user's locale. Applies to **every** module that exposes UI — both new modules being authored from day 1 and existing modules being uplifted to `phoenix_kit ~> 1.8`.
+This guide shows how each PhoenixKit module owns its own Gettext backend, ships its own `.po` files, and registers admin/settings/dashboard tabs with `gettext_backend:` so labels translate at render time according to the user's locale. Applies to **every** module that exposes UI — both new modules being authored from day 1 and existing modules being uplifted to the PhoenixKit release that introduces the `gettext_backend` / `gettext_domain` API. Confirm the exact minimum version against the PhoenixKit CHANGELOG.
 
 ---
 
@@ -19,7 +19,9 @@ def application, do: [extra_applications: [:logger, :gettext]]
 
 defp deps do
   [
-    {:phoenix_kit, "~> 1.8"},
+    # Use the version that introduces the gettext_backend API
+    # — check PhoenixKit's CHANGELOG for the exact minimum.
+    {:phoenix_kit, "~> X.Y"},
     {:gettext, "~> 1.0"}
   ]
 end
@@ -51,9 +53,9 @@ end
 
 ---
 
-## What core gives you (PhoenixKit ≥ 1.8)
+## What core gives you
 
-`PhoenixKit.Dashboard.Tab` and `PhoenixKit.Dashboard.Group` accept two optional fields:
+Starting with the PhoenixKit release that introduces this API (see CHANGELOG for the exact version), `PhoenixKit.Dashboard.Tab` and `PhoenixKit.Dashboard.Group` accept two optional fields:
 
 | Field | Type | Default | Purpose |
 |-------|------|---------|---------|
@@ -86,7 +88,7 @@ This also matches the `dynamic_children/2` callback contract: arity-2 dynamic-ch
 
 | # | Step | Where |
 |---|------|-------|
-| 1 | Bump `{:phoenix_kit, "~> 1.8"}` | `mix.exs` |
+| 1 | Bump the `phoenix_kit` dep to the release that ships the `gettext_backend` API (see PhoenixKit CHANGELOG) | `mix.exs` |
 | 2 | Add `:gettext` to `extra_applications` (verify) | `mix.exs` |
 | 3 | Create the module's own Gettext backend | `lib/phoenix_kit_<x>/gettext.ex` |
 | 4 | Replace every `use Gettext, backend: PhoenixKitWeb.Gettext` with the module's own backend | `grep -rl "PhoenixKitWeb.Gettext" lib/` |
@@ -129,7 +131,9 @@ end
 
 defp deps do
   [
-    {:phoenix_kit, "~> 1.8"},
+    # Use the version that introduces the gettext_backend API
+    # — check PhoenixKit's CHANGELOG for the exact minimum.
+    {:phoenix_kit, "~> X.Y"},
     {:gettext, "~> 1.0"}
   ]
 end
@@ -352,9 +356,9 @@ end
 
 ## Retrofitting an existing module
 
-For each existing `phoenix_kit_<x>` module being uplifted to 1.8:
+For each existing `phoenix_kit_<x>` module being uplifted to the new API:
 
-- [ ] `mix.exs` — bump `{:phoenix_kit, "~> 1.8"}`
+- [ ] `mix.exs` — bump `phoenix_kit` dep to the release that ships the `gettext_backend` API (see PhoenixKit CHANGELOG)
 - [ ] `mix.exs` — confirm `:gettext` is in `extra_applications`
 - [ ] Create `lib/phoenix_kit_<x>/gettext.ex` with `use Gettext.Backend, otp_app: :phoenix_kit_<x>`
 - [ ] `grep -rl "PhoenixKitWeb.Gettext" lib/` returns **zero** results
@@ -426,7 +430,7 @@ end
 
 | Phase | Repo | What |
 |-------|------|------|
-| 1 ✅ | `phoenix_kit` (core) | Released `1.8.0` with `gettext_backend` / `gettext_domain` API |
+| 1 ✅ | `phoenix_kit` (core) | `gettext_backend` / `gettext_domain` API merged on `dev`. Maintainer ships the API in an upcoming release — see PhoenixKit CHANGELOG for the version. |
 | 2 ⏳ | each `phoenix_kit_<x>` package | Apply this guide. Pilot: `phoenix_kit_projects` |
 | 3 ⏳ | parent apps | Drop ETS-patching hacks; pass `gettext_backend:` to their own tabs |
 

--- a/guides/per-module-i18n.md
+++ b/guides/per-module-i18n.md
@@ -89,15 +89,16 @@ This also matches the `dynamic_children/2` callback contract: arity-2 dynamic-ch
 | # | Step | Where |
 |---|------|-------|
 | 1 | Bump the `phoenix_kit` dep to the release that ships the `gettext_backend` API (see PhoenixKit CHANGELOG) | `mix.exs` |
-| 2 | Add `:gettext` to `extra_applications` (verify) | `mix.exs` |
-| 3 | Create the module's own Gettext backend | `lib/phoenix_kit_<x>/gettext.ex` |
-| 4 | Replace every `use Gettext, backend: PhoenixKitWeb.Gettext` with the module's own backend | `grep -rl "PhoenixKitWeb.Gettext" lib/` |
-| 5 | Run `mix gettext.extract --merge` | shell |
-| 6 | For each target locale: `mix gettext.merge priv/gettext --locale <loc>` | shell |
-| 7 | Set `gettext_backend:` (and `gettext_domain:` if needed) on **every** `%Tab{}` and `%Group{}` registration | `admin_tabs/0`, route module |
-| 8 | Fill `priv/gettext/<locale>/LC_MESSAGES/default.po` with translations | manual |
-| 9 | Add a smoke test (see [Test pattern](#test-pattern)) | `test/` |
-| 10 | Bump module version, publish to Hex | `mix.exs`, `mix hex.publish` |
+| 2 | Add `:gettext` to `extra_applications` and to `deps` | `mix.exs` |
+| 3 | Add `priv` to `package: [files: ...]` so `.po` files ship to Hex | `mix.exs` |
+| 4 | Create the module's own Gettext backend | `lib/phoenix_kit_<x>/gettext.ex` |
+| 5 | Replace every `use Gettext, backend: PhoenixKitWeb.Gettext` with the module's own backend | `grep -rl "PhoenixKitWeb.Gettext" lib/` |
+| 6 | Set `gettext_backend:` (and `gettext_domain:` if needed) on **every** `%Tab{}` and `%Group{}` registration | `admin_tabs/0`, route module |
+| 7 | Maintain `priv/gettext/default.pot` and `priv/gettext/<locale>/LC_MESSAGES/default.po` manually (`mix gettext.extract` does **not** see `Tab.new!(label: "…")` plain strings) | `priv/gettext/` |
+| 8 | Fill translations for each target locale (`en` is 1:1) | `priv/gettext/<locale>/LC_MESSAGES/default.po` |
+| 9 | Add conditional skip in `test/test_helper.exs` so CI building against a pre-API `phoenix_kit` doesn't fail (see [§ Conditional CI skip](#conditional-ci-skip)) | `test/test_helper.exs` |
+| 10 | Add a smoke test (see [§ Test pattern](#test-pattern)) | `test/` |
+| 11 | Bump module `@version` and add a CHANGELOG entry | `mix.exs`, `CHANGELOG.md` |
 
 ---
 
@@ -358,17 +359,98 @@ end
 
 For each existing `phoenix_kit_<x>` module being uplifted to the new API:
 
-- [ ] `mix.exs` — bump `phoenix_kit` dep to the release that ships the `gettext_backend` API (see PhoenixKit CHANGELOG)
-- [ ] `mix.exs` — confirm `:gettext` is in `extra_applications`
+- [ ] `mix.exs` — confirm `phoenix_kit` dep constraint admits the release that ships `gettext_backend` (typically `~> 1.7` is wide enough; pin tighter if needed)
+- [ ] `mix.exs` — `:gettext` is in `extra_applications` AND `{:gettext, "~> 1.0"}` is in `deps`
+- [ ] `mix.exs` — `package: [files: ~w(lib priv …)]` includes `priv` (verify with `mix hex.build` + `tar -tzf | grep priv/gettext`)
 - [ ] Create `lib/phoenix_kit_<x>/gettext.ex` with `use Gettext.Backend, otp_app: :phoenix_kit_<x>`
 - [ ] `grep -rl "PhoenixKitWeb.Gettext" lib/` returns **zero** results
-- [ ] Run `mix gettext.extract --merge`
-- [ ] `priv/gettext/{en,ru,et,…}/LC_MESSAGES/default.po` exist and `en/default.po` has `msgstr` = `msgid` for every entry
+- [ ] Maintain `priv/gettext/default.pot` and `priv/gettext/{en,ru,et,…}/LC_MESSAGES/default.po` manually — `mix gettext.extract` does **not** see plain `Tab.new!(label: "…")` strings (no `dgettext` macro call). `en/default.po` has `msgstr` = `msgid` for every entry; `ru`/`et` are filled
 - [ ] Every `Tab.new!`, `%Tab{}`, `Tab.divider/1`, `Tab.group_header/1`, `%Group{}`, `Group.new/1` in your module sets `gettext_backend:`
 - [ ] `dynamic_children:` callbacks return tabs with `gettext_backend:` set (when labels are msgids, not user data)
-- [ ] One smoke test passes (see [Test pattern](#test-pattern))
-- [ ] `mix test` and `mix gettext.extract --merge --check-up-to-date` clean
-- [ ] CHANGELOG entry, version bump, `mix hex.publish`
+- [ ] `test/test_helper.exs` has the conditional `:requires_phoenix_kit_i18n_api` skip (see [§ Conditional CI skip](#conditional-ci-skip))
+- [ ] Smoke test in `test/phoenix_kit/<x>/i18n_test.exs` carries `@moduletag :requires_phoenix_kit_i18n_api` and passes locally with `phoenix_kit` resolved to a release that ships the API
+- [ ] `mix test` clean (locally with API; on CI without API, i18n tests excluded automatically — also clean)
+- [ ] CHANGELOG entry, `@version` bump, commit on a feature branch, push, open PR. `mix hex.publish` is the maintainer's call after the PR merges
+
+---
+
+## Hex package shape
+
+`mix.exs` `package files:` **must include `priv`**. The directory is otherwise excluded from the Hex tarball, so the new `.po` files would not ship and `Gettext.dgettext/3` would silently return raw msgids in production for every consumer that installed from Hex.
+
+```elixir
+defp package do
+  [
+    licenses: ["MIT"],
+    links: %{"GitHub" => @source_url},
+    files: ~w(lib priv .formatter.exs mix.exs README.md CHANGELOG.md LICENSE)
+    #         ^^^^ this
+  ]
+end
+```
+
+Verify locally with:
+
+```bash
+mix hex.build
+tar -tzf phoenix_kit_<x>-*.tar | grep priv/gettext
+# should list every .po and .pot file
+```
+
+---
+
+## Conditional CI skip
+
+The `gettext_backend` API was introduced by [PR #522](https://github.com/BeamLabEU/phoenix_kit/pull/522) on `phoenix_kit` core. Until the consumer's `phoenix_kit` dep resolves to a published release that includes it, `PhoenixKit.Dashboard.Tab.localized_label/1` does not exist and the i18n smoke test would raise `UndefinedFunctionError`. To keep CI green on consumers who haven't yet upgraded, gate the smoke test with a `:requires_phoenix_kit_i18n_api` tag and detect availability in `test_helper.exs`:
+
+```elixir
+# test/test_helper.exs
+require Logger
+
+if Code.ensure_loaded?(PhoenixKit.Dashboard.Tab) and
+     function_exported?(PhoenixKit.Dashboard.Tab, :localized_label, 1) do
+  ExUnit.start()
+else
+  Logger.info(
+    "[test_helper] PhoenixKit.Dashboard.Tab.localized_label/1 not available — " <>
+      "i18n tests excluded. They will run automatically once `phoenix_kit` is " <>
+      "upgraded to a release that ships the gettext_backend API."
+  )
+
+  ExUnit.start(exclude: [:requires_phoenix_kit_i18n_api])
+end
+```
+
+```elixir
+# test/phoenix_kit/<x>/i18n_test.exs
+defmodule PhoenixKit.<X>.I18nTest do
+  use ExUnit.Case, async: false
+
+  @moduletag :requires_phoenix_kit_i18n_api
+
+  # ...
+end
+```
+
+`Code.ensure_loaded?/1` is load-bearing — without it, `function_exported?/3` returns `false` if the `Tab` module hasn't been loaded yet at helper-init time, and the i18n tests get excluded even when the API is available.
+
+---
+
+## Version bump and CHANGELOG (owned packages)
+
+Unlike `phoenix_kit` core (which is maintained by BeamLab — version and CHANGELOG are set by the maintainer at release time), every `phoenix_kit_<x>` package is maintained directly by the team that owns the fork. So for these packages:
+
+- Bump `@version` in `mix.exs` (typically a patch level — `0.1.x → 0.1.(x+1)`).
+- Add a CHANGELOG entry under that version. Format:
+
+```markdown
+## 0.1.3 - 2026-05-08
+
+### Added
+- Per-module Gettext backend (`PhoenixKit.<X>.Gettext`) with `en`/`ru`/`et` catalogues for all admin sidebar tab labels. Requires `phoenix_kit` release that ships the `gettext_backend` Tab API (BeamLabEU/phoenix_kit#522); on older releases tabs render raw English (graceful degradation).
+```
+
+Both go in the same commit as the i18n wiring.
 
 ---
 
@@ -379,6 +461,11 @@ A single smoke test per module is sufficient — core's tests already cover the 
 ```elixir
 defmodule PhoenixKit<X>.I18nSmokeTest do
   use ExUnit.Case, async: false
+
+  # Excluded by `test/test_helper.exs` when running against a `phoenix_kit`
+  # release that pre-dates the `gettext_backend` API. Once the consumer
+  # upgrades, the helper detects it and these tests run automatically.
+  @moduletag :requires_phoenix_kit_i18n_api
 
   alias PhoenixKit.Dashboard.Tab
 
@@ -406,7 +493,7 @@ defmodule PhoenixKit<X>.I18nSmokeTest do
 end
 ```
 
-`async: false` is required because `Gettext.put_locale/2` mutates the calling process's process dictionary; `on_exit` restores it cleanly.
+`async: false` is required because `Gettext.put_locale/2` mutates the calling process's process dictionary; `on_exit` restores it cleanly. Pair this module with the conditional helper from [§ Conditional CI skip](#conditional-ci-skip).
 
 ---
 

--- a/guides/per-module-i18n.md
+++ b/guides/per-module-i18n.md
@@ -1,0 +1,441 @@
+# Per-Module i18n with Gettext
+
+**Translate sidebar tab labels, group labels, and tooltips inside your PhoenixKit module.**
+
+This guide shows how each PhoenixKit module owns its own Gettext backend, ships its own `.po` files, and registers admin/settings/dashboard tabs with `gettext_backend:` so labels translate at render time according to the user's locale. Applies to **every** module that exposes UI — both new modules being authored from day 1 and existing modules being uplifted to `phoenix_kit ~> 1.8`.
+
+---
+
+## Quick Start
+
+```elixir
+# 1. Create the module's Gettext backend
+defmodule PhoenixKitProjects.Gettext do
+  use Gettext.Backend, otp_app: :phoenix_kit_projects
+end
+
+# 2. In mix.exs
+def application, do: [extra_applications: [:logger, :gettext]]
+
+defp deps do
+  [
+    {:phoenix_kit, "~> 1.8"},
+    {:gettext, "~> 1.0"}
+  ]
+end
+
+# 3. Register tabs with gettext_backend
+@impl PhoenixKit.Module
+def admin_tabs do
+  [
+    Tab.new!(
+      id: :admin_projects,
+      label: "Projects",
+      icon: "hero-folder",
+      path: "projects",
+      priority: 400,
+      level: :admin,
+      permission: "projects",
+      group: :admin_modules,
+      gettext_backend: PhoenixKitProjects.Gettext
+    )
+  ]
+end
+
+# 4. Extract msgids and fill translations
+# $ mix gettext.extract --merge
+# Edit priv/gettext/ru/LC_MESSAGES/default.po
+#   msgid "Projects"
+#   msgstr "Проекты"
+```
+
+---
+
+## What core gives you (PhoenixKit ≥ 1.8)
+
+`PhoenixKit.Dashboard.Tab` and `PhoenixKit.Dashboard.Group` accept two optional fields:
+
+| Field | Type | Default | Purpose |
+|-------|------|---------|---------|
+| `gettext_backend` | `module()` or `nil` | `nil` | Module that owns the Gettext catalogue for this tab/group. `nil` keeps the raw label. |
+| `gettext_domain` | `String.t()` | `"default"` | Gettext domain to look the msgid up in. |
+
+Sidebar / `AdminSidebar` / `TabItem` components automatically route every label and tooltip render through:
+
+- `Tab.localized_label/1`
+- `Tab.localized_tooltip/1`
+- `Group.localized_label/1`
+
+Each helper:
+
+1. Returns `nil` if the underlying field (`label` / `tooltip`) is `nil` — divider tabs and unlabeled groups stay safe.
+2. Returns the raw string if `gettext_backend` is `nil` — backwards compatible.
+3. Otherwise calls `Gettext.dgettext(backend, domain, msgid)` against the **process locale** of the LiveView. Locale is set per request by the parent app's locale plug or on-mount hook. **Modules must not set the locale themselves.**
+
+---
+
+## Why each module owns its own backend
+
+When a module ships as a separate Hex package, it cannot rely on the parent application's `PhoenixKitWeb.Gettext` — that backend belongs to the core library, not to your package. Each module ships its own `.po` files in its own `priv/gettext/` and registers translations with `gettext_backend: PhoenixKit<X>.Gettext`. The parent app sets the user's locale once per request; every module's backend then independently looks up its own msgids in its own catalogue.
+
+This also matches the `dynamic_children/2` callback contract: arity-2 dynamic-children functions already receive the current locale, but using `gettext_backend:` on returned `%Tab{}` structs is more declarative and avoids manual `Gettext.put_locale/2` juggling.
+
+---
+
+## Setup checklist
+
+| # | Step | Where |
+|---|------|-------|
+| 1 | Bump `{:phoenix_kit, "~> 1.8"}` | `mix.exs` |
+| 2 | Add `:gettext` to `extra_applications` (verify) | `mix.exs` |
+| 3 | Create the module's own Gettext backend | `lib/phoenix_kit_<x>/gettext.ex` |
+| 4 | Replace every `use Gettext, backend: PhoenixKitWeb.Gettext` with the module's own backend | `grep -rl "PhoenixKitWeb.Gettext" lib/` |
+| 5 | Run `mix gettext.extract --merge` | shell |
+| 6 | For each target locale: `mix gettext.merge priv/gettext --locale <loc>` | shell |
+| 7 | Set `gettext_backend:` (and `gettext_domain:` if needed) on **every** `%Tab{}` and `%Group{}` registration | `admin_tabs/0`, route module |
+| 8 | Fill `priv/gettext/<locale>/LC_MESSAGES/default.po` with translations | manual |
+| 9 | Add a smoke test (see [Test pattern](#test-pattern)) | `test/` |
+| 10 | Bump module version, publish to Hex | `mix.exs`, `mix hex.publish` |
+
+---
+
+## Step-by-step setup
+
+### A. Create the Gettext backend
+
+```elixir
+# lib/phoenix_kit_<x>/gettext.ex
+defmodule PhoenixKit<X>.Gettext do
+  @moduledoc """
+  Gettext backend for phoenix_kit_<x>.
+
+  Locale is set per-request by the parent application; this module's only
+  responsibility is owning the catalogues under `priv/gettext/`.
+  """
+  use Gettext.Backend, otp_app: :phoenix_kit_<x>
+end
+```
+
+`use Gettext.Backend, otp_app: ...` is the **`Gettext 0.26+` form**. The older `use Gettext, otp_app: ...` style is deprecated; do not use it.
+
+### B. `mix.exs`
+
+```elixir
+def application do
+  [
+    extra_applications: [:logger, :gettext]   # :gettext is required at runtime
+  ]
+end
+
+defp deps do
+  [
+    {:phoenix_kit, "~> 1.8"},
+    {:gettext, "~> 1.0"}
+  ]
+end
+```
+
+### C. Switch existing `use Gettext` calls
+
+Find every file in your module that currently uses the parent app's backend:
+
+```bash
+grep -rl "PhoenixKitWeb.Gettext" lib/
+```
+
+Replace:
+
+```elixir
+# Before
+use Gettext, backend: PhoenixKitWeb.Gettext
+
+# After
+use Gettext, backend: PhoenixKit<X>.Gettext
+```
+
+This is mandatory before `hex.publish` — your published package must not reference the parent app's backend.
+
+### D. Wire your tabs and groups
+
+Every `%Tab{}` and `%Group{}` registered by your module's `admin_tabs/0`, `settings_tabs/0`, `user_dashboard_tabs/0`, or `dynamic_children/2` callback must carry the backend:
+
+```elixir
+@impl PhoenixKit.Module
+def admin_tabs do
+  [
+    Tab.new!(
+      id: :admin_projects,
+      label: "Projects",
+      icon: "hero-folder",
+      path: "projects",
+      priority: 400,
+      level: :admin,
+      permission: "projects",
+      group: :admin_modules,
+      gettext_backend: PhoenixKit<X>.Gettext,
+      gettext_domain: "default"     # optional — "default" is the default
+    ),
+    Tab.new!(
+      id: :admin_projects_new,
+      label: "New Project",
+      path: "projects/new",
+      priority: 410,
+      level: :admin,
+      permission: "projects",
+      parent: :admin_projects,
+      gettext_backend: PhoenixKit<X>.Gettext
+    )
+  ]
+end
+```
+
+Groups, when your module contributes them:
+
+```elixir
+%Group{
+  id: :projects_section,
+  label: "Project management",
+  priority: 400,
+  collapsible: true,
+  gettext_backend: PhoenixKit<X>.Gettext
+}
+```
+
+### E. `dynamic_children/2` — locale-aware children
+
+If your tab uses `dynamic_children:` to render child tabs at runtime (e.g. one tab per project), implement the **arity-2** form. Children only need the backend set on items whose labels are msgids; user-supplied data stays raw:
+
+```elixir
+%Tab{
+  id: :admin_projects,
+  label: "Projects",
+  # ... other fields ...
+  dynamic_children: fn _scope, _locale ->
+    PhoenixKit.RepoHelper.repo().all(Project)
+    |> Enum.map(fn project ->
+      %Tab{
+        id: :"admin_project_#{project.id}",
+        label: project.name,        # raw user-supplied — no translation needed
+        path: "projects/#{project.id}",
+        parent: :admin_projects,
+        level: :admin,
+        permission: "projects"
+        # gettext_backend NOT set — project names are user data, not msgids
+      }
+    end)
+  end
+}
+```
+
+> **Rule of thumb:** set `gettext_backend:` only when `label`/`tooltip` is a fixed English msgid that lives in your `.po` files. User-supplied content (project names, document titles, customer names) stays raw.
+
+### F. Dividers and group headers
+
+`Tab.divider/1` and `Tab.group_header/1` accept the same options:
+
+```elixir
+Tab.divider(
+  priority: 150,
+  label: "Account",
+  gettext_backend: PhoenixKit<X>.Gettext
+)
+
+Tab.group_header(
+  id: :reports_header,
+  label: "Reports",
+  priority: 500,
+  gettext_backend: PhoenixKit<X>.Gettext
+)
+```
+
+### G. Tooltips
+
+Tooltips translate via the same backend automatically — set `tooltip:` to the msgid alongside `gettext_backend:` and the sidebar's `title=` attribute will render the translated text:
+
+```elixir
+Tab.new!(
+  id: :admin_projects,
+  label: "Projects",
+  tooltip: "Manage all projects",   # msgid for tooltip translation
+  path: "projects",
+  gettext_backend: PhoenixKit<X>.Gettext
+)
+```
+
+### H. Extract msgids and fill translations
+
+```bash
+# Generate / update the .pot (template)
+mix gettext.extract
+
+# Merge new msgids into each locale's .po
+mix gettext.merge priv/gettext --locale en
+mix gettext.merge priv/gettext --locale ru
+mix gettext.merge priv/gettext --locale et
+```
+
+Edit `priv/gettext/<locale>/LC_MESSAGES/default.po`:
+
+```po
+#: lib/phoenix_kit_<x>/<x>.ex
+msgid "Projects"
+msgstr "Проекты"
+
+#: lib/phoenix_kit_<x>/<x>.ex
+msgid "New Project"
+msgstr "Новый проект"
+
+#: lib/phoenix_kit_<x>/<x>.ex
+msgid "Manage all projects"
+msgstr "Управление всеми проектами"
+```
+
+For `en`: `msgstr` should equal `msgid` (gettext's "no translation needed" convention; without it, gettext returns the empty string for `en` and your label disappears).
+
+---
+
+## Greenfield module example
+
+Full minimal module with i18n built in from day 1:
+
+```elixir
+# lib/phoenix_kit_<x>/<x>.ex
+defmodule PhoenixKit<X> do
+  use PhoenixKit.Module
+
+  alias PhoenixKit.Dashboard.{Tab, Group}
+
+  @impl PhoenixKit.Module
+  def module_key, do: "<x>"
+
+  @impl PhoenixKit.Module
+  def module_name, do: "<X> Module"
+
+  @impl PhoenixKit.Module
+  def permission_metadata do
+    %{
+      key: "<x>",
+      label: "<X>",
+      icon: "hero-folder",
+      description: "<short description>"
+    }
+  end
+
+  @impl PhoenixKit.Module
+  def admin_tabs do
+    [
+      Tab.new!(
+        id: :admin_<x>,
+        label: "<X>",
+        icon: "hero-folder",
+        path: "<x>",
+        priority: 400,
+        level: :admin,
+        permission: "<x>",
+        group: :admin_modules,
+        gettext_backend: PhoenixKit<X>.Gettext
+      )
+    ]
+  end
+end
+```
+
+```elixir
+# lib/phoenix_kit_<x>/gettext.ex
+defmodule PhoenixKit<X>.Gettext do
+  @moduledoc "Gettext backend for phoenix_kit_<x>."
+  use Gettext.Backend, otp_app: :phoenix_kit_<x>
+end
+```
+
+---
+
+## Retrofitting an existing module
+
+For each existing `phoenix_kit_<x>` module being uplifted to 1.8:
+
+- [ ] `mix.exs` — bump `{:phoenix_kit, "~> 1.8"}`
+- [ ] `mix.exs` — confirm `:gettext` is in `extra_applications`
+- [ ] Create `lib/phoenix_kit_<x>/gettext.ex` with `use Gettext.Backend, otp_app: :phoenix_kit_<x>`
+- [ ] `grep -rl "PhoenixKitWeb.Gettext" lib/` returns **zero** results
+- [ ] Run `mix gettext.extract --merge`
+- [ ] `priv/gettext/{en,ru,et,…}/LC_MESSAGES/default.po` exist and `en/default.po` has `msgstr` = `msgid` for every entry
+- [ ] Every `Tab.new!`, `%Tab{}`, `Tab.divider/1`, `Tab.group_header/1`, `%Group{}`, `Group.new/1` in your module sets `gettext_backend:`
+- [ ] `dynamic_children:` callbacks return tabs with `gettext_backend:` set (when labels are msgids, not user data)
+- [ ] One smoke test passes (see [Test pattern](#test-pattern))
+- [ ] `mix test` and `mix gettext.extract --merge --check-up-to-date` clean
+- [ ] CHANGELOG entry, version bump, `mix hex.publish`
+
+---
+
+## Test pattern
+
+A single smoke test per module is sufficient — core's tests already cover the localization machinery itself:
+
+```elixir
+defmodule PhoenixKit<X>.I18nSmokeTest do
+  use ExUnit.Case, async: false
+
+  alias PhoenixKit.Dashboard.Tab
+
+  setup do
+    original = Gettext.get_locale(PhoenixKit<X>.Gettext)
+    on_exit(fn -> Gettext.put_locale(PhoenixKit<X>.Gettext, original) end)
+    :ok
+  end
+
+  test "admin tab labels translate to ru" do
+    Gettext.put_locale(PhoenixKit<X>.Gettext, "ru")
+
+    [tab | _] = PhoenixKit<X>.admin_tabs()
+
+    # Replace with the actual translation you put in ru/default.po
+    assert Tab.localized_label(tab) == "Проекты"
+  end
+
+  test "admin tab labels fall back to msgid for an unknown locale" do
+    Gettext.put_locale(PhoenixKit<X>.Gettext, "xx")
+
+    [tab | _] = PhoenixKit<X>.admin_tabs()
+    assert Tab.localized_label(tab) == tab.label
+  end
+end
+```
+
+`async: false` is required because `Gettext.put_locale/2` mutates the calling process's process dictionary; `on_exit` restores it cleanly.
+
+---
+
+## Common pitfalls
+
+❌ **Do NOT** call `Gettext.put_locale/2` from inside your module — locale is a request-scoped concern owned by the parent app.
+
+❌ **Do NOT** translate before passing to PhoenixKit core APIs that persist data. For example, `Tab.label` is the source of the row label that `Permissions.register_custom_key/2` writes to the database. Translating it before registration would corrupt the canonical key store. Pass the raw msgid; rendering localizes.
+
+❌ **Do NOT** invent a custom domain unless you actually have multiple. `"default"` is the convention; switch to a domain-per-area only when one `default.po` becomes too noisy.
+
+❌ **Do NOT** keep `use Gettext, backend: PhoenixKitWeb.Gettext` in published code. That backend belongs to PhoenixKit core and won't be mounted in every consumer app the same way.
+
+❌ **Do NOT** set `gettext_backend:` on dynamically-generated user-data labels (project names, document titles). These are not msgids; gettext would return the raw string anyway, but the field still wastes a Gettext call per render.
+
+❌ **Do NOT** ship without `mix gettext.extract --merge` — stale `.pot` means newly added msgids never reach `.po` and translators have nothing to translate.
+
+---
+
+## Where this fits in the rollout
+
+| Phase | Repo | What |
+|-------|------|------|
+| 1 ✅ | `phoenix_kit` (core) | Released `1.8.0` with `gettext_backend` / `gettext_domain` API |
+| 2 ⏳ | each `phoenix_kit_<x>` package | Apply this guide. Pilot: `phoenix_kit_projects` |
+| 3 ⏳ | parent apps | Drop ETS-patching hacks; pass `gettext_backend:` to their own tabs |
+
+Phase 2 modules are independent of one another — they can be migrated in parallel by different developers, one PR per repo. Phase 3 happens at any point after phase 1 ships, regardless of phase 2 progress.
+
+---
+
+## Reference
+
+- [`PhoenixKit.Dashboard.Tab`](https://hexdocs.pm/phoenix_kit/PhoenixKit.Dashboard.Tab.html) — `localized_label/1`, `localized_tooltip/1`, `divider/1`, `group_header/1`
+- [`PhoenixKit.Dashboard.Group`](https://hexdocs.pm/phoenix_kit/PhoenixKit.Dashboard.Group.html) — `localized_label/1`
+- [Gettext docs](https://hexdocs.pm/gettext/) — `dgettext`, `Gettext.Backend`, `mix gettext.extract`, `mix gettext.merge`

--- a/lib/phoenix_kit/dashboard/README.md
+++ b/lib/phoenix_kit/dashboard/README.md
@@ -1300,3 +1300,58 @@ separator: false    # Disable separator entirely
 - **Multiple contexts**: Dropdown appears based on position setting
 - **Context switch**: POST to `/phoenix_kit/context/:uuid`, session updated, page redirects back
 - **Persistence**: Selection stored in session, survives navigation
+
+## Localizing Tab and Group Labels
+
+PhoenixKit 1.8+ supports optional gettext-driven translation of tab and group labels via two new fields: `gettext_backend` and `gettext_domain`.
+
+### Fields
+
+| Field | Default | Description |
+|---|---|---|
+| `gettext_backend` | `nil` | A Gettext backend module (e.g. `MyApp.Gettext`). When `nil`, raw labels are rendered unchanged. |
+| `gettext_domain` | `"default"` | The gettext domain to use for translation lookups. |
+
+### Basic Example
+
+```elixir
+Tab.new(
+  id: :dashboard,
+  label: "Dashboard",
+  path: "/dashboard",
+  icon: "hero-home",
+  gettext_backend: MyApp.Gettext
+)
+```
+
+With this configuration, `Tab.localized_label(tab)` will call `Gettext.dgettext(MyApp.Gettext, "default", "Dashboard")` and return the translated string for the current locale.
+
+To use a custom domain:
+
+```elixir
+Tab.new(
+  id: :orders,
+  label: "Orders",
+  path: "/orders",
+  gettext_backend: MyApp.Gettext,
+  gettext_domain: "navigation"
+)
+```
+
+Groups support the same fields:
+
+```elixir
+Group.new(
+  id: :main,
+  label: "Main Navigation",
+  gettext_backend: MyApp.Gettext
+)
+```
+
+### Tooltips
+
+`Tab.localized_tooltip/1` follows the same fallback chain for the `tooltip` field.
+
+### Backwards Compatibility
+
+Tabs and groups without `gettext_backend` continue rendering the raw `label` string unchanged. No migration is required for existing tab registrations.

--- a/lib/phoenix_kit/dashboard/group.ex
+++ b/lib/phoenix_kit/dashboard/group.ex
@@ -12,18 +12,45 @@ defmodule PhoenixKit.Dashboard.Group do
   - `priority` - Sort priority (lower = first, default: 100)
   - `icon` - Optional heroicon name (e.g., `"hero-cube"`)
   - `collapsible` - Whether the group can be collapsed in the sidebar
+  - `gettext_backend` - Optional Gettext backend module for label translation (default: nil)
+  - `gettext_domain` - Gettext domain for translation lookups (default: "default")
   """
 
   @enforce_keys [:id]
-  defstruct [:id, :label, :icon, priority: 100, collapsible: false]
+  defstruct [
+    :id,
+    :label,
+    :icon,
+    :gettext_backend,
+    priority: 100,
+    collapsible: false,
+    gettext_domain: "default"
+  ]
 
   @type t :: %__MODULE__{
           id: atom(),
           label: String.t() | nil,
           priority: integer(),
           icon: String.t() | nil,
-          collapsible: boolean()
+          collapsible: boolean(),
+          gettext_backend: module() | nil,
+          gettext_domain: String.t()
         }
+
+  @doc """
+  Returns the group's label, translated via the configured gettext backend if one is set.
+
+  Falls back to the raw label string when:
+    * `gettext_backend` is `nil` (default — no translation configured)
+    * the label is `nil` (unlabeled groups)
+    * gettext has no translation for the msgid (gettext's own fallback)
+  """
+  @spec localized_label(t()) :: String.t() | nil
+  def localized_label(%__MODULE__{label: nil}), do: nil
+  def localized_label(%__MODULE__{gettext_backend: nil, label: label}), do: label
+
+  def localized_label(%__MODULE__{gettext_backend: backend, gettext_domain: domain, label: label}),
+    do: Gettext.dgettext(backend, domain, label)
 
   @doc """
   Creates a new group from a map or keyword list.
@@ -35,7 +62,9 @@ defmodule PhoenixKit.Dashboard.Group do
       label: attrs[:label] || attrs["label"],
       priority: attrs[:priority] || attrs["priority"] || 100,
       icon: attrs[:icon] || attrs["icon"],
-      collapsible: attrs[:collapsible] || attrs["collapsible"] || false
+      collapsible: attrs[:collapsible] || attrs["collapsible"] || false,
+      gettext_backend: attrs[:gettext_backend] || attrs["gettext_backend"],
+      gettext_domain: attrs[:gettext_domain] || attrs["gettext_domain"] || "default"
     }
   end
 
@@ -45,7 +74,9 @@ defmodule PhoenixKit.Dashboard.Group do
       label: Keyword.get(attrs, :label),
       priority: Keyword.get(attrs, :priority, 100),
       icon: Keyword.get(attrs, :icon),
-      collapsible: Keyword.get(attrs, :collapsible, false)
+      collapsible: Keyword.get(attrs, :collapsible, false),
+      gettext_backend: Keyword.get(attrs, :gettext_backend),
+      gettext_domain: Keyword.get(attrs, :gettext_domain, "default")
     }
   end
 end

--- a/lib/phoenix_kit/dashboard/group.ex
+++ b/lib/phoenix_kit/dashboard/group.ex
@@ -44,13 +44,25 @@ defmodule PhoenixKit.Dashboard.Group do
     * `gettext_backend` is `nil` (default — no translation configured)
     * the label is `nil` (unlabeled groups)
     * gettext has no translation for the msgid (gettext's own fallback)
+
+  Reads `gettext_backend` and `gettext_domain` via `Map.get/2` rather than
+  pattern matching, so an old-shape struct cached in ETS or `:persistent_term`
+  before the 1.8.0 upgrade — which lacks those keys entirely — gracefully
+  falls back to the raw label instead of raising `FunctionClauseError`.
   """
   @spec localized_label(t()) :: String.t() | nil
   def localized_label(%__MODULE__{label: nil}), do: nil
-  def localized_label(%__MODULE__{gettext_backend: nil, label: label}), do: label
 
-  def localized_label(%__MODULE__{gettext_backend: backend, gettext_domain: domain, label: label}),
-    do: Gettext.dgettext(backend, domain, label)
+  def localized_label(%__MODULE__{label: label} = group) do
+    case Map.get(group, :gettext_backend) do
+      nil ->
+        label
+
+      backend ->
+        domain = Map.get(group, :gettext_domain) || "default"
+        Gettext.dgettext(backend, domain, label)
+    end
+  end
 
   @doc """
   Creates a new group from a map or keyword list.

--- a/lib/phoenix_kit/dashboard/tab.ex
+++ b/lib/phoenix_kit/dashboard/tab.ex
@@ -304,32 +304,45 @@ defmodule PhoenixKit.Dashboard.Tab do
     * `gettext_backend` is `nil` (default — no translation configured)
     * the label is `nil` (e.g. divider tabs)
     * gettext has no translation for the msgid (gettext's own fallback)
+
+  Reads `gettext_backend` and `gettext_domain` via `Map.get/2` rather than
+  pattern matching, so an old-shape struct cached in ETS or `:persistent_term`
+  before the 1.8.0 upgrade — which lacks those keys entirely — gracefully
+  falls back to the raw label instead of raising `FunctionClauseError`.
   """
   @spec localized_label(t()) :: String.t() | nil
   def localized_label(%__MODULE__{label: nil}), do: nil
-  def localized_label(%__MODULE__{gettext_backend: nil, label: label}), do: label
 
-  def localized_label(%__MODULE__{gettext_backend: backend, gettext_domain: domain, label: label}),
-    do: Gettext.dgettext(backend, domain, label)
+  def localized_label(%__MODULE__{label: label} = tab) do
+    case Map.get(tab, :gettext_backend) do
+      nil ->
+        label
+
+      backend ->
+        domain = Map.get(tab, :gettext_domain) || "default"
+        Gettext.dgettext(backend, domain, label)
+    end
+  end
 
   @doc """
   Returns the tab's tooltip, translated via the configured gettext backend if one is set.
 
-  Falls back to the raw tooltip string when:
-    * `gettext_backend` is `nil` (default — no translation configured)
-    * the tooltip is `nil`
-    * gettext has no translation for the msgid (gettext's own fallback)
+  Same fallback semantics as `localized_label/1`, including resilience to old
+  struct shapes cached before the 1.8.0 upgrade.
   """
   @spec localized_tooltip(t()) :: String.t() | nil
   def localized_tooltip(%__MODULE__{tooltip: nil}), do: nil
-  def localized_tooltip(%__MODULE__{gettext_backend: nil, tooltip: tooltip}), do: tooltip
 
-  def localized_tooltip(%__MODULE__{
-        gettext_backend: backend,
-        gettext_domain: domain,
-        tooltip: tooltip
-      }),
-      do: Gettext.dgettext(backend, domain, tooltip)
+  def localized_tooltip(%__MODULE__{tooltip: tooltip} = tab) do
+    case Map.get(tab, :gettext_backend) do
+      nil ->
+        tooltip
+
+      backend ->
+        domain = Map.get(tab, :gettext_domain) || "default"
+        Gettext.dgettext(backend, domain, tooltip)
+    end
+  end
 
   @doc """
   Creates a divider pseudo-tab for visual separation.

--- a/lib/phoenix_kit/dashboard/tab.ex
+++ b/lib/phoenix_kit/dashboard/tab.ex
@@ -159,7 +159,9 @@ defmodule PhoenixKit.Dashboard.Tab do
           new_tab: boolean(),
           attention: atom() | nil,
           metadata: map(),
-          inserted_at: DateTime.t() | nil
+          inserted_at: DateTime.t() | nil,
+          gettext_backend: module() | nil,
+          gettext_domain: String.t()
         }
 
   defstruct [
@@ -180,6 +182,7 @@ defmodule PhoenixKit.Dashboard.Tab do
     :permission,
     :live_view,
     :dynamic_children,
+    :gettext_backend,
     priority: 500,
     level: :user,
     subtab_display: :when_active,
@@ -189,7 +192,8 @@ defmodule PhoenixKit.Dashboard.Tab do
     visible: true,
     external: false,
     new_tab: false,
-    metadata: %{}
+    metadata: %{},
+    gettext_domain: "default"
   ]
 
   @doc """
@@ -268,7 +272,9 @@ defmodule PhoenixKit.Dashboard.Tab do
       attention: parse_attention(get_attr(attrs, :attention)),
       live_view: get_attr(attrs, :live_view),
       metadata: get_attr(attrs, :metadata) || %{},
-      inserted_at: UtilsDate.utc_now()
+      inserted_at: UtilsDate.utc_now(),
+      gettext_backend: get_attr(attrs, :gettext_backend),
+      gettext_domain: get_attr(attrs, :gettext_domain) || "default"
     }
   end
 
@@ -292,6 +298,40 @@ defmodule PhoenixKit.Dashboard.Tab do
   end
 
   @doc """
+  Returns the tab's label, translated via the configured gettext backend if one is set.
+
+  Falls back to the raw label string when:
+    * `gettext_backend` is `nil` (default — no translation configured)
+    * the label is `nil` (e.g. divider tabs)
+    * gettext has no translation for the msgid (gettext's own fallback)
+  """
+  @spec localized_label(t()) :: String.t() | nil
+  def localized_label(%__MODULE__{label: nil}), do: nil
+  def localized_label(%__MODULE__{gettext_backend: nil, label: label}), do: label
+
+  def localized_label(%__MODULE__{gettext_backend: backend, gettext_domain: domain, label: label}),
+    do: Gettext.dgettext(backend, domain, label)
+
+  @doc """
+  Returns the tab's tooltip, translated via the configured gettext backend if one is set.
+
+  Falls back to the raw tooltip string when:
+    * `gettext_backend` is `nil` (default — no translation configured)
+    * the tooltip is `nil`
+    * gettext has no translation for the msgid (gettext's own fallback)
+  """
+  @spec localized_tooltip(t()) :: String.t() | nil
+  def localized_tooltip(%__MODULE__{tooltip: nil}), do: nil
+  def localized_tooltip(%__MODULE__{gettext_backend: nil, tooltip: tooltip}), do: tooltip
+
+  def localized_tooltip(%__MODULE__{
+        gettext_backend: backend,
+        gettext_domain: domain,
+        tooltip: tooltip
+      }),
+      do: Gettext.dgettext(backend, domain, tooltip)
+
+  @doc """
   Creates a divider pseudo-tab for visual separation.
 
   ## Options
@@ -300,6 +340,8 @@ defmodule PhoenixKit.Dashboard.Tab do
   - `:priority` - Sort order (required to position the divider)
   - `:group` - Group this divider belongs to (optional)
   - `:label` - Optional label text for the divider (shows as a header)
+  - `:gettext_backend` - Optional Gettext backend module for label translation (default: nil)
+  - `:gettext_domain` - Gettext domain for translation lookups (default: "default")
 
   ## Examples
 
@@ -319,7 +361,9 @@ defmodule PhoenixKit.Dashboard.Tab do
       group: opts[:group],
       match: :exact,
       visible: if(is_nil(opts[:visible]), do: true, else: opts[:visible]),
-      metadata: %{type: :divider}
+      metadata: %{type: :divider},
+      gettext_backend: opts[:gettext_backend],
+      gettext_domain: opts[:gettext_domain] || "default"
     }
   end
 
@@ -334,6 +378,8 @@ defmodule PhoenixKit.Dashboard.Tab do
   - `:icon` - Optional icon for the header
   - `:collapsible` - Whether the group can be collapsed (default: false)
   - `:collapsed` - Initial collapsed state (default: false)
+  - `:gettext_backend` - Optional Gettext backend module for label translation (default: nil)
+  - `:gettext_domain` - Gettext domain for translation lookups (default: "default")
 
   ## Examples
 
@@ -355,7 +401,9 @@ defmodule PhoenixKit.Dashboard.Tab do
         type: :group_header,
         collapsible: opts[:collapsible] || false,
         collapsed: opts[:collapsed] || false
-      }
+      },
+      gettext_backend: opts[:gettext_backend],
+      gettext_domain: opts[:gettext_domain] || "default"
     }
   end
 

--- a/lib/phoenix_kit_web/components/dashboard/admin_sidebar.ex
+++ b/lib/phoenix_kit_web/components/dashboard/admin_sidebar.ex
@@ -23,7 +23,7 @@ defmodule PhoenixKitWeb.Components.Dashboard.AdminSidebar do
 
   require Logger
 
-  alias PhoenixKit.Dashboard.{Registry, Tab}
+  alias PhoenixKit.Dashboard.{Group, Registry, Tab}
   alias PhoenixKitWeb.Components.Dashboard.TabItem
 
   import PhoenixKit.Dashboard.TabHelpers
@@ -98,13 +98,13 @@ defmodule PhoenixKitWeb.Components.Dashboard.AdminSidebar do
   defp admin_tab_group(assigns) do
     ~H"""
     <div class="space-y-1" data-group-id={@group.id}>
-      <%= if @group.label do %>
+      <%= if Group.localized_label(@group) do %>
         <div class="px-3 py-2 text-xs font-semibold text-base-content/50 uppercase tracking-wider">
           <span class="flex items-center gap-2">
             <%= if @group.icon do %>
               <.icon name={@group.icon} class="w-3.5 h-3.5" />
             <% end %>
-            {@group.label}
+            {Group.localized_label(@group)}
           </span>
         </div>
       <% end %>

--- a/lib/phoenix_kit_web/components/dashboard/sidebar.ex
+++ b/lib/phoenix_kit_web/components/dashboard/sidebar.ex
@@ -38,7 +38,7 @@ defmodule PhoenixKitWeb.Components.Dashboard.Sidebar do
 
   use Phoenix.Component
 
-  alias PhoenixKit.Dashboard.{Presence, Registry, Tab}
+  alias PhoenixKit.Dashboard.{Group, Presence, Registry, Tab}
   alias PhoenixKit.Utils.Routes
   alias PhoenixKitWeb.Components.Dashboard.TabItem
 
@@ -199,7 +199,7 @@ defmodule PhoenixKitWeb.Components.Dashboard.Sidebar do
       data-collapsed={@collapsed}
     >
       <%!-- Group Header (if labeled) --%>
-      <%= if @group.label do %>
+      <%= if Group.localized_label(@group) do %>
         <div
           class={[
             "px-3 py-2 text-xs font-semibold text-base-content/50 uppercase tracking-wider",
@@ -213,7 +213,7 @@ defmodule PhoenixKitWeb.Components.Dashboard.Sidebar do
             <%= if @group.icon do %>
               <.icon name={@group.icon} class="w-3.5 h-3.5" />
             <% end %>
-            {@group.label}
+            {Group.localized_label(@group)}
           </span>
           <%= if @group.collapsible do %>
             <.icon
@@ -438,7 +438,7 @@ defmodule PhoenixKitWeb.Components.Dashboard.Sidebar do
                 <%= if tab.icon do %>
                   <.icon name={tab.icon} class="w-4 h-4" />
                 <% end %>
-                <span>{tab.label}</span>
+                <span>{Tab.localized_label(tab)}</span>
                 <%= if tab.badge do %>
                   <PhoenixKitWeb.Components.Dashboard.Badge.dashboard_badge
                     badge={tab.badge}
@@ -580,7 +580,7 @@ defmodule PhoenixKitWeb.Components.Dashboard.Sidebar do
         <%= if @tab.icon do %>
           <.icon name={@tab.icon} class="w-4 h-4" />
         <% end %>
-        <span>{@tab.label}</span>
+        <span>{Tab.localized_label(@tab)}</span>
         <%= if @tab.badge do %>
           <PhoenixKitWeb.Components.Dashboard.Badge.dashboard_badge
             badge={@tab.badge}
@@ -603,7 +603,7 @@ defmodule PhoenixKitWeb.Components.Dashboard.Sidebar do
             <%= if subtab.icon do %>
               <.icon name={subtab.icon} class="w-3 h-3" />
             <% end %>
-            <span>{subtab.label}</span>
+            <span>{Tab.localized_label(subtab)}</span>
             <%= if subtab.badge do %>
               <PhoenixKitWeb.Components.Dashboard.Badge.dashboard_badge
                 badge={subtab.badge}

--- a/lib/phoenix_kit_web/components/dashboard/tab_item.ex
+++ b/lib/phoenix_kit_web/components/dashboard/tab_item.ex
@@ -94,7 +94,7 @@ defmodule PhoenixKitWeb.Components.Dashboard.TabItem do
         rel={if @tab.new_tab, do: "noopener noreferrer", else: nil}
         class={@tab_class}
         style={@tab_style}
-        title={@tab.tooltip}
+        title={Tab.localized_tooltip(@tab)}
         data-tab-id={@tab.id}
         data-parent-id={@tab.parent}
       >
@@ -115,7 +115,7 @@ defmodule PhoenixKitWeb.Components.Dashboard.TabItem do
         navigate={@path}
         class={@tab_class}
         style={@tab_style}
-        title={@tab.tooltip}
+        title={Tab.localized_tooltip(@tab)}
         data-tab-id={@tab.id}
         data-parent-id={@tab.parent}
       >
@@ -134,12 +134,12 @@ defmodule PhoenixKitWeb.Components.Dashboard.TabItem do
 
   defp render_divider(assigns) do
     ~H"""
-    <%= if @tab.label do %>
+    <%= if Tab.localized_label(@tab) do %>
       <div class={[
         "px-3 py-2 text-xs font-semibold text-base-content/50 uppercase tracking-wider",
         @class
       ]}>
-        {@tab.label}
+        {Tab.localized_label(@tab)}
       </div>
     <% else %>
       <div class={["divider my-1", @class]}></div>
@@ -172,7 +172,7 @@ defmodule PhoenixKitWeb.Components.Dashboard.TabItem do
         <%= if @tab.icon do %>
           <.icon name={@tab.icon} class="w-3.5 h-3.5" />
         <% end %>
-        {@tab.label}
+        {Tab.localized_label(@tab)}
       </span>
       <%= if @collapsible do %>
         <.icon
@@ -230,7 +230,7 @@ defmodule PhoenixKitWeb.Components.Dashboard.TabItem do
           if(@wrap_label, do: "break-words leading-tight", else: "truncate"),
           @is_subtab && (@subtab_style[:text_size] || "text-sm")
         ]}>
-          {@tab.label}
+          {Tab.localized_label(@tab)}
         </span>
       <% end %>
     </div>
@@ -275,7 +275,7 @@ defmodule PhoenixKitWeb.Components.Dashboard.TabItem do
             </span>
           <% end %>
         </div>
-        <span class="text-xs mt-1 truncate">{@tab.label}</span>
+        <span class="text-xs mt-1 truncate">{Tab.localized_label(@tab)}</span>
       </.link>
       """
     else

--- a/lib/phoenix_kit_web/live/modules.ex
+++ b/lib/phoenix_kit_web/live/modules.ex
@@ -10,6 +10,7 @@ defmodule PhoenixKitWeb.Live.Modules do
   use Gettext, backend: PhoenixKitWeb.Gettext
 
   alias PhoenixKit.Admin.Events
+  alias PhoenixKit.Dashboard.Tab
   alias PhoenixKit.ModuleDiscovery
   alias PhoenixKit.ModuleRegistry
   alias PhoenixKit.Settings
@@ -403,7 +404,9 @@ defmodule PhoenixKitWeb.Live.Modules do
       end)
       |> Enum.uniq_by(fn tab -> tab.path end)
       |> Enum.take(3)
-      |> Enum.map(fn tab -> %{label: tab.label, path: "/admin/" <> tab.path, icon: tab.icon} end)
+      |> Enum.map(fn tab ->
+        %{label: Tab.localized_label(tab), path: "/admin/" <> tab.path, icon: tab.icon}
+      end)
     else
       []
     end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule PhoenixKit.MixProject do
   use Mix.Project
 
-  @version "1.8.0"
+  @version "1.7.105"
   @description "A foundation for building Elixir Phoenix apps — SaaS, social networks, ERP systems, marketplaces, and more"
   @source_url "https://github.com/BeamLabEU/phoenix_kit"
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule PhoenixKit.MixProject do
   use Mix.Project
 
-  @version "1.7.105"
+  @version "1.8.0"
   @description "A foundation for building Elixir Phoenix apps — SaaS, social networks, ERP systems, marketplaces, and more"
   @source_url "https://github.com/BeamLabEU/phoenix_kit"
 

--- a/mix.exs
+++ b/mix.exs
@@ -192,6 +192,7 @@ defmodule PhoenixKit.MixProject do
         "guides/draggable-list-component.md",
         "guides/README.md",
         "guides/custom-admin-pages.md",
+        "guides/per-module-i18n.md",
         "lib/phoenix_kit/dashboard/ADMIN_README.md"
       ],
       groups_for_extras: [

--- a/test/phoenix_kit/dashboard/group_test.exs
+++ b/test/phoenix_kit/dashboard/group_test.exs
@@ -1,0 +1,123 @@
+defmodule PhoenixKit.Dashboard.GroupTest do
+  @moduledoc """
+  Unit tests for PhoenixKit.Dashboard.Group localized_label/1 and the
+  gettext_backend / gettext_domain fields round-tripping through Group.new/1.
+  """
+
+  use ExUnit.Case, async: false
+
+  alias PhoenixKit.Dashboard.Group
+
+  @backend PhoenixKitWeb.Gettext
+  @known_msgid "Dashboard"
+  @known_ru_translation "Панель управления"
+  @unknown_msgid "This string has no translation"
+
+  setup do
+    original_locale = Gettext.get_locale(@backend)
+
+    on_exit(fn ->
+      Gettext.put_locale(@backend, original_locale)
+    end)
+
+    :ok
+  end
+
+  describe "localized_label/1" do
+    test "returns raw label when gettext_backend is nil (default)" do
+      group = Group.new(id: :main, label: "Main")
+      assert Group.localized_label(group) == "Main"
+    end
+
+    test "critical regression: returns nil when label is nil (unlabeled group)" do
+      group = %Group{id: :x, label: nil}
+      assert Group.localized_label(group) == nil
+    end
+
+    test "returns nil when label is nil even with a gettext_backend set" do
+      group = %Group{id: :x, label: nil, gettext_backend: @backend, gettext_domain: "default"}
+      assert Group.localized_label(group) == nil
+    end
+
+    test "returns translated string when backend and locale are set" do
+      Gettext.put_locale(@backend, "ru")
+
+      group =
+        Group.new(
+          id: :dashboard,
+          label: @known_msgid,
+          gettext_backend: @backend
+        )
+
+      assert Group.localized_label(group) == @known_ru_translation
+    end
+
+    test "falls back to msgid when no translation exists for the requested locale" do
+      Gettext.put_locale(@backend, "ru")
+
+      group =
+        Group.new(
+          id: :unknown,
+          label: @unknown_msgid,
+          gettext_backend: @backend
+        )
+
+      assert Group.localized_label(group) == @unknown_msgid
+    end
+
+    test "renders raw label for a struct constructed without explicitly setting gettext fields" do
+      # Simulates pre-1.8 callers — defstruct supplies nil/`"default"` defaults,
+      # so the result must equal the raw label.
+      group = %Group{id: :legacy, label: "Legacy"}
+      assert Group.localized_label(group) == "Legacy"
+    end
+  end
+
+  describe "Group.new/1 round-trips gettext fields" do
+    test "round-trips gettext_backend and gettext_domain from map" do
+      group =
+        Group.new(%{
+          id: :test,
+          label: "Test",
+          gettext_backend: @backend,
+          gettext_domain: "navigation"
+        })
+
+      assert group.gettext_backend == @backend
+      assert group.gettext_domain == "navigation"
+    end
+
+    test "round-trips gettext_backend and gettext_domain from keyword list" do
+      group =
+        Group.new(
+          id: :test,
+          label: "Test",
+          gettext_backend: @backend,
+          gettext_domain: "navigation"
+        )
+
+      assert group.gettext_backend == @backend
+      assert group.gettext_domain == "navigation"
+    end
+
+    test "gettext_backend defaults to nil (map form)" do
+      group = Group.new(%{id: :test, label: "Test"})
+      assert group.gettext_backend == nil
+    end
+
+    test "gettext_backend defaults to nil (keyword form)" do
+      group = Group.new(id: :test, label: "Test")
+      assert group.gettext_backend == nil
+    end
+
+    test "gettext_domain defaults to 'default' (map form)" do
+      group = Group.new(%{id: :test, label: "Test"})
+      assert group.gettext_domain == "default"
+    end
+
+    test "gettext_domain defaults to 'default' (keyword form)" do
+      group = Group.new(id: :test, label: "Test")
+      assert group.gettext_domain == "default"
+    end
+  end
+end

--- a/test/phoenix_kit/dashboard/group_test.exs
+++ b/test/phoenix_kit/dashboard/group_test.exs
@@ -71,6 +71,21 @@ defmodule PhoenixKit.Dashboard.GroupTest do
       group = %Group{id: :legacy, label: "Legacy"}
       assert Group.localized_label(group) == "Legacy"
     end
+
+    test "tolerates an old-shape struct missing :gettext_backend / :gettext_domain keys" do
+      # Hot-reload + ETS scenario — see the matching test in tab_test.exs
+      # for the full rationale. A %Group{} cached under phoenix_kit ~> 1.7.x
+      # does not carry the new keys; localized_label/1 must gracefully fall
+      # back to the raw label rather than raise FunctionClauseError.
+      stale =
+        %Group{id: :legacy, label: "Legacy"}
+        |> Map.delete(:gettext_backend)
+        |> Map.delete(:gettext_domain)
+
+      refute Map.has_key?(stale, :gettext_backend)
+      refute Map.has_key?(stale, :gettext_domain)
+      assert Group.localized_label(stale) == "Legacy"
+    end
   end
 
   describe "Group.new/1 round-trips gettext fields" do

--- a/test/phoenix_kit/dashboard/tab_test.exs
+++ b/test/phoenix_kit/dashboard/tab_test.exs
@@ -1,0 +1,273 @@
+defmodule PhoenixKit.Dashboard.TabTest do
+  @moduledoc """
+  Unit tests for PhoenixKit.Dashboard.Tab localized_label/1, localized_tooltip/1,
+  and the gettext_backend / gettext_domain fields round-tripping through Tab.new/1.
+  """
+
+  use ExUnit.Case, async: false
+
+  alias PhoenixKit.Dashboard.Tab
+
+  @backend PhoenixKitWeb.Gettext
+  @known_msgid "Dashboard"
+  @known_ru_translation "Панель управления"
+  @unknown_msgid "This string has no translation"
+
+  setup do
+    original_locale = Gettext.get_locale(@backend)
+
+    on_exit(fn ->
+      Gettext.put_locale(@backend, original_locale)
+    end)
+
+    :ok
+  end
+
+  describe "localized_label/1" do
+    test "returns raw label when gettext_backend is nil (default)" do
+      tab = Tab.new!(id: :home, label: "Home", path: "/home")
+      assert Tab.localized_label(tab) == "Home"
+    end
+
+    test "returns nil when label is nil (divider tab)" do
+      tab = %Tab{
+        id: :divider,
+        label: nil,
+        path: nil,
+        gettext_backend: nil,
+        gettext_domain: "default"
+      }
+
+      assert Tab.localized_label(tab) == nil
+    end
+
+    test "returns nil when label is nil even with a gettext_backend set" do
+      tab = %Tab{
+        id: :divider,
+        label: nil,
+        path: nil,
+        gettext_backend: @backend,
+        gettext_domain: "default"
+      }
+
+      assert Tab.localized_label(tab) == nil
+    end
+
+    test "returns translated string when backend and locale are set" do
+      Gettext.put_locale(@backend, "ru")
+
+      tab =
+        Tab.new!(
+          id: :dashboard,
+          label: @known_msgid,
+          path: "/dashboard",
+          gettext_backend: @backend
+        )
+
+      assert Tab.localized_label(tab) == @known_ru_translation
+    end
+
+    test "falls back to msgid when no translation exists for the requested locale" do
+      Gettext.put_locale(@backend, "ru")
+
+      tab =
+        Tab.new!(
+          id: :unknown,
+          label: @unknown_msgid,
+          path: "/unknown",
+          gettext_backend: @backend
+        )
+
+      assert Tab.localized_label(tab) == @unknown_msgid
+    end
+
+    test "uses default domain when gettext_domain not specified" do
+      Gettext.put_locale(@backend, "ru")
+
+      tab =
+        Tab.new!(
+          id: :dashboard,
+          label: @known_msgid,
+          path: "/dashboard",
+          gettext_backend: @backend
+        )
+
+      assert tab.gettext_domain == "default"
+      assert Tab.localized_label(tab) == @known_ru_translation
+    end
+
+    test "renders raw label for a struct constructed without explicitly setting gettext fields" do
+      # Simulates pre-1.8 callers — defstruct supplies nil/`"default"` defaults,
+      # so the result must equal the raw label.
+      tab = %Tab{id: :legacy, label: "Legacy", path: "legacy"}
+      assert Tab.localized_label(tab) == "Legacy"
+    end
+  end
+
+  describe "localized_tooltip/1" do
+    test "returns raw tooltip when gettext_backend is nil" do
+      tab = Tab.new!(id: :home, label: "Home", path: "/home", tooltip: "Go home")
+      assert Tab.localized_tooltip(tab) == "Go home"
+    end
+
+    test "returns nil when tooltip is nil" do
+      tab = Tab.new!(id: :home, label: "Home", path: "/home")
+      assert Tab.localized_tooltip(tab) == nil
+    end
+
+    test "returns nil when tooltip is nil even with backend set" do
+      tab =
+        Tab.new!(
+          id: :home,
+          label: "Home",
+          path: "/home",
+          gettext_backend: @backend
+        )
+
+      assert Tab.localized_tooltip(tab) == nil
+    end
+
+    test "returns translated tooltip when backend and locale are set" do
+      Gettext.put_locale(@backend, "ru")
+
+      tab =
+        Tab.new!(
+          id: :dashboard,
+          label: @known_msgid,
+          path: "/dashboard",
+          tooltip: @known_msgid,
+          gettext_backend: @backend
+        )
+
+      assert Tab.localized_tooltip(tab) == @known_ru_translation
+    end
+
+    test "falls back to msgid when no tooltip translation exists for the requested locale" do
+      Gettext.put_locale(@backend, "ru")
+
+      tab =
+        Tab.new!(
+          id: :unknown,
+          label: "Label",
+          path: "/unknown",
+          tooltip: @unknown_msgid,
+          gettext_backend: @backend
+        )
+
+      assert Tab.localized_tooltip(tab) == @unknown_msgid
+    end
+  end
+
+  describe "Tab.new/1 round-trips gettext fields" do
+    test "round-trips gettext_backend and gettext_domain from keyword list" do
+      {:ok, tab} =
+        Tab.new(
+          id: :test,
+          label: "Test",
+          path: "/test",
+          gettext_backend: @backend,
+          gettext_domain: "navigation"
+        )
+
+      assert tab.gettext_backend == @backend
+      assert tab.gettext_domain == "navigation"
+    end
+
+    test "round-trips gettext_backend and gettext_domain from map" do
+      {:ok, tab} =
+        Tab.new(%{
+          id: :test,
+          label: "Test",
+          path: "/test",
+          gettext_backend: @backend,
+          gettext_domain: "navigation"
+        })
+
+      assert tab.gettext_backend == @backend
+      assert tab.gettext_domain == "navigation"
+    end
+
+    test "gettext_backend defaults to nil" do
+      {:ok, tab} = Tab.new(id: :test, label: "Test", path: "/test")
+      assert tab.gettext_backend == nil
+    end
+
+    test "gettext_domain defaults to 'default'" do
+      {:ok, tab} = Tab.new(id: :test, label: "Test", path: "/test")
+      assert tab.gettext_domain == "default"
+    end
+  end
+
+  describe "divider/1 and group_header/1 gettext support" do
+    test "Tab.divider/1 round-trips gettext_backend and gettext_domain" do
+      tab =
+        Tab.divider(
+          priority: 100,
+          label: "Account",
+          gettext_backend: @backend,
+          gettext_domain: "navigation"
+        )
+
+      assert tab.gettext_backend == @backend
+      assert tab.gettext_domain == "navigation"
+    end
+
+    test "Tab.divider/1 defaults gettext_domain to 'default' when not provided" do
+      tab = Tab.divider(priority: 100, label: "Account", gettext_backend: @backend)
+      assert tab.gettext_domain == "default"
+    end
+
+    test "Tab.divider/1 defaults gettext_backend to nil" do
+      tab = Tab.divider(priority: 100, label: "Account")
+      assert tab.gettext_backend == nil
+      assert tab.gettext_domain == "default"
+    end
+
+    test "localized_label/1 on a divider returns the translated label when locale is set" do
+      Gettext.put_locale(@backend, "ru")
+
+      tab =
+        Tab.divider(
+          priority: 100,
+          label: @known_msgid,
+          gettext_backend: @backend
+        )
+
+      assert Tab.localized_label(tab) == @known_ru_translation
+    end
+
+    test "Tab.group_header/1 round-trips gettext_backend and gettext_domain" do
+      tab =
+        Tab.group_header(
+          id: :foo,
+          label: "Foo",
+          priority: 100,
+          gettext_backend: @backend,
+          gettext_domain: "default"
+        )
+
+      assert tab.gettext_backend == @backend
+      assert tab.gettext_domain == "default"
+    end
+
+    test "Tab.group_header/1 defaults gettext_backend to nil" do
+      tab = Tab.group_header(id: :foo, label: "Foo", priority: 100)
+      assert tab.gettext_backend == nil
+      assert tab.gettext_domain == "default"
+    end
+
+    test "localized_label/1 on a group_header returns the translated label when locale is set" do
+      Gettext.put_locale(@backend, "ru")
+
+      tab =
+        Tab.group_header(
+          id: :section,
+          label: @known_msgid,
+          priority: 100,
+          gettext_backend: @backend
+        )
+
+      assert Tab.localized_label(tab) == @known_ru_translation
+    end
+  end
+end

--- a/test/phoenix_kit/dashboard/tab_test.exs
+++ b/test/phoenix_kit/dashboard/tab_test.exs
@@ -102,6 +102,23 @@ defmodule PhoenixKit.Dashboard.TabTest do
       tab = %Tab{id: :legacy, label: "Legacy", path: "legacy"}
       assert Tab.localized_label(tab) == "Legacy"
     end
+
+    test "tolerates an old-shape struct missing :gettext_backend / :gettext_domain keys" do
+      # Simulates the hot-reload + ETS scenario: a parent app's Registry GenServer
+      # cached Tab structs under phoenix_kit ~> 1.7.x, where neither key existed
+      # in defstruct. After upgrading to 1.8 without restarting, those cached
+      # structs still flow through the sidebar render path. Map.get-based access
+      # in localized_label/1 must fall back to the raw label instead of raising
+      # FunctionClauseError.
+      stale =
+        Tab.new!(id: :legacy, label: "Legacy", path: "legacy")
+        |> Map.delete(:gettext_backend)
+        |> Map.delete(:gettext_domain)
+
+      refute Map.has_key?(stale, :gettext_backend)
+      refute Map.has_key?(stale, :gettext_domain)
+      assert Tab.localized_label(stale) == "Legacy"
+    end
   end
 
   describe "localized_tooltip/1" do
@@ -155,6 +172,15 @@ defmodule PhoenixKit.Dashboard.TabTest do
         )
 
       assert Tab.localized_tooltip(tab) == @unknown_msgid
+    end
+
+    test "tolerates an old-shape struct missing gettext keys (hot-reload safety)" do
+      stale =
+        Tab.new!(id: :legacy, label: "Legacy", path: "/legacy", tooltip: "Help text")
+        |> Map.delete(:gettext_backend)
+        |> Map.delete(:gettext_domain)
+
+      assert Tab.localized_tooltip(stale) == "Help text"
     end
   end
 

--- a/test/phoenix_kit_web/components/dashboard/tab_item_test.exs
+++ b/test/phoenix_kit_web/components/dashboard/tab_item_test.exs
@@ -1,0 +1,134 @@
+defmodule PhoenixKitWeb.Components.Dashboard.TabItemTest do
+  @moduledoc """
+  Render-integration tests for PhoenixKitWeb.Components.Dashboard.TabItem.
+
+  Verifies that:
+  - Tabs without a gettext_backend render raw labels (regression guard).
+  - Tabs with gettext_backend render the translated label for the current locale.
+  - Tooltips are rendered via localized_tooltip (title attr).
+  """
+
+  use ExUnit.Case, async: false
+
+  import Phoenix.LiveViewTest
+
+  alias PhoenixKit.Dashboard.Tab
+  alias PhoenixKitWeb.Components.Dashboard.TabItem
+
+  @backend PhoenixKitWeb.Gettext
+  @known_msgid "Dashboard"
+  @known_ru_translation "Панель управления"
+
+  setup do
+    original_locale = Gettext.get_locale(@backend)
+
+    on_exit(fn ->
+      Gettext.put_locale(@backend, original_locale)
+    end)
+
+    :ok
+  end
+
+  describe "tab_item/1 — label rendering" do
+    test "renders raw label when gettext_backend is nil (regression)" do
+      tab = Tab.new!(id: :home, label: "Home", path: "/home", icon: "hero-home")
+
+      html =
+        render_component(&TabItem.tab_item/1,
+          tab: tab,
+          active: false,
+          locale: nil
+        )
+
+      assert html =~ "Home"
+    end
+
+    test "renders translated label when gettext_backend is set and locale is ru" do
+      Gettext.put_locale(@backend, "ru")
+
+      tab =
+        Tab.new!(
+          id: :dashboard,
+          label: @known_msgid,
+          path: "/dashboard",
+          icon: "hero-home",
+          gettext_backend: @backend
+        )
+
+      html =
+        render_component(&TabItem.tab_item/1,
+          tab: tab,
+          active: false,
+          locale: nil
+        )
+
+      assert html =~ @known_ru_translation
+      refute html =~ @known_msgid
+    end
+
+    test "renders raw label when locale has no translation" do
+      Gettext.put_locale(@backend, "en")
+
+      tab =
+        Tab.new!(
+          id: :dashboard,
+          label: @known_msgid,
+          path: "/dashboard",
+          icon: "hero-home",
+          gettext_backend: @backend
+        )
+
+      html =
+        render_component(&TabItem.tab_item/1,
+          tab: tab,
+          active: false,
+          locale: nil
+        )
+
+      assert html =~ @known_msgid
+    end
+  end
+
+  describe "tab_item/1 — tooltip rendering" do
+    test "renders translated title attr when backend is set and locale is ru" do
+      Gettext.put_locale(@backend, "ru")
+
+      tab =
+        Tab.new!(
+          id: :dashboard,
+          label: @known_msgid,
+          path: "/dashboard",
+          tooltip: @known_msgid,
+          gettext_backend: @backend
+        )
+
+      html =
+        render_component(&TabItem.tab_item/1,
+          tab: tab,
+          active: false,
+          locale: nil
+        )
+
+      assert html =~ ~s(title="#{@known_ru_translation}")
+    end
+
+    test "renders raw tooltip as title when gettext_backend is nil" do
+      tab =
+        Tab.new!(
+          id: :settings,
+          label: "Settings",
+          path: "/settings",
+          tooltip: "Open settings"
+        )
+
+      html =
+        render_component(&TabItem.tab_item/1,
+          tab: tab,
+          active: false,
+          locale: nil
+        )
+
+      assert html =~ ~s(title="Open settings")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds optional `gettext_backend` and `gettext_domain` fields to `PhoenixKit.Dashboard.Tab` and `PhoenixKit.Dashboard.Group`, plus three resolver functions (`Tab.localized_label/1`, `Tab.localized_tooltip/1`, `Group.localized_label/1`).
- Sidebar / AdminSidebar / TabItem components route every label and tooltip render through the localizer (14 sites total) so per-module Gettext backends translate at request time.
- Backwards compatible — tabs without a backend continue rendering raw labels; existing call sites keep their behavior.
- Hot-reload safe — the localizer reads the new fields via `Map.get/2`, so old struct shapes cached in ETS before the upgrade fall back to raw labels rather than raising `FunctionClauseError`.

## Motivation

Today, every parent app that wants translated sidebar tab labels has to hack `PhoenixKit.Dashboard.Registry`'s ETS table at mount-time per LiveView. That patches exactly one tab, leaves every other module's tabs in English, and races between concurrent users on different locales. With this PR, each module declares its own Gettext backend on its tab/group registrations and the sidebar resolves the locale at request time — no ETS patching, no race, no per-LV mount hook.

## Changes

### API additions (backwards compatible)
- `Tab.gettext_backend`, `Tab.gettext_domain` (defaults `nil`, `"default"`)
- `Group.gettext_backend`, `Group.gettext_domain` (same defaults)
- `Tab.localized_label/1`, `Tab.localized_tooltip/1`, `Group.localized_label/1`
- `Tab.new/1`, `Tab.divider/1`, `Tab.group_header/1`, both `Group.new/1` clauses accept the new fields

### Render sites updated
- `lib/phoenix_kit_web/components/dashboard/tab_item.ex` — 7 sites (5 labels, 2 tooltips)
- `lib/phoenix_kit_web/components/dashboard/sidebar.ex` — 5 sites (group label + render, more_menu tab, mobile parent, mobile subtab)
- `lib/phoenix_kit_web/components/dashboard/admin_sidebar.ex` — 2 sites (group label guard + render)

### Documentation
- New guide `guides/per-module-i18n.md` for module developers — setup checklist, step-by-step `mix.exs` / backend / `.po` flow, `dynamic_children/2` locale handling, dividers and group headers, tooltips, greenfield template, retrofitting checklist, smoke test pattern, common pitfalls
- Wired into `mix.exs` ExDoc extras so it ships to hexdocs.pm under "Guides"
- Linked from `guides/README.md` index
- Version-neutral phrasing — defers to the PhoenixKit CHANGELOG for the minimum version once shipped

### Hot-reload safety
A parent app whose Phoenix server keeps running across the upgrade hits stale `%Tab{}` / `%Group{}` structs cached in `Registry`'s ETS — the underlying maps lack the new keys. The localizer uses `Map.get/2` for `gettext_backend` / `gettext_domain` so missing keys are treated as "no backend configured", returning the raw label until the parent restarts and ETS repopulates with the new shape.

### Tests
- 43 unit + render tests in `test/phoenix_kit/dashboard/` and `test/phoenix_kit_web/components/dashboard/` cover raw fallback, nil label, translated render under `ru` locale, helper round-trip, divider/group_header gettext support, hot-reload-safe stale-struct regression
- `async: false` + `on_exit` to isolate `Gettext.put_locale/2` process state

## Non-goals

- **No version bump.** A first revision of this branch bumped `@version 1.7.105 → 1.8.0`; that was reverted because the package version is set by the maintainer at release time. The fourth commit on this branch makes the revert explicit.
- **No CHANGELOG entry.** Maintainer-owned per project conventions. The four commit messages on this branch contain the material for the entry.
- **PhoenixKit's own admin/user tabs are NOT migrated** in this PR. Their labels still render raw English. Migrating them is straightforward (add `gettext_backend: PhoenixKitWeb.Gettext` to ~19 registrations across `admin_tabs.ex`, `registry.ex`, `jobs.ex`) and is intentionally left for a follow-up so this PR stays scoped to the API.

## Rollout plan (after this merges)

| Phase | Repo | What |
|---|---|---|
| 2 | each `phoenix_kit_<x>` Hex package | apply `guides/per-module-i18n.md` — pilot: `phoenix_kit_newsletters` (in progress) |
| 3 | parent apps | drop ETS-patching hacks, set `gettext_backend:` on own tab registrations |

Phase 2 modules are independent — can be migrated in parallel. Phase 3 is independent of Phase 2.

## Test plan

- [x] `mix format --check-formatted` clean
- [x] `mix compile --warnings-as-errors` clean
- [x] `mix credo --strict` clean (7211 mods/funs, 516 files, no issues)
- [x] `mix dialyzer` clean
- [x] 43 dashboard tests pass
- [x] CI re-verifies on the PR branch
- [x] Maintainer review of API shape and docs
- [x] Manual verification in a parent app: `mix deps.compile phoenix_kit --force` + full server restart, navigate `/admin`, confirm sidebar renders without `FunctionClauseError`
