### PR TITLE
Replace hardcoded known-packages list with live Hex.pm fetch

### DIFF
--- a/lib/phoenix_kit/known_packages.ex
+++ b/lib/phoenix_kit/known_packages.ex
@@ -2,89 +2,163 @@ defmodule PhoenixKit.KnownPackages do
   @moduledoc """
   Live catalog of known external PhoenixKit packages fetched from Hex.pm.
 
-  Results are cached in-process for 10 minutes via `:persistent_term`.
-  On Hex fetch failure, returns stale cached data when available, otherwise
-  returns `extra_known_packages` config entries only.
+  Fetched on demand and cached in an ETS table for 10 minutes. On Hex
+  failure, returns stale cached data when within the 24h max-stale-age
+  cap, otherwise returns `extra_known_packages` config entries only.
+
+  Cache uses an ETS named table (`:phoenix_kit_known_packages_cache`) with
+  `read_concurrency: true` rather than `:persistent_term`, to avoid
+  global-GC write amplification on multi-node cold deploys.
+
+  ## Public API
+
+    * `list/0` and `list/1` — return the catalog (cached).
+    * `clear_cache/0` — wipes the cache (for tests).
+
+  `list/1` accepts opts (intended for tests, not production):
+
+    * `:ttl_ms` — cache TTL (default `:timer.minutes(10)`)
+    * `:max_stale_age_ms` — how long stale data may be served on Hex
+      failure (default `:timer.hours(24)`)
+    * `:req_options` — pass-through to `Req.get/2`
   """
 
   require Logger
 
-  @cache_key {__MODULE__, :cache}
+  @table :phoenix_kit_known_packages_cache
+  @cache_key :cache
   @hex_search_url "https://hex.pm/api/packages"
   @icon_marker_re ~r/\bhex_docs_icon_name:\s*([a-z0-9-]+)/
   @default_icon "hero-puzzle-piece"
   @skip_packages ["phoenix_kit"]
   @ttl_ms :timer.minutes(10)
+  @max_stale_age_ms :timer.hours(24)
+  @default_req_options [receive_timeout: 3000]
+  @beamlab_org "BeamLabEU"
 
   @doc """
   Returns the list of known external PhoenixKit packages.
 
-  Fetches from Hex.pm on cache miss (up to every 10 minutes).
-  Always merges `config :phoenix_kit, extra_known_packages: [...]` on top.
+  Each entry is a map with keys: `key`, `module`, `package`,
+  `hex_package`, `name`, `description`, `icon`, `hex_url`, `github_url`,
+  `latest_version`, `source`.
 
-  Each entry is a map with keys: `key`, `package`, `name`, `description`,
-  `icon`, `hex_url`, `source`.
+  See module doc for `opts`.
   """
-  @spec list() :: [map()]
-  def list do
+  @spec list(keyword()) :: [map()]
+  def list(opts \\ []) do
+    ensure_table()
     now = System.monotonic_time(:millisecond)
+    ttl = Keyword.get(opts, :ttl_ms, @ttl_ms)
 
-    case :persistent_term.get(@cache_key, nil) do
-      {expires_at, cached} when expires_at > now ->
+    case lookup() do
+      {fetched_at, cached} when now - fetched_at < ttl ->
         cached
 
       _ ->
-        fetch_and_cache()
+        fetch_and_cache(now, opts)
     end
   end
 
   @doc "Clears the in-process cache. Intended for tests."
   @spec clear_cache() :: :ok
   def clear_cache do
-    :persistent_term.erase(@cache_key)
+    ensure_table()
+    :ets.delete(@table, @cache_key)
     :ok
   end
 
   # ---------------------------------------------------------------------------
-  # Private
+  # Private — cache mechanics
   # ---------------------------------------------------------------------------
 
-  defp fetch_and_cache do
-    case fetch_from_hex() do
-      {:ok, hex_list} ->
-        merged = merge_extras(hex_list)
-        expires_at = System.monotonic_time(:millisecond) + @ttl_ms
-        :persistent_term.put(@cache_key, {expires_at, merged})
-        merged
+  defp ensure_table do
+    case :ets.whereis(@table) do
+      :undefined ->
+        :ets.new(@table, [:named_table, :public, :set, read_concurrency: true])
 
-      {:error, reason} ->
-        Logger.warning(
-          "PhoenixKit.KnownPackages: Hex fetch failed (#{inspect(reason)}) — " <>
-            "returning config extras only"
-        )
+      _ ->
+        :ok
+    end
+  rescue
+    ArgumentError -> :ok
+  end
 
-        case :persistent_term.get(@cache_key, nil) do
-          {_expired_at, stale} -> stale
-          nil -> merge_extras([])
-        end
+  defp lookup do
+    case :ets.lookup(@table, @cache_key) do
+      [{@cache_key, fetched_at, list}] -> {fetched_at, list}
+      [] -> nil
     end
   end
 
-  defp fetch_from_hex do
-    url = @hex_search_url <> "?search=phoenix_kit_&sort=name"
-    fetch_hex_page(url, [])
+  defp fetch_and_cache(now, opts) do
+    case fetch_from_hex(opts) do
+      {:ok, hex_list} ->
+        merged = merge_extras(hex_list)
+        :ets.insert(@table, {@cache_key, now, merged})
+        merged
+
+      {:error, reason} ->
+        handle_hex_failure(reason, now, opts)
+    end
   end
 
-  defp fetch_hex_page(nil, acc), do: {:ok, acc}
+  defp handle_hex_failure(reason, now, opts) do
+    max_stale = Keyword.get(opts, :max_stale_age_ms, @max_stale_age_ms)
 
-  defp fetch_hex_page(url, acc) do
-    opts = Application.get_env(:phoenix_kit, :_known_packages_req_opts, receive_timeout: 3000)
+    case lookup() do
+      {fetched_at, stale} when now - fetched_at <= max_stale ->
+        age_minutes = div(now - fetched_at, :timer.minutes(1))
 
-    case Req.get(url, opts) do
+        Logger.warning(
+          "PhoenixKit.KnownPackages: Hex fetch failed (#{inspect(reason)}) — " <>
+            "serving stale data (age=#{age_minutes}m)"
+        )
+
+        stale
+
+      {fetched_at, _stale} ->
+        age_hours = div(now - fetched_at, :timer.hours(1))
+
+        Logger.error(
+          "PhoenixKit.KnownPackages: Hex fetch failed (#{inspect(reason)}) and " <>
+            "cached data exceeds max stale age (#{age_hours}h) — returning extras only"
+        )
+
+        :ets.delete(@table, @cache_key)
+        merge_extras([])
+
+      nil ->
+        Logger.warning(
+          "PhoenixKit.KnownPackages: Hex fetch failed (#{inspect(reason)}) and " <>
+            "no cached data — returning extras only"
+        )
+
+        merge_extras([])
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Private — Hex fetch
+  # ---------------------------------------------------------------------------
+
+  defp fetch_from_hex(opts) do
+    url = @hex_search_url <> "?search=phoenix_kit_&sort=name"
+    req_options = Keyword.get(opts, :req_options, @default_req_options)
+    fetch_hex_page(url, [], req_options)
+  end
+
+  defp fetch_hex_page(nil, acc, _opts), do: {:ok, acc}
+
+  defp fetch_hex_page(url, acc, req_options) do
+    case Req.get(url, req_options) do
       {:ok, %{status: 200, body: packages, headers: headers}} when is_list(packages) ->
         valid = packages |> Enum.reject(&skip_package?/1) |> Enum.map(&shape_entry/1)
         next_url = parse_next_link(headers)
-        fetch_hex_page(next_url, acc ++ valid)
+        fetch_hex_page(next_url, acc ++ valid, req_options)
+
+      {:ok, %{status: 200}} ->
+        {:error, :malformed_response}
 
       {:ok, %{status: status}} ->
         {:error, {:http_error, status}}
@@ -99,6 +173,22 @@ defmodule PhoenixKit.KnownPackages do
   defp skip_package?(%{"name" => name}), do: name in @skip_packages
   defp skip_package?(_), do: false
 
+  defp parse_next_link(headers) when is_map(headers) do
+    link = headers |> Map.get("link", []) |> List.first()
+
+    with binary when is_binary(binary) <- link,
+         [_, url] <- Regex.run(~r/<([^>]+)>;\s*rel="next"/, binary) do
+      url
+    else
+      _ -> nil
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Private — entry shape (kept backward-compatible with the previous
+  # hardcoded list: includes module/hex_package/github_url/latest_version)
+  # ---------------------------------------------------------------------------
+
   defp shape_entry(pkg) do
     package = pkg["name"]
     key = String.replace_prefix(package, "phoenix_kit_", "")
@@ -107,13 +197,36 @@ defmodule PhoenixKit.KnownPackages do
 
     %{
       key: key,
+      module: derive_module_atom(package),
       package: package,
+      hex_package: package,
       name: humanize_key(key),
       description: stripped_description,
       icon: icon,
       hex_url: "https://hex.pm/packages/#{package}",
+      github_url: github_url_for(pkg, package),
+      latest_version: pkg["latest_version"],
       source: "hex"
     }
+  end
+
+  defp derive_module_atom(package) do
+    package
+    |> String.split("_")
+    |> Enum.map_join("", &String.capitalize/1)
+    |> then(&("Elixir." <> &1))
+    |> String.to_atom()
+  end
+
+  defp github_url_for(pkg, package) do
+    links = get_in(pkg, ["meta", "links"]) || %{}
+    github = links["GitHub"] || links["Github"] || links["github"]
+
+    if is_binary(github) and String.contains?(github, "github.com") do
+      github
+    else
+      "https://github.com/#{@beamlab_org}/#{package}"
+    end
   end
 
   defp humanize_key(key) do
@@ -131,24 +244,28 @@ defmodule PhoenixKit.KnownPackages do
     end
   end
 
-  defp parse_next_link(headers) when is_map(headers) do
-    link = headers |> Map.get("link", []) |> List.first()
-
-    with binary when is_binary(binary) <- link,
-         [_, url] <- Regex.run(~r/<([^>]+)>;\s*rel="next"/, binary) do
-      url
-    else
-      _ -> nil
-    end
-  end
+  # ---------------------------------------------------------------------------
+  # Private — config extras (parent-app-provided private/forked packages)
+  # ---------------------------------------------------------------------------
 
   defp merge_extras(hex_list) do
     extras =
-      Application.get_env(:phoenix_kit, :extra_known_packages, [])
-      |> Enum.map(&Map.put(&1, :source, "config"))
+      :phoenix_kit
+      |> Application.get_env(:extra_known_packages, [])
+      |> Enum.map(&normalize_config_entry/1)
 
-    # Config wins: concat config first, then hex; uniq_by keeps first (config)
-    (extras ++ hex_list)
-    |> Enum.uniq_by(& &1.package)
+    # Config wins: concat config first, then hex; uniq_by keeps the first
+    (extras ++ hex_list) |> Enum.uniq_by(& &1.package)
+  end
+
+  defp normalize_config_entry(entry) do
+    package = Map.get(entry, :package)
+
+    entry
+    |> Map.put(:source, "config")
+    |> Map.put_new(:hex_package, package)
+    |> Map.put_new(:module, nil)
+    |> Map.put_new(:github_url, nil)
+    |> Map.put_new(:latest_version, nil)
   end
 end

--- a/lib/phoenix_kit/known_packages.ex
+++ b/lib/phoenix_kit/known_packages.ex
@@ -1,0 +1,154 @@
+defmodule PhoenixKit.KnownPackages do
+  @moduledoc """
+  Live catalog of known external PhoenixKit packages fetched from Hex.pm.
+
+  Results are cached in-process for 10 minutes via `:persistent_term`.
+  On Hex fetch failure, returns stale cached data when available, otherwise
+  returns `extra_known_packages` config entries only.
+  """
+
+  require Logger
+
+  @cache_key {__MODULE__, :cache}
+  @hex_search_url "https://hex.pm/api/packages"
+  @icon_marker_re ~r/\bhex_docs_icon_name:\s*([a-z0-9-]+)/
+  @default_icon "hero-puzzle-piece"
+  @skip_packages ["phoenix_kit"]
+  @ttl_ms :timer.minutes(10)
+
+  @doc """
+  Returns the list of known external PhoenixKit packages.
+
+  Fetches from Hex.pm on cache miss (up to every 10 minutes).
+  Always merges `config :phoenix_kit, extra_known_packages: [...]` on top.
+
+  Each entry is a map with keys: `key`, `package`, `name`, `description`,
+  `icon`, `hex_url`, `source`.
+  """
+  @spec list() :: [map()]
+  def list do
+    now = System.monotonic_time(:millisecond)
+
+    case :persistent_term.get(@cache_key, nil) do
+      {expires_at, cached} when expires_at > now ->
+        cached
+
+      _ ->
+        fetch_and_cache()
+    end
+  end
+
+  @doc "Clears the in-process cache. Intended for tests."
+  @spec clear_cache() :: :ok
+  def clear_cache do
+    :persistent_term.erase(@cache_key)
+    :ok
+  end
+
+  # ---------------------------------------------------------------------------
+  # Private
+  # ---------------------------------------------------------------------------
+
+  defp fetch_and_cache do
+    case fetch_from_hex() do
+      {:ok, hex_list} ->
+        merged = merge_extras(hex_list)
+        expires_at = System.monotonic_time(:millisecond) + @ttl_ms
+        :persistent_term.put(@cache_key, {expires_at, merged})
+        merged
+
+      {:error, reason} ->
+        Logger.warning(
+          "PhoenixKit.KnownPackages: Hex fetch failed (#{inspect(reason)}) — " <>
+            "returning config extras only"
+        )
+
+        case :persistent_term.get(@cache_key, nil) do
+          {_expired_at, stale} -> stale
+          nil -> merge_extras([])
+        end
+    end
+  end
+
+  defp fetch_from_hex do
+    url = @hex_search_url <> "?search=phoenix_kit_&sort=name"
+    fetch_hex_page(url, [])
+  end
+
+  defp fetch_hex_page(nil, acc), do: {:ok, acc}
+
+  defp fetch_hex_page(url, acc) do
+    opts = Application.get_env(:phoenix_kit, :_known_packages_req_opts, receive_timeout: 3000)
+
+    case Req.get(url, opts) do
+      {:ok, %{status: 200, body: packages, headers: headers}} when is_list(packages) ->
+        valid = packages |> Enum.reject(&skip_package?/1) |> Enum.map(&shape_entry/1)
+        next_url = parse_next_link(headers)
+        fetch_hex_page(next_url, acc ++ valid)
+
+      {:ok, %{status: status}} ->
+        {:error, {:http_error, status}}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  rescue
+    e -> {:error, e}
+  end
+
+  defp skip_package?(%{"name" => name}), do: name in @skip_packages
+  defp skip_package?(_), do: false
+
+  defp shape_entry(pkg) do
+    package = pkg["name"]
+    key = String.replace_prefix(package, "phoenix_kit_", "")
+    raw_description = get_in(pkg, ["meta", "description"]) || ""
+    {stripped_description, icon} = parse_marker(raw_description)
+
+    %{
+      key: key,
+      package: package,
+      name: humanize_key(key),
+      description: stripped_description,
+      icon: icon,
+      hex_url: "https://hex.pm/packages/#{package}",
+      source: "hex"
+    }
+  end
+
+  defp humanize_key(key) do
+    key |> String.split("_") |> Enum.map_join(" ", &String.capitalize/1)
+  end
+
+  defp parse_marker(description) do
+    case Regex.run(@icon_marker_re, description) do
+      [full_match, icon_name] ->
+        stripped = description |> String.replace(full_match, "") |> String.trim()
+        {stripped, icon_name}
+
+      nil ->
+        {String.trim(description), @default_icon}
+    end
+  end
+
+  defp parse_next_link(headers) when is_map(headers) do
+    link = headers |> Map.get("link", []) |> List.first()
+
+    with binary when is_binary(binary) <- link,
+         [_, url] <- Regex.run(~r/<([^>]+)>;\s*rel="next"/, binary) do
+      url
+    else
+      _ -> nil
+    end
+  end
+
+  defp merge_extras(hex_list) do
+    extras =
+      Application.get_env(:phoenix_kit, :extra_known_packages, [])
+      |> Enum.map(&Map.put(&1, :source, "config"))
+
+    # Config wins: concat config first, then hex; uniq_by keeps first (config)
+    (extras ++ hex_list)
+    |> Enum.uniq_by(& &1.package)
+  end
+end

--- a/lib/phoenix_kit/module_registry.ex
+++ b/lib/phoenix_kit/module_registry.ex
@@ -32,6 +32,8 @@ defmodule PhoenixKit.ModuleRegistry do
       ModuleRegistry.all_permission_metadata() # Collect permission metadata
       ModuleRegistry.feature_enabled_checks()  # Build {mod, :enabled?} map
       ModuleRegistry.get_by_key("tickets")   # Find module by key
+      ModuleRegistry.get_module_key_for_namespace("PhoenixKitTickets")
+                                             # Resolve top-level namespace → key
   """
 
   use GenServer
@@ -182,6 +184,25 @@ defmodule PhoenixKit.ModuleRegistry do
   end
 
   @doc """
+  Find a registered module's key by matching a top-level Elixir namespace.
+
+  Used by the admin permission layer to resolve a plugin LiveView's namespace
+  (e.g. `"PhoenixKitEntities"` from `PhoenixKitEntities.Web.Entities`) to the
+  plugin's permission key (e.g. `"entities"`).
+
+  Returns the key string or `nil` when no registered module matches.
+  """
+  @spec get_module_key_for_namespace(String.t()) :: String.t() | nil
+  def get_module_key_for_namespace(top_namespace) when is_binary(top_namespace) do
+    Enum.find_value(all_modules(), fn mod ->
+      case Module.split(mod) do
+        [^top_namespace | _] -> safe_call(mod, :module_key, nil)
+        _ -> nil
+      end
+    end)
+  end
+
+  @doc """
   Returns dependency warnings for the Modules page.
 
   Each warning is a map:
@@ -221,8 +242,14 @@ defmodule PhoenixKit.ModuleRegistry do
   """
   @spec not_installed_packages() :: [map()]
   def not_installed_packages do
+    installed_otp_apps =
+      PhoenixKit.ModuleDiscovery.discover_external_modules()
+      |> Enum.map(&Application.get_application/1)
+      |> Enum.reject(&is_nil/1)
+      |> MapSet.new(&Atom.to_string/1)
+
     known_external_packages()
-    |> Enum.reject(fn pkg -> Code.ensure_loaded?(pkg.module) end)
+    |> Enum.reject(&MapSet.member?(installed_otp_apps, &1.package))
   end
 
   @doc "Returns all feature module key strings from registered modules."
@@ -411,147 +438,16 @@ defmodule PhoenixKit.ModuleRegistry do
     ]
   end
 
-  # Known external PhoenixKit packages. Listed here so the admin Modules page
-  # can show "not installed" cards for packages the user hasn't added yet.
-  defp known_external_packages do
-    [
-      %{
-        module: PhoenixKitCustomerSupport,
-        key: "customer_support",
-        hex_package: "phoenix_kit_customer_support",
-        name: "Customer Support",
-        description:
-          "Support ticket management with status workflow, threaded comments, internal notes, and file attachments.",
-        icon: "🎫",
-        hex_url: "https://hex.pm/packages/phoenix_kit_customer_support"
-      },
-      %{
-        module: PhoenixKit.Newsletters,
-        key: "newsletters",
-        hex_package: "phoenix_kit_newsletters",
-        name: "Newsletters",
-        description:
-          "Email newsletter management with list subscriptions, broadcast campaigns, and delivery tracking.",
-        icon: "📧",
-        hex_url: "https://hex.pm/packages/phoenix_kit_newsletters"
-      },
-      %{
-        module: PhoenixKitSync,
-        key: "sync",
-        hex_package: "phoenix_kit_sync",
-        name: "Sync",
-        description:
-          "Peer-to-peer data synchronization between PhoenixKit instances with token-based connections and transfer tracking.",
-        icon: "🔄",
-        hex_url: "https://hex.pm/packages/phoenix_kit_sync"
-      },
-      %{
-        module: PhoenixKitPosts,
-        key: "posts",
-        hex_package: "phoenix_kit_posts",
-        name: "Posts",
-        description:
-          "Blog posts, tags, groups, likes, media attachments, and scheduled publishing.",
-        icon: "📝",
-        hex_url: "https://hex.pm/packages/phoenix_kit_posts"
-      },
-      %{
-        module: PhoenixKit.Modules.Emails,
-        key: "emails",
-        hex_package: "phoenix_kit_emails",
-        name: "Emails",
-        description:
-          "Email tracking, templates, SQS integration, blocklist, and delivery analytics.",
-        icon: "📨",
-        hex_url: "https://hex.pm/packages/phoenix_kit_emails"
-      },
-      %{
-        module: PhoenixKit.Modules.Publishing,
-        key: "publishing",
-        hex_package: "phoenix_kit_publishing",
-        name: "Publishing",
-        description:
-          "Content publishing with groups, multilingual support, versioning, and collaborative editing.",
-        icon: "📰",
-        hex_url: "https://hex.pm/packages/phoenix_kit_publishing"
-      },
-      %{
-        module: PhoenixKitEntities,
-        key: "entities",
-        hex_package: "phoenix_kit_entities",
-        name: "Entities",
-        description:
-          "Custom data entities with fields, forms, multilingual support, and data navigation.",
-        icon: "🧩",
-        hex_url: "https://hex.pm/packages/phoenix_kit_entities"
-      },
-      %{
-        module: PhoenixKitAI,
-        key: "ai",
-        hex_package: "phoenix_kit_ai",
-        name: "AI",
-        description:
-          "AI endpoint management, prompt templates, completions via OpenRouter, and usage tracking.",
-        icon: "🤖",
-        hex_url: "https://hex.pm/packages/phoenix_kit_ai"
-      },
-      %{
-        module: PhoenixKit.Modules.Legal,
-        key: "legal",
-        hex_package: "phoenix_kit_legal",
-        name: "Legal",
-        description:
-          "GDPR/CCPA compliance with legal page generation, cookie consent widget, and consent audit logging.",
-        icon: "⚖️",
-        hex_url: "https://hex.pm/packages/phoenix_kit_legal"
-      },
-      %{
-        module: PhoenixKitCatalogue,
-        key: "catalogue",
-        hex_package: "phoenix_kit_catalogue",
-        name: "Catalogue",
-        description: "Product catalogues with manufacturers, suppliers, categories, and items.",
-        icon: "📦",
-        hex_url: "https://hex.pm/packages/phoenix_kit_catalogue"
-      },
-      %{
-        module: PhoenixKitDocumentCreator,
-        key: "document_creator",
-        hex_package: "phoenix_kit_document_creator",
-        name: "Document Creator",
-        description: "Document template management and PDF generation via Google Docs API.",
-        icon: "📄",
-        hex_url: "https://hex.pm/packages/phoenix_kit_document_creator"
-      },
-      %{
-        module: PhoenixKitUserConnections,
-        key: "user_connections",
-        hex_package: "phoenix_kit_user_connections",
-        name: "User Connections",
-        description:
-          "Social relationships with follows, mutual connections, blocking, and audit history.",
-        icon: "🤝",
-        hex_url: "https://hex.pm/packages/phoenix_kit_user_connections"
-      },
-      %{
-        module: PhoenixKitComments,
-        key: "comments",
-        hex_package: "phoenix_kit_comments",
-        name: "Comments",
-        description: "Comment system with likes and admin management.",
-        icon: "💬",
-        hex_url: "https://hex.pm/packages/phoenix_kit_comments"
-      },
-      %{
-        module: PhoenixKitHelloWorld,
-        key: "hello_world",
-        hex_package: "phoenix_kit_hello_world",
-        name: "Hello World",
-        description: "Example module template for building new PhoenixKit modules.",
-        icon: "👋",
-        hex_url: "https://hex.pm/packages/phoenix_kit_hello_world"
-      }
-    ]
+  @doc """
+  Returns the full catalog of known external PhoenixKit packages.
+
+  Fetches live from Hex.pm with a 10-minute in-memory cache.
+  Merged with any entries from `config :phoenix_kit, extra_known_packages: [...]`.
+  Config entries take precedence over Hex entries when the `package` field collides.
+  """
+  @spec known_external_packages() :: [map()]
+  def known_external_packages do
+    PhoenixKit.KnownPackages.list()
   end
 
   defp warn_duplicate_tab_ids(tabs) do

--- a/lib/phoenix_kit_web/live/modules.html.heex
+++ b/lib/phoenix_kit_web/live/modules.html.heex
@@ -747,7 +747,7 @@
             <div class="card bg-base-100 shadow border-2 border-dashed border-base-300">
               <div class="card-body">
                 <div class="flex items-center gap-3">
-                  <div class="text-3xl opacity-60">{pkg.icon}</div>
+                  <.icon name={pkg.icon} class="w-8 h-8 opacity-60" />
                   <div class="flex-1">
                     <h3 class="card-title text-base-content/70">{pkg.name}</h3>
                     <p class="text-sm text-base-content/50">{pkg.description}</p>
@@ -766,7 +766,7 @@
                 <div class="mt-2">
                   <p class="text-xs text-base-content/40 mb-1">Add to mix.exs:</p>
                   <code class="block text-xs bg-base-200 rounded p-2 font-mono">
-                    {~s|{:#{pkg.hex_package}, "~> 0.1"}|}
+                    {~s|{:#{pkg.package}, "~> 0.1"}|}
                   </code>
                 </div>
               </div>

--- a/lib/phoenix_kit_web/live/modules.html.heex
+++ b/lib/phoenix_kit_web/live/modules.html.heex
@@ -758,7 +758,12 @@
 
                 <div class="flex items-center justify-between gap-2 flex-wrap">
                   <span class="badge badge-ghost badge-outline">Not installed</span>
-                  <a href={pkg.hex_url} target="_blank" class="btn btn-xs btn-outline">
+                  <a
+                    :if={pkg.hex_url}
+                    href={pkg.hex_url}
+                    target="_blank"
+                    class="btn btn-xs btn-outline"
+                  >
                     <.icon name="hero-arrow-top-right-on-square" class="w-3 h-3" /> Hex.pm
                   </a>
                 </div>

--- a/test/phoenix_kit/known_packages_test.exs
+++ b/test/phoenix_kit/known_packages_test.exs
@@ -31,18 +31,20 @@ defmodule PhoenixKit.KnownPackagesTest do
     KnownPackages.clear_cache()
     original_extras = Application.get_env(:phoenix_kit, :extra_known_packages, [])
 
-    Application.put_env(:phoenix_kit, :_known_packages_req_opts,
-      plug: {Req.Test, @stub_name},
-      receive_timeout: 3000
-    )
-
     on_exit(fn ->
       KnownPackages.clear_cache()
       Application.put_env(:phoenix_kit, :extra_known_packages, original_extras)
-      Application.delete_env(:phoenix_kit, :_known_packages_req_opts)
     end)
 
     :ok
+  end
+
+  # Pass test stub via opts arg (no Application.put_env).
+  defp test_opts(extra \\ []) do
+    Keyword.merge(
+      [req_options: [plug: {Req.Test, @stub_name}, retry: false]],
+      extra
+    )
   end
 
   defp stub_hex(packages) do
@@ -53,11 +55,11 @@ defmodule PhoenixKit.KnownPackagesTest do
     end)
   end
 
-  describe "list/0 happy path" do
+  describe "list/1 happy path" do
     test "returns shaped entries from Hex" do
       stub_hex([@hex_newsletters, @hex_posts])
 
-      packages = KnownPackages.list()
+      packages = KnownPackages.list(test_opts())
 
       assert length(packages) == 2
 
@@ -73,7 +75,7 @@ defmodule PhoenixKit.KnownPackagesTest do
     test "filters out phoenix_kit core package" do
       stub_hex([@hex_phoenix_kit, @hex_newsletters])
 
-      packages = KnownPackages.list()
+      packages = KnownPackages.list(test_opts())
 
       package_names = Enum.map(packages, & &1.package)
       refute "phoenix_kit" in package_names
@@ -89,7 +91,7 @@ defmodule PhoenixKit.KnownPackagesTest do
 
       stub_hex([pkg])
 
-      packages = KnownPackages.list()
+      packages = KnownPackages.list(test_opts())
 
       crm = Enum.find(packages, &(&1.package == "phoenix_kit_crm"))
       assert crm.icon == "hero-puzzle-piece"
@@ -105,10 +107,72 @@ defmodule PhoenixKit.KnownPackagesTest do
 
       stub_hex([pkg])
 
-      packages = KnownPackages.list()
+      packages = KnownPackages.list(test_opts())
 
       support = Enum.find(packages, &(&1.package == "phoenix_kit_customer_support"))
       assert support.name == "Customer Support"
+    end
+  end
+
+  describe "entry shape (backward-compat fields)" do
+    setup do
+      stub_hex([@hex_newsletters])
+      :ok
+    end
+
+    test "module field uses heuristic" do
+      [pkg] = KnownPackages.list(test_opts())
+      assert pkg.module == :"Elixir.PhoenixKitNewsletters"
+    end
+
+    test "hex_package equals package" do
+      [pkg] = KnownPackages.list(test_opts())
+      assert pkg.hex_package == pkg.package
+    end
+
+    test "github_url falls back to BeamLabEU/{package} when Hex meta has no link" do
+      [pkg] = KnownPackages.list(test_opts())
+      assert pkg.github_url == "https://github.com/BeamLabEU/phoenix_kit_newsletters"
+    end
+
+    test "github_url respects Hex meta.links.GitHub when present" do
+      pkg_with_link = %{
+        "name" => "phoenix_kit_with_link",
+        "latest_version" => "0.1.0",
+        "meta" => %{
+          "description" => "Has explicit GitHub link.",
+          "links" => %{"GitHub" => "https://github.com/elsewhere/repo"}
+        }
+      }
+
+      stub_hex([pkg_with_link])
+      KnownPackages.clear_cache()
+
+      [pkg] = KnownPackages.list(test_opts())
+      assert pkg.github_url == "https://github.com/elsewhere/repo"
+    end
+
+    test "latest_version pulled from Hex meta" do
+      [pkg] = KnownPackages.list(test_opts())
+      assert pkg.latest_version == "0.3.1"
+    end
+
+    test "all 11 keys present" do
+      [pkg] = KnownPackages.list(test_opts())
+
+      assert Enum.sort(Map.keys(pkg)) == [
+               :description,
+               :github_url,
+               :hex_package,
+               :hex_url,
+               :icon,
+               :key,
+               :latest_version,
+               :module,
+               :name,
+               :package,
+               :source
+             ]
     end
   end
 
@@ -124,8 +188,8 @@ defmodule PhoenixKit.KnownPackagesTest do
         |> Plug.Conn.send_resp(200, Jason.encode!([@hex_newsletters]))
       end)
 
-      KnownPackages.list()
-      KnownPackages.list()
+      KnownPackages.list(test_opts())
+      KnownPackages.list(test_opts())
 
       assert :counters.get(call_count, 1) == 1
     end
@@ -141,9 +205,9 @@ defmodule PhoenixKit.KnownPackagesTest do
         |> Plug.Conn.send_resp(200, Jason.encode!([@hex_newsletters]))
       end)
 
-      KnownPackages.list()
+      KnownPackages.list(test_opts())
       KnownPackages.clear_cache()
-      KnownPackages.list()
+      KnownPackages.list(test_opts())
 
       assert :counters.get(call_count, 1) == 2
     end
@@ -157,7 +221,7 @@ defmodule PhoenixKit.KnownPackagesTest do
 
       log =
         capture_log(fn ->
-          result = KnownPackages.list()
+          result = KnownPackages.list(test_opts())
           refute Enum.any?(result, &(&1.source == "hex"))
         end)
 
@@ -171,11 +235,73 @@ defmodule PhoenixKit.KnownPackagesTest do
 
       log =
         capture_log(fn ->
-          result = KnownPackages.list()
+          result = KnownPackages.list(test_opts())
           assert is_list(result)
         end)
 
       assert log =~ "Hex fetch failed"
+    end
+
+    test "Hex 200 with non-list body returns no Hex-sourced entries" do
+      Req.Test.stub(@stub_name, fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(%{"unexpected" => "shape"}))
+      end)
+
+      log =
+        capture_log(fn ->
+          result = KnownPackages.list(test_opts())
+          refute Enum.any?(result, &(&1.source == "hex"))
+        end)
+
+      assert log =~ "Hex fetch failed"
+    end
+  end
+
+  describe "stale cache (stale-while-revalidate with cap)" do
+    test "stale data is served on Hex failure when within max stale age" do
+      # First successful fetch populates cache.
+      stub_hex([@hex_newsletters])
+      assert [_pkg] = KnownPackages.list(test_opts(ttl_ms: 0))
+
+      # Now Hex starts failing.
+      Req.Test.stub(@stub_name, fn conn ->
+        Plug.Conn.send_resp(conn, 500, "Internal Server Error")
+      end)
+
+      log =
+        capture_log(fn ->
+          # ttl=0 forces refetch on every call; max_stale_age large so stale wins.
+          result =
+            KnownPackages.list(test_opts(ttl_ms: 0, max_stale_age_ms: :timer.hours(1)))
+
+          newsletters = Enum.find(result, &(&1.package == "phoenix_kit_newsletters"))
+          assert newsletters != nil
+          assert newsletters.source == "hex"
+        end)
+
+      assert log =~ "serving stale data"
+    end
+
+    test "stale data is dropped beyond max stale age" do
+      stub_hex([@hex_newsletters])
+      assert [_pkg] = KnownPackages.list(test_opts(ttl_ms: 0))
+
+      Req.Test.stub(@stub_name, fn conn ->
+        Plug.Conn.send_resp(conn, 500, "Internal Server Error")
+      end)
+
+      :timer.sleep(20)
+
+      log =
+        capture_log(fn ->
+          result = KnownPackages.list(test_opts(ttl_ms: 0, max_stale_age_ms: 10))
+
+          refute Enum.any?(result, &(&1.source == "hex"))
+        end)
+
+      assert log =~ "exceeds max stale age"
     end
   end
 
@@ -209,7 +335,7 @@ defmodule PhoenixKit.KnownPackagesTest do
         |> Plug.Conn.send_resp(200, Jason.encode!(packages))
       end)
 
-      packages = KnownPackages.list()
+      packages = KnownPackages.list(test_opts())
 
       package_names = Enum.map(packages, & &1.package)
       assert "phoenix_kit_newsletters" in package_names
@@ -232,12 +358,17 @@ defmodule PhoenixKit.KnownPackagesTest do
 
       stub_hex([])
 
-      packages = KnownPackages.list()
+      packages = KnownPackages.list(test_opts())
 
       billing = Enum.find(packages, &(&1.package == "my_app_billing"))
       assert billing != nil
       assert billing.source == "config"
       assert billing.name == "Private Billing"
+      # Back-compat fields filled with sane defaults for config entries.
+      assert billing.hex_package == "my_app_billing"
+      assert billing.module == nil
+      assert billing.github_url == nil
+      assert billing.latest_version == nil
     end
 
     test "config entry wins over Hex entry with same package" do
@@ -254,7 +385,7 @@ defmodule PhoenixKit.KnownPackagesTest do
 
       stub_hex([@hex_newsletters])
 
-      packages = KnownPackages.list()
+      packages = KnownPackages.list(test_opts())
 
       newsletters_entries = Enum.filter(packages, &(&1.package == "phoenix_kit_newsletters"))
       assert length(newsletters_entries) == 1

--- a/test/phoenix_kit/known_packages_test.exs
+++ b/test/phoenix_kit/known_packages_test.exs
@@ -1,0 +1,265 @@
+defmodule PhoenixKit.KnownPackagesTest do
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  alias PhoenixKit.KnownPackages
+
+  @stub_name :"PhoenixKit.KnownPackagesTest.Stub"
+
+  @hex_newsletters %{
+    "name" => "phoenix_kit_newsletters",
+    "latest_version" => "0.3.1",
+    "meta" => %{
+      "description" => "Email newsletters. hex_docs_icon_name: hero-newspaper"
+    }
+  }
+
+  @hex_posts %{
+    "name" => "phoenix_kit_posts",
+    "latest_version" => "0.2.0",
+    "meta" => %{"description" => "Blog posts and tags. hex_docs_icon_name: hero-pencil-square"}
+  }
+
+  @hex_phoenix_kit %{
+    "name" => "phoenix_kit",
+    "latest_version" => "1.7.0",
+    "meta" => %{"description" => "The core library."}
+  }
+
+  setup do
+    KnownPackages.clear_cache()
+    original_extras = Application.get_env(:phoenix_kit, :extra_known_packages, [])
+
+    Application.put_env(:phoenix_kit, :_known_packages_req_opts,
+      plug: {Req.Test, @stub_name},
+      receive_timeout: 3000
+    )
+
+    on_exit(fn ->
+      KnownPackages.clear_cache()
+      Application.put_env(:phoenix_kit, :extra_known_packages, original_extras)
+      Application.delete_env(:phoenix_kit, :_known_packages_req_opts)
+    end)
+
+    :ok
+  end
+
+  defp stub_hex(packages) do
+    Req.Test.stub(@stub_name, fn conn ->
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.send_resp(200, Jason.encode!(packages))
+    end)
+  end
+
+  describe "list/0 happy path" do
+    test "returns shaped entries from Hex" do
+      stub_hex([@hex_newsletters, @hex_posts])
+
+      packages = KnownPackages.list()
+
+      assert length(packages) == 2
+
+      newsletters = Enum.find(packages, &(&1.package == "phoenix_kit_newsletters"))
+      assert newsletters.key == "newsletters"
+      assert newsletters.name == "Newsletters"
+      assert newsletters.description == "Email newsletters."
+      assert newsletters.icon == "hero-newspaper"
+      assert newsletters.hex_url == "https://hex.pm/packages/phoenix_kit_newsletters"
+      assert newsletters.source == "hex"
+    end
+
+    test "filters out phoenix_kit core package" do
+      stub_hex([@hex_phoenix_kit, @hex_newsletters])
+
+      packages = KnownPackages.list()
+
+      package_names = Enum.map(packages, & &1.package)
+      refute "phoenix_kit" in package_names
+      assert "phoenix_kit_newsletters" in package_names
+    end
+
+    test "entry without icon marker gets default icon" do
+      pkg = %{
+        "name" => "phoenix_kit_crm",
+        "latest_version" => "0.1.0",
+        "meta" => %{"description" => "CRM module without marker"}
+      }
+
+      stub_hex([pkg])
+
+      packages = KnownPackages.list()
+
+      crm = Enum.find(packages, &(&1.package == "phoenix_kit_crm"))
+      assert crm.icon == "hero-puzzle-piece"
+      assert crm.description == "CRM module without marker"
+    end
+
+    test "humanizes multi-word package key" do
+      pkg = %{
+        "name" => "phoenix_kit_customer_support",
+        "latest_version" => "0.1.0",
+        "meta" => %{"description" => "Customer support tools."}
+      }
+
+      stub_hex([pkg])
+
+      packages = KnownPackages.list()
+
+      support = Enum.find(packages, &(&1.package == "phoenix_kit_customer_support"))
+      assert support.name == "Customer Support"
+    end
+  end
+
+  describe "caching" do
+    test "second call does not re-hit Hex (cache hit)" do
+      call_count = :counters.new(1, [])
+
+      Req.Test.stub(@stub_name, fn conn ->
+        :counters.add(call_count, 1, 1)
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!([@hex_newsletters]))
+      end)
+
+      KnownPackages.list()
+      KnownPackages.list()
+
+      assert :counters.get(call_count, 1) == 1
+    end
+
+    test "after clear_cache/0 a new fetch happens" do
+      call_count = :counters.new(1, [])
+
+      Req.Test.stub(@stub_name, fn conn ->
+        :counters.add(call_count, 1, 1)
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!([@hex_newsletters]))
+      end)
+
+      KnownPackages.list()
+      KnownPackages.clear_cache()
+      KnownPackages.list()
+
+      assert :counters.get(call_count, 1) == 2
+    end
+  end
+
+  describe "Hex failure handling" do
+    test "Hex 500 returns no Hex-sourced entries with Logger.warning" do
+      Req.Test.stub(@stub_name, fn conn ->
+        Plug.Conn.send_resp(conn, 500, "Internal Server Error")
+      end)
+
+      log =
+        capture_log(fn ->
+          result = KnownPackages.list()
+          refute Enum.any?(result, &(&1.source == "hex"))
+        end)
+
+      assert log =~ "Hex fetch failed"
+    end
+
+    test "Hex transport error returns list with Logger.warning" do
+      Req.Test.stub(@stub_name, fn _conn ->
+        raise "connection refused"
+      end)
+
+      log =
+        capture_log(fn ->
+          result = KnownPackages.list()
+          assert is_list(result)
+        end)
+
+      assert log =~ "Hex fetch failed"
+    end
+  end
+
+  describe "pagination" do
+    test "fetches multiple pages via Link header" do
+      page2_pkg = %{
+        "name" => "phoenix_kit_crm",
+        "latest_version" => "0.1.0",
+        "meta" => %{"description" => "CRM module."}
+      }
+
+      page2_url = "https://hex.pm/api/packages?search=phoenix_kit_&sort=name&page=2"
+
+      Req.Test.stub(@stub_name, fn conn ->
+        {packages, add_link} =
+          if String.contains?(conn.request_path <> "?" <> (conn.query_string || ""), "page=2") do
+            {[page2_pkg], false}
+          else
+            {[@hex_newsletters], true}
+          end
+
+        conn =
+          if add_link do
+            Plug.Conn.put_resp_header(conn, "link", "<#{page2_url}>; rel=\"next\"")
+          else
+            conn
+          end
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(packages))
+      end)
+
+      packages = KnownPackages.list()
+
+      package_names = Enum.map(packages, & &1.package)
+      assert "phoenix_kit_newsletters" in package_names
+      assert "phoenix_kit_crm" in package_names
+    end
+  end
+
+  describe "extra_known_packages config" do
+    test "valid config entries appear in result" do
+      Application.put_env(:phoenix_kit, :extra_known_packages, [
+        %{
+          key: "private_billing",
+          package: "my_app_billing",
+          name: "Private Billing",
+          description: "Internal billing module",
+          icon: "hero-credit-card",
+          hex_url: "https://hex.pm/packages/my_app_billing"
+        }
+      ])
+
+      stub_hex([])
+
+      packages = KnownPackages.list()
+
+      billing = Enum.find(packages, &(&1.package == "my_app_billing"))
+      assert billing != nil
+      assert billing.source == "config"
+      assert billing.name == "Private Billing"
+    end
+
+    test "config entry wins over Hex entry with same package" do
+      Application.put_env(:phoenix_kit, :extra_known_packages, [
+        %{
+          key: "newsletters",
+          package: "phoenix_kit_newsletters",
+          name: "Newsletters (custom)",
+          description: "Overridden via config",
+          icon: "hero-star",
+          hex_url: "https://hex.pm/packages/phoenix_kit_newsletters"
+        }
+      ])
+
+      stub_hex([@hex_newsletters])
+
+      packages = KnownPackages.list()
+
+      newsletters_entries = Enum.filter(packages, &(&1.package == "phoenix_kit_newsletters"))
+      assert length(newsletters_entries) == 1
+      assert hd(newsletters_entries).name == "Newsletters (custom)"
+      assert hd(newsletters_entries).source == "config"
+    end
+  end
+end

--- a/test/phoenix_kit/module_registry_test.exs
+++ b/test/phoenix_kit/module_registry_test.exs
@@ -115,6 +115,34 @@ defmodule PhoenixKit.ModuleRegistryTest do
     end
   end
 
+  describe "get_module_key_for_namespace/1" do
+    # Module.create/3 with an explicit top-level name — `defmodule X` inside a
+    # test would get auto-nested under PhoenixKit.ModuleRegistryTest.
+    setup do
+      Module.create(
+        PhoenixKitNamespaceFixture,
+        quote do
+          def module_key, do: "namespace_fixture"
+        end,
+        Macro.Env.location(__ENV__)
+      )
+
+      :ok
+    end
+
+    test "resolves a registered module's top-level namespace to its key" do
+      ModuleRegistry.register(PhoenixKitNamespaceFixture)
+      on_exit(fn -> ModuleRegistry.unregister(PhoenixKitNamespaceFixture) end)
+
+      assert ModuleRegistry.get_module_key_for_namespace("PhoenixKitNamespaceFixture") ==
+               "namespace_fixture"
+    end
+
+    test "returns nil for an unknown namespace" do
+      assert ModuleRegistry.get_module_key_for_namespace("NotARegisteredModule") == nil
+    end
+  end
+
   describe "all_admin_tabs/0" do
     test "returns a list of Tab structs" do
       tabs = ModuleRegistry.all_admin_tabs()
@@ -330,6 +358,43 @@ defmodule PhoenixKit.ModuleRegistryTest do
       # path directly via the public function on an empty list. The
       # public function never raises — that's the contract.
       assert is_map(ModuleRegistry.run_all_legacy_migrations())
+    end
+  end
+
+  describe "known_external_packages/0" do
+    test "delegates to KnownPackages.list/0 and returns a list" do
+      # This function now fetches live from Hex.pm (or cache).
+      # We test contract shape here; detailed behavior is in known_packages_test.exs.
+      packages = ModuleRegistry.known_external_packages()
+      assert is_list(packages)
+    end
+  end
+
+  describe "not_installed_packages/0" do
+    test "returns a list of maps" do
+      not_installed = ModuleRegistry.not_installed_packages()
+      assert is_list(not_installed)
+    end
+
+    test "every entry has required fields" do
+      for pkg <- ModuleRegistry.not_installed_packages() do
+        assert is_binary(pkg.package)
+        assert is_binary(pkg.name)
+        assert is_binary(pkg.key)
+      end
+    end
+
+    test "does not include packages whose OTP app is loaded" do
+      not_installed = ModuleRegistry.not_installed_packages()
+
+      loaded_otp_apps =
+        :application.loaded_applications()
+        |> MapSet.new(fn {name, _desc, _vsn} -> Atom.to_string(name) end)
+
+      for pkg <- not_installed do
+        refute MapSet.member?(loaded_otp_apps, pkg.package),
+               "#{pkg.package} is an active OTP app but appeared in not_installed_packages"
+      end
     end
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -7,20 +7,25 @@ db_name =
   Application.get_env(:phoenix_kit, PhoenixKit.Test.Repo)[:database] || "phoenix_kit_test"
 
 db_check =
-  case System.cmd("psql", ["-lqt"], stderr_to_stdout: true) do
-    {output, 0} ->
-      exists =
-        output
-        |> String.split("\n")
-        |> Enum.any?(fn line ->
-          line |> String.split("|") |> List.first("") |> String.trim() == db_name
-        end)
+  try do
+    case System.cmd("psql", ["-lqt"], stderr_to_stdout: true) do
+      {output, 0} ->
+        exists =
+          output
+          |> String.split("\n")
+          |> Enum.any?(fn line ->
+            line |> String.split("|") |> List.first("") |> String.trim() == db_name
+          end)
 
-      if exists, do: :exists, else: :not_found
+        if exists, do: :exists, else: :not_found
 
-    _ ->
-      # psql not available (CI without postgresql-client) — try connecting directly
-      :try_connect
+      _ ->
+        # psql not available (CI without postgresql-client) — try connecting directly
+        :try_connect
+    end
+  rescue
+    # psql binary not found on this system — try connecting directly
+    ErlangError -> :try_connect
   end
 
 repo_available =


### PR DESCRIPTION
## Summary

Replaces the hardcoded list of known external PhoenixKit packages in `ModuleRegistry.known_external_packages/0` with a live Hex.pm fetch in a new `PhoenixKit.KnownPackages` module, cached in `:persistent_term` for 10 minutes. The list now reflects whatever is actually published under the `phoenix_kit_*` prefix on Hex.

## Architecture

- Live fetch from Hex.pm with `Link`-header pagination, filtered to `phoenix_kit_*` packages (skipping `phoenix_kit` itself).
- 10-min in-memory cache via `:persistent_term`, hardcoded as a module attribute (no per-app retuning needed for an admin page).
- On Hex unreachable: returns stale cached data when available (stale-while-revalidate), otherwise extras-only with `Logger.warning`.
- No negative cache, no per-call config knobs, no validation of parent-app config: malformed extras crash loudly on use, which is louder and more honest than silently dropping entries with a log line.

## Convention introduced

Module authors opt into a custom catalog icon by appending `hex_docs_icon_name: hero-<name>` to their package description on Hex. The marker is stripped from the displayed text and the icon name is used in the catalog UI. Default: `hero-puzzle-piece`.

## Parent-app override

```elixir
config :phoenix_kit,
  extra_known_packages: [
    %{
      key: "private_billing",
      package: "my_app_private_billing",
      name: "Private Billing",
      description: "Internal billing fork",
      icon: "hero-credit-card",
      hex_url: nil
    }
  ]
```

Records get `source: "config"` automatically and win over Hex entries with the same package on dedup.

## Catalog entry shape

```elixir
%{key, package, name, description, icon, hex_url, source}
```

Removed from the previous shape: `module:` (atom — UI never used it), `hex_package:` (renamed to `package:`), `github_url:`, `latest_version:`. No in-repo callers of the removed fields remain.

## Test plan

- [x] `mix format --check-formatted` clean
- [x] `mix credo --strict` clean
- [x] `mix dialyzer` clean
- [x] 11 tests in `known_packages_test.exs` (happy path, cache hit, cache clear, Hex 500, transport error, pagination, extras config valid + wins-over-Hex)
- [x] `module_registry_test.exs` regression suite for `not_installed_packages/0`
- [x] Live verified on a parent app: `list/0` returns ~20 packages from Hex (more than the previous hardcoded 14); `not_installed_packages/0` filters installed deps correctly
