### PR TITLE
Add publishing routing-strategy shim to phoenix_kit_routes/0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -654,6 +654,45 @@ config :phoenix_kit,
   route_modules: [PhoenixKitEntities.Routes]
 ```
 
+### Publishing routing strategy
+
+`phoenix_kit_routes/0` emits a publishing-specific dispatch shim when
+`PhoenixKitPublishing.RouterDispatch` is loaded. The shim exists because
+publishing's `/:language/:group/*path` catch-all matches every two-or-
+more-segment URL and Phoenix has no fall-through after a route matches —
+so any host route declared after `phoenix_kit_routes()` shaped
+`/:locale/<literal>/...` was silently shadowed (`/fr/services/view/foo`
+hitting publishing's 404 instead of the host's `ServicesLive`).
+
+Three pieces, all emitted by `compile_publishing_routing/1` in
+`integration.ex`:
+
+1. An internal scope at `/<url_prefix>/__phoenix_kit_publishing_dispatch`
+   that registers publishing's catch-all under the standard `:browser` +
+   `:phoenix_kit_*` pipelines, plus a `:phoenix_kit_publishing_internal`
+   pipeline that runs `PhoenixKitPublishing.RouterDispatch.restore_path/2`.
+2. A `def call/2` override on the host router (Phoenix.Router publishes
+   `defoverridable init: 1, call: 2` from `match_dispatch/0`). The
+   override calls `RouterDispatch.maybe_rewrite/1`; on cache hit it
+   prepends the internal prefix to `path_info` + `request_path` and stashes
+   the originals in `conn.private`, then `super(conn, opts)` runs Phoenix's
+   matcher against the internal-prefix scope. On miss, the conn passes
+   through unchanged so host routes win.
+3. `restore_path/2` un-rewrites the conn after the route binds but before
+   the controller runs, so canonical-URL generation reads the URL the
+   client sent — without it, publishing's `default_language_no_prefix`
+   redirect spins on the internal prefix forever.
+
+Compile-time gated on `Code.ensure_loaded?(PhoenixKitPublishing.RouterDispatch)`:
+installs without publishing in the dep tree get an empty AST. **`mix
+phx.routes` shows publishing routes under the internal prefix**, not at
+the user-facing URL — known blind spot, surface in support docs.
+
+The mechanism generalizes to any future module with a similar dynamic
+catch-all problem. For now it's hardcoded to publishing per the
+"don't generalize prematurely" principle; lift to a registry shape
+when a second module needs it.
+
 
 ## TODOs
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -668,9 +668,14 @@ Three pieces, all emitted by `compile_publishing_routing/1` in
 `integration.ex`:
 
 1. An internal scope at `/<url_prefix>/__phoenix_kit_publishing_dispatch`
-   that registers publishing's catch-all under the standard `:browser` +
-   `:phoenix_kit_*` pipelines, plus a `:phoenix_kit_publishing_internal`
-   pipeline that runs `PhoenixKitPublishing.RouterDispatch.restore_path/2`.
+   with two sub-scopes — `/localized` (binds `:language` + `:group`) and
+   `/root` (binds `:group` only). Without the discriminator, both forms
+   match a 2-segment internal path and Phoenix's first-match-wins picks
+   the wrong one; the override picks the right sub-scope based on which
+   segment resolved to a known group. Both sub-scopes use the standard
+   `:browser` + `:phoenix_kit_*` pipelines plus a
+   `:phoenix_kit_publishing_internal` pipeline that runs
+   `PhoenixKitPublishing.RouterDispatch.restore_path/2`.
 2. A `def call/2` override on the host router (Phoenix.Router publishes
    `defoverridable init: 1, call: 2` from `match_dispatch/0`). The
    override calls `RouterDispatch.maybe_rewrite/1`; on cache hit it

--- a/lib/phoenix_kit_web/integration.ex
+++ b/lib/phoenix_kit_web/integration.ex
@@ -1152,6 +1152,21 @@ defmodule PhoenixKitWeb.Integration do
     # Auto-discovered public routes from external PhoenixKit modules
     module_public_routes = compile_module_public_routes(url_prefix)
 
+    # Publishing routing-strategy integration. When the publishing module
+    # (with its `RouterDispatch` helper) is in the dep tree, emit:
+    #
+    #   * the internal-prefix scope (`/__phoenix_kit_publishing_dispatch/...`)
+    #     under which publishing's catch-all routes are registered
+    #   * a `def call/2` override that path-rewrites publishing-bound URLs
+    #     into that prefix so Phoenix's matcher dispatches via the standard
+    #     pipeline (sessions, CSRF, locale, scope) and host routes still
+    #     win for URLs that don't resolve to a known publishing group.
+    #
+    # See `PhoenixKitPublishing.RouterDispatch` for the full mechanism
+    # (`maybe_rewrite/1`, `restore_path/2`, the `defoverridable call/2`
+    # extension point on Phoenix.Router).
+    publishing_routing = compile_publishing_routing(url_prefix)
+
     # Snapshot discovered modules so the host router auto-recompiles when deps change
     current_hash = PhoenixKit.ModuleDiscovery.module_hash()
     mix_lock_path = Path.expand("mix.lock")
@@ -1184,6 +1199,69 @@ defmodule PhoenixKitWeb.Integration do
 
       # External route modules with public routes
       unquote_splicing(external_public_routes)
+
+      # Publishing internal-prefix scope + call/2 override (when publishing is installed)
+      unquote(publishing_routing)
+    end
+  end
+
+  # Build the publishing routing-strategy AST. Returns `quote do end` (no-op)
+  # when publishing is not installed, so the macro stays a single-shape
+  # expansion without compile-time conditionals leaking into the host module.
+  #
+  # `apply/3` is the idiomatic dodge for the compile-time "undefined function"
+  # warning when calling into an optional dep — the `Code.ensure_loaded?/1`
+  # guard above is the runtime correctness check; `apply/3` shields the
+  # compiler's static-resolution pass. Drop both once publishing becomes a
+  # required dep (it isn't, by design — installs without publishing should
+  # compile without it on the system).
+  @doc false
+  defp compile_publishing_routing(url_prefix) do
+    if Code.ensure_loaded?(PhoenixKitPublishing.RouterDispatch) do
+      internal_prefix = apply(PhoenixKitPublishing.RouterDispatch, :internal_prefix, [])
+
+      internal_scope_path =
+        case url_prefix do
+          "/" -> "/" <> internal_prefix
+          prefix -> prefix <> "/" <> internal_prefix
+        end
+
+      quote do
+        pipeline :phoenix_kit_publishing_internal do
+          plug PhoenixKitPublishing.RouterDispatch, :restore_path
+        end
+
+        scope unquote(internal_scope_path), PhoenixKit.Modules.Publishing.Web do
+          pipe_through [
+            :browser,
+            :phoenix_kit_auto_setup,
+            :phoenix_kit_locale_validation,
+            :phoenix_kit_optional_scope,
+            :phoenix_kit_publishing_internal
+          ]
+
+          get "/:language/:group", Controller, :show
+          get "/:language/:group/*path", Controller, :show
+          get "/:group", Controller, :show
+          get "/:group/*path", Controller, :show
+        end
+
+        # Override Phoenix.Router's call/2 (defoverridable from `use Phoenix.Router`).
+        # Path-rewrites publishing-bound URLs before super() runs the matcher.
+        # See PhoenixKitPublishing.RouterDispatch for the rationale.
+        def call(conn, opts) do
+          conn =
+            case PhoenixKitPublishing.RouterDispatch.maybe_rewrite(conn) do
+              {:rewrite, rewritten} -> rewritten
+              :pass -> conn
+            end
+
+          super(conn, opts)
+        end
+      end
+    else
+      quote do
+      end
     end
   end
 

--- a/lib/phoenix_kit_web/integration.ex
+++ b/lib/phoenix_kit_web/integration.ex
@@ -1219,12 +1219,17 @@ defmodule PhoenixKitWeb.Integration do
   defp compile_publishing_routing(url_prefix) do
     if Code.ensure_loaded?(PhoenixKitPublishing.RouterDispatch) do
       internal_prefix = apply(PhoenixKitPublishing.RouterDispatch, :internal_prefix, [])
+      localized_segment = apply(PhoenixKitPublishing.RouterDispatch, :localized_segment, [])
+      root_segment = apply(PhoenixKitPublishing.RouterDispatch, :root_segment, [])
 
       internal_scope_path =
         case url_prefix do
           "/" -> "/" <> internal_prefix
           prefix -> prefix <> "/" <> internal_prefix
         end
+
+      localized_sub = "/" <> localized_segment
+      root_sub = "/" <> root_segment
 
       quote do
         pipeline :phoenix_kit_publishing_internal do
@@ -1240,10 +1245,21 @@ defmodule PhoenixKitWeb.Integration do
             :phoenix_kit_publishing_internal
           ]
 
-          get "/:language/:group", Controller, :show
-          get "/:language/:group/*path", Controller, :show
-          get "/:group", Controller, :show
-          get "/:group/*path", Controller, :show
+          # Localized form — URL had a leading locale; bind :language + :group.
+          scope unquote(localized_sub) do
+            get "/:language/:group", Controller, :show
+            get "/:language/:group/*path", Controller, :show
+          end
+
+          # Non-localized form — URL had no leading locale; bind :group only.
+          # Without this discriminator scope, the localized routes above would
+          # also match a 2-segment internal path (Phoenix first-match-wins),
+          # binding `language=<group-slug>` and `group=<post-slug>` — which
+          # then 404s in the controller because the post slug isn't a group.
+          scope unquote(root_sub) do
+            get "/:group", Controller, :show
+            get "/:group/*path", Controller, :show
+          end
         end
 
         # Override Phoenix.Router's call/2 (defoverridable from `use Phoenix.Router`).


### PR DESCRIPTION
## Summary

Pairs with `BeamLabEU/phoenix_kit_publishing#14`.

`phoenix_kit_routes/0` now emits a publishing-specific dispatch shim
when `PhoenixKitPublishing.RouterDispatch` is loaded:

* an internal-prefix scope at
  `/<url_prefix>/__phoenix_kit_publishing_dispatch` with two sub-scopes
  (`/localized` binding `:language` + `:group`, `/root` binding
  `:group` only), each piped through the standard `:browser` +
  `:phoenix_kit_*` pipelines plus a new `:phoenix_kit_publishing_internal`
  pipeline that runs `RouterDispatch.restore_path/2`;
* a `def call/2` override on the host router (Phoenix.Router publishes
  `defoverridable init: 1, call: 2` from `match_dispatch/0` — a
  documented extension point) that calls `RouterDispatch.maybe_rewrite/1`
  before `super(conn, opts)`. Publishing-bound URLs get path-rewritten
  onto the internal prefix and dispatched via Phoenix's normal
  pipeline; URLs that don't resolve to a known publishing group pass
  through unchanged so host routes win Phoenix's first-match.

Compile-time gated on
`Code.ensure_loaded?(PhoenixKitPublishing.RouterDispatch)`. Installs
that don't have publishing in the dep tree get an empty AST — no
behaviour change.

### Why

Publishing's old `Routes.public_routes/1` registered
`/:language/:group(/*path)` and `/:group(/*path)` directly under the
host's URL prefix. Under `url_prefix: "/"` those routes match every
two-or-more-segment URL, and Phoenix.Router has no per-segment regex
constraint mechanism — so any host route declared after
`phoenix_kit_routes()` shaped `/:locale/<literal>/...` was silently
shadowed: publishing's controller matched first, didn't find the
group, returned 404. Canary host's
`/fr/services/view/nos-services-a-nice` (and three other
`/:locale/services/...` routes) were dead this way after they
installed `phoenix_kit_legal` (which transitively pulls publishing).

The dispatch shim flips the trust direction. Publishing's catch-all
no longer sits at the host's absolute root claiming everything;
instead the override checks each request against the listing-cache /
DB and rewrites only when the URL belongs to a known publishing
group. Host routes get a fair shot at every URL.

See `BeamLabEU/phoenix_kit_publishing#14` for the matching
`PhoenixKitPublishing.RouterDispatch` module, the policy details
(`maybe_rewrite/1`, `restore_path/2`, the `defoverridable` edge case
for hosts with their own `def call/2`), and the 19-test pinning suite.

## Coordination notice

This change is conditional on `PhoenixKitPublishing.RouterDispatch`
being present, so:

* Hosts running this core change with an older publishing version (no
  `RouterDispatch` module) — `Code.ensure_loaded?` returns false, the
  helper emits no-op AST, publishing's old `Routes.public_routes/1`
  still registers the catch-all as before. **Behaviour unchanged.**
* Hosts running this core change with the new publishing version
  (`RouterDispatch` present, `Routes.public_routes/1` returns no-op) —
  the macro emits the override + internal scope. **Bug fixed.**
* Hosts running the new publishing version with an older core (no
  macro change) — publishing's `Routes.public_routes/1` no longer
  registers the catch-all and the override isn't emitted, so
  publishing public URLs return Phoenix `NoRouteError`.
  **Regression for them** — so the publishing PR shouldn't ship to
  Hex without this core release also being out.

Both versions need to ship together (or core ships first, then
publishing). The publishing PR description flags the same constraint
in the other direction.

## Verification

```
mix format --check-formatted   # clean
mix credo --strict             # clean (one nit fixed during the sweep)
mix test                       # 1055 tests, 4 failures (all pre-existing — V107
                                 migration tests + a permissions test, unrelated
                                 to this change; verified by stashing the diff
                                 and re-running)
```

Browser smoke (workbench `phoenix_kit_parent` setup with the canary
collision shape — `url_prefix: "/"` + `/:locale` scope after
`phoenix_kit_routes()`):

| URL | Result |
|-----|--------|
| `/en/services/view/test-slug` | 200 — host's ServicesLive (was 404 pre-fix) |
| `/fr/services/view/x` | 200 — multi-locale |
| `/en/db-test-1/markdown-rendering-demo` | 200 → canonical `/db-test-1/...`, body shows post |
| `/db-test-1/markdown-rendering-demo` | 200 — canonical works directly |
| `/ku-ku/the-new-post` | 302 — group listing fallback (regex-collision regression closed) |
| `/admin/dashboard` | 302 → log-in (admin still routes) |
| `/` | 200 — host home |
| `/some-unknown-route` | 404 — genuine Phoenix NoRoute, not publishing's smart-fallback |

`document.documentElement.outerHTML.includes('__phoenix_kit_publishing_dispatch')`
returned `false` on every rendered publishing page checked. Zero leakage
of the internal prefix or either discriminator segment in canonical, og,
links, JS, headers.

Canary install (separate host, four-locale config, three publishing
groups including `ku-ku` slug-mode) verified the same matrix
end-to-end + session/CSRF + view-source — all green after both
commits land.

## Test plan

- [x] `mix precommit` clean
- [x] All publishing test suite (1018 tests, 0 failures) passes against the new macro shape via the matching publishing PR
- [x] Browser smoke covers the eight URL classes in the matrix above
- [x] HTML body sweep for prefix / `localized` / `root` segment leakage — 0 occurrences
- [x] Canary install pins both branches via git deps and re-ran the full matrix — all green
- [x] Pre-existing 4 test failures verified unrelated by stash-and-rerun

## Files

- `lib/phoenix_kit_web/integration.ex` (+94 lines: `compile_publishing_routing/1` private helper + splice point in `phoenix_kit_routes/0`)
- `AGENTS.md` (+44 lines: "Publishing routing strategy" section under "External module route discovery")