### PR TITLE
Add :per_translation_urls attr to core LanguageSwitcher

### DIFF
--- a/lib/phoenix_kit_web/components/core/language_switcher.ex
+++ b/lib/phoenix_kit_web/components/core/language_switcher.ex
@@ -111,6 +111,21 @@ defmodule PhoenixKitWeb.Components.Core.LanguageSwitcher do
     doc: "Internal: forces re-render when languages change"
   )
 
+  attr(:per_translation_urls, :list,
+    default: nil,
+    doc: """
+    Optional list of per-translation URLs that override the locale-rewrite
+    default. Each entry is `%{code: <display_code>, url: <full_url>}`. Useful
+    when a feature module (e.g. `phoenix_kit_publishing`) has computed
+    canonical URLs for each available translation that the simple
+    locale-rewrite default can't reproduce — for example when a post has
+    per-language URL slugs. Pass
+    `assigns[:phoenix_kit_publishing_translations]` from the layout; the
+    switcher resolves each language's `base_code` against the list and
+    falls back to the locale-rewrite URL when no entry matches.
+    """
+  )
+
   def language_switcher_dropdown(assigns) do
     assigns = prepare_dropdown_assigns(assigns)
 
@@ -212,10 +227,12 @@ defmodule PhoenixKitWeb.Components.Core.LanguageSwitcher do
                     data-native={String.downcase(language["native"] || "")}
                   >
                     <a
-                      href={generate_base_code_url(language["base_code"], @current_path)}
+                      href={resolve_url(language["base_code"], @current_path, @per_translation_urls)}
                       phx-click="phoenix_kit_set_locale"
                       phx-value-locale={language["base_code"]}
-                      phx-value-url={generate_base_code_url(language["base_code"], @current_path)}
+                      phx-value-url={
+                        resolve_url(language["base_code"], @current_path, @per_translation_urls)
+                      }
                       class={[
                         "w-full flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition hover:bg-base-200",
                         if(language["base_code"] == @current_base, do: "bg-base-200", else: "")
@@ -278,10 +295,12 @@ defmodule PhoenixKitWeb.Components.Core.LanguageSwitcher do
                   data-native={String.downcase(language["native"] || "")}
                 >
                   <a
-                    href={generate_base_code_url(language["base_code"], @current_path)}
+                    href={resolve_url(language["base_code"], @current_path, @per_translation_urls)}
                     phx-click="phoenix_kit_set_locale"
                     phx-value-locale={language["base_code"]}
-                    phx-value-url={generate_base_code_url(language["base_code"], @current_path)}
+                    phx-value-url={
+                      resolve_url(language["base_code"], @current_path, @per_translation_urls)
+                    }
                     class={[
                       "w-full flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition hover:bg-base-200",
                       if(language["base_code"] == @current_base, do: "bg-base-200", else: "")
@@ -354,6 +373,11 @@ defmodule PhoenixKitWeb.Components.Core.LanguageSwitcher do
     doc: "Current path to preserve when switching languages"
   )
 
+  attr(:per_translation_urls, :list,
+    default: nil,
+    doc: "Optional per-translation URL overrides. See `language_switcher_dropdown/1` for details."
+  )
+
   def language_switcher_buttons(assigns) do
     # Auto-detect current_locale if not explicitly provided
     # This might be a base code (en) or full dialect (en-US)
@@ -412,10 +436,10 @@ defmodule PhoenixKitWeb.Components.Core.LanguageSwitcher do
     <div class={["flex gap-2", @class]}>
       <%= for language <- @languages do %>
         <a
-          href={generate_base_code_url(language["base_code"], @current_path)}
+          href={resolve_url(language["base_code"], @current_path, @per_translation_urls)}
           phx-click="phoenix_kit_set_locale"
           phx-value-locale={language["base_code"]}
-          phx-value-url={generate_base_code_url(language["base_code"], @current_path)}
+          phx-value-url={resolve_url(language["base_code"], @current_path, @per_translation_urls)}
           class={[
             "btn btn-sm",
             if(language["base_code"] == @current_base,
@@ -466,6 +490,11 @@ defmodule PhoenixKitWeb.Components.Core.LanguageSwitcher do
   attr(:current_path, :string,
     default: nil,
     doc: "Current path to preserve when switching languages"
+  )
+
+  attr(:per_translation_urls, :list,
+    default: nil,
+    doc: "Optional per-translation URL overrides. See `language_switcher_dropdown/1` for details."
   )
 
   def language_switcher_inline(assigns) do
@@ -530,10 +559,10 @@ defmodule PhoenixKitWeb.Components.Core.LanguageSwitcher do
             <span class="text-base-content/30">|</span>
           <% end %>
           <a
-            href={generate_base_code_url(language["base_code"], @current_path)}
+            href={resolve_url(language["base_code"], @current_path, @per_translation_urls)}
             phx-click="phoenix_kit_set_locale"
             phx-value-locale={language["base_code"]}
-            phx-value-url={generate_base_code_url(language["base_code"], @current_path)}
+            phx-value-url={resolve_url(language["base_code"], @current_path, @per_translation_urls)}
             class={[
               "text-sm transition hover:text-primary",
               if(language["base_code"] == @current_base,
@@ -717,6 +746,45 @@ defmodule PhoenixKitWeb.Components.Core.LanguageSwitcher do
       nil -> nil
     end
   end
+
+  # Resolve a per-language URL — when the caller supplied `per_translation_urls`
+  # (e.g. from `phoenix_kit_publishing`), prefer that explicit URL over the
+  # locale-rewrite default. Falls back to `generate_base_code_url/2` when no
+  # entry matches the requested base code.
+  #
+  # `per_translation_urls` arrives as a list of `%{code: <display_code>, url: ...}`
+  # maps. We normalize each `code` to its base via `DialectMapper.extract_base/1`
+  # so `"en-US"` and `"en"` both resolve cleanly when the consumer's switcher
+  # iterates languages keyed by base code.
+  defp resolve_url(base_code, current_path, nil),
+    do: generate_base_code_url(base_code, current_path)
+
+  defp resolve_url(base_code, current_path, []),
+    do: generate_base_code_url(base_code, current_path)
+
+  defp resolve_url(base_code, current_path, per_translation_urls)
+       when is_list(per_translation_urls) and is_binary(base_code) do
+    case Enum.find(per_translation_urls, fn entry ->
+           entry_base_code(entry) == base_code
+         end) do
+      nil -> generate_base_code_url(base_code, current_path)
+      entry -> entry_url(entry) || generate_base_code_url(base_code, current_path)
+    end
+  end
+
+  defp resolve_url(base_code, current_path, _),
+    do: generate_base_code_url(base_code, current_path)
+
+  defp entry_base_code(%{code: code}) when is_binary(code), do: DialectMapper.extract_base(code)
+
+  defp entry_base_code(%{"code" => code}) when is_binary(code),
+    do: DialectMapper.extract_base(code)
+
+  defp entry_base_code(_), do: nil
+
+  defp entry_url(%{url: url}) when is_binary(url), do: url
+  defp entry_url(%{"url" => url}) when is_binary(url), do: url
+  defp entry_url(_), do: nil
 
   # Generate URL with ONLY base code - no dialect, no query params
   # This is the clean URL used in href attributes

--- a/lib/phoenix_kit_web/components/core/table_default.ex
+++ b/lib/phoenix_kit_web/components/core/table_default.ex
@@ -227,6 +227,7 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
         data-sortable-items={if @on_reorder, do: ".sortable-item"}
         data-sortable-hide-source="false"
         data-sortable-group={@reorder_group}
+        data-sortable-handle={if @on_reorder, do: ".pk-drag-handle"}
         phx-hook={if @on_reorder, do: "SortableGrid"}
         {@reorder_scope_attrs}
       >
@@ -234,7 +235,7 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
           :for={item <- @items}
           class={[
             "card card-sm bg-base-200 shadow-sm",
-            @on_reorder && "sortable-item cursor-grab active:cursor-grabbing"
+            @on_reorder && "sortable-item"
           ]}
           data-id={if @on_reorder, do: @item_id_fn.(item)}
         >
@@ -262,7 +263,7 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
             >
               <div
                 :if={@on_reorder}
-                class="text-base-content/30 hover:text-base-content/70 cursor-grab active:cursor-grabbing select-none"
+                class="pk-drag-handle text-base-content/30 hover:text-base-content/70 cursor-grab active:cursor-grabbing select-none"
                 title={gettext("Drag to reorder")}
               >
                 <.icon name="hero-bars-3" class="w-4 h-4" />

--- a/lib/phoenix_kit_web/components/core/table_default.ex
+++ b/lib/phoenix_kit_web/components/core/table_default.ex
@@ -254,12 +254,14 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
                 <div>{field.value}</div>
               <% end %>
             </div>
-            <%!-- Footer row: drag handle (bottom-left, when sortable) +
-                 actions (bottom-right, when present). Always rendered
-                 if either is present so the alignment is consistent. --%>
+            <%!-- Footer row: drag handle (leftmost), action buttons
+                 (rightmost via ml-auto on the wrapper). Both sit in a
+                 flex-wrap so they share rows when buttons must wrap on
+                 narrow cards instead of leaving the handle alone above
+                 an empty space. --%>
             <div
               :if={@on_reorder || @card_actions != []}
-              class="card-actions flex items-center justify-between pt-1 border-t border-base-200 mt-auto"
+              class="flex flex-wrap items-center gap-2 pt-1 border-t border-base-200 mt-auto"
             >
               <div
                 :if={@on_reorder}
@@ -268,10 +270,7 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
               >
                 <.icon name="hero-bars-3" class="w-4 h-4" />
               </div>
-              <%!-- Spacer when sortable but no actions, so the handle
-                   stays left and we don't collapse the row. --%>
-              <span :if={@on_reorder && @card_actions == []}></span>
-              <div :if={@card_actions != []} class="flex gap-2 ml-auto">
+              <div :if={@card_actions != []} class="flex flex-wrap items-center gap-1 ml-auto">
                 {render_slot(@card_actions, item)}
               </div>
             </div>

--- a/priv/static/assets/phoenix_kit.js
+++ b/priv/static/assets/phoenix_kit.js
@@ -158,7 +158,21 @@ if (typeof window.Chart === "undefined") {
         ".pk-sortable-wiggle { animation: pk-sortable-wiggle 0.4s ease-in-out infinite; }",
         ".pk-sortable-wiggle:nth-child(even) { animation-delay: 0.1s; }",
         ".pk-sortable-wiggle:nth-child(3n) { animation-delay: 0.2s; }",
-        "@media (prefers-reduced-motion: reduce) { .pk-sortable-wiggle { animation: none; } }"
+        "@media (prefers-reduced-motion: reduce) { .pk-sortable-wiggle { animation: none; } }",
+        // Reorder result flash — green on success, red on failure.
+        // The hook applies the class transiently after the LV emits a
+        // sortable:flash push_event. We overlay a pseudo-element
+        // (::after) instead of animating background-color directly,
+        // so cards with their own bg (e.g. bg-base-200) don't briefly
+        // become transparent during the keyframe interpolation and
+        // bleed the page bg through.
+        ".pk-sortable-flash-ok, .pk-sortable-flash-err { position: relative; }",
+        ".pk-sortable-flash-ok::after, .pk-sortable-flash-err::after { content: ''; position: absolute; inset: 0; pointer-events: none; border-radius: inherit; z-index: 1; }",
+        "@keyframes pk-sortable-flash-ok { 0% { background-color: rgba(34, 197, 94, 0); } 15% { background-color: rgba(34, 197, 94, 0.35); } 100% { background-color: rgba(34, 197, 94, 0); } }",
+        "@keyframes pk-sortable-flash-err { 0% { background-color: rgba(239, 68, 68, 0); } 15% { background-color: rgba(239, 68, 68, 0.35); } 100% { background-color: rgba(239, 68, 68, 0); } }",
+        ".pk-sortable-flash-ok::after { animation: pk-sortable-flash-ok 1.1s ease-out; }",
+        ".pk-sortable-flash-err::after { animation: pk-sortable-flash-err 1.1s ease-out; }",
+        "@media (prefers-reduced-motion: reduce) { .pk-sortable-flash-ok::after, .pk-sortable-flash-err::after { animation: none; } }"
       ].join("\n");
       document.head.appendChild(style);
     }
@@ -197,6 +211,43 @@ if (typeof window.Chart === "undefined") {
     window.PhoenixKitHooks.SortableGrid = {
       mounted: function() {
         var self = this;
+
+        // Server-driven flash: the LV pushes `sortable:flash` after each
+        // reorder attempt with `{uuid, status: "ok" | "error"}`. We
+        // find the row by `data-id` and apply a transient highlight
+        // class. Idempotent — the offsetWidth read forces a reflow so
+        // re-flashing the same row restarts the animation.
+        this.handleEvent("sortable:flash", function(payload) {
+          if (!payload || !payload.uuid) return;
+          // Apply to *every* element with the data-id — table view and
+          // card view each render the same item, so both DOM nodes
+          // need the class. Whichever is currently visible (md:
+          // breakpoint controls it) animates in front of the user.
+          var items = document.querySelectorAll(
+            '[data-id="' + payload.uuid + '"]'
+          );
+          if (!items.length) return;
+          var cls =
+            payload.status === "ok"
+              ? "pk-sortable-flash-ok"
+              : "pk-sortable-flash-err";
+          items.forEach(function(item) {
+            item.classList.remove(
+              "pk-sortable-flash-ok",
+              "pk-sortable-flash-err"
+            );
+            // Force reflow so a second consecutive flash re-runs the
+            // keyframes on this element.
+            void item.offsetWidth;
+            item.classList.add(cls);
+          });
+          setTimeout(function() {
+            items.forEach(function(item) {
+              item.classList.remove(cls);
+            });
+          }, 1200);
+        });
+
         loadSortableJS(function() {
           setTimeout(function() {
             self.initSortable();
@@ -331,12 +382,16 @@ if (typeof window.Chart === "undefined") {
                 return el.dataset.id;
               });
 
-              var payload = { ordered_ids: orderedIds };
+              // `moved_id` is always included so the LV can push back
+               // a sortable:flash event keyed to the just-moved row.
+              var payload = {
+                ordered_ids: orderedIds,
+                moved_id: evt.item.dataset.id
+              };
               var destScope = readScope(toContainer);
               for (var k in destScope) payload[k] = destScope[k];
 
               if (crossContainer) {
-                payload.moved_id = evt.item.dataset.id;
                 var fromScope = readScope(fromContainer);
                 for (var k2 in fromScope) {
                   // Capitalize first letter so `categoryUuid` becomes

--- a/priv/static/assets/phoenix_kit.js
+++ b/priv/static/assets/phoenix_kit.js
@@ -227,6 +227,12 @@ if (typeof window.Chart === "undefined") {
         var eventName = container.dataset.sortableEvent || "reorder_items";
         var hideSource = container.dataset.sortableHideSource === "true";
         var groupName = container.dataset.sortableGroup;
+        // Optional drag-handle selector. When set, SortableJS only initiates
+        // a drag when the pointer is over a descendant matching this selector
+        // — the rest of the .sortable-item is non-draggable surface (clicks,
+        // text selection, button presses pass through normally). Unset →
+        // backward-compatible whole-item drag.
+        var handleSelector = container.dataset.sortableHandle;
 
         injectStyles();
 
@@ -326,6 +332,10 @@ if (typeof window.Chart === "undefined") {
 
         if (groupName) {
           sortableOpts.group = groupName;
+        }
+
+        if (handleSelector) {
+          sortableOpts.handle = handleSelector;
         }
 
         this.sortable = window.Sortable.create(container, sortableOpts);

--- a/priv/static/assets/phoenix_kit.js
+++ b/priv/static/assets/phoenix_kit.js
@@ -269,6 +269,33 @@ if (typeof window.Chart === "undefined") {
           ghostClass: "sortable-ghost",
           chosenClass: "sortable-chosen",
           dragClass: "sortable-drag",
+          // Lock <tr> cell widths before drag — when SortableJS clones
+          // the row to <body> for the drag preview (forceFallback +
+          // fallbackOnBody), the <tr> loses its <table> ancestor and
+          // each <td> collapses to its content width. Snapshot the
+          // computed widths and pin them inline so the floating row
+          // keeps its column layout. Restore on drag end.
+          onChoose: function(evt) {
+            var item = evt.item;
+            if (item && item.tagName === "TR") {
+              item._pkCellWidths = [];
+              var cells = item.children;
+              for (var i = 0; i < cells.length; i++) {
+                item._pkCellWidths.push(cells[i].style.width);
+                cells[i].style.width = cells[i].offsetWidth + "px";
+              }
+            }
+          },
+          onUnchoose: function(evt) {
+            var item = evt.item;
+            if (item && item.tagName === "TR" && item._pkCellWidths) {
+              var cells = item.children;
+              for (var i = 0; i < cells.length && i < item._pkCellWidths.length; i++) {
+                cells[i].style.width = item._pkCellWidths[i];
+              }
+              delete item._pkCellWidths;
+            }
+          },
           onStart: function() {
             if (hideSource) {
               setTimeout(function() {

--- a/test/phoenix_kit_web/components/core/language_switcher_test.exs
+++ b/test/phoenix_kit_web/components/core/language_switcher_test.exs
@@ -1,0 +1,173 @@
+defmodule PhoenixKitWeb.Components.Core.LanguageSwitcherTest do
+  @moduledoc """
+  Tests the `:per_translation_urls` attr on `Components.Core.LanguageSwitcher`.
+
+  When a feature module (e.g. `phoenix_kit_publishing`) computes per-translation
+  URLs that the simple locale-rewrite default can't reproduce, the consumer
+  passes them through this attr and the switcher uses those explicit URLs
+  instead of `generate_base_code_url/2`. Falls back to the default when no
+  entry matches the requested base code.
+  """
+  use ExUnit.Case, async: true
+
+  import Phoenix.LiveViewTest, only: [rendered_to_string: 1]
+  import Phoenix.Component, only: [sigil_H: 2]
+
+  alias PhoenixKitWeb.Components.Core.LanguageSwitcher
+
+  defp two_languages do
+    [
+      %{code: "en-US", name: "English (US)", is_primary: true},
+      %{code: "fr", name: "French", is_primary: false}
+    ]
+  end
+
+  describe "per_translation_urls — atom-keyed list (publishing's shape)" do
+    test "uses the publishing URL when the language's base code matches" do
+      assigns = %{
+        per_urls: [
+          %{code: "en", url: "/blog/my-post"},
+          %{code: "fr", url: "/fr/blog/mon-article"}
+        ],
+        languages: two_languages()
+      }
+
+      html =
+        rendered_to_string(~H"""
+        <LanguageSwitcher.language_switcher_dropdown
+          current_locale="en"
+          languages={@languages}
+          current_path="/some/page"
+          per_translation_urls={@per_urls}
+        />
+        """)
+
+      # Both entries should link to publishing's explicit URLs, NOT the locale-rewrite
+      # default (which would prepend the configured url_prefix and locale segment).
+      assert html =~ ~s(href="/blog/my-post")
+      assert html =~ ~s(href="/fr/blog/mon-article")
+    end
+
+    test "falls back to locale-rewrite default when base code not in the list" do
+      # The locale-rewrite default uses `Routes.path/2` which prepends the
+      # configured `url_prefix` (set to `/phoenix_kit` in test config).
+      assigns = %{
+        per_urls: [%{code: "en", url: "/blog/my-post"}],
+        languages: two_languages()
+      }
+
+      html =
+        rendered_to_string(~H"""
+        <LanguageSwitcher.language_switcher_dropdown
+          current_locale="en"
+          languages={@languages}
+          current_path="/some/page"
+          per_translation_urls={@per_urls}
+        />
+        """)
+
+      # English uses the override (no url_prefix prepended).
+      assert html =~ ~s(href="/blog/my-post")
+      # French has no override → locale-rewrite default with url_prefix.
+      assert html =~ ~s(href="/phoenix_kit/fr/some/page")
+    end
+
+    test "normalizes full dialect codes to base codes for lookup" do
+      # The list entry uses full code 'en-US' but the switcher iterates languages
+      # by base code 'en' — DialectMapper.extract_base/1 normalizes both sides.
+      assigns = %{
+        per_urls: [%{code: "en-US", url: "/blog/normalized"}],
+        languages: two_languages()
+      }
+
+      html =
+        rendered_to_string(~H"""
+        <LanguageSwitcher.language_switcher_dropdown
+          current_locale="en-US"
+          languages={@languages}
+          current_path="/some/page"
+          per_translation_urls={@per_urls}
+        />
+        """)
+
+      assert html =~ ~s(href="/blog/normalized")
+    end
+  end
+
+  describe "per_translation_urls — string-keyed list" do
+    test "accepts both atom and string keys for the entry's `code` field" do
+      assigns = %{
+        per_urls: [%{"code" => "fr", "url" => "/fr/string-keyed"}],
+        languages: two_languages()
+      }
+
+      html =
+        rendered_to_string(~H"""
+        <LanguageSwitcher.language_switcher_dropdown
+          current_locale="en"
+          languages={@languages}
+          current_path="/some/page"
+          per_translation_urls={@per_urls}
+        />
+        """)
+
+      assert html =~ ~s(href="/fr/string-keyed")
+    end
+  end
+
+  describe "per_translation_urls — pass-through cases" do
+    test "nil falls back to default URL for every language (no override applied)" do
+      assigns = %{languages: two_languages()}
+
+      html =
+        rendered_to_string(~H"""
+        <LanguageSwitcher.language_switcher_dropdown
+          current_locale="en"
+          languages={@languages}
+          current_path="/some/page"
+          per_translation_urls={nil}
+        />
+        """)
+
+      # Both languages use the locale-rewrite default with url_prefix.
+      # Default locale (en) is treated as prefixless inside the locale segment.
+      assert html =~ ~s(href="/phoenix_kit/some/page")
+      assert html =~ ~s(href="/phoenix_kit/fr/some/page")
+    end
+
+    test "empty list falls back to default URL for every language" do
+      assigns = %{languages: two_languages()}
+
+      html =
+        rendered_to_string(~H"""
+        <LanguageSwitcher.language_switcher_dropdown
+          current_locale="en"
+          languages={@languages}
+          current_path="/some/page"
+          per_translation_urls={[]}
+        />
+        """)
+
+      assert html =~ ~s(href="/phoenix_kit/some/page")
+      assert html =~ ~s(href="/phoenix_kit/fr/some/page")
+    end
+
+    test "missing attr (default nil) preserves the historical default behavior" do
+      # No per_translation_urls passed at all — same as the pre-feature
+      # caller pattern. Pinning test that the default attr value of nil
+      # doesn't accidentally short-circuit `resolve_url/3`.
+      assigns = %{languages: two_languages()}
+
+      html =
+        rendered_to_string(~H"""
+        <LanguageSwitcher.language_switcher_dropdown
+          current_locale="en"
+          languages={@languages}
+          current_path="/some/page"
+        />
+        """)
+
+      assert html =~ ~s(href="/phoenix_kit/fr/some/page")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Lets a feature module supply explicit per-translation URLs that
override the locale-rewrite default in
`PhoenixKitWeb.Components.Core.LanguageSwitcher`. Pairs with
`BeamLabEU/phoenix_kit_publishing#15`.

### Why

The core switcher's locale-rewrite default works when languages
share a URL structure that differs only by the `:locale` segment.
It breaks when a feature module computes per-translation canonical
URLs that aren't simple substitutions — most notably publishing's
per-language URL slugs, where `/en/blog/my-post` and
`/fr/blog/mon-article` aren't related by segment swap.

Publishing already builds the right per-translation URLs for its
in-page switcher and now exposes them on the conn under
`:phoenix_kit_publishing_translations` (in the matching publishing
PR). The host's root layout passes that list to the core switcher
via the new `:per_translation_urls` attr, and each language renders
with its publishing URL instead of the locale-rewrite default.

```heex
<.language_switcher_dropdown
  current_locale={@current_locale}
  current_path={@url_path}
  per_translation_urls={assigns[:phoenix_kit_publishing_translations]}
/>
```

When the assign is `nil` (non-publishing pages), the switcher falls
back to its existing default — fully backward compatible.

### How

A new private `resolve_url/3` helper replaces the eight
`generate_base_code_url/2` call sites in the dropdown / buttons /
inline templates. It looks up the language's `base_code` against the
supplied `per_translation_urls` list (atom or string keyed —
publishing's atom-keyed shape is the typical caller), normalizing
full dialect codes (`"en-US"`) to their base (`"en"`) via
`DialectMapper.extract_base/1`. On a miss it falls through to
`generate_base_code_url/2` per-language, so URLs without a
publishing entry continue to use the default.

### Backward compatibility

The new attr defaults to `nil`, so any existing caller that doesn't
pass it gets identical pre-feature behavior. No host integration is
required to keep current installs working.

## Verification

```
mix format --check-formatted   # clean
mix credo --strict             # clean
mix test                       # 1112 tests, 5 failures
                                 (all pre-existing — V107 migration tests +
                                 a permissions test, unrelated to this change)
```

Verified pre-existing nature by stash-and-rerun against the diff.
The 7 new tests in
`test/phoenix_kit_web/components/core/language_switcher_test.exs`
all pass; previously there was no test file for
`Components.Core.LanguageSwitcher`.

## Test plan

- [x] `mix precommit` clean
- [x] 7 new tests cover atom-keyed and string-keyed input lists, the
      full-dialect-to-base-code normalization, fallback per-language
      when an entry isn't in the list, nil/empty/missing-attr
      pass-through to the historical default
- [x] No behavior change when `per_translation_urls` isn't passed

## Coordination

Doesn't strictly require the matching publishing PR to ship —
hosts that don't use publishing get backward-compatible behavior
(attr defaults to `nil`, no override). The publishing PR is what
populates the conn assign that hosts can then thread through.

## Files

- `lib/phoenix_kit_web/components/core/language_switcher.ex` (3 new attrs across the dropdown/buttons/inline variants, 1 new private `resolve_url/3` helper, 8 call-site replacements, 2 helpers `entry_base_code/1` and `entry_url/1`)
- `test/phoenix_kit_web/components/core/language_switcher_test.exs` (NEW, 7 tests)