### PR TITLE
Add selected-card indicator to SortableGrid styles

### DIFF
--- a/priv/static/assets/phoenix_kit.js
+++ b/priv/static/assets/phoenix_kit.js
@@ -159,6 +159,13 @@ if (typeof window.Chart === "undefined") {
         ".pk-sortable-wiggle:nth-child(even) { animation-delay: 0.1s; }",
         ".pk-sortable-wiggle:nth-child(3n) { animation-delay: 0.2s; }",
         "@media (prefers-reduced-motion: reduce) { .pk-sortable-wiggle { animation: none; } }",
+        // Selected-card indicator. The `<.table_default>` card view is
+        // opaque to consumers (no per-item selected attr), so we lean
+        // on :has() to paint any sortable card whose internal checkbox
+        // is checked. Stronger than a flat tint: bumped bg + 4px
+        // primary left border mirroring the table row treatment so
+        // selection is unambiguous at a glance.
+        ".sortable-item.card:has(input[type=\"checkbox\"]:checked) { background-color: oklch(var(--p) / 0.15) !important; box-shadow: inset 4px 0 0 0 oklch(var(--p)); }",
         // Reorder result flash — green on success, red on failure.
         // The hook applies the class transiently after the LV emits a
         // sortable:flash push_event. We overlay a pseudo-element


### PR DESCRIPTION
## Summary

- Sortable cards (`<.table_default>` mobile card view, currently the catalogue items list) now paint a **15% primary tint + 4px primary left-edge accent** when the card's internal checkbox is checked.
- Implemented via a CSS `:has()` rule injected by the SortableGrid hook because the card view is opaque to consumers (no per-item selected attr).
- Mirrors the table-row treatment in the catalogue's `item_table` (consumer-side companion change in `phoenix_kit_catalogue`).

## Test plan

- [ ] Open a list with bulk-selectable cards on mobile (e.g. catalogue detail items in card view).
- [ ] Tick a card's checkbox → card gains the primary tint + left accent.
- [ ] Untick → tint goes away cleanly.
- [ ] Tick multiple → all selected cards highlight independently.