### PR TITLE
Tighten i18n docs: do not bump @version or write CHANGELOG

### DIFF
--- a/dev_docs/instructions/2026-05-08-per-module-i18n-procedure.md
+++ b/dev_docs/instructions/2026-05-08-per-module-i18n-procedure.md
@@ -165,22 +165,17 @@ mix test test/phoenix_kit/<x>/i18n_test.exs
 
 Then re-add the path override for committing prep.
 
-### 8. Bump `@version` and write CHANGELOG
+### 8. Do NOT bump `@version`. Do NOT write a CHANGELOG entry.
 
-For every owned `phoenix_kit_<x>` package, the team is the maintainer — so unlike `phoenix_kit` core, **you do bump version and write the CHANGELOG entry**:
+**The package version (`@version` in `mix.exs`) and the `CHANGELOG.md` are maintainer-owned across `phoenix_kit` core AND every `phoenix_kit_<x>` child module.** Even on forks the team owns locally, the maintainer derives the version bump and the CHANGELOG entry from your commit messages at release time.
 
-```elixir
-# mix.exs
-@version "0.1.<n+1>"
-```
+What this means at this step:
 
-```markdown
-# CHANGELOG.md
-## 0.1.<n+1> - YYYY-MM-DD
+- Leave `@version` exactly as it stands at HEAD. Do not edit the line.
+- Leave `CHANGELOG.md` exactly as it stands at HEAD. Do not add an entry.
+- Make the commit message itself descriptive enough to feed straight into the maintainer's release notes — first line ≤ 70 chars summarising the change, body explaining the wiring, dependencies on other PRs, and any out-of-scope notes.
 
-### Added
-- Per-module Gettext backend (`PhoenixKit.<X>.Gettext`) with `en`/`ru`/`et` catalogues for all admin sidebar tab labels. Requires `phoenix_kit` release that ships the `gettext_backend` Tab API ([BeamLabEU/phoenix_kit#522](https://github.com/BeamLabEU/phoenix_kit/pull/522)); on older releases tabs render raw English (graceful degradation).
-```
+If you find yourself reaching for `@version` in `mix.exs`, stop. The earlier rollout of this playbook (Phase 2 across newsletters / customer_support / emails / billing / ecommerce / legal / crm) had every implementer agent bump `@version` and add a CHANGELOG entry — and the maintainer ended up overwriting both on every PR. The rule was tightened after that round: **don't.**
 
 ### 9. Stage and commit on `main`
 
@@ -190,14 +185,19 @@ Switch `mix.exs` to **clean form** (no `path:`) before committing. Then:
 # Make sure the path override is gone from the file you're about to commit
 grep -n 'path:.*pk-pr' mix.exs && echo "STILL HAS PATH OVERRIDE — fix"
 
+# Make sure you have NOT modified mix.exs @version or CHANGELOG.md
+git diff --staged mix.exs | grep -E '^\+.*@version' && echo "STILL TOUCHED @version — revert that line"
+git diff --staged CHANGELOG.md | head -1 && echo "CHANGELOG should be clean — revert it from HEAD"
+
 git add \
   mix.exs mix.lock \
   lib/phoenix_kit/<x>/gettext.ex \
   lib/phoenix_kit/<x>/<x>.ex \
   priv/gettext/ \
   test/test_helper.exs \
-  test/phoenix_kit/<x>/i18n_test.exs \
-  CHANGELOG.md
+  test/phoenix_kit/<x>/i18n_test.exs
+
+# DO NOT add: CHANGELOG.md (untouched), and revert any @version edit in mix.exs
 
 git commit -m '...' # see Newsletters PR #12 for tone — descriptive, links PR #522
 ```

--- a/guides/per-module-i18n.md
+++ b/guides/per-module-i18n.md
@@ -98,7 +98,8 @@ This also matches the `dynamic_children/2` callback contract: arity-2 dynamic-ch
 | 8 | Fill translations for each target locale (`en` is 1:1) | `priv/gettext/<locale>/LC_MESSAGES/default.po` |
 | 9 | Add conditional skip in `test/test_helper.exs` so CI building against a pre-API `phoenix_kit` doesn't fail (see [§ Conditional CI skip](#conditional-ci-skip)) | `test/test_helper.exs` |
 | 10 | Add a smoke test (see [§ Test pattern](#test-pattern)) | `test/` |
-| 11 | Bump module `@version` and add a CHANGELOG entry | `mix.exs`, `CHANGELOG.md` |
+
+> **Do NOT bump `@version` or write a `CHANGELOG.md` entry.** Both are maintainer-owned across **core and every `phoenix_kit_<x>` child module** — the maintainer derives the version and the CHANGELOG entry from your commit messages at release time. Write descriptive commit messages; that's the contribution. See [§ Version and CHANGELOG ownership](#version-and-changelog-ownership).
 
 ---
 
@@ -370,7 +371,8 @@ For each existing `phoenix_kit_<x>` module being uplifted to the new API:
 - [ ] `test/test_helper.exs` has the conditional `:requires_phoenix_kit_i18n_api` skip (see [§ Conditional CI skip](#conditional-ci-skip))
 - [ ] Smoke test in `test/phoenix_kit/<x>/i18n_test.exs` carries `@moduletag :requires_phoenix_kit_i18n_api` and passes locally with `phoenix_kit` resolved to a release that ships the API
 - [ ] `mix test` clean (locally with API; on CI without API, i18n tests excluded automatically — also clean)
-- [ ] CHANGELOG entry, `@version` bump, commit on a feature branch, push, open PR. `mix hex.publish` is the maintainer's call after the PR merges
+- [ ] **Do NOT** bump `@version` or write a CHANGELOG entry — both are maintainer-owned (see [§ Version and CHANGELOG ownership](#version-and-changelog-ownership)). Write a descriptive commit message instead.
+- [ ] Commit on a feature branch, push, open PR.
 
 ---
 
@@ -436,21 +438,24 @@ end
 
 ---
 
-## Version bump and CHANGELOG (owned packages)
+## Version and CHANGELOG ownership
 
-Unlike `phoenix_kit` core (which is maintained by BeamLab — version and CHANGELOG are set by the maintainer at release time), every `phoenix_kit_<x>` package is maintained directly by the team that owns the fork. So for these packages:
+**The package version (`@version` in `mix.exs`) and the `CHANGELOG.md` are owned by the maintainer.** This applies uniformly to `phoenix_kit` core **and** every `phoenix_kit_<x>` child module — even the modules whose forks you maintain locally. The maintainer derives the version bump (patch / minor / major) and the CHANGELOG entry from the commit messages on the merged PR; agents and contributors do not touch either.
 
-- Bump `@version` in `mix.exs` (typically a patch level — `0.1.x → 0.1.(x+1)`).
-- Add a CHANGELOG entry under that version. Format:
+What contributors **do**:
 
-```markdown
-## 0.1.3 - 2026-05-08
+- Write descriptive commit messages that read like a CHANGELOG entry — what changed, why, links to related issues / PRs / dependencies. The first line is the title; the body explains the rest.
+- Leave `@version` exactly as it stands at HEAD.
+- Leave `CHANGELOG.md` exactly as it stands at HEAD.
 
-### Added
-- Per-module Gettext backend (`PhoenixKit.<X>.Gettext`) with `en`/`ru`/`et` catalogues for all admin sidebar tab labels. Requires `phoenix_kit` release that ships the `gettext_backend` Tab API (BeamLabEU/phoenix_kit#522); on older releases tabs render raw English (graceful degradation).
-```
+What contributors **do NOT**:
 
-Both go in the same commit as the i18n wiring.
+- Edit `@version` in `mix.exs` (even by one patch).
+- Add or modify entries in `CHANGELOG.md`.
+
+If you find yourself wanting to bump the version "for visibility", stop and improve the commit message instead. The maintainer reads commit bodies when assembling the release notes.
+
+This rule is intentional: it keeps version bumps centralized so the maintainer can squash a feature PR and a follow-up fix into a single release without coordinating two version-line edits, and it removes a frequent source of merge conflicts on `mix.exs` `@version` and `CHANGELOG.md` first-entry header.
 
 ---
 


### PR DESCRIPTION
## Summary

After Phase 2 of the per-module i18n rollout merged across 7 child packages, the maintainer overwrote `@version` and `CHANGELOG.md` on every single merge. The earlier docs (the public guide added in #522 and the internal playbook at `dev_docs/instructions/2026-05-08-per-module-i18n-procedure.md`) instructed agents to bump `@version` and write a CHANGELOG entry — that advice produced merge friction on every PR.

This PR inverts the rule across both documents: contributors and agents do **not** edit `@version` and do **not** add CHANGELOG entries — for `phoenix_kit` core **and** every `phoenix_kit_<x>` child module. The maintainer derives both from PR commit messages at release time.

## Changes

### `guides/per-module-i18n.md`

- Setup checklist step 11 ("Bump module `@version` and add a CHANGELOG entry") **deleted**; replaced with an explicit callout pointing at the new ownership section.
- Section "Version bump and CHANGELOG (owned packages)" replaced with **"Version and CHANGELOG ownership"** — explicitly forbids both edits for ALL packages, including locally-owned forks.
- Retrofit checklist last item flipped from "do" to "do NOT", with a pointer at the ownership section.

### `dev_docs/instructions/2026-05-08-per-module-i18n-procedure.md`

- Step 8 renamed: "Bump `@version` and write CHANGELOG" → **"Do NOT bump `@version`. Do NOT write a CHANGELOG entry."** Includes a rollout-history note documenting *why* the rule was tightened (Phase 2 maintainer overwrites).
- Step 9 (stage and commit) gained two pre-commit verification grep commands:
  ```bash
  git diff --staged mix.exs | grep -E '^\+.*@version' && echo "STILL TOUCHED @version — revert that line"
  git diff --staged CHANGELOG.md | head -1 && echo "CHANGELOG should be clean — revert it from HEAD"
  ```
  These flag accidental edits before commit.

## Why this is a uniform rule (not just for core)

Earlier convention treated `phoenix_kit` core differently from owned forks — core's CHANGELOG was maintainer-owned, but for `phoenix_kit_newsletters` and friends the team was the maintainer and the original guide/playbook said "you do bump version and write CHANGELOG entry". Phase 2 rollout proved that distinction false in practice: the maintainer reviewed each PR and rewrote both lines anyway, every time, because:

1. **Squash + release timing.** A feature PR + follow-up fix often merge in the same release; coordinating two version-line edits across two PRs creates merge conflicts.
2. **Release notes assembly.** The maintainer reads commit bodies to write the CHANGELOG — so the source of truth is the commit message, not a separately-edited file.
3. **Merge conflict frequency.** `mix.exs` `@version` and `CHANGELOG.md` first-entry header are the two most conflict-prone lines in any active package; pre-edits compound the noise.

The new rule eliminates all three. Contributors put their effort into commit messages; the maintainer owns the rest.

## Test plan

- [x] No code changes; docs-only.
- [x] Verified the public guide's Quick Start, Setup checklist, Step-by-step setup, Greenfield example, Retrofitting checklist, Test pattern, Common pitfalls, and Where-this-fits-in-the-rollout sections still flow consistently after the inversion.
- [x] Verified the playbook's gotchas 1-16 still reference the correct step numbers.
- [ ] Maintainer review.

## Out of scope

- No update to the 7 already-merged Phase 2 PRs — those are merged, the maintainer already overwrote `@version` and `CHANGELOG.md` on each. The CRM PR (#5 in `phoenix_kit_crm`, still open) carries the old rule's `@version` bump + CHANGELOG entry; the maintainer can squash those out at merge time, same as the others.
