### PR TITLE
Add admin sidebar i18n, wide-screen settings, complete Estonian catalog

### DIFF
--- a/lib/modules/languages/languages.ex
+++ b/lib/modules/languages/languages.ex
@@ -387,7 +387,8 @@ defmodule PhoenixKit.Modules.Languages do
         priority: 928,
         level: :admin,
         parent: :admin_settings,
-        permission: "languages"
+        permission: "languages",
+        gettext_backend: PhoenixKitWeb.Gettext
       )
     ]
   end

--- a/lib/modules/maintenance/maintenance.ex
+++ b/lib/modules/maintenance/maintenance.ex
@@ -524,7 +524,8 @@ defmodule PhoenixKit.Modules.Maintenance do
         priority: 932,
         level: :admin,
         parent: :admin_settings,
-        permission: "maintenance"
+        permission: "maintenance",
+        gettext_backend: PhoenixKitWeb.Gettext
       )
     ]
   end

--- a/lib/modules/referrals/referrals.ex
+++ b/lib/modules/referrals/referrals.ex
@@ -654,7 +654,8 @@ defmodule PhoenixKit.Modules.Referrals do
         priority: 920,
         level: :admin,
         parent: :admin_settings,
-        permission: "referrals"
+        permission: "referrals",
+        gettext_backend: PhoenixKitWeb.Gettext
       )
     ]
   end

--- a/lib/modules/referrals/web/settings.html.heex
+++ b/lib/modules/referrals/web/settings.html.heex
@@ -14,7 +14,7 @@
     />
 
     <%!-- Main Content --%>
-    <div class="max-w-4xl mx-auto space-y-8">
+    <div class="space-y-8">
       <%!-- Status Card --%>
       <div class="card bg-base-100 shadow-xl">
         <div class="card-body">

--- a/lib/modules/seo/seo.ex
+++ b/lib/modules/seo/seo.ex
@@ -123,7 +123,8 @@ defmodule PhoenixKit.Modules.SEO do
         priority: 930,
         level: :admin,
         parent: :admin_settings,
-        permission: "seo"
+        permission: "seo",
+        gettext_backend: PhoenixKitWeb.Gettext
       )
     ]
   end

--- a/lib/modules/sitemap/sitemap.ex
+++ b/lib/modules/sitemap/sitemap.ex
@@ -763,7 +763,8 @@ defmodule PhoenixKit.Modules.Sitemap do
         priority: 931,
         level: :admin,
         parent: :admin_settings,
-        permission: "sitemap"
+        permission: "sitemap",
+        gettext_backend: PhoenixKitWeb.Gettext
       )
     ]
   end

--- a/lib/modules/sitemap/web/settings.html.heex
+++ b/lib/modules/sitemap/web/settings.html.heex
@@ -27,7 +27,7 @@
       </:actions>
     </.admin_page_header>
 
-    <div class="max-w-6xl mx-auto space-y-6">
+    <div class="space-y-6">
       <%!-- Stats Cards --%>
       <div class="stats shadow w-full">
         <div class="stat">

--- a/lib/modules/sitemap/web/settings.html.heex
+++ b/lib/modules/sitemap/web/settings.html.heex
@@ -1,7 +1,7 @@
 <PhoenixKitWeb.Components.LayoutWrapper.app_layout
   flash={@flash}
   phoenix_kit_current_scope={assigns[:phoenix_kit_current_scope]}
-  page_title="Sitemap Settings"
+  page_title={gettext("Sitemap Settings")}
   current_path={@current_path}
   project_title={@project_title}
   current_locale={@current_locale}
@@ -9,13 +9,13 @@
   <div class="container flex flex-col mx-auto px-4 py-6">
     <.admin_page_header
       back={Routes.path("/admin/modules", locale: @current_locale)}
-      title="Sitemap Settings"
-      subtitle="Configure sitemap generation and scheduling"
+      title={gettext("Sitemap Settings")}
+      subtitle={gettext("Configure sitemap generation and scheduling")}
     >
       <:actions>
         <label class="label cursor-pointer gap-2">
           <span class="label-text font-medium">
-            {if @config.enabled, do: "Enabled", else: "Disabled"}
+            {if @config.enabled, do: gettext("Enabled"), else: gettext("Disabled")}
           </span>
           <input
             type="checkbox"
@@ -34,7 +34,7 @@
           <div class="stat-figure text-primary">
             <.icon name="hero-link" class="w-8 h-8" />
           </div>
-          <div class="stat-title">Total URLs</div>
+          <div class="stat-title">{gettext("Total URLs")}</div>
           <div class="stat-value text-primary">{@config.url_count || 0}</div>
         </div>
 
@@ -42,7 +42,7 @@
           <div class="stat-figure text-secondary">
             <.icon name="hero-document-duplicate" class="w-8 h-8" />
           </div>
-          <div class="stat-title">Sitemap Files</div>
+          <div class="stat-title">{gettext("Sitemap Files")}</div>
           <div class="stat-value text-secondary">{length(@module_files)}</div>
         </div>
 
@@ -50,7 +50,7 @@
           <div class="stat-figure text-info">
             <.icon name="hero-clock" class="w-8 h-8" />
           </div>
-          <div class="stat-title">Last Generated</div>
+          <div class="stat-title">{gettext("Last Generated")}</div>
           <div class="stat-value text-info text-lg">
             {format_timestamp(@config.last_generated)}
           </div>
@@ -66,10 +66,10 @@
               <.icon :if={!@generating} name="hero-arrow-path" class="w-6 h-6" />
             </button>
           </div>
-          <div class="stat-title">Actions</div>
+          <div class="stat-title">{gettext("Actions")}</div>
           <div class="stat-value text-lg">
             <button class="btn btn-sm btn-ghost" phx-click="regenerate" disabled={@generating}>
-              Regenerate All
+              {gettext("Regenerate All")}
             </button>
           </div>
         </div>
@@ -81,12 +81,12 @@
           <div class="flex items-center justify-between">
             <div>
               <h2 class="card-title">
-                <.icon name="hero-map" class="w-5 h-5" /> Router Discovery
+                <.icon name="hero-map" class="w-5 h-5" /> {gettext("Router Discovery")}
               </h2>
               <p class="text-sm text-base-content/60 mt-1">
-                When enabled, scans all routes and builds a single flat sitemap.xml
-                with URLs from all content sources (shop, entities, posts, publishing).
-                When disabled, each source generates its own sitemap file.
+                {gettext(
+                  "When enabled, scans all routes and builds a single flat sitemap.xml with URLs from all content sources (shop, entities, posts, publishing). When disabled, each source generates its own sitemap file."
+                )}
               </p>
             </div>
             <input
@@ -103,33 +103,33 @@
             <div class="alert alert-info">
               <.icon name="hero-information-circle" class="w-5 h-5" />
               <span>
-                Flat mode active — /sitemap.xml contains all URLs in a single &lt;urlset&gt;
+                {gettext("Flat mode active — /sitemap.xml contains all URLs in a single <urlset>")}
               </span>
             </div>
             <div class="flex flex-wrap gap-2 mt-3">
-              <span class="badge badge-primary">Routes</span>
-              <span class="badge badge-primary">Static</span>
+              <span class="badge badge-primary">{gettext("Routes")}</span>
+              <span class="badge badge-primary">{gettext("Static")}</span>
               <span class={
                 if @module_enabled.publishing,
                   do: "badge badge-primary",
                   else: "badge badge-ghost"
               }>
-                Publishing
+                {gettext("Publishing")}
               </span>
               <span class={
                 if @module_enabled.entities, do: "badge badge-primary", else: "badge badge-ghost"
               }>
-                Entities
+                {gettext("Entities")}
               </span>
               <span class={
                 if @module_enabled.posts, do: "badge badge-primary", else: "badge badge-ghost"
               }>
-                Posts
+                {gettext("Posts")}
               </span>
               <span class={
                 if @module_enabled.shop, do: "badge badge-primary", else: "badge badge-ghost"
               }>
-                Shop
+                {gettext("Shop")}
               </span>
             </div>
           </div>
@@ -140,10 +140,12 @@
       <div :if={!@config.router_discovery_enabled} class="card bg-base-200 shadow-md">
         <div class="card-body">
           <h2 class="card-title">
-            <.icon name="hero-circle-stack" class="w-5 h-5" /> Module Sitemaps
+            <.icon name="hero-circle-stack" class="w-5 h-5" /> {gettext("Module Sitemaps")}
           </h2>
           <p class="text-sm text-base-content/60 mb-4">
-            Each source generates its own sitemap file, referenced by the main sitemap index
+            {gettext(
+              "Each source generates its own sitemap file, referenced by the main sitemap index"
+            )}
           </p>
 
           <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -152,7 +154,7 @@
               <div class="flex items-center justify-between mb-2">
                 <div class="flex items-center gap-2">
                   <.icon name="hero-document-text" class="w-4 h-4 text-primary" />
-                  <span class="font-medium">Static Pages</span>
+                  <span class="font-medium">{gettext("Static Pages")}</span>
                 </div>
                 <input
                   type="checkbox"
@@ -162,7 +164,9 @@
                   phx-value-source="static"
                 />
               </div>
-              <p class="text-xs text-base-content/60 mb-2">Homepage and custom static URLs</p>
+              <p class="text-xs text-base-content/60 mb-2">
+                {gettext("Homepage and custom static URLs")}
+              </p>
               <div class="flex items-center justify-between text-xs">
                 <div class="flex items-center gap-2">
                   <span class="badge badge-sm badge-outline">
@@ -181,7 +185,7 @@
                     href={Routes.path("/sitemaps/#{f}.xml", locale: :none)}
                     target="_blank"
                     class="btn btn-ghost btn-xs"
-                    title="View sitemap"
+                    title={gettext("View sitemap")}
                   >
                     <.icon name="hero-arrow-top-right-on-square" class="w-3 h-3" />
                   </.link>
@@ -194,9 +198,9 @@
               <div class="flex items-center justify-between mb-2">
                 <div class="flex items-center gap-2">
                   <.icon name="hero-newspaper" class="w-4 h-4 text-primary" />
-                  <span class="font-medium">Publishing</span>
+                  <span class="font-medium">{gettext("Publishing")}</span>
                   <span :if={!@module_enabled.publishing} class="badge badge-xs badge-warning">
-                    module off
+                    {gettext("module off")}
                   </span>
                 </div>
                 <input
@@ -208,7 +212,9 @@
                   disabled={!@module_enabled.publishing}
                 />
               </div>
-              <p class="text-xs text-base-content/60 mb-2">Blog groups and published posts</p>
+              <p class="text-xs text-base-content/60 mb-2">
+                {gettext("Blog groups and published posts")}
+              </p>
               <div class="flex items-center justify-between text-xs">
                 <div class="flex items-center gap-2 flex-wrap">
                   <span class="badge badge-sm badge-outline">
@@ -227,7 +233,7 @@
                     href={Routes.path("/sitemaps/#{f}.xml", locale: :none)}
                     target="_blank"
                     class="btn btn-ghost btn-xs"
-                    title="View sitemap"
+                    title={gettext("View sitemap")}
                   >
                     <.icon name="hero-arrow-top-right-on-square" class="w-3 h-3" />
                   </.link>
@@ -235,7 +241,7 @@
               </div>
               <%!-- Split by blog toggle --%>
               <label class="flex items-center justify-between cursor-pointer mt-3 pt-3 border-t border-base-300">
-                <span class="text-xs">Split by blog group</span>
+                <span class="text-xs">{gettext("Split by blog group")}</span>
                 <input
                   type="checkbox"
                   class="toggle toggle-xs toggle-secondary"
@@ -250,9 +256,9 @@
               <div class="flex items-center justify-between mb-2">
                 <div class="flex items-center gap-2">
                   <.icon name="hero-cube" class="w-4 h-4 text-primary" />
-                  <span class="font-medium">Entities</span>
+                  <span class="font-medium">{gettext("Entities")}</span>
                   <span :if={!@module_enabled.entities} class="badge badge-xs badge-warning">
-                    module off
+                    {gettext("module off")}
                   </span>
                 </div>
                 <input
@@ -265,7 +271,7 @@
                 />
               </div>
               <p class="text-xs text-base-content/60 mb-2">
-                Dynamic content types (per-type files)
+                {gettext("Dynamic content types (per-type files)")}
               </p>
               <div class="flex items-center justify-between text-xs">
                 <div class="flex items-center gap-2 flex-wrap">
@@ -285,7 +291,7 @@
                     href={Routes.path("/sitemaps/#{f}.xml", locale: :none)}
                     target="_blank"
                     class="btn btn-ghost btn-xs"
-                    title="View sitemap"
+                    title={gettext("View sitemap")}
                   >
                     <.icon name="hero-arrow-top-right-on-square" class="w-3 h-3" />
                   </.link>
@@ -298,13 +304,15 @@
               <div class="flex items-center justify-between mb-2">
                 <div class="flex items-center gap-2">
                   <.icon name="hero-pencil-square" class="w-4 h-4 text-primary" />
-                  <span class="font-medium">Posts</span>
+                  <span class="font-medium">{gettext("Posts")}</span>
                   <span :if={!@module_enabled.posts} class="badge badge-xs badge-warning">
-                    module off
+                    {gettext("module off")}
                   </span>
                 </div>
               </div>
-              <p class="text-xs text-base-content/60 mb-2">Public posts from Posts module</p>
+              <p class="text-xs text-base-content/60 mb-2">
+                {gettext("Public posts from Posts module")}
+              </p>
               <div class="flex items-center justify-between text-xs">
                 <div class="flex items-center gap-2">
                   <span class="badge badge-sm badge-outline">
@@ -323,7 +331,7 @@
                     href={Routes.path("/sitemaps/#{f}.xml", locale: :none)}
                     target="_blank"
                     class="btn btn-ghost btn-xs"
-                    title="View sitemap"
+                    title={gettext("View sitemap")}
                   >
                     <.icon name="hero-arrow-top-right-on-square" class="w-3 h-3" />
                   </.link>
@@ -336,9 +344,9 @@
               <div class="flex items-center justify-between mb-2">
                 <div class="flex items-center gap-2">
                   <.icon name="hero-shopping-bag" class="w-4 h-4 text-primary" />
-                  <span class="font-medium">Shop</span>
+                  <span class="font-medium">{gettext("Shop")}</span>
                   <span :if={!@module_enabled.shop} class="badge badge-xs badge-warning">
-                    module off
+                    {gettext("module off")}
                   </span>
                 </div>
                 <input
@@ -350,7 +358,9 @@
                   disabled={!@module_enabled.shop}
                 />
               </div>
-              <p class="text-xs text-base-content/60 mb-2">Products, categories, catalog</p>
+              <p class="text-xs text-base-content/60 mb-2">
+                {gettext("Products, categories, catalog")}
+              </p>
               <div class="flex items-center justify-between text-xs">
                 <div class="flex items-center gap-2">
                   <span class="badge badge-sm badge-outline">
@@ -369,7 +379,7 @@
                     href={Routes.path("/sitemaps/#{f}.xml", locale: :none)}
                     target="_blank"
                     class="btn btn-ghost btn-xs"
-                    title="View sitemap"
+                    title={gettext("View sitemap")}
                   >
                     <.icon name="hero-arrow-top-right-on-square" class="w-3 h-3" />
                   </.link>
@@ -384,37 +394,39 @@
       <div class="card bg-base-200 shadow-md">
         <div class="card-body">
           <h2 class="card-title">
-            <.icon name="hero-lock-closed" class="w-5 h-5" /> Auth Pages
+            <.icon name="hero-lock-closed" class="w-5 h-5" /> {gettext("Auth Pages")}
           </h2>
 
           <div class="grid grid-cols-1 sm:grid-cols-3 gap-3 mt-2">
             <%!-- Login - always excluded --%>
             <div class="flex items-center justify-between p-3 rounded-lg bg-base-100">
               <div>
-                <span class="label-text font-medium">Login</span>
+                <span class="label-text font-medium">{gettext("Login")}</span>
                 <span class="text-xs text-base-content/60 block">
-                  Always excluded from sitemap
+                  {gettext("Always excluded from sitemap")}
                 </span>
               </div>
-              <span class="badge badge-sm badge-error badge-outline">Excluded</span>
+              <span class="badge badge-sm badge-error badge-outline">{gettext("Excluded")}</span>
             </div>
 
             <%!-- Logout - always excluded --%>
             <div class="flex items-center justify-between p-3 rounded-lg bg-base-100">
               <div>
-                <span class="label-text font-medium">Logout</span>
+                <span class="label-text font-medium">{gettext("Logout")}</span>
                 <span class="text-xs text-base-content/60 block">
-                  Always excluded from sitemap
+                  {gettext("Always excluded from sitemap")}
                 </span>
               </div>
-              <span class="badge badge-sm badge-error badge-outline">Excluded</span>
+              <span class="badge badge-sm badge-error badge-outline">{gettext("Excluded")}</span>
             </div>
 
             <%!-- Registration - toggleable --%>
             <label class="flex items-center justify-between cursor-pointer p-3 rounded-lg bg-base-100">
               <div>
-                <span class="label-text font-medium">Registration</span>
-                <span class="text-xs text-base-content/60 block">Include in static sitemap</span>
+                <span class="label-text font-medium">{gettext("Registration")}</span>
+                <span class="text-xs text-base-content/60 block">
+                  {gettext("Include in static sitemap")}
+                </span>
               </div>
               <input
                 type="checkbox"
@@ -432,14 +444,14 @@
         <div class="card bg-base-200 shadow-md">
           <div class="card-body">
             <h2 class="card-title">
-              <.icon name="hero-cog-6-tooth" class="w-5 h-5" /> Configuration
+              <.icon name="hero-cog-6-tooth" class="w-5 h-5" /> {gettext("Configuration")}
             </h2>
 
             <div class="space-y-4 mt-4">
               <%!-- Site URL (read-only) --%>
               <div class="form-control">
                 <label class="label">
-                  <span class="label-text font-medium">Site URL</span>
+                  <span class="label-text font-medium">{gettext("Site URL")}</span>
                 </label>
                 <div class="flex gap-2">
                   <input
@@ -452,7 +464,7 @@
                   <.link
                     navigate={Routes.path("/admin/settings", locale: @current_locale)}
                     class="btn btn-outline btn-sm"
-                    title="Edit in Settings"
+                    title={gettext("Edit in Settings")}
                   >
                     <.icon name="hero-pencil" class="w-4 h-4" />
                   </.link>
@@ -462,9 +474,9 @@
               <%!-- XSL Styling --%>
               <label class="flex items-center justify-between cursor-pointer">
                 <div>
-                  <span class="label-text font-medium">Browser Display Styling</span>
+                  <span class="label-text font-medium">{gettext("Browser Display Styling")}</span>
                   <span class="text-xs text-base-content/60 block">
-                    Style XML with XSL for beautiful browser display
+                    {gettext("Style XML with XSL for beautiful browser display")}
                   </span>
                 </div>
                 <input
@@ -478,7 +490,7 @@
               <%!-- Display Style --%>
               <form phx-change="update_style" class="form-control">
                 <label class="label">
-                  <span class="label-text font-medium">Display Style</span>
+                  <span class="label-text font-medium">{gettext("Display Style")}</span>
                 </label>
                 <label class="select w-full">
                   <select
@@ -486,10 +498,10 @@
                     disabled={!@config.html_enabled}
                   >
                     <option value="table" selected={@config.html_style in ["table", "grouped"]}>
-                      Table (Clean table layout)
+                      {gettext("Table (Clean table layout)")}
                     </option>
                     <option value="minimal" selected={@config.html_style in ["minimal", "flat"]}>
-                      Minimal (Simple list)
+                      {gettext("Minimal (Simple list)")}
                     </option>
                   </select>
                 </label>
@@ -503,7 +515,7 @@
           <div class="card-body">
             <div class="flex items-center justify-between">
               <h2 class="card-title">
-                <.icon name="hero-clock" class="w-5 h-5" /> Scheduled Generation
+                <.icon name="hero-clock" class="w-5 h-5" /> {gettext("Scheduled Generation")}
               </h2>
               <input
                 type="checkbox"
@@ -514,29 +526,29 @@
             </div>
 
             <form phx-change="update_interval" class="flex items-center gap-4 mt-4">
-              <span class="text-sm">Regenerate every</span>
+              <span class="text-sm">{gettext("Regenerate every")}</span>
               <label class="select select-sm">
                 <select
                   name="interval"
                   disabled={!@config.schedule_enabled}
                 >
                   <option value="1" selected={@config.schedule_interval_hours == 1}>
-                    1 hour
+                    {gettext("1 hour")}
                   </option>
                   <option value="6" selected={@config.schedule_interval_hours == 6}>
-                    6 hours
+                    {gettext("6 hours")}
                   </option>
                   <option value="12" selected={@config.schedule_interval_hours == 12}>
-                    12 hours
+                    {gettext("12 hours")}
                   </option>
                   <option value="24" selected={@config.schedule_interval_hours == 24}>
-                    24 hours
+                    {gettext("24 hours")}
                   </option>
                   <option value="48" selected={@config.schedule_interval_hours == 48}>
-                    48 hours
+                    {gettext("48 hours")}
                   </option>
                   <option value="168" selected={@config.schedule_interval_hours == 168}>
-                    Weekly
+                    {gettext("Weekly")}
                   </option>
                 </select>
               </label>
@@ -549,16 +561,18 @@
       <div class="card bg-base-200 shadow-md">
         <div class="card-body">
           <h2 class="card-title">
-            <.icon name="hero-bolt" class="w-5 h-5" /> Quick Actions
+            <.icon name="hero-bolt" class="w-5 h-5" /> {gettext("Quick Actions")}
           </h2>
 
           <div class="flex flex-wrap gap-3 mt-4">
             <button class="btn btn-outline btn-sm" phx-click="preview" phx-value-type="xml">
-              <.icon name="hero-code-bracket" class="w-4 h-4 mr-1" /> Preview Sitemap Source
+              <.icon name="hero-code-bracket" class="w-4 h-4 mr-1" /> {gettext(
+                "Preview Sitemap Source"
+              )}
             </button>
 
             <button class="btn btn-outline btn-sm btn-warning" phx-click="invalidate_cache">
-              <.icon name="hero-trash" class="w-4 h-4 mr-1" /> Clear All Sitemaps
+              <.icon name="hero-trash" class="w-4 h-4 mr-1" /> {gettext("Clear All Sitemaps")}
             </button>
           </div>
 
@@ -567,14 +581,16 @@
             :if={!@config.router_discovery_enabled && @module_files != []}
             class="mt-4 pt-4 border-t border-base-300"
           >
-            <p class="text-sm font-medium text-base-content mb-3">Generated sitemap files:</p>
+            <p class="text-sm font-medium text-base-content mb-3">
+              {gettext("Generated sitemap files:")}
+            </p>
             <div class="flex flex-wrap gap-2">
               <.link
                 href={Routes.path("/sitemap.xml", locale: :none)}
                 target="_blank"
                 class="btn btn-sm btn-primary btn-outline gap-1"
               >
-                <.icon name="hero-globe-alt" class="w-4 h-4" /> sitemap.xml (index)
+                <.icon name="hero-globe-alt" class="w-4 h-4" /> {gettext("sitemap.xml (index)")}
               </.link>
               <.link
                 :for={f <- @module_files}
@@ -605,11 +621,9 @@
 
           <p class="text-xs text-base-content/60 mt-3">
             <.icon name="hero-information-circle" class="w-3 h-3 inline" />
-            <%= if @config.router_discovery_enabled do %>
-              /sitemap.xml contains all URLs in a single &lt;urlset&gt;
-            <% else %>
-              /sitemap.xml is a sitemapindex referencing per-module sitemap files
-            <% end %>
+            {if @config.router_discovery_enabled,
+              do: gettext("/sitemap.xml contains all URLs in a single <urlset>"),
+              else: gettext("/sitemap.xml is a sitemapindex referencing per-module sitemap files")}
           </p>
         </div>
       </div>
@@ -619,7 +633,7 @@
     <div :if={@show_preview} class="modal modal-open">
       <div class="modal-box max-w-4xl max-h-[80vh]">
         <div class="flex justify-between items-center mb-4">
-          <h3 class="font-bold text-lg">Sitemap Source</h3>
+          <h3 class="font-bold text-lg">{gettext("Sitemap Source")}</h3>
           <button class="btn btn-ghost btn-sm btn-circle" phx-click="close_preview">
             <.icon name="hero-x-mark" class="w-4 h-4" />
           </button>
@@ -635,9 +649,11 @@
             target="_blank"
             class="btn btn-primary"
           >
-            <.icon name="hero-arrow-top-right-on-square" class="w-4 h-4 mr-1" /> Open in Browser
+            <.icon name="hero-arrow-top-right-on-square" class="w-4 h-4 mr-1" /> {gettext(
+              "Open in Browser"
+            )}
           </.link>
-          <button class="btn" phx-click="close_preview">Close</button>
+          <button class="btn" phx-click="close_preview">{gettext("Close")}</button>
         </div>
       </div>
       <div class="modal-backdrop" phx-click="close_preview"></div>

--- a/lib/modules/storage/web/settings.html.heex
+++ b/lib/modules/storage/web/settings.html.heex
@@ -6,7 +6,7 @@
   current_locale={@current_locale}
   project_title={@project_title}
 >
-  <div class="container mx-auto px-4 py-8 max-w-6xl">
+  <div class="container mx-auto px-4 py-8">
     <.admin_page_header
       back={PhoenixKit.Utils.Routes.path("/admin/modules")}
       title={gettext("Media Settings")}

--- a/lib/phoenix_kit/dashboard/admin_tabs.ex
+++ b/lib/phoenix_kit/dashboard/admin_tabs.ex
@@ -25,7 +25,8 @@ defmodule PhoenixKit.Dashboard.AdminTabs do
       level: :admin,
       permission: permission,
       parent: parent,
-      match: Keyword.get(opts, :match, :prefix)
+      match: Keyword.get(opts, :match, :prefix),
+      gettext_backend: PhoenixKitWeb.Gettext
     }
   end
 
@@ -65,7 +66,8 @@ defmodule PhoenixKit.Dashboard.AdminTabs do
         level: :admin,
         permission: "dashboard",
         match: :exact,
-        group: :admin_main
+        group: :admin_main,
+        gettext_backend: PhoenixKitWeb.Gettext
       },
       # Users parent
       %Tab{
@@ -79,7 +81,8 @@ defmodule PhoenixKit.Dashboard.AdminTabs do
         match: :prefix,
         group: :admin_main,
         subtab_display: :when_active,
-        highlight_with_subtabs: false
+        highlight_with_subtabs: false,
+        gettext_backend: PhoenixKitWeb.Gettext
       },
       # Users subtabs
       admin_subtab(
@@ -147,7 +150,8 @@ defmodule PhoenixKit.Dashboard.AdminTabs do
         level: :admin,
         permission: "dashboard",
         match: :prefix,
-        group: :admin_main
+        group: :admin_main,
+        gettext_backend: PhoenixKitWeb.Gettext
       },
       # Media
       %Tab{
@@ -159,7 +163,8 @@ defmodule PhoenixKit.Dashboard.AdminTabs do
         level: :admin,
         permission: "media",
         match: :prefix,
-        group: :admin_main
+        group: :admin_main,
+        gettext_backend: PhoenixKitWeb.Gettext
       }
     ]
 
@@ -184,7 +189,8 @@ defmodule PhoenixKit.Dashboard.AdminTabs do
             level: :admin,
             permission: "modules",
             match: :exact,
-            group: :admin_modules
+            group: :admin_modules,
+            gettext_backend: PhoenixKitWeb.Gettext
           },
           :admin
         )
@@ -217,7 +223,8 @@ defmodule PhoenixKit.Dashboard.AdminTabs do
           group: :admin_system,
           subtab_display: :when_active,
           highlight_with_subtabs: false,
-          visible: &__MODULE__.settings_visible?/1
+          visible: &__MODULE__.settings_visible?/1,
+          gettext_backend: PhoenixKitWeb.Gettext
         },
         :admin
       )
@@ -281,7 +288,8 @@ defmodule PhoenixKit.Dashboard.AdminTabs do
         match: :prefix,
         parent: :admin_settings,
         subtab_display: :when_active,
-        highlight_with_subtabs: false
+        highlight_with_subtabs: false,
+        gettext_backend: PhoenixKitWeb.Gettext
       },
       admin_subtab(
         :admin_settings_media_dimensions,

--- a/lib/phoenix_kit/jobs.ex
+++ b/lib/phoenix_kit/jobs.ex
@@ -191,7 +191,8 @@ defmodule PhoenixKit.Jobs do
         level: :admin,
         permission: "jobs",
         match: :prefix,
-        group: :admin_modules
+        group: :admin_modules,
+        gettext_backend: PhoenixKitWeb.Gettext
       )
     ]
   end

--- a/lib/phoenix_kit_web/components/core/badge.ex
+++ b/lib/phoenix_kit_web/components/core/badge.ex
@@ -7,6 +7,7 @@ defmodule PhoenixKitWeb.Components.Core.Badge do
   """
 
   use Phoenix.Component
+  use Gettext, backend: PhoenixKitWeb.Gettext
   alias PhoenixKit.Utils.Date, as: UtilsDate
 
   @doc """
@@ -99,9 +100,9 @@ defmodule PhoenixKitWeb.Components.Core.Badge do
   defp status_class(true, _), do: "badge-success"
 
   # User status text
-  defp status_text(false, _), do: "Inactive"
-  defp status_text(true, nil), do: "Unconfirmed"
-  defp status_text(true, _), do: "Active"
+  defp status_text(false, _), do: gettext("Inactive")
+  defp status_text(true, nil), do: gettext("Unconfirmed")
+  defp status_text(true, _), do: gettext("Active")
 
   # Code status for referral codes
   defp code_status_class(code) do
@@ -121,13 +122,13 @@ defmodule PhoenixKitWeb.Components.Core.Badge do
   defp code_status_text(code) do
     cond do
       code.number_of_uses >= code.max_uses ->
-        "Expired"
+        gettext("Expired")
 
       code.expiration_date && DateTime.compare(UtilsDate.utc_now(), code.expiration_date) == :gt ->
-        "Expired"
+        gettext("Expired")
 
       true ->
-        "Active"
+        gettext("Active")
     end
   end
 
@@ -151,10 +152,15 @@ defmodule PhoenixKitWeb.Components.Core.Badge do
   def category_badge(assigns) do
     ~H"""
     <div class={["badge", category_class(@category), size_class(@size), @class]}>
-      {String.capitalize(@category)}
+      {category_text(@category)}
     </div>
     """
   end
+
+  defp category_text("system"), do: gettext("System")
+  defp category_text("marketing"), do: gettext("Marketing")
+  defp category_text("transactional"), do: gettext("Transactional")
+  defp category_text(other), do: String.capitalize(to_string(other))
 
   # Template category classes
   defp category_class("system"), do: "badge-info"
@@ -182,7 +188,7 @@ defmodule PhoenixKitWeb.Components.Core.Badge do
   def enabled_badge(assigns) do
     ~H"""
     <span class={["badge", enabled_class(@enabled), size_class(@size), @class]}>
-      {if @enabled, do: "Active", else: "Disabled"}
+      {if @enabled, do: gettext("Active"), else: gettext("Disabled")}
     </span>
     """
   end

--- a/lib/phoenix_kit_web/components/core/time_display.ex
+++ b/lib/phoenix_kit_web/components/core/time_display.ex
@@ -8,6 +8,7 @@ defmodule PhoenixKitWeb.Components.Core.TimeDisplay do
   """
 
   use Phoenix.Component
+  use Gettext, backend: PhoenixKitWeb.Gettext
   alias PhoenixKit.Utils.Date, as: UtilsDate
 
   @doc """
@@ -179,14 +180,14 @@ defmodule PhoenixKitWeb.Components.Core.TimeDisplay do
     format_seconds_ago(diff_seconds)
   end
 
-  defp format_time_ago(_), do: "Unknown"
+  defp format_time_ago(_), do: gettext("Unknown")
 
   defp format_seconds_ago(diff_seconds) do
     cond do
-      diff_seconds < 60 -> "#{diff_seconds}s ago"
-      diff_seconds < 3_600 -> "#{div(diff_seconds, 60)}m ago"
-      diff_seconds < 86_400 -> "#{div(diff_seconds, 3_600)}h ago"
-      true -> "#{div(diff_seconds, 86_400)}d ago"
+      diff_seconds < 60 -> gettext("%{count}s ago", count: diff_seconds)
+      diff_seconds < 3_600 -> gettext("%{count}m ago", count: div(diff_seconds, 60))
+      diff_seconds < 86_400 -> gettext("%{count}h ago", count: div(diff_seconds, 3_600))
+      true -> gettext("%{count}d ago", count: div(diff_seconds, 86_400))
     end
   end
 
@@ -202,13 +203,13 @@ defmodule PhoenixKitWeb.Components.Core.TimeDisplay do
 
   defp format_datetime_title(_), do: nil
 
-  defp format_expiration(nil), do: "No expiration"
+  defp format_expiration(nil), do: gettext("No expiration")
 
   defp format_expiration(date) do
     Calendar.strftime(date, "%B %d, %Y")
   end
 
-  defp format_age(days) when days < 1, do: {"badge-success", "Today"}
+  defp format_age(days) when days < 1, do: {"badge-success", gettext("Today")}
   defp format_age(days) when days < 7, do: {"badge-info", "#{days}d"}
   defp format_age(days) when days < 30, do: {"badge-warning", "#{days}d"}
   defp format_age(days), do: {"badge-error", "#{days}d"}

--- a/lib/phoenix_kit_web/live/modules/languages.html.heex
+++ b/lib/phoenix_kit_web/live/modules/languages.html.heex
@@ -20,16 +20,16 @@
     <%!-- Summary Section --%>
     <div class="card bg-base-100 shadow-xl mb-6">
       <div class="card-body">
-        <h3 class="card-title text-xl">Summary</h3>
+        <h3 class="card-title text-xl">{gettext("Summary")}</h3>
 
         <%!-- Stats Row --%>
         <div class="stats stats-vertical lg:stats-horizontal shadow bg-base-200 mt-2">
           <div class="stat">
-            <div class="stat-title">Languages Enabled</div>
+            <div class="stat-title">{gettext("Languages Enabled")}</div>
             <div class="stat-value text-primary">{@enabled_count}</div>
           </div>
           <div class="stat">
-            <div class="stat-title">Countries Covered</div>
+            <div class="stat-title">{gettext("Countries Covered")}</div>
             <div class="stat-value text-secondary">{@covered_count}</div>
           </div>
         </div>
@@ -38,7 +38,7 @@
           <%!-- Enabled Languages List --%>
           <div class="mt-4">
             <div class="flex items-center justify-between mb-2">
-              <h4 class="font-semibold">Enabled Languages</h4>
+              <h4 class="font-semibold">{gettext("Enabled Languages")}</h4>
               <div class="flex items-center gap-3">
                 <button
                   phx-click="toggle_reorder"
@@ -48,17 +48,19 @@
                   ]}
                 >
                   <%= if @show_reorder do %>
-                    <.icon name="hero-check" class="w-3 h-3" /> Done
+                    <.icon name="hero-check" class="w-3 h-3" /> {gettext("Done")}
                   <% else %>
-                    <.icon name="hero-arrows-up-down" class="w-3 h-3" /> Reorder
+                    <.icon name="hero-arrows-up-down" class="w-3 h-3" /> {gettext("Reorder")}
                   <% end %>
                 </button>
                 <div class="flex items-center gap-3 text-xs text-base-content/60">
                   <span class="flex items-center gap-1">
-                    <span class="badge badge-secondary badge-xs h-auto"></span> Default
+                    <span class="badge badge-secondary badge-xs h-auto"></span> {gettext(
+                      "Default"
+                    )}
                   </span>
                   <span class="flex items-center gap-1">
-                    <span class="badge badge-primary badge-xs h-auto"></span> Enabled
+                    <span class="badge badge-primary badge-xs h-auto"></span> {gettext("Enabled")}
                   </span>
                 </div>
               </div>
@@ -116,7 +118,7 @@
                         <li>
                           <button phx-click="set_default" phx-value-code={lang.code}>
                             <PhoenixKitWeb.Components.Core.Icons.icon_star class="w-4 h-4" />
-                            Set Default
+                            {gettext("Set Default")}
                           </button>
                         </li>
                         <li>
@@ -125,12 +127,16 @@
                             phx-value-code={lang.code}
                             class="text-error"
                           >
-                            <PhoenixKitWeb.Components.Core.Icons.icon_x class="w-4 h-4" /> Disable
+                            <PhoenixKitWeb.Components.Core.Icons.icon_x class="w-4 h-4" /> {gettext(
+                              "Disable"
+                            )}
                           </button>
                         </li>
                       <% else %>
                         <li class="disabled">
-                          <span class="text-base-content/60 text-sm">Default language</span>
+                          <span class="text-base-content/60 text-sm">
+                            {gettext("Default language")}
+                          </span>
                         </li>
                       <% end %>
                     </ul>
@@ -142,7 +148,7 @@
 
           <%!-- Covered Countries List --%>
           <div class="mt-4">
-            <h4 class="font-semibold mb-2">Countries Covered</h4>
+            <h4 class="font-semibold mb-2">{gettext("Countries Covered")}</h4>
             <div class="flex flex-wrap gap-2">
               <%= for {country, flag} <- @covered_countries do %>
                 <span class="badge badge-outline">{flag} {country}</span>
@@ -150,7 +156,7 @@
             </div>
           </div>
         <% else %>
-          <p class="text-base-content/60 mt-4">No languages enabled yet.</p>
+          <p class="text-base-content/60 mt-4">{gettext("No languages enabled yet.")}</p>
         <% end %>
       </div>
     </div>
@@ -159,7 +165,7 @@
     <div class="card bg-base-100 shadow-xl">
       <div class="card-body">
         <div class="mb-4">
-          <h3 class="card-title text-xl">Available Languages</h3>
+          <h3 class="card-title text-xl">{gettext("Available Languages")}</h3>
           <p class="text-sm text-base-content/60 mt-1">
             Enable languages for your application ({@enabled_count} enabled)
           </p>
@@ -214,7 +220,7 @@
                                 </span>
                                 <%= if language.code == @default_code do %>
                                   <span class="badge badge-primary badge-xs h-auto">
-                                    Default
+                                    {gettext("Default")}
                                   </span>
                                 <% end %>
                               </div>
@@ -261,7 +267,7 @@
     <div class="alert alert-info mt-6">
       <PhoenixKitWeb.Components.Core.Icons.icon_info class="w-5 h-5" />
       <div>
-        <h3 class="font-bold">Language Configuration</h3>
+        <h3 class="font-bold">{gettext("Language Configuration")}</h3>
         <div class="text-sm space-y-1">
           <p>• Toggle languages on/off to enable or disable them for your application</p>
           <p>• The default language cannot be disabled and serves as the fallback</p>
@@ -273,7 +279,7 @@
     <%!-- Frontend Language Switcher Component Section --%>
     <div class="card bg-base-100 shadow-xl mt-6">
       <div class="card-body">
-        <h2 class="card-title text-xl mb-4">Frontend Language Switcher</h2>
+        <h2 class="card-title text-xl mb-4">{gettext("Frontend Language Switcher")}</h2>
         <p class="text-base-content/70 mb-6">
           Configure and preview the language switcher component for your frontend application.
         </p>
@@ -283,12 +289,12 @@
           <div class="grid grid-cols-1 lg:grid-cols-3 gap-6 auto-rows-fr">
             <%!-- Left Column: Settings --%>
             <div class="lg:col-span-1 border border-base-200 rounded-lg p-4 flex flex-col">
-              <h3 class="font-bold mb-4">Switcher Settings</h3>
+              <h3 class="font-bold mb-4">{gettext("Switcher Settings")}</h3>
               <div class="space-y-4">
                 <%!-- Show Flags Toggle --%>
                 <div class="form-control">
                   <label class="label cursor-pointer">
-                    <span class="label-text">Show Flags</span>
+                    <span class="label-text">{gettext("Show Flags")}</span>
                     <input
                       type="checkbox"
                       class="toggle toggle-sm toggle-primary"
@@ -302,7 +308,7 @@
                 <%!-- Show Language Names Toggle --%>
                 <div class="form-control">
                   <label class="label cursor-pointer">
-                    <span class="label-text">Show Names</span>
+                    <span class="label-text">{gettext("Show Names")}</span>
                     <input
                       type="checkbox"
                       class="toggle toggle-sm toggle-primary"
@@ -316,7 +322,7 @@
                 <%!-- Show Native Names Toggle --%>
                 <div class="form-control">
                   <label class="label cursor-pointer">
-                    <span class="label-text">Native Names</span>
+                    <span class="label-text">{gettext("Native Names")}</span>
                     <input
                       type="checkbox"
                       class="toggle toggle-sm toggle-primary"
@@ -330,7 +336,7 @@
                 <%!-- Go to Home Page Toggle --%>
                 <div class="form-control">
                   <label class="label cursor-pointer">
-                    <span class="label-text">Go to Home</span>
+                    <span class="label-text">{gettext("Go to Home")}</span>
                     <input
                       type="checkbox"
                       class="toggle toggle-sm toggle-primary"
@@ -344,7 +350,7 @@
                 <%!-- Hide Current Language Toggle --%>
                 <div class="form-control">
                   <label class="label cursor-pointer">
-                    <span class="label-text">Hide Current</span>
+                    <span class="label-text">{gettext("Hide Current")}</span>
                     <input
                       type="checkbox"
                       class="toggle toggle-sm toggle-primary"
@@ -361,7 +367,7 @@
             <div class="lg:col-span-2 space-y-4">
               <%!-- Live Preview --%>
               <div class="border border-base-200 rounded-lg p-4">
-                <h3 class="font-bold mb-3">Live Preview</h3>
+                <h3 class="font-bold mb-3">{gettext("Live Preview")}</h3>
                 <div class="bg-base-200 rounded p-4 flex items-center justify-center min-h-24">
                   <.language_switcher_dropdown
                     current_locale={@current_locale}
@@ -375,7 +381,7 @@
 
               <%!-- Generated Code --%>
               <div class="border border-base-200 rounded-lg p-4">
-                <h3 class="font-bold mb-3">Generated Code</h3>
+                <h3 class="font-bold mb-3">{gettext("Generated Code")}</h3>
                 <div class="text-xs text-base-content/60 bg-base-200 rounded p-3 font-mono overflow-x-auto">
                   <pre>{generate_switcher_code(@switcher_show_flags, @switcher_show_names, @switcher_goto_home, @switcher_hide_current, @switcher_show_native_names)}</pre>
                 </div>
@@ -390,7 +396,7 @@
           <div class="alert alert-warning mt-6">
             <PhoenixKitWeb.Components.Core.Icons.icon_warning class="w-5 h-5" />
             <div>
-              <h3 class="font-bold">Implementation Notes</h3>
+              <h3 class="font-bold">{gettext("Implementation Notes")}</h3>
               <div class="text-sm space-y-1">
                 <p>
                   • Make sure <code class="bg-base-300 px-2 py-1 rounded">@current_locale</code>
@@ -408,7 +414,7 @@
           <div class="alert alert-info">
             <PhoenixKitWeb.Components.Core.Icons.icon_info class="w-5 h-5" />
             <div>
-              <h3 class="font-bold">Enable and Configure Languages</h3>
+              <h3 class="font-bold">{gettext("Enable and Configure Languages")}</h3>
               <p class="text-sm mt-2">
                 <%= if not @ml_enabled do %>
                   First, enable the Languages module using the toggle at the top, then add at least one language to see live previews of the language switcher component.

--- a/lib/phoenix_kit_web/live/settings.html.heex
+++ b/lib/phoenix_kit_web/live/settings.html.heex
@@ -14,529 +14,523 @@
     />
 
     <%!-- Settings Form --%>
-    <div class="max-w-2xl mx-auto">
-      <div class="card bg-base-100 shadow-xl">
-        <div class="card-body">
-          <h2 class="card-title text-xl mb-6">{gettext("System Configuration")}</h2>
+    <div class="card bg-base-100 shadow-xl">
+      <div class="card-body">
+        <h2 class="card-title text-xl mb-6">{gettext("System Configuration")}</h2>
 
-          <.form
-            :let={_form}
-            for={@changeset}
-            id="settings_form"
-            phx-submit="save_settings"
-            phx-change="validate_settings"
-            class="space-y-6"
-          >
-            <%!-- Hidden fields for required settings from Users page --%>
-            <%!-- Use @saved_settings to preserve database values, not @settings which may have incorrect form state --%>
-            <input
-              type="hidden"
-              name="settings[allow_registration]"
-              value={@saved_settings["allow_registration"]}
-            />
-            <input
-              type="hidden"
-              name="settings[new_user_default_role]"
-              value={@saved_settings["new_user_default_role"]}
-            />
-            <input
-              type="hidden"
-              name="settings[new_user_default_status]"
-              value={@saved_settings["new_user_default_status"]}
-            />
-            <input
-              type="hidden"
-              name="settings[track_registration_geolocation]"
-              value={@saved_settings["track_registration_geolocation"]}
-            />
+        <.form
+          :let={_form}
+          for={@changeset}
+          id="settings_form"
+          phx-submit="save_settings"
+          phx-change="validate_settings"
+          class="space-y-6"
+        >
+          <%!-- Hidden fields for required settings from Users page --%>
+          <%!-- Use @saved_settings to preserve database values, not @settings which may have incorrect form state --%>
+          <input
+            type="hidden"
+            name="settings[allow_registration]"
+            value={@saved_settings["allow_registration"]}
+          />
+          <input
+            type="hidden"
+            name="settings[new_user_default_role]"
+            value={@saved_settings["new_user_default_role"]}
+          />
+          <input
+            type="hidden"
+            name="settings[new_user_default_status]"
+            value={@saved_settings["new_user_default_status"]}
+          />
+          <input
+            type="hidden"
+            name="settings[track_registration_geolocation]"
+            value={@saved_settings["track_registration_geolocation"]}
+          />
 
-            <%!-- Project Title Setting --%>
-            <div class="form-control w-full">
-              <label class="label">
-                <span class="label-text text-base font-medium">{gettext("Project Title")}</span>
-                <span class="label-text-alt text-sm text-base-content/60">
-                  {gettext("Application name display")}
-                </span>
-              </label>
-              <input
-                name="settings[project_title]"
-                type="text"
-                value={@settings["project_title"]}
-                class="input input-bordered w-full focus:input-primary"
-                placeholder={gettext("Enter project title")}
-                phx-debounce="500"
-              />
-              <div class="label">
-                <span class="label-text-alt text-xs text-base-content/50">
-                  <%= if @settings["project_title"] != @saved_settings["project_title"] do %>
-                    <span class="text-warning">
-                      {gettext("Selected:")} {@settings["project_title"]}
-                    </span>
-                    <span class="text-base-content/40">
-                      | {gettext("Saved:")} {@saved_settings["project_title"]}
-                    </span>
-                  <% else %>
-                    {gettext("Saved:")} {@settings["project_title"]}
-                  <% end %>
-                </span>
-              </div>
+          <%!-- Project Title Setting --%>
+          <div class="form-control w-full">
+            <label class="label">
+              <span class="label-text text-base font-medium">{gettext("Project Title")}</span>
+              <span class="label-text-alt text-sm text-base-content/60">
+                {gettext("Application name display")}
+              </span>
+            </label>
+            <input
+              name="settings[project_title]"
+              type="text"
+              value={@settings["project_title"]}
+              class="input input-bordered w-full focus:input-primary"
+              placeholder={gettext("Enter project title")}
+              phx-debounce="500"
+            />
+            <div class="label">
+              <span class="label-text-alt text-xs text-base-content/50">
+                <%= if @settings["project_title"] != @saved_settings["project_title"] do %>
+                  <span class="text-warning">
+                    {gettext("Selected:")} {@settings["project_title"]}
+                  </span>
+                  <span class="text-base-content/40">
+                    | {gettext("Saved:")} {@saved_settings["project_title"]}
+                  </span>
+                <% else %>
+                  {gettext("Saved:")} {@settings["project_title"]}
+                <% end %>
+              </span>
             </div>
+          </div>
 
-            <%!-- Project Logo --%>
-            <div class="form-control w-full">
-              <label class="label">
-                <span class="label-text text-base font-medium">{gettext("Project Logo")}</span>
-              </label>
-              <input
-                type="hidden"
-                name="settings[auth_logo_file_uuid]"
-                value={@settings["auth_logo_file_uuid"]}
-              />
-              <%= if (@settings["auth_logo_file_uuid"] || "") != "" do %>
-                <div class="flex items-center gap-3 p-2 bg-base-200 rounded-lg">
-                  <img
-                    src={signed_preview_url(@settings["auth_logo_file_uuid"], "medium")}
-                    alt="Logo preview"
-                    class="h-20 object-contain"
-                  />
-                  <button
-                    type="button"
-                    class="btn btn-ghost btn-sm"
-                    phx-click="clear_image"
-                    phx-value-target="logo"
-                  >
-                    {gettext("Remove")}
-                  </button>
-                </div>
-              <% else %>
+          <%!-- Project Logo --%>
+          <div class="form-control w-full">
+            <label class="label">
+              <span class="label-text text-base font-medium">{gettext("Project Logo")}</span>
+            </label>
+            <input
+              type="hidden"
+              name="settings[auth_logo_file_uuid]"
+              value={@settings["auth_logo_file_uuid"]}
+            />
+            <%= if (@settings["auth_logo_file_uuid"] || "") != "" do %>
+              <div class="flex items-center gap-3 p-2 bg-base-200 rounded-lg">
+                <img
+                  src={signed_preview_url(@settings["auth_logo_file_uuid"], "medium")}
+                  alt="Logo preview"
+                  class="h-20 object-contain"
+                />
                 <button
                   type="button"
-                  class="btn btn-outline btn-sm w-fit"
-                  phx-click="open_media_selector"
+                  class="btn btn-ghost btn-sm"
+                  phx-click="clear_image"
                   phx-value-target="logo"
                 >
-                  {gettext("Select Image")}
+                  {gettext("Remove")}
                 </button>
-              <% end %>
-              <div class="label">
-                <span class="label-text-alt text-xs text-base-content/50">
-                  {gettext(
-                    "Logo displayed across the application. Leave empty to show project title text."
-                  )}
-                </span>
               </div>
+            <% else %>
+              <button
+                type="button"
+                class="btn btn-outline btn-sm w-fit"
+                phx-click="open_media_selector"
+                phx-value-target="logo"
+              >
+                {gettext("Select Image")}
+              </button>
+            <% end %>
+            <div class="label">
+              <span class="label-text-alt text-xs text-base-content/50">
+                {gettext(
+                  "Logo displayed across the application. Leave empty to show project title text."
+                )}
+              </span>
             </div>
+          </div>
 
-            <%!-- Site Icon (Favicon) --%>
-            <div class="form-control w-full">
-              <label class="label">
-                <span class="label-text text-base font-medium">{gettext("Site Icon")}</span>
-              </label>
-              <input
-                type="hidden"
-                name="settings[site_icon_file_uuid]"
-                value={@settings["site_icon_file_uuid"]}
-              />
+          <%!-- Site Icon (Favicon) --%>
+          <div class="form-control w-full">
+            <label class="label">
+              <span class="label-text text-base font-medium">{gettext("Site Icon")}</span>
+            </label>
+            <input
+              type="hidden"
+              name="settings[site_icon_file_uuid]"
+              value={@settings["site_icon_file_uuid"]}
+            />
 
-              <%!-- Browser Tab Preview --%>
-              <div class="mb-3">
-                <div class="inline-flex items-center bg-base-200 rounded-t-lg border border-base-300 px-3 py-1.5 gap-2 max-w-xs">
-                  <%= if (@settings["site_icon_file_uuid"] || "") != "" do %>
-                    <img
-                      src={signed_preview_url(@settings["site_icon_file_uuid"], "thumbnail")}
-                      alt=""
-                      class="w-4 h-4 rounded-sm object-cover"
-                    />
-                  <% else %>
-                    <div class="w-4 h-4 rounded-sm bg-base-300"></div>
-                  <% end %>
-                  <span class="text-xs truncate max-w-[180px]">
-                    {if (@settings["default_tab_title"] || "") != "",
-                      do: @settings["default_tab_title"],
-                      else: @settings["project_title"] || "My Site"}
-                  </span>
-                  <span class="text-base-content/30 text-xs">×</span>
-                </div>
-              </div>
-
-              <%= if (@settings["site_icon_file_uuid"] || "") != "" do %>
-                <div class="flex items-center gap-3 p-2 bg-base-200 rounded-lg">
+            <%!-- Browser Tab Preview --%>
+            <div class="mb-3">
+              <div class="inline-flex items-center bg-base-200 rounded-t-lg border border-base-300 px-3 py-1.5 gap-2 max-w-xs">
+                <%= if (@settings["site_icon_file_uuid"] || "") != "" do %>
                   <img
                     src={signed_preview_url(@settings["site_icon_file_uuid"], "thumbnail")}
-                    alt="Site icon preview"
-                    class="h-12 w-12 rounded object-cover"
+                    alt=""
+                    class="w-4 h-4 rounded-sm object-cover"
                   />
-                  <button
-                    type="button"
-                    class="btn btn-ghost btn-sm"
-                    phx-click="clear_image"
-                    phx-value-target="site_icon"
-                  >
-                    {gettext("Remove")}
-                  </button>
-                </div>
-              <% else %>
+                <% else %>
+                  <div class="w-4 h-4 rounded-sm bg-base-300"></div>
+                <% end %>
+                <span class="text-xs truncate max-w-[180px]">
+                  {if (@settings["default_tab_title"] || "") != "",
+                    do: @settings["default_tab_title"],
+                    else: @settings["project_title"] || "My Site"}
+                </span>
+                <span class="text-base-content/30 text-xs">×</span>
+              </div>
+            </div>
+
+            <%= if (@settings["site_icon_file_uuid"] || "") != "" do %>
+              <div class="flex items-center gap-3 p-2 bg-base-200 rounded-lg">
+                <img
+                  src={signed_preview_url(@settings["site_icon_file_uuid"], "thumbnail")}
+                  alt="Site icon preview"
+                  class="h-12 w-12 rounded object-cover"
+                />
                 <button
                   type="button"
-                  class="btn btn-outline btn-sm w-fit"
-                  phx-click="open_media_selector"
+                  class="btn btn-ghost btn-sm"
+                  phx-click="clear_image"
                   phx-value-target="site_icon"
                 >
-                  {gettext("Select Image")}
+                  {gettext("Remove")}
                 </button>
-              <% end %>
-              <div class="label">
-                <span class="label-text-alt text-xs text-base-content/50">
-                  {gettext(
-                    "Shown in browser tabs and bookmarks. Should be square, at least 512×512 pixels."
-                  )}
-                </span>
               </div>
+            <% else %>
+              <button
+                type="button"
+                class="btn btn-outline btn-sm w-fit"
+                phx-click="open_media_selector"
+                phx-value-target="site_icon"
+              >
+                {gettext("Select Image")}
+              </button>
+            <% end %>
+            <div class="label">
+              <span class="label-text-alt text-xs text-base-content/50">
+                {gettext(
+                  "Shown in browser tabs and bookmarks. Should be square, at least 512×512 pixels."
+                )}
+              </span>
             </div>
+          </div>
 
-            <%!-- Default Tab Title --%>
-            <div class="form-control w-full">
-              <label class="label">
-                <span class="label-text text-base font-medium">
-                  {gettext("Default Tab Title")}
-                </span>
-                <span class="label-text-alt text-sm text-base-content/60">
-                  {gettext("Browser tab fallback")}
-                </span>
-              </label>
+          <%!-- Default Tab Title --%>
+          <div class="form-control w-full">
+            <label class="label">
+              <span class="label-text text-base font-medium">
+                {gettext("Default Tab Title")}
+              </span>
+              <span class="label-text-alt text-sm text-base-content/60">
+                {gettext("Browser tab fallback")}
+              </span>
+            </label>
+            <input
+              name="settings[default_tab_title]"
+              type="text"
+              value={@settings["default_tab_title"]}
+              class="input input-bordered w-full focus:input-primary"
+              placeholder={gettext("e.g. Welcome to My Site")}
+              phx-debounce="500"
+            />
+            <div class="label">
+              <span class="label-text-alt text-xs text-base-content/50">
+                {gettext("Text shown in the browser tab when a page doesn't set its own title.")}
+              </span>
+            </div>
+          </div>
+
+          <%!-- Notifications --%>
+          <div class="form-control w-full">
+            <label class="label">
+              <span class="label-text text-base font-medium">
+                {gettext("Notifications")}
+              </span>
+              <span class="label-text-alt text-sm text-base-content/60">
+                {gettext("Per-user inbox driven by the activity feed")}
+              </span>
+            </label>
+            <div class="flex items-center gap-3">
+              <input type="hidden" name="settings[notifications_enabled]" value="false" />
               <input
-                name="settings[default_tab_title]"
-                type="text"
-                value={@settings["default_tab_title"]}
-                class="input input-bordered w-full focus:input-primary"
-                placeholder={gettext("e.g. Welcome to My Site")}
-                phx-debounce="500"
+                name="settings[notifications_enabled]"
+                type="checkbox"
+                value="true"
+                checked={@settings["notifications_enabled"] == "true"}
+                class="checkbox checkbox-primary"
               />
-              <div class="label">
-                <span class="label-text-alt text-xs text-base-content/50">
-                  {gettext("Text shown in the browser tab when a page doesn't set its own title.")}
-                </span>
-              </div>
+              <span class="label-text">
+                {gettext("Enable user notifications")}
+              </span>
             </div>
-
-            <%!-- Notifications --%>
-            <div class="form-control w-full">
-              <label class="label">
-                <span class="label-text text-base font-medium">
-                  {gettext("Notifications")}
-                </span>
-                <span class="label-text-alt text-sm text-base-content/60">
-                  {gettext("Per-user inbox driven by the activity feed")}
-                </span>
-              </label>
-              <div class="flex items-center gap-3">
-                <input type="hidden" name="settings[notifications_enabled]" value="false" />
-                <input
-                  name="settings[notifications_enabled]"
-                  type="checkbox"
-                  value="true"
-                  checked={@settings["notifications_enabled"] == "true"}
-                  class="checkbox checkbox-primary"
-                />
-                <span class="label-text">
-                  {gettext("Enable user notifications")}
-                </span>
-              </div>
-              <div class="label">
-                <span class="label-text-alt text-xs text-base-content/50">
-                  {gettext(
-                    "When on, users receive a bell notification whenever an activity targets them (e.g., their post is liked)."
-                  )}
-                </span>
-              </div>
+            <div class="label">
+              <span class="label-text-alt text-xs text-base-content/50">
+                {gettext(
+                  "When on, users receive a bell notification whenever an activity targets them (e.g., their post is liked)."
+                )}
+              </span>
             </div>
+          </div>
 
-            <%!-- Site Address URL Setting --%>
-            <div class="form-control w-full">
-              <label class="label">
-                <span class="label-text text-base font-medium">
-                  {gettext("Site Address (URL)")}
-                </span>
-              </label>
-              <input
-                name="settings[site_url]"
-                type="url"
-                value={@settings["site_url"]}
-                class="input input-bordered w-full focus:input-primary"
-                placeholder="https://site.com"
-                phx-debounce="500"
-              />
-              <div class="label">
-                <span class="label-text-alt text-xs text-base-content/50">
-                  <%= if @settings["site_url"] != @saved_settings["site_url"] do %>
-                    <span class="text-warning">
-                      {gettext("Selected:")} {if @settings["site_url"] != "",
-                        do: @settings["site_url"],
-                        else: gettext("(empty)")}
-                    </span>
-                    <span class="text-base-content/40">
-                      | {gettext("Saved:")} {if @saved_settings["site_url"] != "",
-                        do: @saved_settings["site_url"],
-                        else: gettext("(empty)")}
-                    </span>
-                  <% else %>
-                    {gettext("Saved:")} {if @settings["site_url"] != "",
+          <%!-- Site Address URL Setting --%>
+          <div class="form-control w-full">
+            <label class="label">
+              <span class="label-text text-base font-medium">
+                {gettext("Site Address (URL)")}
+              </span>
+            </label>
+            <input
+              name="settings[site_url]"
+              type="url"
+              value={@settings["site_url"]}
+              class="input input-bordered w-full focus:input-primary"
+              placeholder="https://site.com"
+              phx-debounce="500"
+            />
+            <div class="label">
+              <span class="label-text-alt text-xs text-base-content/50">
+                <%= if @settings["site_url"] != @saved_settings["site_url"] do %>
+                  <span class="text-warning">
+                    {gettext("Selected:")} {if @settings["site_url"] != "",
                       do: @settings["site_url"],
                       else: gettext("(empty)")}
-                  <% end %>
-                </span>
-              </div>
+                  </span>
+                  <span class="text-base-content/40">
+                    | {gettext("Saved:")} {if @saved_settings["site_url"] != "",
+                      do: @saved_settings["site_url"],
+                      else: gettext("(empty)")}
+                  </span>
+                <% else %>
+                  {gettext("Saved:")} {if @settings["site_url"] != "",
+                    do: @settings["site_url"],
+                    else: gettext("(empty)")}
+                <% end %>
+              </span>
             </div>
+          </div>
 
-            <%!-- Week Start Day Setting --%>
-            <div class="form-control w-full">
-              <label class="label">
-                <span class="label-text text-base font-medium">{gettext("Week Start On")}</span>
-                <span class="label-text-alt text-sm text-base-content/60">
-                  {gettext("First day of the week")}
-                </span>
-              </label>
-              <label class="select w-full focus:select-primary">
-                <select name="settings[week_start_day]">
-                  <%= for {label, value} <- @setting_options["week_start_day"] do %>
-                    <option value={value} selected={value == @settings["week_start_day"]}>
-                      {label}
-                    </option>
-                  <% end %>
-                </select>
-              </label>
-              <div class="label">
-                <span class="label-text-alt text-xs text-base-content/50">
-                  <%= if @settings["week_start_day"] != @saved_settings["week_start_day"] do %>
-                    <span class="text-warning">
-                      {gettext("Selected:")} {get_option_label(
-                        @settings["week_start_day"],
-                        @setting_options["week_start_day"]
-                      )}
-                    </span>
-                    <span class="text-base-content/40">
-                      | {gettext("Saved:")} {get_option_label(
-                        @saved_settings["week_start_day"],
-                        @setting_options["week_start_day"]
-                      )}
-                    </span>
-                  <% else %>
-                    {gettext("Saved:")} {get_option_label(
+          <%!-- Week Start Day Setting --%>
+          <div class="form-control w-full">
+            <label class="label">
+              <span class="label-text text-base font-medium">{gettext("Week Start On")}</span>
+              <span class="label-text-alt text-sm text-base-content/60">
+                {gettext("First day of the week")}
+              </span>
+            </label>
+            <label class="select w-full focus:select-primary">
+              <select name="settings[week_start_day]">
+                <%= for {label, value} <- @setting_options["week_start_day"] do %>
+                  <option value={value} selected={value == @settings["week_start_day"]}>
+                    {label}
+                  </option>
+                <% end %>
+              </select>
+            </label>
+            <div class="label">
+              <span class="label-text-alt text-xs text-base-content/50">
+                <%= if @settings["week_start_day"] != @saved_settings["week_start_day"] do %>
+                  <span class="text-warning">
+                    {gettext("Selected:")} {get_option_label(
                       @settings["week_start_day"],
                       @setting_options["week_start_day"]
                     )}
-                  <% end %>
-                </span>
-              </div>
+                  </span>
+                  <span class="text-base-content/40">
+                    | {gettext("Saved:")} {get_option_label(
+                      @saved_settings["week_start_day"],
+                      @setting_options["week_start_day"]
+                    )}
+                  </span>
+                <% else %>
+                  {gettext("Saved:")} {get_option_label(
+                    @settings["week_start_day"],
+                    @setting_options["week_start_day"]
+                  )}
+                <% end %>
+              </span>
             </div>
+          </div>
 
-            <%!-- Time Zone Setting --%>
-            <div class="form-control w-full">
-              <label class="label">
-                <span class="label-text text-base font-medium">{gettext("Time Zone")}</span>
-                <span class="label-text-alt text-sm text-base-content/60">
-                  {gettext("System default timezone")}
-                </span>
-              </label>
-              <label class="select w-full focus:select-primary">
-                <select name="settings[time_zone]">
-                  <%= for {label, value} <- @setting_options["time_zone"] do %>
-                    <option value={value} selected={value == @settings["time_zone"]}>
-                      {label}
-                    </option>
-                  <% end %>
-                </select>
-              </label>
-              <div class="label">
-                <span class="label-text-alt text-xs text-base-content/50">
-                  <%= if @settings["time_zone"] != @saved_settings["time_zone"] do %>
-                    <span class="text-warning">
-                      {gettext("Selected:")} {get_timezone_label(
-                        @settings["time_zone"],
-                        @setting_options
-                      )}
-                    </span>
-                    <span class="text-base-content/40">
-                      | {gettext("Saved:")} {get_timezone_label(
-                        @saved_settings["time_zone"],
-                        @setting_options
-                      )}
-                    </span>
-                  <% else %>
-                    {gettext("Saved:")} {get_timezone_label(
+          <%!-- Time Zone Setting --%>
+          <div class="form-control w-full">
+            <label class="label">
+              <span class="label-text text-base font-medium">{gettext("Time Zone")}</span>
+              <span class="label-text-alt text-sm text-base-content/60">
+                {gettext("System default timezone")}
+              </span>
+            </label>
+            <label class="select w-full focus:select-primary">
+              <select name="settings[time_zone]">
+                <%= for {label, value} <- @setting_options["time_zone"] do %>
+                  <option value={value} selected={value == @settings["time_zone"]}>
+                    {label}
+                  </option>
+                <% end %>
+              </select>
+            </label>
+            <div class="label">
+              <span class="label-text-alt text-xs text-base-content/50">
+                <%= if @settings["time_zone"] != @saved_settings["time_zone"] do %>
+                  <span class="text-warning">
+                    {gettext("Selected:")} {get_timezone_label(
                       @settings["time_zone"],
                       @setting_options
                     )}
-                  <% end %>
-                </span>
-              </div>
+                  </span>
+                  <span class="text-base-content/40">
+                    | {gettext("Saved:")} {get_timezone_label(
+                      @saved_settings["time_zone"],
+                      @setting_options
+                    )}
+                  </span>
+                <% else %>
+                  {gettext("Saved:")} {get_timezone_label(
+                    @settings["time_zone"],
+                    @setting_options
+                  )}
+                <% end %>
+              </span>
             </div>
+          </div>
 
-            <%!-- Date Format Setting --%>
-            <div class="form-control w-full">
-              <label class="label">
-                <span class="label-text text-base font-medium">{gettext("Date Format")}</span>
-                <span class="label-text-alt text-sm text-base-content/60">
-                  {gettext("How dates are displayed")}
-                </span>
-              </label>
-              <label class="select w-full focus:select-primary">
-                <select name="settings[date_format]">
-                  <%= for {label, value} <- @setting_options["date_format"] do %>
-                    <option value={value} selected={value == @settings["date_format"]}>
-                      {label}
-                    </option>
-                  <% end %>
-                </select>
-              </label>
-              <div class="label">
-                <span class="label-text-alt text-xs text-base-content/50">
-                  <%= if @settings["date_format"] != @saved_settings["date_format"] do %>
-                    <span class="text-warning">
-                      {gettext("Selected:")} {get_option_label(
-                        @settings["date_format"],
-                        @setting_options["date_format"]
-                      )}
-                    </span>
-                    <span class="text-base-content/40">
-                      | {gettext("Saved:")} {get_option_label(
-                        @saved_settings["date_format"],
-                        @setting_options["date_format"]
-                      )}
-                    </span>
-                  <% else %>
-                    {gettext("Saved:")} {get_option_label(
+          <%!-- Date Format Setting --%>
+          <div class="form-control w-full">
+            <label class="label">
+              <span class="label-text text-base font-medium">{gettext("Date Format")}</span>
+              <span class="label-text-alt text-sm text-base-content/60">
+                {gettext("How dates are displayed")}
+              </span>
+            </label>
+            <label class="select w-full focus:select-primary">
+              <select name="settings[date_format]">
+                <%= for {label, value} <- @setting_options["date_format"] do %>
+                  <option value={value} selected={value == @settings["date_format"]}>
+                    {label}
+                  </option>
+                <% end %>
+              </select>
+            </label>
+            <div class="label">
+              <span class="label-text-alt text-xs text-base-content/50">
+                <%= if @settings["date_format"] != @saved_settings["date_format"] do %>
+                  <span class="text-warning">
+                    {gettext("Selected:")} {get_option_label(
                       @settings["date_format"],
                       @setting_options["date_format"]
                     )}
-                  <% end %>
-                </span>
-              </div>
+                  </span>
+                  <span class="text-base-content/40">
+                    | {gettext("Saved:")} {get_option_label(
+                      @saved_settings["date_format"],
+                      @setting_options["date_format"]
+                    )}
+                  </span>
+                <% else %>
+                  {gettext("Saved:")} {get_option_label(
+                    @settings["date_format"],
+                    @setting_options["date_format"]
+                  )}
+                <% end %>
+              </span>
             </div>
+          </div>
 
-            <%!-- Time Format Setting --%>
-            <div class="form-control w-full">
-              <label class="label">
-                <span class="label-text text-base font-medium">{gettext("Time Format")}</span>
-                <span class="label-text-alt text-sm text-base-content/60">
-                  {gettext("How times are displayed")}
-                </span>
-              </label>
-              <label class="select w-full focus:select-primary">
-                <select name="settings[time_format]">
-                  <%= for {label, value} <- @setting_options["time_format"] do %>
-                    <option value={value} selected={value == @settings["time_format"]}>
-                      {label}
-                    </option>
-                  <% end %>
-                </select>
-              </label>
-              <div class="label">
-                <span class="label-text-alt text-xs text-base-content/50">
-                  <%= if @settings["time_format"] != @saved_settings["time_format"] do %>
-                    <span class="text-warning">
-                      {gettext("Selected:")} {get_option_label(
-                        @settings["time_format"],
-                        @setting_options["time_format"]
-                      )}
-                    </span>
-                    <span class="text-base-content/40">
-                      | {gettext("Saved:")} {get_option_label(
-                        @saved_settings["time_format"],
-                        @setting_options["time_format"]
-                      )}
-                    </span>
-                  <% else %>
-                    {gettext("Saved:")} {get_option_label(
+          <%!-- Time Format Setting --%>
+          <div class="form-control w-full">
+            <label class="label">
+              <span class="label-text text-base font-medium">{gettext("Time Format")}</span>
+              <span class="label-text-alt text-sm text-base-content/60">
+                {gettext("How times are displayed")}
+              </span>
+            </label>
+            <label class="select w-full focus:select-primary">
+              <select name="settings[time_format]">
+                <%= for {label, value} <- @setting_options["time_format"] do %>
+                  <option value={value} selected={value == @settings["time_format"]}>
+                    {label}
+                  </option>
+                <% end %>
+              </select>
+            </label>
+            <div class="label">
+              <span class="label-text-alt text-xs text-base-content/50">
+                <%= if @settings["time_format"] != @saved_settings["time_format"] do %>
+                  <span class="text-warning">
+                    {gettext("Selected:")} {get_option_label(
                       @settings["time_format"],
                       @setting_options["time_format"]
                     )}
-                  <% end %>
-                </span>
-              </div>
-            </div>
-
-            <%!-- Action Buttons --%>
-            <div class="flex gap-3 pt-4">
-              <button
-                type="submit"
-                class={[
-                  "btn btn-primary flex-1",
-                  if(@saving, do: "loading", else: "")
-                ]}
-                disabled={@saving}
-              >
-                <%= if @saving do %>
-                  {gettext("Saving...")}
+                  </span>
+                  <span class="text-base-content/40">
+                    | {gettext("Saved:")} {get_option_label(
+                      @saved_settings["time_format"],
+                      @setting_options["time_format"]
+                    )}
+                  </span>
                 <% else %>
-                  {gettext("Save All Settings")}
+                  {gettext("Saved:")} {get_option_label(
+                    @settings["time_format"],
+                    @setting_options["time_format"]
+                  )}
                 <% end %>
-              </button>
-
-              <button
-                type="button"
-                class="btn btn-outline"
-                phx-click="reset_to_defaults"
-              >
-                <PhoenixKitWeb.Components.Core.Icons.icon_refresh class="w-4 h-4 mr-2" /> {gettext(
-                  "Reset"
-                )}
-              </button>
+              </span>
             </div>
-          </.form>
+          </div>
 
-          <%!-- Information Panel --%>
-          <div class="divider">{gettext("Information")}</div>
+          <%!-- Action Buttons --%>
+          <div class="flex gap-3 pt-4">
+            <button
+              type="submit"
+              class={[
+                "btn btn-primary flex-1",
+                if(@saving, do: "loading", else: "")
+              ]}
+              disabled={@saving}
+            >
+              <%= if @saving do %>
+                {gettext("Saving...")}
+              <% else %>
+                {gettext("Save All Settings")}
+              <% end %>
+            </button>
 
-          <div class="bg-base-200 rounded-lg p-4 mt-6">
-            <div class="flex items-start gap-3">
-              <div class="text-2xl">💡</div>
-              <div class="flex-1">
-                <h3 class="font-semibold text-base-content mb-2">
-                  {gettext("About System Settings")}
-                </h3>
-                <ul class="text-sm text-base-content/70 space-y-1">
-                  <li>
-                    {gettext(
-                      "• Make changes to dropdowns and click \"Save All Settings\" to apply"
-                    )}
-                  </li>
-                  <li>
-                    {gettext(
-                      "• Changes show \"Selected\" vs \"Saved\" values until you click Save"
-                    )}
-                  </li>
-                  <li>
-                    {gettext(
-                      "• User settings (registration, defaults, custom fields) are managed separately"
-                    )}
-                  </li>
-                  <li>
-                    {gettext(
-                      "• Week start day controls which day begins the week (useful for calendar features)"
-                    )}
-                  </li>
-                  <li>
-                    {gettext("• Time zone affects date/time display throughout the system")}
-                  </li>
-                  <li>
-                    {gettext(
-                      "• Date formats control how dates appear (e.g. Users dashboard \"Registered\" field)"
-                    )}
-                  </li>
-                  <li>{gettext("• Time formats control 12-hour vs 24-hour time display")}</li>
-                  <li>
-                    {gettext(
-                      "• Settings are applied system-wide and use Timex for robust formatting"
-                    )}
-                  </li>
-                  <li>
-                    {gettext(
-                      "• Currently supports 6 date formats including \"September 2, 2025\" style"
-                    )}
-                  </li>
-                </ul>
-              </div>
+            <button
+              type="button"
+              class="btn btn-outline"
+              phx-click="reset_to_defaults"
+            >
+              <PhoenixKitWeb.Components.Core.Icons.icon_refresh class="w-4 h-4 mr-2" /> {gettext(
+                "Reset"
+              )}
+            </button>
+          </div>
+        </.form>
+
+        <%!-- Information Panel --%>
+        <div class="divider">{gettext("Information")}</div>
+
+        <div class="bg-base-200 rounded-lg p-4 mt-6">
+          <div class="flex items-start gap-3">
+            <div class="text-2xl">💡</div>
+            <div class="flex-1">
+              <h3 class="font-semibold text-base-content mb-2">
+                {gettext("About System Settings")}
+              </h3>
+              <ul class="text-sm text-base-content/70 space-y-1">
+                <li>
+                  {gettext("• Make changes to dropdowns and click \"Save All Settings\" to apply")}
+                </li>
+                <li>
+                  {gettext("• Changes show \"Selected\" vs \"Saved\" values until you click Save")}
+                </li>
+                <li>
+                  {gettext(
+                    "• User settings (registration, defaults, custom fields) are managed separately"
+                  )}
+                </li>
+                <li>
+                  {gettext(
+                    "• Week start day controls which day begins the week (useful for calendar features)"
+                  )}
+                </li>
+                <li>
+                  {gettext("• Time zone affects date/time display throughout the system")}
+                </li>
+                <li>
+                  {gettext(
+                    "• Date formats control how dates appear (e.g. Users dashboard \"Registered\" field)"
+                  )}
+                </li>
+                <li>{gettext("• Time formats control 12-hour vs 24-hour time display")}</li>
+                <li>
+                  {gettext(
+                    "• Settings are applied system-wide and use Timex for robust formatting"
+                  )}
+                </li>
+                <li>
+                  {gettext(
+                    "• Currently supports 6 date formats including \"September 2, 2025\" style"
+                  )}
+                </li>
+              </ul>
             </div>
           </div>
         </div>

--- a/lib/phoenix_kit_web/live/settings/authorization.html.heex
+++ b/lib/phoenix_kit_web/live/settings/authorization.html.heex
@@ -14,79 +14,79 @@
     />
 
     <%!-- Settings Form --%>
-    <div class="max-w-2xl mx-auto">
-      <div class="card bg-base-100 shadow-xl">
-        <div class="card-body">
-          <h2 class="card-title text-xl mb-6">{gettext("Authorization Configuration")}</h2>
+    <div class="card bg-base-100 shadow-xl">
+      <div class="card-body">
+        <h2 class="card-title text-xl mb-6">{gettext("Authorization Configuration")}</h2>
 
-          <.form
-            :let={_form}
-            for={@changeset}
-            id="authorization_settings_form"
-            phx-submit="save_settings"
-            phx-change="validate_settings"
-            class="space-y-6"
-          >
-            <%!-- Hidden fields for required settings from other pages --%>
-            <%!-- General Settings --%>
-            <input
-              type="hidden"
-              name="settings[project_title]"
-              value={@saved_settings["project_title"]}
-            />
-            <input
-              type="hidden"
-              name="settings[site_url]"
-              value={@saved_settings["site_url"]}
-            />
-            <input
-              type="hidden"
-              name="settings[week_start_day]"
-              value={@saved_settings["week_start_day"]}
-            />
-            <input
-              type="hidden"
-              name="settings[time_zone]"
-              value={@saved_settings["time_zone"]}
-            />
-            <input
-              type="hidden"
-              name="settings[date_format]"
-              value={@saved_settings["date_format"]}
-            />
-            <input
-              type="hidden"
-              name="settings[time_format]"
-              value={@saved_settings["time_format"]}
-            />
+        <.form
+          :let={_form}
+          for={@changeset}
+          id="authorization_settings_form"
+          phx-submit="save_settings"
+          phx-change="validate_settings"
+          class="space-y-6"
+        >
+          <%!-- Hidden fields for required settings from other pages --%>
+          <%!-- General Settings --%>
+          <input
+            type="hidden"
+            name="settings[project_title]"
+            value={@saved_settings["project_title"]}
+          />
+          <input
+            type="hidden"
+            name="settings[site_url]"
+            value={@saved_settings["site_url"]}
+          />
+          <input
+            type="hidden"
+            name="settings[week_start_day]"
+            value={@saved_settings["week_start_day"]}
+          />
+          <input
+            type="hidden"
+            name="settings[time_zone]"
+            value={@saved_settings["time_zone"]}
+          />
+          <input
+            type="hidden"
+            name="settings[date_format]"
+            value={@saved_settings["date_format"]}
+          />
+          <input
+            type="hidden"
+            name="settings[time_format]"
+            value={@saved_settings["time_format"]}
+          />
 
-            <%!-- Users Settings --%>
-            <input
-              type="hidden"
-              name="settings[allow_registration]"
-              value={@saved_settings["allow_registration"]}
-            />
-            <input
-              type="hidden"
-              name="settings[new_user_default_role]"
-              value={@saved_settings["new_user_default_role"]}
-            />
-            <input
-              type="hidden"
-              name="settings[new_user_default_status]"
-              value={@saved_settings["new_user_default_status"]}
-            />
-            <input
-              type="hidden"
-              name="settings[track_registration_geolocation]"
-              value={@saved_settings["track_registration_geolocation"]}
-            />
+          <%!-- Users Settings --%>
+          <input
+            type="hidden"
+            name="settings[allow_registration]"
+            value={@saved_settings["allow_registration"]}
+          />
+          <input
+            type="hidden"
+            name="settings[new_user_default_role]"
+            value={@saved_settings["new_user_default_role"]}
+          />
+          <input
+            type="hidden"
+            name="settings[new_user_default_status]"
+            value={@saved_settings["new_user_default_status"]}
+          />
+          <input
+            type="hidden"
+            name="settings[track_registration_geolocation]"
+            value={@saved_settings["track_registration_geolocation"]}
+          />
 
-            <%!-- Login Page Branding --%>
-            <div class="divider text-sm text-base-content/50">
-              {gettext("Login Page Branding")}
-            </div>
+          <%!-- Login Page Branding --%>
+          <div class="divider text-sm text-base-content/50">
+            {gettext("Login Page Branding")}
+          </div>
 
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
             <div class="form-control w-full">
               <label class="label">
                 <span class="label-text text-base font-medium">
@@ -185,209 +185,211 @@
                 </span>
               </div>
             </div>
+          </div>
 
-            <div class="form-control w-full">
-              <label class="label">
-                <span class="label-text text-base font-medium">
-                  {gettext("Background Color")}
-                </span>
-              </label>
-              <input
-                name="settings[auth_background_color]"
-                type="text"
-                value={@settings["auth_background_color"]}
-                class="input input-bordered w-full focus:input-primary"
-                placeholder={gettext("#1a1a2e or linear-gradient(135deg, #667eea, #764ba2)")}
-                phx-debounce="500"
-              />
-              <div class="label">
-                <span class="label-text-alt text-xs text-base-content/50">
-                  {gettext(
-                    "CSS color or gradient for auth page background. Ignored if a background image is set."
-                  )}
+          <div class="form-control w-full">
+            <label class="label">
+              <span class="label-text text-base font-medium">
+                {gettext("Background Color")}
+              </span>
+            </label>
+            <input
+              name="settings[auth_background_color]"
+              type="text"
+              value={@settings["auth_background_color"]}
+              class="input input-bordered w-full focus:input-primary"
+              placeholder={gettext("#1a1a2e or linear-gradient(135deg, #667eea, #764ba2)")}
+              phx-debounce="500"
+            />
+            <div class="label">
+              <span class="label-text-alt text-xs text-base-content/50">
+                {gettext(
+                  "CSS color or gradient for auth page background. Ignored if a background image is set."
+                )}
+              </span>
+            </div>
+          </div>
+
+          <%!-- Authentication Methods Setting --%>
+          <div class="form-control w-full">
+            <label class="label">
+              <span class="label-text text-base font-medium">
+                {gettext("Authentication Methods")}
+              </span>
+              <span class="label-text-alt text-sm text-base-content/60">
+                {gettext("Control available login/registration methods")}
+              </span>
+            </label>
+
+            <%!-- Magic Link Methods --%>
+            <div class="mb-3">
+              <div class="text-sm font-semibold text-base-content/70 mb-2">
+                {gettext("Magic Link")}
+              </div>
+              <div class="flex items-center gap-3 mb-2 ml-4">
+                <input
+                  name="settings[magic_link_login_enabled]"
+                  type="hidden"
+                  value="false"
+                />
+                <input
+                  name="settings[magic_link_login_enabled]"
+                  type="checkbox"
+                  value="true"
+                  checked={@settings["magic_link_login_enabled"] == "true"}
+                  class="checkbox checkbox-primary"
+                />
+                <span class="label-text">{gettext("Enable Magic Link for login")}</span>
+              </div>
+              <div class="flex items-center gap-3 ml-4">
+                <input
+                  name="settings[magic_link_registration_enabled]"
+                  type="hidden"
+                  value="false"
+                />
+                <input
+                  name="settings[magic_link_registration_enabled]"
+                  type="checkbox"
+                  value="true"
+                  checked={
+                    @settings["magic_link_registration_enabled"] == "true" and
+                      @settings["allow_registration"] == "true"
+                  }
+                  disabled={@settings["allow_registration"] != "true"}
+                  class="checkbox checkbox-primary"
+                />
+                <span class={[
+                  "label-text",
+                  @settings["allow_registration"] != "true" && "text-base-content/40"
+                ]}>
+                  {gettext("Enable Magic Link for registration")}
+                  <%= if @settings["allow_registration"] != "true" do %>
+                    <span class="text-xs italic">{gettext("(registration disabled)")}</span>
+                  <% end %>
                 </span>
               </div>
             </div>
 
-            <%!-- Authentication Methods Setting --%>
-            <div class="form-control w-full">
-              <label class="label">
-                <span class="label-text text-base font-medium">
-                  {gettext("Authentication Methods")}
+            <%!-- OAuth Methods --%>
+            <div>
+              <div class="text-sm font-semibold text-base-content/70 mb-2">
+                {gettext("OAuth Providers")}
+              </div>
+              <div class="flex items-center gap-3 mb-2 ml-4">
+                <input name="settings[oauth_enabled]" type="hidden" value="false" />
+                <input
+                  name="settings[oauth_enabled]"
+                  type="checkbox"
+                  value="true"
+                  checked={@settings["oauth_enabled"] == "true"}
+                  class="checkbox checkbox-primary"
+                />
+                <span class="label-text font-semibold">
+                  {gettext("Enable OAuth (Master Switch)")}
                 </span>
-                <span class="label-text-alt text-sm text-base-content/60">
-                  {gettext("Control available login/registration methods")}
-                </span>
-              </label>
+              </div>
 
-              <%!-- Magic Link Methods --%>
-              <div class="mb-3">
-                <div class="text-sm font-semibold text-base-content/70 mb-2">
-                  {gettext("Magic Link")}
-                </div>
-                <div class="flex items-center gap-3 mb-2 ml-4">
+              <%!-- Individual OAuth Providers (disabled if master is off) --%>
+              <div class={[
+                "ml-8 space-y-2",
+                if(@settings["oauth_enabled"] != "true", do: "opacity-50", else: "")
+              ]}>
+                <div class="flex items-center gap-3">
                   <input
-                    name="settings[magic_link_login_enabled]"
+                    name="settings[oauth_google_enabled]"
                     type="hidden"
                     value="false"
                   />
                   <input
-                    name="settings[magic_link_login_enabled]"
+                    name="settings[oauth_google_enabled]"
                     type="checkbox"
                     value="true"
-                    checked={@settings["magic_link_login_enabled"] == "true"}
-                    class="checkbox checkbox-primary"
+                    checked={@settings["oauth_google_enabled"] == "true"}
+                    class={[
+                      "checkbox checkbox-primary",
+                      if(@settings["oauth_enabled"] != "true",
+                        do: "pointer-events-none",
+                        else: ""
+                      )
+                    ]}
                   />
-                  <span class="label-text">{gettext("Enable Magic Link for login")}</span>
+                  <span class="label-text">{gettext("Google Sign-In")}</span>
                 </div>
-                <div class="flex items-center gap-3 ml-4">
+                <div class="flex items-center gap-3">
+                  <input name="settings[oauth_apple_enabled]" type="hidden" value="false" />
                   <input
-                    name="settings[magic_link_registration_enabled]"
+                    name="settings[oauth_apple_enabled]"
+                    type="checkbox"
+                    value="true"
+                    checked={@settings["oauth_apple_enabled"] == "true"}
+                    class={[
+                      "checkbox checkbox-primary",
+                      if(@settings["oauth_enabled"] != "true",
+                        do: "pointer-events-none",
+                        else: ""
+                      )
+                    ]}
+                  />
+                  <span class="label-text">{gettext("Apple Sign-In")}</span>
+                </div>
+                <div class="flex items-center gap-3">
+                  <input
+                    name="settings[oauth_github_enabled]"
                     type="hidden"
                     value="false"
                   />
                   <input
-                    name="settings[magic_link_registration_enabled]"
+                    name="settings[oauth_github_enabled]"
                     type="checkbox"
                     value="true"
-                    checked={
-                      @settings["magic_link_registration_enabled"] == "true" and
-                        @settings["allow_registration"] == "true"
-                    }
-                    disabled={@settings["allow_registration"] != "true"}
-                    class="checkbox checkbox-primary"
+                    checked={@settings["oauth_github_enabled"] == "true"}
+                    class={[
+                      "checkbox checkbox-primary",
+                      if(@settings["oauth_enabled"] != "true",
+                        do: "pointer-events-none",
+                        else: ""
+                      )
+                    ]}
                   />
-                  <span class={[
-                    "label-text",
-                    @settings["allow_registration"] != "true" && "text-base-content/40"
-                  ]}>
-                    {gettext("Enable Magic Link for registration")}
-                    <%= if @settings["allow_registration"] != "true" do %>
-                      <span class="text-xs italic">{gettext("(registration disabled)")}</span>
-                    <% end %>
-                  </span>
+                  <span class="label-text">{gettext("GitHub Sign-In")}</span>
                 </div>
-              </div>
-
-              <%!-- OAuth Methods --%>
-              <div>
-                <div class="text-sm font-semibold text-base-content/70 mb-2">
-                  {gettext("OAuth Providers")}
-                </div>
-                <div class="flex items-center gap-3 mb-2 ml-4">
-                  <input name="settings[oauth_enabled]" type="hidden" value="false" />
+                <div class="flex items-center gap-3">
                   <input
-                    name="settings[oauth_enabled]"
+                    name="settings[oauth_facebook_enabled]"
+                    type="hidden"
+                    value="false"
+                  />
+                  <input
+                    name="settings[oauth_facebook_enabled]"
                     type="checkbox"
                     value="true"
-                    checked={@settings["oauth_enabled"] == "true"}
-                    class="checkbox checkbox-primary"
+                    checked={@settings["oauth_facebook_enabled"] == "true"}
+                    class={[
+                      "checkbox checkbox-primary",
+                      if(@settings["oauth_enabled"] != "true",
+                        do: "pointer-events-none",
+                        else: ""
+                      )
+                    ]}
                   />
-                  <span class="label-text font-semibold">
-                    {gettext("Enable OAuth (Master Switch)")}
-                  </span>
-                </div>
-
-                <%!-- Individual OAuth Providers (disabled if master is off) --%>
-                <div class={[
-                  "ml-8 space-y-2",
-                  if(@settings["oauth_enabled"] != "true", do: "opacity-50", else: "")
-                ]}>
-                  <div class="flex items-center gap-3">
-                    <input
-                      name="settings[oauth_google_enabled]"
-                      type="hidden"
-                      value="false"
-                    />
-                    <input
-                      name="settings[oauth_google_enabled]"
-                      type="checkbox"
-                      value="true"
-                      checked={@settings["oauth_google_enabled"] == "true"}
-                      class={[
-                        "checkbox checkbox-primary",
-                        if(@settings["oauth_enabled"] != "true",
-                          do: "pointer-events-none",
-                          else: ""
-                        )
-                      ]}
-                    />
-                    <span class="label-text">{gettext("Google Sign-In")}</span>
-                  </div>
-                  <div class="flex items-center gap-3">
-                    <input name="settings[oauth_apple_enabled]" type="hidden" value="false" />
-                    <input
-                      name="settings[oauth_apple_enabled]"
-                      type="checkbox"
-                      value="true"
-                      checked={@settings["oauth_apple_enabled"] == "true"}
-                      class={[
-                        "checkbox checkbox-primary",
-                        if(@settings["oauth_enabled"] != "true",
-                          do: "pointer-events-none",
-                          else: ""
-                        )
-                      ]}
-                    />
-                    <span class="label-text">{gettext("Apple Sign-In")}</span>
-                  </div>
-                  <div class="flex items-center gap-3">
-                    <input
-                      name="settings[oauth_github_enabled]"
-                      type="hidden"
-                      value="false"
-                    />
-                    <input
-                      name="settings[oauth_github_enabled]"
-                      type="checkbox"
-                      value="true"
-                      checked={@settings["oauth_github_enabled"] == "true"}
-                      class={[
-                        "checkbox checkbox-primary",
-                        if(@settings["oauth_enabled"] != "true",
-                          do: "pointer-events-none",
-                          else: ""
-                        )
-                      ]}
-                    />
-                    <span class="label-text">{gettext("GitHub Sign-In")}</span>
-                  </div>
-                  <div class="flex items-center gap-3">
-                    <input
-                      name="settings[oauth_facebook_enabled]"
-                      type="hidden"
-                      value="false"
-                    />
-                    <input
-                      name="settings[oauth_facebook_enabled]"
-                      type="checkbox"
-                      value="true"
-                      checked={@settings["oauth_facebook_enabled"] == "true"}
-                      class={[
-                        "checkbox checkbox-primary",
-                        if(@settings["oauth_enabled"] != "true",
-                          do: "pointer-events-none",
-                          else: ""
-                        )
-                      ]}
-                    />
-                    <span class="label-text">{gettext("Facebook Sign-In")}</span>
-                  </div>
+                  <span class="label-text">{gettext("Facebook Sign-In")}</span>
                 </div>
               </div>
+            </div>
 
-              <%!-- OAuth Provider Credential Forms --%>
-              <%= if @settings["oauth_enabled"] == "true" do %>
-                <%!-- Google OAuth Credentials --%>
-                <div class={[
-                  if(@settings["oauth_google_enabled"] != "true", do: "hidden", else: "")
-                ]}>
-                  <div class="card bg-base-200 p-4 mt-3">
-                    <h3 class="font-semibold mb-3 flex items-center gap-2">
-                      <PhoenixKitWeb.Components.Core.Icons.icon_google class="h-5 w-5" />
-                      {gettext("Google OAuth Credentials")}
-                    </h3>
+            <%!-- OAuth Provider Credential Forms --%>
+            <%= if @settings["oauth_enabled"] == "true" do %>
+              <%!-- Google OAuth Credentials --%>
+              <div class={[
+                if(@settings["oauth_google_enabled"] != "true", do: "hidden", else: "")
+              ]}>
+                <div class="card bg-base-200 p-4 mt-3">
+                  <h3 class="font-semibold mb-3 flex items-center gap-2">
+                    <PhoenixKitWeb.Components.Core.Icons.icon_google class="h-5 w-5" />
+                    {gettext("Google OAuth Credentials")}
+                  </h3>
 
+                  <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
                     <div class="form-control">
                       <label class="label">
                         <span class="label-text">{gettext("Client ID")}</span>
@@ -401,7 +403,7 @@
                       />
                     </div>
 
-                    <div class="form-control mt-2">
+                    <div class="form-control">
                       <label class="label">
                         <span class="label-text">{gettext("Client Secret")}</span>
                       </label>
@@ -413,126 +415,128 @@
                         class="input input-bordered"
                       />
                     </div>
+                  </div>
 
-                    <button
-                      type="button"
-                      phx-click="test_oauth"
-                      phx-value-provider="google"
-                      class="btn btn-sm btn-outline mt-3 w-fit"
-                    >
-                      {gettext("Test Credentials")}
-                    </button>
+                  <button
+                    type="button"
+                    phx-click="test_oauth"
+                    phx-value-provider="google"
+                    class="btn btn-sm btn-outline mt-3 w-fit"
+                  >
+                    {gettext("Test Credentials")}
+                  </button>
 
-                    <%!-- Google OAuth Setup Instructions --%>
-                    <div class="collapse collapse-arrow bg-base-200 mt-4">
-                      <input type="checkbox" class="peer" />
-                      <div class="collapse-title text-sm font-medium">
-                        {gettext("Setup Instructions")}
-                      </div>
-                      <div class="collapse-content text-sm space-y-4">
-                        <%!-- Callback URL Section --%>
-                        <div class="bg-base-100 border border-base-300 rounded-lg p-4">
-                          <div class="flex items-start gap-3">
-                            <.icon
-                              name="hero-information-circle"
-                              class="stroke-current shrink-0 h-5 w-5 text-info mt-0.5"
-                            />
-                            <div class="flex-1 min-w-0">
-                              <div class="text-sm font-semibold text-base-content mb-2">
-                                {gettext("Callback URL")}
-                              </div>
-                              <div class="flex items-center gap-2">
-                                <code class="flex-1 px-3 py-2 bg-base-200 text-base-content border border-base-300 rounded font-mono text-xs break-all">
-                                  {get_oauth_callback_url(@settings, "google")}
-                                </code>
-                                <button
-                                  type="button"
-                                  class="btn btn-sm btn-square btn-outline"
-                                  onclick={"navigator.clipboard.writeText('#{get_oauth_callback_url(@settings, "google")}')"}
-                                  title={gettext("Copy to clipboard")}
-                                >
-                                  <.icon name="hero-clipboard" class="h-4 w-4" />
-                                </button>
-                              </div>
-                              <div class="text-xs text-base-content/60 mt-2">
-                                {gettext("Copy this URL to Google Cloud Console")}
-                              </div>
+                  <%!-- Google OAuth Setup Instructions --%>
+                  <div class="collapse collapse-arrow bg-base-200 mt-4">
+                    <input type="checkbox" class="peer" />
+                    <div class="collapse-title text-sm font-medium">
+                      {gettext("Setup Instructions")}
+                    </div>
+                    <div class="collapse-content text-sm space-y-4">
+                      <%!-- Callback URL Section --%>
+                      <div class="bg-base-100 border border-base-300 rounded-lg p-4">
+                        <div class="flex items-start gap-3">
+                          <.icon
+                            name="hero-information-circle"
+                            class="stroke-current shrink-0 h-5 w-5 text-info mt-0.5"
+                          />
+                          <div class="flex-1 min-w-0">
+                            <div class="text-sm font-semibold text-base-content mb-2">
+                              {gettext("Callback URL")}
+                            </div>
+                            <div class="flex items-center gap-2">
+                              <code class="flex-1 px-3 py-2 bg-base-200 text-base-content border border-base-300 rounded font-mono text-xs break-all">
+                                {get_oauth_callback_url(@settings, "google")}
+                              </code>
+                              <button
+                                type="button"
+                                class="btn btn-sm btn-square btn-outline"
+                                onclick={"navigator.clipboard.writeText('#{get_oauth_callback_url(@settings, "google")}')"}
+                                title={gettext("Copy to clipboard")}
+                              >
+                                <.icon name="hero-clipboard" class="h-4 w-4" />
+                              </button>
+                            </div>
+                            <div class="text-xs text-base-content/60 mt-2">
+                              {gettext("Copy this URL to Google Cloud Console")}
                             </div>
                           </div>
                         </div>
+                      </div>
 
-                        <%!-- Step-by-step Instructions --%>
-                        <div class="space-y-3">
-                          <ol class="list-decimal list-inside space-y-2 text-base-content/80">
-                            <li>
-                              {gettext("Visit")}
-                              <a
-                                href="https://console.cloud.google.com/apis/credentials"
-                                target="_blank"
-                                class="link link-primary"
-                              >
-                                Google Cloud Console
-                              </a>
-                            </li>
-                            <li>{gettext("Create project or select existing one")}</li>
-                            <li>
-                              {gettext("Go to")} <strong>Credentials</strong>
-                              → <strong>Create Credentials</strong>
-                              → <strong>OAuth client ID</strong>
-                            </li>
-                            <li>
-                              {gettext("Select")}
-                              <strong>Web application</strong> {gettext("type")}
-                            </li>
-                            <li>
-                              {gettext("Add callback URL above to")}
-                              <strong>Authorized redirect URIs</strong>
-                            </li>
-                            <li>{gettext("Copy Client ID and Secret to fields above")}</li>
-                            <li>
-                              {gettext("Click")}
-                              <strong>Test Credentials</strong> {gettext("to verify setup")}
-                            </li>
-                          </ol>
-                        </div>
+                      <%!-- Step-by-step Instructions --%>
+                      <div class="space-y-3">
+                        <ol class="list-decimal list-inside space-y-2 text-base-content/80">
+                          <li>
+                            {gettext("Visit")}
+                            <a
+                              href="https://console.cloud.google.com/apis/credentials"
+                              target="_blank"
+                              class="link link-primary"
+                            >
+                              Google Cloud Console
+                            </a>
+                          </li>
+                          <li>{gettext("Create project or select existing one")}</li>
+                          <li>
+                            {gettext("Go to")} <strong>Credentials</strong>
+                            → <strong>Create Credentials</strong>
+                            → <strong>OAuth client ID</strong>
+                          </li>
+                          <li>
+                            {gettext("Select")}
+                            <strong>Web application</strong> {gettext("type")}
+                          </li>
+                          <li>
+                            {gettext("Add callback URL above to")}
+                            <strong>Authorized redirect URIs</strong>
+                          </li>
+                          <li>{gettext("Copy Client ID and Secret to fields above")}</li>
+                          <li>
+                            {gettext("Click")}
+                            <strong>Test Credentials</strong> {gettext("to verify setup")}
+                          </li>
+                        </ol>
+                      </div>
 
-                        <%!-- Reverse Proxy Notice --%>
-                        <div class="bg-base-200 border border-base-300 rounded-lg p-3 text-xs">
-                          <div class="flex items-start gap-2">
-                            <.icon
-                              name="hero-information-circle"
-                              class="h-4 w-4 text-info shrink-0 mt-0.5"
-                            />
-                            <div class="text-base-content/80">
-                              <strong class="text-base-content">
-                                {gettext("Reverse Proxy Users:")}
-                              </strong>
-                              {gettext("If behind nginx/apache, ensure")}
-                              <code class="px-1 py-0.5 bg-base-300 text-base-content rounded text-xs">
-                                X-Forwarded-Proto
-                              </code>
-                              {gettext("header is set to")}
-                              <code class="px-1 py-0.5 bg-base-300 text-base-content rounded text-xs">
-                                https
-                              </code>
-                            </div>
+                      <%!-- Reverse Proxy Notice --%>
+                      <div class="bg-base-200 border border-base-300 rounded-lg p-3 text-xs">
+                        <div class="flex items-start gap-2">
+                          <.icon
+                            name="hero-information-circle"
+                            class="h-4 w-4 text-info shrink-0 mt-0.5"
+                          />
+                          <div class="text-base-content/80">
+                            <strong class="text-base-content">
+                              {gettext("Reverse Proxy Users:")}
+                            </strong>
+                            {gettext("If behind nginx/apache, ensure")}
+                            <code class="px-1 py-0.5 bg-base-300 text-base-content rounded text-xs">
+                              X-Forwarded-Proto
+                            </code>
+                            {gettext("header is set to")}
+                            <code class="px-1 py-0.5 bg-base-300 text-base-content rounded text-xs">
+                              https
+                            </code>
                           </div>
                         </div>
                       </div>
                     </div>
                   </div>
                 </div>
+              </div>
 
-                <%!-- Apple OAuth Credentials --%>
-                <div class={[
-                  if(@settings["oauth_apple_enabled"] != "true", do: "hidden", else: "")
-                ]}>
-                  <div class="card bg-base-200 p-4 mt-3">
-                    <h3 class="font-semibold mb-3 flex items-center gap-2">
-                      <PhoenixKitWeb.Components.Core.Icons.icon_apple class="h-5 w-5" />
-                      {gettext("Apple OAuth Credentials")}
-                    </h3>
+              <%!-- Apple OAuth Credentials --%>
+              <div class={[
+                if(@settings["oauth_apple_enabled"] != "true", do: "hidden", else: "")
+              ]}>
+                <div class="card bg-base-200 p-4 mt-3">
+                  <h3 class="font-semibold mb-3 flex items-center gap-2">
+                    <PhoenixKitWeb.Components.Core.Icons.icon_apple class="h-5 w-5" />
+                    {gettext("Apple OAuth Credentials")}
+                  </h3>
 
+                  <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
                     <div class="form-control">
                       <label class="label">
                         <span class="label-text">{gettext("Client ID")}</span>
@@ -546,7 +550,7 @@
                       />
                     </div>
 
-                    <div class="form-control mt-2">
+                    <div class="form-control">
                       <label class="label">
                         <span class="label-text">{gettext("Team ID")}</span>
                       </label>
@@ -558,163 +562,165 @@
                         class="input input-bordered"
                       />
                     </div>
+                  </div>
 
-                    <div class="form-control mt-2">
-                      <label class="label">
-                        <span class="label-text">{gettext("Key ID")}</span>
-                      </label>
-                      <input
-                        type="text"
-                        name="settings[oauth_apple_key_id]"
-                        value={@settings["oauth_apple_key_id"] || ""}
-                        placeholder={gettext("Your Apple Key ID")}
-                        class="input input-bordered"
-                      />
+                  <div class="form-control mt-3">
+                    <label class="label">
+                      <span class="label-text">{gettext("Key ID")}</span>
+                    </label>
+                    <input
+                      type="text"
+                      name="settings[oauth_apple_key_id]"
+                      value={@settings["oauth_apple_key_id"] || ""}
+                      placeholder={gettext("Your Apple Key ID")}
+                      class="input input-bordered"
+                    />
+                  </div>
+
+                  <div class="form-control mt-3">
+                    <label class="label">
+                      <span class="label-text">{gettext("Private Key")}</span>
+                    </label>
+                    <textarea
+                      name="settings[oauth_apple_private_key]"
+                      rows="5"
+                      placeholder="-----BEGIN PRIVATE KEY-----&#10;Your Apple private key content&#10;-----END PRIVATE KEY-----"
+                      class="textarea textarea-bordered font-mono text-xs"
+                    >{@settings["oauth_apple_private_key"] || ""}</textarea>
+                  </div>
+
+                  <button
+                    type="button"
+                    phx-click="test_oauth"
+                    phx-value-provider="apple"
+                    class="btn btn-sm btn-outline mt-3 w-fit"
+                  >
+                    {gettext("Test Credentials")}
+                  </button>
+
+                  <%!-- Apple OAuth Setup Instructions --%>
+                  <div class="collapse collapse-arrow bg-base-200 mt-4">
+                    <input type="checkbox" class="peer" />
+                    <div class="collapse-title text-sm font-medium">
+                      {gettext("Setup Instructions")}
                     </div>
-
-                    <div class="form-control mt-2">
-                      <label class="label">
-                        <span class="label-text">{gettext("Private Key")}</span>
-                      </label>
-                      <textarea
-                        name="settings[oauth_apple_private_key]"
-                        rows="5"
-                        placeholder="-----BEGIN PRIVATE KEY-----&#10;Your Apple private key content&#10;-----END PRIVATE KEY-----"
-                        class="textarea textarea-bordered font-mono text-xs"
-                      >{@settings["oauth_apple_private_key"] || ""}</textarea>
-                    </div>
-
-                    <button
-                      type="button"
-                      phx-click="test_oauth"
-                      phx-value-provider="apple"
-                      class="btn btn-sm btn-outline mt-3 w-fit"
-                    >
-                      {gettext("Test Credentials")}
-                    </button>
-
-                    <%!-- Apple OAuth Setup Instructions --%>
-                    <div class="collapse collapse-arrow bg-base-200 mt-4">
-                      <input type="checkbox" class="peer" />
-                      <div class="collapse-title text-sm font-medium">
-                        {gettext("Setup Instructions")}
-                      </div>
-                      <div class="collapse-content text-sm space-y-4">
-                        <%!-- Callback URL Section --%>
-                        <div class="bg-base-100 border border-base-300 rounded-lg p-4">
-                          <div class="flex items-start gap-3">
-                            <.icon
-                              name="hero-information-circle"
-                              class="stroke-current shrink-0 h-5 w-5 text-info mt-0.5"
-                            />
-                            <div class="flex-1 min-w-0">
-                              <div class="text-sm font-semibold text-base-content mb-2">
-                                {gettext("Callback URL")}
-                              </div>
-                              <div class="flex items-center gap-2">
-                                <code class="flex-1 px-3 py-2 bg-base-200 text-base-content border border-base-300 rounded font-mono text-xs break-all">
-                                  {get_oauth_callback_url(@settings, "apple")}
-                                </code>
-                                <button
-                                  type="button"
-                                  class="btn btn-sm btn-square btn-outline"
-                                  onclick={"navigator.clipboard.writeText('#{get_oauth_callback_url(@settings, "apple")}')"}
-                                  title={gettext("Copy to clipboard")}
-                                >
-                                  <.icon name="hero-clipboard" class="h-4 w-4" />
-                                </button>
-                              </div>
-                              <div class="text-xs text-base-content/60 mt-2">
-                                {gettext("Copy this URL to Apple Developer Console")}
-                              </div>
+                    <div class="collapse-content text-sm space-y-4">
+                      <%!-- Callback URL Section --%>
+                      <div class="bg-base-100 border border-base-300 rounded-lg p-4">
+                        <div class="flex items-start gap-3">
+                          <.icon
+                            name="hero-information-circle"
+                            class="stroke-current shrink-0 h-5 w-5 text-info mt-0.5"
+                          />
+                          <div class="flex-1 min-w-0">
+                            <div class="text-sm font-semibold text-base-content mb-2">
+                              {gettext("Callback URL")}
+                            </div>
+                            <div class="flex items-center gap-2">
+                              <code class="flex-1 px-3 py-2 bg-base-200 text-base-content border border-base-300 rounded font-mono text-xs break-all">
+                                {get_oauth_callback_url(@settings, "apple")}
+                              </code>
+                              <button
+                                type="button"
+                                class="btn btn-sm btn-square btn-outline"
+                                onclick={"navigator.clipboard.writeText('#{get_oauth_callback_url(@settings, "apple")}')"}
+                                title={gettext("Copy to clipboard")}
+                              >
+                                <.icon name="hero-clipboard" class="h-4 w-4" />
+                              </button>
+                            </div>
+                            <div class="text-xs text-base-content/60 mt-2">
+                              {gettext("Copy this URL to Apple Developer Console")}
                             </div>
                           </div>
                         </div>
+                      </div>
 
-                        <%!-- Step-by-step Instructions --%>
-                        <div class="space-y-3">
-                          <ol class="list-decimal list-inside space-y-2 text-base-content/80">
-                            <li>
-                              {gettext("Visit")}
-                              <a
-                                href="https://developer.apple.com/account/resources/identifiers/list"
-                                target="_blank"
-                                class="link link-primary"
-                              >
-                                Apple Developer Console
-                              </a>
-                            </li>
-                            <li>{gettext("Create an App ID or select existing one")}</li>
-                            <li>
-                              {gettext("Enable")}
-                              <strong>Sign in with Apple</strong> {gettext("capability")}
-                            </li>
-                            <li>
-                              {gettext("Create a")}
-                              <strong>Services ID</strong> {gettext("for web authentication")}
-                            </li>
-                            <li>
-                              {gettext("Configure")}
-                              <strong>Sign in with Apple</strong> {gettext("for the Services ID")}
-                            </li>
-                            <li>
-                              {gettext("Add callback URL above to")} <strong>Return URLs</strong>
-                            </li>
-                            <li>
-                              {gettext("Create a")} <strong>Private Key</strong>
-                              {gettext("with Sign in with Apple enabled")}
-                            </li>
-                            <li>
-                              {gettext("Copy")} <strong>Team ID</strong>, <strong>Key ID</strong>,
-                              <strong>Client ID</strong>
-                              ({gettext("Services ID")}), {gettext("and")}
-                              <strong>Private Key</strong>
-                              {gettext("to fields above")}
-                            </li>
-                            <li>
-                              {gettext("Click")}
-                              <strong>Test Credentials</strong> {gettext("to verify setup")}
-                            </li>
-                          </ol>
-                        </div>
+                      <%!-- Step-by-step Instructions --%>
+                      <div class="space-y-3">
+                        <ol class="list-decimal list-inside space-y-2 text-base-content/80">
+                          <li>
+                            {gettext("Visit")}
+                            <a
+                              href="https://developer.apple.com/account/resources/identifiers/list"
+                              target="_blank"
+                              class="link link-primary"
+                            >
+                              Apple Developer Console
+                            </a>
+                          </li>
+                          <li>{gettext("Create an App ID or select existing one")}</li>
+                          <li>
+                            {gettext("Enable")}
+                            <strong>Sign in with Apple</strong> {gettext("capability")}
+                          </li>
+                          <li>
+                            {gettext("Create a")}
+                            <strong>Services ID</strong> {gettext("for web authentication")}
+                          </li>
+                          <li>
+                            {gettext("Configure")}
+                            <strong>Sign in with Apple</strong> {gettext("for the Services ID")}
+                          </li>
+                          <li>
+                            {gettext("Add callback URL above to")} <strong>Return URLs</strong>
+                          </li>
+                          <li>
+                            {gettext("Create a")} <strong>Private Key</strong>
+                            {gettext("with Sign in with Apple enabled")}
+                          </li>
+                          <li>
+                            {gettext("Copy")} <strong>Team ID</strong>, <strong>Key ID</strong>,
+                            <strong>Client ID</strong>
+                            ({gettext("Services ID")}), {gettext("and")}
+                            <strong>Private Key</strong>
+                            {gettext("to fields above")}
+                          </li>
+                          <li>
+                            {gettext("Click")}
+                            <strong>Test Credentials</strong> {gettext("to verify setup")}
+                          </li>
+                        </ol>
+                      </div>
 
-                        <%!-- Reverse Proxy Notice --%>
-                        <div class="bg-base-200 border border-base-300 rounded-lg p-3 text-xs">
-                          <div class="flex items-start gap-2">
-                            <.icon
-                              name="hero-information-circle"
-                              class="h-4 w-4 text-info shrink-0 mt-0.5"
-                            />
-                            <div class="text-base-content/80">
-                              <strong class="text-base-content">
-                                {gettext("Reverse Proxy Users:")}
-                              </strong>
-                              {gettext("If behind nginx/apache, ensure")}
-                              <code class="px-1 py-0.5 bg-base-300 text-base-content rounded text-xs">
-                                X-Forwarded-Proto
-                              </code>
-                              {gettext("header is set to")}
-                              <code class="px-1 py-0.5 bg-base-300 text-base-content rounded text-xs">
-                                https
-                              </code>
-                            </div>
+                      <%!-- Reverse Proxy Notice --%>
+                      <div class="bg-base-200 border border-base-300 rounded-lg p-3 text-xs">
+                        <div class="flex items-start gap-2">
+                          <.icon
+                            name="hero-information-circle"
+                            class="h-4 w-4 text-info shrink-0 mt-0.5"
+                          />
+                          <div class="text-base-content/80">
+                            <strong class="text-base-content">
+                              {gettext("Reverse Proxy Users:")}
+                            </strong>
+                            {gettext("If behind nginx/apache, ensure")}
+                            <code class="px-1 py-0.5 bg-base-300 text-base-content rounded text-xs">
+                              X-Forwarded-Proto
+                            </code>
+                            {gettext("header is set to")}
+                            <code class="px-1 py-0.5 bg-base-300 text-base-content rounded text-xs">
+                              https
+                            </code>
                           </div>
                         </div>
                       </div>
                     </div>
                   </div>
                 </div>
+              </div>
 
-                <%!-- GitHub OAuth Credentials --%>
-                <div class={[
-                  "card bg-base-200 p-4 mt-3",
-                  if(@settings["oauth_github_enabled"] != "true", do: "hidden", else: "")
-                ]}>
-                  <h3 class="font-semibold mb-3 flex items-center gap-2">
-                    <PhoenixKitWeb.Components.Core.Icons.icon_github class="h-5 w-5" />
-                    {gettext("GitHub OAuth Credentials")}
-                  </h3>
+              <%!-- GitHub OAuth Credentials --%>
+              <div class={[
+                "card bg-base-200 p-4 mt-3",
+                if(@settings["oauth_github_enabled"] != "true", do: "hidden", else: "")
+              ]}>
+                <h3 class="font-semibold mb-3 flex items-center gap-2">
+                  <PhoenixKitWeb.Components.Core.Icons.icon_github class="h-5 w-5" />
+                  {gettext("GitHub OAuth Credentials")}
+                </h3>
 
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
                   <div class="form-control">
                     <label class="label">
                       <span class="label-text">{gettext("Client ID")}</span>
@@ -728,7 +734,7 @@
                     />
                   </div>
 
-                  <div class="form-control mt-2">
+                  <div class="form-control">
                     <label class="label">
                       <span class="label-text">{gettext("Client Secret")}</span>
                     </label>
@@ -740,129 +746,131 @@
                       class="input input-bordered"
                     />
                   </div>
+                </div>
 
-                  <button
-                    type="button"
-                    phx-click="test_oauth"
-                    phx-value-provider="github"
-                    class="btn btn-sm btn-outline mt-3 w-fit"
-                  >
-                    {gettext("Test Credentials")}
-                  </button>
+                <button
+                  type="button"
+                  phx-click="test_oauth"
+                  phx-value-provider="github"
+                  class="btn btn-sm btn-outline mt-3 w-fit"
+                >
+                  {gettext("Test Credentials")}
+                </button>
 
-                  <%!-- GitHub OAuth Setup Instructions --%>
-                  <div class="collapse collapse-arrow bg-base-200 mt-4">
-                    <input type="checkbox" class="peer" />
-                    <div class="collapse-title text-sm font-medium">
-                      {gettext("Setup Instructions")}
-                    </div>
-                    <div class="collapse-content text-sm space-y-4">
-                      <%!-- Callback URL Section --%>
-                      <div class="bg-base-100 border border-base-300 rounded-lg p-4">
-                        <div class="flex items-start gap-3">
-                          <.icon
-                            name="hero-information-circle"
-                            class="stroke-current shrink-0 h-5 w-5 text-info mt-0.5"
-                          />
-                          <div class="flex-1 min-w-0">
-                            <div class="text-sm font-semibold text-base-content mb-2">
-                              {gettext("Callback URL")}
-                            </div>
-                            <div class="flex items-center gap-2">
-                              <code class="flex-1 px-3 py-2 bg-base-200 text-base-content border border-base-300 rounded font-mono text-xs break-all">
-                                {get_oauth_callback_url(@settings, "github")}
-                              </code>
-                              <button
-                                type="button"
-                                class="btn btn-sm btn-square btn-outline"
-                                onclick={"navigator.clipboard.writeText('#{get_oauth_callback_url(@settings, "github")}')"}
-                                title={gettext("Copy to clipboard")}
-                              >
-                                <.icon name="hero-clipboard" class="h-4 w-4" />
-                              </button>
-                            </div>
-                            <div class="text-xs text-base-content/60 mt-2">
-                              {gettext("Copy this URL to GitHub OAuth Apps")}
-                            </div>
+                <%!-- GitHub OAuth Setup Instructions --%>
+                <div class="collapse collapse-arrow bg-base-200 mt-4">
+                  <input type="checkbox" class="peer" />
+                  <div class="collapse-title text-sm font-medium">
+                    {gettext("Setup Instructions")}
+                  </div>
+                  <div class="collapse-content text-sm space-y-4">
+                    <%!-- Callback URL Section --%>
+                    <div class="bg-base-100 border border-base-300 rounded-lg p-4">
+                      <div class="flex items-start gap-3">
+                        <.icon
+                          name="hero-information-circle"
+                          class="stroke-current shrink-0 h-5 w-5 text-info mt-0.5"
+                        />
+                        <div class="flex-1 min-w-0">
+                          <div class="text-sm font-semibold text-base-content mb-2">
+                            {gettext("Callback URL")}
+                          </div>
+                          <div class="flex items-center gap-2">
+                            <code class="flex-1 px-3 py-2 bg-base-200 text-base-content border border-base-300 rounded font-mono text-xs break-all">
+                              {get_oauth_callback_url(@settings, "github")}
+                            </code>
+                            <button
+                              type="button"
+                              class="btn btn-sm btn-square btn-outline"
+                              onclick={"navigator.clipboard.writeText('#{get_oauth_callback_url(@settings, "github")}')"}
+                              title={gettext("Copy to clipboard")}
+                            >
+                              <.icon name="hero-clipboard" class="h-4 w-4" />
+                            </button>
+                          </div>
+                          <div class="text-xs text-base-content/60 mt-2">
+                            {gettext("Copy this URL to GitHub OAuth Apps")}
                           </div>
                         </div>
                       </div>
+                    </div>
 
-                      <%!-- Step-by-step Instructions --%>
-                      <div class="space-y-3">
-                        <ol class="list-decimal list-inside space-y-2 text-base-content/80">
-                          <li>
-                            {gettext("Visit")}
-                            <a
-                              href="https://github.com/settings/developers"
-                              target="_blank"
-                              class="link link-primary"
-                            >
-                              GitHub Developer Settings
-                            </a>
-                          </li>
-                          <li>
-                            {gettext("Go to")} <strong>OAuth Apps</strong>
-                            → <strong>New OAuth App</strong>
-                          </li>
-                          <li>
-                            {gettext("Enter")} <strong>Application name</strong>
-                            {gettext("and")} <strong>Homepage URL</strong>
-                          </li>
-                          <li>
-                            {gettext("Add callback URL above to")}
-                            <strong>Authorization callback URL</strong>
-                          </li>
-                          <li>
-                            {gettext("Click")} <strong>Register application</strong>
-                          </li>
-                          <li>
-                            {gettext("Copy")} <strong>Client ID</strong>
-                            {gettext("and generate/copy")} <strong>Client Secret</strong>
-                          </li>
-                          <li>
-                            {gettext("Click")}
-                            <strong>Test Credentials</strong> {gettext("to verify setup")}
-                          </li>
-                        </ol>
-                      </div>
+                    <%!-- Step-by-step Instructions --%>
+                    <div class="space-y-3">
+                      <ol class="list-decimal list-inside space-y-2 text-base-content/80">
+                        <li>
+                          {gettext("Visit")}
+                          <a
+                            href="https://github.com/settings/developers"
+                            target="_blank"
+                            class="link link-primary"
+                          >
+                            GitHub Developer Settings
+                          </a>
+                        </li>
+                        <li>
+                          {gettext("Go to")} <strong>OAuth Apps</strong>
+                          → <strong>New OAuth App</strong>
+                        </li>
+                        <li>
+                          {gettext("Enter")} <strong>Application name</strong>
+                          {gettext("and")} <strong>Homepage URL</strong>
+                        </li>
+                        <li>
+                          {gettext("Add callback URL above to")}
+                          <strong>Authorization callback URL</strong>
+                        </li>
+                        <li>
+                          {gettext("Click")} <strong>Register application</strong>
+                        </li>
+                        <li>
+                          {gettext("Copy")} <strong>Client ID</strong>
+                          {gettext("and generate/copy")} <strong>Client Secret</strong>
+                        </li>
+                        <li>
+                          {gettext("Click")}
+                          <strong>Test Credentials</strong> {gettext("to verify setup")}
+                        </li>
+                      </ol>
+                    </div>
 
-                      <%!-- Reverse Proxy Notice --%>
-                      <div class="bg-base-200 border border-base-300 rounded-lg p-3 text-xs">
-                        <div class="flex items-start gap-2">
-                          <.icon
-                            name="hero-information-circle"
-                            class="h-4 w-4 text-info shrink-0 mt-0.5"
-                          />
-                          <div class="text-base-content/80">
-                            <strong class="text-base-content">
-                              {gettext("Reverse Proxy Users:")}
-                            </strong>
-                            {gettext("If behind nginx/apache, ensure")}
-                            <code class="px-1 py-0.5 bg-base-300 text-base-content rounded text-xs">
-                              X-Forwarded-Proto
-                            </code>
-                            {gettext("header is set to")}
-                            <code class="px-1 py-0.5 bg-base-300 text-base-content rounded text-xs">
-                              https
-                            </code>
-                          </div>
+                    <%!-- Reverse Proxy Notice --%>
+                    <div class="bg-base-200 border border-base-300 rounded-lg p-3 text-xs">
+                      <div class="flex items-start gap-2">
+                        <.icon
+                          name="hero-information-circle"
+                          class="h-4 w-4 text-info shrink-0 mt-0.5"
+                        />
+                        <div class="text-base-content/80">
+                          <strong class="text-base-content">
+                            {gettext("Reverse Proxy Users:")}
+                          </strong>
+                          {gettext("If behind nginx/apache, ensure")}
+                          <code class="px-1 py-0.5 bg-base-300 text-base-content rounded text-xs">
+                            X-Forwarded-Proto
+                          </code>
+                          {gettext("header is set to")}
+                          <code class="px-1 py-0.5 bg-base-300 text-base-content rounded text-xs">
+                            https
+                          </code>
                         </div>
                       </div>
                     </div>
                   </div>
                 </div>
+              </div>
 
-                <%!-- Facebook OAuth Credentials --%>
-                <div class={[
-                  "card bg-base-200 p-4 mt-3",
-                  if(@settings["oauth_facebook_enabled"] != "true", do: "hidden", else: "")
-                ]}>
-                  <h3 class="font-semibold mb-3 flex items-center gap-2">
-                    <PhoenixKitWeb.Components.Core.Icons.icon_facebook class="h-5 w-5" />
-                    {gettext("Facebook OAuth Credentials")}
-                  </h3>
+              <%!-- Facebook OAuth Credentials --%>
+              <div class={[
+                "card bg-base-200 p-4 mt-3",
+                if(@settings["oauth_facebook_enabled"] != "true", do: "hidden", else: "")
+              ]}>
+                <h3 class="font-semibold mb-3 flex items-center gap-2">
+                  <PhoenixKitWeb.Components.Core.Icons.icon_facebook class="h-5 w-5" />
+                  {gettext("Facebook OAuth Credentials")}
+                </h3>
 
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
                   <div class="form-control">
                     <label class="label">
                       <span class="label-text">{gettext("App ID")}</span>
@@ -876,7 +884,7 @@
                     />
                   </div>
 
-                  <div class="form-control mt-2">
+                  <div class="form-control">
                     <label class="label">
                       <span class="label-text">{gettext("App Secret")}</span>
                     </label>
@@ -888,177 +896,177 @@
                       class="input input-bordered"
                     />
                   </div>
-
-                  <button
-                    type="button"
-                    phx-click="test_oauth"
-                    phx-value-provider="facebook"
-                    class="btn btn-sm btn-outline mt-3 w-fit"
-                  >
-                    {gettext("Test Credentials")}
-                  </button>
-
-                  <%!-- Facebook OAuth Setup Instructions --%>
-                  <div class="collapse collapse-arrow bg-base-200 mt-4">
-                    <input type="checkbox" class="peer" />
-                    <div class="collapse-title text-sm font-medium">
-                      {gettext("Setup Instructions")}
-                    </div>
-                    <div class="collapse-content text-sm space-y-4">
-                      <%!-- Callback URL Section --%>
-                      <div class="bg-base-100 border border-base-300 rounded-lg p-4">
-                        <div class="flex items-start gap-3">
-                          <.icon
-                            name="hero-information-circle"
-                            class="stroke-current shrink-0 h-5 w-5 text-info mt-0.5"
-                          />
-                          <div class="flex-1 min-w-0">
-                            <div class="text-sm font-semibold text-base-content mb-2">
-                              {gettext("Callback URL")}
-                            </div>
-                            <div class="flex items-center gap-2">
-                              <code class="flex-1 px-3 py-2 bg-base-200 text-base-content border border-base-300 rounded font-mono text-xs break-all">
-                                {get_oauth_callback_url(@settings, "facebook")}
-                              </code>
-                              <button
-                                type="button"
-                                class="btn btn-sm btn-square btn-outline"
-                                onclick={"navigator.clipboard.writeText('#{get_oauth_callback_url(@settings, "facebook")}')"}
-                                title={gettext("Copy to clipboard")}
-                              >
-                                <.icon name="hero-clipboard" class="h-4 w-4" />
-                              </button>
-                            </div>
-                            <div class="text-xs text-base-content/60 mt-2">
-                              {gettext("Copy this URL to Facebook App Settings")}
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-
-                      <%!-- Step-by-step Instructions --%>
-                      <div class="space-y-3">
-                        <ol class="list-decimal list-inside space-y-2 text-base-content/80">
-                          <li>
-                            {gettext("Visit")}
-                            <a
-                              href="https://developers.facebook.com/apps"
-                              target="_blank"
-                              class="link link-primary"
-                            >
-                              Facebook Developers Console
-                            </a>
-                          </li>
-                          <li>
-                            {gettext("Create a new app or select existing one")}
-                          </li>
-                          <li>
-                            {gettext("Add")} <strong>Facebook Login</strong> {gettext("product")}
-                          </li>
-                          <li>
-                            {gettext("Go to")} <strong>Facebook Login</strong>
-                            → <strong>Settings</strong>
-                          </li>
-                          <li>
-                            {gettext("Add callback URL above to")}
-                            <strong>Valid OAuth Redirect URIs</strong>
-                          </li>
-                          <li>
-                            {gettext("Go to")} <strong>Settings</strong> → <strong>Basic</strong>
-                          </li>
-                          <li>
-                            {gettext("Copy")} <strong>App ID</strong>
-                            {gettext("and")} <strong>App Secret</strong>
-                            {gettext("to fields above")}
-                          </li>
-                          <li>
-                            {gettext("Switch app from")} <strong>Development</strong>
-                            {gettext("to")} <strong>Live</strong>
-                            {gettext("mode")}
-                          </li>
-                          <li>
-                            {gettext("Click")}
-                            <strong>Test Credentials</strong> {gettext("to verify setup")}
-                          </li>
-                        </ol>
-                      </div>
-
-                      <%!-- Reverse Proxy Notice --%>
-                      <div class="bg-base-200 border border-base-300 rounded-lg p-3 text-xs">
-                        <div class="flex items-start gap-2">
-                          <.icon
-                            name="hero-information-circle"
-                            class="h-4 w-4 text-info shrink-0 mt-0.5"
-                          />
-                          <div class="text-base-content/80">
-                            <strong class="text-base-content">
-                              {gettext("Reverse Proxy Users:")}
-                            </strong>
-                            {gettext("If behind nginx/apache, ensure")}
-                            <code class="px-1 py-0.5 bg-base-300 text-base-content rounded text-xs">
-                              X-Forwarded-Proto
-                            </code>
-                            {gettext("header is set to")}
-                            <code class="px-1 py-0.5 bg-base-300 text-base-content rounded text-xs">
-                              https
-                            </code>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
                 </div>
 
-                <%!-- OAuth Configuration Notice --%>
-                <div class="alert alert-info text-sm mt-3">
-                  <.icon name="hero-information-circle" class="stroke-current shrink-0 h-5 w-5" />
-                  <div>
-                    <div class="font-semibold">{gettext("OAuth Setup Instructions")}</div>
-                    <div class="text-xs">
-                      <p>{gettext("1. Enable the provider above and save settings")}</p>
-                      <p>{gettext("2. Enter your OAuth credentials in the form that appears")}</p>
-                      <p>{gettext("3. Save settings again to store credentials")}</p>
-                      <p>{gettext("4. Click \"Test Credentials\" to verify configuration")}</p>
-                      <p class="mt-1">
-                        {gettext(
-                          "Note: OAuth providers require ueberauth dependencies to be installed."
-                        )}
-                      </p>
-                    </div>
-                  </div>
-                </div>
-
-                <%!-- Reload OAuth Configuration Button --%>
                 <button
                   type="button"
-                  phx-click="reload_oauth_config"
-                  class="btn btn-sm btn-outline btn-secondary mt-3"
+                  phx-click="test_oauth"
+                  phx-value-provider="facebook"
+                  class="btn btn-sm btn-outline mt-3 w-fit"
                 >
-                  <PhoenixKitWeb.Components.Core.Icons.icon_refresh class="h-4 w-4" />
-                  {gettext("Reload OAuth Configuration")}
+                  {gettext("Test Credentials")}
                 </button>
-              <% end %>
-            </div>
 
-            <%!-- Action Buttons --%>
-            <div class="flex gap-3 pt-4">
+                <%!-- Facebook OAuth Setup Instructions --%>
+                <div class="collapse collapse-arrow bg-base-200 mt-4">
+                  <input type="checkbox" class="peer" />
+                  <div class="collapse-title text-sm font-medium">
+                    {gettext("Setup Instructions")}
+                  </div>
+                  <div class="collapse-content text-sm space-y-4">
+                    <%!-- Callback URL Section --%>
+                    <div class="bg-base-100 border border-base-300 rounded-lg p-4">
+                      <div class="flex items-start gap-3">
+                        <.icon
+                          name="hero-information-circle"
+                          class="stroke-current shrink-0 h-5 w-5 text-info mt-0.5"
+                        />
+                        <div class="flex-1 min-w-0">
+                          <div class="text-sm font-semibold text-base-content mb-2">
+                            {gettext("Callback URL")}
+                          </div>
+                          <div class="flex items-center gap-2">
+                            <code class="flex-1 px-3 py-2 bg-base-200 text-base-content border border-base-300 rounded font-mono text-xs break-all">
+                              {get_oauth_callback_url(@settings, "facebook")}
+                            </code>
+                            <button
+                              type="button"
+                              class="btn btn-sm btn-square btn-outline"
+                              onclick={"navigator.clipboard.writeText('#{get_oauth_callback_url(@settings, "facebook")}')"}
+                              title={gettext("Copy to clipboard")}
+                            >
+                              <.icon name="hero-clipboard" class="h-4 w-4" />
+                            </button>
+                          </div>
+                          <div class="text-xs text-base-content/60 mt-2">
+                            {gettext("Copy this URL to Facebook App Settings")}
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+
+                    <%!-- Step-by-step Instructions --%>
+                    <div class="space-y-3">
+                      <ol class="list-decimal list-inside space-y-2 text-base-content/80">
+                        <li>
+                          {gettext("Visit")}
+                          <a
+                            href="https://developers.facebook.com/apps"
+                            target="_blank"
+                            class="link link-primary"
+                          >
+                            Facebook Developers Console
+                          </a>
+                        </li>
+                        <li>
+                          {gettext("Create a new app or select existing one")}
+                        </li>
+                        <li>
+                          {gettext("Add")} <strong>Facebook Login</strong> {gettext("product")}
+                        </li>
+                        <li>
+                          {gettext("Go to")} <strong>Facebook Login</strong>
+                          → <strong>Settings</strong>
+                        </li>
+                        <li>
+                          {gettext("Add callback URL above to")}
+                          <strong>Valid OAuth Redirect URIs</strong>
+                        </li>
+                        <li>
+                          {gettext("Go to")} <strong>Settings</strong> → <strong>Basic</strong>
+                        </li>
+                        <li>
+                          {gettext("Copy")} <strong>App ID</strong>
+                          {gettext("and")} <strong>App Secret</strong>
+                          {gettext("to fields above")}
+                        </li>
+                        <li>
+                          {gettext("Switch app from")} <strong>Development</strong>
+                          {gettext("to")} <strong>Live</strong>
+                          {gettext("mode")}
+                        </li>
+                        <li>
+                          {gettext("Click")}
+                          <strong>Test Credentials</strong> {gettext("to verify setup")}
+                        </li>
+                      </ol>
+                    </div>
+
+                    <%!-- Reverse Proxy Notice --%>
+                    <div class="bg-base-200 border border-base-300 rounded-lg p-3 text-xs">
+                      <div class="flex items-start gap-2">
+                        <.icon
+                          name="hero-information-circle"
+                          class="h-4 w-4 text-info shrink-0 mt-0.5"
+                        />
+                        <div class="text-base-content/80">
+                          <strong class="text-base-content">
+                            {gettext("Reverse Proxy Users:")}
+                          </strong>
+                          {gettext("If behind nginx/apache, ensure")}
+                          <code class="px-1 py-0.5 bg-base-300 text-base-content rounded text-xs">
+                            X-Forwarded-Proto
+                          </code>
+                          {gettext("header is set to")}
+                          <code class="px-1 py-0.5 bg-base-300 text-base-content rounded text-xs">
+                            https
+                          </code>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <%!-- OAuth Configuration Notice --%>
+              <div class="alert alert-info text-sm mt-3 max-w-prose">
+                <.icon name="hero-information-circle" class="stroke-current shrink-0 h-5 w-5" />
+                <div>
+                  <div class="font-semibold">{gettext("OAuth Setup Instructions")}</div>
+                  <div class="text-xs">
+                    <p>{gettext("1. Enable the provider above and save settings")}</p>
+                    <p>{gettext("2. Enter your OAuth credentials in the form that appears")}</p>
+                    <p>{gettext("3. Save settings again to store credentials")}</p>
+                    <p>{gettext("4. Click \"Test Credentials\" to verify configuration")}</p>
+                    <p class="mt-1">
+                      {gettext(
+                        "Note: OAuth providers require ueberauth dependencies to be installed."
+                      )}
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              <%!-- Reload OAuth Configuration Button --%>
               <button
-                type="submit"
-                class={[
-                  "btn btn-primary flex-1",
-                  if(@saving, do: "loading", else: "")
-                ]}
-                disabled={@saving}
+                type="button"
+                phx-click="reload_oauth_config"
+                class="btn btn-sm btn-outline btn-secondary mt-3"
               >
-                <%= if @saving do %>
-                  {gettext("Saving...")}
-                <% else %>
-                  {gettext("Save Authorization Settings")}
-                <% end %>
+                <PhoenixKitWeb.Components.Core.Icons.icon_refresh class="h-4 w-4" />
+                {gettext("Reload OAuth Configuration")}
               </button>
-            </div>
-          </.form>
-        </div>
+            <% end %>
+          </div>
+
+          <%!-- Action Buttons --%>
+          <div class="flex gap-3 pt-4">
+            <button
+              type="submit"
+              class={[
+                "btn btn-primary flex-1",
+                if(@saving, do: "loading", else: "")
+              ]}
+              disabled={@saving}
+            >
+              <%= if @saving do %>
+                {gettext("Saving...")}
+              <% else %>
+                {gettext("Save Authorization Settings")}
+              <% end %>
+            </button>
+          </div>
+        </.form>
       </div>
     </div>
   </div>

--- a/lib/phoenix_kit_web/live/settings/integration_form.html.heex
+++ b/lib/phoenix_kit_web/live/settings/integration_form.html.heex
@@ -26,7 +26,7 @@
     </div>
 
     <%!-- Step 1: Provider picker (new mode, no provider selected yet) --%>
-    <div :if={@live_action == :new && @selected_provider == nil} class="max-w-2xl mx-auto">
+    <div :if={@live_action == :new && @selected_provider == nil} class="max-w-4xl mx-auto">
       <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
         <button
           :for={provider <- @providers}
@@ -48,7 +48,7 @@
     </div>
 
     <%!-- Step 2: Setup form (provider selected in new mode, or edit mode) --%>
-    <div :if={@provider != nil} class="space-y-6 max-w-2xl mx-auto">
+    <div :if={@provider != nil} class="space-y-6 max-w-4xl mx-auto">
       <%!-- Back to provider picker (new mode only) --%>
       <button
         :if={@live_action == :new && @name == nil}

--- a/lib/phoenix_kit_web/live/settings/seo.html.heex
+++ b/lib/phoenix_kit_web/live/settings/seo.html.heex
@@ -17,60 +17,58 @@
       }
     />
 
-    <div class="flex justify-center">
-      <div class="card bg-base-100 shadow-xl border border-base-200 w-full max-w-3xl">
-        <div class="card-body space-y-4">
-          <div class="flex items-start justify-between gap-4">
-            <div>
-              <p class="text-sm uppercase tracking-wide text-primary font-semibold">
-                {gettext("Robots Directive")}
-              </p>
-              <h2 class="text-2xl font-bold">{gettext("Noindex · Nofollow")}</h2>
-              <p class="text-base text-base-content/70">
-                {gettext("Adds")}
-                <code class="font-mono text-sm bg-base-200 rounded px-1.5 py-0.5">
-                  &lt;meta name="robots" content="noindex,nofollow"&gt;
-                </code>
-                {gettext(
-                  "to every PhoenixKit layout, blocking crawlers from indexing or following links."
-                )}
-              </p>
-            </div>
-            <label class="flex items-center gap-2 cursor-pointer">
-              <span class="text-sm font-semibold text-base-content/70">
-                {if @no_index_enabled, do: gettext("Enabled"), else: gettext("Disabled")}
-              </span>
-              <input
-                type="checkbox"
-                class="toggle toggle-primary toggle-lg"
-                checked={@no_index_enabled}
-                phx-click="toggle_no_index"
-              />
-            </label>
+    <div class="card bg-base-100 shadow-xl border border-base-200">
+      <div class="card-body space-y-4">
+        <div class="flex items-start justify-between gap-4">
+          <div>
+            <p class="text-sm uppercase tracking-wide text-primary font-semibold">
+              {gettext("Robots Directive")}
+            </p>
+            <h2 class="text-2xl font-bold">{gettext("Noindex · Nofollow")}</h2>
+            <p class="text-base text-base-content/70">
+              {gettext("Adds")}
+              <code class="font-mono text-sm bg-base-200 rounded px-1.5 py-0.5">
+                &lt;meta name="robots" content="noindex,nofollow"&gt;
+              </code>
+              {gettext(
+                "to every PhoenixKit layout, blocking crawlers from indexing or following links."
+              )}
+            </p>
           </div>
-
-          <div class={[
-            "alert",
-            if(@no_index_enabled, do: "alert-warning", else: "alert-info"),
-            "bg-base-200/70"
-          ]}>
-            <.icon
-              name={
-                if @no_index_enabled, do: "hero-no-symbol", else: "hero-magnifying-glass-circle"
-              }
-              class="w-6 h-6"
+          <label class="flex items-center gap-2 cursor-pointer">
+            <span class="text-sm font-semibold text-base-content/70">
+              {if @no_index_enabled, do: gettext("Enabled"), else: gettext("Disabled")}
+            </span>
+            <input
+              type="checkbox"
+              class="toggle toggle-primary toggle-lg"
+              checked={@no_index_enabled}
+              phx-click="toggle_no_index"
             />
-            <div class="text-sm leading-relaxed">
-              <%= if @no_index_enabled do %>
-                {gettext(
-                  "Search engines are instructed to skip this environment. Remove this before launch."
-                )}
-              <% else %>
-                {gettext(
-                  "Crawlers are allowed to index the site. Enable the toggle to hide staging deployments."
-                )}
-              <% end %>
-            </div>
+          </label>
+        </div>
+
+        <div class={[
+          "alert",
+          if(@no_index_enabled, do: "alert-warning", else: "alert-info"),
+          "bg-base-200/70"
+        ]}>
+          <.icon
+            name={
+              if @no_index_enabled, do: "hero-no-symbol", else: "hero-magnifying-glass-circle"
+            }
+            class="w-6 h-6"
+          />
+          <div class="text-sm leading-relaxed">
+            <%= if @no_index_enabled do %>
+              {gettext(
+                "Search engines are instructed to skip this environment. Remove this before launch."
+              )}
+            <% else %>
+              {gettext(
+                "Crawlers are allowed to index the site. Enable the toggle to hide staging deployments."
+              )}
+            <% end %>
           </div>
         </div>
       </div>

--- a/lib/phoenix_kit_web/live/settings/users.html.heex
+++ b/lib/phoenix_kit_web/live/settings/users.html.heex
@@ -355,7 +355,57 @@
                 </div>
               <% else %>
                 <%!-- Table Display --%>
-                <.table_default variant="zebra" size="sm">
+                <.table_default
+                  id="user-custom-fields-table"
+                  variant="zebra"
+                  size="sm"
+                  toggleable
+                  items={Enum.sort_by(@field_definitions, & &1["position"])}
+                  card_title={fn field -> field["label"] end}
+                  card_fields={
+                    fn field ->
+                      [
+                        %{label: gettext("Key:"), value: field["key"]},
+                        %{label: gettext("Type"), value: field["type"]},
+                        %{
+                          label: gettext("Required"),
+                          value: if(field["required"], do: gettext("Yes"), else: gettext("No"))
+                        },
+                        %{
+                          label: gettext("Status"),
+                          value:
+                            if(field["enabled"],
+                              do: gettext("Enabled"),
+                              else: gettext("Disabled")
+                            )
+                        },
+                        %{
+                          label: gettext("User Access"),
+                          value:
+                            if(Map.get(field, "user_accessible", true),
+                              do: gettext("User Editable"),
+                              else: gettext("Admin Only")
+                            )
+                        }
+                      ]
+                    end
+                  }
+                >
+                  <:toolbar_title>
+                    <span class="text-sm text-base-content/60">
+                      {length(@field_definitions)} {gettext("Custom Fields")}
+                    </span>
+                  </:toolbar_title>
+                  <:toolbar_actions>
+                    <button
+                      type="button"
+                      class="btn btn-primary btn-sm"
+                      phx-click="show_add_field_form"
+                    >
+                      <.icon name="hero-plus" class="w-4 h-4" /> {gettext("Add Custom Field")}
+                    </button>
+                  </:toolbar_actions>
+
                   <.table_default_header>
                     <.table_default_row>
                       <.table_default_header_cell>{gettext("Field")}</.table_default_header_cell>
@@ -374,103 +424,119 @@
                   </.table_default_header>
 
                   <.table_default_body>
-                    <%= for field <- Enum.sort_by(@field_definitions, & &1["position"]) do %>
-                      <.table_default_row>
-                        <.table_default_cell>
-                          <div class="font-semibold">{field["label"]}</div>
-                          <div class="text-xs text-base-content/60">
-                            {gettext("Key:")}
-                            <code class="bg-base-300 px-1 rounded">{field["key"]}</code>
-                          </div>
-                        </.table_default_cell>
-                        <.table_default_cell>
-                          <span class="badge badge-sm h-auto">{field["type"]}</span>
-                        </.table_default_cell>
-                        <.table_default_cell>
-                          <%= if field["required"] do %>
-                            <span class="badge badge-sm badge-warning">{gettext("Yes")}</span>
-                          <% else %>
-                            <span class="badge badge-sm badge-ghost">{gettext("No")}</span>
-                          <% end %>
-                        </.table_default_cell>
-                        <.table_default_cell>
-                          <%= if field["enabled"] do %>
-                            <span class="badge badge-sm badge-success">{gettext("Enabled")}</span>
-                          <% else %>
-                            <span class="badge badge-sm badge-ghost">{gettext("Disabled")}</span>
-                          <% end %>
-                        </.table_default_cell>
-                        <.table_default_cell>
-                          <%= if Map.get(field, "user_accessible", true) do %>
-                            <span class="badge badge-sm badge-success">
-                              {gettext("User Editable")}
-                            </span>
-                          <% else %>
-                            <span class="badge badge-sm badge-warning">
-                              {gettext("Admin Only")}
-                            </span>
-                          <% end %>
-                        </.table_default_cell>
-                        <.table_default_cell>
-                          <div class="flex gap-1">
-                            <button
-                              type="button"
-                              class="btn btn-xs btn-ghost tooltip tooltip-bottom"
-                              data-tip={
-                                if field["enabled"],
-                                  do: gettext("Disable"),
-                                  else: gettext("Enable")
-                              }
-                              phx-click="toggle_field_enabled"
-                              phx-value-key={field["key"]}
-                            >
-                              <%= if field["enabled"] do %>
-                                <.icon name="hero-eye" class="w-3 h-3 hidden sm:inline" />
-                                <span class="sm:hidden whitespace-nowrap">
-                                  {gettext("Disable")}
-                                </span>
-                              <% else %>
-                                <.icon name="hero-eye-slash" class="w-3 h-3 hidden sm:inline" />
-                                <span class="sm:hidden whitespace-nowrap">
-                                  {gettext("Enable")}
-                                </span>
-                              <% end %>
-                            </button>
-                            <button
-                              type="button"
-                              class="btn btn-xs btn-ghost tooltip tooltip-bottom"
-                              data-tip={gettext("Edit")}
-                              phx-click="show_edit_field_form"
-                              phx-value-key={field["key"]}
-                            >
-                              <.icon name="hero-pencil" class="w-3 h-3 hidden sm:inline" />
-                              <span class="sm:hidden whitespace-nowrap">{gettext("Edit")}</span>
-                            </button>
-                            <button
-                              type="button"
-                              class="btn btn-xs btn-ghost text-error tooltip tooltip-bottom"
-                              data-tip={gettext("Delete")}
-                              phx-click="delete_field"
-                              phx-value-key={field["key"]}
-                              onclick="return confirm('Are you sure you want to delete this field?')"
-                            >
-                              <.icon name="hero-trash" class="w-3 h-3 hidden sm:inline" />
-                              <span class="sm:hidden whitespace-nowrap">{gettext("Delete")}</span>
-                            </button>
-                          </div>
-                        </.table_default_cell>
-                      </.table_default_row>
-                    <% end %>
+                    <.table_default_row :for={
+                      field <- Enum.sort_by(@field_definitions, & &1["position"])
+                    }>
+                      <.table_default_cell>
+                        <div class="font-semibold">{field["label"]}</div>
+                        <div class="text-xs text-base-content/60">
+                          {gettext("Key:")}
+                          <code class="bg-base-300 px-1 rounded">{field["key"]}</code>
+                        </div>
+                      </.table_default_cell>
+                      <.table_default_cell>
+                        <span class="badge badge-sm h-auto">{field["type"]}</span>
+                      </.table_default_cell>
+                      <.table_default_cell>
+                        <%= if field["required"] do %>
+                          <span class="badge badge-sm badge-warning">{gettext("Yes")}</span>
+                        <% else %>
+                          <span class="badge badge-sm badge-ghost">{gettext("No")}</span>
+                        <% end %>
+                      </.table_default_cell>
+                      <.table_default_cell>
+                        <%= if field["enabled"] do %>
+                          <span class="badge badge-sm badge-success">{gettext("Enabled")}</span>
+                        <% else %>
+                          <span class="badge badge-sm badge-ghost">{gettext("Disabled")}</span>
+                        <% end %>
+                      </.table_default_cell>
+                      <.table_default_cell>
+                        <%= if Map.get(field, "user_accessible", true) do %>
+                          <span class="badge badge-sm badge-success">
+                            {gettext("User Editable")}
+                          </span>
+                        <% else %>
+                          <span class="badge badge-sm badge-warning">
+                            {gettext("Admin Only")}
+                          </span>
+                        <% end %>
+                      </.table_default_cell>
+                      <.table_default_cell>
+                        <div class="flex gap-1">
+                          <button
+                            type="button"
+                            class="btn btn-xs btn-ghost tooltip tooltip-bottom"
+                            data-tip={
+                              if field["enabled"],
+                                do: gettext("Disable"),
+                                else: gettext("Enable")
+                            }
+                            phx-click="toggle_field_enabled"
+                            phx-value-key={field["key"]}
+                          >
+                            <%= if field["enabled"] do %>
+                              <.icon name="hero-eye" class="w-3 h-3" />
+                            <% else %>
+                              <.icon name="hero-eye-slash" class="w-3 h-3" />
+                            <% end %>
+                          </button>
+                          <button
+                            type="button"
+                            class="btn btn-xs btn-ghost tooltip tooltip-bottom"
+                            data-tip={gettext("Edit")}
+                            phx-click="show_edit_field_form"
+                            phx-value-key={field["key"]}
+                          >
+                            <.icon name="hero-pencil" class="w-3 h-3" />
+                          </button>
+                          <button
+                            type="button"
+                            class="btn btn-xs btn-ghost text-error tooltip tooltip-bottom"
+                            data-tip={gettext("Delete")}
+                            phx-click="delete_field"
+                            phx-value-key={field["key"]}
+                            onclick="return confirm('Are you sure you want to delete this field?')"
+                          >
+                            <.icon name="hero-trash" class="w-3 h-3" />
+                          </button>
+                        </div>
+                      </.table_default_cell>
+                    </.table_default_row>
                   </.table_default_body>
-                </.table_default>
 
-                <button
-                  type="button"
-                  class="btn btn-outline btn-sm mt-2"
-                  phx-click="show_add_field_form"
-                >
-                  <.icon name="hero-plus" class="w-4 h-4" /> {gettext("Add Custom Field")}
-                </button>
+                  <:card_actions :let={field}>
+                    <button
+                      type="button"
+                      class="btn btn-sm btn-ghost gap-1"
+                      phx-click="toggle_field_enabled"
+                      phx-value-key={field["key"]}
+                    >
+                      <%= if field["enabled"] do %>
+                        <.icon name="hero-eye" class="w-4 h-4" /> {gettext("Disable")}
+                      <% else %>
+                        <.icon name="hero-eye-slash" class="w-4 h-4" /> {gettext("Enable")}
+                      <% end %>
+                    </button>
+                    <button
+                      type="button"
+                      class="btn btn-sm btn-ghost gap-1"
+                      phx-click="show_edit_field_form"
+                      phx-value-key={field["key"]}
+                    >
+                      <.icon name="hero-pencil" class="w-4 h-4" /> {gettext("Edit")}
+                    </button>
+                    <button
+                      type="button"
+                      class="btn btn-sm btn-ghost text-error gap-1"
+                      phx-click="delete_field"
+                      phx-value-key={field["key"]}
+                      onclick="return confirm('Are you sure you want to delete this field?')"
+                    >
+                      <.icon name="hero-trash" class="w-4 h-4" /> {gettext("Delete")}
+                    </button>
+                  </:card_actions>
+                </.table_default>
               <% end %>
             </div>
 

--- a/lib/phoenix_kit_web/live/settings/users.html.heex
+++ b/lib/phoenix_kit_web/live/settings/users.html.heex
@@ -14,7 +14,7 @@
     />
 
     <%!-- Settings Form --%>
-    <div class="max-w-2xl mx-auto space-y-6">
+    <div class="space-y-6">
       <%!-- User Configuration Settings Card --%>
       <div class="card bg-base-100 shadow-xl">
         <div class="card-body">
@@ -179,7 +179,7 @@
 
               <%!-- Privacy Notice for Geolocation --%>
               <%= if @settings["track_registration_geolocation"] == "true" do %>
-                <div class="alert alert-info text-sm mt-2">
+                <div class="alert alert-info text-sm mt-2 max-w-prose">
                   <.icon name="hero-information-circle" class="w-5 h-5" />
                   <div>
                     <div class="font-semibold">
@@ -198,130 +198,135 @@
               <% end %>
             </div>
 
-            <%!-- New User Default Role Setting --%>
-            <div class="form-control w-full">
-              <label class="label">
-                <span class="label-text text-base font-medium">
-                  {gettext("New User Default Role")}
-                </span>
-                <span class="label-text-alt text-sm text-base-content/60">
-                  {gettext("Role assigned to new user registrations")}
-                </span>
-              </label>
-              <label class="select w-full focus:select-primary">
-                <select name="settings[new_user_default_role]">
-                  <%= for {label, value} <- @setting_options["new_user_default_role"] do %>
-                    <option value={value} selected={value == @settings["new_user_default_role"]}>
-                      {label}
-                    </option>
-                  <% end %>
-                </select>
-              </label>
-              <div class="label">
-                <span class="label-text-alt text-xs text-base-content/50">
-                  <%= if @settings["new_user_default_role"] != @saved_settings["new_user_default_role"] do %>
-                    <span class="text-warning">
-                      {gettext("Selected:")} {get_option_label(
+            <%!-- New User Default Role + Status --%>
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+              <div class="form-control w-full">
+                <label class="label">
+                  <span class="label-text text-base font-medium">
+                    {gettext("New User Default Role")}
+                  </span>
+                  <span class="label-text-alt text-sm text-base-content/60">
+                    {gettext("Role assigned to new user registrations")}
+                  </span>
+                </label>
+                <label class="select w-full focus:select-primary">
+                  <select name="settings[new_user_default_role]">
+                    <%= for {label, value} <- @setting_options["new_user_default_role"] do %>
+                      <option value={value} selected={value == @settings["new_user_default_role"]}>
+                        {label}
+                      </option>
+                    <% end %>
+                  </select>
+                </label>
+                <div class="label">
+                  <span class="label-text-alt text-xs text-base-content/50">
+                    <%= if @settings["new_user_default_role"] != @saved_settings["new_user_default_role"] do %>
+                      <span class="text-warning">
+                        {gettext("Selected:")} {get_option_label(
+                          @settings["new_user_default_role"],
+                          @setting_options["new_user_default_role"]
+                        )}
+                      </span>
+                      <span class="text-base-content/40">
+                        | {gettext("Saved:")} {get_option_label(
+                          @saved_settings["new_user_default_role"],
+                          @setting_options["new_user_default_role"]
+                        )}
+                      </span>
+                    <% else %>
+                      {gettext("Saved:")} {get_option_label(
                         @settings["new_user_default_role"],
                         @setting_options["new_user_default_role"]
                       )}
-                    </span>
-                    <span class="text-base-content/40">
-                      | {gettext("Saved:")} {get_option_label(
-                        @saved_settings["new_user_default_role"],
-                        @setting_options["new_user_default_role"]
-                      )}
-                    </span>
-                  <% else %>
-                    {gettext("Saved:")} {get_option_label(
-                      @settings["new_user_default_role"],
-                      @setting_options["new_user_default_role"]
-                    )}
-                  <% end %>
-                </span>
-              </div>
+                    <% end %>
+                  </span>
+                </div>
 
-              <%!-- Security Warning for Admin Role --%>
-              <%= if @settings["new_user_default_role"] == "Admin" do %>
-                <div class="alert alert-warning text-sm mt-2">
-                  <.icon name="hero-exclamation-triangle" class="w-5 h-5" />
-                  <div>
-                    <div class="font-semibold">
-                      {gettext("Security Notice: Medium Risk")}
-                    </div>
-                    <div class="text-xs">
-                      {gettext(
-                        "All new users will receive administrative privileges and access to the admin panel."
-                      )}
-                      {gettext("Consider \"User\" for most installations to maintain security.")}
+                <%!-- Security Warning for Admin Role --%>
+                <%= if @settings["new_user_default_role"] == "Admin" do %>
+                  <div class="alert alert-warning text-sm mt-2 max-w-prose">
+                    <.icon name="hero-exclamation-triangle" class="w-5 h-5" />
+                    <div>
+                      <div class="font-semibold">
+                        {gettext("Security Notice: Medium Risk")}
+                      </div>
+                      <div class="text-xs">
+                        {gettext(
+                          "All new users will receive administrative privileges and access to the admin panel."
+                        )}
+                        {gettext("Consider \"User\" for most installations to maintain security.")}
+                      </div>
                     </div>
                   </div>
-                </div>
-              <% end %>
-            </div>
+                <% end %>
+              </div>
 
-            <%!-- New User Default Status Setting --%>
-            <div class="form-control w-full">
-              <label class="label">
-                <span class="label-text text-base font-medium">
-                  {gettext("New User Default Status")}
-                </span>
-                <span class="label-text-alt text-sm text-base-content/60">
-                  {gettext("Active status for new user registrations")}
-                </span>
-              </label>
-              <label class="select w-full focus:select-primary">
-                <select name="settings[new_user_default_status]">
-                  <%= for {label, value} <- @setting_options["new_user_default_status"] do %>
-                    <option value={value} selected={value == @settings["new_user_default_status"]}>
-                      {label}
-                    </option>
-                  <% end %>
-                </select>
-              </label>
-              <div class="label">
-                <span class="label-text-alt text-xs text-base-content/50">
-                  <%= if @settings["new_user_default_status"] != @saved_settings["new_user_default_status"] do %>
-                    <span class="text-warning">
-                      {gettext("Selected:")} {get_option_label(
+              <%!-- New User Default Status --%>
+              <div class="form-control w-full">
+                <label class="label">
+                  <span class="label-text text-base font-medium">
+                    {gettext("New User Default Status")}
+                  </span>
+                  <span class="label-text-alt text-sm text-base-content/60">
+                    {gettext("Active status for new user registrations")}
+                  </span>
+                </label>
+                <label class="select w-full focus:select-primary">
+                  <select name="settings[new_user_default_status]">
+                    <%= for {label, value} <- @setting_options["new_user_default_status"] do %>
+                      <option
+                        value={value}
+                        selected={value == @settings["new_user_default_status"]}
+                      >
+                        {label}
+                      </option>
+                    <% end %>
+                  </select>
+                </label>
+                <div class="label">
+                  <span class="label-text-alt text-xs text-base-content/50">
+                    <%= if @settings["new_user_default_status"] != @saved_settings["new_user_default_status"] do %>
+                      <span class="text-warning">
+                        {gettext("Selected:")} {get_option_label(
+                          @settings["new_user_default_status"],
+                          @setting_options["new_user_default_status"]
+                        )}
+                      </span>
+                      <span class="text-base-content/40">
+                        | {gettext("Saved:")} {get_option_label(
+                          @saved_settings["new_user_default_status"],
+                          @setting_options["new_user_default_status"]
+                        )}
+                      </span>
+                    <% else %>
+                      {gettext("Saved:")} {get_option_label(
                         @settings["new_user_default_status"],
                         @setting_options["new_user_default_status"]
                       )}
-                    </span>
-                    <span class="text-base-content/40">
-                      | {gettext("Saved:")} {get_option_label(
-                        @saved_settings["new_user_default_status"],
-                        @setting_options["new_user_default_status"]
-                      )}
-                    </span>
-                  <% else %>
-                    {gettext("Saved:")} {get_option_label(
-                      @settings["new_user_default_status"],
-                      @setting_options["new_user_default_status"]
-                    )}
-                  <% end %>
-                </span>
-              </div>
+                    <% end %>
+                  </span>
+                </div>
 
-              <%!-- Security Warning for Inactive Status --%>
-              <%= if @settings["new_user_default_status"] == "false" do %>
-                <div class="alert alert-warning text-sm mt-2">
-                  <.icon name="hero-exclamation-triangle" class="w-5 h-5" />
-                  <div>
-                    <div class="font-semibold">
-                      {gettext("Security Notice: Inactive Default")}
-                    </div>
-                    <div class="text-xs">
-                      {gettext(
-                        "New users will be created as inactive and will not be able to log in until an admin activates their account."
-                      )}
-                      {gettext(
-                        "The first user (Owner) will always be active regardless of this setting."
-                      )}
+                <%!-- Security Warning for Inactive Status --%>
+                <%= if @settings["new_user_default_status"] == "false" do %>
+                  <div class="alert alert-warning text-sm mt-2 max-w-prose">
+                    <.icon name="hero-exclamation-triangle" class="w-5 h-5" />
+                    <div>
+                      <div class="font-semibold">
+                        {gettext("Security Notice: Inactive Default")}
+                      </div>
+                      <div class="text-xs">
+                        {gettext(
+                          "New users will be created as inactive and will not be able to log in until an admin activates their account."
+                        )}
+                        {gettext(
+                          "The first user (Owner) will always be active regardless of this setting."
+                        )}
+                      </div>
                     </div>
                   </div>
-                </div>
-              <% end %>
+                <% end %>
+              </div>
             </div>
 
             <%!-- Divider for Custom Fields --%>
@@ -414,7 +419,7 @@
                         {gettext("Required")}
                       </.table_default_header_cell>
                       <.table_default_header_cell>{gettext("Status")}</.table_default_header_cell>
-                      <.table_default_header_cell>
+                      <.table_default_header_cell class="whitespace-nowrap">
                         {gettext("User Access")}
                       </.table_default_header_cell>
                       <.table_default_header_cell>
@@ -453,11 +458,11 @@
                       </.table_default_cell>
                       <.table_default_cell>
                         <%= if Map.get(field, "user_accessible", true) do %>
-                          <span class="badge badge-sm badge-success">
+                          <span class="badge badge-sm badge-success whitespace-nowrap">
                             {gettext("User Editable")}
                           </span>
                         <% else %>
-                          <span class="badge badge-sm badge-warning">
+                          <span class="badge badge-sm badge-warning whitespace-nowrap">
                             {gettext("Admin Only")}
                           </span>
                         <% end %>

--- a/lib/phoenix_kit_web/live/users/users.html.heex
+++ b/lib/phoenix_kit_web/live/users/users.html.heex
@@ -277,7 +277,9 @@
                             <%= if user.is_active do %>
                               <span class="badge badge-outline badge-xs h-auto">Active</span>
                             <% else %>
-                              <span class="badge badge-error badge-xs h-auto">Inactive</span>
+                              <span class="badge badge-error badge-xs h-auto">
+                                {gettext("Inactive")}
+                              </span>
                             <% end %>
                           </div>
                         <% column_id == "registered" -> %>

--- a/lib/phoenix_kit_web/live/users/users.html.heex
+++ b/lib/phoenix_kit_web/live/users/users.html.heex
@@ -275,7 +275,9 @@
                               <span class="badge badge-warning badge-sm h-auto">Pending</span>
                             <% end %>
                             <%= if user.is_active do %>
-                              <span class="badge badge-outline badge-xs h-auto">Active</span>
+                              <span class="badge badge-outline badge-xs h-auto">
+                                {gettext("Active")}
+                              </span>
                             <% else %>
                               <span class="badge badge-error badge-xs h-auto">
                                 {gettext("Inactive")}

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -6184,3 +6184,48 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "requires the"
 msgstr ""
+
+#: lib/phoenix_kit/dashboard/admin_tabs.ex:148
+#, elixir-autogen, elixir-format
+msgid "Activity"
+msgstr ""
+
+#: lib/phoenix_kit/dashboard/admin_tabs.ex:245
+#, elixir-autogen, elixir-format
+msgid "Authorization"
+msgstr ""
+
+#: lib/phoenix_kit/dashboard/admin_tabs.ex:294
+#, elixir-autogen, elixir-format
+msgid "Dimensions"
+msgstr ""
+
+#: lib/phoenix_kit/dashboard/admin_tabs.ex:235
+#, elixir-autogen, elixir-format
+msgid "General"
+msgstr ""
+
+#: lib/phoenix_kit/dashboard/admin_tabs.ex:102
+#, elixir-autogen, elixir-format
+msgid "Live Sessions"
+msgstr ""
+
+#: lib/modules/maintenance/maintenance.ex:528
+#, elixir-autogen, elixir-format
+msgid "Maintenance"
+msgstr ""
+
+#: lib/phoenix_kit/dashboard/admin_tabs.ex:93
+#, elixir-autogen, elixir-format
+msgid "Manage Users"
+msgstr ""
+
+#: lib/phoenix_kit/dashboard/admin_tabs.ex:160
+#, elixir-autogen, elixir-format
+msgid "Media"
+msgstr ""
+
+#: lib/modules/referrals/referrals.ex:658
+#, elixir-autogen, elixir-format
+msgid "Referrals"
+msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -6269,3 +6269,66 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "%{count}d ago"
 msgstr ""
+
+msgid "Summary"
+msgstr ""
+
+msgid "Languages Enabled"
+msgstr ""
+
+msgid "Countries Covered"
+msgstr ""
+
+msgid "Enabled Languages"
+msgstr ""
+
+msgid "Default language"
+msgstr ""
+
+msgid "Available Languages"
+msgstr ""
+
+msgid "Language Configuration"
+msgstr ""
+
+msgid "Frontend Language Switcher"
+msgstr ""
+
+msgid "Switcher Settings"
+msgstr ""
+
+msgid "Show Flags"
+msgstr ""
+
+msgid "Show Names"
+msgstr ""
+
+msgid "Native Names"
+msgstr ""
+
+msgid "Go to Home"
+msgstr ""
+
+msgid "Hide Current"
+msgstr ""
+
+msgid "Generated Code"
+msgstr ""
+
+msgid "Implementation Notes"
+msgstr ""
+
+msgid "Enable and Configure Languages"
+msgstr ""
+
+msgid "Done"
+msgstr ""
+
+msgid "Reorder"
+msgstr ""
+
+msgid "Default"
+msgstr ""
+
+msgid "No languages enabled yet."
+msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -6332,3 +6332,171 @@ msgstr ""
 
 msgid "No languages enabled yet."
 msgstr ""
+
+msgid "Sitemap Settings"
+msgstr ""
+
+msgid "Configure sitemap generation and scheduling"
+msgstr ""
+
+msgid "Total URLs"
+msgstr ""
+
+msgid "Sitemap Files"
+msgstr ""
+
+msgid "Last Generated"
+msgstr ""
+
+msgid "Regenerate All"
+msgstr ""
+
+msgid "Router Discovery"
+msgstr ""
+
+msgid "When enabled, scans all routes and builds a single flat sitemap.xml with URLs from all content sources (shop, entities, posts, publishing). When disabled, each source generates its own sitemap file."
+msgstr ""
+
+msgid "Flat mode active — /sitemap.xml contains all URLs in a single <urlset>"
+msgstr ""
+
+msgid "Routes"
+msgstr ""
+
+msgid "Static"
+msgstr ""
+
+msgid "Publishing"
+msgstr ""
+
+msgid "Entities"
+msgstr ""
+
+msgid "Posts"
+msgstr ""
+
+msgid "Shop"
+msgstr ""
+
+msgid "Module Sitemaps"
+msgstr ""
+
+msgid "Each source generates its own sitemap file, referenced by the main sitemap index"
+msgstr ""
+
+msgid "Static Pages"
+msgstr ""
+
+msgid "Homepage and custom static URLs"
+msgstr ""
+
+msgid "View sitemap"
+msgstr ""
+
+msgid "module off"
+msgstr ""
+
+msgid "Blog groups and published posts"
+msgstr ""
+
+msgid "Split by blog group"
+msgstr ""
+
+msgid "Dynamic content types (per-type files)"
+msgstr ""
+
+msgid "Public posts from Posts module"
+msgstr ""
+
+msgid "Products, categories, catalog"
+msgstr ""
+
+msgid "Auth Pages"
+msgstr ""
+
+msgid "Login"
+msgstr ""
+
+msgid "Always excluded from sitemap"
+msgstr ""
+
+msgid "Excluded"
+msgstr ""
+
+msgid "Logout"
+msgstr ""
+
+msgid "Registration"
+msgstr ""
+
+msgid "Include in static sitemap"
+msgstr ""
+
+msgid "Configuration"
+msgstr ""
+
+msgid "Edit in Settings"
+msgstr ""
+
+msgid "Browser Display Styling"
+msgstr ""
+
+msgid "Style XML with XSL for beautiful browser display"
+msgstr ""
+
+msgid "Display Style"
+msgstr ""
+
+msgid "Table (Clean table layout)"
+msgstr ""
+
+msgid "Minimal (Simple list)"
+msgstr ""
+
+msgid "Scheduled Generation"
+msgstr ""
+
+msgid "Regenerate every"
+msgstr ""
+
+msgid "1 hour"
+msgstr ""
+
+msgid "6 hours"
+msgstr ""
+
+msgid "12 hours"
+msgstr ""
+
+msgid "24 hours"
+msgstr ""
+
+msgid "48 hours"
+msgstr ""
+
+msgid "Weekly"
+msgstr ""
+
+msgid "Preview Sitemap Source"
+msgstr ""
+
+msgid "Clear All Sitemaps"
+msgstr ""
+
+msgid "Generated sitemap files:"
+msgstr ""
+
+msgid "sitemap.xml (index)"
+msgstr ""
+
+msgid "/sitemap.xml contains all URLs in a single <urlset>"
+msgstr ""
+
+msgid "/sitemap.xml is a sitemapindex referencing per-module sitemap files"
+msgstr ""
+
+msgid "Sitemap Source"
+msgstr ""
+
+msgid "Open in Browser"
+msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -6229,3 +6229,43 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Referrals"
 msgstr ""
+
+#: lib/phoenix_kit_web/components/core/badge.ex:125
+#, elixir-autogen, elixir-format
+msgid "Expired"
+msgstr ""
+
+#: lib/phoenix_kit_web/components/core/badge.ex:162
+#, elixir-autogen, elixir-format
+msgid "Transactional"
+msgstr ""
+
+#: lib/phoenix_kit_web/components/core/time_display.ex:206
+#, elixir-autogen, elixir-format
+msgid "No expiration"
+msgstr ""
+
+#: lib/phoenix_kit_web/components/core/time_display.ex:212
+#, elixir-autogen, elixir-format
+msgid "Today"
+msgstr ""
+
+#: lib/phoenix_kit_web/components/core/time_display.ex:187
+#, elixir-autogen, elixir-format
+msgid "%{count}s ago"
+msgstr ""
+
+#: lib/phoenix_kit_web/components/core/time_display.ex:188
+#, elixir-autogen, elixir-format
+msgid "%{count}m ago"
+msgstr ""
+
+#: lib/phoenix_kit_web/components/core/time_display.ex:189
+#, elixir-autogen, elixir-format
+msgid "%{count}h ago"
+msgstr ""
+
+#: lib/phoenix_kit_web/components/core/time_display.ex:190
+#, elixir-autogen, elixir-format
+msgid "%{count}d ago"
+msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -6270,3 +6270,66 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "%{count}d ago"
 msgstr ""
+
+msgid "Summary"
+msgstr ""
+
+msgid "Languages Enabled"
+msgstr ""
+
+msgid "Countries Covered"
+msgstr ""
+
+msgid "Enabled Languages"
+msgstr ""
+
+msgid "Default language"
+msgstr ""
+
+msgid "Available Languages"
+msgstr ""
+
+msgid "Language Configuration"
+msgstr ""
+
+msgid "Frontend Language Switcher"
+msgstr ""
+
+msgid "Switcher Settings"
+msgstr ""
+
+msgid "Show Flags"
+msgstr ""
+
+msgid "Show Names"
+msgstr ""
+
+msgid "Native Names"
+msgstr ""
+
+msgid "Go to Home"
+msgstr ""
+
+msgid "Hide Current"
+msgstr ""
+
+msgid "Generated Code"
+msgstr ""
+
+msgid "Implementation Notes"
+msgstr ""
+
+msgid "Enable and Configure Languages"
+msgstr ""
+
+msgid "Done"
+msgstr ""
+
+msgid "Reorder"
+msgstr ""
+
+msgid "Default"
+msgstr ""
+
+msgid "No languages enabled yet."
+msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -6333,3 +6333,171 @@ msgstr ""
 
 msgid "No languages enabled yet."
 msgstr ""
+
+msgid "Sitemap Settings"
+msgstr ""
+
+msgid "Configure sitemap generation and scheduling"
+msgstr ""
+
+msgid "Total URLs"
+msgstr ""
+
+msgid "Sitemap Files"
+msgstr ""
+
+msgid "Last Generated"
+msgstr ""
+
+msgid "Regenerate All"
+msgstr ""
+
+msgid "Router Discovery"
+msgstr ""
+
+msgid "When enabled, scans all routes and builds a single flat sitemap.xml with URLs from all content sources (shop, entities, posts, publishing). When disabled, each source generates its own sitemap file."
+msgstr ""
+
+msgid "Flat mode active — /sitemap.xml contains all URLs in a single <urlset>"
+msgstr ""
+
+msgid "Routes"
+msgstr ""
+
+msgid "Static"
+msgstr ""
+
+msgid "Publishing"
+msgstr ""
+
+msgid "Entities"
+msgstr ""
+
+msgid "Posts"
+msgstr ""
+
+msgid "Shop"
+msgstr ""
+
+msgid "Module Sitemaps"
+msgstr ""
+
+msgid "Each source generates its own sitemap file, referenced by the main sitemap index"
+msgstr ""
+
+msgid "Static Pages"
+msgstr ""
+
+msgid "Homepage and custom static URLs"
+msgstr ""
+
+msgid "View sitemap"
+msgstr ""
+
+msgid "module off"
+msgstr ""
+
+msgid "Blog groups and published posts"
+msgstr ""
+
+msgid "Split by blog group"
+msgstr ""
+
+msgid "Dynamic content types (per-type files)"
+msgstr ""
+
+msgid "Public posts from Posts module"
+msgstr ""
+
+msgid "Products, categories, catalog"
+msgstr ""
+
+msgid "Auth Pages"
+msgstr ""
+
+msgid "Login"
+msgstr ""
+
+msgid "Always excluded from sitemap"
+msgstr ""
+
+msgid "Excluded"
+msgstr ""
+
+msgid "Logout"
+msgstr ""
+
+msgid "Registration"
+msgstr ""
+
+msgid "Include in static sitemap"
+msgstr ""
+
+msgid "Configuration"
+msgstr ""
+
+msgid "Edit in Settings"
+msgstr ""
+
+msgid "Browser Display Styling"
+msgstr ""
+
+msgid "Style XML with XSL for beautiful browser display"
+msgstr ""
+
+msgid "Display Style"
+msgstr ""
+
+msgid "Table (Clean table layout)"
+msgstr ""
+
+msgid "Minimal (Simple list)"
+msgstr ""
+
+msgid "Scheduled Generation"
+msgstr ""
+
+msgid "Regenerate every"
+msgstr ""
+
+msgid "1 hour"
+msgstr ""
+
+msgid "6 hours"
+msgstr ""
+
+msgid "12 hours"
+msgstr ""
+
+msgid "24 hours"
+msgstr ""
+
+msgid "48 hours"
+msgstr ""
+
+msgid "Weekly"
+msgstr ""
+
+msgid "Preview Sitemap Source"
+msgstr ""
+
+msgid "Clear All Sitemaps"
+msgstr ""
+
+msgid "Generated sitemap files:"
+msgstr ""
+
+msgid "sitemap.xml (index)"
+msgstr ""
+
+msgid "/sitemap.xml contains all URLs in a single <urlset>"
+msgstr ""
+
+msgid "/sitemap.xml is a sitemapindex referencing per-module sitemap files"
+msgstr ""
+
+msgid "Sitemap Source"
+msgstr ""
+
+msgid "Open in Browser"
+msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -6185,3 +6185,48 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "requires the"
 msgstr ""
+
+#: lib/phoenix_kit/dashboard/admin_tabs.ex:148
+#, elixir-autogen, elixir-format
+msgid "Activity"
+msgstr ""
+
+#: lib/phoenix_kit/dashboard/admin_tabs.ex:245
+#, elixir-autogen, elixir-format
+msgid "Authorization"
+msgstr ""
+
+#: lib/phoenix_kit/dashboard/admin_tabs.ex:294
+#, elixir-autogen, elixir-format
+msgid "Dimensions"
+msgstr ""
+
+#: lib/phoenix_kit/dashboard/admin_tabs.ex:235
+#, elixir-autogen, elixir-format
+msgid "General"
+msgstr ""
+
+#: lib/phoenix_kit/dashboard/admin_tabs.ex:102
+#, elixir-autogen, elixir-format
+msgid "Live Sessions"
+msgstr ""
+
+#: lib/modules/maintenance/maintenance.ex:528
+#, elixir-autogen, elixir-format
+msgid "Maintenance"
+msgstr ""
+
+#: lib/phoenix_kit/dashboard/admin_tabs.ex:93
+#, elixir-autogen, elixir-format
+msgid "Manage Users"
+msgstr ""
+
+#: lib/phoenix_kit/dashboard/admin_tabs.ex:160
+#, elixir-autogen, elixir-format
+msgid "Media"
+msgstr ""
+
+#: lib/modules/referrals/referrals.ex:658
+#, elixir-autogen, elixir-format
+msgid "Referrals"
+msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -6230,3 +6230,43 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Referrals"
 msgstr ""
+
+#: lib/phoenix_kit_web/components/core/badge.ex:125
+#, elixir-autogen, elixir-format
+msgid "Expired"
+msgstr ""
+
+#: lib/phoenix_kit_web/components/core/badge.ex:162
+#, elixir-autogen, elixir-format
+msgid "Transactional"
+msgstr ""
+
+#: lib/phoenix_kit_web/components/core/time_display.ex:206
+#, elixir-autogen, elixir-format
+msgid "No expiration"
+msgstr ""
+
+#: lib/phoenix_kit_web/components/core/time_display.ex:212
+#, elixir-autogen, elixir-format
+msgid "Today"
+msgstr ""
+
+#: lib/phoenix_kit_web/components/core/time_display.ex:187
+#, elixir-autogen, elixir-format
+msgid "%{count}s ago"
+msgstr ""
+
+#: lib/phoenix_kit_web/components/core/time_display.ex:188
+#, elixir-autogen, elixir-format
+msgid "%{count}m ago"
+msgstr ""
+
+#: lib/phoenix_kit_web/components/core/time_display.ex:189
+#, elixir-autogen, elixir-format
+msgid "%{count}h ago"
+msgstr ""
+
+#: lib/phoenix_kit_web/components/core/time_display.ex:190
+#, elixir-autogen, elixir-format
+msgid "%{count}d ago"
+msgstr ""

--- a/priv/gettext/et/LC_MESSAGES/default.po
+++ b/priv/gettext/et/LC_MESSAGES/default.po
@@ -6355,3 +6355,171 @@ msgstr "Vaikimisi"
 
 msgid "No languages enabled yet."
 msgstr "Ühtegi keelt pole veel lubatud."
+
+msgid "Sitemap Settings"
+msgstr "Saidikaardi seaded"
+
+msgid "Configure sitemap generation and scheduling"
+msgstr "Seadista saidikaardi genereerimist ja ajakava"
+
+msgid "Total URLs"
+msgstr "URL-e kokku"
+
+msgid "Sitemap Files"
+msgstr "Saidikaardi failid"
+
+msgid "Last Generated"
+msgstr "Viimati genereeritud"
+
+msgid "Regenerate All"
+msgstr "Genereeri kõik uuesti"
+
+msgid "Router Discovery"
+msgstr "Marsruutide tuvastamine"
+
+msgid "When enabled, scans all routes and builds a single flat sitemap.xml with URLs from all content sources (shop, entities, posts, publishing). When disabled, each source generates its own sitemap file."
+msgstr "Kui lubatud, skannib kõiki marsruute ja loob ühe tasase sitemap.xml faili kõigi sisuallikate URL-idega (pood, üksused, postitused, avaldamine). Kui keelatud, loob iga allikas oma saidikaardi faili."
+
+msgid "Flat mode active — /sitemap.xml contains all URLs in a single <urlset>"
+msgstr "Tasane režiim on aktiivne — /sitemap.xml sisaldab kõiki URL-e ühes <urlset>"
+
+msgid "Routes"
+msgstr "Marsruudid"
+
+msgid "Static"
+msgstr "Staatilised"
+
+msgid "Publishing"
+msgstr "Avaldamine"
+
+msgid "Entities"
+msgstr "Üksused"
+
+msgid "Posts"
+msgstr "Postitused"
+
+msgid "Shop"
+msgstr "Pood"
+
+msgid "Module Sitemaps"
+msgstr "Moodulite saidikaardid"
+
+msgid "Each source generates its own sitemap file, referenced by the main sitemap index"
+msgstr "Iga allikas loob oma saidikaardi faili, millele viitab põhiindeks"
+
+msgid "Static Pages"
+msgstr "Staatilised lehed"
+
+msgid "Homepage and custom static URLs"
+msgstr "Avaleht ja kohandatud staatilised URL-id"
+
+msgid "View sitemap"
+msgstr "Vaata saidikaart"
+
+msgid "module off"
+msgstr "moodul väljas"
+
+msgid "Blog groups and published posts"
+msgstr "Blogigruppe ja avaldatud postitused"
+
+msgid "Split by blog group"
+msgstr "Jaga blogigruppide kaupa"
+
+msgid "Dynamic content types (per-type files)"
+msgstr "Dünaamilised sisutüübid (eraldi failid igale tüübile)"
+
+msgid "Public posts from Posts module"
+msgstr "Avalikud postitused Posts moodulist"
+
+msgid "Products, categories, catalog"
+msgstr "Tooted, kategooriad, kataloog"
+
+msgid "Auth Pages"
+msgstr "Autentimislehed"
+
+msgid "Login"
+msgstr "Sisselogimine"
+
+msgid "Always excluded from sitemap"
+msgstr "Alati saidikaardist välistatud"
+
+msgid "Excluded"
+msgstr "Välistatud"
+
+msgid "Logout"
+msgstr "Väljalogimine"
+
+msgid "Registration"
+msgstr "Registreerimine"
+
+msgid "Include in static sitemap"
+msgstr "Lisa staatilisse saidikaardi"
+
+msgid "Configuration"
+msgstr "Seadistus"
+
+msgid "Edit in Settings"
+msgstr "Muuda seadetes"
+
+msgid "Browser Display Styling"
+msgstr "Brauseri kuvamise stiil"
+
+msgid "Style XML with XSL for beautiful browser display"
+msgstr "Stiili XML XSL-iga brauseri kauniks kuvamiseks"
+
+msgid "Display Style"
+msgstr "Kuvamisstiil"
+
+msgid "Table (Clean table layout)"
+msgstr "Tabel (puhas tabelivaade)"
+
+msgid "Minimal (Simple list)"
+msgstr "Minimaalne (lihtne loend)"
+
+msgid "Scheduled Generation"
+msgstr "Ajastatud genereerimine"
+
+msgid "Regenerate every"
+msgstr "Genereeri uuesti iga"
+
+msgid "1 hour"
+msgstr "1 tund"
+
+msgid "6 hours"
+msgstr "6 tundi"
+
+msgid "12 hours"
+msgstr "12 tundi"
+
+msgid "24 hours"
+msgstr "24 tundi"
+
+msgid "48 hours"
+msgstr "48 tundi"
+
+msgid "Weekly"
+msgstr "Iga nädal"
+
+msgid "Preview Sitemap Source"
+msgstr "Eelvaade saidikaardi lähtekood"
+
+msgid "Clear All Sitemaps"
+msgstr "Kustuta kõik saidikaardid"
+
+msgid "Generated sitemap files:"
+msgstr "Genereeritud saidikaardi failid:"
+
+msgid "sitemap.xml (index)"
+msgstr "sitemap.xml (indeks)"
+
+msgid "/sitemap.xml contains all URLs in a single <urlset>"
+msgstr "/sitemap.xml sisaldab kõiki URL-e ühes <urlset>"
+
+msgid "/sitemap.xml is a sitemapindex referencing per-module sitemap files"
+msgstr "/sitemap.xml on saidikaardi indeks, mis viitab moodulite saidikaardi failidele"
+
+msgid "Sitemap Source"
+msgstr "Saidikaardi lähtekood"
+
+msgid "Open in Browser"
+msgstr "Ava brauseris"

--- a/priv/gettext/et/LC_MESSAGES/default.po
+++ b/priv/gettext/et/LC_MESSAGES/default.po
@@ -23,22 +23,22 @@ msgstr ""
 #: lib/phoenix_kit_web/live/dashboard/index.ex:11
 #, elixir-autogen
 msgid "Dashboard"
-msgstr ""
+msgstr "Töölaud"
 
 #: lib/phoenix_kit_web/live/dashboard.html.heex:13
 #, elixir-autogen
 msgid "Welcome to the %{project_title} administration panel"
-msgstr ""
+msgstr "Tere tulemast %{project_title} administraatori paneelile"
 
 #: lib/phoenix_kit_web/live/dashboard.html.heex:132
 #, elixir-autogen
 msgid "Platform Statistics"
-msgstr ""
+msgstr "Platvormi statistika"
 
 #: lib/phoenix_kit_web/live/dashboard.html.heex:341
 #, elixir-autogen
 msgid "System Information"
-msgstr ""
+msgstr "Süsteemi teave"
 
 ## Navigation menu items
 #: lib/phoenix_kit_web/live/dashboard.html.heex:29
@@ -46,12 +46,12 @@ msgstr ""
 #: lib/phoenix_kit_web/live/users/roles.html.heex:166
 #, elixir-autogen
 msgid "Users"
-msgstr ""
+msgstr "Kasutajad"
 
 #: lib/phoenix_kit_web/live/dashboard.html.heex:30
 #, elixir-autogen
 msgid "User management"
-msgstr ""
+msgstr "Kasutajate haldamine"
 
 #: lib/phoenix_kit_web/live/dashboard.html.heex:44
 #: lib/phoenix_kit_web/live/users/roles.ex:47
@@ -60,37 +60,37 @@ msgstr ""
 #: lib/phoenix_kit_web/live/users/users.html.heex:477
 #, elixir-autogen
 msgid "Roles"
-msgstr ""
+msgstr "Rollid"
 
 #: lib/phoenix_kit_web/live/dashboard.html.heex:45
 #, elixir-autogen
 msgid "Role management"
-msgstr ""
+msgstr "Rollide haldamine"
 
 #: lib/phoenix_kit_web/live/dashboard.html.heex:59
 #, elixir-autogen
 msgid "Sessions"
-msgstr ""
+msgstr "Sessioonid"
 
 #: lib/phoenix_kit_web/live/dashboard.html.heex:60
 #, elixir-autogen
 msgid "Active sessions"
-msgstr ""
+msgstr "Aktiivsed sessioonid"
 
 #: lib/phoenix_kit_web/live/dashboard.html.heex:74
 #, elixir-autogen
 msgid "Live Activity"
-msgstr ""
+msgstr "Reaalajas tegevus"
 
 #: lib/phoenix_kit_web/live/dashboard.html.heex:75
 #, elixir-autogen
 msgid "Real-time visitors"
-msgstr ""
+msgstr "Reaalajas külastajad"
 
 #: lib/phoenix_kit_web/live/dashboard.html.heex:89
 #, elixir-autogen
 msgid "Add User"
-msgstr ""
+msgstr "Lisa kasutaja"
 
 #: lib/phoenix_kit_web/live/dashboard.html.heex:90
 #, elixir-autogen, fuzzy
@@ -104,201 +104,201 @@ msgstr "Loo konto"
 #: lib/phoenix_kit_web/users/user_form.html.heex:819
 #, elixir-autogen
 msgid "Email"
-msgstr ""
+msgstr "E-post"
 
 #: lib/phoenix_kit_web/live/dashboard.html.heex:106
 #, elixir-autogen
 msgid "Email logs & analytics"
-msgstr ""
+msgstr "E-posti logid ja analüütika"
 
 #: lib/modules/storage/web/health.html.heex:75
 #: lib/phoenix_kit_web/live/dashboard.html.heex:121
 #, elixir-autogen
 msgid "Refresh"
-msgstr ""
+msgstr "Värskenda"
 
 #: lib/phoenix_kit_web/live/dashboard.html.heex:122
 #, elixir-autogen
 msgid "Update statistics"
-msgstr ""
+msgstr "Uuenda statistikat"
 
 ## Statistics cards
 #: lib/phoenix_kit_web/live/dashboard.html.heex:140
 #, elixir-autogen
 msgid "System Owners"
-msgstr ""
+msgstr "Süsteemi omanikud"
 
 #: lib/phoenix_kit_web/live/dashboard.html.heex:141
 #, elixir-autogen
 msgid "Complete system authority"
-msgstr ""
+msgstr "Täielik süsteemi volitused"
 
 #: lib/phoenix_kit_web/live/dashboard.html.heex:151
 #, elixir-autogen
 msgid "Administrators"
-msgstr ""
+msgstr "Administraatorid"
 
 #: lib/phoenix_kit_web/live/dashboard.html.heex:152
 #, elixir-autogen
 msgid "Management privileges"
-msgstr ""
+msgstr "Halduspriviileegid"
 
 #: lib/phoenix_kit_web/live/dashboard.html.heex:162
 #, elixir-autogen
 msgid "Total Users"
-msgstr ""
+msgstr "Kasutajaid kokku"
 
 #: lib/phoenix_kit_web/live/dashboard.html.heex:163
 #, elixir-autogen
 msgid "Registered accounts"
-msgstr ""
+msgstr "Registreeritud kontod"
 
 #: lib/phoenix_kit_web/live/dashboard.html.heex:173
 #: lib/phoenix_kit_web/live/dashboard.html.heex:178
 #, elixir-autogen
 msgid "Active Sessions"
-msgstr ""
+msgstr "Aktiivsed sessioonid"
 
 #: lib/phoenix_kit_web/live/dashboard.html.heex:179
 #, elixir-autogen
 msgid "Currently logged in"
-msgstr ""
+msgstr "Praegu sisse logitud"
 
 #: lib/phoenix_kit_web/live/dashboard.html.heex:189
 #, elixir-autogen
 msgid "Unique Users"
-msgstr ""
+msgstr "Unikaalsed kasutajad"
 
 #: lib/phoenix_kit_web/live/dashboard.html.heex:190
 #, elixir-autogen
 msgid "With active sessions"
-msgstr ""
+msgstr "Aktiivsete seansidega"
 
 #: lib/phoenix_kit_web/live/dashboard.html.heex:200
 #, elixir-autogen
 msgid "Today's Sessions"
-msgstr ""
+msgstr "Tänased sessioonid"
 
 #: lib/phoenix_kit_web/live/dashboard.html.heex:201
 #, elixir-autogen
 msgid "New login activity"
-msgstr ""
+msgstr "Uued sisselogimised"
 
 #: lib/phoenix_kit_web/live/dashboard.html.heex:211
 #, elixir-autogen
 msgid "Expired Sessions"
-msgstr ""
+msgstr "Aegunud sessioonid"
 
 #: lib/phoenix_kit_web/live/dashboard.html.heex:212
 #, elixir-autogen
 msgid "Need cleanup"
-msgstr ""
+msgstr "Vajavad puhastamist"
 
 #: lib/phoenix_kit_web/live/dashboard.html.heex:223
 #, elixir-autogen
 msgid "Real-Time Activity"
-msgstr ""
+msgstr "Reaalajas tegevus"
 
 #: lib/phoenix_kit_web/live/dashboard.html.heex:228
 #, elixir-autogen
 msgid "Active Visitors"
-msgstr ""
+msgstr "Aktiivsed külastajad"
 
 #: lib/phoenix_kit_web/live/dashboard.html.heex:229
 #, elixir-autogen
 msgid "Real-time connections"
-msgstr ""
+msgstr "Reaalajas ühendused"
 
 #: lib/phoenix_kit_web/live/dashboard.html.heex:239
 #, elixir-autogen
 msgid "Anonymous"
-msgstr ""
+msgstr "Anonüümne"
 
 #: lib/phoenix_kit_web/live/dashboard.html.heex:240
 #, elixir-autogen
 msgid "Unregistered visitors"
-msgstr ""
+msgstr "Registreerimata külastajad"
 
 #: lib/phoenix_kit_web/live/dashboard.html.heex:250
 #, elixir-autogen
 msgid "Authenticated"
-msgstr ""
+msgstr "Autentitud"
 
 #: lib/phoenix_kit_web/live/dashboard.html.heex:251
 #, elixir-autogen
 msgid "Logged in users"
-msgstr ""
+msgstr "Sisse logitud kasutajad"
 
 #: lib/phoenix_kit_web/live/dashboard.html.heex:264
 #, elixir-autogen
 msgid "Unique Visitors"
-msgstr ""
+msgstr "Unikaalsed külastajad"
 
 #: lib/phoenix_kit_web/live/dashboard.html.heex:265
 #, elixir-autogen
 msgid "Individual connections"
-msgstr ""
+msgstr "Individuaalsed ühendused"
 
 #: lib/phoenix_kit_web/live/dashboard.html.heex:280
 #, elixir-autogen
 msgid "Active Users"
-msgstr ""
+msgstr "Aktiivsed kasutajad"
 
 #: lib/phoenix_kit_web/live/dashboard.html.heex:281
 #, elixir-autogen
 msgid "Currently online"
-msgstr ""
+msgstr "Praegu võrgus"
 
 #: lib/phoenix_kit_web/live/dashboard.html.heex:292
 #, elixir-autogen
 msgid "Inactive Users"
-msgstr ""
+msgstr "Mitteaktiivsed kasutajad"
 
 #: lib/phoenix_kit_web/live/dashboard.html.heex:293
 #, elixir-autogen
 msgid "Disabled accounts"
-msgstr ""
+msgstr "Keelatud kontod"
 
 #: lib/phoenix_kit_web/live/dashboard.html.heex:304
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:256
 #, elixir-autogen
 msgid "Email Confirmed"
-msgstr ""
+msgstr "E-post kinnitatud"
 
 #: lib/phoenix_kit_web/live/dashboard.html.heex:305
 #, elixir-autogen
 msgid "Verified emails"
-msgstr ""
+msgstr "Kinnitatud e-postid"
 
 #: lib/phoenix_kit_web/live/dashboard.html.heex:316
 #, elixir-autogen
 msgid "Pending Email"
-msgstr ""
+msgstr "E-post kinnitamata"
 
 #: lib/phoenix_kit_web/live/dashboard.html.heex:317
 #, elixir-autogen
 msgid "Awaiting confirmation"
-msgstr ""
+msgstr "Kinnitust oodatakse"
 
 #: lib/phoenix_kit_web/live/dashboard.html.heex:328
 #, elixir-autogen
 msgid "Regular Users"
-msgstr ""
+msgstr "Tavalised kasutajad"
 
 #: lib/phoenix_kit_web/live/dashboard.html.heex:329
 #, elixir-autogen
 msgid "Standard access level"
-msgstr ""
+msgstr "Standardne juurdepääsutase"
 
 #: lib/phoenix_kit_web/live/dashboard.html.heex:365
 #, elixir-autogen
 msgid "Role System"
-msgstr ""
+msgstr "Rollisüsteem"
 
 #: lib/phoenix_kit_web/live/dashboard.html.heex:369
 #, elixir-autogen
 msgid "Authentication"
-msgstr ""
+msgstr "Autentimine"
 
 #: lib/phoenix_kit_web/live/dashboard.html.heex:364
 #: lib/phoenix_kit_web/live/modules.html.heex:69
@@ -308,7 +308,7 @@ msgstr ""
 #: lib/phoenix_kit_web/users/user_form.html.heex:765
 #, elixir-autogen
 msgid "Active"
-msgstr ""
+msgstr "Aktiivne"
 
 #: lib/modules/storage/web/dimensions.html.heex:137
 #: lib/modules/storage/web/dimensions.html.heex:200
@@ -338,83 +338,83 @@ msgstr ""
 #: lib/phoenix_kit_web/live/settings/users.html.heex:398
 #, elixir-autogen
 msgid "Enabled"
-msgstr ""
+msgstr "Lubatud"
 
 ## Flash messages
 #: lib/phoenix_kit_web/live/dashboard.ex:79
 #, elixir-autogen
 msgid "Statistics refreshed successfully"
-msgstr ""
+msgstr "Statistika uuendatud edukalt"
 
 #: lib/phoenix_kit_web/components/core/flash.ex:59
 #, elixir-autogen, elixir-format
 msgid "close"
-msgstr ""
+msgstr "sulge"
 
 #: lib/phoenix_kit_web/live/users/roles.html.heex:425
 #, elixir-autogen, elixir-format
 msgid "%{granted} of %{total} manageable permissions granted"
-msgstr ""
+msgstr "%{granted} %{total} hallatavast õigusest antud"
 
 #: lib/phoenix_kit_web/components/language_switcher.ex:824
 #, elixir-autogen, elixir-format
 msgid "%{language} (Archived)"
-msgstr ""
+msgstr "%{language} (Arhiveeritud)"
 
 #: lib/phoenix_kit_web/components/language_switcher.ex:820
 #, elixir-autogen, elixir-format
 msgid "%{language} (Draft)"
-msgstr ""
+msgstr "%{language} (Mustand)"
 
 #: lib/phoenix_kit_web/components/language_switcher.ex:816
 #, elixir-autogen, elixir-format
 msgid "%{language} (Published)"
-msgstr ""
+msgstr "%{language} (Avaldatud)"
 
 #: lib/phoenix_kit_web/live/components/user_settings.ex:383
 #, elixir-autogen, elixir-format
 msgid "%{provider} account disconnected successfully"
-msgstr ""
+msgstr "%{provider} konto lahti ühendatud edukalt"
 
 #: lib/phoenix_kit_web/live/users/roles.html.heex:432
 #, elixir-autogen, elixir-format
 msgid "(%{count} for disabled modules, preserved on save)"
-msgstr ""
+msgstr "(%{count} keelatud moodulite jaoks, säilitatakse salvestamisel)"
 
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:129
 #, elixir-autogen, elixir-format
 msgid "(optional)"
-msgstr ""
+msgstr "(valikuline)"
 
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:83
 #, elixir-autogen, elixir-format
 msgid "123 Business Street"
-msgstr ""
+msgstr "123 Äritänav"
 
 #: lib/phoenix_kit_web/live/components/user_settings.ex:196
 #, elixir-autogen, elixir-format
 msgid "A link to confirm your email change has been sent to the new address."
-msgstr ""
+msgstr "E-posti muutmise kinnituslink on saadetud uuele aadressile."
 
 #: lib/phoenix_kit_web/live/users/permissions_matrix.html.heex:204
 #, elixir-autogen, elixir-format
 msgid "About Permissions"
-msgstr ""
+msgstr "Õiguste kohta"
 
 #: lib/phoenix_kit_web/legal_gettext_manifest.ex:45
 #, elixir-autogen, elixir-format
 msgid "Accept All"
-msgstr ""
+msgstr "Nõustu kõigega"
 
 #: lib/phoenix_kit/integrations/integrations.ex:939
 #, elixir-autogen, elixir-format
 msgid "Access denied"
-msgstr ""
+msgstr "Juurdepääs keelatud"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:238
 #, elixir-autogen, elixir-format
 msgid "Account Information"
-msgstr ""
+msgstr "Konto teave"
 
 #: lib/modules/storage/web/dimensions.html.heex:151
 #: lib/modules/storage/web/dimensions.html.heex:351
@@ -430,134 +430,134 @@ msgstr ""
 #: lib/phoenix_kit_web/users/user_form.html.heex:822
 #, elixir-autogen, elixir-format
 msgid "Actions"
-msgstr ""
+msgstr "Tegevused"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:956
 #: lib/phoenix_kit_web/live/settings/users.html.heex:655
 #: lib/phoenix_kit_web/users/user_form.html.heex:721
 #, elixir-autogen, elixir-format
 msgid "Add"
-msgstr ""
+msgstr "Lisa"
 
 #: lib/phoenix_kit_web/components/language_switcher.ex:807
 #: lib/phoenix_kit_web/components/language_switcher.ex:812
 #, elixir-autogen, elixir-format
 msgid "Add %{language} translation"
-msgstr ""
+msgstr "Lisa %{language} tõlge"
 
 #: lib/phoenix_kit_web/live/settings/users.html.heex:679
 #, elixir-autogen, elixir-format
 msgid "Add Field"
-msgstr ""
+msgstr "Lisa väli"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:421
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:449
 #, elixir-autogen, elixir-format
 msgid "Add Note"
-msgstr ""
+msgstr "Lisa märkus"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:529
 #, elixir-autogen, elixir-format
 msgid "Add a note above to start documenting information about this user."
-msgstr ""
+msgstr "Lisa märkus ülal, et alustada selle kasutaja teabe dokumenteerimist."
 
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:69
 #, elixir-autogen, elixir-format
 msgid "Address"
-msgstr ""
+msgstr "Aadress"
 
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:91
 #, elixir-autogen, elixir-format
 msgid "Address Line 2"
-msgstr ""
+msgstr "Aadressirida 2"
 
 #: lib/phoenix_kit_web/legal_gettext_manifest.ex:47
 #, elixir-autogen, elixir-format
 msgid "Address imported from Organization"
-msgstr ""
+msgstr "Aadress imporditud organisatsioonist"
 
 #: lib/phoenix_kit_web/components/layout_wrapper.ex:311
 #, elixir-autogen, elixir-format
 msgid "Admin"
-msgstr ""
+msgstr "Admin"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:647
 #, elixir-autogen, elixir-format
 msgid "Admin notes about this user"
-msgstr ""
+msgstr "Administraatori märkused selle kasutaja kohta"
 
 #: lib/phoenix_kit_web/live/users/roles.html.heex:301
 #, elixir-autogen, elixir-format
 msgid "All available roles"
-msgstr ""
+msgstr "Kõik saadaolevad rollid"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:643
 #, elixir-autogen, elixir-format
 msgid "All session tokens and authentication data"
-msgstr ""
+msgstr "Kõik seansi tokenid ja autentimisandmed"
 
 #: lib/phoenix_kit_web/components/language_switcher.ex:831
 #, elixir-autogen, elixir-format
 msgid "Archived"
-msgstr ""
+msgstr "Arhiveeritud"
 
 #: lib/phoenix_kit_web/live/users/roles.html.heex:320
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete the role \"%{role_name}\"? This action cannot be undone."
-msgstr ""
+msgstr "Kas olete kindel, et soovite kustutada rolli \"%{role_name}\"? Seda toimingut ei saa tagasi võtta."
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:510
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete this note?"
-msgstr ""
+msgstr "Kas oled kindel, et soovid kustutada selle märkuse?"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:633
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to permanently delete"
-msgstr ""
+msgstr "Kas oled kindel, et soovid jäädavalt kustutada"
 
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:208
 #, elixir-autogen, elixir-format
 msgid "Bank Details"
-msgstr ""
+msgstr "Pangaandmed"
 
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:217
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:224
 #, elixir-autogen, elixir-format
 msgid "Bank Name"
-msgstr ""
+msgstr "Panga nimi"
 
 #: lib/phoenix_kit_web/live/settings/organization.ex:236
 #, elixir-autogen, elixir-format
 msgid "Bank details saved"
-msgstr ""
+msgstr "Pangaandmed salvestatud"
 
 #: lib/modules/storage/web/bucket_form.html.heex:21
 #: lib/modules/storage/web/dimension_form.html.heex:21
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:170
 #, elixir-autogen, elixir-format
 msgid "Basic Information"
-msgstr ""
+msgstr "Põhiandmed"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:645
 #, elixir-autogen, elixir-format
 msgid "Billing profiles and payment methods"
-msgstr ""
+msgstr "Arveldusprofiilid ja maksemeetodid"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:405
 #, elixir-autogen, elixir-format
 msgid "Blocked"
-msgstr ""
+msgstr "Blokeeritud"
 
 #: lib/phoenix_kit_web/components/core/markdown_editor.ex:453
 #, elixir-autogen, elixir-format
 msgid "Bold"
-msgstr ""
+msgstr "Paks"
 
 #: lib/phoenix_kit_web/components/core/markdown_editor.ex:539
 #, elixir-autogen, elixir-format
 msgid "Bullet List"
-msgstr ""
+msgstr "Punktloend"
 
 #: lib/modules/maintenance/settings.ex:448
 #: lib/modules/storage/web/bucket_form.html.heex:388
@@ -572,78 +572,78 @@ msgstr ""
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:672
 #, elixir-autogen, elixir-format
 msgid "Cancel"
-msgstr ""
+msgstr "Tühista"
 
 #: lib/phoenix_kit_web/live/users/roles.ex:349
 #, elixir-autogen, elixir-format
 msgid "Cannot delete role: it is currently assigned to users"
-msgstr ""
+msgstr "Rolli ei saa kustutada: see on praegu kasutajatele määratud"
 
 #: lib/phoenix_kit_web/live/users/user_details.ex:135
 #, elixir-autogen, elixir-format
 msgid "Cannot delete the last system owner"
-msgstr ""
+msgstr "Viimast süsteemi omanikku ei saa kustutada"
 
 #: lib/phoenix_kit_web/live/users/user_details.ex:129
 #, elixir-autogen, elixir-format
 msgid "Cannot delete your own account"
-msgstr ""
+msgstr "Oma kontot ei saa kustutada"
 
 #: lib/phoenix_kit_web/live/components/user_settings.ex:417
 #, elixir-autogen, elixir-format
 msgid "Cannot disconnect %{provider}. Please ensure you have at least one sign-in method available."
-msgstr ""
+msgstr "Ei saa %{provider} lahti ühendada. Palun veendu, et sul on vähemalt üks sisselogimismeetod saadaval."
 
 #: lib/phoenix_kit_web/live/components/user_settings.ex:412
 #, elixir-autogen, elixir-format
 msgid "Cannot disconnect %{provider}. This is your only sign-in method. Please set a password or connect another provider first."
-msgstr ""
+msgstr "Ei saa %{provider} lahti ühendada. See on sinu ainus sisselogimismeetod. Palun määra parool või ühenda kõigepealt teine teenusepakkuja."
 
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:107
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:115
 #, elixir-autogen, elixir-format
 msgid "City"
-msgstr ""
+msgstr "Linn"
 
 #: lib/phoenix_kit_web/live/settings/organization.ex:286
 #, elixir-autogen, elixir-format
 msgid "City is required"
-msgstr ""
+msgstr "Linn on kohustuslik"
 
 #: lib/phoenix_kit_web/live/users/permissions_matrix.html.heex:206
 #, elixir-autogen, elixir-format
 msgid "Click any check or cross icon to toggle a permission for that role. The Owner role always has full access and cannot be modified. You cannot edit permissions for your own role or for roles with higher authority. You can only grant or revoke permissions that your own role has."
-msgstr ""
+msgstr "Klõpsa mis tahes linnukese või risti ikoonil, et lülitada selle rolli õigust. Omaniku rollil on alati täielik juurdepääs ja seda ei saa muuta. Sa ei saa muuta oma rolli ega kõrgema volitusega rollide õigusi. Sa saad anda või tühistada ainult neid õigusi, mis sinu rollil on."
 
 #: lib/phoenix_kit_web/legal_gettext_manifest.ex:50
 #, elixir-autogen, elixir-format
 msgid "Close"
-msgstr ""
+msgstr "Sulge"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:658
 #, elixir-autogen, elixir-format
 msgid "Comments - Content preserved, marked as deleted author"
-msgstr ""
+msgstr "Kommentaarid – sisu säilitatud, märgitud kustutatud autorina"
 
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:22
 #, elixir-autogen, elixir-format
 msgid "Company Information"
-msgstr ""
+msgstr "Ettevõtte teave"
 
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:34
 #, elixir-autogen, elixir-format
 msgid "Company Name"
-msgstr ""
+msgstr "Ettevõtte nimi"
 
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Company information shared across Legal and Billing modules"
-msgstr ""
+msgstr "Ettevõtte teave jagatud Juriidilise ja Arvelduse moodulitega"
 
 #: lib/phoenix_kit_web/live/settings/organization.ex:282
 #, elixir-autogen, elixir-format
 msgid "Company name is required"
-msgstr ""
+msgstr "Ettevõtte nimi on kohustuslik"
 
 #: lib/phoenix_kit_web/live/modules.html.heex:58
 #: lib/phoenix_kit_web/live/modules.html.heex:108
@@ -671,12 +671,12 @@ msgstr "Seadista"
 #: lib/phoenix_kit_web/live/users/users.html.heex:496
 #, elixir-autogen, elixir-format
 msgid "Confirm"
-msgstr ""
+msgstr "Kinnita"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:116
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
-msgstr ""
+msgstr "Kinnitatud"
 
 #: lib/phoenix_kit_web/live/modules.html.heex:352
 #: lib/phoenix_kit_web/live/modules.html.heex:394
@@ -689,69 +689,69 @@ msgstr "Ühendused"
 #: lib/phoenix_kit_web/legal_gettext_manifest.ex:51
 #, elixir-autogen, elixir-format
 msgid "Consent widget settings saved"
-msgstr ""
+msgstr "Nõusolekuviidiku seaded salvestatud"
 
 #: lib/phoenix_kit_web/components/multilang_form.ex:566
 #, elixir-autogen, elixir-format
 msgid "Content Language"
-msgstr ""
+msgstr "Sisu keel"
 
 #: lib/phoenix_kit_web/legal_gettext_manifest.ex:52
 #, elixir-autogen, elixir-format
 msgid "Cookie Policy"
-msgstr ""
+msgstr "Küpsisepoliitika"
 
 #: lib/phoenix_kit_web/legal_gettext_manifest.ex:53
 #, elixir-autogen, elixir-format
 msgid "Cookie consent"
-msgstr ""
+msgstr "Küpsiste nõusolek"
 
 #: lib/phoenix_kit_web/legal_gettext_manifest.ex:54
 #, elixir-autogen, elixir-format
 msgid "Cookie consent widget disabled"
-msgstr ""
+msgstr "Küpsiste nõusolekuviidik keelatud"
 
 #: lib/phoenix_kit_web/legal_gettext_manifest.ex:55
 #, elixir-autogen, elixir-format
 msgid "Cookie consent widget enabled"
-msgstr ""
+msgstr "Küpsiste nõusolekuviidik lubatud"
 
 #: lib/phoenix_kit_web/legal_gettext_manifest.ex:56
 #, elixir-autogen, elixir-format
 msgid "Cookie preferences"
-msgstr ""
+msgstr "Küpsiste eelistused"
 
 #: lib/phoenix_kit_web/live/users/permissions_matrix.html.heex:39
 #: lib/phoenix_kit_web/live/users/roles.html.heex:359
 #, elixir-autogen, elixir-format
 msgid "Core Sections"
-msgstr ""
+msgstr "Põhilõigud"
 
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:50
 #, elixir-autogen, elixir-format
 msgid "Country"
-msgstr ""
+msgstr "Riik"
 
 #: lib/phoenix_kit_web/live/settings/organization.ex:283
 #, elixir-autogen, elixir-format
 msgid "Country is required"
-msgstr ""
+msgstr "Riik on kohustuslik"
 
 #: lib/phoenix_kit_web/live/users/roles.html.heex:258
 #, elixir-autogen, elixir-format
 msgid "Create First Role"
-msgstr ""
+msgstr "Loo esimene roll"
 
 #: lib/phoenix_kit_web/live/users/roles.html.heex:18
 #: lib/phoenix_kit_web/live/users/roles.html.heex:112
 #, elixir-autogen, elixir-format
 msgid "Create New Role"
-msgstr ""
+msgstr "Loo uus roll"
 
 #: lib/phoenix_kit_web/live/users/roles.html.heex:45
 #, elixir-autogen, elixir-format
 msgid "Create Role"
-msgstr ""
+msgstr "Loo roll"
 
 #: lib/phoenix_kit_web/users/login.html.heex:121
 #, elixir-autogen, elixir-format
@@ -761,13 +761,13 @@ msgstr "Loo konto"
 #: lib/phoenix_kit_web/live/users/roles.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Create and manage user roles"
-msgstr ""
+msgstr "Loo ja halda kasutajarolle"
 
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:182
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:235
 #, elixir-autogen, elixir-format
 msgid "Created"
-msgstr ""
+msgstr "Loodud"
 
 #: lib/phoenix_kit_web/live/users/permissions_matrix.html.heex:135
 #: lib/phoenix_kit_web/live/users/roles.html.heex:97
@@ -775,48 +775,48 @@ msgstr ""
 #: lib/phoenix_kit_web/live/users/roles.html.heex:403
 #, elixir-autogen, elixir-format
 msgid "Custom"
-msgstr ""
+msgstr "Kohandatud"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:317
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:340
 #, elixir-autogen, elixir-format
 msgid "Custom Fields"
-msgstr ""
+msgstr "Kohandatud väljad"
 
 #: lib/phoenix_kit_web/live/users/roles.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "Custom Role"
-msgstr ""
+msgstr "Kohandatud roll"
 
 #: lib/phoenix_kit_web/live/users/roles.html.heex:287
 #, elixir-autogen, elixir-format
 msgid "Custom Roles"
-msgstr ""
+msgstr "Kohandatud rollid"
 
 #: lib/phoenix_kit_web/legal_gettext_manifest.ex:57
 #, elixir-autogen, elixir-format
 msgid "Customize"
-msgstr ""
+msgstr "Kohanda"
 
 #: lib/phoenix_kit_web/live/dashboard.html.heex:361
 #, elixir-autogen, elixir-format
 msgid "DB / Latest Migration"
-msgstr ""
+msgstr "DB / Viimane migratsioon"
 
 #: lib/phoenix_kit_web/legal_gettext_manifest.ex:58
 #, elixir-autogen, elixir-format
 msgid "DPO contact saved"
-msgstr ""
+msgstr "Andmekaitsejärelevaataja kontakt salvestatud"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:653
 #, elixir-autogen, elixir-format
 msgid "Data that will be anonymized (preserved without PII):"
-msgstr ""
+msgstr "Andmed, mis anonümiseeritakse (säilitatakse ilma isikuandmeteta):"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:639
 #, elixir-autogen, elixir-format
 msgid "Data that will be permanently deleted:"
-msgstr ""
+msgstr "Andmed, mis kustutatakse jäädavalt:"
 
 #: lib/modules/storage/web/dimensions.html.heex:239
 #: lib/modules/storage/web/dimensions.html.heex:274
@@ -835,25 +835,25 @@ msgstr ""
 #: lib/phoenix_kit_web/live/users/users.html.heex:514
 #, elixir-autogen, elixir-format
 msgid "Delete"
-msgstr ""
+msgstr "Kustuta"
 
 #: lib/phoenix_kit_web/live/users/roles.html.heex:315
 #: lib/phoenix_kit_web/live/users/roles.html.heex:325
 #, elixir-autogen, elixir-format
 msgid "Delete Role"
-msgstr ""
+msgstr "Kustuta roll"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:628
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:669
 #, elixir-autogen, elixir-format
 msgid "Delete User"
-msgstr ""
+msgstr "Kustuta kasutaja"
 
 #: lib/phoenix_kit_web/live/users/roles.html.heex:34
 #: lib/phoenix_kit_web/live/users/roles.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Describe what this role can do (optional)"
-msgstr ""
+msgstr "Kirjelda, mida see roll teha saab (valikuline)"
 
 #: lib/phoenix_kit_web/live/users/roles.html.heex:33
 #: lib/phoenix_kit_web/live/users/roles.html.heex:67
@@ -861,7 +861,7 @@ msgstr ""
 #: lib/phoenix_kit_web/live/users/roles.html.heex:165
 #, elixir-autogen, elixir-format
 msgid "Description"
-msgstr ""
+msgstr "Kirjeldus"
 
 #: lib/modules/storage/web/dimensions.html.heex:137
 #: lib/modules/storage/web/dimensions.html.heex:204
@@ -889,17 +889,17 @@ msgstr ""
 #: lib/phoenix_kit_web/live/settings/users.html.heex:400
 #, elixir-autogen, elixir-format
 msgid "Disabled"
-msgstr ""
+msgstr "Keelatud"
 
 #: lib/phoenix_kit_web/components/core/modal.ex:265
 #, elixir-autogen, elixir-format
 msgid "Do you want to continue?"
-msgstr ""
+msgstr "Kas soovid jätkata?"
 
 #: lib/phoenix_kit_web/components/language_switcher.ex:830
 #, elixir-autogen, elixir-format
 msgid "Draft"
-msgstr ""
+msgstr "Mustand"
 
 #: lib/modules/storage/web/dimensions.html.heex:220
 #: lib/modules/storage/web/dimensions.html.heex:257
@@ -917,42 +917,42 @@ msgstr ""
 #: lib/phoenix_kit_web/live/users/users.html.heex:469
 #, elixir-autogen, elixir-format
 msgid "Edit"
-msgstr ""
+msgstr "Muuda"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:419
 #, elixir-autogen, elixir-format
 msgid "Edit Note"
-msgstr ""
+msgstr "Muuda märkust"
 
 #: lib/phoenix_kit_web/live/users/roles.html.heex:52
 #, elixir-autogen, elixir-format
 msgid "Edit Role"
-msgstr ""
+msgstr "Muuda rolli"
 
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:358
 #, elixir-autogen, elixir-format
 msgid "Edit in General"
-msgstr ""
+msgstr "Muuda üldistes seadetes"
 
 #: lib/phoenix_kit_web/live/dashboard/settings.ex:25
 #, elixir-autogen, elixir-format
 msgid "Email change link is invalid or it has expired."
-msgstr ""
+msgstr "E-posti muutmise link on kehtetu või aegunud."
 
 #: lib/phoenix_kit_web/live/dashboard/settings.ex:19
 #, elixir-autogen, elixir-format
 msgid "Email changed successfully."
-msgstr ""
+msgstr "E-post muudetud edukalt."
 
 #: lib/phoenix_kit_web/legal_gettext_manifest.ex:61
 #, elixir-autogen, elixir-format
 msgid "Email imported from General Settings"
-msgstr ""
+msgstr "E-post imporditud üldseadetest"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:660
 #, elixir-autogen, elixir-format
 msgid "Email logs - Compliance records retained, anonymized"
-msgstr ""
+msgstr "E-posti logid – vastavusrekordid säilitatud, anonümiseeritud"
 
 #: lib/phoenix_kit_web/users/login.html.heex:22
 #, elixir-autogen, elixir-format
@@ -962,13 +962,13 @@ msgstr "E-post või kasutajanimi"
 #: lib/phoenix_kit_web/components/core/markdown_editor.ex:420
 #, elixir-autogen, elixir-format
 msgid "Enable JavaScript or allow inline scripts for this page."
-msgstr ""
+msgstr "Luba JavaScript või luba reasisesed skriptid selle lehe jaoks."
 
 #: lib/phoenix_kit_web/live/users/roles.html.heex:24
 #: lib/phoenix_kit_web/live/users/roles.html.heex:58
 #, elixir-autogen, elixir-format
 msgid "Enter role name (e.g., Manager, Editor)"
-msgstr ""
+msgstr "Sisesta rolli nimi (nt Manager, Editor)"
 
 #: lib/phoenix_kit_web/users/login.html.heex:30
 #, elixir-autogen, elixir-format
@@ -985,124 +985,124 @@ msgstr "Sisesta oma parool"
 #: lib/phoenix_kit_web/live/settings/integrations.ex:168
 #, elixir-autogen, elixir-format
 msgid "Error"
-msgstr ""
+msgstr "Viga"
 
 #: lib/phoenix_kit_web/live/users/user_details.ex:233
 #, elixir-autogen, elixir-format
 msgid "Failed to delete note"
-msgstr ""
+msgstr "Märkuse kustutamine ebaõnnestus"
 
 #: lib/phoenix_kit_web/live/users/roles.ex:355
 #, elixir-autogen, elixir-format
 msgid "Failed to delete role"
-msgstr ""
+msgstr "Rolli kustutamine ebaõnnestus"
 
 #: lib/phoenix_kit_web/live/users/user_details.ex:141
 #, elixir-autogen, elixir-format
 msgid "Failed to delete user"
-msgstr ""
+msgstr "Kasutaja kustutamine ebaõnnestus"
 
 #: lib/phoenix_kit_web/live/components/user_settings.ex:403
 #, elixir-autogen, elixir-format
 msgid "Failed to disconnect provider. Please try again."
-msgstr ""
+msgstr "Teenusepakkuja lahtiühendamine ebaõnnestus. Palun proovi uuesti."
 
 #: lib/phoenix_kit_web/legal_gettext_manifest.ex:63
 #, elixir-autogen, elixir-format
 msgid "Failed to generate page: %{reason}"
-msgstr ""
+msgstr "Lehe genereerimine ebaõnnestus: %{reason}"
 
 #: lib/phoenix_kit_web/live/users/permissions_matrix.ex:157
 #, elixir-autogen, elixir-format
 msgid "Failed to grant %{label} to %{role_name}"
-msgstr ""
+msgstr "Ei saanud anda %{label} rollile %{role_name}"
 
 #: lib/phoenix_kit_web/legal_gettext_manifest.ex:64
 #, elixir-autogen, elixir-format
 msgid "Failed to import address"
-msgstr ""
+msgstr "Aadressi importimine ebaõnnestus"
 
 #: lib/phoenix_kit_web/legal_gettext_manifest.ex:65
 #, elixir-autogen, elixir-format
 msgid "Failed to import email"
-msgstr ""
+msgstr "E-posti importimine ebaõnnestus"
 
 #: lib/phoenix_kit_web/legal_gettext_manifest.ex:66
 #, elixir-autogen, elixir-format
 msgid "Failed to publish page: %{reason}"
-msgstr ""
+msgstr "Lehe avaldamine ebaõnnestus: %{reason}"
 
 #: lib/phoenix_kit_web/live/users/permissions_matrix.ex:131
 #, elixir-autogen, elixir-format
 msgid "Failed to revoke %{label} from %{role_name}"
-msgstr ""
+msgstr "Ei saanud tühistada %{label} rollilt %{role_name}"
 
 #: lib/phoenix_kit_web/legal_gettext_manifest.ex:67
 #, elixir-autogen, elixir-format
 msgid "Failed to save DPO contact"
-msgstr ""
+msgstr "Andmekaitsejärelevaataja kontakti salvestamine ebaõnnestus"
 
 #: lib/phoenix_kit_web/legal_gettext_manifest.ex:68
 #, elixir-autogen, elixir-format
 msgid "Failed to save frameworks"
-msgstr ""
+msgstr "Raamistike salvestamine ebaõnnestus"
 
 #: lib/phoenix_kit_web/legal_gettext_manifest.ex:69
 #, elixir-autogen, elixir-format
 msgid "Failed to save settings"
-msgstr ""
+msgstr "Seadete salvestamine ebaõnnestus"
 
 #: lib/phoenix_kit_web/live/settings/seo.ex:74
 #, elixir-autogen, elixir-format
 msgid "Failed to update SEO settings"
-msgstr ""
+msgstr "SEO seadete uuendamine ebaõnnestus"
 
 #: lib/phoenix_kit_web/live/users/roles.ex:325
 #, elixir-autogen, elixir-format
 msgid "Failed to update permissions"
-msgstr ""
+msgstr "Õiguste uuendamine ebaõnnestus"
 
 #: lib/phoenix_kit_web/legal_gettext_manifest.ex:70
 #, elixir-autogen, elixir-format
 msgid "Failed to update setting"
-msgstr ""
+msgstr "Seade uuendamine ebaõnnestus"
 
 #: lib/phoenix_kit_web/live/users/permissions_matrix.html.heex:87
 #: lib/phoenix_kit_web/live/users/roles.html.heex:380
 #, elixir-autogen, elixir-format
 msgid "Feature Modules"
-msgstr ""
+msgstr "Funktsionaalsed moodulid"
 
 #: lib/modules/storage/web/settings.html.heex:173
 #: lib/modules/storage/web/settings.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Files"
-msgstr ""
+msgstr "Failid"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:661
 #, elixir-autogen, elixir-format
 msgid "Files - Content preserved, ownership removed"
-msgstr ""
+msgstr "Failid – sisu säilitatud, omandiõigus eemaldatud"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:215
 #, elixir-autogen, elixir-format
 msgid "First Name"
-msgstr ""
+msgstr "Eesnimi"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:369
 #, elixir-autogen, elixir-format
 msgid "Followers"
-msgstr ""
+msgstr "Jälgijad"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:378
 #, elixir-autogen, elixir-format
 msgid "Following"
-msgstr ""
+msgstr "Jälgitavad"
 
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:211
 #, elixir-autogen, elixir-format
 msgid "For bank transfer payments on invoices"
-msgstr ""
+msgstr "Pangaülekande makseteks arvetel"
 
 #: lib/phoenix_kit_web/users/login.html.heex:66
 #, elixir-autogen, elixir-format
@@ -1113,32 +1113,32 @@ msgstr "Unustasid parooli?"
 #: lib/modules/storage/web/dimensions.html.heex:149
 #, elixir-autogen, elixir-format
 msgid "Format"
-msgstr ""
+msgstr "Vorming"
 
 #: lib/phoenix_kit_web/legal_gettext_manifest.ex:71
 #, elixir-autogen, elixir-format
 msgid "Generated %{count} pages"
-msgstr ""
+msgstr "Genereeritud %{count} lehte"
 
 #: lib/phoenix_kit_web/live/users/roles.html.heex:348
 #, elixir-autogen, elixir-format
 msgid "Grant All"
-msgstr ""
+msgstr "Anna kõik"
 
 #: lib/phoenix_kit_web/live/users/permissions_matrix.ex:145
 #, elixir-autogen, elixir-format
 msgid "Granted %{label} to %{role_name}"
-msgstr ""
+msgstr "Antud %{label} rollile %{role_name}"
 
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:232
 #, elixir-autogen, elixir-format
 msgid "IBAN"
-msgstr ""
+msgstr "IBAN"
 
 #: lib/phoenix_kit_web/components/core/markdown_editor.ex:624
 #, elixir-autogen, elixir-format
 msgid "Image"
-msgstr ""
+msgstr "Pilt"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:112
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:251
@@ -1146,50 +1146,50 @@ msgstr ""
 #: lib/phoenix_kit_web/users/user_form.html.heex:769
 #, elixir-autogen, elixir-format
 msgid "Inactive"
-msgstr ""
+msgstr "Mitteaktiivne"
 
 #: lib/phoenix_kit_web/components/core/modal.ex:481
 #: lib/phoenix_kit_web/live/settings.html.heex:489
 #, elixir-autogen, elixir-format
 msgid "Information"
-msgstr ""
+msgstr "Teave"
 
 #: lib/phoenix_kit_web/components/core/markdown_editor.ex:477
 #, elixir-autogen, elixir-format
 msgid "Inline Code"
-msgstr ""
+msgstr "Reasisene kood"
 
 #: lib/phoenix_kit_web/components/core/markdown_editor.ex:511
 #: lib/phoenix_kit_web/components/core/markdown_editor.ex:620
 #, elixir-autogen, elixir-format
 msgid "Insert Image"
-msgstr ""
+msgstr "Lisa pilt"
 
 #: lib/phoenix_kit_web/components/core/markdown_editor.ex:499
 #, elixir-autogen, elixir-format
 msgid "Insert Link"
-msgstr ""
+msgstr "Lisa link"
 
 #: lib/phoenix_kit_web/components/core/markdown_editor.ex:524
 #: lib/phoenix_kit_web/components/core/markdown_editor.ex:635
 #, elixir-autogen, elixir-format
 msgid "Insert Video"
-msgstr ""
+msgstr "Lisa video"
 
 #: lib/phoenix_kit_web/components/core/markdown_editor.ex:610
 #, elixir-autogen, elixir-format
 msgid "Insert:"
-msgstr ""
+msgstr "Lisa:"
 
 #: lib/phoenix_kit_web/components/core/markdown_editor.ex:417
 #, elixir-autogen, elixir-format
 msgid "Interactive editor features need JavaScript"
-msgstr ""
+msgstr "Interaktiivse redaktori funktsioonid vajavad JavaScripti"
 
 #: lib/phoenix_kit_web/components/core/markdown_editor.ex:461
 #, elixir-autogen, elixir-format
 msgid "Italic"
-msgstr ""
+msgstr "Kaldkiri"
 
 #: lib/phoenix_kit_web/users/login.html.heex:57
 #, elixir-autogen, elixir-format
@@ -1199,32 +1199,32 @@ msgstr "Jäta mind sisselogituks"
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:221
 #, elixir-autogen, elixir-format
 msgid "Last Name"
-msgstr ""
+msgstr "Perekonnanimi"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:276
 #, elixir-autogen, elixir-format
 msgid "Last Updated"
-msgstr ""
+msgstr "Viimati uuendatud"
 
 #: lib/phoenix_kit_web/legal_gettext_manifest.ex:74
 #, elixir-autogen, elixir-format
 msgid "Legal Settings"
-msgstr ""
+msgstr "Juriidilised seaded"
 
 #: lib/phoenix_kit_web/live/modules.ex:239
 #, elixir-autogen, elixir-format
 msgid "Legal module disabled"
-msgstr ""
+msgstr "Juriidiline moodul keelatud"
 
 #: lib/phoenix_kit_web/live/modules.ex:240
 #, elixir-autogen, elixir-format
 msgid "Legal module enabled"
-msgstr ""
+msgstr "Juriidiline moodul lubatud"
 
 #: lib/phoenix_kit_web/components/core/markdown_editor.ex:485
 #, elixir-autogen, elixir-format
 msgid "Line Break"
-msgstr ""
+msgstr "Reavahe"
 
 #: lib/phoenix_kit_web/users/login.html.heex:75
 #, elixir-autogen, elixir-format
@@ -1244,7 +1244,7 @@ msgstr "Logi parooliga sisse"
 #: lib/phoenix_kit_web/legal_gettext_manifest.ex:76
 #, elixir-autogen, elixir-format
 msgid "Manage your cookie settings"
-msgstr ""
+msgstr "Halda oma küpsiste seadeid"
 
 #: lib/modules/storage/web/dimensions.html.heex:116
 #: lib/modules/storage/web/dimensions.html.heex:147
@@ -1252,18 +1252,18 @@ msgstr ""
 #: lib/modules/storage/web/dimensions.html.heex:345
 #, elixir-autogen, elixir-format
 msgid "Mode"
-msgstr ""
+msgstr "Režiim"
 
 #: lib/phoenix_kit_web/live/users/permissions_matrix.html.heex:22
 #, elixir-autogen, elixir-format
 msgid "Module"
-msgstr ""
+msgstr "Moodul"
 
 #: lib/phoenix_kit_web/live/users/roles.html.heex:28
 #: lib/phoenix_kit_web/live/users/roles.html.heex:62
 #, elixir-autogen, elixir-format
 msgid "Must be unique, 1-50 characters."
-msgstr ""
+msgstr "Peab olema unikaalne, 1-50 tähemärki."
 
 #: lib/phoenix_kit_web/users/login.html.heex:116
 #, elixir-autogen, elixir-format
@@ -1275,42 +1275,42 @@ msgstr "Esimest korda %{project_title}?"
 #: lib/phoenix_kit_web/live/users/user_details.ex:387
 #, elixir-autogen, elixir-format
 msgid "No"
-msgstr ""
+msgstr "Ei"
 
 #: lib/phoenix_kit_web/live/users/roles.html.heex:194
 #, elixir-autogen, elixir-format
 msgid "No description"
-msgstr ""
+msgstr "Kirjeldus puudub"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:527
 #, elixir-autogen, elixir-format
 msgid "No notes yet"
-msgstr ""
+msgstr "Märkusi veel pole"
 
 #: lib/phoenix_kit_web/live/users/roles.ex:289
 #, elixir-autogen, elixir-format
 msgid "No role selected"
-msgstr ""
+msgstr "Rolli pole valitud"
 
 #: lib/phoenix_kit_web/live/users/roles.html.heex:249
 #, elixir-autogen, elixir-format
 msgid "No roles found"
-msgstr ""
+msgstr "Rolle ei leitud"
 
 #: lib/phoenix_kit_web/live/settings/seo.ex:61
 #, elixir-autogen, elixir-format
 msgid "Noindex/nofollow disabled. Site can be indexed again."
-msgstr ""
+msgstr "Noindex/nofollow keelatud. Saiti saab uuesti indekseerida."
 
 #: lib/phoenix_kit_web/live/settings/seo.ex:59
 #, elixir-autogen, elixir-format
 msgid "Noindex/nofollow enabled. Search engines will not index this site."
-msgstr ""
+msgstr "Noindex/nofollow lubatud. Otsingumootorid ei indekseeri seda saiti."
 
 #: lib/phoenix_kit_web/live/users/permissions_matrix.ex:218
 #, elixir-autogen, elixir-format
 msgid "Not authenticated"
-msgstr ""
+msgstr "Autentimata"
 
 #: lib/phoenix_kit/integrations/integrations.ex:831
 #: lib/phoenix_kit/integrations/integrations.ex:838
@@ -1318,70 +1318,70 @@ msgstr ""
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:376
 #, elixir-autogen, elixir-format
 msgid "Not configured"
-msgstr ""
+msgstr "Konfigureerimata"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:262
 #, elixir-autogen, elixir-format
 msgid "Not confirmed"
-msgstr ""
+msgstr "Kinnitamata"
 
 #: lib/phoenix_kit_web/live/users/user_details.ex:160
 #, elixir-autogen, elixir-format
 msgid "Note added successfully"
-msgstr ""
+msgstr "Märkus lisatud edukalt"
 
 #: lib/phoenix_kit_web/live/users/user_details.ex:230
 #, elixir-autogen, elixir-format
 msgid "Note deleted successfully"
-msgstr ""
+msgstr "Märkus kustutatud edukalt"
 
 #: lib/phoenix_kit_web/live/users/user_details.ex:206
 #, elixir-autogen, elixir-format
 msgid "Note updated successfully"
-msgstr ""
+msgstr "Märkus uuendatud edukalt"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:63
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:462
 #, elixir-autogen, elixir-format
 msgid "Notes"
-msgstr ""
+msgstr "Märkused"
 
 #: lib/phoenix_kit_web/components/core/markdown_editor.ex:547
 #, elixir-autogen, elixir-format
 msgid "Numbered List"
-msgstr ""
+msgstr "Nummerdatud loend"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:644
 #, elixir-autogen, elixir-format
 msgid "OAuth provider connections"
-msgstr ""
+msgstr "OAuth teenusepakkuja ühendused"
 
 #: lib/phoenix_kit_web/components/core/modal.ex:423
 #, elixir-autogen, elixir-format
 msgid "OK"
-msgstr ""
+msgstr "OK"
 
 #: lib/phoenix_kit_web/live/users/permissions_matrix.ex:227
 #, elixir-autogen, elixir-format
 msgid "Only the Owner can edit Admin permissions"
-msgstr ""
+msgstr "Ainult Omanik saab muuta Administraatori õigusi"
 
 #: lib/phoenix_kit_web/live/modules.html.heex:97
 #: lib/phoenix_kit_web/users/user_form.html.heex:245
 #, elixir-autogen, elixir-format
 msgid "Optional"
-msgstr ""
+msgstr "Valikuline"
 
 #: lib/phoenix_kit_web/live/users/roles.html.heex:37
 #: lib/phoenix_kit_web/live/users/roles.html.heex:71
 #, elixir-autogen, elixir-format
 msgid "Optional, up to 500 characters."
-msgstr ""
+msgstr "Valikuline, kuni 500 tähemärki."
 
 #: lib/phoenix_kit_web/live/settings/users.html.heex:614
 #, elixir-autogen, elixir-format
 msgid "Options"
-msgstr ""
+msgstr "Valikud"
 
 #: lib/phoenix_kit_web/users/login.html.heex:91
 #, elixir-autogen, elixir-format
@@ -1391,38 +1391,38 @@ msgstr "Või jätka"
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:656
 #, elixir-autogen, elixir-format
 msgid "Orders - Financial records preserved, anonymized"
-msgstr ""
+msgstr "Tellimused – finantsrekordid säilitatud, anonümiseeritud"
 
 #: lib/phoenix_kit_web/live/settings/organization.ex:45
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:12
 #, elixir-autogen, elixir-format
 msgid "Organization Settings"
-msgstr ""
+msgstr "Organisatsiooni seaded"
 
 #: lib/phoenix_kit_web/live/settings/organization.ex:148
 #, elixir-autogen, elixir-format
 msgid "Organization information saved"
-msgstr ""
+msgstr "Organisatsiooni teave salvestatud"
 
 #: lib/phoenix_kit_web/live/users/permissions_matrix.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Overview of role permissions across all modules"
-msgstr ""
+msgstr "Rollide õiguste ülevaade kõigis moodulites"
 
 #: lib/phoenix_kit_web/live/users/permissions_matrix.ex:221
 #, elixir-autogen, elixir-format
 msgid "Owner role always has full access and cannot be modified"
-msgstr ""
+msgstr "Omaniku rollil on alati täielik juurdepääs ja seda ei saa muuta"
 
 #: lib/phoenix_kit_web/legal_gettext_manifest.ex:79
 #, elixir-autogen, elixir-format
 msgid "Page generated successfully"
-msgstr ""
+msgstr "Leht genereeritud edukalt"
 
 #: lib/phoenix_kit_web/legal_gettext_manifest.ex:80
 #, elixir-autogen, elixir-format
 msgid "Page published successfully"
-msgstr ""
+msgstr "Leht avaldatud edukalt"
 
 #: lib/phoenix_kit_web/users/login.html.heex:38
 #, elixir-autogen, elixir-format
@@ -1432,18 +1432,18 @@ msgstr "Parool"
 #: lib/phoenix_kit_web/live/components/user_settings.ex:247
 #, elixir-autogen, elixir-format
 msgid "Password changed successfully."
-msgstr ""
+msgstr "Parool muudetud edukalt."
 
 #: lib/phoenix_kit_web/live/modules.html.heex:268
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:396
 #, elixir-autogen, elixir-format
 msgid "Pending"
-msgstr ""
+msgstr "Ootel"
 
 #: lib/phoenix_kit_web/live/users/permissions_matrix.ex:229
 #, elixir-autogen, elixir-format
 msgid "Permission denied"
-msgstr ""
+msgstr "Luba keelatud"
 
 #: lib/phoenix_kit_web/live/users/permissions_matrix.ex:29
 #: lib/phoenix_kit_web/live/users/permissions_matrix.html.heex:4
@@ -1452,85 +1452,85 @@ msgstr ""
 #: lib/phoenix_kit_web/live/users/roles.html.heex:234
 #, elixir-autogen, elixir-format
 msgid "Permissions"
-msgstr ""
+msgstr "Õigused"
 
 #: lib/phoenix_kit_web/live/users/roles.html.heex:335
 #, elixir-autogen, elixir-format
 msgid "Permissions for"
-msgstr ""
+msgstr "Õigused rollile"
 
 #: lib/phoenix_kit_web/live/users/roles.ex:314
 #, elixir-autogen, elixir-format
 msgid "Permissions updated for %{role_name}"
-msgstr ""
+msgstr "Õigused uuendatud rollile %{role_name}"
 
 #: lib/phoenix_kit_web/live/dashboard.html.heex:349
 #, elixir-autogen, elixir-format
 msgid "PhoenixKit Version"
-msgstr ""
+msgstr "PhoenixKit versioon"
 
 #: lib/phoenix_kit_web/live/modules.ex:226
 #, elixir-autogen, elixir-format
 msgid "Please enable Publishing module first"
-msgstr ""
+msgstr "Palun luba kõigepealt Avaldamise moodul"
 
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:135
 #, elixir-autogen, elixir-format
 msgid "Postal Code"
-msgstr ""
+msgstr "Sihtnumber"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:657
 #, elixir-autogen, elixir-format
 msgid "Posts - Content preserved, marked as deleted author"
-msgstr ""
+msgstr "Postitused – sisu säilitatud, märgitud kustutatud autorina"
 
 #: lib/phoenix_kit_web/components/language_switcher.ex:432
 #, elixir-autogen, elixir-format
 msgid "Primary"
-msgstr ""
+msgstr "Peamine"
 
 #: lib/phoenix_kit_web/components/multilang_form.ex:571
 #, elixir-autogen, elixir-format
 msgid "Primary: %{lang}"
-msgstr ""
+msgstr "Peamine: %{lang}"
 
 #: lib/modules/storage/web/bucket_form.html.heex:346
 #: lib/modules/storage/web/settings.html.heex:165
 #: lib/modules/storage/web/settings.html.heex:188
 #, elixir-autogen, elixir-format
 msgid "Priority"
-msgstr ""
+msgstr "Prioriteet"
 
 #: lib/phoenix_kit_web/legal_gettext_manifest.ex:83
 #, elixir-autogen, elixir-format
 msgid "Privacy Preferences"
-msgstr ""
+msgstr "Privaatsuse eelistused"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:41
 #, elixir-autogen, elixir-format
 msgid "Profile"
-msgstr ""
+msgstr "Profiil"
 
 #: lib/phoenix_kit_web/live/components/user_settings.ex:319
 #, elixir-autogen, elixir-format
 msgid "Profile updated successfully"
-msgstr ""
+msgstr "Profiil uuendatud edukalt"
 
 #: lib/phoenix_kit_web/live/users/roles.html.heex:146
 #: lib/phoenix_kit_web/live/users/roles.html.heex:225
 #, elixir-autogen, elixir-format
 msgid "Protected"
-msgstr ""
+msgstr "Kaitstud"
 
 #: lib/phoenix_kit_web/live/users/roles.html.heex:275
 #, elixir-autogen, elixir-format
 msgid "Protected core roles"
-msgstr ""
+msgstr "Kaitstud põhirollid"
 
 #: lib/phoenix_kit_web/live/components/user_settings.ex:393
 #, elixir-autogen, elixir-format
 msgid "Provider not found"
-msgstr ""
+msgstr "Teenusepakkujat ei leitud"
 
 #: lib/phoenix_kit_web/components/language_switcher.ex:829
 #: lib/phoenix_kit_web/live/modules.html.heex:264
@@ -1541,37 +1541,37 @@ msgstr "Avaldatud"
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:268
 #, elixir-autogen, elixir-format
 msgid "Registered"
-msgstr ""
+msgstr "Registreeritud"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:290
 #, elixir-autogen, elixir-format
 msgid "Registration Details"
-msgstr ""
+msgstr "Registreerimisandmed"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:295
 #, elixir-autogen, elixir-format
 msgid "Registration IP"
-msgstr ""
+msgstr "Registreerimise IP"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:303
 #, elixir-autogen, elixir-format
 msgid "Registration Location"
-msgstr ""
+msgstr "Registreerimise asukoht"
 
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:179
 #, elixir-autogen, elixir-format
 msgid "Registration Number"
-msgstr ""
+msgstr "Registreerimisnumber"
 
 #: lib/phoenix_kit_web/legal_gettext_manifest.ex:84
 #, elixir-autogen, elixir-format
 msgid "Reject"
-msgstr ""
+msgstr "Keeldu"
 
 #: lib/phoenix_kit_web/legal_gettext_manifest.ex:85
 #, elixir-autogen, elixir-format
 msgid "Reject All"
-msgstr ""
+msgstr "Keeldu kõigest"
 
 #: lib/phoenix_kit_web/live/settings.html.heex:108
 #: lib/phoenix_kit_web/live/settings.html.heex:175
@@ -1581,132 +1581,132 @@ msgstr ""
 #: lib/phoenix_kit_web/live/settings/integrations.html.heex:202
 #, elixir-autogen, elixir-format
 msgid "Remove"
-msgstr ""
+msgstr "Eemalda"
 
 #: lib/phoenix_kit_web/legal_gettext_manifest.ex:87
 #: lib/phoenix_kit_web/live/modules.html.heex:97
 #: lib/phoenix_kit_web/live/settings/users.html.heex:364
 #, elixir-autogen, elixir-format
 msgid "Required"
-msgstr ""
+msgstr "Kohustuslik"
 
 #: lib/phoenix_kit_web/live/users/roles.html.heex:351
 #, elixir-autogen, elixir-format
 msgid "Revoke All"
-msgstr ""
+msgstr "Tühista kõik"
 
 #: lib/phoenix_kit_web/live/users/permissions_matrix.ex:119
 #, elixir-autogen, elixir-format
 msgid "Revoked %{label} from %{role_name}"
-msgstr ""
+msgstr "Tühistatud %{label} rollilt %{role_name}"
 
 #: lib/phoenix_kit_web/live/users/roles.html.heex:163
 #, elixir-autogen, elixir-format
 msgid "Role"
-msgstr ""
+msgstr "Roll"
 
 #: lib/phoenix_kit_web/live/users/roles.ex:104
 #, elixir-autogen, elixir-format
 msgid "Role \"%{role_name}\" created. Click Permissions to configure access."
-msgstr ""
+msgstr "Roll \"%{role_name}\" loodud. Klõpsake Õigused, et seadistada juurdepääs."
 
 #: lib/phoenix_kit_web/live/users/roles.ex:483
 #: lib/phoenix_kit_web/live/users/roles.ex:497
 #, elixir-autogen, elixir-format
 msgid "Role \"%{role_name}\" was deleted"
-msgstr ""
+msgstr "Roll \"%{role_name}\" kustutati"
 
 #: lib/phoenix_kit_web/live/users/roles.html.heex:4
 #: lib/phoenix_kit_web/live/users/roles.html.heex:12
 #, elixir-autogen, elixir-format
 msgid "Role Management"
-msgstr ""
+msgstr "Rollide haldamine"
 
 #: lib/phoenix_kit_web/live/users/roles.html.heex:23
 #: lib/phoenix_kit_web/live/users/roles.html.heex:57
 #, elixir-autogen, elixir-format
 msgid "Role Name *"
-msgstr ""
+msgstr "Rolli nimi *"
 
 #: lib/phoenix_kit_web/live/users/roles.html.heex:266
 #, elixir-autogen, elixir-format
 msgid "Role Statistics"
-msgstr ""
+msgstr "Rollide statistika"
 
 #: lib/phoenix_kit_web/live/users/roles.ex:108
 #, elixir-autogen, elixir-format
 msgid "Role created successfully"
-msgstr ""
+msgstr "Roll loodud edukalt"
 
 #: lib/phoenix_kit_web/live/users/roles.ex:339
 #, elixir-autogen, elixir-format
 msgid "Role deleted successfully"
-msgstr ""
+msgstr "Roll kustutatud edukalt"
 
 #: lib/phoenix_kit_web/live/users/roles.ex:130
 #, elixir-autogen, elixir-format
 msgid "Role no longer exists"
-msgstr ""
+msgstr "Roll ei eksisteeri enam"
 
 #: lib/phoenix_kit_web/live/users/permissions_matrix.ex:96
 #: lib/phoenix_kit_web/live/users/roles.ex:223
 #, elixir-autogen, elixir-format
 msgid "Role not found"
-msgstr ""
+msgstr "Rolli ei leitud"
 
 #: lib/phoenix_kit_web/live/users/roles.ex:139
 #, elixir-autogen, elixir-format
 msgid "Role updated successfully"
-msgstr ""
+msgstr "Roll uuendatud edukalt"
 
 #: lib/phoenix_kit_web/live/settings/seo.ex:35
 #, elixir-autogen, elixir-format
 msgid "SEO module is disabled. Enable it from the Modules page to configure settings."
-msgstr ""
+msgstr "SEO moodul on keelatud. Luba see Moodulite lehelt seadete konfigureerimiseks."
 
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:245
 #, elixir-autogen, elixir-format
 msgid "SWIFT/BIC"
-msgstr ""
+msgstr "SWIFT/BIC"
 
 #: lib/phoenix_kit_web/components/core/markdown_editor.ex:591
 #: lib/phoenix_kit_web/components/core/markdown_editor.ex:677
 #, elixir-autogen, elixir-format
 msgid "Save"
-msgstr ""
+msgstr "Salvesta"
 
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:260
 #, elixir-autogen, elixir-format
 msgid "Save Bank Details"
-msgstr ""
+msgstr "Salvesta pangaandmed"
 
 #: lib/modules/maintenance/settings.ex:440
 #: lib/phoenix_kit_web/live/settings/integration_form.html.heex:274
 #, elixir-autogen, elixir-format
 msgid "Save Changes"
-msgstr ""
+msgstr "Salvesta muudatused"
 
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:194
 #, elixir-autogen, elixir-format
 msgid "Save Company Info"
-msgstr ""
+msgstr "Salvesta ettevõtte teave"
 
 #: lib/phoenix_kit_web/live/users/roles.html.heex:444
 #, elixir-autogen, elixir-format
 msgid "Save Permissions"
-msgstr ""
+msgstr "Salvesta õigused"
 
 #: lib/phoenix_kit_web/legal_gettext_manifest.ex:90
 #, elixir-autogen, elixir-format
 msgid "Save Preferences"
-msgstr ""
+msgstr "Salvesta eelistused"
 
 #: lib/phoenix_kit_web/components/core/markdown_editor.ex:575
 #: lib/phoenix_kit_web/components/core/markdown_editor.ex:661
 #: lib/phoenix_kit_web/live/settings/integration_form.ex:580
 #, elixir-autogen, elixir-format
 msgid "Saved"
-msgstr ""
+msgstr "Salvestatud"
 
 #: lib/phoenix_kit_web/components/core/markdown_editor.ex:568
 #: lib/phoenix_kit_web/components/core/markdown_editor.ex:654
@@ -1715,17 +1715,17 @@ msgstr ""
 #: lib/phoenix_kit_web/live/settings/users.html.heex:488
 #, elixir-autogen, elixir-format
 msgid "Saving..."
-msgstr ""
+msgstr "Salvestamine..."
 
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:59
 #, elixir-autogen, elixir-format
 msgid "Select country..."
-msgstr ""
+msgstr "Vali riik..."
 
 #: lib/phoenix_kit_web/live/users/roles.html.heex:340
 #, elixir-autogen, elixir-format
 msgid "Select which sections and modules this role can access. You can only grant permissions that your own role has."
-msgstr ""
+msgstr "Vali, millistele lõikudele ja moodulitele see roll pääseb juurde. Sa saad anda ainult neid õigusi, mis sinu rollil on."
 
 #: lib/modules/maintenance/web/maintenance_page_live.ex:116
 #: lib/modules/storage/web/bucket_form.html.heex:319
@@ -1742,12 +1742,12 @@ msgstr "Seaded"
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:389
 #, elixir-autogen, elixir-format
 msgid "Shared across modules"
-msgstr ""
+msgstr "Jagatud moodulite vahel"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:646
 #, elixir-autogen, elixir-format
 msgid "Shopping carts and pending orders"
-msgstr ""
+msgstr "Ostukorvid ja ootel tellimused"
 
 ## Login page translations
 #: lib/phoenix_kit_web/users/login.html.heex:7
@@ -1763,18 +1763,18 @@ msgstr "Logi sisse Magic Linkiga"
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:349
 #, elixir-autogen, elixir-format
 msgid "Site URL"
-msgstr ""
+msgstr "Saidi URL"
 
 #: lib/phoenix_kit_web/live/users/roles.html.heex:252
 #, elixir-autogen, elixir-format
 msgid "Start by creating your first custom role."
-msgstr ""
+msgstr "Alusta oma esimese kohandatud rolli loomisega."
 
 #: lib/phoenix_kit_web/live/settings/organization.ex:367
 #: lib/phoenix_kit_web/live/settings/organization.ex:368
 #, elixir-autogen, elixir-format
 msgid "State/Province"
-msgstr ""
+msgstr "Maakond/provints"
 
 #: lib/modules/storage/web/dimensions.html.heex:136
 #: lib/modules/storage/web/dimensions.html.heex:150
@@ -1793,95 +1793,95 @@ msgstr ""
 #: lib/phoenix_kit_web/users/user_form.html.heex:741
 #, elixir-autogen, elixir-format
 msgid "Status"
-msgstr ""
+msgstr "Olek"
 
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:75
 #, elixir-autogen, elixir-format
 msgid "Street Address"
-msgstr ""
+msgstr "Tänavaadress"
 
 #: lib/phoenix_kit_web/live/settings/organization.ex:285
 #, elixir-autogen, elixir-format
 msgid "Street address is required"
-msgstr ""
+msgstr "Tänavaadress on kohustuslik"
 
 #: lib/phoenix_kit_web/components/core/markdown_editor.ex:469
 #, elixir-autogen, elixir-format
 msgid "Strikethrough"
-msgstr ""
+msgstr "Läbikriipsutus"
 
 #: lib/phoenix_kit_web/components/core/modal.ex:482
 #, elixir-autogen, elixir-format
 msgid "Success"
-msgstr ""
+msgstr "Õnnestus"
 
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:98
 #, elixir-autogen, elixir-format
 msgid "Suite, Floor, Building (optional)"
-msgstr ""
+msgstr "Korter, korrus, hoone (valikuline)"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:659
 #, elixir-autogen, elixir-format
 msgid "Support tickets - History preserved, anonymized"
-msgstr ""
+msgstr "Tugipileted – ajalugu säilitatud, anonümiseeritud"
 
 #: lib/phoenix_kit_web/live/users/roles.html.heex:181
 #, elixir-autogen, elixir-format
 msgid "System Role"
-msgstr ""
+msgstr "Süsteemi roll"
 
 #: lib/phoenix_kit_web/live/users/roles.html.heex:274
 #, elixir-autogen, elixir-format
 msgid "System Roles"
-msgstr ""
+msgstr "Süsteemi rollid"
 
 #: lib/phoenix_kit_web/live/users/roles.ex:359
 #, elixir-autogen, elixir-format
 msgid "System roles cannot be deleted"
-msgstr ""
+msgstr "Süsteemi rolle ei saa kustutada"
 
 #: lib/phoenix_kit_web/live/users/roles.ex:81
 #, elixir-autogen, elixir-format
 msgid "System roles cannot be edited"
-msgstr ""
+msgstr "Süsteemi rolle ei saa muuta"
 
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:147
 #, elixir-autogen, elixir-format
 msgid "Tax & Registration"
-msgstr ""
+msgstr "Maks ja registreerimine"
 
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:163
 #, elixir-autogen, elixir-format
 msgid "Tax ID"
-msgstr ""
+msgstr "Maksukohustuslase number"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:634
 #, elixir-autogen, elixir-format
 msgid "This action cannot be undone."
-msgstr ""
+msgstr "Seda toimingut ei saa tagasi võtta."
 
 #: lib/phoenix_kit_web/live/users/user_details.ex:295
 #: lib/phoenix_kit_web/live/users/user_details.ex:313
 #, elixir-autogen, elixir-format
 msgid "This user has been deleted"
-msgstr ""
+msgstr "See kasutaja on kustutatud"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:227
 #, elixir-autogen, elixir-format
 msgid "Timezone"
-msgstr ""
+msgstr "Ajavöönd"
 
 #: lib/phoenix_kit_web/live/modules.html.heex:260
 #: lib/phoenix_kit_web/live/modules.html.heex:332
 #: lib/phoenix_kit_web/live/users/permissions_matrix.html.heex:181
 #, elixir-autogen, elixir-format
 msgid "Total"
-msgstr ""
+msgstr "Kokku"
 
 #: lib/phoenix_kit_web/live/users/roles.html.heex:300
 #, elixir-autogen, elixir-format
 msgid "Total Roles"
-msgstr ""
+msgstr "Rolle kokku"
 
 #: lib/modules/storage/web/health.html.heex:197
 #: lib/modules/storage/web/health.html.heex:220
@@ -1891,98 +1891,98 @@ msgstr ""
 #: lib/phoenix_kit_web/live/users/roles.html.heex:164
 #, elixir-autogen, elixir-format
 msgid "Type"
-msgstr ""
+msgstr "Tüüp"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Unconfirmed"
-msgstr ""
+msgstr "Kinnitamata"
 
 #: lib/phoenix_kit_web/components/language_switcher.ex:832
 #, elixir-autogen, elixir-format
 msgid "Unknown"
-msgstr ""
+msgstr "Tundmatu"
 
 #: lib/phoenix_kit_web/components/core/markdown_editor.ex:571
 #: lib/phoenix_kit_web/components/core/markdown_editor.ex:657
 #, elixir-autogen, elixir-format
 msgid "Unsaved changes"
-msgstr ""
+msgstr "Salvestamata muudatused"
 
 #: lib/phoenix_kit_web/live/settings/users.html.heex:679
 #, elixir-autogen, elixir-format
 msgid "Update Field"
-msgstr ""
+msgstr "Uuenda välja"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:444
 #, elixir-autogen, elixir-format
 msgid "Update Note"
-msgstr ""
+msgstr "Uuenda märkust"
 
 #: lib/phoenix_kit_web/live/users/roles.html.heex:79
 #, elixir-autogen, elixir-format
 msgid "Update Role"
-msgstr ""
+msgstr "Uuenda rolli"
 
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:25
 #, elixir-autogen, elixir-format
 msgid "Used in legal documents and invoices"
-msgstr ""
+msgstr "Kasutatakse juriidilistes dokumentides ja arvetel"
 
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:362
 #, elixir-autogen, elixir-format
 msgid "Used in legal documents and sitemap generation"
-msgstr ""
+msgstr "Kasutatakse juriidilistes dokumentides ja saidikava genereerimisel"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:242
 #, elixir-autogen, elixir-format
 msgid "User ID"
-msgstr ""
+msgstr "Kasutaja ID"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:642
 #, elixir-autogen, elixir-format
 msgid "User account and profile information"
-msgstr ""
+msgstr "Kasutaja konto ja profiiliteave"
 
 #: lib/phoenix_kit_web/live/users/user_details.ex:122
 #, elixir-autogen, elixir-format
 msgid "User deleted successfully"
-msgstr ""
+msgstr "Kasutaja kustutatud edukalt"
 
 #: lib/phoenix_kit_web/live/users/user_details.ex:33
 #, elixir-autogen, elixir-format
 msgid "User not found"
-msgstr ""
+msgstr "Kasutajat ei leitud"
 
 #: lib/phoenix_kit_web/live/users/roles.html.heex:288
 #, elixir-autogen, elixir-format
 msgid "User-defined roles"
-msgstr ""
+msgstr "Kasutaja määratud rollid"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:209
 #, elixir-autogen, elixir-format
 msgid "Username"
-msgstr ""
+msgstr "Kasutajanimi"
 
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:154
 #, elixir-autogen, elixir-format
 msgid "VAT Number"
-msgstr ""
+msgstr "Käibemaksukohustuslase number"
 
 #: lib/phoenix_kit_web/live/settings/organization.ex:284
 #, elixir-autogen, elixir-format
 msgid "VAT number is required"
-msgstr ""
+msgstr "Käibemaksukohustuslase number on kohustuslik"
 
 #: lib/phoenix_kit_web/live/settings/organization.ex:300
 #, elixir-autogen, elixir-format
 msgid "VAT number must be in EU format (e.g., %{country}123456789)"
-msgstr ""
+msgstr "Käibemaksukohustuslase number peab olema EL-i vormingus (nt %{country}123456789)"
 
 #: lib/phoenix_kit_web/components/core/markdown_editor.ex:639
 #, elixir-autogen, elixir-format
 msgid "Video"
-msgstr ""
+msgstr "Video"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:592
 #: lib/phoenix_kit_web/live/users/users.html.heex:366
@@ -1990,50 +1990,50 @@ msgstr ""
 #: lib/phoenix_kit_web/users/user_form.html.heex:780
 #, elixir-autogen, elixir-format
 msgid "View"
-msgstr ""
+msgstr "Vaata"
 
 #: lib/phoenix_kit_web/components/core/modal.ex:483
 #, elixir-autogen, elixir-format
 msgid "Warning"
-msgstr ""
+msgstr "Hoiatus"
 
 #: lib/phoenix_kit_web/legal_gettext_manifest.ex:93
 #, elixir-autogen, elixir-format
 msgid "We use cookies to enhance your browsing experience and analyze our traffic."
-msgstr ""
+msgstr "Kasutame küpsiseid, et parandada teie sirvimiskogemust ja analüüsida meie liiklust."
 
 #: lib/phoenix_kit_web/legal_gettext_manifest.ex:94
 #, elixir-autogen, elixir-format
 msgid "We value your privacy"
-msgstr ""
+msgstr "Hindame teie privaatsust"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:433
 #, elixir-autogen, elixir-format
 msgid "Write a note about this user..."
-msgstr ""
+msgstr "Kirjuta märkus selle kasutaja kohta..."
 
 #: lib/phoenix_kit_web/live/settings/users.html.heex:391
 #: lib/phoenix_kit_web/live/users/user_details.ex:384
 #: lib/phoenix_kit_web/live/users/user_details.ex:385
 #, elixir-autogen, elixir-format
 msgid "Yes"
-msgstr ""
+msgstr "Jah"
 
 #: lib/phoenix_kit_web/live/users/permissions_matrix.ex:89
 #: lib/phoenix_kit_web/live/users/roles.ex:257
 #, elixir-autogen, elixir-format
 msgid "You can only manage permissions you have"
-msgstr ""
+msgstr "Sa saad hallata ainult õigusi, mis sul on"
 
 #: lib/phoenix_kit_web/live/users/roles.ex:298
 #, elixir-autogen, elixir-format
 msgid "You cannot edit permissions for this role"
-msgstr ""
+msgstr "Sa ei saa muuta selle rolli õigusi"
 
 #: lib/phoenix_kit_web/live/users/permissions_matrix.ex:224
 #, elixir-autogen, elixir-format
 msgid "You cannot edit permissions for your own role"
-msgstr ""
+msgstr "Sa ei saa muuta oma rolli õigusi"
 
 #: lib/phoenix_kit_web/live/users/permissions_matrix.ex:100
 #: lib/phoenix_kit_web/live/users/roles.ex:227
@@ -2043,61 +2043,61 @@ msgstr ""
 #: lib/phoenix_kit_web/live/users/roles.ex:293
 #, elixir-autogen, elixir-format
 msgid "You don't have permission to manage permissions"
-msgstr ""
+msgstr "Sul puudub luba õiguste haldamiseks"
 
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:42
 #, elixir-autogen, elixir-format
 msgid "Your Company Name"
-msgstr ""
+msgstr "Teie ettevõtte nimi"
 
 #: lib/phoenix_kit_web/live/dashboard/index.ex:29
 #, elixir-autogen, elixir-format
 msgid "Your personal dashboard is ready. Explore your account settings and manage your profile from here."
-msgstr ""
+msgstr "Teie isiklik armatuurlaud on valmis. Uurige oma konto seadeid ja hallake oma profiili siit."
 
 #: lib/phoenix_kit_web/live/users/permissions_matrix.html.heex:51
 #: lib/phoenix_kit_web/live/users/permissions_matrix.html.heex:99
 #: lib/phoenix_kit_web/live/users/permissions_matrix.html.heex:147
 #, elixir-autogen, elixir-format
 msgid "always"
-msgstr ""
+msgstr "alati"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:485
 #, elixir-autogen, elixir-format
 msgid "edited"
-msgstr ""
+msgstr "muudetud"
 
 #: lib/phoenix_kit_web/live/users/roles.html.heex:201
 #, elixir-autogen, elixir-format
 msgid "users"
-msgstr ""
+msgstr "kasutajat"
 
 #: lib/phoenix_kit_web/live/users/users.html.heex:427
 #: lib/phoenix_kit_web/live/users/users.html.heex:504
 #, elixir-autogen, elixir-format
 msgid "Activate"
-msgstr ""
+msgstr "Aktiveeri"
 
 #: lib/phoenix_kit_web/live/users/users.html.heex:121
 #, elixir-autogen, elixir-format
 msgid "All Types"
-msgstr ""
+msgstr "Kõik tüübid"
 
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:328
 #, elixir-autogen, elixir-format
 msgid "Apply"
-msgstr ""
+msgstr "Rakenda"
 
 #: lib/phoenix_kit_web/live/users/users.html.heex:426
 #: lib/phoenix_kit_web/live/users/users.html.heex:504
 #, elixir-autogen, elixir-format
 msgid "Deactivate"
-msgstr ""
+msgstr "Deaktiveeri"
 
 #: lib/modules/storage/web/settings.html.heex:278
 #, elixir-autogen, elixir-format
 msgid "Delete bucket"
-msgstr ""
+msgstr "Kustuta bucket"
 
 #: lib/modules/storage/web/dimensions.html.heex:228
 #: lib/modules/storage/web/dimensions.html.heex:265
@@ -2109,12 +2109,12 @@ msgstr ""
 #: lib/phoenix_kit_web/live/settings/users.html.heex:430
 #, elixir-autogen, elixir-format
 msgid "Disable"
-msgstr ""
+msgstr "Keela"
 
 #: lib/modules/storage/web/settings.html.heex:261
 #, elixir-autogen, elixir-format
 msgid "Edit bucket"
-msgstr ""
+msgstr "Muuda bucket"
 
 #: lib/modules/storage/web/dimensions.html.heex:228
 #: lib/modules/storage/web/dimensions.html.heex:265
@@ -2127,207 +2127,207 @@ msgstr ""
 #: lib/phoenix_kit_web/live/settings/users.html.heex:435
 #, elixir-autogen, elixir-format
 msgid "Enable"
-msgstr ""
+msgstr "Luba"
 
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:188
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:237
 #: lib/phoenix_kit_web/users/user_form.html.heex:821
 #, elixir-autogen, elixir-format
 msgid "Expires"
-msgstr ""
+msgstr "Aegub"
 
 #: lib/phoenix_kit_web/live/modules.ex:257
 #, elixir-autogen, elixir-format
 msgid "Failed to %{action} Legal module"
-msgstr ""
+msgstr "Juriidilise mooduli %{action} ebaõnnestus"
 
 #: lib/phoenix_kit_web/live/modules/jobs/index.html.heex:223
 #: lib/phoenix_kit_web/live/modules/jobs/index.html.heex:228
 #, elixir-autogen, elixir-format
 msgid "Hide"
-msgstr ""
+msgstr "Peida"
 
 #: lib/modules/maintenance/settings.ex:459
 #, elixir-autogen, elixir-format
 msgid "Live Preview"
-msgstr ""
+msgstr "Reaalajas eelvaade"
 
 #: lib/phoenix_kit_web/components/multilang_form.ex:671
 #, elixir-autogen, elixir-format
 msgid "Loading language content"
-msgstr ""
+msgstr "Keele sisu laadimine"
 
 #: lib/phoenix_kit_web/legal_gettext_manifest.ex:77
 #, elixir-autogen, elixir-format
 msgid "Marketing"
-msgstr ""
+msgstr "Turundus"
 
 #: lib/modules/storage/web/settings.html.heex:161
 #: lib/modules/storage/web/settings.html.heex:187
 #, elixir-autogen, elixir-format
 msgid "Provider"
-msgstr ""
+msgstr "Teenusepakkuja"
 
 #: lib/modules/storage/web/settings.html.heex:479
 #, elixir-autogen, elixir-format
 msgid "Quick Actions"
-msgstr ""
+msgstr "Kiiraktsioonid"
 
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:218
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:314
 #, elixir-autogen, elixir-format
 msgid "Revoke"
-msgstr ""
+msgstr "Tühista"
 
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:225
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:321
 #, elixir-autogen, elixir-format
 msgid "Revoke all"
-msgstr ""
+msgstr "Tühista kõik"
 
 #: lib/phoenix_kit_web/live/modules/languages.html.heex:228
 #: lib/phoenix_kit_web/live/modules/languages.html.heex:232
 #, elixir-autogen, elixir-format
 msgid "Set Default"
-msgstr ""
+msgstr "Määra vaikimisi"
 
 #: lib/modules/storage/web/dimensions.html.heex:108
 #: lib/modules/storage/web/dimensions.html.heex:146
 #, elixir-autogen, elixir-format
 msgid "Size"
-msgstr ""
+msgstr "Suurus"
 
 #: lib/modules/storage/web/health.html.heex:67
 #, elixir-autogen, elixir-format
 msgid "Syncing..."
-msgstr ""
+msgstr "Sünkroonimine..."
 
 #: lib/phoenix_kit_web/live/users/roles.html.heex:97
 #: lib/phoenix_kit_web/live/users/roles.html.heex:119
 #, elixir-autogen, elixir-format
 msgid "System"
-msgstr ""
+msgstr "Süsteem"
 
 #: lib/phoenix_kit_web/live/users/users.html.heex:410
 #: lib/phoenix_kit_web/live/users/users.html.heex:496
 #, elixir-autogen, elixir-format
 msgid "Unconfirm"
-msgstr ""
+msgstr "Tühista kinnitus"
 
 #: lib/phoenix_kit_web/components/multilang_form.ex:578
 #, elixir-autogen, elixir-format
 msgid "Use the language tabs below to translate this record's content. The primary language (marked with a star) is required. Other languages are optional — any empty fields will fall back to the primary language value."
-msgstr ""
+msgstr "Kasuta allpool olevaid keelekaarti selle kirje sisu tõlkimiseks. Esmane keel (tärniga tähistatud) on kohustuslik. Muud keeled on valikulised — tühjad väljad kasutavad esmase keele väärtust."
 
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "days"
-msgstr ""
+msgstr "päeva"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:200
 #, elixir-autogen, elixir-format
 msgid "#1a1a2e or linear-gradient(135deg, #667eea, #764ba2)"
-msgstr ""
+msgstr "#1a1a2e or linear-gradient(135deg, #667eea, #764ba2)"
 
 #: lib/phoenix_kit_web/components/language_switcher.ex:799
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{language} (Unknown language)"
-msgstr ""
+msgstr "%{language} (Tundmatu keel)"
 
 #: lib/phoenix_kit_web/live/settings.html.heex:275
 #: lib/phoenix_kit_web/live/settings.html.heex:280
 #: lib/phoenix_kit_web/live/settings.html.heex:285
 #, elixir-autogen, elixir-format, fuzzy
 msgid "(empty)"
-msgstr ""
+msgstr "(tühi)"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:266
 #, elixir-autogen, elixir-format
 msgid "(registration disabled)"
-msgstr ""
+msgstr "(registreerimine keelatud)"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:1018
 #, elixir-autogen, elixir-format
 msgid "1. Enable the provider above and save settings"
-msgstr ""
+msgstr "1. Luba ülalolev teenusepakkuja ja salvesta seaded"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:1019
 #, elixir-autogen, elixir-format
 msgid "2. Enter your OAuth credentials in the form that appears"
-msgstr ""
+msgstr "2. Sisesta oma OAuth mandaadid ilmuvas vormis"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:1020
 #, elixir-autogen, elixir-format
 msgid "3. Save settings again to store credentials"
-msgstr ""
+msgstr "3. Salvesta seaded uuesti mandaatide salvestamiseks"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:1021
 #, elixir-autogen, elixir-format
 msgid "4. Click \"Test Credentials\" to verify configuration"
-msgstr ""
+msgstr "4. Klõpsake \"Test Credentials\", et kontrollida seadistust"
 
 #: lib/modules/storage/web/settings.html.heex:532
 #, elixir-autogen, elixir-format, fuzzy
 msgid "AWS S3 Integration"
-msgstr ""
+msgstr "AWS S3 integratsioon"
 
 #: lib/phoenix_kit_web/live/settings.html.heex:496
 #, elixir-autogen, elixir-format
 msgid "About System Settings"
-msgstr ""
+msgstr "Süsteemi seadete kohta"
 
 #: lib/modules/storage/web/bucket_form.html.heex:245
 #, elixir-autogen, elixir-format
 msgid "Access Credentials"
-msgstr ""
+msgstr "Juurdepääsumandaadid"
 
 #: lib/modules/storage/web/bucket_form.html.heex:251
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Access Key ID"
-msgstr ""
+msgstr "Juurdepääsuvõtme ID"
 
 #: lib/modules/storage/web/bucket_form.html.heex:325
 #, elixir-autogen, elixir-format
 msgid "Access Type"
-msgstr ""
+msgstr "Juurdepääsu tüüp"
 
 #: lib/modules/storage/web/settings.html.heex:328
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Active Buckets"
-msgstr ""
+msgstr "Aktiivsed bucketid"
 
 #: lib/phoenix_kit_web/live/settings/users.html.heex:270
 #, elixir-autogen, elixir-format
 msgid "Active status for new user registrations"
-msgstr ""
+msgstr "Aktiivne olek uute kasutajate registreerimisel"
 
 #: lib/modules/storage/web/settings.html.heex:121
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add Bucket"
-msgstr ""
+msgstr "Lisa bucket"
 
 #: lib/phoenix_kit_web/live/settings/users.html.heex:472
 #: lib/phoenix_kit_web/live/settings/users.html.heex:503
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add Custom Field"
-msgstr ""
+msgstr "Lisa kohandatud väli"
 
 #: lib/phoenix_kit_web/live/settings/users.html.heex:353
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add First Field"
-msgstr ""
+msgstr "Lisa esimene väli"
 
 #: lib/modules/storage/web/dimensions.html.heex:66
 #: lib/modules/storage/web/dimensions.html.heex:91
 #, elixir-autogen, elixir-format
 msgid "Add Image Dimension"
-msgstr ""
+msgstr "Lisa pildi dimensioon"
 
 #: lib/modules/storage/web/dimensions.html.heex:74
 #: lib/modules/storage/web/dimensions.html.heex:294
 #, elixir-autogen, elixir-format
 msgid "Add Video Dimension"
-msgstr ""
+msgstr "Lisa video dimensioon"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:488
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:661
@@ -2335,12 +2335,12 @@ msgstr ""
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:963
 #, elixir-autogen, elixir-format
 msgid "Add callback URL above to"
-msgstr ""
+msgstr "Lisa tagasihelistamise URL ülal"
 
 #: lib/phoenix_kit_web/live/settings/seo.html.heex:30
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Adds"
-msgstr ""
+msgstr "Lisab"
 
 ## This is a PO Template file.
 ##
@@ -2354,74 +2354,74 @@ msgstr ""
 #: lib/modules/storage/web/settings.html.heex:558
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Admin Dashboard"
-msgstr ""
+msgstr "Administraatori armatuurlaud"
 
 #: lib/phoenix_kit_web/live/settings/users.html.heex:410
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Admin Only"
-msgstr ""
+msgstr "Ainult administraatorile"
 
 #: lib/modules/storage/web/settings.html.heex:508
 #, elixir-autogen, elixir-format
 msgid "Advanced Features Coming Soon"
-msgstr ""
+msgstr "Täiustatud funktsioonid tulemas varsti"
 
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:186
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:236
 #, elixir-autogen, elixir-format
 msgid "Age"
-msgstr ""
+msgstr "Vanus"
 
 #: lib/phoenix_kit_web/live/settings/users.html.heex:253
 #, elixir-autogen, elixir-format
 msgid "All new users will receive administrative privileges and access to the admin panel."
-msgstr ""
+msgstr "Kõik uued kasutajad saavad administraatori õigused ja juurdepääsu administraatori paneelile."
 
 #: lib/phoenix_kit_web/live/settings/users.html.heex:86
 #, elixir-autogen, elixir-format
 msgid "Anyone can register"
-msgstr ""
+msgstr "Kõik saavad registreeruda"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:868
 #, elixir-autogen, elixir-format
 msgid "App ID"
-msgstr ""
+msgstr "Rakenduse ID"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:881
 #, elixir-autogen, elixir-format
 msgid "App Secret"
-msgstr ""
+msgstr "Rakenduse saladus"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:533
 #, elixir-autogen, elixir-format
 msgid "Apple OAuth Credentials"
-msgstr ""
+msgstr "Apple OAuth mandaadid"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:332
 #, elixir-autogen, elixir-format
 msgid "Apple Sign-In"
-msgstr ""
+msgstr "Apple sisselogimine"
 
 #: lib/phoenix_kit_web/live/settings.html.heex:58
 #, elixir-autogen, elixir-format
 msgid "Application name display"
-msgstr ""
+msgstr "Rakenduse nime kuvamine"
 
 #: lib/modules/storage/web/settings.html.heex:467
 #, elixir-autogen, elixir-format
 msgid "Apply Changes"
-msgstr ""
+msgstr "Rakenda muudatused"
 
 #: lib/modules/storage/web/settings.html.heex:464
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Applying..."
-msgstr ""
+msgstr "Rakendamine..."
 
 #: lib/modules/storage/web/settings.html.heex:273
 #: lib/modules/storage/web/settings.html.heex:309
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Are you sure you want to delete this bucket? This will remove all location records."
-msgstr ""
+msgstr "Kas oled kindel, et soovid kustutada selle bucketi? See eemaldab kõik asukoharekordid."
 
 #: lib/modules/storage/web/dimensions.html.heex:236
 #: lib/modules/storage/web/dimensions.html.heex:271
@@ -2429,12 +2429,12 @@ msgstr ""
 #: lib/modules/storage/web/dimensions.html.heex:471
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Are you sure you want to delete this dimension?"
-msgstr ""
+msgstr "Kas oled kindel, et soovid kustutada selle dimensiooni?"
 
 #: lib/modules/storage/web/dimensions.html.heex:35
 #, elixir-autogen, elixir-format
 msgid "Are you sure? This will delete all current dimensions and restore the default 8 dimensions. This action cannot be undone."
-msgstr ""
+msgstr "Kas oled kindel? See kustutab kõik praegused dimensioonid ja taastab 8 vaikimisi dimensiooni. Seda toimingut ei saa tagasi võtta."
 
 #: lib/modules/storage/web/dimensions.html.heex:119
 #: lib/modules/storage/web/dimensions.html.heex:172
@@ -2442,83 +2442,83 @@ msgstr ""
 #: lib/modules/storage/web/dimensions.html.heex:372
 #, elixir-autogen, elixir-format
 msgid "Aspect Ratio"
-msgstr ""
+msgstr "Kuvasuhe"
 
 #: lib/phoenix_kit_web/live/settings/users.html.heex:668
 #, elixir-autogen, elixir-format
 msgid "At least one option is required for %{type} fields"
-msgstr ""
+msgstr "%{type} väljade jaoks on vaja vähemalt ühte valikut"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:216
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Authentication Methods"
-msgstr ""
+msgstr "Autentimismeetodid"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:20
 #, elixir-autogen, elixir-format
 msgid "Authorization Configuration"
-msgstr ""
+msgstr "Volitamise konfiguratsioon"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:12
 #, elixir-autogen, elixir-format
 msgid "Authorization Settings"
-msgstr ""
+msgstr "Volitamise seaded"
 
 #: lib/modules/storage/web/settings.html.heex:425
 #, elixir-autogen, elixir-format
 msgid "Auto-Generate Variants"
-msgstr ""
+msgstr "Automaatselt genereeri variante"
 
 #: lib/modules/storage/web/settings.html.heex:584
 #, elixir-autogen, elixir-format
 msgid "Automatic Failover"
-msgstr ""
+msgstr "Automaatne tõrkesiire"
 
 #: lib/modules/storage/web/settings.html.heex:427
 #, elixir-autogen, elixir-format
 msgid "Automatically resize images and videos to configured dimensions"
-msgstr ""
+msgstr "Automaatselt muuda piltide ja videote suurust konfigureeritud dimensioonidele"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Background Color"
-msgstr ""
+msgstr "Taustavärv"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:93
 #, elixir-autogen, elixir-format
 msgid "Background Image (Desktop)"
-msgstr ""
+msgstr "Taustapilt (lauaarvuti)"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:141
 #, elixir-autogen, elixir-format
 msgid "Background Image (Mobile)"
-msgstr ""
+msgstr "Taustapilt (mobiil)"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:131
 #, elixir-autogen, elixir-format
 msgid "Background image for auth pages on desktop screens (wider than 768px)."
-msgstr ""
+msgstr "Autentimislehtede taustapilt lauaarvuti ekraanidel (laiem kui 768px)."
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:182
 #, elixir-autogen, elixir-format
 msgid "Background image for auth pages on mobile screens (768px and below). Falls back to desktop image if not set."
-msgstr ""
+msgstr "Autentimislehtede taustapilt mobiiliekraanidel (768px ja alla). Kasutab lauaarvuti pilti, kui pole määratud."
 
 #: lib/modules/storage/web/bucket_form.html.heex:25
 #: lib/modules/storage/web/bucket_form.html.heex:198
 #, elixir-autogen, elixir-format
 msgid "Bucket Name"
-msgstr ""
+msgstr "Bucketi nimi"
 
 #: lib/modules/storage/web/settings.html.heex:134
 #, elixir-autogen, elixir-format
 msgid "Buckets can be local directories or cloud storage providers (AWS S3, Backblaze B2, Cloudflare R2)."
-msgstr ""
+msgstr "Bucketid võivad olla kohalikud kataloogid või pilvemälupakkujad (AWS S3, Backblaze B2, Cloudflare R2)."
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:205
 #, elixir-autogen, elixir-format
 msgid "CSS color or gradient for auth page background. Ignored if a background image is set."
-msgstr ""
+msgstr "CSS värv või gradient autentimislehe taustaks. Ignoreeritakse, kui taustapilt on määratud."
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:442
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:612
@@ -2526,12 +2526,12 @@ msgstr ""
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:917
 #, elixir-autogen, elixir-format
 msgid "Callback URL"
-msgstr ""
+msgstr "Tagasihelistamise URL"
 
 #: lib/modules/storage/web/settings.html.heex:473
 #, elixir-autogen, elixir-format
 msgid "Changes will be saved immediately"
-msgstr ""
+msgstr "Muudatused salvestatakse kohe"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:493
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:675
@@ -2540,7 +2540,7 @@ msgstr ""
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:980
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Click"
-msgstr ""
+msgstr "Klõpsa"
 
 #: lib/phoenix_kit/integrations/providers.ex:115
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:393
@@ -2548,7 +2548,7 @@ msgstr ""
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:720
 #, elixir-autogen, elixir-format
 msgid "Client ID"
-msgstr ""
+msgstr "Kliendi ID"
 
 #: lib/phoenix_kit/integrations/providers.ex:124
 #: lib/phoenix_kit/integrations/providers.ex:420
@@ -2556,75 +2556,75 @@ msgstr ""
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:733
 #, elixir-autogen, elixir-format
 msgid "Client Secret"
-msgstr ""
+msgstr "Kliendi saladus"
 
 #: lib/modules/storage/web/dimensions.html.heex:328
 #: lib/modules/storage/web/dimensions.html.heex:349
 #, elixir-autogen, elixir-format
 msgid "Codec"
-msgstr ""
+msgstr "Kodek"
 
 #: lib/modules/storage/web/dimension_form.html.heex:165
 #, elixir-autogen, elixir-format
 msgid "Codec Override"
-msgstr ""
+msgstr "Kodeki ülekate"
 
 #: lib/modules/storage/web/dimension_form.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Configure dimension presets for automatic file variant generation"
-msgstr ""
+msgstr "Seadista dimensioonipresetid automaatseks failivariantide genereerimiseks"
 
 #: lib/phoenix_kit_web/live/settings/seo.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "Configure environment-wide search optimization defaults and metadata directives from a single place."
-msgstr ""
+msgstr "Seadista keskkonnalaiused otsinguoptimeerimise vaikimisi seaded ja metaandmete direktiivid ühest kohast."
 
 #: lib/phoenix_kit_web/live/settings.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Configure system preferences and options"
-msgstr ""
+msgstr "Seadista süsteemi eelistused ja valikud"
 
 #: lib/phoenix_kit_web/live/settings/users.html.heex:256
 #, elixir-autogen, elixir-format
 msgid "Consider \"User\" for most installations to maintain security."
-msgstr ""
+msgstr "Enamiku paigalduste puhul kasutage turbe tagamiseks \"Kasutaja\"."
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:219
 #, elixir-autogen, elixir-format
 msgid "Control available login/registration methods"
-msgstr ""
+msgstr "Kontrolli saadaolevaid sisselogimis-/registreerimismeetodeid"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:668
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:820
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:970
 #, elixir-autogen, elixir-format
 msgid "Copy"
-msgstr ""
+msgstr "Kopeeri"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:491
 #, elixir-autogen, elixir-format
 msgid "Copy Client ID and Secret to fields above"
-msgstr ""
+msgstr "Kopeeri Kliendi ID ja Saladus ülal olevatesse väljadesse"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:628
 #, elixir-autogen, elixir-format
 msgid "Copy this URL to Apple Developer Console"
-msgstr ""
+msgstr "Kopeeri see URL Apple Developer Console'i"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:933
 #, elixir-autogen, elixir-format
 msgid "Copy this URL to Facebook App Settings"
-msgstr ""
+msgstr "Kopeeri see URL Facebook App Settings'isse"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:785
 #, elixir-autogen, elixir-format
 msgid "Copy this URL to GitHub OAuth Apps"
-msgstr ""
+msgstr "Kopeeri see URL GitHub OAuth Apps'i"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:458
 #, elixir-autogen, elixir-format
 msgid "Copy this URL to Google Cloud Console"
-msgstr ""
+msgstr "Kopeeri see URL Google Cloud Console'i"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:452
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:622
@@ -2632,193 +2632,193 @@ msgstr ""
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:927
 #, elixir-autogen, elixir-format
 msgid "Copy to clipboard"
-msgstr ""
+msgstr "Kopeeri lõikelauale"
 
 #: lib/modules/storage/web/settings.html.heex:24
 #, elixir-autogen, elixir-format
 msgid "Core System Module"
-msgstr ""
+msgstr "Põhisüsteemi moodul"
 
 #: lib/phoenix_kit_web/live/settings/seo.html.heex:69
 #, elixir-autogen, elixir-format
 msgid "Crawlers are allowed to index the site. Enable the toggle to hide staging deployments."
-msgstr ""
+msgstr "Roomajad võivad saiti indekseerida. Luba lüliti, et peita vahe-paigaldused."
 
 #: lib/modules/storage/web/bucket_form.html.heex:423
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Create Path"
-msgstr ""
+msgstr "Loo tee"
 
 #: lib/modules/storage/web/bucket_form.html.heex:408
 #, elixir-autogen, elixir-format
 msgid "Create Storage Path"
-msgstr ""
+msgstr "Loo salvestustee"
 
 #: lib/modules/storage/web/settings.html.heex:143
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Create Your First Bucket"
-msgstr ""
+msgstr "Loo oma esimene bucket"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:653
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:664
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Create a"
-msgstr ""
+msgstr "Loo"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:953
 #, elixir-autogen, elixir-format
 msgid "Create a new app or select existing one"
-msgstr ""
+msgstr "Loo uus rakendus või vali olemasolev"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:647
 #, elixir-autogen, elixir-format
 msgid "Create an App ID or select existing one"
-msgstr ""
+msgstr "Loo rakenduse ID või vali olemasolev"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:477
 #, elixir-autogen, elixir-format
 msgid "Create project or select existing one"
-msgstr ""
+msgstr "Loo projekt või vali olemasolev"
 
 #: lib/modules/storage/web/dimensions.html.heex:57
 #, elixir-autogen, elixir-format
 msgid "Create your first dimension preset to start generating file variants."
-msgstr ""
+msgstr "Loo oma esimene dimensioonipresett failivariantide genereerimiseks."
 
 #: lib/modules/storage/web/settings.html.heex:332
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Currently in use"
-msgstr ""
+msgstr "Praegu kasutusel"
 
 #: lib/phoenix_kit_web/live/settings/users.html.heex:328
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Custom User Fields"
-msgstr ""
+msgstr "Kohandatud kasutajaväljad"
 
 #: lib/phoenix_kit_web/live/settings.html.heex:378
 #, elixir-autogen, elixir-format
 msgid "Date Format"
-msgstr ""
+msgstr "Kuupäeva vorming"
 
 #: lib/modules/storage/web/settings.html.heex:336
 #, elixir-autogen, elixir-format
 msgid "Default Bucket"
-msgstr ""
+msgstr "Vaikimisi bucket"
 
 #: lib/phoenix_kit_web/live/settings/users.html.heex:337
 #, elixir-autogen, elixir-format
 msgid "Define additional profile fields for users"
-msgstr ""
+msgstr "Defineeri kasutajatele täiendavad profiiliväljad"
 
 #: lib/modules/storage/web/dimension_form.html.heex:26
 #, elixir-autogen, elixir-format
 msgid "Dimension Name"
-msgstr ""
+msgstr "Dimensiooni nimi"
 
 #: lib/modules/storage/web/dimensions.html.heex:22
 #, elixir-autogen, elixir-format
 msgid "Dimension Presets"
-msgstr ""
+msgstr "Dimensioonipresetid"
 
 #: lib/modules/storage/web/dimensions.html.heex:24
 #, elixir-autogen, elixir-format
 msgid "Dimensions define the target sizes for automatic variant generation. Images are resized and videos are transcoded to these preset sizes."
-msgstr ""
+msgstr "Dimensioonid määravad automaatse variandi genereerimise sihtsuurused. Piltide suurust muudetakse ja videoid transkoditakse nende presetitud suurusteni."
 
 #: lib/modules/storage/web/settings.html.heex:547
 #, elixir-autogen, elixir-format
 msgid "Distribute files across multiple remote servers and datacenters"
-msgstr ""
+msgstr "Jaota failid mitme kaugserveri ja andmekeskuse vahel"
 
 #: lib/phoenix_kit_web/live/settings/users.html.heex:502
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Edit Custom Field"
-msgstr ""
+msgstr "Muuda kohandatud välja"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:241
 #, elixir-autogen, elixir-format
 msgid "Enable Magic Link for login"
-msgstr ""
+msgstr "Luba Magic Link sisselogimiseks"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:264
 #, elixir-autogen, elixir-format
 msgid "Enable Magic Link for registration"
-msgstr ""
+msgstr "Luba Magic Link registreerimiseks"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:287
 #, elixir-autogen, elixir-format
 msgid "Enable OAuth (Master Switch)"
-msgstr ""
+msgstr "Luba OAuth (peamine lüliti)"
 
 #: lib/modules/storage/web/bucket_form.html.heex:218
 #, elixir-autogen, elixir-format
 msgid "Endpoint"
-msgstr ""
+msgstr "Lõpp-punkt"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:809
 #, elixir-autogen, elixir-format
 msgid "Enter"
-msgstr ""
+msgstr "Sisesta"
 
 #: lib/modules/storage/web/settings.html.heex:398
 #, elixir-autogen, elixir-format
 msgid "Enter number of copies"
-msgstr ""
+msgstr "Sisesta koopiate arv"
 
 #: lib/phoenix_kit_web/live/settings/users.html.heex:646
 #, elixir-autogen, elixir-format
 msgid "Enter option value"
-msgstr ""
+msgstr "Sisesta valiku väärtus"
 
 #: lib/phoenix_kit_web/live/settings.html.heex:66
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enter project title"
-msgstr ""
+msgstr "Sisesta projekti pealkiri"
 
 #: lib/phoenix_kit_web/components/core/flash.ex:96
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Error!"
-msgstr ""
+msgstr "Viga!"
 
 #: lib/modules/storage/web/settings.html.heex:90
 #, elixir-autogen, elixir-format
 msgid "FFmpeg Not Installed"
-msgstr ""
+msgstr "FFmpeg ei ole paigaldatud"
 
 #: lib/modules/storage/web/settings.html.heex:92
 #, elixir-autogen, elixir-format
 msgid "FFmpeg is required for video processing, transcoding, and thumbnail generation."
-msgstr ""
+msgstr "FFmpeg on vajalik video töötlemiseks, transkodeerimiseks ja pisipiltide genereerimiseks."
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:863
 #, elixir-autogen, elixir-format
 msgid "Facebook OAuth Credentials"
-msgstr ""
+msgstr "Facebook OAuth mandaadid"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:374
 #, elixir-autogen, elixir-format
 msgid "Facebook Sign-In"
-msgstr ""
+msgstr "Facebook sisselogimine"
 
 #: lib/phoenix_kit_web/live/settings/users.html.heex:361
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Field"
-msgstr ""
+msgstr "Väli"
 
 #: lib/phoenix_kit_web/live/settings/users.html.heex:510
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Field Key"
-msgstr ""
+msgstr "Välja võti"
 
 #: lib/modules/storage/web/settings.html.heex:571
 #, elixir-autogen, elixir-format
 msgid "File Tracking"
-msgstr ""
+msgstr "Failide jälgimine"
 
 #: lib/phoenix_kit_web/live/settings.html.heex:296
 #, elixir-autogen, elixir-format
 msgid "First day of the week"
-msgstr ""
+msgstr "Nädala esimene päev"
 
 #: lib/modules/storage/web/dimensions.html.heex:120
 #: lib/modules/storage/web/dimensions.html.heex:176
@@ -2826,33 +2826,33 @@ msgstr ""
 #: lib/modules/storage/web/dimensions.html.heex:376
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Fixed"
-msgstr ""
+msgstr "Fikseeritud"
 
 #: lib/modules/storage/web/dimension_form.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "Format Override"
-msgstr ""
+msgstr "Vormingu ülekate"
 
 #: lib/modules/storage/web/dimensions.html.heex:493
 #, elixir-autogen, elixir-format
 msgid "Format Override:"
-msgstr ""
+msgstr "Vormingu ülekate:"
 
 #: lib/phoenix_kit_web/live/settings/users.html.heex:140
 #: lib/phoenix_kit_web/live/settings/users.html.heex:165
 #, elixir-autogen, elixir-format
 msgid "Geolocation:"
-msgstr ""
+msgstr "Geolokatsiooni:"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:715
 #, elixir-autogen, elixir-format
 msgid "GitHub OAuth Credentials"
-msgstr ""
+msgstr "GitHub OAuth mandaadid"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:353
 #, elixir-autogen, elixir-format
 msgid "GitHub Sign-In"
-msgstr ""
+msgstr "GitHub sisselogimine"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:479
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:805
@@ -2860,32 +2860,32 @@ msgstr ""
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:967
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Go to"
-msgstr ""
+msgstr "Mine"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:388
 #, elixir-autogen, elixir-format
 msgid "Google OAuth Credentials"
-msgstr ""
+msgstr "Google OAuth mandaadid"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:315
 #, elixir-autogen, elixir-format
 msgid "Google Sign-In"
-msgstr ""
+msgstr "Google sisselogimine"
 
 #: lib/modules/storage/web/dimension_form.html.heex:106
 #, elixir-autogen, elixir-format
 msgid "Height (px)"
-msgstr ""
+msgstr "Kõrgus (px)"
 
 #: lib/phoenix_kit_web/live/settings.html.heex:380
 #, elixir-autogen, elixir-format
 msgid "How dates are displayed"
-msgstr ""
+msgstr "Kuidas kuupäevi kuvatakse"
 
 #: lib/phoenix_kit_web/live/settings.html.heex:422
 #, elixir-autogen, elixir-format
 msgid "How times are displayed"
-msgstr ""
+msgstr "Kuidas kellaaegu kuvatakse"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:510
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:692
@@ -2893,124 +2893,124 @@ msgstr ""
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:997
 #, elixir-autogen, elixir-format
 msgid "If behind nginx/apache, ensure"
-msgstr ""
+msgstr "Kui kasutate nginx/apache'i, veenduge"
 
 #: lib/modules/storage/web/dimensions.html.heex:83
 #, elixir-autogen, elixir-format
 msgid "Image Dimensions"
-msgstr ""
+msgstr "Pildi dimensioonid"
 
 #: lib/modules/storage/web/settings.html.heex:64
 #, elixir-autogen, elixir-format
 msgid "ImageMagick Not Installed"
-msgstr ""
+msgstr "ImageMagick ei ole paigaldatud"
 
 #: lib/modules/storage/web/settings.html.heex:66
 #, elixir-autogen, elixir-format
 msgid "ImageMagick is required for image processing and variant generation."
-msgstr ""
+msgstr "ImageMagick on vajalik piltide töötlemiseks ja variantide genereerimiseks."
 
 #: lib/modules/storage/web/dimensions.html.heex:490
 #, elixir-autogen, elixir-format
 msgid "Images use 1-100 scale (compression quality)"
-msgstr ""
+msgstr "Pildid kasutavad 1-100 skaalat (tihenduse kvaliteet)"
 
 #: lib/modules/storage/web/settings.html.heex:70
 #: lib/modules/storage/web/settings.html.heex:98
 #, elixir-autogen, elixir-format
 msgid "Installation:"
-msgstr ""
+msgstr "Paigaldamine:"
 
 #: lib/modules/storage/web/dimensions.html.heex:12
 #, elixir-autogen, elixir-format
 msgid "Instance Dimensions"
-msgstr ""
+msgstr "Instantsi dimensioonid"
 
 #: lib/modules/storage/web/settings.html.heex:27
 #, elixir-autogen, elixir-format
 msgid "It provides essential file management functionality across PhoenixKit."
-msgstr ""
+msgstr "See pakub olulist failihalduse funktsionaalsust kogu PhoenixKitis."
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:564
 #, elixir-autogen, elixir-format
 msgid "Key ID"
-msgstr ""
+msgstr "Võtme ID"
 
 #: lib/phoenix_kit_web/live/settings/users.html.heex:382
 #, elixir-autogen, elixir-format
 msgid "Key:"
-msgstr ""
+msgstr "Võti:"
 
 #: lib/phoenix_kit_web/live/settings/users.html.heex:531
 #, elixir-autogen, elixir-format
 msgid "Label"
-msgstr ""
+msgstr "Silt"
 
 #: lib/modules/storage/web/dimensions.html.heex:494
 #, elixir-autogen, elixir-format
 msgid "Leave empty to preserve original format, or specify jpg/png/webp/mp4"
-msgstr ""
+msgstr "Jäta tühjaks algse vormingu säilitamiseks või täpsusta jpg/png/webp/mp4"
 
 #: lib/phoenix_kit_web/legal_gettext_manifest.ex:73
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Legal"
-msgstr ""
+msgstr "Juriidiline"
 
 #: lib/modules/storage/web/bucket_form.html.heex:51
 #: lib/modules/storage/web/bucket_form.html.heex:88
 #, elixir-autogen, elixir-format
 msgid "Local Filesystem"
-msgstr ""
+msgstr "Kohalik failisüsteem"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:87
 #, elixir-autogen, elixir-format
 msgid "Login Page Branding"
-msgstr ""
+msgstr "Sisselogimislehe kujundus"
 
 #: lib/phoenix_kit_web/live/settings/users.html.heex:523
 #, elixir-autogen, elixir-format
 msgid "Lowercase letters, numbers, underscores only"
-msgstr ""
+msgstr "Ainult väiketähed, numbrid ja allkriipsud"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:226
 #, elixir-autogen, elixir-format
 msgid "Magic Link"
-msgstr ""
+msgstr "Magic Link"
 
 #: lib/modules/storage/web/dimension_form.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Maintain Aspect Ratio"
-msgstr ""
+msgstr "Säilita kuvasuhe"
 
 #: lib/phoenix_kit_web/live/settings/users.html.heex:334
 #, elixir-autogen, elixir-format
 msgid "Manage Custom Fields"
-msgstr ""
+msgstr "Halda kohandatud välju"
 
 #: lib/modules/storage/web/settings.html.heex:486
 #, elixir-autogen, elixir-format
 msgid "Manage Dimensions"
-msgstr ""
+msgstr "Halda dimensioone"
 
 #: lib/modules/storage/web/dimensions.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Manage dimension presets for automatic file instance generation"
-msgstr ""
+msgstr "Halda dimensioonipresetid automaatseks failiinstantsi genereerimiseks"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Manage login page branding and authentication methods"
-msgstr ""
+msgstr "Halda sisselogimislehe kujundust ja autentimismeetodeid"
 
 #: lib/phoenix_kit_web/live/settings/users.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Manage user registration, defaults, and custom fields"
-msgstr ""
+msgstr "Halda kasutajate registreerimist, vaikimisi seadeid ja kohandatud välju"
 
 #: lib/modules/storage/web/settings.html.heex:404
 #, elixir-autogen, elixir-format
 msgid "Maximum %{count} copies based on %{buckets} active bucket(s)."
-msgstr ""
+msgstr "Maksimaalselt %{count} koopiat, arvestades %{buckets} aktiivset bucket(i)."
 
 #: lib/modules/storage/web/dimensions.html.heex:145
 #: lib/modules/storage/web/dimensions.html.heex:341
@@ -3020,92 +3020,92 @@ msgstr ""
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:553
 #, elixir-autogen, elixir-format
 msgid "Name"
-msgstr ""
+msgstr "Nimi"
 
 #: lib/phoenix_kit_web/live/settings/users.html.heex:205
 #, elixir-autogen, elixir-format
 msgid "New User Default Role"
-msgstr ""
+msgstr "Uue kasutaja vaikimisi roll"
 
 #: lib/phoenix_kit_web/live/settings/users.html.heex:267
 #, elixir-autogen, elixir-format
 msgid "New User Default Status"
-msgstr ""
+msgstr "Uue kasutaja vaikimisi olek"
 
 #: lib/phoenix_kit_web/live/settings/users.html.heex:315
 #, elixir-autogen, elixir-format
 msgid "New users will be created as inactive and will not be able to log in until an admin activates their account."
-msgstr ""
+msgstr "Uued kasutajad luuakse mitteaktiivsena ja nad ei saa sisse logida, kuni administraator aktiveerib nende konto."
 
 #: lib/modules/storage/web/settings.html.heex:375
 #, elixir-autogen, elixir-format
 msgid "No active buckets available. Enable buckets to configure redundancy."
-msgstr ""
+msgstr "Aktiivseid buckete pole saadaval. Luba bucketid redundantsuse konfigureerimiseks."
 
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:246
 #, elixir-autogen, elixir-format
 msgid "No active sessions found."
-msgstr ""
+msgstr "Aktiivseid seansse ei leitud."
 
 #: lib/modules/storage/web/settings.html.heex:471
 #, elixir-autogen, elixir-format
 msgid "No changes to apply"
-msgstr ""
+msgstr "Pole muudatusi rakendamiseks"
 
 #: lib/phoenix_kit_web/live/settings/users.html.heex:346
 #, elixir-autogen, elixir-format
 msgid "No custom fields defined yet"
-msgstr ""
+msgstr "Kohandatud väljad pole veel määratud"
 
 #: lib/modules/storage/web/dimensions.html.heex:54
 #, elixir-autogen, elixir-format
 msgid "No dimensions configured"
-msgstr ""
+msgstr "Dimensioonid pole konfigureeritud"
 
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:248
 #, elixir-autogen, elixir-format
 msgid "No sessions match your current filters."
-msgstr ""
+msgstr "Ükski seanss ei vasta teie praegustele filtritele."
 
 #: lib/phoenix_kit_web/live/settings/seo.html.heex:28
 #, elixir-autogen, elixir-format
 msgid "Noindex · Nofollow"
-msgstr ""
+msgstr "Noindex · Nofollow"
 
 #: lib/modules/storage/web/settings.html.heex:341
 #, elixir-autogen, elixir-format, fuzzy
 msgid "None"
-msgstr ""
+msgstr "Puudub"
 
 #: lib/phoenix_kit_web/components/core/flash.ex:95
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Note"
-msgstr ""
+msgstr "Märkus"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:1023
 #, elixir-autogen, elixir-format
 msgid "Note: OAuth providers require ueberauth dependencies to be installed."
-msgstr ""
+msgstr "Märkus: OAuth teenusepakkujad vajavad ueberauth sõltuvuste paigaldamist."
 
 #: lib/modules/storage/web/settings.html.heex:368
 #, elixir-autogen, elixir-format
 msgid "Number of copies to store"
-msgstr ""
+msgstr "Salvestatavate koopiate arv"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:275
 #, elixir-autogen, elixir-format, fuzzy
 msgid "OAuth Providers"
-msgstr ""
+msgstr "OAuth teenusepakkujad"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:1016
 #, elixir-autogen, elixir-format
 msgid "OAuth Setup Instructions"
-msgstr ""
+msgstr "OAuth seadistamisjuhised"
 
 #: lib/modules/storage/web/settings.html.heex:400
 #, elixir-autogen, elixir-format
 msgid "Only 1 active bucket available. Add more buckets to enable redundancy."
-msgstr ""
+msgstr "Ainult 1 aktiivne bucket saadaval. Lisa rohkem buckete redundantsuse lubamiseks."
 
 #: lib/modules/storage/web/dimensions.html.heex:127
 #: lib/modules/storage/web/dimensions.html.heex:187
@@ -3113,114 +3113,114 @@ msgstr ""
 #: lib/modules/storage/web/dimensions.html.heex:387
 #, elixir-autogen, elixir-format
 msgid "Original"
-msgstr ""
+msgstr "Originaal"
 
 #: lib/phoenix_kit_web/live/settings/users.html.heex:538
 #, elixir-autogen, elixir-format
 msgid "Phone Number"
-msgstr ""
+msgstr "Telefoninumber"
 
 #: lib/modules/storage/web/settings.html.heex:573
 #, elixir-autogen, elixir-format
 msgid "PostgreSQL-based file registry with location tracking"
-msgstr ""
+msgstr "PostgreSQL-põhine failiregister asukoha jälgimisega"
 
 #: lib/modules/storage/web/dimension_form.html.heex:173
 #, elixir-autogen, elixir-format
 msgid "Preserve original"
-msgstr ""
+msgstr "Säilita originaal"
 
 #: lib/phoenix_kit_web/live/settings/users.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "Privacy Notice: IP Geolocation Data"
-msgstr ""
+msgstr "Privaatsusteade: IP geolokatsiooniandmed"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:577
 #, elixir-autogen, elixir-format
 msgid "Private Key"
-msgstr ""
+msgstr "Privaatvõti"
 
 #: lib/phoenix_kit_web/live/settings.html.heex:56
 #, elixir-autogen, elixir-format
 msgid "Project Title"
-msgstr ""
+msgstr "Projekti pealkiri"
 
 #: lib/modules/storage/web/dimension_form.html.heex:139
 #: lib/modules/storage/web/dimensions.html.heex:123
 #: lib/modules/storage/web/dimensions.html.heex:148
 #, elixir-autogen, elixir-format
 msgid "Quality"
-msgstr ""
+msgstr "Kvaliteet"
 
 #: lib/modules/storage/web/dimension_form.html.heex:137
 #: lib/modules/storage/web/dimensions.html.heex:326
 #: lib/modules/storage/web/dimensions.html.heex:347
 #, elixir-autogen, elixir-format
 msgid "Quality (CRF)"
-msgstr ""
+msgstr "Kvaliteet (CRF)"
 
 #: lib/modules/storage/web/dimensions.html.heex:489
 #, elixir-autogen, elixir-format
 msgid "Quality Settings:"
-msgstr ""
+msgstr "Kvaliteedi seaded:"
 
 #: lib/modules/storage/web/settings.html.heex:168
 #: lib/modules/storage/web/settings.html.heex:228
 #, elixir-autogen, elixir-format
 msgid "Random"
-msgstr ""
+msgstr "Juhuslik"
 
 #: lib/modules/storage/web/settings.html.heex:383
 #, elixir-autogen, elixir-format
 msgid "Reduce redundancy or enable more buckets."
-msgstr ""
+msgstr "Vähenda redundantsust või luba rohkem buckete."
 
 #: lib/modules/storage/web/settings.html.heex:366
 #, elixir-autogen, elixir-format
 msgid "Redundancy Copies"
-msgstr ""
+msgstr "Redundantsuse koopiad"
 
 #: lib/phoenix_kit_web/live/settings/users.html.heex:70
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration Settings"
-msgstr ""
+msgstr "Registreerimise seaded"
 
 #: lib/phoenix_kit_web/live/settings/users.html.heex:138
 #: lib/phoenix_kit_web/live/settings/users.html.heex:163
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration:"
-msgstr ""
+msgstr "Registreerimine:"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:1038
 #, elixir-autogen, elixir-format
 msgid "Reload OAuth Configuration"
-msgstr ""
+msgstr "Laadi OAuth konfiguratsioon uuesti"
 
 #: lib/modules/storage/web/settings.html.heex:545
 #, elixir-autogen, elixir-format
 msgid "Remote Servers"
-msgstr ""
+msgstr "Kaugserverid"
 
 #: lib/phoenix_kit_web/live/settings/users.html.heex:576
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Required field"
-msgstr ""
+msgstr "Kohustuslik väli"
 
 #: lib/phoenix_kit_web/live/settings.html.heex:481
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Reset"
-msgstr ""
+msgstr "Lähtesta"
 
 #: lib/modules/storage/web/dimensions.html.heex:41
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Reset to Defaults"
-msgstr ""
+msgstr "Lähtesta vaikimisi seadetele"
 
 #: lib/modules/storage/web/dimensions.html.heex:311
 #: lib/modules/storage/web/dimensions.html.heex:343
 #, elixir-autogen, elixir-format
 msgid "Resolution"
-msgstr ""
+msgstr "Resolutsioon"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:508
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:690
@@ -3228,43 +3228,43 @@ msgstr ""
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:995
 #, elixir-autogen, elixir-format
 msgid "Reverse Proxy Users:"
-msgstr ""
+msgstr "Pöördproxy kasutajad:"
 
 #: lib/phoenix_kit_web/live/settings/seo.html.heex:26
 #, elixir-autogen, elixir-format
 msgid "Robots Directive"
-msgstr ""
+msgstr "Robotite direktiiv"
 
 #: lib/phoenix_kit_web/live/users/roles.html.heex:126
 #: lib/phoenix_kit_web/live/users/roles.html.heex:205
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Role actions"
-msgstr ""
+msgstr "Rolli tegevused"
 
 #: lib/phoenix_kit_web/live/settings/users.html.heex:208
 #, elixir-autogen, elixir-format
 msgid "Role assigned to new user registrations"
-msgstr ""
+msgstr "Roll määratud uutele kasutajate registreerimistele"
 
 #: lib/phoenix_kit_web/live/settings/seo.html.heex:12
 #, elixir-autogen, elixir-format, fuzzy
 msgid "SEO Settings"
-msgstr ""
+msgstr "SEO seaded"
 
 #: lib/phoenix_kit_web/live/settings.html.heex:472
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Save All Settings"
-msgstr ""
+msgstr "Salvesta kõik seaded"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:1056
 #, elixir-autogen, elixir-format
 msgid "Save Authorization Settings"
-msgstr ""
+msgstr "Salvesta volitamise seaded"
 
 #: lib/phoenix_kit_web/live/settings/users.html.heex:490
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Save User Settings"
-msgstr ""
+msgstr "Salvesta kasutaja seaded"
 
 #: lib/phoenix_kit_web/live/settings.html.heex:76
 #: lib/phoenix_kit_web/live/settings.html.heex:79
@@ -3285,32 +3285,32 @@ msgstr ""
 #: lib/phoenix_kit_web/live/settings/users.html.heex:298
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Saved:"
-msgstr ""
+msgstr "Salvestatud:"
 
 #: lib/phoenix_kit_web/live/settings/seo.html.heex:65
 #, elixir-autogen, elixir-format
 msgid "Search engines are instructed to skip this environment. Remove this before launch."
-msgstr ""
+msgstr "Otsingumootorid on juhendatud seda keskkonda vahele jätma. Eemalda see enne käivitamist."
 
 #: lib/modules/storage/web/bucket_form.html.heex:265
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Secret Access Key"
-msgstr ""
+msgstr "Saladuse juurdepääsuvõti"
 
 #: lib/phoenix_kit_web/live/settings/users.html.heex:312
 #, elixir-autogen, elixir-format
 msgid "Security Notice: Inactive Default"
-msgstr ""
+msgstr "Turvahoiatus: vaikimisi mitteaktiivne"
 
 #: lib/phoenix_kit_web/live/settings/users.html.heex:250
 #, elixir-autogen, elixir-format
 msgid "Security Notice: Medium Risk"
-msgstr ""
+msgstr "Turvahoiatus: keskmine risk"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:484
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select"
-msgstr ""
+msgstr "Vali"
 
 #: lib/phoenix_kit_web/live/settings.html.heex:118
 #: lib/phoenix_kit_web/live/settings.html.heex:185
@@ -3318,12 +3318,12 @@ msgstr ""
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:177
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select Image"
-msgstr ""
+msgstr "Vali pilt"
 
 #: lib/modules/storage/web/bucket_form.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "Select provider..."
-msgstr ""
+msgstr "Vali teenusepakkuja..."
 
 #: lib/phoenix_kit_web/live/settings.html.heex:73
 #: lib/phoenix_kit_web/live/settings.html.heex:273
@@ -3335,23 +3335,23 @@ msgstr ""
 #: lib/phoenix_kit_web/live/settings/users.html.heex:286
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Selected:"
-msgstr ""
+msgstr "Valitud:"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:670
 #, elixir-autogen, elixir-format
 msgid "Services ID"
-msgstr ""
+msgstr "Teenuste ID"
 
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:212
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:308
 #, elixir-autogen, elixir-format
 msgid "Session actions"
-msgstr ""
+msgstr "Seansi tegevused"
 
 #: lib/modules/storage/web/settings.html.heex:339
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Set"
-msgstr ""
+msgstr "Määra"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:430
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:600
@@ -3360,78 +3360,78 @@ msgstr ""
 #: lib/phoenix_kit_web/live/settings/integration_form.html.heex:394
 #, elixir-autogen, elixir-format
 msgid "Setup Instructions"
-msgstr ""
+msgstr "Seadistusjuhised"
 
 #: lib/phoenix_kit_web/live/settings/users.html.heex:116
 #, elixir-autogen, elixir-format
 msgid "Show username field on registration"
-msgstr ""
+msgstr "Näita kasutajanime välja registreerimisel"
 
 #: lib/phoenix_kit_web/live/settings.html.heex:258
 #, elixir-autogen, elixir-format
 msgid "Site Address (URL)"
-msgstr ""
+msgstr "Saidi aadress (URL)"
 
 #: lib/modules/storage/web/settings.html.heex:491
 #, elixir-autogen, elixir-format
 msgid "Soon"
-msgstr ""
+msgstr "Varsti"
 
 #: lib/modules/storage/web/bucket_form.html.heex:117
 #, elixir-autogen, elixir-format
 msgid "Storage Path"
-msgstr ""
+msgstr "Salvestustee"
 
 #: lib/modules/storage/web/bucket_form.html.heex:42
 #: lib/modules/storage/web/bucket_form.html.heex:83
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Storage Provider"
-msgstr ""
+msgstr "Salvestuspakkuja"
 
 #: lib/modules/storage/web/settings.html.heex:521
 #, elixir-autogen, elixir-format
 msgid "Store files across 1-5 redundant locations with automatic failover"
-msgstr ""
+msgstr "Salvesta failid 1-5 redundantses asukohas automaatse tõrkesiirdega"
 
 #: lib/modules/storage/web/settings.html.heex:534
 #, elixir-autogen, elixir-format
 msgid "Store files in Amazon S3 buckets for cloud redundancy"
-msgstr ""
+msgstr "Salvesta failid Amazon S3 bucketites pilveredundantsuse jaoks"
 
 #: lib/phoenix_kit_web/components/core/flash.ex:94
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Success!"
-msgstr ""
+msgstr "Õnnestus!"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:975
 #, elixir-autogen, elixir-format
 msgid "Switch app from"
-msgstr ""
+msgstr "Vaheta rakendus"
 
 #: lib/modules/storage/web/settings.html.heex:498
 #, elixir-autogen, elixir-format
 msgid "Sync Files"
-msgstr ""
+msgstr "Sünkrooni failid"
 
 #: lib/phoenix_kit_web/live/settings.html.heex:20
 #, elixir-autogen, elixir-format, fuzzy
 msgid "System Configuration"
-msgstr ""
+msgstr "Süsteemi konfiguratsioon"
 
 #: lib/phoenix_kit_web/live/settings.html.heex:338
 #, elixir-autogen, elixir-format
 msgid "System default timezone"
-msgstr ""
+msgstr "Süsteemi vaikimisi ajavöönd"
 
 #: lib/modules/storage/web/dimension_form.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Target Width (px)"
-msgstr ""
+msgstr "Sihilaius (px)"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:551
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Team ID"
-msgstr ""
+msgstr "Meeskonna ID"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:423
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:593
@@ -3439,127 +3439,127 @@ msgstr ""
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:898
 #, elixir-autogen, elixir-format
 msgid "Test Credentials"
-msgstr ""
+msgstr "Testi mandaate"
 
 #: lib/phoenix_kit_web/live/settings/users.html.heex:318
 #, elixir-autogen, elixir-format
 msgid "The first user (Owner) will always be active regardless of this setting."
-msgstr ""
+msgstr "Esimene kasutaja (Omanik) on alati aktiivne, sõltumata sellest seadest."
 
 #: lib/modules/storage/web/dimensions.html.heex:27
 #, elixir-autogen, elixir-format
 msgid "The migration seeds 8 default dimensions: 4 image sizes (thumbnail, small, medium, large) and 4 video variants (360p, 720p, 1080p, video_thumbnail)."
-msgstr ""
+msgstr "Migratsioon loob 8 vaikimisi dimensiooni: 4 pildi suurust (pisipilt, väike, keskmine, suur) ja 4 videovarianti (360p, 720p, 1080p, video_thumbnail)."
 
 #: lib/modules/storage/web/bucket_form.html.heex:410
 #, elixir-autogen, elixir-format
 msgid "The storage path"
-msgstr ""
+msgstr "Salvestustee"
 
 #: lib/modules/storage/web/settings.html.heex:41
 #, elixir-autogen, elixir-format
 msgid "This will NOT delete any uploaded files."
-msgstr ""
+msgstr "See EI kustuta üleslaaditud faile."
 
 #: lib/modules/storage/web/settings.html.heex:47
 #, elixir-autogen, elixir-format
 msgid "This will reset dimensions and settings to defaults, and create a local bucket if none exist. Your uploaded files will NOT be deleted. Continue?"
-msgstr ""
+msgstr "See lähtestab dimensioonid ja seaded vaikimisi väärtustele ning loob kohaliku bucketi, kui ühtegi pole. Teie üleslaaditud faile EI kustutata. Jätkata?"
 
 #: lib/phoenix_kit_web/live/settings.html.heex:420
 #, elixir-autogen, elixir-format
 msgid "Time Format"
-msgstr ""
+msgstr "Kellaaja vorming"
 
 #: lib/phoenix_kit_web/live/settings.html.heex:336
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Time Zone"
-msgstr ""
+msgstr "Ajavöönd"
 
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:180
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:233
 #, elixir-autogen, elixir-format
 msgid "Token"
-msgstr ""
+msgstr "Token"
 
 #: lib/modules/storage/web/settings.html.heex:322
 #: lib/phoenix_kit_web/live/modules.html.heex:65
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Total Buckets"
-msgstr ""
+msgstr "Buckete kokku"
 
 #: lib/phoenix_kit_web/live/settings/users.html.heex:101
 #, elixir-autogen, elixir-format
 msgid "Track user registration location"
-msgstr ""
+msgstr "Jälgi kasutaja registreerimise asukohta"
 
 #: lib/phoenix_kit_web/live/settings/users.html.heex:661
 #, elixir-autogen, elixir-format
 msgid "Type an option and press Enter or click Add"
-msgstr ""
+msgstr "Sisesta valik ja vajuta Enter või klõpsa Lisa"
 
 ## Navigation menu items
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:232
 #: lib/phoenix_kit_web/users/user_form.html.heex:739
 #, elixir-autogen, elixir-format, fuzzy
 msgid "User"
-msgstr ""
+msgstr "Kasutaja"
 
 #: lib/phoenix_kit_web/live/settings/users.html.heex:368
 #, elixir-autogen, elixir-format
 msgid "User Access"
-msgstr ""
+msgstr "Kasutaja juurdepääs"
 
 #: lib/phoenix_kit_web/live/settings/users.html.heex:21
 #, elixir-autogen, elixir-format
 msgid "User Configuration"
-msgstr ""
+msgstr "Kasutaja konfiguratsioon"
 
 #: lib/phoenix_kit_web/live/settings/users.html.heex:406
 #, elixir-autogen, elixir-format
 msgid "User Editable"
-msgstr ""
+msgstr "Kasutaja muudetav"
 
 #: lib/phoenix_kit_web/live/settings/users.html.heex:12
 #, elixir-autogen, elixir-format, fuzzy
 msgid "User Settings"
-msgstr ""
+msgstr "Kasutaja seaded"
 
 #: lib/phoenix_kit_web/live/users/users.html.heex:358
 #: lib/phoenix_kit_web/live/users/users.html.heex:460
 #, elixir-autogen, elixir-format
 msgid "User actions"
-msgstr ""
+msgstr "Kasutaja tegevused"
 
 #: lib/phoenix_kit_web/live/settings/users.html.heex:599
 #, elixir-autogen, elixir-format
 msgid "User can edit this field"
-msgstr ""
+msgstr "Kasutaja saab seda välja muuta"
 
 #: lib/phoenix_kit_web/live/settings/users.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Uses free APIs: IP-API.com (45 requests/minute) with ipapi.co (1000 requests/day) fallback. Defaults to OFF for privacy."
-msgstr ""
+msgstr "Kasutab tasuta API-sid: IP-API.com (45 päringut/minutis) tagavaraga ipapi.co (1000 päringut/päevas). Privaatsuse tagamiseks vaikimisi VÄLJAS."
 
 #: lib/modules/storage/web/dimensions.html.heex:487
 #, elixir-autogen, elixir-format
 msgid "Variant Generation System"
-msgstr ""
+msgstr "Variantide genereerimise süsteem"
 
 #: lib/modules/storage/web/dimensions.html.heex:284
 #, elixir-autogen, elixir-format
 msgid "Video Dimensions"
-msgstr ""
+msgstr "Video dimensioonid"
 
 #: lib/modules/storage/web/dimensions.html.heex:491
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Video Settings:"
-msgstr ""
+msgstr "Video seaded:"
 
 #: lib/modules/storage/web/dimensions.html.heex:492
 #, elixir-autogen, elixir-format
 msgid "Videos use CRF 0-51 scale (lower = higher quality)"
-msgstr ""
+msgstr "Videod kasutavad CRF 0-51 skaalat (madalam = parem kvaliteet)"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:468
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:638
@@ -3567,87 +3567,87 @@ msgstr ""
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:943
 #, elixir-autogen, elixir-format
 msgid "Visit"
-msgstr ""
+msgstr "Külasta"
 
 #: lib/phoenix_kit_web/live/settings.html.heex:294
 #, elixir-autogen, elixir-format
 msgid "Week Start On"
-msgstr ""
+msgstr "Nädal algab"
 
 #: lib/modules/storage/web/settings.html.heex:609
 #, elixir-autogen, elixir-format
 msgid "When a file is requested, the system automatically tries each location until it successfully retrieves the file."
-msgstr ""
+msgstr "Kui failile pääseb juurde, proovib süsteem automaatselt iga asukohta, kuni fail on edukalt kätte saadud."
 
 #: lib/phoenix_kit_web/live/settings/users.html.heex:603
 #, elixir-autogen, elixir-format
 msgid "When checked, users can view and edit this field on their settings page. When unchecked, only admins can edit it."
-msgstr ""
+msgstr "Kui märgitud, saavad kasutajad seda välja oma seadete lehel vaadata ja muuta. Kui märgimata, saavad seda muuta ainult administraatorid."
 
 #: lib/phoenix_kit_web/live/settings/users.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "When enabled, registration IP addresses and approximate location data (country, region, city) will be collected for analytics."
-msgstr ""
+msgstr "Kui lubatud, kogutakse analüütika jaoks registreerimise IP-aadressid ja ligikaudsed asukohaandmed (riik, piirkond, linn)."
 
 #: lib/modules/storage/web/dimension_form.html.heex:87
 #, elixir-autogen, elixir-format
 msgid "Width (px)"
-msgstr ""
+msgstr "Laius (px)"
 
 #: lib/modules/storage/web/settings.html.heex:67
 #, elixir-autogen, elixir-format
 msgid "Without it, image resizing, cropping, and format conversion will not work."
-msgstr ""
+msgstr "Ilma selleta ei tööta piltide suuruse muutmine, kärpimine ega vorminguteisendamine."
 
 #: lib/modules/storage/web/settings.html.heex:95
 #, elixir-autogen, elixir-format
 msgid "Without it, video file processing will not work."
-msgstr ""
+msgstr "Ilma selleta ei tööta videofailide töötlemine."
 
 #: lib/modules/storage/web/bucket_form.html.heex:413
 #, elixir-autogen, elixir-format
 msgid "Would you like to create it now?"
-msgstr ""
+msgstr "Kas soovid selle nüüd luua?"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:570
 #, elixir-autogen, elixir-format
 msgid "Your Apple Key ID"
-msgstr ""
+msgstr "Teie Apple võtme ID"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:557
 #, elixir-autogen, elixir-format
 msgid "Your Apple Team ID"
-msgstr ""
+msgstr "Teie Apple meeskonna ID"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:874
 #, elixir-autogen, elixir-format
 msgid "Your Facebook App ID"
-msgstr ""
+msgstr "Teie Facebook rakenduse ID"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:887
 #, elixir-autogen, elixir-format
 msgid "Your Facebook App Secret"
-msgstr ""
+msgstr "Teie Facebook rakenduse saladus"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:726
 #, elixir-autogen, elixir-format
 msgid "Your GitHub OAuth Client ID"
-msgstr ""
+msgstr "Teie GitHub OAuth kliendi ID"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:739
 #, elixir-autogen, elixir-format
 msgid "Your GitHub OAuth Client Secret"
-msgstr ""
+msgstr "Teie GitHub OAuth kliendi saladus"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:399
 #, elixir-autogen, elixir-format
 msgid "Your Google OAuth Client ID"
-msgstr ""
+msgstr "Teie Google OAuth kliendi ID"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:412
 #, elixir-autogen, elixir-format
 msgid "Your Google OAuth Client Secret"
-msgstr ""
+msgstr "Teie Google OAuth kliendi saladus"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:670
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:810
@@ -3655,42 +3655,42 @@ msgstr ""
 #: lib/phoenix_kit_web/live/settings/integrations.ex:151
 #, elixir-autogen, elixir-format, fuzzy
 msgid "and"
-msgstr ""
+msgstr "ja"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:821
 #, elixir-autogen, elixir-format
 msgid "and generate/copy"
-msgstr ""
+msgstr "ja genereeri/kopeeri"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:650
 #, elixir-autogen, elixir-format
 msgid "capability"
-msgstr ""
+msgstr "võimekus"
 
 #: lib/modules/storage/web/bucket_form.html.heex:411
 #, elixir-autogen, elixir-format, fuzzy
 msgid "does not exist."
-msgstr ""
+msgstr "ei eksisteeri."
 
 #: lib/modules/storage/web/dimension_form.html.heex:34
 #, elixir-autogen, elixir-format
 msgid "e.g., thumbnail, medium, 720p"
-msgstr ""
+msgstr "nt pisipilt, keskmine, 720p"
 
 #: lib/modules/storage/web/settings.html.heex:235
 #, elixir-autogen, elixir-format, fuzzy
 msgid "files"
-msgstr ""
+msgstr "faili"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:658
 #, elixir-autogen, elixir-format
 msgid "for the Services ID"
-msgstr ""
+msgstr "teenuste ID jaoks"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:654
 #, elixir-autogen, elixir-format
 msgid "for web authentication"
-msgstr ""
+msgstr "veebi autentimiseks"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:514
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:696
@@ -3698,38 +3698,38 @@ msgstr ""
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:1001
 #, elixir-autogen, elixir-format
 msgid "header is set to"
-msgstr ""
+msgstr "päis on seatud"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:977
 #, elixir-autogen, elixir-format, fuzzy
 msgid "mode"
-msgstr ""
+msgstr "režiim"
 
 #: lib/phoenix_kit_web/live/settings/users.html.heex:616
 #, elixir-autogen, elixir-format, fuzzy
 msgid "option(s)"
-msgstr ""
+msgstr "valik(ud)"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:956
 #, elixir-autogen, elixir-format
 msgid "product"
-msgstr ""
+msgstr "toode"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:976
 #, elixir-autogen, elixir-format
 msgid "to"
-msgstr ""
+msgstr "aadressile"
 
 #: lib/phoenix_kit_web/live/settings/seo.html.heex:34
 #, elixir-autogen, elixir-format
 msgid "to every PhoenixKit layout, blocking crawlers from indexing or following links."
-msgstr ""
+msgstr "igale PhoenixKiti paigutusele, blokeerides roomajad indekseerimisest ja linkide jälgimisest."
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:672
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:972
 #, elixir-autogen, elixir-format
 msgid "to fields above"
-msgstr ""
+msgstr "ülal olevatesse väljadesse"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:494
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:676
@@ -3737,257 +3737,257 @@ msgstr ""
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:981
 #, elixir-autogen, elixir-format
 msgid "to verify setup"
-msgstr ""
+msgstr "konfiguratsiooni kontrollimiseks"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:485
 #, elixir-autogen, elixir-format, fuzzy
 msgid "type"
-msgstr ""
+msgstr "tüüp"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:665
 #, elixir-autogen, elixir-format
 msgid "with Sign in with Apple enabled"
-msgstr ""
+msgstr "Apple sisselogimisega lubatud"
 
 #: lib/phoenix_kit_web/live/users/roles.html.heex:100
 #, elixir-autogen, elixir-format
 msgid "—"
-msgstr ""
+msgstr "—"
 
 #: lib/phoenix_kit_web/live/settings.html.heex:505
 #, elixir-autogen, elixir-format
 msgid "• Changes show \"Selected\" vs \"Saved\" values until you click Save"
-msgstr ""
+msgstr "• Muudatused näitavad \"Valitud\" vs \"Salvestatud\" väärtusi kuni klõpsate Salvesta"
 
 #: lib/phoenix_kit_web/live/settings.html.heex:534
 #, elixir-autogen, elixir-format
 msgid "• Currently supports 6 date formats including \"September 2, 2025\" style"
-msgstr ""
+msgstr "• Toetab praegu 6 kuupäevavormingut, sealhulgas \"September 2, 2025\" stiil"
 
 #: lib/phoenix_kit_web/live/settings.html.heex:523
 #, elixir-autogen, elixir-format
 msgid "• Date formats control how dates appear (e.g. Users dashboard \"Registered\" field)"
-msgstr ""
+msgstr "• Kuupäevavormingud juhivad kuupäevade kuvamist (nt kasutajate töölaua \"Registreeritud\" väli)"
 
 #: lib/phoenix_kit_web/live/settings.html.heex:500
 #, elixir-autogen, elixir-format
 msgid "• Make changes to dropdowns and click \"Save All Settings\" to apply"
-msgstr ""
+msgstr "• Tehke muudatused ripploendites ja klõpsake \"Salvesta kõik seaded\" rakendamiseks"
 
 #: lib/phoenix_kit_web/live/settings.html.heex:529
 #, elixir-autogen, elixir-format
 msgid "• Settings are applied system-wide and use Timex for robust formatting"
-msgstr ""
+msgstr "• Seadeid rakendatakse kogu süsteemis ja kasutatakse Timexi tugevaks vormindamiseks"
 
 #: lib/phoenix_kit_web/live/settings.html.heex:527
 #, elixir-autogen, elixir-format
 msgid "• Time formats control 12-hour vs 24-hour time display"
-msgstr ""
+msgstr "• Kellaajavorming kontrollib 12-tunnist vs 24-tunnist ajakuvamist"
 
 #: lib/phoenix_kit_web/live/settings.html.heex:520
 #, elixir-autogen, elixir-format
 msgid "• Time zone affects date/time display throughout the system"
-msgstr ""
+msgstr "• Ajavöönd mõjutab kuupäeva/kellaaja kuvamist kogu süsteemis"
 
 #: lib/phoenix_kit_web/live/settings.html.heex:510
 #, elixir-autogen, elixir-format
 msgid "• User settings (registration, defaults, custom fields) are managed separately"
-msgstr ""
+msgstr "• Kasutaja seadeid (registreerimine, vaikimisi seaded, kohandatud väljad) hallatakse eraldi"
 
 #: lib/phoenix_kit_web/live/settings.html.heex:515
 #, elixir-autogen, elixir-format
 msgid "• Week start day controls which day begins the week (useful for calendar features)"
-msgstr ""
+msgstr "• Nädala alguspäev kontrollib, milline päev alustab nädalat (kasulik kalenderifunktsioonide jaoks)"
 
 #: lib/phoenix_kit_web/legal_gettext_manifest.ex:46
 #, elixir-autogen, elixir-format
 msgid "Acceptable Use Policy"
-msgstr ""
+msgstr "Vastuvõetava kasutuse poliitika"
 
 #: lib/phoenix_kit_web/legal_gettext_manifest.ex:48
 #, elixir-autogen, elixir-format
 msgid "Analytics"
-msgstr ""
+msgstr "Analüütika"
 
 #: lib/phoenix_kit_web/legal_gettext_manifest.ex:49
 #, elixir-autogen, elixir-format
 msgid "CCPA Notice at Collection"
-msgstr ""
+msgstr "CCPA teade kogumisel"
 
 #: lib/phoenix_kit_web/legal_gettext_manifest.ex:59
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Data Retention Policy"
-msgstr ""
+msgstr "Andmete säilitamise poliitika"
 
 #: lib/phoenix_kit_web/legal_gettext_manifest.ex:60
 #, elixir-autogen, elixir-format
 msgid "Do Not Sell My Personal Information"
-msgstr ""
+msgstr "Ärge müüge minu isikuandmeid"
 
 #: lib/phoenix_kit_web/legal_gettext_manifest.ex:62
 #, elixir-autogen, elixir-format
 msgid "Essential"
-msgstr ""
+msgstr "Oluline"
 
 #: lib/phoenix_kit_web/legal_gettext_manifest.ex:72
 #, elixir-autogen, elixir-format
 msgid "Help us understand how you use our site to improve your experience."
-msgstr ""
+msgstr "Aidake meil mõista, kuidas kasutate meie saiti, et parandada teie kogemust."
 
 #: lib/phoenix_kit_web/legal_gettext_manifest.ex:75
 #, elixir-autogen, elixir-format
 msgid "Legal pages reset successfully. You can now regenerate them."
-msgstr ""
+msgstr "Juriidilised lehed lähtestati edukalt. Saate need nüüd uuesti genereerida."
 
 #: lib/phoenix_kit_web/legal_gettext_manifest.ex:78
 #, elixir-autogen, elixir-format
 msgid "No issues detected — reset not needed"
-msgstr ""
+msgstr "Probleeme ei tuvastatud — lähtestamine pole vajalik"
 
 #: lib/phoenix_kit_web/legal_gettext_manifest.ex:81
 #, elixir-autogen, elixir-format
 msgid "Preferences"
-msgstr ""
+msgstr "Eelistused"
 
 #: lib/phoenix_kit_web/legal_gettext_manifest.ex:82
 #, elixir-autogen, elixir-format
 msgid "Privacy Policy"
-msgstr ""
+msgstr "Privaatsuspoliitika"
 
 #: lib/phoenix_kit_web/legal_gettext_manifest.ex:86
 #, elixir-autogen, elixir-format
 msgid "Remember your settings like language and region preferences."
-msgstr ""
+msgstr "Meeldejätmine teie seadetest, nagu keele- ja piirkondlikud eelistused."
 
 #: lib/phoenix_kit_web/legal_gettext_manifest.ex:88
 #, elixir-autogen, elixir-format
 msgid "Required for core functionality. These cannot be disabled."
-msgstr ""
+msgstr "Vajalik põhifunktsionaalsuse jaoks. Neid ei saa keelata."
 
 #: lib/phoenix_kit_web/legal_gettext_manifest.ex:89
 #, elixir-autogen, elixir-format
 msgid "Reset failed: %{reason}"
-msgstr ""
+msgstr "Lähtestamine ebaõnnestus: %{reason}"
 
 #: lib/phoenix_kit_web/legal_gettext_manifest.ex:91
 #, elixir-autogen, elixir-format
 msgid "Terms of Service"
-msgstr ""
+msgstr "Teenuse tingimused"
 
 #: lib/phoenix_kit_web/legal_gettext_manifest.ex:92
 #, elixir-autogen, elixir-format
 msgid "Used for personalized advertising and measuring ad effectiveness."
-msgstr ""
+msgstr "Kasutatakse personaliseeritud reklaami ja reklaamiefektiivsuse mõõtmiseks."
 
 #: lib/modules/storage/web/health.html.heex:34
 #, elixir-autogen, elixir-format
 msgid "%{count}+ locations each"
-msgstr ""
+msgstr "%{count}+ asukoha igaüks"
 
 #: lib/phoenix_kit_web/components/language_switcher.ex:805
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{language} (Disabled — %{status})"
-msgstr ""
+msgstr "%{language} (Keelatud — %{status})"
 
 #: lib/modules/storage/web/health.html.heex:158
 #, elixir-autogen, elixir-format
 msgid "%{n} errors"
-msgstr ""
+msgstr "%{n} viga"
 
 #: lib/modules/storage/web/health.html.heex:122
 #, elixir-autogen, elixir-format
 msgid "%{n} failed"
-msgstr ""
+msgstr "%{n} ebaõnnestus"
 
 #: lib/modules/storage/web/health.html.heex:120
 #, elixir-autogen, elixir-format
 msgid "%{n} synced"
-msgstr ""
+msgstr "%{n} sünkroonitud"
 
 #: lib/modules/storage/web/bucket_form.html.heex:356
 #, elixir-autogen, elixir-format
 msgid "0 = auto, 1+ = higher priority"
-msgstr ""
+msgstr "0 = automaatne, 1+ = kõrgem prioriteet"
 
 #: lib/modules/storage/web/dimension_form.html.heex:157
 #, elixir-autogen, elixir-format
 msgid "1-100, higher = better quality. 80-90 recommended."
-msgstr ""
+msgstr "1-100, kõrgem = parem kvaliteet. 80-90 on soovituslik."
 
 #: lib/modules/storage/web/bucket_form.html.heex:35
 #, elixir-autogen, elixir-format
 msgid "A friendly name to identify this storage location"
-msgstr ""
+msgstr "Sõbralik nimi selle salvestuskoha tuvastamiseks"
 
 #: lib/modules/storage/web/dimension_form.html.heex:39
 #, elixir-autogen, elixir-format
 msgid "A unique name to identify this dimension preset"
-msgstr ""
+msgstr "Unikaalne nimi selle dimensioonipreset'i tuvastamiseks"
 
 #: lib/phoenix_kit/integrations/providers.ex:211
 #, elixir-autogen, elixir-format
 msgid "AI model access via OpenRouter (100+ models)"
-msgstr ""
+msgstr "Juurdepääs AI mudelitele OpenRouteri kaudu (100+ mudelit)"
 
 #: lib/phoenix_kit_web/live/settings/integration_form.html.heex:184
 #, elixir-autogen, elixir-format
 msgid "API Credentials"
-msgstr ""
+msgstr "API mandaadid"
 
 #: lib/phoenix_kit/integrations/providers.ex:224
 #: lib/phoenix_kit/integrations/providers.ex:277
 #: lib/phoenix_kit/integrations/providers.ex:338
 #, elixir-autogen, elixir-format
 msgid "API Key"
-msgstr ""
+msgstr "API võti"
 
 #: lib/modules/storage/web/bucket_form.html.heex:194
 #, elixir-autogen, elixir-format, fuzzy
 msgid "AWS Bucket Name"
-msgstr ""
+msgstr "AWS bucketi nimi"
 
 #: lib/modules/storage/web/bucket_form.html.heex:148
 #, elixir-autogen, elixir-format, fuzzy
 msgid "AWS Region"
-msgstr ""
+msgstr "AWS piirkond"
 
 #: lib/modules/storage/web/bucket_form.html.heex:127
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Absolute path where files will be stored on disk"
-msgstr ""
+msgstr "Absoluutne tee, kuhu failid kettale salvestatakse"
 
 #: lib/phoenix_kit_web/components/invitation_banner.ex:53
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Accept"
-msgstr ""
+msgstr "Nõustu"
 
 #: lib/phoenix_kit_web/live/settings/integrations.html.heex:46
 #: lib/phoenix_kit_web/live/settings/integrations.html.heex:81
 #, elixir-autogen, elixir-format
 msgid "Account"
-msgstr ""
+msgstr "Konto"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:175
 #: lib/phoenix_kit_web/users/registration.html.heex:102
 #: lib/phoenix_kit_web/users/user_form.html.heex:176
 #, elixir-autogen, elixir-format
 msgid "Account Type"
-msgstr ""
+msgstr "Konto tüüp"
 
 #: lib/phoenix_kit_web/live/settings/integration_form.ex:207
 #, elixir-autogen, elixir-format
 msgid "Account disconnected"
-msgstr ""
+msgstr "Konto lahti ühendatud"
 
 #: lib/phoenix_kit_web/live/users/users.html.heex:112
 #, elixir-autogen, elixir-format
 msgid "Account type"
-msgstr ""
+msgstr "Konto tüüp"
 
 #: lib/modules/maintenance/settings.ex:277
 #, elixir-autogen, elixir-format
 msgid "Active due to scheduled window."
-msgstr ""
+msgstr "Aktiivne planeeritud akna tõttu."
 
 #: lib/phoenix_kit_web/live/settings/integration_form.ex:27
 #: lib/phoenix_kit_web/live/settings/integration_form.ex:66
@@ -3995,244 +3995,244 @@ msgstr ""
 #: lib/phoenix_kit_web/live/settings/integrations.html.heex:224
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add Integration"
-msgstr ""
+msgstr "Lisa integratsioon"
 
 #: lib/phoenix_kit/integrations/providers.ex:250
 #, elixir-autogen, elixir-format
 msgid "Add credits (optional)"
-msgstr ""
+msgstr "Lisa krediite (valikuline)"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:546
 #, elixir-autogen, elixir-format
 msgid "Add members from the user edit page"
-msgstr ""
+msgstr "Lisa liikmeid kasutaja muutmise lehelt"
 
 #: lib/phoenix_kit_web/components/core/integration_picker.ex:253
 #, elixir-autogen, elixir-format
 msgid "Add one in Settings → Integrations"
-msgstr ""
+msgstr "Lisa üks Seaded → Integratsioonid alt"
 
 #: lib/modules/maintenance/web/maintenance_page_live.ex:106
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Admin Preview"
-msgstr ""
+msgstr "Administraatori eelvaade"
 
 #: lib/modules/storage/web/health.html.heex:179
 #, elixir-autogen, elixir-format
 msgid "All Healthy"
-msgstr ""
+msgstr "Kõik terved"
 
 #: lib/modules/storage/web/health.html.heex:181
 #, elixir-autogen, elixir-format
 msgid "All files meet the redundancy target of %{n} copies."
-msgstr ""
+msgstr "Kõik failid vastavad redundantsuse eesmärgile %{n} koopiat."
 
 #: lib/modules/storage/web/dimension_form.html.heex:199
 #, elixir-autogen, elixir-format
 msgid "Alternative Formats"
-msgstr ""
+msgstr "Alternatiivsed vormingud"
 
 #: lib/phoenix_kit/integrations/providers.ex:185
 #, elixir-autogen, elixir-format
 msgid "Application type: **Web application** (do not select \"Desktop app\" — it won't support redirect URIs)"
-msgstr ""
+msgstr "Rakenduse tüüp: **Veebirakendus** (ärge valige \"Töölauarakendus\" — see ei toeta suunamisteede URI-sid)"
 
 #: lib/phoenix_kit_web/live/settings/integration_form.html.heex:466
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Are you sure you want to disconnect this account?"
-msgstr ""
+msgstr "Kas oled kindel, et soovid selle konto lahti ühendada?"
 
 #: lib/phoenix_kit_web/live/settings/integrations.html.heex:151
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Are you sure you want to disconnect?"
-msgstr ""
+msgstr "Kas oled kindel, et soovid lahti ühendada?"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:603
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Are you sure you want to remove this member?"
-msgstr ""
+msgstr "Kas oled kindel, et soovid selle liikme eemaldada?"
 
 #: lib/phoenix_kit_web/live/settings/integration_form.ex:108
 #, elixir-autogen, elixir-format
 msgid "Authorization failed: %{reason}"
-msgstr ""
+msgstr "Volitamine ebaõnnestus: %{reason}"
 
 #: lib/phoenix_kit_web/live/settings/integration_form.html.heex:357
 #, elixir-autogen, elixir-format
 msgid "Authorize access to your %{provider} account. This will open a sign-in page where you choose which account to connect."
-msgstr ""
+msgstr "Volita juurdepääs oma %{provider} kontole. See avab sisselogimislehe, kus saad valida, millise konto ühendada."
 
 #: lib/phoenix_kit_web/live/components/user_settings.ex:76
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Avatar updated successfully!"
-msgstr ""
+msgstr "Avatar uuendatud edukalt!"
 
 #: lib/modules/storage/web/bucket_form.html.heex:195
 #, elixir-autogen, elixir-format
 msgid "Backblaze Bucket Name"
-msgstr ""
+msgstr "Backblaze bucketi nimi"
 
 #: lib/modules/storage/web/bucket_form.html.heex:215
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Backblaze Endpoint"
-msgstr ""
+msgstr "Backblaze lõpp-punkt"
 
 #: lib/modules/storage/web/bucket_form.html.heex:164
 #, elixir-autogen, elixir-format
 msgid "Backblaze Region"
-msgstr ""
+msgstr "Backblaze piirkond"
 
 #: lib/modules/storage/web/health.html.heex:44
 #, elixir-autogen, elixir-format
 msgid "Below redundancy target"
-msgstr ""
+msgstr "Alla redundantsuse eesmärgi"
 
 #: lib/modules/storage/web/dimension_form.html.heex:74
 #, elixir-autogen, elixir-format
 msgid "Both width and height are used for fixed dimensions"
-msgstr ""
+msgstr "Fikseeritud dimensioonide jaoks kasutatakse nii laiust kui ka kõrgust"
 
 #: lib/phoenix_kit_web/live/settings.html.heex:204
 #, elixir-autogen, elixir-format
 msgid "Browser tab fallback"
-msgstr ""
+msgstr "Brauserikaardi varuväärtus"
 
 #: lib/modules/storage/web/settings.html.heex:252
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Bucket actions"
-msgstr ""
+msgstr "Bucketi tegevused"
 
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:186
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Business reg. number (optional)"
-msgstr ""
+msgstr "Äriregistri number (valikuline)"
 
 #: lib/modules/storage/web/dimension_form.html.heex:155
 #, elixir-autogen, elixir-format
 msgid "CRF 0-51, lower = higher quality. 18-28 recommended."
-msgstr ""
+msgstr "CRF 0-51, madalam = parem kvaliteet. 18-28 on soovituslik."
 
 #: lib/phoenix_kit_web/users/user_form.html.heex:841
 #, elixir-autogen, elixir-format
 msgid "Cancel invitation"
-msgstr ""
+msgstr "Tühista kutse"
 
 #: lib/phoenix_kit_web/users/user_form.html.heex:842
 #, elixir-autogen, elixir-format
 msgid "Cancel this invitation?"
-msgstr ""
+msgstr "Kas tühistada see kutse?"
 
 #: lib/modules/storage/web/bucket_form.html.heex:101
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cannot be changed"
-msgstr ""
+msgstr "Ei saa muuta"
 
 #: lib/modules/maintenance/settings.ex:103
 #, elixir-autogen, elixir-format
 msgid "Changes discarded"
-msgstr ""
+msgstr "Muudatused tühistatud"
 
 #: lib/modules/maintenance/settings.ex:425
 #, elixir-autogen, elixir-format
 msgid "Changes to header and message text take effect immediately after saving."
-msgstr ""
+msgstr "Pealkirja ja sõnumi teksti muudatused rakenduvad koheselt pärast salvestamist."
 
 #: lib/modules/storage/web/health.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Check file redundancy against configured target"
-msgstr ""
+msgstr "Kontrolli faili redundantsust konfigureeritud eesmärgi suhtes"
 
 #: lib/phoenix_kit_web/live/settings/integration_form.html.heex:59
 #, elixir-autogen, elixir-format
 msgid "Choose a different service"
-msgstr ""
+msgstr "Vali muu teenus"
 
 #: lib/phoenix_kit_web/live/settings/integration_form.html.heex:17
 #, elixir-autogen, elixir-format
 msgid "Choose a service to connect"
-msgstr ""
+msgstr "Vali ühendatav teenus"
 
 #: lib/modules/maintenance/settings.ex:367
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Clear Schedule"
-msgstr ""
+msgstr "Tühista ajakava"
 
 #: lib/phoenix_kit/integrations/providers.ex:184
 #, elixir-autogen, elixir-format
 msgid "Click **Create Credentials → OAuth client ID**"
-msgstr ""
+msgstr "Klõpsa **Loo mandaadid → OAuth kliendi ID**"
 
 #: lib/phoenix_kit/integrations/providers.ex:244
 #, elixir-autogen, elixir-format
 msgid "Click **Create Key**"
-msgstr ""
+msgstr "Klõpsa **Loo võti**"
 
 #: lib/phoenix_kit/integrations/providers.ex:195
 #: lib/phoenix_kit/integrations/providers.ex:499
 #, elixir-autogen, elixir-format
 msgid "Click **Save**, then **Connect Account**"
-msgstr ""
+msgstr "Klõpsa **Salvesta**, seejärel **Ühenda konto**"
 
 #: lib/modules/storage/web/bucket_form.html.heex:196
 #, elixir-autogen, elixir-format
 msgid "Cloudflare Bucket Name"
-msgstr ""
+msgstr "Cloudflare bucketi nimi"
 
 #: lib/modules/storage/web/bucket_form.html.heex:216
 #, elixir-autogen, elixir-format
 msgid "Cloudflare Endpoint"
-msgstr ""
+msgstr "Cloudflare lõpp-punkt"
 
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:391
 #, elixir-autogen, elixir-format
 msgid "Company info, tax settings, and bank details are shared across Legal, Billing, and Shop modules."
-msgstr ""
+msgstr "Ettevõtte teave, maksuseaded ja pangaandmed jagatud Juriidilise, Arvelduse ja Poe moodulitega."
 
 #: lib/phoenix_kit_web/users/user_form.html.heex:209
 #, elixir-autogen, elixir-format
 msgid "Company or organization name"
-msgstr ""
+msgstr "Ettevõtte või organisatsiooni nimi"
 
 #: lib/phoenix_kit_web/live/settings/integration_form.html.heex:374
 #, elixir-autogen, elixir-format
 msgid "Complete Step 1 first to enable account connection."
-msgstr ""
+msgstr "Lõpeta esmalt 1. samm konto ühendamise lubamiseks."
 
 #: lib/modules/storage/web/settings.html.heex:14
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Configure media storage buckets and file processing settings for your application"
-msgstr ""
+msgstr "Seadista rakenduse meediumisalvestuse bucketid ja failide töötlemise seaded"
 
 #: lib/modules/storage/web/bucket_form.html.heex:13
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Configure storage provider settings"
-msgstr ""
+msgstr "Seadista salvestuspakkuja seaded"
 
 #: lib/modules/storage/web/settings.html.heex:324
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Configured media locations"
-msgstr ""
+msgstr "Konfigureeritud meediumia asukohad"
 
 #: lib/phoenix_kit_web/live/settings/integration_form.html.heex:370
 #, elixir-autogen, elixir-format
 msgid "Connect %{provider} Account"
-msgstr ""
+msgstr "Ühenda %{provider} konto"
 
 #: lib/phoenix_kit_web/live/settings/integration_form.html.heex:321
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Connect Account"
-msgstr ""
+msgstr "Ühenda konto"
 
 #: lib/phoenix_kit/integrations/providers.ex:193
 #: lib/phoenix_kit/integrations/providers.ex:497
 #, elixir-autogen, elixir-format
 msgid "Connect and authorize"
-msgstr ""
+msgstr "Ühenda ja volita"
 
 #: lib/phoenix_kit_web/live/settings/integrations.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Connect external services for use across modules"
-msgstr ""
+msgstr "Ühenda välised teenused kasutamiseks kõigis moodulites"
 
 #: lib/phoenix_kit_web/components/core/integration_picker.ex:196
 #: lib/phoenix_kit_web/live/settings/integration_form.html.heex:91
@@ -4241,76 +4241,76 @@ msgstr ""
 #: lib/phoenix_kit_web/live/settings/integrations.ex:165
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Connected"
-msgstr ""
+msgstr "Ühendatud"
 
 #: lib/phoenix_kit_web/live/settings/integration_form.html.heex:351
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Connected on"
-msgstr ""
+msgstr "Ühendatud"
 
 #: lib/phoenix_kit_web/live/settings/integration_form.html.heex:197
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Connection Name"
-msgstr ""
+msgstr "Ühenduse nimi"
 
 #: lib/modules/storage/web/bucket_form.html.heex:304
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Connection failed"
-msgstr ""
+msgstr "Ühendus ebaõnnestus"
 
 #: lib/phoenix_kit_web/live/settings/integration_form.ex:288
 #: lib/phoenix_kit_web/live/settings/integrations.ex:61
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Connection removed"
-msgstr ""
+msgstr "Ühendus eemaldatud"
 
 #: lib/modules/storage/web/bucket_form.html.heex:298
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Connection successful"
-msgstr ""
+msgstr "Ühendus õnnestus"
 
 #: lib/phoenix_kit_web/live/settings/integration_form.ex:361
 #: lib/phoenix_kit_web/live/settings/integration_form.ex:456
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Connection verified"
-msgstr ""
+msgstr "Ühendus kontrollitud"
 
 #: lib/phoenix_kit/integrations/providers.ex:189
 #, elixir-autogen, elixir-format
 msgid "Copy the **Client ID** and **Client Secret** into the form above"
-msgstr ""
+msgstr "Kopeeri **Kliendi ID** ja **Kliendi saladus** ülalolevasse vormi"
 
 #: lib/phoenix_kit/integrations/providers.ex:246
 #, elixir-autogen, elixir-format
 msgid "Copy the key and paste it into the form above"
-msgstr ""
+msgstr "Kopeeri võti ja kleebi see ülalolevasse vormi"
 
 #: lib/phoenix_kit/integrations/integrations.ex:941
 #, elixir-autogen, elixir-format
 msgid "Could not reach the service"
-msgstr ""
+msgstr "Teenusele ei saanud juurde pääseda"
 
 #: lib/phoenix_kit/integrations/providers.ex:135
 #, elixir-autogen, elixir-format
 msgid "Create a Google Cloud project"
-msgstr ""
+msgstr "Loo Google Cloud projekt"
 
 #: lib/phoenix_kit/integrations/providers.ex:138
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Create a new project or select an existing one"
-msgstr ""
+msgstr "Loo uus projekt või vali olemasolev"
 
 #: lib/phoenix_kit/integrations/providers.ex:242
 #: lib/phoenix_kit/integrations/providers.ex:310
 #: lib/phoenix_kit/integrations/providers.ex:368
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Create an API key"
-msgstr ""
+msgstr "Loo API võti"
 
 #: lib/phoenix_kit/integrations/providers.ex:179
 #, elixir-autogen, elixir-format
 msgid "Create an OAuth Client"
-msgstr ""
+msgstr "Loo OAuth klient"
 
 #: lib/phoenix_kit/integrations/providers.ex:235
 #, elixir-autogen, elixir-format, fuzzy
@@ -4320,409 +4320,409 @@ msgstr "Loo konto"
 #: lib/modules/storage/web/settings.html.heex:449
 #, elixir-autogen, elixir-format
 msgid "Current limit: %{size} MB"
-msgstr ""
+msgstr "Praegune limiit: %{size} MB"
 
 #: lib/modules/maintenance/settings.ex:321
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Current time"
-msgstr ""
+msgstr "Praegune aeg"
 
 #: lib/modules/maintenance/settings.ex:259
 #, elixir-autogen, elixir-format
 msgid "Customize the maintenance page and schedule"
-msgstr ""
+msgstr "Kohanda hoolduselehte ja ajakava"
 
 #: lib/phoenix_kit_web/components/invitation_banner.ex:61
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Decline"
-msgstr ""
+msgstr "Keeldu"
 
 #: lib/phoenix_kit_web/live/settings.html.heex:201
 #, elixir-autogen, elixir-format
 msgid "Default Tab Title"
-msgstr ""
+msgstr "Vaikimisi kaardi pealkiri"
 
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:296
 #, elixir-autogen, elixir-format
 msgid "Default Tax Rate"
-msgstr ""
+msgstr "Vaikimisi maksumäär"
 
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:275
 #, elixir-autogen, elixir-format
 msgid "Default tax rate applied across Billing and Shop modules"
-msgstr ""
+msgstr "Vaikimisi maksumäär, mida rakendatakse Arvelduse ja Poe moodulites"
 
 #: lib/modules/maintenance/settings.ex:417
 #, elixir-autogen, elixir-format
 msgid "Detailed message shown below the header"
-msgstr ""
+msgstr "Üksikasjalik sõnum, mis kuvatakse pealkirja all"
 
 #: lib/modules/storage/web/dimensions.html.heex:211
 #: lib/modules/storage/web/dimensions.html.heex:411
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Dimension actions"
-msgstr ""
+msgstr "Dimensiooni tegevused"
 
 #: lib/phoenix_kit_web/live/settings/integration_form.html.heex:469
 #: lib/phoenix_kit_web/live/settings/integrations.html.heex:149
 #: lib/phoenix_kit_web/live/settings/integrations.html.heex:194
 #, elixir-autogen, elixir-format
 msgid "Disconnect"
-msgstr ""
+msgstr "Ühenda lahti"
 
 #: lib/phoenix_kit_web/live/settings/integrations.html.heex:196
 #, elixir-autogen, elixir-format
 msgid "Disconnect?"
-msgstr ""
+msgstr "Ühenda lahti?"
 
 #: lib/phoenix_kit_web/live/settings/integrations.ex:47
 #, elixir-autogen, elixir-format
 msgid "Disconnected"
-msgstr ""
+msgstr "Ühendus katkestatud"
 
 #: lib/phoenix_kit/integrations/providers.ex:153
 #, elixir-autogen, elixir-format
 msgid "Drive API handles file listing, creation, copying, and PDF export. Docs API is used for reading document content and substituting template variables."
-msgstr ""
+msgstr "Drive API haldab failide loetlemist, loomist, kopeerimist ja PDF-eksporti. Docs API-d kasutatakse dokumendi sisu lugemiseks ja mallmuutujate asendamiseks."
 
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:171
 #, elixir-autogen, elixir-format
 msgid "EU format: %{country}123456789"
-msgstr ""
+msgstr "EL-i vorming: %{country}123456789"
 
 #: lib/phoenix_kit_web/live/settings/integration_form.ex:81
 #, elixir-autogen, elixir-format
 msgid "Edit Integration"
-msgstr ""
+msgstr "Muuda integratsiooni"
 
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:290
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enable Tax"
-msgstr ""
+msgstr "Luba maks"
 
 #: lib/modules/storage/web/bucket_form.html.heex:372
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enable bucket"
-msgstr ""
+msgstr "Luba bucket"
 
 #: lib/phoenix_kit_web/live/settings/users.html.heex:132
 #, elixir-autogen, elixir-format
 msgid "Enable organization accounts"
-msgstr ""
+msgstr "Luba organisatsioonikontod"
 
 #: lib/phoenix_kit/integrations/providers.ex:142
 #, elixir-autogen, elixir-format
 msgid "Enable required APIs"
-msgstr ""
+msgstr "Luba vajalikud API-d"
 
 #: lib/phoenix_kit_web/live/settings.html.heex:242
 #, elixir-autogen, elixir-format
 msgid "Enable user notifications"
-msgstr ""
+msgstr "Luba kasutaja teatised"
 
 #: lib/modules/maintenance/settings.ex:273
 #, elixir-autogen, elixir-format
 msgid "Enabled manually AND within scheduled window."
-msgstr ""
+msgstr "Lubatud käsitsi JA planeeritud akna sees."
 
 #: lib/modules/maintenance/settings.ex:275
 #, elixir-autogen, elixir-format
 msgid "Enabled manually via toggle."
-msgstr ""
+msgstr "Lubatud käsitsi lüliti abil."
 
 #: lib/modules/maintenance/settings.ex:342
 #, elixir-autogen, elixir-format
 msgid "End Time"
-msgstr ""
+msgstr "Lõpuaeg"
 
 #: lib/modules/maintenance/settings.ex:530
 #, elixir-autogen, elixir-format
 msgid "End time must be after start time"
-msgstr ""
+msgstr "Lõpuaeg peab olema pärast algusaega"
 
 #: lib/modules/maintenance/settings.ex:527
 #, elixir-autogen, elixir-format
 msgid "End time must be in the future"
-msgstr ""
+msgstr "Lõpuaeg peab olema tulevikus"
 
 #: lib/phoenix_kit_web/live/settings/integration_form.html.heex:187
 #, elixir-autogen, elixir-format
 msgid "Enter your API credentials from the developer console."
-msgstr ""
+msgstr "Sisesta oma API mandaadid arendajakonsoolist."
 
 #: lib/modules/maintenance/web/maintenance_page_live.ex:144
 #, elixir-autogen, elixir-format
 msgid "Expected back in"
-msgstr ""
+msgstr "Oodatakse tagasi"
 
 #: lib/phoenix_kit_web/hooks/invitation_hook.ex:76
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to accept invitation. Please try again."
-msgstr ""
+msgstr "Kutse vastuvõtmine ebaõnnestus. Palun proovi uuesti."
 
 #: lib/phoenix_kit_web/users/user_form.ex:312
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to add member"
-msgstr ""
+msgstr "Liikme lisamine ebaõnnestus"
 
 #: lib/phoenix_kit_web/live/settings/integration_form.ex:234
 #, elixir-autogen, elixir-format
 msgid "Failed to build authorization URL"
-msgstr ""
+msgstr "Volitamise URL-i loomine ebaõnnestus"
 
 #: lib/phoenix_kit_web/users/user_form.ex:378
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to cancel invitation"
-msgstr ""
+msgstr "Kutse tühistamine ebaõnnestus"
 
 #: lib/phoenix_kit_web/live/settings/integration_form.ex:414
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to connect. Please try again."
-msgstr ""
+msgstr "Ühendamine ebaõnnestus. Palun proovi uuesti."
 
 #: lib/phoenix_kit_web/hooks/invitation_hook.ex:96
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to decline invitation. Please try again."
-msgstr ""
+msgstr "Kutsest keeldumine ebaõnnestus. Palun proovi uuesti."
 
 #: lib/phoenix_kit_web/live/settings/integrations.ex:65
 #, elixir-autogen, elixir-format
 msgid "Failed to remove connection"
-msgstr ""
+msgstr "Ühenduse eemaldamine ebaõnnestus"
 
 #: lib/phoenix_kit_web/live/users/user_details.ex:254
 #: lib/phoenix_kit_web/users/user_form.ex:336
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to remove member"
-msgstr ""
+msgstr "Liikme eemaldamine ebaõnnestus"
 
 #: lib/phoenix_kit_web/live/settings/integration_form.ex:519
 #: lib/phoenix_kit_web/live/settings/integration_form.ex:546
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to save"
-msgstr ""
+msgstr "Salvestamine ebaõnnestus"
 
 #: lib/phoenix_kit_web/live/components/user_settings.ex:473
 #, elixir-autogen, elixir-format
 msgid "Failed to save notification preferences."
-msgstr ""
+msgstr "Teatiste eelistuste salvestamine ebaõnnestus."
 
 #: lib/modules/maintenance/settings.ex:539
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to save schedule"
-msgstr ""
+msgstr "Ajakava salvestamine ebaõnnestus"
 
 #: lib/phoenix_kit_web/users/user_form.ex:361
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to send invitation"
-msgstr ""
+msgstr "Kutse saatmine ebaõnnestus"
 
 #: lib/modules/maintenance/settings.ex:144
 #, elixir-autogen, elixir-format
 msgid "Failed to toggle maintenance mode"
-msgstr ""
+msgstr "Hoolduseolekurežiimi lülitamine ebaõnnestus"
 
 #: lib/phoenix_kit_web/live/components/user_settings.ex:83
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to update avatar"
-msgstr ""
+msgstr "Avatari uuendamine ebaõnnestus"
 
 #: lib/modules/storage/web/health.html.heex:219
 #, elixir-autogen, elixir-format, fuzzy
 msgid "File"
-msgstr ""
+msgstr "Fail"
 
 #: lib/modules/storage/web/settings.html.heex:606
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Files are tracked in PostgreSQL with support for multiple media locations (local, S3, remote servers)."
-msgstr ""
+msgstr "Faile jälgitakse PostgreSQL-is mitme meediumiasukoha toega (kohalik, S3, kaugserverid)."
 
 #: lib/modules/storage/web/health.html.heex:24
 #, elixir-autogen, elixir-format
 msgid "Files with completed variants"
-msgstr ""
+msgstr "Failid lõpetatud variantidega"
 
 #: lib/phoenix_kit/integrations/providers.ex:119
 #, elixir-autogen, elixir-format
 msgid "From Google Cloud Console → APIs & Services → Credentials"
-msgstr ""
+msgstr "Google Cloud Console → API-d ja teenused → Mandaadid alt"
 
 #: lib/phoenix_kit/integrations/providers.ex:228
 #, elixir-autogen, elixir-format
 msgid "From openrouter.ai/keys"
-msgstr ""
+msgstr "openrouter.ai/keys alt"
 
 #: lib/modules/storage/web/dimension_form.html.heex:202
 #, elixir-autogen, elixir-format
 msgid "Generate additional format variants alongside the primary format. Modern formats like WebP and AVIF offer better compression."
-msgstr ""
+msgstr "Genereeri täiendavaid vorminguvariantide kõrval peamise vorminguga. Kaasaegsed vormingud nagu WebP ja AVIF pakuvad paremat tihendust."
 
 #: lib/phoenix_kit/integrations/providers.ex:245
 #, elixir-autogen, elixir-format
 msgid "Give it a name (e.g., your app name)"
-msgstr ""
+msgstr "Andke sellele nimi (nt teie rakenduse nimi)"
 
 #: lib/phoenix_kit/integrations/providers.ex:148
 #, elixir-autogen, elixir-format
 msgid "Go back to the Library and search for **Google Docs API**, click it, then click **Enable**"
-msgstr ""
+msgstr "Minge tagasi Raamatukogusse ja otsige **Google Docs API**, klõpsake seda, seejärel klõpsake **Luba**"
 
 #: lib/phoenix_kit/integrations/providers.ex:181
 #, elixir-autogen, elixir-format
 msgid "Go to [APIs & Services → Credentials](https://console.cloud.google.com/apis/credentials)"
-msgstr ""
+msgstr "Mine [API-d ja teenused → Mandaadid](https://console.cloud.google.com/apis/credentials) lehele"
 
 #: lib/phoenix_kit/integrations/providers.ex:144
 #, elixir-autogen, elixir-format
 msgid "Go to [APIs & Services → Library](https://console.cloud.google.com/apis/library)"
-msgstr ""
+msgstr "Mine [API-d ja teenused → Raamatukogu](https://console.cloud.google.com/apis/library) lehele"
 
 #: lib/phoenix_kit/integrations/providers.ex:163
 #, elixir-autogen, elixir-format
 msgid "Go to [Audience](https://console.cloud.google.com/auth/audience) — set user type to **External** (or Internal for Google Workspace)"
-msgstr ""
+msgstr "Mine [Sihtrühm](https://console.cloud.google.com/auth/audience) lehele — määra kasutajatüübiks **Väline** (või Sisemine Google Workspace'i jaoks)"
 
 #: lib/phoenix_kit/integrations/providers.ex:160
 #, elixir-autogen, elixir-format
 msgid "Go to [Branding](https://console.cloud.google.com/auth/branding) in the sidebar — fill in the **App name** and **User support email**, then save"
-msgstr ""
+msgstr "Mine [Kujundus](https://console.cloud.google.com/auth/branding) lehele külgribal — täida **Rakenduse nimi** ja **Kasutajatoe e-post**, seejärel salvesta"
 
 #: lib/phoenix_kit/integrations/providers.ex:253
 #, elixir-autogen, elixir-format
 msgid "Go to [Credits](https://openrouter.ai/credits) to add funds"
-msgstr ""
+msgstr "Mine [Krediidid](https://openrouter.ai/credits) lehele raha lisamiseks"
 
 #: lib/phoenix_kit/integrations/providers.ex:169
 #, elixir-autogen, elixir-format
 msgid "Go to [Data Access](https://console.cloud.google.com/auth/scopes) — click **Add or Remove Scopes** and add the Drive and Docs scopes. This step may not be required — the app requests the needed scopes at connect time regardless."
-msgstr ""
+msgstr "Mine [Andmete juurdepääs](https://console.cloud.google.com/auth/scopes) lehele — klõpsa **Lisa või eemalda ulatus** ja lisa Drive ja Docs ulatused. See samm ei pruugi olla vajalik — rakendus küsib vajalikud ulatused igal juhul ühendamise ajal."
 
 #: lib/phoenix_kit/integrations/providers.ex:237
 #, elixir-autogen, elixir-format
 msgid "Go to [openrouter.ai](https://openrouter.ai) and sign up or log in"
-msgstr ""
+msgstr "Mine [openrouter.ai](https://openrouter.ai) lehele ja registreeru või logi sisse"
 
 #: lib/phoenix_kit/integrations/providers.ex:137
 #, elixir-autogen, elixir-format
 msgid "Go to the [Google Cloud Console](https://console.cloud.google.com)"
-msgstr ""
+msgstr "Mine [Google Cloud Console](https://console.cloud.google.com) lehele"
 
 #: lib/phoenix_kit/integrations/providers.ex:100
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Google"
-msgstr ""
+msgstr "Google"
 
 #: lib/phoenix_kit/integrations/providers.ex:101
 #, elixir-autogen, elixir-format
 msgid "Google Docs, Drive, Calendar, Sheets, Gmail"
-msgstr ""
+msgstr "Google Docs, Drive, Calendar, Sheets, Gmail"
 
 #: lib/phoenix_kit/integrations/providers.ex:196
 #, elixir-autogen, elixir-format
 msgid "Google will show an \"unverified app\" warning — click **Advanced → Go to (app name)** to proceed"
-msgstr ""
+msgstr "Google kuvab hoiatuse \"Kontrollimata rakendus\" — jätkamiseks klõpsake **Täpsemalt → Mine (rakenduse nimi)**"
 
 #: lib/phoenix_kit/integrations/providers.ex:199
 #, elixir-autogen, elixir-format
 msgid "Grant access to Google Docs and Google Drive"
-msgstr ""
+msgstr "Anna juurdepääs Google Docs'ile ja Google Drive'ile"
 
 #: lib/modules/maintenance/settings.ex:386
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Header Text"
-msgstr ""
+msgstr "Pealkirja tekst"
 
 #: lib/modules/storage/web/health.html.heex:51
 #, elixir-autogen, elixir-format
 msgid "Health"
-msgstr ""
+msgstr "Seisund"
 
 #: lib/modules/storage/web/health.html.heex:31
 #, elixir-autogen, elixir-format
 msgid "Healthy"
-msgstr ""
+msgstr "Tervislik"
 
 #: lib/modules/storage/web/settings.html.heex:38
 #, elixir-autogen, elixir-format, fuzzy
 msgid "If your media module isn't working correctly, use this to reset configuration to defaults."
-msgstr ""
+msgstr "Kui meediamoodul ei tööta õigesti, kasuta seda konfiguratsiooni lähtestamiseks vaikimisi väärtustele."
 
 #: lib/phoenix_kit_web/components/core/integration_picker.ex:227
 #, elixir-autogen, elixir-format
 msgid "Integration deleted"
-msgstr ""
+msgstr "Integratsioon kustutatud"
 
 #: lib/phoenix_kit_web/live/settings/integrations.ex:25
 #: lib/phoenix_kit_web/live/settings/integrations.html.heex:12
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Integrations"
-msgstr ""
+msgstr "Integratsioonid"
 
 #: lib/phoenix_kit/integrations/integrations.ex:938
 #, elixir-autogen, elixir-format
 msgid "Invalid credentials"
-msgstr ""
+msgstr "Valed mandaadid"
 
 #: lib/phoenix_kit_web/live/settings/integration_form.ex:128
 #, elixir-autogen, elixir-format
 msgid "Invalid integration URL"
-msgstr ""
+msgstr "Vale integratsiooni URL"
 
 #: lib/phoenix_kit_web/users/user_form.ex:373
 #, elixir-autogen, elixir-format
 msgid "Invitation cancelled"
-msgstr ""
+msgstr "Kutse tühistatud"
 
 #: lib/phoenix_kit_web/hooks/invitation_hook.ex:90
 #, elixir-autogen, elixir-format
 msgid "Invitation declined."
-msgstr ""
+msgstr "Kutsest keelduti."
 
 #: lib/phoenix_kit_web/users/user_form.ex:350
 #, elixir-autogen, elixir-format
 msgid "Invitation sent to %{email}"
-msgstr ""
+msgstr "Kutse saadetud aadressile %{email}"
 
 #: lib/phoenix_kit_web/users/user_form.html.heex:864
 #, elixir-autogen, elixir-format
 msgid "Invite"
-msgstr ""
+msgstr "Kutsu"
 
 #: lib/phoenix_kit_web/users/user_form.html.heex:860
 #, elixir-autogen, elixir-format
 msgid "Invite by email..."
-msgstr ""
+msgstr "Kutsu e-postiga..."
 
 #: lib/phoenix_kit_web/users/user_form.html.heex:820
 #, elixir-autogen, elixir-format
 msgid "Invited"
-msgstr ""
+msgstr "Kutsutud"
 
 #: lib/modules/storage/web/dimension_form.html.heex:186
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Leave empty to preserve the original file format"
-msgstr ""
+msgstr "Jäta tühjaks algse falivormingu säilitamiseks"
 
 #: lib/modules/storage/web/bucket_form.html.heex:113
 #, elixir-autogen, elixir-format
 msgid "Local Storage"
-msgstr ""
+msgstr "Kohalik salvestus"
 
 #: lib/modules/storage/web/health.html.heex:199
 #: lib/modules/storage/web/health.html.heex:221
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Locations"
-msgstr ""
+msgstr "Asukohad"
 
 #: lib/phoenix_kit_web/live/settings.html.heex:123
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Logo displayed across the application. Leave empty to show project title text."
-msgstr ""
+msgstr "Logo kuvatakse kogu rakenduses. Jäta tühjaks projekti pealkirja teksti kuvamiseks."
 
 #: lib/modules/maintenance/settings.ex:399
 #, elixir-autogen, elixir-format
 msgid "Main heading shown on maintenance page"
-msgstr ""
+msgstr "Peamine pealkiri, mis kuvatakse hoolduselehel"
 
 #: lib/modules/maintenance/settings.ex:394
 #: lib/phoenix_kit_web/live/modules.html.heex:536
@@ -4733,274 +4733,274 @@ msgstr "Hoolduseolekurežiim"
 #: lib/modules/maintenance/settings.ex:256
 #, elixir-autogen, elixir-format
 msgid "Maintenance Mode Settings"
-msgstr ""
+msgstr "Hoolduseolekurežiimi seaded"
 
 #: lib/modules/maintenance/settings.ex:269
 #, elixir-autogen, elixir-format
 msgid "Maintenance is active"
-msgstr ""
+msgstr "Hooldus on aktiivne"
 
 #: lib/modules/maintenance/web/maintenance_page_live.ex:109
 #, elixir-autogen, elixir-format
 msgid "Maintenance is active — regular users see this page."
-msgstr ""
+msgstr "Hooldus on aktiivne — tavalised kasutajad näevad seda lehte."
 
 #: lib/modules/maintenance/settings.ex:279
 #, elixir-autogen, elixir-format
 msgid "Maintenance is active."
-msgstr ""
+msgstr "Hooldus on aktiivne."
 
 #: lib/modules/maintenance/web/maintenance_page_live.ex:111
 #, elixir-autogen, elixir-format
 msgid "Maintenance is not active — this is a preview of the page."
-msgstr ""
+msgstr "Hooldus pole aktiivne — see on lehe eelvaade."
 
 #: lib/modules/maintenance/settings.ex:134
 #, elixir-autogen, elixir-format
 msgid "Maintenance mode activated — non-admin users will see the maintenance page"
-msgstr ""
+msgstr "Hoolduseolekurežiim aktiveeritud — mitte-administraator kasutajad näevad hoolduselehte"
 
 #: lib/modules/maintenance/settings.ex:137
 #, elixir-autogen, elixir-format
 msgid "Maintenance mode deactivated — site is now accessible to all users"
-msgstr ""
+msgstr "Hoolduseolekurežiim deaktiveeritud — sait on nüüd kõigile kasutajatele juurdepääsetav"
 
 #: lib/modules/maintenance/settings.ex:297
 #, elixir-autogen, elixir-format
 msgid "Maintenance mode is manually enabled"
-msgstr ""
+msgstr "Hoolduseolekurežiim on käsitsi lubatud"
 
 #: lib/modules/maintenance/settings.ex:298
 #, elixir-autogen, elixir-format
 msgid "Maintenance mode is off (can still activate via schedule)"
-msgstr ""
+msgstr "Hoolduseolekurežiim on väljas (saab aktiveerida ajakava kaudu)"
 
 #: lib/modules/maintenance/settings.ex:89
 #, elixir-autogen, elixir-format
 msgid "Maintenance mode settings saved successfully"
-msgstr ""
+msgstr "Hoolduseolekurežiimi seaded salvestatud edukalt"
 
 #: lib/modules/maintenance/settings.ex:189
 #, elixir-autogen, elixir-format
 msgid "Maintenance schedule cleared"
-msgstr ""
+msgstr "Hoolduse ajakava tühistatud"
 
 #: lib/modules/maintenance/settings.ex:170
 #, elixir-autogen, elixir-format
 msgid "Maintenance schedule saved"
-msgstr ""
+msgstr "Hoolduse ajakava salvestatud"
 
 #: lib/phoenix_kit_web/live/dashboard/settings.ex:55
 #, elixir-autogen, elixir-format
 msgid "Manage your account settings and preferences"
-msgstr ""
+msgstr "Halda oma konto seadeid ja eelistusi"
 
 #: lib/modules/maintenance/settings.ex:293
 #, elixir-autogen, elixir-format
 msgid "Manual Toggle"
-msgstr ""
+msgstr "Käsitsi lüliti"
 
 #: lib/modules/storage/web/settings.html.heex:436
 #, elixir-autogen, elixir-format
 msgid "Max Upload Size (MB)"
-msgstr ""
+msgstr "Maksimaalne üleslaadimise suurus (MB)"
 
 #: lib/modules/storage/web/settings.html.heex:438
 #, elixir-autogen, elixir-format
 msgid "Maximum file size allowed per upload"
-msgstr ""
+msgstr "Maksimaalne failisuurus üleslaadimise kohta"
 
 #: lib/modules/storage/web/settings.html.heex:115
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Media Buckets"
-msgstr ""
+msgstr "Meedia bucketid"
 
 #: lib/modules/storage/web/settings.html.heex:355
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Media Configuration"
-msgstr ""
+msgstr "Meedia konfiguratsioon"
 
 #: lib/modules/storage/web/health.ex:34
 #, elixir-autogen, elixir-format
 msgid "Media Health"
-msgstr ""
+msgstr "Meedia seisund"
 
 #: lib/modules/storage/web/settings.html.heex:36
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Media Module Repair"
-msgstr ""
+msgstr "Meediamooduli parandamine"
 
 #: lib/modules/storage/web/settings.html.heex:12
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Media Settings"
-msgstr ""
+msgstr "Meedia seaded"
 
 #: lib/modules/storage/web/settings.html.heex:490
 #, elixir-autogen, elixir-format
 msgid "Media Stats"
-msgstr ""
+msgstr "Meedia statistika"
 
 #: lib/modules/storage/web/settings.html.heex:601
 #, elixir-autogen, elixir-format
 msgid "Media System Architecture"
-msgstr ""
+msgstr "Meediasüsteemi arhitektuur"
 
 #: lib/modules/storage/web/settings.html.heex:26
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Media is a core system module that is always enabled and cannot be disabled."
-msgstr ""
+msgstr "Meedia on põhisüsteemi moodul, mis on alati lubatud ja mida ei saa keelata."
 
 #: lib/phoenix_kit_web/users/user_form.ex:304
 #, elixir-autogen, elixir-format
 msgid "Member added to organization"
-msgstr ""
+msgstr "Liige lisatud organisatsiooni"
 
 #: lib/phoenix_kit_web/live/users/user_details.ex:251
 #: lib/phoenix_kit_web/users/user_form.ex:331
 #, elixir-autogen, elixir-format
 msgid "Member removed from organization"
-msgstr ""
+msgstr "Liige eemaldatud organisatsioonist"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:77
 #, elixir-autogen, elixir-format
 msgid "Members"
-msgstr ""
+msgstr "Liikmed"
 
 #: lib/modules/maintenance/settings.ex:406
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Message Text"
-msgstr ""
+msgstr "Sõnumi tekst"
 
 #: lib/phoenix_kit_web/components/core/integration_picker.ex:228
 #, elixir-autogen, elixir-format
 msgid "Missing"
-msgstr ""
+msgstr "Puudub"
 
 #: lib/modules/storage/web/health.html.heex:250
 #, elixir-autogen, elixir-format
 msgid "Missing %{n}"
-msgstr ""
+msgstr "Puudub %{n}"
 
 #: lib/modules/storage/web/health.html.heex:208
 #, elixir-autogen, elixir-format
 msgid "Missing %{n} copies"
-msgstr ""
+msgstr "Puudub %{n} koopiat"
 
 #: lib/modules/storage/web/settings.html.heex:560
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Monitor media health, locations, and file distribution"
-msgstr ""
+msgstr "Jälgi meedia seisundit, asukohti ja failide jaotust"
 
 #: lib/modules/storage/web/settings.html.heex:519
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Multi-Location Media Storage"
-msgstr ""
+msgstr "Mitme asukoha meediasalvestus"
 
 #: lib/phoenix_kit/integrations/providers.ex:238
 #, elixir-autogen, elixir-format
 msgid "Navigate to [Keys](https://openrouter.ai/keys)"
-msgstr ""
+msgstr "Mine [Võtmed](https://openrouter.ai/keys) lehele"
 
 #: lib/phoenix_kit/integrations/providers.ex:174
 #, elixir-autogen, elixir-format
 msgid "Navigate to the OAuth section using the search bar or the hamburger menu: search for \"OAuth\", or go to the sidebar: **APIs & Services → OAuth consent screen**. This opens a different section with its own sidebar."
-msgstr ""
+msgstr "Navigeerige OAuth jaotisesse otsinguribi või hamburgeri menüü abil: otsige \"OAuth\" või minge külgribale: **APIs & Services → OAuth consent screen**. See avab eraldi jaotise oma külgribaga."
 
 #: lib/modules/storage/web/settings.html.heex:129
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No Media Buckets Configured"
-msgstr ""
+msgstr "Meedia bucketid pole konfigureeritud"
 
 #: lib/phoenix_kit/integrations/integrations.ex:909
 #, elixir-autogen, elixir-format
 msgid "No access token"
-msgstr ""
+msgstr "Juurdepääsutokenit pole"
 
 #: lib/modules/storage/web/health.html.heex:206
 #: lib/modules/storage/web/health.html.heex:247
 #, elixir-autogen, elixir-format
 msgid "No copies"
-msgstr ""
+msgstr "Koopiaid pole"
 
 #: lib/phoenix_kit/integrations/integrations.ex:921
 #, elixir-autogen, elixir-format
 msgid "No credentials configured"
-msgstr ""
+msgstr "Mandaadid pole konfigureeritud"
 
 #: lib/phoenix_kit_web/live/settings/integrations.html.heex:218
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No integrations configured"
-msgstr ""
+msgstr "Integratsioonid pole konfigureeritud"
 
 #: lib/phoenix_kit_web/components/core/integration_picker.ex:247
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No integrations configured."
-msgstr ""
+msgstr "Integratsioonid pole konfigureeritud."
 
 #: lib/phoenix_kit_web/components/core/integration_picker.ex:245
 #, elixir-autogen, elixir-format
 msgid "No integrations match your search."
-msgstr ""
+msgstr "Ükski integratsioon ei vasta teie otsingule."
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:545
 #: lib/phoenix_kit_web/users/user_form.html.heex:731
 #, elixir-autogen, elixir-format
 msgid "No members yet"
-msgstr ""
+msgstr "Liikmeid pole veel"
 
 #: lib/phoenix_kit_web/users/user_form.html.heex:813
 #, elixir-autogen, elixir-format
 msgid "No pending invitations"
-msgstr ""
+msgstr "Ootel kutseid pole"
 
 #: lib/modules/maintenance/settings.ex:281
 #, elixir-autogen, elixir-format
 msgid "Non-admin users are seeing the maintenance page."
-msgstr ""
+msgstr "Mitte-administraator kasutajad näevad hoolduselehte."
 
 #: lib/phoenix_kit_web/components/core/integration_picker.ex:202
 #: lib/phoenix_kit_web/live/settings/integration_form.html.heex:98
 #: lib/phoenix_kit_web/live/settings/integrations.ex:167
 #, elixir-autogen, elixir-format
 msgid "Not connected"
-msgstr ""
+msgstr "Ühendamata"
 
 #: lib/phoenix_kit_web/live/settings/integration_form.html.heex:94
 #: lib/phoenix_kit_web/live/settings/integrations.ex:166
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Not tested"
-msgstr ""
+msgstr "Testimata"
 
 #: lib/phoenix_kit_web/live/components/user_settings.ex:466
 #, elixir-autogen, elixir-format
 msgid "Notification preferences saved."
-msgstr ""
+msgstr "Teatiste eelistused salvestatud."
 
 #: lib/phoenix_kit_web/live/components/user_settings.ex:1114
 #: lib/phoenix_kit_web/live/settings.html.heex:226
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Notifications"
-msgstr ""
+msgstr "Teatised"
 
 #: lib/modules/storage/web/bucket_form.html.heex:374
 #, elixir-autogen, elixir-format
 msgid "Only enabled buckets receive new uploads"
-msgstr ""
+msgstr "Ainult lubatud bucketid saavad uusi üleslaadimisi"
 
 #: lib/modules/storage/web/dimension_form.html.heex:72
 #, elixir-autogen, elixir-format
 msgid "Only width is used, height is calculated automatically"
-msgstr ""
+msgstr "Kasutatakse ainult laiust, kõrgus arvutatakse automaatselt"
 
 #: lib/phoenix_kit/integrations/providers.ex:210
 #, elixir-autogen, elixir-format, fuzzy
 msgid "OpenRouter"
-msgstr ""
+msgstr "OpenRouter"
 
 #: lib/phoenix_kit_web/live/users/users.html.heex:233
 #, elixir-autogen, elixir-format
 msgid "Org"
-msgstr ""
+msgstr "Org"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:125
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:149
@@ -5012,44 +5012,44 @@ msgstr ""
 #: lib/phoenix_kit_web/users/user_form.html.heex:244
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Organization"
-msgstr ""
+msgstr "Organisatsioon"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:541
 #: lib/phoenix_kit_web/users/user_form.html.heex:695
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Organization Members"
-msgstr ""
+msgstr "Organisatsiooni liikmed"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:185
 #: lib/phoenix_kit_web/users/registration.html.heex:132
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Organization Name"
-msgstr ""
+msgstr "Organisatsiooni nimi"
 
 #: lib/phoenix_kit_web/users/user_form.html.heex:208
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Organization Name *"
-msgstr ""
+msgstr "Organisatsiooni nimi *"
 
 #: lib/modules/maintenance/settings.ex:381
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Page Content"
-msgstr ""
+msgstr "Lehe sisu"
 
 #: lib/modules/storage/web/health.html.heex:98
 #, elixir-autogen, elixir-format
 msgid "Pause"
-msgstr ""
+msgstr "Peata"
 
 #: lib/phoenix_kit_web/users/user_form.html.heex:806
 #, elixir-autogen, elixir-format
 msgid "Pending Invitations"
-msgstr ""
+msgstr "Ootel kutsed"
 
 #: lib/phoenix_kit_web/live/settings.html.heex:229
 #, elixir-autogen, elixir-format
 msgid "Per-user inbox driven by the activity feed"
-msgstr ""
+msgstr "Kasutajapõhine postkast, mida juhib tegevusvoog"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:126
 #: lib/phoenix_kit_web/live/users/users.html.heex:124
@@ -5057,273 +5057,273 @@ msgstr ""
 #: lib/phoenix_kit_web/users/user_form.html.heex:187
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Person"
-msgstr ""
+msgstr "Isik"
 
 #: lib/phoenix_kit_web/live/components/user_settings.ex:1125
 #, elixir-autogen, elixir-format
 msgid "Pick which notification types you want to receive. Unchecked types are muted — activities still record in the audit log but no bell notification is created for you."
-msgstr ""
+msgstr "Vali, milliseid teatiste tüüpe soovid saada. Märkimata tüübid on summutatud — tegevused salvestatakse ikkagi auditilogi, kuid kellukese teatist ei looda."
 
 #: lib/phoenix_kit_web/live/settings/integration_form.ex:172
 #, elixir-autogen, elixir-format
 msgid "Please enter a connection name."
-msgstr ""
+msgstr "Palun sisesta ühenduse nimi."
 
 #: lib/modules/maintenance/settings.ex:521
 #, elixir-autogen, elixir-format
 msgid "Please enter at least a start or end time"
-msgstr ""
+msgstr "Palun sisesta vähemalt algus- või lõpuaeg"
 
 #: lib/phoenix_kit_web/live/settings/integration_form.ex:231
 #, elixir-autogen, elixir-format
 msgid "Please save your Client ID first"
-msgstr ""
+msgstr "Palun salvesta kõigepealt oma Kliendi ID"
 
 #: lib/modules/storage/web/settings.html.heex:344
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Primary media location"
-msgstr ""
+msgstr "Peamine meediumia asukoht"
 
 #: lib/modules/storage/web/bucket_form.html.heex:338
 #, elixir-autogen, elixir-format
 msgid "Private (proxied)"
-msgstr ""
+msgstr "Privaatne (puhverdatud)"
 
 #: lib/phoenix_kit_web/live/settings.html.heex:88
 #, elixir-autogen, elixir-format
 msgid "Project Logo"
-msgstr ""
+msgstr "Projekti logo"
 
 #: lib/modules/storage/web/bucket_form.html.heex:139
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Provider Configuration"
-msgstr ""
+msgstr "Teenusepakkuja konfiguratsioon"
 
 #: lib/modules/storage/web/bucket_form.html.heex:332
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Public (direct URL)"
-msgstr ""
+msgstr "Avalik (otselink)"
 
 #: lib/modules/storage/web/dimension_form.html.heex:130
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Quality & Format"
-msgstr ""
+msgstr "Kvaliteet ja vorming"
 
 #: lib/modules/storage/web/health.html.heex:56
 #, elixir-autogen, elixir-format
 msgid "Redundancy target: %{n} copies"
-msgstr ""
+msgstr "Redundantsuse eesmärk: %{n} koopiat"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:601
 #: lib/phoenix_kit_web/users/user_form.html.heex:789
 #, elixir-autogen, elixir-format
 msgid "Remove from organization"
-msgstr ""
+msgstr "Eemalda organisatsioonist"
 
 #: lib/phoenix_kit_web/users/user_form.html.heex:790
 #, elixir-autogen, elixir-format
 msgid "Remove this member from the organization?"
-msgstr ""
+msgstr "Eemaldada see liige organisatsioonist?"
 
 #: lib/modules/storage/web/settings.html.heex:53
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Repair Media Module"
-msgstr ""
+msgstr "Paranda meediamoodulit"
 
 #: lib/modules/storage/web/health.html.heex:94
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Resume"
-msgstr ""
+msgstr "Jätka"
 
 #: lib/modules/storage/web/bucket_form.html.heex:398
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Save Bucket"
-msgstr ""
+msgstr "Salvesta bucket"
 
 #: lib/modules/maintenance/settings.ex:363
 #, elixir-autogen, elixir-format
 msgid "Save Schedule"
-msgstr ""
+msgstr "Salvesta ajakava"
 
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:336
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Save Tax Settings"
-msgstr ""
+msgstr "Salvesta maksuseaded"
 
 #: lib/phoenix_kit_web/live/components/user_settings.ex:1162
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Save preferences"
-msgstr ""
+msgstr "Salvesta eelistused"
 
 #: lib/modules/maintenance/settings.ex:440
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Saved!"
-msgstr ""
+msgstr "Salvestatud!"
 
 #: lib/modules/maintenance/settings.ex:533
 #, elixir-autogen, elixir-format
 msgid "Schedule cannot be more than a year in the future"
-msgstr ""
+msgstr "Ajakava ei saa olla rohkem kui aasta tulevikus"
 
 #: lib/modules/maintenance/settings.ex:317
 #, elixir-autogen, elixir-format
 msgid "Scheduled Maintenance"
-msgstr ""
+msgstr "Planeeritud hooldus"
 
 #: lib/modules/maintenance/settings.ex:357
 #, elixir-autogen, elixir-format
 msgid "Scheduled window is currently active"
-msgstr ""
+msgstr "Planeeritud aken on praegu aktiivne"
 
 #: lib/modules/storage/web/settings.html.heex:586
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Seamless file retrieval even when media locations fail"
-msgstr ""
+msgstr "Sujuv failide hankimine isegi kui meediumia asukohad ei tööta"
 
 #: lib/phoenix_kit/integrations/providers.ex:147
 #, elixir-autogen, elixir-format
 msgid "Search for **Google Drive API**, click it, then click **Enable**"
-msgstr ""
+msgstr "Otsi **Google Drive API**, klõpsa seda, seejärel klõpsa **Luba**"
 
 #: lib/phoenix_kit_web/components/core/integration_picker.ex:126
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Search integrations..."
-msgstr ""
+msgstr "Otsi integratsioone..."
 
 #: lib/phoenix_kit_web/live/settings/integration_form.ex:422
 #, elixir-autogen, elixir-format
 msgid "Security check failed. Please try connecting again."
-msgstr ""
+msgstr "Turvaline kontroll ebaõnnestus. Palun proovi uuesti ühendada."
 
 #: lib/phoenix_kit_web/users/user_form.html.heex:710
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select a user to add..."
-msgstr ""
+msgstr "Vali lisatav kasutaja..."
 
 #: lib/phoenix_kit_web/live/settings/integrations.html.heex:79
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Service"
-msgstr ""
+msgstr "Teenus"
 
 #: lib/phoenix_kit/integrations/integrations.ex:940
 #, elixir-autogen, elixir-format
 msgid "Service error %{status}"
-msgstr ""
+msgstr "Teenuse viga %{status}"
 
 #: lib/modules/maintenance/settings.ex:320
 #, elixir-autogen, elixir-format
 msgid "Set a time window for automatic maintenance activation."
-msgstr ""
+msgstr "Määra ajaaken automaatseks hoolduse aktiveerimiseks."
 
 #: lib/phoenix_kit/integrations/providers.ex:158
 #, elixir-autogen, elixir-format
 msgid "Set up OAuth consent"
-msgstr ""
+msgstr "Seadista OAuth nõusolek"
 
 #: lib/phoenix_kit_web/live/settings.html.heex:190
 #, elixir-autogen, elixir-format
 msgid "Shown in browser tabs and bookmarks. Should be square, at least 512×512 pixels."
-msgstr ""
+msgstr "Kuvatakse brauserikaartidel ja järjehoidjates. Peaks olema ruudukujuline, vähemalt 512×512 pikslit."
 
 #: lib/phoenix_kit_web/live/settings.html.heex:133
 #, elixir-autogen, elixir-format
 msgid "Site Icon"
-msgstr ""
+msgstr "Saidi ikoon"
 
 #: lib/modules/storage/web/dimension_form.html.heex:52
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Size Configuration"
-msgstr ""
+msgstr "Suuruse konfiguratsioon"
 
 #: lib/phoenix_kit/integrations/providers.ex:252
 #, elixir-autogen, elixir-format
 msgid "Some models are free, but most require credits"
-msgstr ""
+msgstr "Mõned mudelid on tasuta, kuid enamik vajab krediite"
 
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:319
 #, elixir-autogen, elixir-format
 msgid "Standard rate for your country: %{rate}%"
-msgstr ""
+msgstr "Standardmäär teie riigis: %{rate}%"
 
 #: lib/modules/maintenance/settings.ex:329
 #, elixir-autogen, elixir-format
 msgid "Start Time"
-msgstr ""
+msgstr "Algusaeg"
 
 #: lib/modules/maintenance/settings.ex:524
 #, elixir-autogen, elixir-format
 msgid "Start time must be in the future"
-msgstr ""
+msgstr "Algusaeg peab olema tulevikus"
 
 #: lib/phoenix_kit_web/live/settings/integration_form.html.heex:182
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Step 1"
-msgstr ""
+msgstr "Samm 1"
 
 #: lib/phoenix_kit_web/live/settings/integration_form.html.heex:319
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Step 2"
-msgstr ""
+msgstr "Samm 2"
 
 #: lib/phoenix_kit/integrations/providers.ex:166
 #, elixir-autogen, elixir-format
 msgid "Still on Audience — while the app is in **Testing** status, add the Google account you will connect as a **Test user** (this must be the same account whose Drive will store your files)"
-msgstr ""
+msgstr "Ikka Sihtrühm lehel — kuni rakendus on **Testimine** olekus, lisage Google konto, mille ühendate, kui **Testkasutaja** (see peab olema sama konto, mille Drive salvestab teie failid)"
 
 #: lib/modules/storage/web/health.html.heex:106
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Stop"
-msgstr ""
+msgstr "Peata"
 
 #: lib/modules/storage/web/health.html.heex:103
 #, elixir-autogen, elixir-format
 msgid "Stop the sync? Files already synced will be kept."
-msgstr ""
+msgstr "Kas peatada sünkroonimine? Juba sünkroonitud failid säilitatakse."
 
 #: lib/modules/storage/web/health.html.heex:70
 #, elixir-autogen, elixir-format
 msgid "Sync All"
-msgstr ""
+msgstr "Sünkrooni kõik"
 
 #: lib/modules/storage/web/health.html.heex:156
 #, elixir-autogen, elixir-format
 msgid "Sync Log"
-msgstr ""
+msgstr "Sünkroonimise logi"
 
 #: lib/modules/storage/web/health.ex:151
 #, elixir-autogen, elixir-format
 msgid "Sync complete: %{synced} synced, %{failed} failed"
-msgstr ""
+msgstr "Sünkroonimine lõpetatud: %{synced} sünkroonitud, %{failed} ebaõnnestus"
 
 #: lib/modules/storage/web/health.ex:52
 #, elixir-autogen, elixir-format
 msgid "Sync is already running"
-msgstr ""
+msgstr "Sünkroonimine on juba käimas"
 
 #: lib/modules/storage/web/health.html.heex:87
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Sync paused"
-msgstr ""
+msgstr "Sünkroonimine peatatud"
 
 #: lib/modules/storage/web/health.ex:170
 #, elixir-autogen, elixir-format
 msgid "Sync stopped: %{synced} synced, %{failed} failed"
-msgstr ""
+msgstr "Sünkroonimine peatatud: %{synced} sünkroonitud, %{failed} ebaõnnestus"
 
 #: lib/modules/storage/web/health.html.heex:89
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Syncing files..."
-msgstr ""
+msgstr "Failide sünkroonimine..."
 
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:272
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Tax Settings"
-msgstr ""
+msgstr "Maksuseaded"
 
 #: lib/phoenix_kit_web/live/settings/organization.ex:184
 #, elixir-autogen, elixir-format
 msgid "Tax settings saved"
-msgstr ""
+msgstr "Maksuseaded salvestatud"
 
 #: lib/modules/storage/web/bucket_form.html.heex:291
 #: lib/phoenix_kit_web/live/settings/integration_form.html.heex:307
@@ -5331,13 +5331,13 @@ msgstr ""
 #: lib/phoenix_kit_web/live/settings/integrations.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "Test Connection"
-msgstr ""
+msgstr "Testi ühendust"
 
 #: lib/phoenix_kit_web/live/settings/integration_form.ex:367
 #: lib/phoenix_kit_web/live/settings/integration_form.ex:462
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Test failed"
-msgstr ""
+msgstr "Test ebaõnnestus"
 
 #: lib/modules/storage/web/bucket_form.html.heex:288
 #: lib/phoenix_kit_web/live/settings/integration_form.html.heex:307
@@ -5345,279 +5345,279 @@ msgstr ""
 #: lib/phoenix_kit_web/live/settings/integrations.html.heex:108
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Testing..."
-msgstr ""
+msgstr "Testimine..."
 
 #: lib/phoenix_kit_web/live/settings.html.heex:217
 #, elixir-autogen, elixir-format
 msgid "Text shown in the browser tab when a page doesn't set its own title."
-msgstr ""
+msgstr "Tekst, mis kuvatakse brauserikaardil, kui lehel pole oma pealkirja määratud."
 
 #: lib/modules/storage/web/settings.html.heex:603
 #, elixir-autogen, elixir-format, fuzzy
 msgid "The media system is designed for distributed file management with automatic redundancy."
-msgstr ""
+msgstr "Meediasüsteem on loodud hajutatud failihalduseks automaatse redundantsusega."
 
 #: lib/phoenix_kit_web/components/core/integration_picker.ex:231
 #, elixir-autogen, elixir-format
 msgid "The selected integration no longer exists. Please choose a different one."
-msgstr ""
+msgstr "Valitud integratsioon ei eksisteeri enam. Palun vali mõni muu."
 
 #: lib/phoenix_kit_web/live/settings/integrations.html.heex:160
 #: lib/phoenix_kit_web/live/settings/integrations.html.heex:205
 #, elixir-autogen, elixir-format
 msgid "This integration may be in use by other parts of the system. Remove it permanently?"
-msgstr ""
+msgstr "See integratsioon võib olla kasutusel muudes süsteemi osades. Eemaldada jäädavalt?"
 
 #: lib/phoenix_kit_web/hooks/invitation_hook.ex:72
 #, elixir-autogen, elixir-format
 msgid "This invitation has expired."
-msgstr ""
+msgstr "See kutse on aegunud."
 
 #: lib/modules/maintenance/settings.ex:479
 #, elixir-autogen, elixir-format
 msgid "This is how non-admin users will see the maintenance page"
-msgstr ""
+msgstr "Nii näevad mitte-administraator kasutajad hoolduselehte"
 
 #: lib/modules/storage/web/bucket_form.html.heex:197
 #, elixir-autogen, elixir-format
 msgid "Tigris Bucket Name"
-msgstr ""
+msgstr "Tigris bucketi nimi"
 
 #: lib/modules/storage/web/bucket_form.html.heex:217
 #, elixir-autogen, elixir-format
 msgid "Tigris Endpoint"
-msgstr ""
+msgstr "Tigris lõpp-punkt"
 
 #: lib/modules/storage/web/bucket_form.html.heex:180
 #, elixir-autogen, elixir-format
 msgid "Tigris Region"
-msgstr ""
+msgstr "Tigris piirkond"
 
 #: lib/modules/storage/web/health.html.heex:22
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Total Files"
-msgstr ""
+msgstr "Faile kokku"
 
 #: lib/phoenix_kit/integrations/providers.ex:188
 #, elixir-autogen, elixir-format
 msgid "Under **Authorized redirect URIs**, add: `{redirect_uri}`"
-msgstr ""
+msgstr "**Volitatud ümbersuunamise URL-id** all lisage: `{redirect_uri}`"
 
 #: lib/modules/storage/web/health.html.heex:42
 #, elixir-autogen, elixir-format
 msgid "Under-replicated"
-msgstr ""
+msgstr "Ebapiisav replikatsioon"
 
 #: lib/phoenix_kit/integrations/integrations.ex:830
 #: lib/phoenix_kit/integrations/integrations.ex:891
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Unknown provider"
-msgstr ""
+msgstr "Tundmatu teenusepakkuja"
 
 #: lib/phoenix_kit_web/users/user_form.html.heex:732
 #, elixir-autogen, elixir-format
 msgid "Use the dropdown above to add members"
-msgstr ""
+msgstr "Kasuta ülalolevat rippmenüüd liikmete lisamiseks"
 
 #: lib/phoenix_kit/integrations/integrations.ex:868
 #: lib/phoenix_kit/integrations/integrations.ex:900
 #, elixir-autogen, elixir-format
 msgid "Validation failed unexpectedly"
-msgstr ""
+msgstr "Valideerimine ebaõnnestus ootamatult"
 
 #: lib/modules/maintenance/settings.ex:412
 #, elixir-autogen, elixir-format
 msgid "We'll be back soon..."
-msgstr ""
+msgstr "Oleme varsti tagasi..."
 
 #: lib/phoenix_kit_web/live/dashboard/index.ex:23
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Welcome to your personal dashboard"
-msgstr ""
+msgstr "Tere tulemast oma isiklikule armatuurlauale"
 
 #: lib/phoenix_kit_web/live/settings.html.heex:247
 #, elixir-autogen, elixir-format
 msgid "When on, users receive a bell notification whenever an activity targets them (e.g., their post is liked)."
-msgstr ""
+msgstr "Kui sees, saavad kasutajad kellukese teatise iga kord, kui tegevus on suunatud neile (nt nende postitus saab meeldimise)."
 
 #: lib/phoenix_kit_web/users/user_form.ex:355
 #, elixir-autogen, elixir-format
 msgid "You cannot invite yourself"
-msgstr ""
+msgstr "Sa ei saa ennast kutsuda"
 
 #: lib/phoenix_kit_web/hooks/invitation_hook.ex:67
 #, elixir-autogen, elixir-format
 msgid "You joined the organization!"
-msgstr ""
+msgstr "Liitusite organisatsiooniga!"
 
 #: lib/modules/storage/web/settings.html.heex:131
 #, elixir-autogen, elixir-format, fuzzy
 msgid "You need to create at least one media bucket before files can be uploaded."
-msgstr ""
+msgstr "Enne failide üleslaadimist peate looma vähemalt ühe meedia bucketi."
 
 #: lib/phoenix_kit/integrations/providers.ex:200
 #: lib/phoenix_kit/integrations/providers.ex:503
 #, elixir-autogen, elixir-format
 msgid "You'll be redirected back here once connected"
-msgstr ""
+msgstr "Teid suunatakse tagasi siia pärast ühendamist"
 
 #: lib/phoenix_kit_web/live/settings/integrations.html.heex:55
 #, elixir-autogen, elixir-format, fuzzy
 msgid "connections"
-msgstr ""
+msgstr "ühendust"
 
 #: lib/phoenix_kit_web/live/settings.html.heex:212
 #, elixir-autogen, elixir-format
 msgid "e.g. Welcome to My Site"
-msgstr ""
+msgstr "nt Tere tulemast minu saidile"
 
 #: lib/modules/storage/web/bucket_form.html.heex:31
 #, elixir-autogen, elixir-format
 msgid "e.g., Production Media, Backup Storage"
-msgstr ""
+msgstr "nt Tootmise meedia, Varukoopia salvestus"
 
 #: lib/phoenix_kit_web/components/invitation_banner.ex:44
 #, elixir-autogen, elixir-format
 msgid "invited you to join their organization."
-msgstr ""
+msgstr "kutsus teid oma organisatsiooniga liituma."
 
 #: lib/phoenix_kit_web/live/users/roles.html.heex:107
 #, elixir-autogen, elixir-format, fuzzy
 msgid "roles"
-msgstr ""
+msgstr "rolli"
 
 #: lib/phoenix_kit_web/live/settings/integration_form.ex:740
 #, elixir-autogen, elixir-format
 msgid "%{n} days ago"
-msgstr ""
+msgstr "%{n} päeva tagasi"
 
 #: lib/phoenix_kit_web/live/settings/integration_form.ex:737
 #, elixir-autogen, elixir-format
 msgid "%{n} hours ago"
-msgstr ""
+msgstr "%{n} tundi tagasi"
 
 #: lib/phoenix_kit_web/live/settings/integration_form.ex:734
 #, elixir-autogen, elixir-format
 msgid "%{n} minutes ago"
-msgstr ""
+msgstr "%{n} minutit tagasi"
 
 #: lib/phoenix_kit_web/live/settings/integration_form.ex:739
 #, elixir-autogen, elixir-format
 msgid "1 day ago"
-msgstr ""
+msgstr "1 päev tagasi"
 
 #: lib/phoenix_kit_web/live/settings/integration_form.ex:736
 #, elixir-autogen, elixir-format
 msgid "1 hour ago"
-msgstr ""
+msgstr "1 tund tagasi"
 
 #: lib/phoenix_kit_web/live/settings/integration_form.ex:733
 #, elixir-autogen, elixir-format
 msgid "1 minute ago"
-msgstr ""
+msgstr "1 minut tagasi"
 
 #: lib/phoenix_kit_web/live/settings/integration_form.ex:321
 #: lib/phoenix_kit_web/live/settings/integration_form.ex:482
 #, elixir-autogen, elixir-format
 msgid "A connection with that name already exists."
-msgstr ""
+msgstr "Sellise nimega ühendus on juba olemas."
 
 #: lib/phoenix_kit/integrations/providers.ex:325
 #, elixir-autogen, elixir-format
 msgid "AI model access via DeepSeek (deepseek-chat, deepseek-reasoner)"
-msgstr ""
+msgstr "Juurdepääs AI mudelitele DeepSeeki kaudu (deepseek-chat, deepseek-reasoner)"
 
 #: lib/phoenix_kit/integrations/providers.ex:264
 #, elixir-autogen, elixir-format
 msgid "AI model access via Mistral AI (Mistral Large, Codestral, Pixtral)"
-msgstr ""
+msgstr "Juurdepääs AI mudelitele Mistral AI kaudu (Mistral Large, Codestral, Pixtral)"
 
 #: lib/phoenix_kit/integrations/providers.ex:469
 #, elixir-autogen, elixir-format
 msgid "Add a client secret"
-msgstr ""
+msgstr "Lisa kliendi saladus"
 
 #: lib/phoenix_kit/integrations/providers.ex:297
 #, elixir-autogen, elixir-format
 msgid "Add a payment method (required)"
-msgstr ""
+msgstr "Lisa makseviis (kohustuslik)"
 
 #: lib/phoenix_kit/integrations/providers.ex:357
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add credits"
-msgstr ""
+msgstr "Lisa krediite"
 
 #: lib/phoenix_kit/integrations/providers.ex:484
 #, elixir-autogen, elixir-format
 msgid "Add the permissions your integration needs: `User.Read` is included by default; add `Mail.Read`, `Files.Read.All`, `Calendars.Read`, etc. as required"
-msgstr ""
+msgstr "Lisa integratsioonile vajalikud õigused: `User.Read` on vaikimisi lisatud; vajadusel lisage `Mail.Read`, `Files.Read.All`, `Calendars.Read` jt"
 
 #: lib/phoenix_kit/integrations/providers.ex:411
 #, elixir-autogen, elixir-format
 msgid "Application (client) ID"
-msgstr ""
+msgstr "Rakenduse (kliendi) ID"
 
 #: lib/phoenix_kit_web/live/settings/integration_form.html.heex:457
 #, elixir-autogen, elixir-format
 msgid "Clears the OAuth tokens. Credentials and the connection itself stay so you can reconnect with one click."
-msgstr ""
+msgstr "Tühjendab OAuth tokenid. Mandaadid ja ühendus ise jäävad, nii et saad ühe klõpsuga uuesti ühendada."
 
 #: lib/phoenix_kit/integrations/providers.ex:371
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Click **Create API key**, give it a name"
-msgstr ""
+msgstr "Klõpsa **Loo API võti**, anna sellele nimi"
 
 #: lib/phoenix_kit/integrations/providers.ex:313
 #, elixir-autogen, elixir-format
 msgid "Click **Create new key**, give it a name, set an expiry if desired"
-msgstr ""
+msgstr "Klõpsa **Loo uus võti**, anna sellele nimi, määra aegumiskuupäev soovi korral"
 
 #: lib/phoenix_kit/integrations/providers.ex:456
 #, elixir-autogen, elixir-format
 msgid "Click **New registration**, give the app a name"
-msgstr ""
+msgstr "Klõpsa **Uus registreerimine**, anna rakendusele nimi"
 
 #: lib/phoenix_kit/integrations/providers.ex:461
 #, elixir-autogen, elixir-format
 msgid "Click **Register**"
-msgstr ""
+msgstr "Klõpsa **Registreeri**"
 
 #: lib/phoenix_kit/integrations/providers.ex:479
 #, elixir-autogen, elixir-format
 msgid "Configure API permissions"
-msgstr ""
+msgstr "Seadista API õigused"
 
 #: lib/phoenix_kit_web/live/settings/integrations.html.heex:220
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Connect external services like %{providers}."
-msgstr ""
+msgstr "Ühenda välised teenused nagu %{providers}."
 
 #: lib/phoenix_kit_web/live/settings/integration_form.ex:325
 #: lib/phoenix_kit_web/live/settings/integration_form.ex:485
 #, elixir-autogen, elixir-format
 msgid "Connection name can't be blank."
-msgstr ""
+msgstr "Ühenduse nimi ei saa olla tühi."
 
 #: lib/phoenix_kit_web/live/settings/integration_form.ex:311
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Connection renamed"
-msgstr ""
+msgstr "Ühendus ümber nimetatud"
 
 #: lib/phoenix_kit/integrations/providers.ex:473
 #, elixir-autogen, elixir-format
 msgid "Copy the **Value** column (not the Secret ID) into the form above — the value is shown ONCE and disappears on page refresh"
-msgstr ""
+msgstr "Kopeeri **Väärtus** veerg (mitte Saladuse ID) ülalolevasse vormi — väärtust kuvatakse ÜHEKORDSELT ja see kaob lehe värskendamisel"
 
 #: lib/phoenix_kit/integrations/providers.ex:314
 #: lib/phoenix_kit/integrations/providers.ex:372
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Copy the key (shown once) and paste it into the form above"
-msgstr ""
+msgstr "Kopeeri võti (kuvatakse ühekordselt) ja kleebi see ülalolevasse vormi"
 
 #: lib/phoenix_kit_web/live/settings/integration_form.html.heex:274
 #, elixir-autogen, elixir-format
 msgid "Create Connection"
-msgstr ""
+msgstr "Loo ühendus"
 
 #: lib/phoenix_kit/integrations/providers.ex:349
 #, elixir-autogen, elixir-format, fuzzy
@@ -5632,188 +5632,188 @@ msgstr "Loo konto"
 #: lib/phoenix_kit_web/live/settings/integration_form.html.heex:439
 #, elixir-autogen, elixir-format
 msgid "Danger Zone"
-msgstr ""
+msgstr "Ohumärkide tsoon"
 
 #: lib/phoenix_kit/integrations/providers.ex:324
 #, elixir-autogen, elixir-format
 msgid "DeepSeek"
-msgstr ""
+msgstr "DeepSeek"
 
 #: lib/phoenix_kit/integrations/providers.ex:362
 #, elixir-autogen, elixir-format
 msgid "DeepSeek requires a positive balance before you can call the chat or reasoner endpoints, even on cheap models"
-msgstr ""
+msgstr "DeepSeek nõuab positiivset jääki enne chat või reasoner lõpp-punktide kutsumist, isegi odavate mudelite puhul"
 
 #: lib/phoenix_kit_web/live/settings/integration_form.html.heex:479
 #, elixir-autogen, elixir-format
 msgid "Delete this connection"
-msgstr ""
+msgstr "Kustuta see ühendus"
 
 #: lib/phoenix_kit_web/live/settings/integration_form.html.heex:455
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Disconnect account"
-msgstr ""
+msgstr "Ühenda konto lahti"
 
 #: lib/phoenix_kit_web/components/core/table_default.ex:269
 #, elixir-autogen, elixir-format
 msgid "Drag to reorder"
-msgstr ""
+msgstr "Lohistage järjestuse muutmiseks"
 
 #: lib/phoenix_kit_web/live/settings/integration_form.ex:168
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to load connection"
-msgstr ""
+msgstr "Ühenduse laadimine ebaõnnestus"
 
 #: lib/phoenix_kit_web/live/settings/integration_form.ex:292
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to remove connection."
-msgstr ""
+msgstr "Ühenduse eemaldamine ebaõnnestus."
 
 #: lib/phoenix_kit_web/live/settings/integration_form.ex:336
 #: lib/phoenix_kit_web/live/settings/integration_form.ex:496
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to rename connection."
-msgstr ""
+msgstr "Ühenduse ümbernimetamine ebaõnnestus."
 
 #: lib/phoenix_kit/integrations/providers.ex:302
 #, elixir-autogen, elixir-format
 msgid "Free models still require a billing-enabled workspace"
-msgstr ""
+msgstr "Tasuta mudelid vajavad ikkagi arveldamisvõimalustega tööruumi"
 
 #: lib/phoenix_kit/integrations/providers.ex:415
 #, elixir-autogen, elixir-format
 msgid "From Azure Portal → App registrations → your app → Overview"
-msgstr ""
+msgstr "Azure Portal → Rakenduste registreerimised → teie rakendus → Ülevaade alt"
 
 #: lib/phoenix_kit/integrations/providers.ex:281
 #, elixir-autogen, elixir-format
 msgid "From console.mistral.ai/api-keys"
-msgstr ""
+msgstr "console.mistral.ai/api-keys alt"
 
 #: lib/phoenix_kit/integrations/providers.ex:342
 #, elixir-autogen, elixir-format
 msgid "From platform.deepseek.com/api_keys"
-msgstr ""
+msgstr "platform.deepseek.com/api_keys alt"
 
 #: lib/phoenix_kit/integrations/providers.ex:425
 #, elixir-autogen, elixir-format
 msgid "From your app → Certificates & secrets → New client secret. Copy the *Value*, not the Secret ID."
-msgstr ""
+msgstr "Teie rakendus → Sertifikaadid ja saladused → Uus kliendi saladus alt. Kopeeri *Väärtus*, mitte Saladuse ID."
 
 #: lib/phoenix_kit/integrations/providers.ex:481
 #, elixir-autogen, elixir-format
 msgid "Go to **API permissions → Add a permission → Microsoft Graph → Delegated permissions**"
-msgstr ""
+msgstr "Mine **API õigused → Lisa luba → Microsoft Graph → Delegeeritud õigused** lehele"
 
 #: lib/phoenix_kit/integrations/providers.ex:471
 #, elixir-autogen, elixir-format
 msgid "Go to **Certificates & secrets → New client secret**"
-msgstr ""
+msgstr "Mine **Sertifikaadid ja saladused → Uus kliendi saladus** lehele"
 
 #: lib/phoenix_kit/integrations/providers.ex:312
 #, elixir-autogen, elixir-format
 msgid "Go to [API Keys](https://console.mistral.ai/api-keys)"
-msgstr ""
+msgstr "Mine [API võtmed](https://console.mistral.ai/api-keys) lehele"
 
 #: lib/phoenix_kit/integrations/providers.ex:370
 #, elixir-autogen, elixir-format
 msgid "Go to [API Keys](https://platform.deepseek.com/api_keys)"
-msgstr ""
+msgstr "Mine [API võtmed](https://platform.deepseek.com/api_keys) lehele"
 
 #: lib/phoenix_kit/integrations/providers.ex:359
 #, elixir-autogen, elixir-format
 msgid "Go to [Top up](https://platform.deepseek.com/top_up) and add at least the minimum amount"
-msgstr ""
+msgstr "Mine [Täienda](https://platform.deepseek.com/top_up) lehele ja lisa vähemalt minimaalne summa"
 
 #: lib/phoenix_kit/integrations/providers.ex:299
 #, elixir-autogen, elixir-format
 msgid "Go to [Workspace → Billing](https://console.mistral.ai/billing/plans) and choose **Experiment** (pay-as-you-go) or a paid tier"
-msgstr ""
+msgstr "Mine [Tööruum → Arveldamine](https://console.mistral.ai/billing/plans) lehele ja vali **Eksperiment** (maksa kasutamise järgi) või tasuline tase"
 
 #: lib/phoenix_kit/integrations/providers.ex:290
 #, elixir-autogen, elixir-format
 msgid "Go to [console.mistral.ai](https://console.mistral.ai) and sign up or log in"
-msgstr ""
+msgstr "Mine [console.mistral.ai](https://console.mistral.ai) lehele ja registreeru või logi sisse"
 
 #: lib/phoenix_kit/integrations/providers.ex:351
 #, elixir-autogen, elixir-format
 msgid "Go to [platform.deepseek.com](https://platform.deepseek.com) and sign up or log in"
-msgstr ""
+msgstr "Mine [platform.deepseek.com](https://platform.deepseek.com) lehele ja registreeru või logi sisse"
 
 #: lib/phoenix_kit/integrations/providers.ex:453
 #, elixir-autogen, elixir-format
 msgid "Go to the [Azure Portal](https://portal.azure.com) and search for **App registrations**"
-msgstr ""
+msgstr "Mine [Azure Portal](https://portal.azure.com) lehele ja otsi **Rakenduste registreerimised**"
 
 #: lib/phoenix_kit/integrations/providers.ex:464
 #, elixir-autogen, elixir-format
 msgid "If you picked a single-tenant audience, fill in **Tenant ID** above with your Directory (tenant) ID GUID — leaving it as `common` only works for multi-tenant + personal apps."
-msgstr ""
+msgstr "Kui valisite ühekordse rentnikuga sihtrühma, täitke **Rentniku ID** ülalpool oma kataloogi (rentniku) ID GUID-iga — `common` jätmine töötab ainult mitme rentnikuga + isiklike rakenduste puhul."
 
 #: lib/phoenix_kit/integrations/providers.ex:487
 #, elixir-autogen, elixir-format
 msgid "If your tenant requires admin consent, click **Grant admin consent for <tenant>** before the connect flow will work"
-msgstr ""
+msgstr "Kui teie rentnik nõuab administraatori nõusolekut, klõpsake **Anna administraatori nõusolek <tenant> jaoks** enne kui ühenduse voog töötab"
 
 #: lib/phoenix_kit_web/live/settings/integration_form.ex:121
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Integration not found"
-msgstr ""
+msgstr "Integratsiooni ei leitud"
 
 #: lib/phoenix_kit_web/live/settings/integration_form.html.heex:131
 #, elixir-autogen, elixir-format
 msgid "Last tested"
-msgstr ""
+msgstr "Viimati testitud"
 
 #: lib/phoenix_kit/integrations/providers.ex:437
 #, elixir-autogen, elixir-format
 msgid "Leave as `common` for multi-tenant + personal accounts. For single-tenant apps, paste your Directory (tenant) ID GUID. Use `consumers` for personal-only or `organizations` for any work-or-school account."
-msgstr ""
+msgstr "Jätke `common` mitme rentnikuga + isiklike kontode jaoks. Ühekordse rentnikuga rakenduste jaoks kleepige oma Kataloogi (rentniku) ID GUID. Kasutage `consumers` ainult isiklike või `organizations` töökoha-või kooli kontode jaoks."
 
 #: lib/phoenix_kit_web/live/settings/integration_form.html.heex:210
 #, elixir-autogen, elixir-format
 msgid "Letters, digits, hyphens, and underscores. Must be unique per provider."
-msgstr ""
+msgstr "Tähed, numbrid, sidekriipsud ja allkriipsud. Peab olema teenusepakkuja lõikes unikaalne."
 
 #: lib/phoenix_kit/integrations/providers.ex:382
 #, elixir-autogen, elixir-format
 msgid "Microsoft 365"
-msgstr ""
+msgstr "Microsoft 365"
 
 #: lib/phoenix_kit/integrations/providers.ex:383
 #, elixir-autogen, elixir-format
 msgid "Microsoft Graph — Outlook, OneDrive, Teams, Calendar, SharePoint"
-msgstr ""
+msgstr "Microsoft Graph — Outlook, OneDrive, Teams, Calendar, SharePoint"
 
 #: lib/phoenix_kit/integrations/providers.ex:500
 #, elixir-autogen, elixir-format
 msgid "Microsoft will show the consent screen — click **Accept** to grant the requested permissions"
-msgstr ""
+msgstr "Microsoft näitab nõusolekuekraani — klõpsa **Nõustu** taotletud õiguste andmiseks"
 
 #: lib/phoenix_kit/integrations/providers.ex:263
 #, elixir-autogen, elixir-format
 msgid "Mistral"
-msgstr ""
+msgstr "Mistral"
 
 #: lib/phoenix_kit/integrations/providers.ex:305
 #, elixir-autogen, elixir-format
 msgid "Mistral does not offer credits without billing setup; this is a hard requirement before keys can be created."
-msgstr ""
+msgstr "Mistral ei paku krediite ilma arvelduse seadistamiseta; see on kohustuslik nõue enne võtmete loomist."
 
 #: lib/phoenix_kit_web/live/settings/integration_form.html.heex:490
 #, elixir-autogen, elixir-format
 msgid "Permanently delete this connection? This cannot be undone."
-msgstr ""
+msgstr "Kustutada see ühendus jäädavalt? Seda ei saa tagasi võtta."
 
 #: lib/phoenix_kit/integrations/providers.ex:451
 #, elixir-autogen, elixir-format
 msgid "Register an application in Microsoft Entra ID (Azure AD)"
-msgstr ""
+msgstr "Registreerige rakendus Microsoft Entra ID-s (Azure AD)"
 
 #: lib/phoenix_kit_web/live/settings/integration_form.html.heex:481
 #, elixir-autogen, elixir-format
 msgid "Removes the integration permanently. Any module pinned to this connection will stop working until repointed."
-msgstr ""
+msgstr "Eemaldab integratsiooni jäädavalt. Ükski moodul, mis on selle ühendusega seotud, ei tööta, kuni see on ümber suunatud."
 
 #: lib/phoenix_kit_web/components/core/table_default.ex:499
 #, elixir-autogen, elixir-format
@@ -5823,48 +5823,48 @@ msgstr "Otsi..."
 #: lib/phoenix_kit/integrations/providers.ex:472
 #, elixir-autogen, elixir-format
 msgid "Set an expiration (24 months is common; renew before it lapses)"
-msgstr ""
+msgstr "Määrake aegumisaeg (24 kuud on tavaline; uuendage enne aegumist)"
 
 #: lib/phoenix_kit/integrations/providers.ex:432
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Tenant ID"
-msgstr ""
+msgstr "Rentniku ID"
 
 #: lib/phoenix_kit/integrations/providers.ex:492
 #, elixir-autogen, elixir-format
 msgid "The `default_scopes` in the provider definition request `openid email profile offline_access User.Read` — extra scopes can be added per-connect by passing `extra_scopes` to `authorization_url/5`."
-msgstr ""
+msgstr "`default_scopes` teenusepakkuja definitsioonis taotleb `openid email profile offline_access User.Read` — täiendavaid ulatusi saab lisada ühenduse kaupa, edastades `extra_scopes` parameetri `authorization_url/5` funktsioonile."
 
 #: lib/phoenix_kit/integrations/providers.ex:460
 #, elixir-autogen, elixir-format
 msgid "Under **Redirect URI**, choose **Web** and enter: `{redirect_uri}`"
-msgstr ""
+msgstr "**Ümbersuunamise URI** all valige **Veebi** ja sisestage: `{redirect_uri}`"
 
 #: lib/phoenix_kit/integrations/providers.ex:457
 #, elixir-autogen, elixir-format
 msgid "Under **Supported account types**, choose the audience: *Personal Microsoft accounts only*, *Accounts in any organizational directory*, or *Accounts in this organizational directory only* depending on who should sign in"
-msgstr ""
+msgstr "**Toetatud kontotüübid** all valige sihtrühm: *Ainult isiklikud Microsoft kontod*, *Kontod mis tahes organisatsioonilises kataloogis* või *Kontod ainult selles organisatsioonilises kataloogis* sõltuvalt sellest, kes peaks sisse logima"
 
 #: lib/phoenix_kit_web/live/settings/integration_form.ex:332
 #: lib/phoenix_kit_web/live/settings/integration_form.ex:492
 #, elixir-autogen, elixir-format
 msgid "Use letters, digits, hyphens, and underscores only."
-msgstr ""
+msgstr "Kasuta ainult tähti, numbreid, sidekriipse ja allkriipse."
 
 #: lib/phoenix_kit/integrations/providers.ex:293
 #, elixir-autogen, elixir-format
 msgid "You may need to verify your phone number before creating API keys"
-msgstr ""
+msgstr "Enne API võtmete loomist võib olla vaja telefoninumber kinnitada"
 
 #: lib/phoenix_kit_web/live/settings/integration_form.html.heex:205
 #, elixir-autogen, elixir-format
 msgid "e.g. main, personal, work"
-msgstr ""
+msgstr "nt main, isiklik, töö"
 
 #: lib/phoenix_kit_web/live/settings/integration_form.ex:721
 #, elixir-autogen, elixir-format
 msgid "just now"
-msgstr ""
+msgstr "just nüüd"
 
 #: lib/phoenix_kit_web/live/modules.html.heex:298
 #, elixir-autogen, elixir-format
@@ -6207,3 +6207,48 @@ msgstr "moodul peab olema lubatud. Mõned funktsioonid ei pruugi korralikult tö
 #, elixir-autogen, elixir-format
 msgid "requires the"
 msgstr "nõuab, et"
+
+#: lib/phoenix_kit/dashboard/admin_tabs.ex:148
+#, elixir-autogen, elixir-format
+msgid "Activity"
+msgstr "Tegevus"
+
+#: lib/phoenix_kit/dashboard/admin_tabs.ex:245
+#, elixir-autogen, elixir-format
+msgid "Authorization"
+msgstr "Volitamine"
+
+#: lib/phoenix_kit/dashboard/admin_tabs.ex:294
+#, elixir-autogen, elixir-format
+msgid "Dimensions"
+msgstr "Mõõtmed"
+
+#: lib/phoenix_kit/dashboard/admin_tabs.ex:235
+#, elixir-autogen, elixir-format
+msgid "General"
+msgstr "Üldine"
+
+#: lib/phoenix_kit/dashboard/admin_tabs.ex:102
+#, elixir-autogen, elixir-format
+msgid "Live Sessions"
+msgstr "Aktiivsed sessioonid"
+
+#: lib/modules/maintenance/maintenance.ex:528
+#, elixir-autogen, elixir-format
+msgid "Maintenance"
+msgstr "Hooldus"
+
+#: lib/phoenix_kit/dashboard/admin_tabs.ex:93
+#, elixir-autogen, elixir-format
+msgid "Manage Users"
+msgstr "Halda kasutajaid"
+
+#: lib/phoenix_kit/dashboard/admin_tabs.ex:160
+#, elixir-autogen, elixir-format
+msgid "Media"
+msgstr "Meedia"
+
+#: lib/modules/referrals/referrals.ex:658
+#, elixir-autogen, elixir-format
+msgid "Referrals"
+msgstr "Soovitused"

--- a/priv/gettext/et/LC_MESSAGES/default.po
+++ b/priv/gettext/et/LC_MESSAGES/default.po
@@ -6252,3 +6252,43 @@ msgstr "Meedia"
 #, elixir-autogen, elixir-format
 msgid "Referrals"
 msgstr "Soovitused"
+
+#: lib/phoenix_kit_web/components/core/badge.ex:125
+#, elixir-autogen, elixir-format
+msgid "Expired"
+msgstr "Aegunud"
+
+#: lib/phoenix_kit_web/components/core/badge.ex:162
+#, elixir-autogen, elixir-format
+msgid "Transactional"
+msgstr "Tehinguline"
+
+#: lib/phoenix_kit_web/components/core/time_display.ex:206
+#, elixir-autogen, elixir-format
+msgid "No expiration"
+msgstr "Aegumiseta"
+
+#: lib/phoenix_kit_web/components/core/time_display.ex:212
+#, elixir-autogen, elixir-format
+msgid "Today"
+msgstr "Täna"
+
+#: lib/phoenix_kit_web/components/core/time_display.ex:187
+#, elixir-autogen, elixir-format
+msgid "%{count}s ago"
+msgstr "%{count} s tagasi"
+
+#: lib/phoenix_kit_web/components/core/time_display.ex:188
+#, elixir-autogen, elixir-format
+msgid "%{count}m ago"
+msgstr "%{count} min tagasi"
+
+#: lib/phoenix_kit_web/components/core/time_display.ex:189
+#, elixir-autogen, elixir-format
+msgid "%{count}h ago"
+msgstr "%{count} t tagasi"
+
+#: lib/phoenix_kit_web/components/core/time_display.ex:190
+#, elixir-autogen, elixir-format
+msgid "%{count}d ago"
+msgstr "%{count} päeva tagasi"

--- a/priv/gettext/et/LC_MESSAGES/default.po
+++ b/priv/gettext/et/LC_MESSAGES/default.po
@@ -6292,3 +6292,66 @@ msgstr "%{count} t tagasi"
 #, elixir-autogen, elixir-format
 msgid "%{count}d ago"
 msgstr "%{count} päeva tagasi"
+
+msgid "Summary"
+msgstr "Kokkuvõte"
+
+msgid "Languages Enabled"
+msgstr "Lubatud keeled"
+
+msgid "Countries Covered"
+msgstr "Kaetud riigid"
+
+msgid "Enabled Languages"
+msgstr "Lubatud keeled"
+
+msgid "Default language"
+msgstr "Vaikekeel"
+
+msgid "Available Languages"
+msgstr "Saadaolevad keeled"
+
+msgid "Language Configuration"
+msgstr "Keele seadistus"
+
+msgid "Frontend Language Switcher"
+msgstr "Esikülje keelevahetaja"
+
+msgid "Switcher Settings"
+msgstr "Vahetaja seaded"
+
+msgid "Show Flags"
+msgstr "Näita lippe"
+
+msgid "Show Names"
+msgstr "Näita nimesid"
+
+msgid "Native Names"
+msgstr "Emakeelsed nimed"
+
+msgid "Go to Home"
+msgstr "Mine avalehele"
+
+msgid "Hide Current"
+msgstr "Peida praegune"
+
+msgid "Generated Code"
+msgstr "Genereeritud kood"
+
+msgid "Implementation Notes"
+msgstr "Rakenduse märkused"
+
+msgid "Enable and Configure Languages"
+msgstr "Luba ja seadista keeled"
+
+msgid "Done"
+msgstr "Valmis"
+
+msgid "Reorder"
+msgstr "Muuda järjekorda"
+
+msgid "Default"
+msgstr "Vaikimisi"
+
+msgid "No languages enabled yet."
+msgstr "Ühtegi keelt pole veel lubatud."

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -6194,3 +6194,48 @@ msgstr "должен быть включён. Некоторые функции 
 #, elixir-autogen, elixir-format
 msgid "requires the"
 msgstr "требует, чтобы модуль"
+
+#: lib/phoenix_kit/dashboard/admin_tabs.ex:148
+#, elixir-autogen, elixir-format
+msgid "Activity"
+msgstr "Активность"
+
+#: lib/phoenix_kit/dashboard/admin_tabs.ex:245
+#, elixir-autogen, elixir-format
+msgid "Authorization"
+msgstr "Авторизация"
+
+#: lib/phoenix_kit/dashboard/admin_tabs.ex:294
+#, elixir-autogen, elixir-format
+msgid "Dimensions"
+msgstr "Размеры"
+
+#: lib/phoenix_kit/dashboard/admin_tabs.ex:235
+#, elixir-autogen, elixir-format
+msgid "General"
+msgstr "Общие"
+
+#: lib/phoenix_kit/dashboard/admin_tabs.ex:102
+#, elixir-autogen, elixir-format
+msgid "Live Sessions"
+msgstr "Активные сессии"
+
+#: lib/modules/maintenance/maintenance.ex:528
+#, elixir-autogen, elixir-format
+msgid "Maintenance"
+msgstr "Обслуживание"
+
+#: lib/phoenix_kit/dashboard/admin_tabs.ex:93
+#, elixir-autogen, elixir-format
+msgid "Manage Users"
+msgstr "Управление пользователями"
+
+#: lib/phoenix_kit/dashboard/admin_tabs.ex:160
+#, elixir-autogen, elixir-format
+msgid "Media"
+msgstr "Медиа"
+
+#: lib/modules/referrals/referrals.ex:658
+#, elixir-autogen, elixir-format
+msgid "Referrals"
+msgstr "Рефералы"

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -6342,3 +6342,171 @@ msgstr "По умолчанию"
 
 msgid "No languages enabled yet."
 msgstr "Языки ещё не включены."
+
+msgid "Sitemap Settings"
+msgstr "Настройки карты сайта"
+
+msgid "Configure sitemap generation and scheduling"
+msgstr "Настройка генерации и расписания карты сайта"
+
+msgid "Total URLs"
+msgstr "Всего URL"
+
+msgid "Sitemap Files"
+msgstr "Файлы карты сайта"
+
+msgid "Last Generated"
+msgstr "Последняя генерация"
+
+msgid "Regenerate All"
+msgstr "Перегенерировать всё"
+
+msgid "Router Discovery"
+msgstr "Обнаружение маршрутов"
+
+msgid "When enabled, scans all routes and builds a single flat sitemap.xml with URLs from all content sources (shop, entities, posts, publishing). When disabled, each source generates its own sitemap file."
+msgstr "При включении сканирует все маршруты и создаёт единый плоский sitemap.xml со всеми URL из всех источников контента (магазин, сущности, публикации, записи). При отключении каждый источник генерирует свой файл карты сайта."
+
+msgid "Flat mode active — /sitemap.xml contains all URLs in a single <urlset>"
+msgstr "Плоский режим активен — /sitemap.xml содержит все URL в одном <urlset>"
+
+msgid "Routes"
+msgstr "Маршруты"
+
+msgid "Static"
+msgstr "Статические"
+
+msgid "Publishing"
+msgstr "Публикации"
+
+msgid "Entities"
+msgstr "Сущности"
+
+msgid "Posts"
+msgstr "Записи"
+
+msgid "Shop"
+msgstr "Магазин"
+
+msgid "Module Sitemaps"
+msgstr "Карты сайта модулей"
+
+msgid "Each source generates its own sitemap file, referenced by the main sitemap index"
+msgstr "Каждый источник генерирует свой файл карты сайта, на который ссылается главный индекс"
+
+msgid "Static Pages"
+msgstr "Статические страницы"
+
+msgid "Homepage and custom static URLs"
+msgstr "Главная страница и пользовательские статические URL"
+
+msgid "View sitemap"
+msgstr "Просмотр карты сайта"
+
+msgid "module off"
+msgstr "модуль отключён"
+
+msgid "Blog groups and published posts"
+msgstr "Группы блогов и опубликованные записи"
+
+msgid "Split by blog group"
+msgstr "Разделить по группам блогов"
+
+msgid "Dynamic content types (per-type files)"
+msgstr "Динамические типы контента (отдельные файлы для каждого типа)"
+
+msgid "Public posts from Posts module"
+msgstr "Публичные записи из модуля Posts"
+
+msgid "Products, categories, catalog"
+msgstr "Товары, категории, каталог"
+
+msgid "Auth Pages"
+msgstr "Страницы авторизации"
+
+msgid "Login"
+msgstr "Вход"
+
+msgid "Always excluded from sitemap"
+msgstr "Всегда исключена из карты сайта"
+
+msgid "Excluded"
+msgstr "Исключено"
+
+msgid "Logout"
+msgstr "Выход"
+
+msgid "Registration"
+msgstr "Регистрация"
+
+msgid "Include in static sitemap"
+msgstr "Включить в статическую карту сайта"
+
+msgid "Configuration"
+msgstr "Конфигурация"
+
+msgid "Edit in Settings"
+msgstr "Изменить в настройках"
+
+msgid "Browser Display Styling"
+msgstr "Стилизация для браузера"
+
+msgid "Style XML with XSL for beautiful browser display"
+msgstr "Стилизовать XML с помощью XSL для красивого отображения в браузере"
+
+msgid "Display Style"
+msgstr "Стиль отображения"
+
+msgid "Table (Clean table layout)"
+msgstr "Таблица (чистый табличный вид)"
+
+msgid "Minimal (Simple list)"
+msgstr "Минимальный (простой список)"
+
+msgid "Scheduled Generation"
+msgstr "Запланированная генерация"
+
+msgid "Regenerate every"
+msgstr "Перегенерировать каждые"
+
+msgid "1 hour"
+msgstr "1 час"
+
+msgid "6 hours"
+msgstr "6 часов"
+
+msgid "12 hours"
+msgstr "12 часов"
+
+msgid "24 hours"
+msgstr "24 часа"
+
+msgid "48 hours"
+msgstr "48 часов"
+
+msgid "Weekly"
+msgstr "Еженедельно"
+
+msgid "Preview Sitemap Source"
+msgstr "Предпросмотр источника карты сайта"
+
+msgid "Clear All Sitemaps"
+msgstr "Очистить все карты сайта"
+
+msgid "Generated sitemap files:"
+msgstr "Сгенерированные файлы карты сайта:"
+
+msgid "sitemap.xml (index)"
+msgstr "sitemap.xml (индекс)"
+
+msgid "/sitemap.xml contains all URLs in a single <urlset>"
+msgstr "/sitemap.xml содержит все URL в одном <urlset>"
+
+msgid "/sitemap.xml is a sitemapindex referencing per-module sitemap files"
+msgstr "/sitemap.xml — это индекс карт сайта, ссылающийся на файлы отдельных модулей"
+
+msgid "Sitemap Source"
+msgstr "Исходный код карты сайта"
+
+msgid "Open in Browser"
+msgstr "Открыть в браузере"

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -881,7 +881,7 @@ msgstr "Описание"
 #: lib/phoenix_kit_web/live/settings/users.html.heex:400
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Disabled"
-msgstr "Отключенные аккаунты"
+msgstr "Отключено"
 
 #: lib/phoenix_kit_web/components/core/modal.ex:265
 #, elixir-autogen, elixir-format
@@ -1138,7 +1138,7 @@ msgstr "Изображение"
 #: lib/phoenix_kit_web/users/user_form.html.heex:769
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Inactive"
-msgstr "Неактивные пользователи"
+msgstr "Неактивен"
 
 #: lib/phoenix_kit_web/components/core/modal.ex:481
 #: lib/phoenix_kit_web/live/settings.html.heex:489
@@ -6239,3 +6239,43 @@ msgstr "Медиа"
 #, elixir-autogen, elixir-format
 msgid "Referrals"
 msgstr "Рефералы"
+
+#: lib/phoenix_kit_web/components/core/badge.ex:125
+#, elixir-autogen, elixir-format
+msgid "Expired"
+msgstr "Истёк"
+
+#: lib/phoenix_kit_web/components/core/badge.ex:162
+#, elixir-autogen, elixir-format
+msgid "Transactional"
+msgstr "Транзакционный"
+
+#: lib/phoenix_kit_web/components/core/time_display.ex:206
+#, elixir-autogen, elixir-format
+msgid "No expiration"
+msgstr "Без срока действия"
+
+#: lib/phoenix_kit_web/components/core/time_display.ex:212
+#, elixir-autogen, elixir-format
+msgid "Today"
+msgstr "Сегодня"
+
+#: lib/phoenix_kit_web/components/core/time_display.ex:187
+#, elixir-autogen, elixir-format
+msgid "%{count}s ago"
+msgstr "%{count} с назад"
+
+#: lib/phoenix_kit_web/components/core/time_display.ex:188
+#, elixir-autogen, elixir-format
+msgid "%{count}m ago"
+msgstr "%{count} мин назад"
+
+#: lib/phoenix_kit_web/components/core/time_display.ex:189
+#, elixir-autogen, elixir-format
+msgid "%{count}h ago"
+msgstr "%{count} ч назад"
+
+#: lib/phoenix_kit_web/components/core/time_display.ex:190
+#, elixir-autogen, elixir-format
+msgid "%{count}d ago"
+msgstr "%{count} дн назад"

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -2103,7 +2103,7 @@ msgstr "Удалить бакет"
 #: lib/phoenix_kit_web/live/settings/users.html.heex:430
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Disable"
-msgstr "Отключенные аккаунты"
+msgstr "Отключить"
 
 #: lib/modules/storage/web/settings.html.heex:261
 #, elixir-autogen, elixir-format
@@ -6279,3 +6279,66 @@ msgstr "%{count} ч назад"
 #, elixir-autogen, elixir-format
 msgid "%{count}d ago"
 msgstr "%{count} дн назад"
+
+msgid "Summary"
+msgstr "Сводка"
+
+msgid "Languages Enabled"
+msgstr "Включенные языки"
+
+msgid "Countries Covered"
+msgstr "Охваченные страны"
+
+msgid "Enabled Languages"
+msgstr "Включенные языки"
+
+msgid "Default language"
+msgstr "Язык по умолчанию"
+
+msgid "Available Languages"
+msgstr "Доступные языки"
+
+msgid "Language Configuration"
+msgstr "Настройка языков"
+
+msgid "Frontend Language Switcher"
+msgstr "Переключатель языков на фронтенде"
+
+msgid "Switcher Settings"
+msgstr "Настройки переключателя"
+
+msgid "Show Flags"
+msgstr "Показывать флаги"
+
+msgid "Show Names"
+msgstr "Показывать названия"
+
+msgid "Native Names"
+msgstr "Названия на родном языке"
+
+msgid "Go to Home"
+msgstr "Перейти на главную"
+
+msgid "Hide Current"
+msgstr "Скрыть текущий"
+
+msgid "Generated Code"
+msgstr "Сгенерированный код"
+
+msgid "Implementation Notes"
+msgstr "Заметки по внедрению"
+
+msgid "Enable and Configure Languages"
+msgstr "Включить и настроить языки"
+
+msgid "Done"
+msgstr "Готово"
+
+msgid "Reorder"
+msgstr "Изменить порядок"
+
+msgid "Default"
+msgstr "По умолчанию"
+
+msgid "No languages enabled yet."
+msgstr "Языки ещё не включены."


### PR DESCRIPTION
## Summary
- Wire gettext_backend to every core admin/settings Tab so the sidebar translates per locale
- Complete the Estonian translation catalog (was 92/1143, now 1142/1143; ru already complete)
- Widen the admin settings pages so they use the full container width on wide screens
- Wrap previously-raw English strings in core components (badge, time_display) and on the General Settings, sitemap, and languages pages
- Add a card-view toggle to the Custom User Fields table on /admin/settings/users

## Changes by commit
- c5fd5bae — gettext_backend on all 24 core admin tabs + card-view conversion on Custom Fields table
- 373478f5 — 9 manual tab-label msgids + full Estonian translation in default.po
- 3ea70ec1 — drop max-w-2xl wrappers on settings sub-pages, add grid layouts and max-w-prose
- d867cb57 — same widescreen pass for in-core modules (sitemap, storage, referrals)
- 1fe0ad78 — wrap badge.ex / time_display.ex strings in gettext + fix two pre-existing wrong ru translations
- 24ceec90 — widen the top-level General Settings + wrap /admin/modules/languages
- afcc281a — wrap sitemap settings (75 gettext calls, 56 new msgids)

## Test plan
- [x] mix format clean
- [x] mix credo --strict 0 issues
- [x] mix compile (no warnings-as-errors)
- [x] mix dialyzer passes
- [ ] Visual check of admin sidebar in ru/et locale on a parent app
- [ ] Visual check of each /admin/settings/* page on wide screen