### PR TITLE
Integrations V114: uuid-only storage keys + picker UX + form fixes + C12 sweep

### DIFF
--- a/dev_docs/pull_requests/2026/526-add-selected-card-indicator-to-sortablegrid-styles/FOLLOW_UP.md
+++ b/dev_docs/pull_requests/2026/526-add-selected-card-indicator-to-sortablegrid-styles/FOLLOW_UP.md
@@ -1,0 +1,50 @@
+# FOLLOW_UP — PR #526 (Add selected-card indicator to SortableGrid styles)
+
+Triaged 2026-05-12.
+
+`CLAUDE_REVIEW.md` opens with `APPROVE` — single 7-line CSS rule in
+`priv/static/assets/phoenix_kit.js`. Two NITPICKs and one
+IMPROVEMENT-LOW; no BUG findings.
+
+## Fixed (pre-existing)
+
+- ~~NITPICK — `!important` on `background-color` is redundant given
+  the rule's specificity vs `bg-base-200` and the late-injected
+  source order.~~ Fixed post-merge in commit `3521fa2f`
+  ("Remove redundant !important from selected-card indicator").
+  Current rule at `phoenix_kit.js:170` no longer carries the
+  `!important`.
+
+## Skipped (with rationale)
+
+- **NITPICK — `:has()` selector broader than PR body implies.** The
+  rule matches any descendant `input[type="checkbox"]:checked` inside
+  `.sortable-item.card`, not specifically the bulk-select checkbox.
+  Benign for every current consumer (only `phoenix_kit_catalogue`
+  uses the sortable card view, and it has exactly one checkbox per
+  card — the bulk-select). The review explicitly calls this
+  "ergonomic, not correctness" and says to switch to an opt-in
+  data attribute only "if a second consumer hits this." No second
+  consumer exists today; leave the rule as-is until one does.
+
+- **IMPROVEMENT-LOW — No automated coverage.** Component test
+  coverage for `phoenix_kit_web/components/core/` is already a
+  tracked TODO in `phoenix_kit/AGENTS.md` (the `<.table_default>`
+  card-view-sortable wiring is in scope there). The reviewer
+  explicitly suggested folding this rule into that future
+  component-coverage sweep rather than addressing per-PR. Defer.
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `priv/static/assets/phoenix_kit.js` | One CSS rule added at line ~170. Already amended post-merge to drop the redundant `!important` (commit `3521fa2f`). |
+
+## Verification
+
+`grep -n 'sortable-item.card:has' priv/static/assets/phoenix_kit.js`
+→ rule present at line 170. `!important` confirmed absent.
+
+## Open
+
+None.

--- a/lib/phoenix_kit/integrations/integrations.ex
+++ b/lib/phoenix_kit/integrations/integrations.ex
@@ -507,6 +507,23 @@ defmodule PhoenixKit.Integrations do
   For bot token providers: returns credentials for the caller to use directly.
 
   `opts` are passed through to `Req.request/1`.
+
+  ## Security — `url` must come from a trusted source
+
+  The integration's Bearer token is attached to every request this
+  function dispatches. If a caller passes a URL that came from
+  unvalidated user input, the token leaks to whatever host that URL
+  points at. Callers MUST validate the URL before invoking — pin to
+  a domain allowlist (the provider's own host, typically), enforce
+  `https`, and reject RFC1918 / loopback / link-local ranges.
+
+  Internal usage (`OpenRouterClient.fetch_models/2`, OAuth refresh,
+  userinfo lookups) builds URLs from the Providers registry, which is
+  hardcoded and therefore safe. The schema-level `validate_base_url/1`
+  guard in `PhoenixKitAI.Endpoint` covers the AI module's
+  operator-supplied `base_url` case. New callsites that take URLs
+  from anywhere else need their own guard before reaching this
+  function — there's no allowlist enforcement here.
   """
   @spec authenticated_request(String.t(), atom(), String.t(), keyword()) ::
           {:ok, Req.Response.t()} | {:error, term()}
@@ -845,9 +862,24 @@ defmodule PhoenixKit.Integrations do
 
     result
   rescue
-    e ->
+    # Narrow rescue — only catch exceptions we expect from the
+    # validate path so genuine logic bugs (KeyError, ArgumentError,
+    # MatchError, etc.) bubble up to the supervisor instead of getting
+    # swallowed under a generic "validation failed" message. The three
+    # caught classes cover the realistic failure modes:
+    #
+    #   * `DBConnection.OwnershipError` — sandbox checkout race in
+    #     tests that hit this path from an async-shared connection.
+    #   * `Postgrex.Error` — DB outage / table-missing mid-flight
+    #     during the `record_validation` write that `validate_connection`
+    #     itself doesn't perform but called helpers (log_activity,
+    #     `Providers.get` if backed by DB later) might.
+    #   * `Req.TransportError` / generic transport — should already
+    #     be returned as `{:error, _}` by `check_http/2`; this is the
+    #     belt-and-braces case.
+    e in [DBConnection.OwnershipError, Postgrex.Error, Req.TransportError] ->
       Logger.error(
-        "[Integrations] validate_connection crashed for #{uuid}: #{Exception.message(e)}"
+        "[Integrations] validate_connection error for #{uuid}: #{Exception.message(e)}"
       )
 
       {:error, gettext("Validation failed unexpectedly")}

--- a/lib/phoenix_kit/integrations/integrations.ex
+++ b/lib/phoenix_kit/integrations/integrations.ex
@@ -4,12 +4,15 @@ defmodule PhoenixKit.Integrations do
 
   Stores credentials (OAuth tokens, API keys, bot tokens, etc.) using the
   existing `PhoenixKit.Settings` system with `value_json` JSONB storage.
-  Each integration is a JSON blob under a key like
-  `"integration:google:default"` (`integration:{provider}:{name}`).
+  Each integration row's `key` column is just its UUID; the `module`
+  column is stamped `"integrations"` and the JSONB body holds
+  `{"provider", "name", "auth_type", "status", ...}`. There is no
+  composite key shape — provider and name are pure JSONB.
 
   Connections are referenced by the storage row's UUID. Names are pure
-  user-chosen labels with no system semantics — they can be renamed or
-  removed freely; consumer modules pin to UUIDs that survive renames.
+  user-chosen labels with no system semantics — any string is allowed
+  (including spaces and duplicates within a provider); consumer modules
+  pin to UUIDs that survive renames.
 
   ## Auth types supported
 
@@ -53,16 +56,17 @@ defmodule PhoenixKit.Integrations do
 
   - `add_connection/3` — row birth, no uuid exists yet
   - `get_integration/1`, `find_uuid_by_provider_name/1` — read shims for
-    legacy `migrate_legacy/0` callbacks that walk pre-uuid data shapes
+    legacy `migrate_legacy/0` callbacks that walk pre-uuid data shapes.
+    Since names are no longer unique, these now return first-match.
 
-  The structural rule: `"integration:{provider}:{name}"` storage-key
-  construction happens only inside `add_connection/3` (creation) and
-  module-side `migrate_legacy/0` migrators (translation). Every other
-  caller routes by uuid, so a corrupted JSONB `provider`/`name` field
-  cannot leak into a new storage key.
+  The `key` column is the row's UUIDv7 — collisions are structurally
+  impossible. JSONB `provider`/`name` are pure data; corruption there
+  affects only this row's content, never routing.
   """
 
   use Gettext, backend: PhoenixKitWeb.Gettext
+
+  import Ecto.Query, only: [from: 2]
 
   require Logger
 
@@ -94,23 +98,28 @@ defmodule PhoenixKit.Integrations do
   @spec get_integration(String.t()) ::
           {:ok, map()} | {:error, :not_configured | :invalid_provider_key}
   def get_integration(provider_key) when is_binary(provider_key) and provider_key != "" do
-    # Check if this looks like a UUID (used when endpoints store the settings UUID)
-    data =
-      if uuid?(provider_key) do
-        Settings.get_json_setting_by_uuid(provider_key)
-      else
-        Settings.get_json_setting(settings_key(provider_key), nil)
-      end
+    cond do
+      uuid?(provider_key) ->
+        case Settings.get_json_setting_by_uuid(provider_key) do
+          %{} = data -> {:ok, Encryption.decrypt_fields(data)}
+          _ -> {:error, :not_configured}
+        end
 
-    case data do
-      nil ->
-        # No on-read legacy fallback in core anymore — module-side
-        # `migrate_legacy/0` callbacks handle data-shape migrations.
-        # Boot-time orchestration via `ModuleRegistry.run_all_legacy_migrations/0`.
-        {:error, :not_configured}
+      true ->
+        # `"provider:name"` string lookup — first-match by name. Names
+        # are no longer unique, so this returns the first row whose JSONB
+        # name matches. Used by legacy `migrate_legacy/0` callbacks; new
+        # callers should use uuid-based lookups.
+        case find_uuid_by_provider_name(provider_key) do
+          {:ok, uuid} ->
+            case Settings.get_json_setting_by_uuid(uuid) do
+              %{} = data -> {:ok, Encryption.decrypt_fields(data)}
+              _ -> {:error, :not_configured}
+            end
 
-      %{} = data ->
-        {:ok, Encryption.decrypt_fields(data)}
+          _ ->
+            {:error, :not_configured}
+        end
     end
   end
 
@@ -128,19 +137,17 @@ defmodule PhoenixKit.Integrations do
           {:ok, %{uuid: String.t(), provider: String.t(), name: String.t(), data: map()}}
           | {:error, :not_configured | :invalid_uuid}
   def get_integration_by_uuid(uuid) when is_binary(uuid) and uuid != "" do
-    # Read the row's `key` column directly — it's the canonical
-    # `integration:{provider}:{name}` shape and can't drift from the
-    # row's actual location. The JSONB `provider` / `name` fields are
-    # internal duplicates that have historically gotten out of sync
-    # (a buggy save round can write `name` = "foo:default" because of
-    # a bad full_key concat upstream); always source provider+name
-    # from the storage key, never from the JSONB body.
+    # The storage row is identified solely by its uuid. Provider and name
+    # both live in JSONB (`data["provider"]` / `data["name"]`). The row's
+    # `module` column is the discriminator that distinguishes integration
+    # rows from other settings.
     case Queries.get_setting_by_uuid(uuid) do
-      %{key: "integration:" <> rest, value_json: data} when is_map(data) ->
-        {provider, name} = parse_provider_name(rest)
+      %{module: "integrations", value_json: data} when is_map(data) ->
+        decrypted = Encryption.decrypt_fields(data)
+        provider = Map.get(decrypted, "provider", "")
+        name = Map.get(decrypted, "name", "")
 
-        {:ok,
-         %{uuid: uuid, provider: provider, name: name, data: Encryption.decrypt_fields(data)}}
+        {:ok, %{uuid: uuid, provider: provider, name: name, data: decrypted}}
 
       _ ->
         {:error, :not_configured}
@@ -178,8 +185,22 @@ defmodule PhoenixKit.Integrations do
   end
 
   def find_uuid_by_provider_name(string) when is_binary(string) and string != "" do
-    {provider, name} = parse_provider_name(string)
-    find_uuid_by_provider_name({provider, name})
+    case String.split(string, ":", parts: 2) do
+      [provider, name] when provider != "" and name != "" ->
+        find_uuid_by_provider_name({provider, name})
+
+      [provider] when provider != "" ->
+        # Bare provider — first connection of that provider (sorted by
+        # name, lowercase). Used as the "any connection of this kind"
+        # fallback by legacy paths.
+        case list_connections(provider) do
+          [%{uuid: uuid} | _] -> {:ok, uuid}
+          _ -> {:error, :not_found}
+        end
+
+      _ ->
+        {:error, :invalid}
+    end
   end
 
   def find_uuid_by_provider_name(_), do: {:error, :invalid}
@@ -246,7 +267,10 @@ defmodule PhoenixKit.Integrations do
       if is_uuid do
         Settings.get_json_setting_by_uuid(provider_key)
       else
-        Settings.get_json_setting(settings_key(provider_key), nil)
+        case find_uuid_by_provider_name(provider_key) do
+          {:ok, uuid} -> Settings.get_json_setting_by_uuid(uuid)
+          _ -> nil
+        end
       end
 
     case data do
@@ -297,8 +321,8 @@ defmodule PhoenixKit.Integrations do
   @spec save_setup(String.t(), map(), String.t() | nil) ::
           {:ok, map()} | {:error, :not_configured | :invalid_uuid | term()}
   def save_setup(uuid, attrs, actor_uuid \\ nil) when is_binary(uuid) and is_map(attrs) do
-    with {:ok, %{provider_key: provider_key, data: existing}} <- resolve_uuid(uuid) do
-      {base_provider, name} = parse_provider_name(provider_key)
+    with {:ok, %{provider: base_provider, name: name, setting: setting, data: existing}} <-
+           resolve_uuid(uuid) do
       provider = Providers.get(base_provider)
 
       data =
@@ -310,13 +334,14 @@ defmodule PhoenixKit.Integrations do
         |> maybe_set_status(provider)
         |> maybe_set_connected_at()
 
-      case save_integration(provider_key, data) do
+      case save_integration(setting, data) do
         {:ok, saved} = result ->
-          Events.broadcast_setup_saved(provider_key, saved)
+          Events.broadcast_setup_saved(base_provider, saved)
 
           log_activity(
             "integration.setup_saved",
-            provider_key,
+            base_provider,
+            name,
             %{"status" => saved["status"]},
             "manual",
             actor_uuid
@@ -346,8 +371,7 @@ defmodule PhoenixKit.Integrations do
           {:ok, String.t()} | {:error, term()}
   def authorization_url(uuid, redirect_uri, extra_scopes \\ nil, state \\ nil)
       when is_binary(uuid) do
-    with {:ok, %{provider_key: provider_key, data: data}} <- resolve_uuid(uuid),
-         {base_provider, _name} = parse_provider_name(provider_key),
+    with {:ok, %{provider: base_provider, data: data}} <- resolve_uuid(uuid),
          {:ok, provider} <- fetch_provider(base_provider) do
       OAuth.authorization_url(provider.oauth_config, data, redirect_uri, extra_scopes, state)
     end
@@ -360,8 +384,8 @@ defmodule PhoenixKit.Integrations do
   @spec exchange_code(String.t(), String.t(), String.t(), String.t() | nil) ::
           {:ok, map()} | {:error, term()}
   def exchange_code(uuid, code, redirect_uri, actor_uuid \\ nil) when is_binary(uuid) do
-    with {:ok, %{provider_key: provider_key, data: data}} <- resolve_uuid(uuid),
-         {base_provider, _name} = parse_provider_name(provider_key),
+    with {:ok, %{provider: base_provider, name: name, setting: setting, data: data}} <-
+           resolve_uuid(uuid),
          {:ok, provider} <- fetch_provider(base_provider),
          {:ok, token_data} <- OAuth.exchange_code(provider.oauth_config, data, code, redirect_uri) do
       userinfo = fetch_userinfo_safe(provider, token_data["access_token"])
@@ -377,16 +401,15 @@ defmodule PhoenixKit.Integrations do
         )
         |> maybe_set_userinfo(userinfo)
 
-      case save_integration(provider_key, updated) do
+      case save_integration(setting, updated) do
         {:ok, saved} = result ->
-          Events.broadcast_connected(provider_key, saved)
+          Events.broadcast_connected(base_provider, saved)
 
           log_activity(
             "integration.connected",
-            provider_key,
-            %{
-              "account" => saved["external_account_id"]
-            },
+            base_provider,
+            name,
+            %{"account" => saved["external_account_id"]},
             "manual",
             actor_uuid
           )
@@ -411,15 +434,15 @@ defmodule PhoenixKit.Integrations do
   @spec refresh_access_token(String.t()) :: {:ok, String.t()} | {:error, term()}
   def refresh_access_token(uuid) when is_binary(uuid) do
     result =
-      with {:ok, %{provider_key: provider_key, data: data}} <- resolve_uuid(uuid),
-           {base_provider, _name} = parse_provider_name(provider_key),
+      with {:ok, %{provider: base_provider, name: name, setting: setting, data: data}} <-
+             resolve_uuid(uuid),
            {:ok, provider} <- fetch_provider(base_provider),
            {:ok, new_token, updated_fields} <-
              OAuth.refresh_access_token(provider.oauth_config, data) do
         updated = Map.merge(data, updated_fields)
-        save_integration(provider_key, updated)
+        save_integration(setting, updated)
 
-        log_activity("integration.token_refreshed", provider_key, %{}, "auto", nil)
+        log_activity("integration.token_refreshed", base_provider, name, %{}, "auto", nil)
 
         {:ok, new_token}
       end
@@ -446,7 +469,7 @@ defmodule PhoenixKit.Integrations do
   @spec disconnect(String.t(), String.t() | nil) :: :ok
   def disconnect(uuid, actor_uuid \\ nil) when is_binary(uuid) do
     case resolve_uuid(uuid) do
-      {:ok, %{provider_key: provider_key, data: data}} ->
+      {:ok, %{provider: base_provider, name: name, setting: setting, data: data}} ->
         auth_type = data["auth_type"]
 
         cleaned =
@@ -462,9 +485,9 @@ defmodule PhoenixKit.Integrations do
               |> Map.put("status", "disconnected")
           end
 
-        save_integration(provider_key, cleaned)
-        Events.broadcast_disconnected(provider_key)
-        log_activity("integration.disconnected", provider_key, %{}, "manual", actor_uuid)
+        save_integration(setting, cleaned)
+        Events.broadcast_disconnected(base_provider)
+        log_activity("integration.disconnected", base_provider, name, %{}, "manual", actor_uuid)
         :ok
 
       {:error, _} ->
@@ -528,98 +551,85 @@ defmodule PhoenixKit.Integrations do
   end
 
   @doc """
-  Returns the settings key for a provider connection.
-
-  Accepts `"google"` (returns default connection key) or
-  `"google:personal"` (returns named connection key).
-
-  ## Examples
-
-      iex> PhoenixKit.Integrations.settings_key("google")
-      "integration:google:default"
-
-      iex> PhoenixKit.Integrations.settings_key("google:personal")
-      "integration:google:personal"
-  """
-  @spec settings_key(String.t()) :: String.t()
-  def settings_key(provider_key) do
-    {provider, name} = parse_provider_name(provider_key)
-    "integration:#{provider}:#{name}"
-  end
-
-  @doc """
   Lists all connections for a provider.
 
-  Returns a list of `%{uuid: uuid, name: name, data: data}` maps, with "default" first.
-  The `uuid` is the stable identifier for the settings row.
+  Returns a list of `%{uuid, name, data, date_added}` maps, sorted by
+  name (case-insensitive). Filters by `module = "integrations"` and
+  JSONB `provider` — provider and name both live in JSONB; the row's
+  `uuid` is the stable identifier. `date_added` is the row's creation
+  timestamp (UTC, second precision), useful for "Created N days ago"
+  display in UI pickers.
   """
-  @spec list_connections(String.t()) :: [%{uuid: String.t(), name: String.t(), data: map()}]
-  def list_connections(provider_key) do
-    prefix = "integration:#{provider_key}:"
+  @spec list_connections(String.t()) :: [
+          %{
+            uuid: String.t(),
+            name: String.t(),
+            data: map(),
+            date_added: DateTime.t() | nil
+          }
+        ]
+  def list_connections(provider_key) when is_binary(provider_key) do
+    PhoenixKit.RepoHelper.repo().all(
+      from s in Setting,
+        where: s.module == ^@settings_module,
+        where: fragment("?->>'provider' = ?", s.value_json, ^provider_key)
+    )
+    |> Enum.map(&to_connection_map/1)
+    |> Enum.sort_by(fn %{name: name} -> String.downcase(name) end)
+  end
 
-    connections =
-      Settings.get_json_settings_by_prefix_with_uuid(prefix)
-      |> Enum.map(fn {uuid, key, data} ->
-        name = key |> String.replace_prefix(prefix, "")
-        %{uuid: uuid, name: name, data: Encryption.decrypt_fields(data)}
-      end)
+  defp to_connection_map(%Setting{uuid: uuid, value_json: data, date_added: date_added}) do
+    decrypted = Encryption.decrypt_fields(data || %{})
 
-    # Also check for old non-named key (e.g., "integration:google" without ":default")
-    # and include it as "default" if no default connection exists yet
-    has_default = Enum.any?(connections, fn %{name: name} -> name == "default" end)
-
-    connections =
-      if has_default do
-        connections
-      else
-        old_key = "integration:#{provider_key}"
-
-        case Queries.get_setting_by_key(old_key) do
-          %{uuid: uuid, value_json: data} when is_map(data) and map_size(data) > 0 ->
-            [%{uuid: uuid, name: "default", data: Encryption.decrypt_fields(data)} | connections]
-
-          _ ->
-            connections
-        end
-      end
-
-    Enum.sort_by(connections, fn %{name: name} -> if name == "default", do: "0", else: name end)
+    %{
+      uuid: uuid,
+      name: Map.get(decrypted, "name", ""),
+      data: decrypted,
+      date_added: date_added
+    }
   end
 
   @doc """
   Loads all connections for multiple providers in a single database query.
 
-  More efficient than calling `list_connections/1` in a loop.
-  Returns a map of `provider_key => [%{uuid, name, data}]`.
+  More efficient than calling `list_connections/1` in a loop. Returns a
+  map of `provider_key => [%{uuid, name, data, date_added}]`, with every
+  requested provider key present (empty list when no connections exist).
   """
   @spec load_all_connections([String.t()]) :: %{
-          String.t() => [%{uuid: String.t(), name: String.t(), data: map()}]
+          String.t() => [
+            %{
+              uuid: String.t(),
+              name: String.t(),
+              data: map(),
+              date_added: DateTime.t() | nil
+            }
+          ]
         }
   def load_all_connections(provider_keys) when is_list(provider_keys) do
-    prefixes = Enum.map(provider_keys, &"integration:#{&1}:")
+    all_settings =
+      PhoenixKit.RepoHelper.repo().all(
+        from s in Setting,
+          where: s.module == ^@settings_module,
+          where: fragment("?->>'provider' = ANY(?)", s.value_json, ^provider_keys)
+      )
 
-    # Single query for all providers
-    all_settings = Settings.get_json_settings_by_prefixes_with_uuid(prefixes)
-
-    # Group by provider
     grouped =
-      Enum.reduce(all_settings, %{}, fn {uuid, key, data}, acc ->
-        # key is like "integration:google:default" — extract provider and name
-        case String.split(key, ":", parts: 3) do
-          ["integration", provider, name] ->
-            conn = %{uuid: uuid, name: name, data: Encryption.decrypt_fields(data)}
-            Map.update(acc, provider, [conn], &[conn | &1])
+      Enum.reduce(all_settings, %{}, fn %Setting{} = setting, acc ->
+        conn = to_connection_map(setting)
+        provider = conn.data["provider"]
 
-          _ ->
-            acc
+        if is_binary(provider) do
+          Map.update(acc, provider, [conn], &[conn | &1])
+        else
+          acc
         end
       end)
 
-    # Sort each provider's connections (default first) and fill missing providers
     Map.new(provider_keys, fn pk ->
       connections =
         Map.get(grouped, pk, [])
-        |> Enum.sort_by(fn %{name: name} -> if name == "default", do: "0", else: name end)
+        |> Enum.sort_by(fn %{name: name} -> String.downcase(name) end)
 
       {pk, connections}
     end)
@@ -628,59 +638,64 @@ defmodule PhoenixKit.Integrations do
   @doc """
   Adds a new named connection for a provider.
 
-  This is the row-birth path — the only place a new
-  `integration:{provider}:{name}` storage key is constructed. Every
-  other public API takes the row's uuid; callers can find it via the
-  returned `:uuid` or by listing the provider's connections.
-
-  The name can be any string alphanumeric with hyphens / underscores
-  (e.g., "company-drive"), starting with an alphanumeric character.
+  This is the row-birth path. The row's UUIDv7 is generated up front and
+  used as both the `uuid` and the `key` column; provider and name live
+  in JSONB. Names are pure user-chosen labels with no character or
+  uniqueness restrictions — any non-empty string (after trim) is valid,
+  duplicates within a provider are allowed.
 
   Returns `{:ok, %{uuid: uuid, data: data}}` on success.
   """
   @spec add_connection(String.t(), String.t(), String.t() | nil) ::
           {:ok, %{uuid: String.t(), data: map()}}
-          | {:error, :empty_name | :invalid_name | :already_exists | term()}
-  @name_pattern ~r/^[a-zA-Z0-9][a-zA-Z0-9\-_]*$/
-
+          | {:error, :empty_name | term()}
   def add_connection(provider_key, name, actor_uuid \\ nil)
       when is_binary(provider_key) and is_binary(name) do
-    name = String.trim(name)
-    storage_key = "#{provider_key}:#{name}"
+    trimmed = String.trim(name)
 
-    cond do
-      name == "" ->
-        {:error, :empty_name}
+    if trimmed == "" do
+      {:error, :empty_name}
+    else
+      data = %{
+        "provider" => provider_key,
+        "name" => trimmed,
+        "auth_type" => provider_auth_type(provider_key),
+        "status" => "disconnected"
+      }
 
-      not Regex.match?(@name_pattern, name) ->
-        {:error, :invalid_name}
-
-      Settings.get_json_setting(settings_key(storage_key), nil) != nil ->
-        {:error, :already_exists}
-
-      true ->
-        data = %{
-          "provider" => provider_key,
-          "name" => name,
-          "auth_type" => provider_auth_type(provider_key),
-          "status" => "disconnected"
-        }
-
-        with {:ok, saved} <- save_integration(storage_key, data),
-             %{uuid: uuid} <- Queries.get_setting_by_key(settings_key(storage_key)) do
-          Events.broadcast_connection_added(provider_key, name)
+      case insert_integration_row(data) do
+        {:ok, %Setting{uuid: uuid}} ->
+          Events.broadcast_connection_added(provider_key, trimmed)
 
           log_activity(
             "integration.connection_added",
             provider_key,
-            %{"name" => name},
+            trimmed,
+            %{},
             "manual",
             actor_uuid
           )
 
-          {:ok, %{uuid: uuid, data: saved}}
-        end
+          {:ok, %{uuid: uuid, data: data}}
+
+        {:error, _} = error ->
+          error
+      end
     end
+  end
+
+  # Row-birth path: generate a UUIDv7, use it as both the primary key
+  # and the `key` column, and insert with `module = "integrations"`. The
+  # `put_change(:uuid, ...)` forces the changeset to use our generated
+  # uuid instead of letting Ecto autogenerate a different one.
+  defp insert_integration_row(data) do
+    uuid = UUIDv7.generate()
+    encrypted = Encryption.encrypt_fields(data)
+
+    %Setting{}
+    |> Setting.changeset(%{key: uuid, value_json: encrypted, module: @settings_module})
+    |> Ecto.Changeset.put_change(:uuid, uuid)
+    |> Queries.insert_setting()
   end
 
   @doc """
@@ -694,17 +709,16 @@ defmodule PhoenixKit.Integrations do
   @spec remove_connection(String.t(), String.t() | nil) :: :ok | {:error, term()}
   def remove_connection(uuid, actor_uuid \\ nil) when is_binary(uuid) do
     case resolve_uuid(uuid) do
-      {:ok, %{provider_key: provider_key, setting: setting}} ->
-        {provider, name} = parse_provider_name(provider_key)
-
+      {:ok, %{provider: provider, name: name, setting: setting}} ->
         case Settings.delete_setting(setting.key) do
           {:ok, _} ->
             Events.broadcast_connection_removed(provider, name)
 
             log_activity(
               "integration.connection_removed",
-              provider_key,
-              %{"name" => name},
+              provider,
+              name,
+              %{},
               "manual",
               actor_uuid
             )
@@ -726,84 +740,54 @@ defmodule PhoenixKit.Integrations do
   @doc """
   Renames a connection identified by uuid.
 
-  Updates the row's `key` column in place (preserving the uuid) and
-  rewrites the JSONB `name` field. Consumers that pinned to the uuid
-  keep working across the rename — that's the whole point of uuid-based
-  references. Names are pure user-chosen labels; any name (including
-  the literal string `"default"`) is valid.
+  Updates only the JSONB `name` field; the storage key (= row uuid) is
+  untouched, so consumers that pinned to the uuid keep working across
+  the rename. Names are pure user-chosen labels; any non-empty string
+  is valid, duplicates within a provider are allowed.
 
-  No-ops when `new_name` matches the current name. Refuses if the new
-  name already exists for this provider, or if it doesn't match the
-  connection-name pattern.
+  No-ops when `new_name` (after trim) matches the current name.
 
-  Returns `{:ok, new_data}` on success, with the same JSONB body as
-  before but `"name"` rewritten.
+  Returns `{:ok, new_data}` on success.
   """
   @spec rename_connection(String.t(), String.t(), String.t() | nil) ::
           {:ok, map()}
-          | {:error, :empty_name | :invalid_name | :already_exists | :not_configured | term()}
+          | {:error, :empty_name | :not_configured | term()}
   def rename_connection(uuid, new_name, actor_uuid \\ nil)
       when is_binary(uuid) and is_binary(new_name) do
-    new_name = String.trim(new_name)
+    trimmed = String.trim(new_name)
 
-    with {:ok, %{provider_key: provider_key, setting: setting, data: data}} <- resolve_uuid(uuid) do
-      {provider, old_name} = parse_provider_name(provider_key)
-
+    with {:ok, %{provider: provider, name: old_name, setting: setting, data: data}} <-
+           resolve_uuid(uuid) do
       cond do
-        new_name == old_name ->
+        trimmed == old_name ->
           {:ok, data}
 
-        new_name == "" ->
+        trimmed == "" ->
           {:error, :empty_name}
 
-        not Regex.match?(@name_pattern, new_name) ->
-          {:error, :invalid_name}
-
-        Settings.get_json_setting(settings_key("#{provider}:#{new_name}"), nil) != nil ->
-          {:error, :already_exists}
-
         true ->
-          do_rename_connection(setting, provider, old_name, new_name, actor_uuid)
+          updated = Map.put(data, "name", trimmed)
+
+          case save_integration(setting, updated) do
+            {:ok, saved} ->
+              Events.broadcast_connection_renamed(provider, old_name, trimmed)
+
+              log_activity(
+                "integration.connection_renamed",
+                provider,
+                trimmed,
+                %{"old_name" => old_name, "new_name" => trimmed},
+                "manual",
+                actor_uuid
+              )
+
+              {:ok, saved}
+
+            error ->
+              error
+          end
       end
     end
-  end
-
-  defp do_rename_connection(setting, provider, old_name, new_name, actor_uuid) do
-    new_key = "integration:#{provider}:#{new_name}"
-    new_data = Map.put(setting.value_json || %{}, "name", new_name)
-
-    case rename_setting_row(setting, new_key, new_data) do
-      {:ok, _updated} ->
-        Events.broadcast_connection_renamed(provider, old_name, new_name)
-
-        log_activity(
-          "integration.connection_renamed",
-          "#{provider}:#{new_name}",
-          %{"old_name" => old_name, "new_name" => new_name},
-          "manual",
-          actor_uuid
-        )
-
-        {:ok, Encryption.decrypt_fields(new_data)}
-
-      error ->
-        error
-    end
-  end
-
-  # In-place key + value rewrite via Ecto changeset; preserves the row
-  # uuid (which is the stable reference consumers store on their own
-  # records). Goes through `Repo.update` so the same encryption /
-  # cache-invalidation hooks fire as for `update_setting`.
-  defp rename_setting_row(setting, new_key, new_data) do
-    encrypted_data = Encryption.encrypt_fields(new_data)
-
-    setting
-    |> Setting.changeset(%{
-      key: new_key,
-      value_json: encrypted_data
-    })
-    |> PhoenixKit.RepoHelper.repo().update()
   end
 
   # ---------------------------------------------------------------------------
@@ -819,10 +803,9 @@ defmodule PhoenixKit.Integrations do
   """
   @spec validate_connection(String.t(), String.t() | nil) :: :ok | {:error, String.t()}
   def validate_connection(uuid, actor_uuid \\ nil) when is_binary(uuid) do
-    {result, log_provider_key} =
+    {result, log_provider, log_name} =
       case resolve_uuid(uuid) do
-        {:ok, %{provider_key: provider_key, data: data}} ->
-          {base_provider, _name} = parse_provider_name(provider_key)
+        {:ok, %{provider: base_provider, name: name, data: data}} ->
           provider = Providers.get(base_provider)
 
           inner =
@@ -832,17 +815,18 @@ defmodule PhoenixKit.Integrations do
               true -> do_validate(provider, data)
             end
 
-          {inner, provider_key}
+          {inner, base_provider, name}
 
         {:error, _} ->
-          {{:error, gettext("Not configured")}, uuid}
+          {{:error, gettext("Not configured")}, "unknown", ""}
       end
 
     case result do
       :ok ->
         log_activity(
           "integration.validated",
-          log_provider_key,
+          log_provider,
+          log_name,
           %{"result" => "ok"},
           "manual",
           actor_uuid
@@ -851,7 +835,8 @@ defmodule PhoenixKit.Integrations do
       {:error, reason} ->
         log_activity(
           "integration.validated",
-          log_provider_key,
+          log_provider,
+          log_name,
           %{"result" => "error", "reason" => reason},
           "manual",
           actor_uuid
@@ -961,7 +946,7 @@ defmodule PhoenixKit.Integrations do
     {new_status, validation_text} = validation_fields(result)
 
     case resolve_uuid(uuid) do
-      {:ok, %{provider_key: provider_key, data: data}} ->
+      {:ok, %{provider: base_provider, setting: setting, data: data}} ->
         status_changed =
           data["status"] != new_status or data["validation_status"] != validation_text
 
@@ -990,9 +975,9 @@ defmodule PhoenixKit.Integrations do
 
         updated = Map.merge(data, update)
 
-        case save_integration(provider_key, updated) do
+        case save_integration(setting, updated) do
           {:ok, _} ->
-            if status_changed, do: Events.broadcast_validated(provider_key, result)
+            if status_changed, do: Events.broadcast_validated(base_provider, result)
             :ok
 
           _ ->
@@ -1024,10 +1009,11 @@ defmodule PhoenixKit.Integrations do
     record_validation(uuid, {:error, reason_text})
 
     case resolve_uuid(uuid) do
-      {:ok, %{provider_key: provider_key}} ->
+      {:ok, %{provider: provider, name: name}} ->
         log_activity(
           "integration.token_refresh_failed",
-          provider_key,
+          provider,
+          name,
           %{"reason" => reason_text},
           "auto",
           nil
@@ -1040,9 +1026,9 @@ defmodule PhoenixKit.Integrations do
 
   defp maybe_record_recovery(uuid) do
     case resolve_uuid(uuid) do
-      {:ok, %{provider_key: provider_key, data: %{"status" => "error"}}} ->
+      {:ok, %{provider: provider, name: name, data: %{"status" => "error"}}} ->
         record_validation(uuid, :ok)
-        log_activity("integration.auto_recovered", provider_key, %{}, "auto", nil)
+        log_activity("integration.auto_recovered", provider, name, %{}, "auto", nil)
 
       _ ->
         :ok
@@ -1058,20 +1044,19 @@ defmodule PhoenixKit.Integrations do
   defp uuid?(str), do: is_binary(str) and Regex.match?(@uuid_pattern, str)
 
   # Resolve a settings-row uuid to its storage info — single source of
-  # truth for the uuid-strict public API. Sources `provider_key`
-  # (`"provider:name"`) directly from the row's `key` column so a
-  # corrupted JSONB `provider`/`name` field cannot leak into downstream
-  # writes. Returns the live `Setting` struct too so callers like
-  # `rename_connection/3` can update in place via changeset.
+  # truth for the uuid-strict public API. Provider and name are sourced
+  # from JSONB; the live `Setting` struct is returned so callers can
+  # update in place via changeset.
   defp resolve_uuid(uuid) when is_binary(uuid) and uuid != "" do
     case Queries.get_setting_by_uuid(uuid) do
-      %Setting{key: "integration:" <> provider_key} = setting ->
+      %Setting{module: "integrations"} = setting ->
         decrypted = Encryption.decrypt_fields(setting.value_json || %{})
 
         {:ok,
          %{
            uuid: uuid,
-           provider_key: provider_key,
+           provider: Map.get(decrypted, "provider", ""),
+           name: Map.get(decrypted, "name", ""),
            setting: setting,
            data: decrypted
          }}
@@ -1083,13 +1068,6 @@ defmodule PhoenixKit.Integrations do
 
   defp resolve_uuid(_), do: {:error, :invalid_uuid}
 
-  defp parse_provider_name(key) do
-    case String.split(key, ":", parts: 2) do
-      [provider, name] when name != "" -> {provider, name}
-      [provider] -> {provider, "default"}
-    end
-  end
-
   defp provider_auth_type(provider_key) do
     case Providers.get(provider_key) do
       %{auth_type: auth_type} -> Atom.to_string(auth_type)
@@ -1097,20 +1075,19 @@ defmodule PhoenixKit.Integrations do
     end
   end
 
-  defp save_integration(provider_key, data) do
+  defp save_integration(%Setting{} = setting, data) do
     encrypted_data = Encryption.encrypt_fields(data)
 
-    case Settings.update_json_setting_with_module(
-           settings_key(provider_key),
-           encrypted_data,
-           @settings_module
-         ) do
+    setting
+    |> Setting.update_changeset(%{value_json: encrypted_data, module: @settings_module})
+    |> Queries.update_setting()
+    |> case do
       {:ok, _setting} ->
         {:ok, data}
 
       {:error, changeset} = error ->
         Logger.error(
-          "[Integrations] Failed to save integration for #{provider_key}: #{inspect(changeset)}"
+          "[Integrations] Failed to save integration #{setting.uuid}: #{inspect(changeset)}"
         )
 
         error
@@ -1250,9 +1227,8 @@ defmodule PhoenixKit.Integrations do
   # Activity logging
   # ---------------------------------------------------------------------------
 
-  defp log_activity(action, provider_key, metadata, mode, actor_uuid) do
-    {provider, name} = parse_provider_name(provider_key)
-
+  defp log_activity(action, provider, name, metadata, mode, actor_uuid)
+       when is_binary(provider) and is_binary(name) do
     if Code.ensure_loaded?(PhoenixKit.Activity) do
       PhoenixKit.Activity.log(%{
         action: action,

--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -529,7 +529,26 @@ defmodule PhoenixKit.Migrations.Postgres do
   - Replaces unique index with partial index (slug-mode only, WHERE slug IS NOT NULL)
   - Adds unique index on `(group_uuid, post_date, post_time)` for timestamp-mode posts
 
-  ### V113 - System-managed media flag for Tessera tiles + comments↔files junction ⚡ LATEST
+  ### V114 - Integrations storage: uuid-only keys ⚡ LATEST
+  - Rewrites every `phoenix_kit_settings` row keyed
+    `integration:<provider>:<name>` so that `key = uuid` (the row's
+    primary key). Provider and name move into JSONB
+    (`value_json->>'provider'`, `value_json->>'name'`); the `module`
+    column (`'integrations'`) becomes the row-class discriminator.
+  - Backfills any missing `provider`/`name` JSONB fields from the old
+    composite key. Legacy V0-shape keys without a `:name` segment fold
+    to `name = 'default'`.
+  - Lifts both name restrictions on `add_connection/3` /
+    `rename_connection/3`: any non-empty string (after trim) is
+    allowed, including spaces, punctuation, and duplicates within a
+    provider. The `key` column's unique constraint is satisfied by
+    the UUIDv7, not by the human-chosen label.
+  - `down/1` rewrites keys back to the composite shape. Duplicate
+    `(provider, name)` pairs cannot be represented in the old shape,
+    so on collision the name is suffixed with `-<8-char uuid>` to
+    keep the rewrite well-defined.
+
+  ### V113 - System-managed media flag for Tessera tiles + comments↔files junction
   - Adds `system_managed BOOLEAN DEFAULT false NOT NULL` to
     `phoenix_kit_files`. Marks internally-generated media (DZI tile
     pyramids + per-tile chunks) so the MediaBrowser can exclude them
@@ -917,7 +936,7 @@ defmodule PhoenixKit.Migrations.Postgres do
   use Ecto.Migration
 
   @initial_version 1
-  @current_version 113
+  @current_version 114
   @default_prefix "public"
 
   @doc false

--- a/lib/phoenix_kit/migrations/postgres/v114.ex
+++ b/lib/phoenix_kit/migrations/postgres/v114.ex
@@ -1,0 +1,140 @@
+defmodule PhoenixKit.Migrations.Postgres.V114 do
+  @moduledoc """
+  V114: Switch integration storage rows to uuid-only keys.
+
+  Before V113, each integration row in `phoenix_kit_settings` had a
+  composite key of the shape `integration:<provider>:<name>` (e.g.
+  `"integration:google:default"`). That key construction baked the
+  human-chosen name into the row's identity, which forced two
+  unfortunate constraints:
+
+    * Names had to match a strict regex (`[a-zA-Z0-9][a-zA-Z0-9\\-_]*`)
+      because they were path-style segments in the key column.
+    * Names had to be unique per provider — the `key` column has a
+      unique index, so two `integration:openrouter:work` rows would
+      collide at insert time.
+
+  Both restrictions were storage-layout artifacts, not product
+  decisions. Operators wanted "My Company Drive" and a second OpenRouter
+  account also called "personal" without the system pushing back.
+
+  V113 lifts both by collapsing the storage key to just the row's UUID.
+  The `module` column (already set to `"integrations"` for every
+  integration row via `@settings_module`) becomes the sole row-class
+  discriminator, and `provider` + `name` live purely in `value_json`.
+
+  ## Migration steps
+
+  1. For every row in `phoenix_kit_settings` whose `key` starts with
+     `integration:`:
+
+     a. Parse `provider` and `name` from the key (handling the legacy
+        V0 shape `integration:google` without a name as
+        `provider=google`, `name="default"`).
+     b. Ensure `value_json` has `"provider"` and `"name"` populated
+        (idempotent — leaves correct values alone).
+     c. Ensure `module = 'integrations'` (was already set for
+        integrations created via `add_connection/3`, but legacy rows
+        pre-`@settings_module` may have it NULL).
+     d. Rewrite the `key` column to the row's `uuid`.
+
+  2. Stamp the table comment with `'113'`.
+
+  All work happens in a single transaction (handled by the outer
+  migrator). Per-row updates use only the row's `uuid` for routing —
+  the new shape is `key = uuid`, so the row's PK is what we touch.
+
+  ## Down migration
+
+  The down path is best-effort: duplicate `(provider, name)` pairs
+  cannot be represented in the old shape, so on a name collision we
+  suffix `-<short_uuid>` to keep the rewrite well-defined. Round-trip
+  `down → up` therefore changes those names by a suffix. Acceptable
+  for a one-shot data migration that operators rarely roll back.
+  """
+
+  use Ecto.Migration
+
+  def up(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    rewrite_keys_to_uuid(p)
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '114'")
+  end
+
+  def down(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    rewrite_keys_to_composite(p)
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '113'")
+  end
+
+  # `up` — rewrite every `integration:%`-keyed row to `key = uuid`.
+  #
+  # Done in pure SQL via a single CTE so we don't load every row into
+  # Elixir memory. The `substring(key from '^integration:([^:]+)')` pulls
+  # the provider; the rest of the suffix (or `'default'` when absent) is
+  # the name. JSONB merge guarantees we don't clobber an existing
+  # `provider`/`name` field — `jsonb_strip_nulls(... || jsonb_build_object(...))`
+  # uses concat semantics so the JSONB body wins where it already has a
+  # value.
+  #
+  # The `WHERE` filter is selective: only rows whose `key` literally
+  # starts with `integration:` get touched. Already-migrated rows
+  # (`key` is a uuid string) silently skip.
+  defp rewrite_keys_to_uuid(p) do
+    execute("""
+    UPDATE #{p}phoenix_kit_settings AS s
+       SET key = s.uuid::text,
+           module = 'integrations',
+           value_json = COALESCE(s.value_json, '{}'::jsonb)
+                        || jsonb_build_object(
+                             'provider',
+                             COALESCE(
+                               NULLIF(s.value_json->>'provider', ''),
+                               split_part(substring(s.key from 13), ':', 1)
+                             ),
+                             'name',
+                             COALESCE(
+                               NULLIF(s.value_json->>'name', ''),
+                               NULLIF(split_part(substring(s.key from 13), ':', 2), ''),
+                               'default'
+                             )
+                           )
+     WHERE s.key LIKE 'integration:%';
+    """)
+  end
+
+  # `down` — rewrite back to the composite shape, with `-<short_uuid>`
+  # suffix on name collisions. Single CTE-driven update.
+  defp rewrite_keys_to_composite(p) do
+    execute("""
+    WITH ordered AS (
+      SELECT
+        s.uuid,
+        s.value_json->>'provider' AS provider,
+        s.value_json->>'name'     AS name,
+        ROW_NUMBER() OVER (
+          PARTITION BY s.value_json->>'provider', s.value_json->>'name'
+          ORDER BY s.date_added NULLS LAST, s.uuid
+        ) AS rn
+      FROM #{p}phoenix_kit_settings s
+      WHERE s.module = 'integrations'
+        AND s.key = s.uuid::text
+    )
+    UPDATE #{p}phoenix_kit_settings AS s
+       SET key = 'integration:' || o.provider || ':' ||
+                 CASE
+                   WHEN o.rn = 1 THEN o.name
+                   ELSE o.name || '-' || substring(s.uuid::text from 1 for 8)
+                 END
+      FROM ordered o
+     WHERE s.uuid = o.uuid;
+    """)
+  end
+
+  defp prefix_str("public"), do: ""
+  defp prefix_str(prefix) when is_binary(prefix), do: "#{prefix}."
+end

--- a/lib/phoenix_kit/users/permissions.ex
+++ b/lib/phoenix_kit/users/permissions.ex
@@ -337,7 +337,17 @@ defmodule PhoenixKit.Users.Permissions do
     "users" => "Users",
     "media" => "Media",
     "settings" => "Settings",
-    "modules" => "Modules"
+    "modules" => "Modules",
+    # `db` was extracted into `phoenix_kit_db` but core still
+    # references the key (e.g. `auth.ex` `/admin/db` route).
+    # `phoenix_kit_db` registers `"db" => "DB"` via its
+    # `permission_metadata/0`, but only when the module is loaded
+    # in the parent app. Core's own test environment doesn't load
+    # external modules, so without this fallback `module_label("db")`
+    # produces `String.capitalize("db")` = `"Db"`. Pin the canonical
+    # label here so the display is correct regardless of whether
+    # the external module is installed.
+    "db" => "DB"
   }
 
   @core_icons %{
@@ -345,7 +355,10 @@ defmodule PhoenixKit.Users.Permissions do
     "users" => "hero-users",
     "media" => "hero-photo",
     "settings" => "hero-cog-6-tooth",
-    "modules" => "hero-squares-2x2"
+    "modules" => "hero-squares-2x2",
+    # Mirrors `phoenix_kit_db`'s registered icon. See `@core_labels`
+    # above for the rationale.
+    "db" => "hero-server-stack"
   }
 
   @core_descriptions %{
@@ -353,7 +366,10 @@ defmodule PhoenixKit.Users.Permissions do
     "users" => "User accounts, roles, and access management",
     "media" => "File uploads, image processing, and storage buckets",
     "settings" => "General, organization, and user preference settings",
-    "modules" => "Enable, disable, and configure feature modules"
+    "modules" => "Enable, disable, and configure feature modules",
+    # Mirrors `phoenix_kit_db`'s registered description. See
+    # `@core_labels` above for the rationale.
+    "db" => "Database explorer and schema inspection"
   }
 
   @doc "Returns a human-readable label for a module key."

--- a/lib/phoenix_kit_web/components/core/integration_picker.ex
+++ b/lib/phoenix_kit_web/components/core/integration_picker.ex
@@ -58,6 +58,9 @@ defmodule PhoenixKitWeb.Components.Core.IntegrationPicker do
   use Gettext, backend: PhoenixKitWeb.Gettext
 
   import PhoenixKitWeb.Components.Core.Icon, only: [icon: 1]
+  import PhoenixKitWeb.Components.Core.TimeDisplay, only: [time_ago: 1]
+
+  alias PhoenixKit.Integrations.Providers
 
   @doc """
   Renders an integration picker as a grid of cards.
@@ -140,76 +143,16 @@ defmodule PhoenixKitWeb.Components.Core.IntegrationPicker do
           if(@compact, do: "grid-cols-1", else: "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3")
         ]}
       >
-        <button
+        <.connection_card
           :for={conn <- @filtered_connections}
-          type="button"
-          phx-click={@on_select}
-          phx-value-uuid={conn.uuid}
-          phx-value-action={select_action(@multiple, conn.uuid, @selected_set)}
-          data-search-text={search_text(conn)}
-          class={[
-            "card bg-base-100 border text-left transition-all cursor-pointer",
-            "hover:shadow-md hover:border-primary/50",
-            if(MapSet.member?(@selected_set, conn.uuid),
-              do: "border-primary ring-2 ring-primary/20",
-              else: "border-base-300"
-            )
-          ]}
-        >
-          <div class={["card-body", if(@compact, do: "p-3", else: "p-4")]}>
-            <div class="flex items-center gap-3">
-              <%!-- Provider icon --%>
-              <span
-                :if={is_map(conn[:provider]) && conn.provider[:icon]}
-                class="w-8 h-8 flex items-center justify-center bg-base-200 rounded-lg shrink-0"
-              >
-                <.icon name={conn.provider.icon} class="w-4 h-4" />
-              </span>
-
-              <div class="flex-1 min-w-0">
-                <%!-- Connection name (always the user-chosen label —
-                     `default` is no longer system-privileged post-#511) --%>
-                <div class="flex items-center gap-2">
-                  <span class="font-medium truncate">
-                    {conn.name}
-                  </span>
-                  <span
-                    :if={is_map(conn[:provider])}
-                    class="badge badge-ghost badge-xs shrink-0"
-                  >
-                    {conn.provider.name}
-                  </span>
-                </div>
-
-                <%!-- Account info --%>
-                <p
-                  :if={conn.data["external_account_id"]}
-                  class="text-xs text-base-content/60 truncate"
-                >
-                  {conn.data["external_account_id"]}
-                </p>
-              </div>
-
-              <%!-- Status + selection indicator --%>
-              <div class="flex items-center gap-2 shrink-0">
-                <span :if={conn.data["status"] == "connected"} class="badge badge-success badge-xs">
-                  {gettext("Connected")}
-                </span>
-                <span
-                  :if={conn.data["status"] != "connected"}
-                  class="badge badge-ghost badge-xs"
-                >
-                  {gettext("Not connected")}
-                </span>
-
-                <%!-- Selection check --%>
-                <span :if={MapSet.member?(@selected_set, conn.uuid)}>
-                  <.icon name="hero-check-circle-solid" class="w-5 h-5 text-primary" />
-                </span>
-              </div>
-            </div>
-          </div>
-        </button>
+          conn={conn}
+          provider_def={provider_def(conn)}
+          selected={MapSet.member?(@selected_set, conn.uuid)}
+          compact={@compact}
+          on_select={@on_select}
+          action={select_action(@multiple, conn.uuid, @selected_set)}
+          show_provider_badge={is_nil(@provider)}
+        />
       </div>
 
       <%!-- Deleted integration cards --%>
@@ -258,20 +201,209 @@ defmodule PhoenixKitWeb.Components.Core.IntegrationPicker do
     """
   end
 
+  # Per-card render — extracted so the grid loop stays readable. The
+  # provider definition (icon + display name) is auto-resolved from
+  # `conn.data["provider"]` via the Providers registry, so callers
+  # don't need to pre-attach it.
+  attr :conn, :map, required: true
+  attr :provider_def, :any, required: true
+  attr :selected, :boolean, required: true
+  attr :compact, :boolean, required: true
+  attr :on_select, :string, required: true
+  attr :action, :string, required: true
+  attr :show_provider_badge, :boolean, default: true
+
+  defp connection_card(assigns) do
+    ~H"""
+    <button
+      type="button"
+      phx-click={@on_select}
+      phx-value-uuid={@conn.uuid}
+      phx-value-action={@action}
+      data-search-text={search_text(@conn, @provider_def)}
+      class={[
+        "card bg-base-100 border text-left transition-all cursor-pointer",
+        "hover:shadow-md hover:border-primary/50",
+        # Instant click feedback: `.phx-click-loading` is applied
+        # automatically by LiveView to elements with `phx-click`
+        # while the event is in flight. Dimming + disabling pointer
+        # events bridges the perception gap between "click registered"
+        # and "server-side state caught up" (which can take 100-500ms
+        # while connected? + select_provider_connection round-trip).
+        "phx-click-loading:opacity-60 phx-click-loading:pointer-events-none",
+        if(@selected,
+          do: "border-primary ring-2 ring-primary/20",
+          else: "border-base-300"
+        )
+      ]}
+    >
+      <div class={["card-body", if(@compact, do: "p-3", else: "p-4")]}>
+        <div class="flex items-center gap-3">
+          <%!-- Provider icon --%>
+          <span
+            :if={@provider_def && @provider_def[:icon]}
+            class="w-8 h-8 flex items-center justify-center bg-base-200 rounded-lg shrink-0"
+          >
+            <.icon name={@provider_def.icon} class="w-4 h-4" />
+          </span>
+
+          <div class="flex-1 min-w-0">
+            <%!-- Connection name. Names are pure user-chosen labels
+                 (post-V113): duplicates allowed, no privileged values,
+                 the masked-credential subtitle below disambiguates
+                 when two cards share a name. --%>
+            <div class="flex items-center gap-2">
+              <span class="font-medium truncate">
+                {@conn.name}
+              </span>
+              <%!-- Provider badge — redundant when the picker is
+                   filtering to a single provider (every card is the
+                   same provider in that case). Shown only when the
+                   picker is rendering mixed-provider connections,
+                   which happens when the caller passes no `provider`
+                   attr. --%>
+              <span
+                :if={@show_provider_badge && @provider_def && @provider_def[:name]}
+                class="badge badge-ghost badge-xs shrink-0"
+              >
+                {@provider_def.name}
+              </span>
+            </div>
+
+            <%!-- Subtitle: OAuth `external_account_id` (e.g.
+                 "user@gmail.com") when present, otherwise a masked
+                 credential tail (api_key / bot_token / access_key).
+                 Empty when neither exists. --%>
+            <p
+              :if={connection_subtitle(@conn) not in [nil, ""]}
+              class="text-xs text-base-content/60 truncate"
+            >
+              {connection_subtitle(@conn)}
+            </p>
+
+            <%!-- Age — "Created 3 days ago" using shared time_ago
+                 hook so the value stays live without a server round
+                 trip. Helps disambiguate same-named connections. --%>
+            <p :if={@conn[:date_added]} class="text-xs text-base-content/40">
+              {gettext("Created")} <.time_ago datetime={@conn.date_added} class="text-xs" />
+            </p>
+          </div>
+
+          <%!-- Status + selection indicator --%>
+          <div class="flex items-center gap-2 shrink-0">
+            <%!-- In-flight spinner. Hidden by default; shown when
+                 LiveView applies `.phx-click-loading` to this button
+                 (the click handler's round-trip window). Hides the
+                 status badge during loading so the spinner has a
+                 clear visual home. --%>
+            <span class="hidden phx-click-loading:inline-flex">
+              <span class="loading loading-spinner loading-xs"></span>
+            </span>
+
+            <%!-- Status badge. Surfaces the row's actual `status`
+                 (connected / configured / error / disconnected) with
+                 a distinct label + colour for each, rather than
+                 collapsing every non-`"connected"` state into a
+                 single "Not connected". For error rows, the
+                 validation message (e.g. "Invalid credentials")
+                 hovers as the `title` attribute so the operator can
+                 see WHY without clicking through. --%>
+            <% {status_label, status_class} = status_badge(@conn.data) %>
+            <span
+              class={"badge badge-xs phx-click-loading:hidden " <> status_class}
+              title={@conn.data["validation_status"]}
+            >
+              {status_label}
+            </span>
+
+            <%!-- Selection check. Always rendered so the row layout
+                 doesn't reflow on pick/unpick; ghosted via low-contrast
+                 colour when the card isn't selected, so it reads as
+                 "selectable" rather than active. --%>
+            <.icon
+              name="hero-check-circle-solid"
+              class={
+                "w-5 h-5 " <>
+                  if(@selected, do: "text-primary", else: "text-base-content/20")
+              }
+            />
+          </div>
+        </div>
+      </div>
+    </button>
+    """
+  end
+
+  # Maps the row's `status` field to a `{label, daisyUI-class}` pair
+  # for the card's status badge. The four canonical statuses
+  # (`connected`, `configured`, `error`, `disconnected`) get distinct
+  # labels + colours so operators can tell at a glance whether the
+  # row is healthy, untested, broken, or empty.
+  defp status_badge(%{} = data) do
+    case Map.get(data, "status") do
+      "connected" -> {gettext("Connected"), "badge-success"}
+      "error" -> {gettext("Auth failed"), "badge-error"}
+      "configured" -> {gettext("Not tested"), "badge-warning"}
+      "disconnected" -> {gettext("Not connected"), "badge-ghost"}
+      _ -> {gettext("Not connected"), "badge-ghost"}
+    end
+  end
+
   defp filter_by_provider(connections, nil), do: connections
 
   defp filter_by_provider(connections, provider) do
-    Enum.filter(connections, fn conn ->
-      key = conn_provider_key(conn)
-      key == provider or String.starts_with?(key, provider <> ":")
+    Enum.filter(connections, fn conn -> conn_provider_key(conn) == provider end)
+  end
+
+  defp conn_provider_key(conn), do: conn.data["provider"] || ""
+
+  # Resolves the provider definition (icon + display name) for a
+  # connection. Reads the bare provider string from JSONB and looks
+  # it up in the registry. Returns `nil` when the provider isn't
+  # registered (e.g. a custom provider contributed by a now-uninstalled
+  # module).
+  defp provider_def(conn) do
+    case conn.data["provider"] do
+      provider when is_binary(provider) and provider != "" -> Providers.get(provider)
+      _ -> nil
+    end
+  end
+
+  # Subtitle priority:
+  # 1. OAuth account identifier (`external_account_id`) — already a
+  #    human-readable string from the provider's userinfo endpoint.
+  # 2. Masked credential tail — first 8 + ellipsis + last 4 of whichever
+  #    credential field is present. Short keys (< 14 chars) fully mask
+  #    so a 13-char key doesn't leak most of itself.
+  # 3. Empty — show nothing, the card has just the name + age.
+  defp connection_subtitle(conn) do
+    case conn.data["external_account_id"] do
+      account when is_binary(account) and account != "" ->
+        account
+
+      _ ->
+        conn.data
+        |> credential_value()
+        |> mask_credential()
+    end
+  end
+
+  defp credential_value(data) do
+    Enum.find_value(~w(api_key bot_token access_key), fn key ->
+      case data[key] do
+        v when is_binary(v) and v != "" -> v
+        _ -> nil
+      end
     end)
   end
 
-  defp conn_provider_key(conn) do
-    cond do
-      is_map(conn[:provider]) -> conn.provider.key
-      is_binary(conn[:provider_key]) -> conn.provider_key
-      true -> conn.data["provider"] || ""
+  defp mask_credential(nil), do: nil
+
+  defp mask_credential(value) when is_binary(value) do
+    if String.length(value) < 14 do
+      "•••"
+    else
+      String.slice(value, 0, 8) <> "…" <> String.slice(value, -4..-1)
     end
   end
 
@@ -284,14 +416,16 @@ defmodule PhoenixKitWeb.Components.Core.IntegrationPicker do
     Enum.filter(connections, fn conn ->
       name = String.downcase(conn.name || "")
       account = String.downcase(conn.data["external_account_id"] || "")
+      provider = String.downcase(conn.data["provider"] || "")
 
-      provider_name =
-        if is_map(conn[:provider]),
-          do: String.downcase(conn.provider.name || ""),
-          else: String.downcase(conn.data["provider"] || "")
+      provider_display =
+        case provider_def(conn) do
+          %{name: name} when is_binary(name) -> String.downcase(name)
+          _ -> ""
+        end
 
       String.contains?(name, q) or String.contains?(account, q) or
-        String.contains?(provider_name, q)
+        String.contains?(provider, q) or String.contains?(provider_display, q)
     end)
   end
 
@@ -303,12 +437,12 @@ defmodule PhoenixKitWeb.Components.Core.IntegrationPicker do
     if MapSet.member?(selected_set, uuid), do: "deselect", else: "select"
   end
 
-  defp search_text(conn) do
+  defp search_text(conn, provider_def) do
     parts = [
       conn.name,
       conn.data["external_account_id"],
       conn.data["provider"],
-      if(is_map(conn[:provider]), do: conn.provider.name)
+      provider_def && provider_def[:name]
     ]
 
     parts |> Enum.reject(&is_nil/1) |> Enum.join(" ") |> String.downcase()

--- a/lib/phoenix_kit_web/live/settings/integration_form.ex
+++ b/lib/phoenix_kit_web/live/settings/integration_form.ex
@@ -162,17 +162,19 @@ defmodule PhoenixKitWeb.Live.Settings.IntegrationForm do
       {:ok, %{uuid: uuid}} ->
         save_and_redirect(uuid, provider_key, name, params, socket)
 
-      {:error, :already_exists} ->
-        case lookup_connection_uuid(provider_key, name) do
-          {:ok, uuid} -> save_and_redirect(uuid, provider_key, name, params, socket)
-          :error -> {:noreply, assign(socket, :error, gettext("Failed to load connection"))}
-        end
-
       {:error, :empty_name} ->
-        {:noreply, assign(socket, :error, gettext("Please enter a connection name."))}
+        {:noreply,
+         socket
+         |> assign(:new_name, name)
+         |> assign(:form_values, extract_setup_attrs(provider_key, params))
+         |> assign(:error, gettext("Please enter a connection name."))}
 
       {:error, reason} ->
-        {:noreply, assign(socket, :error, "Failed: #{inspect(reason)}")}
+        {:noreply,
+         socket
+         |> assign(:new_name, name)
+         |> assign(:form_values, extract_setup_attrs(provider_key, params))
+         |> assign(:error, "Failed: #{inspect(reason)}")}
     end
   end
 
@@ -313,24 +315,8 @@ defmodule PhoenixKitWeb.Live.Settings.IntegrationForm do
 
         {:noreply, socket}
 
-      {:error, :already_exists} ->
-        {:noreply,
-         assign(
-           socket,
-           :error,
-           gettext("A connection with that name already exists.")
-         )}
-
       {:error, :empty_name} ->
         {:noreply, assign(socket, :error, gettext("Connection name can't be blank."))}
-
-      {:error, :invalid_name} ->
-        {:noreply,
-         assign(
-           socket,
-           :error,
-           gettext("Use letters, digits, hyphens, and underscores only.")
-         )}
 
       {:error, _other} ->
         {:noreply, assign(socket, :error, gettext("Failed to rename connection."))}
@@ -466,6 +452,7 @@ defmodule PhoenixKitWeb.Live.Settings.IntegrationForm do
 
   defp save_form_with_rename(params, socket) do
     uuid = socket.assigns.uuid
+    provider_key = socket.assigns.selected_provider
     new_name = String.trim(params["name"])
 
     case Integrations.rename_connection(uuid, new_name, actor_uuid(socket)) do
@@ -478,22 +465,17 @@ defmodule PhoenixKitWeb.Live.Settings.IntegrationForm do
         # Now save credentials under the new name.
         handle_event("save_setup", params, socket)
 
-      {:error, :already_exists} ->
-        {:noreply, assign(socket, :error, gettext("A connection with that name already exists."))}
-
       {:error, :empty_name} ->
-        {:noreply, assign(socket, :error, gettext("Connection name can't be blank."))}
-
-      {:error, :invalid_name} ->
         {:noreply,
-         assign(
-           socket,
-           :error,
-           gettext("Use letters, digits, hyphens, and underscores only.")
-         )}
+         socket
+         |> assign(:form_values, extract_setup_attrs(provider_key, params))
+         |> assign(:error, gettext("Connection name can't be blank."))}
 
       {:error, _other} ->
-        {:noreply, assign(socket, :error, gettext("Failed to rename connection."))}
+        {:noreply,
+         socket
+         |> assign(:form_values, extract_setup_attrs(provider_key, params))
+         |> assign(:error, gettext("Failed to rename connection."))}
     end
   end
 
@@ -517,15 +499,6 @@ defmodule PhoenixKitWeb.Live.Settings.IntegrationForm do
 
       {:error, _} ->
         {:noreply, assign(socket, :error, gettext("Failed to save"))}
-    end
-  end
-
-  defp lookup_connection_uuid(provider_key, name) do
-    Integrations.list_connections(provider_key)
-    |> Enum.find(fn %{name: n} -> n == name end)
-    |> case do
-      %{uuid: uuid} when is_binary(uuid) -> {:ok, uuid}
-      _ -> :error
     end
   end
 

--- a/lib/phoenix_kit_web/live/settings/integration_form.html.heex
+++ b/lib/phoenix_kit_web/live/settings/integration_form.html.heex
@@ -202,16 +202,9 @@
                 name="name"
                 value={@name || @new_name}
                 class="input input-bordered w-full"
-                placeholder={gettext("e.g. main, personal, work")}
+                placeholder={gettext("e.g. Main, Personal, My Company Drive")}
                 required
               />
-              <label class="label">
-                <span class="label-text-alt text-base-content/50">
-                  {gettext(
-                    "Letters, digits, hyphens, and underscores. Must be unique per provider."
-                  )}
-                </span>
-              </label>
             </div>
 
             <%!-- Provider-specific fields. Even credential-shaped

--- a/lib/phoenix_kit_web/live/settings/integration_form.html.heex
+++ b/lib/phoenix_kit_web/live/settings/integration_form.html.heex
@@ -263,7 +263,11 @@
                  preserved across the no-op save, and the auto-test
                  re-verifies it. --%>
             <div class="flex flex-wrap gap-2 items-center pt-2">
-              <button type="submit" class="btn btn-primary">
+              <button
+                type="submit"
+                class="btn btn-primary"
+                phx-disable-with={gettext("Saving…")}
+              >
                 {if @name, do: gettext("Save Changes"), else: gettext("Create Connection")}
               </button>
 
@@ -295,6 +299,7 @@
                 formnovalidate
                 class={"btn btn-outline #{if @testing, do: "loading"}"}
                 disabled={@testing}
+                phx-disable-with={gettext("Testing…")}
               >
                 <.icon :if={!@testing} name="hero-signal" class="w-4 h-4" />
                 {if @testing, do: gettext("Testing..."), else: gettext("Test Connection")}
@@ -457,6 +462,7 @@
               phx-click="disconnect_account"
               class="btn btn-outline btn-warning btn-sm shrink-0"
               data-confirm={gettext("Are you sure you want to disconnect this account?")}
+              phx-disable-with={gettext("Disconnecting…")}
             >
               <.icon name="hero-link-slash" class="w-4 h-4" />
               {gettext("Disconnect")}
@@ -481,6 +487,7 @@
               phx-click="delete_connection"
               class="btn btn-outline btn-error btn-sm shrink-0"
               data-confirm={gettext("Permanently delete this connection? This cannot be undone.")}
+              phx-disable-with={gettext("Deleting…")}
             >
               <.icon name="hero-trash" class="w-4 h-4" />
               {gettext("Delete")}

--- a/test/integration/integrations_test.exs
+++ b/test/integration/integrations_test.exs
@@ -15,22 +15,23 @@ defmodule PhoenixKit.Integration.IntegrationsTest do
     do: setup_conn(provider, "default", attrs)
 
   defp setup_conn(provider, name, attrs) when is_binary(name) and is_map(attrs) do
-    uuid =
-      case Integrations.add_connection(provider, name) do
-        {:ok, %{uuid: uuid}} ->
-          uuid
-
-        {:error, :already_exists} ->
-          [%{uuid: uuid}] =
-            Integrations.list_connections(provider) |> Enum.filter(&(&1.name == name))
-
-          uuid
-      end
+    {:ok, %{uuid: uuid}} = Integrations.add_connection(provider, name)
 
     if map_size(attrs) > 0 do
       {:ok, _} = Integrations.save_setup(uuid, attrs)
     end
 
+    uuid
+  end
+
+  # Helper: seed a connection row with arbitrary JSONB attributes,
+  # bypassing `save_setup/3`'s provider-fields filter. Used by tests
+  # that need to inject `access_token`, `status: "connected"`, or
+  # other fields outside the provider's declared `setup_fields`.
+  defp seed_raw(provider, name \\ "default", attrs) when is_map(attrs) do
+    {:ok, %{uuid: uuid}} = Integrations.add_connection(provider, name)
+    current = Settings.get_json_setting_by_uuid(uuid) || %{}
+    Settings.update_json_setting_with_module(uuid, Map.merge(current, attrs), "integrations")
     uuid
   end
 
@@ -75,6 +76,25 @@ defmodule PhoenixKit.Integration.IntegrationsTest do
     test "returns :not_configured when uuid doesn't resolve" do
       ghost_uuid = "00000000-0000-7000-8000-000000000000"
       assert {:error, :not_configured} = Integrations.save_setup(ghost_uuid, %{"x" => "y"})
+    end
+
+    test "preserves the JSONB name across save_setup (post-V113 regression)" do
+      # Regression: pre-V113 the row's storage key was
+      # `integration:<provider>:<name>`, and save_setup parsed `name`
+      # back out of the key to re-stamp `data["name"]`. Post-V113 the
+      # key is just the uuid, so parsing it would put the uuid string
+      # into `data["name"]`. save_setup must source `name` from the
+      # existing JSONB body (set at row birth in add_connection/3),
+      # not from the storage key.
+      uuid = setup_conn("openrouter", "My Display Name")
+
+      {:ok, data} = Integrations.save_setup(uuid, %{"api_key" => "sk-or-test"})
+
+      assert data["name"] == "My Display Name"
+      refute data["name"] == uuid
+
+      # Round-trip through get_integration_by_uuid pins the same.
+      assert {:ok, %{name: "My Display Name"}} = Integrations.get_integration_by_uuid(uuid)
     end
   end
 
@@ -137,10 +157,8 @@ defmodule PhoenixKit.Integration.IntegrationsTest do
       # Simulate a connected OAuth provider — seed the row directly so
       # the test can prove that disconnect surgically removes only the
       # token fields and not the persisted client credentials.
-      Settings.update_json_setting_with_module(
-        Integrations.settings_key("google"),
-        %{
-          "provider" => "google",
+      uuid =
+        seed_raw("google", %{
           "auth_type" => "oauth2",
           "client_id" => "my-client-id",
           "client_secret" => "my-client-secret",
@@ -148,11 +166,8 @@ defmodule PhoenixKit.Integration.IntegrationsTest do
           "refresh_token" => "1//refresh-token",
           "status" => "connected",
           "external_account_id" => "user@gmail.com"
-        },
-        "integrations"
-      )
+        })
 
-      [%{uuid: uuid}] = Integrations.list_connections("google")
       assert Integrations.connected?(uuid)
 
       :ok = Integrations.disconnect(uuid)
@@ -184,20 +199,15 @@ defmodule PhoenixKit.Integration.IntegrationsTest do
 
   describe "disconnect/2 for key_secret provider" do
     test "removes credentials like other non-OAuth types" do
-      Settings.update_json_setting_with_module(
-        Integrations.settings_key("aws"),
-        %{
-          "provider" => "aws",
+      uuid =
+        seed_raw("aws", %{
           "auth_type" => "key_secret",
           "access_key" => "AKIATEST",
           "secret_key" => "secret123",
           "status" => "connected",
           "metadata" => %{"region" => "us-east-1"}
-        },
-        "integrations"
-      )
+        })
 
-      [%{uuid: uuid}] = Integrations.list_connections("aws")
       :ok = Integrations.disconnect(uuid)
 
       {:ok, data} = Integrations.get_integration("aws")
@@ -239,29 +249,21 @@ defmodule PhoenixKit.Integration.IntegrationsTest do
       assert {:error, :invalid_uuid} = Integrations.get_integration_by_uuid(:atom)
     end
 
-    test "sources provider+name from the storage key, ignoring JSONB body drift" do
-      # Defensive: the JSONB `provider`/`name` fields are duplicates of
-      # information already encoded in the row's `key` column. If the
-      # JSONB body has drifted (corrupted by a previous bug, partial
-      # restore, etc.), `get_integration_by_uuid/1` must still return
-      # the canonical provider+name parsed from `key` so the form LV
-      # can recover.
-      Settings.update_json_setting_with_module(
-        Integrations.settings_key("openrouter"),
-        %{
+    test "sources provider+name from JSONB (key is now uuid-only)" do
+      # Post-V113 storage shape: the row's `key` column is just the
+      # row's uuid; provider and name live in JSONB. This test pins
+      # the new invariant — write specific JSONB values and read
+      # them back verbatim via the uuid lookup.
+      uuid =
+        seed_raw("openrouter", "primary", %{
           "api_key" => "key",
-          # Drift: JSONB claims provider/name that disagree with the row's key
-          "provider" => "openrouter:default",
-          "name" => "default:default"
-        },
-        "integrations"
-      )
-
-      [%{uuid: uuid}] = Integrations.list_connections("openrouter")
+          "provider" => "openrouter",
+          "name" => "primary"
+        })
 
       assert {:ok, result} = Integrations.get_integration_by_uuid(uuid)
       assert result.provider == "openrouter"
-      assert result.name == "default"
+      assert result.name == "primary"
     end
   end
 
@@ -271,99 +273,59 @@ defmodule PhoenixKit.Integration.IntegrationsTest do
 
   describe "get_credentials/1 for different auth types" do
     test "returns credentials for connected OAuth (access_token present)" do
-      Settings.update_json_setting_with_module(
-        Integrations.settings_key("google"),
-        %{
-          "provider" => "google",
-          "auth_type" => "oauth2",
-          "access_token" => "ya29.token",
-          "status" => "connected"
-        },
-        "integrations"
-      )
+      seed_raw("google", %{
+        "auth_type" => "oauth2",
+        "access_token" => "ya29.token",
+        "status" => "connected"
+      })
 
       assert {:ok, creds} = Integrations.get_credentials("google")
       assert creds["access_token"] == "ya29.token"
     end
 
     test "returns credentials for bot_token provider" do
-      Settings.update_json_setting_with_module(
-        Integrations.settings_key("telegram"),
-        %{
-          "provider" => "telegram",
-          "auth_type" => "bot_token",
-          "bot_token" => "123456:ABC-DEF",
-          "status" => "connected"
-        },
-        "integrations"
-      )
+      seed_raw("telegram", %{
+        "auth_type" => "bot_token",
+        "bot_token" => "123456:ABC-DEF",
+        "status" => "connected"
+      })
 
       assert {:ok, creds} = Integrations.get_credentials("telegram")
       assert creds["bot_token"] == "123456:ABC-DEF"
     end
 
     test "returns credentials for key_secret provider" do
-      Settings.update_json_setting_with_module(
-        Integrations.settings_key("aws"),
-        %{
-          "provider" => "aws",
-          "auth_type" => "key_secret",
-          "access_key" => "AKIATEST",
-          "secret_key" => "secret",
-          "status" => "connected"
-        },
-        "integrations"
-      )
+      seed_raw("aws", %{
+        "auth_type" => "key_secret",
+        "access_key" => "AKIATEST",
+        "secret_key" => "secret",
+        "status" => "connected"
+      })
 
       assert {:ok, creds} = Integrations.get_credentials("aws")
       assert creds["access_key"] == "AKIATEST"
     end
 
     test "returns credentials for custom credentials provider" do
-      Settings.update_json_setting_with_module(
-        Integrations.settings_key("smtp"),
-        %{
-          "provider" => "smtp",
-          "auth_type" => "credentials",
-          "credentials" => %{"host" => "smtp.test.com", "port" => 587},
-          "status" => "connected"
-        },
-        "integrations"
-      )
+      seed_raw("smtp", %{
+        "auth_type" => "credentials",
+        "credentials" => %{"host" => "smtp.test.com", "port" => 587},
+        "status" => "connected"
+      })
 
       assert {:ok, creds} = Integrations.get_credentials("smtp")
       assert creds["credentials"]["host"] == "smtp.test.com"
     end
 
     test "returns error when only setup creds exist (no tokens)" do
-      Settings.update_json_setting_with_module(
-        Integrations.settings_key("google"),
-        %{
-          "provider" => "google",
-          "auth_type" => "oauth2",
-          "client_id" => "my-id",
-          "client_secret" => "my-secret",
-          "status" => "disconnected"
-        },
-        "integrations"
-      )
+      seed_raw("google", %{
+        "auth_type" => "oauth2",
+        "client_id" => "my-id",
+        "client_secret" => "my-secret",
+        "status" => "disconnected"
+      })
 
       assert {:error, :not_configured} = Integrations.get_credentials("google")
-    end
-  end
-
-  # ===========================================================================
-  # settings_key
-  # ===========================================================================
-
-  describe "settings_key/1" do
-    test "prefixes with integration: and default name" do
-      assert Integrations.settings_key("google") == "integration:google:default"
-      assert Integrations.settings_key("openrouter") == "integration:openrouter:default"
-    end
-
-    test "supports explicit name" do
-      assert Integrations.settings_key("google:personal") == "integration:google:personal"
     end
   end
 
@@ -401,26 +363,40 @@ defmodule PhoenixKit.Integration.IntegrationsTest do
       assert {:ok, %{uuid: ^uuid, name: "personal"}} = Integrations.get_integration_by_uuid(uuid)
     end
 
+    test "the row's storage key equals its uuid (post-V113 invariant)" do
+      {:ok, %{uuid: uuid}} = Integrations.add_connection("google", "anything")
+      setting = PhoenixKit.Settings.Queries.get_setting_by_uuid(uuid)
+      assert setting.key == uuid
+      assert setting.module == "integrations"
+    end
+
     test "rejects empty name" do
       assert {:error, :empty_name} = Integrations.add_connection("google", "")
+      assert {:error, :empty_name} = Integrations.add_connection("google", "   ")
     end
 
-    test "rejects invalid name with special characters" do
-      assert {:error, :invalid_name} = Integrations.add_connection("google", "my drive!")
+    test "accepts names with spaces and punctuation" do
+      {:ok, %{data: data}} = Integrations.add_connection("google", "My Company Drive (US)")
+      assert data["name"] == "My Company Drive (US)"
     end
 
-    test "rejects name starting with hyphen" do
-      assert {:error, :invalid_name} = Integrations.add_connection("google", "-bad")
+    test "accepts names with leading punctuation" do
+      {:ok, %{data: data}} = Integrations.add_connection("google", "-leading-dash")
+      assert data["name"] == "-leading-dash"
     end
 
-    test "accepts name with hyphens and underscores" do
-      {:ok, %{data: data}} = Integrations.add_connection("google", "my-company_drive")
-      assert data["name"] == "my-company_drive"
+    test "accepts duplicate names within a provider" do
+      {:ok, %{uuid: uuid1}} = Integrations.add_connection("google", "work")
+      {:ok, %{uuid: uuid2}} = Integrations.add_connection("google", "work")
+
+      # Two distinct rows, both named "work" — each pinned by its own uuid.
+      assert uuid1 != uuid2
+      assert length(Integrations.list_connections("google")) == 2
     end
 
-    test "rejects duplicate name" do
-      {:ok, _} = Integrations.add_connection("google", "work")
-      assert {:error, :already_exists} = Integrations.add_connection("google", "work")
+    test "trims whitespace from name" do
+      {:ok, %{data: data}} = Integrations.add_connection("google", "  primary  ")
+      assert data["name"] == "primary"
     end
   end
 
@@ -448,16 +424,17 @@ defmodule PhoenixKit.Integration.IntegrationsTest do
   end
 
   describe "rename_connection/3" do
-    test "renames a connection: updates row's key column in place, preserves uuid" do
+    test "renames a connection: updates JSONB name, preserves uuid + storage key" do
       uuid = setup_conn("google", "personal", %{"client_id" => "cid"})
 
       assert {:ok, data} = Integrations.rename_connection(uuid, "work")
 
       assert data["name"] == "work"
-      # uuid is stable across rename — the whole point of uuid-strict API.
+      # uuid is stable across rename.
       assert {:ok, %{name: "work"}} = Integrations.get_integration_by_uuid(uuid)
-      assert {:error, :not_configured} = Integrations.get_integration("google:personal")
-      assert {:ok, %{"client_id" => "cid"}} = Integrations.get_integration("google:work")
+      # Storage key is the row uuid; it doesn't change on rename.
+      setting = PhoenixKit.Settings.Queries.get_setting_by_uuid(uuid)
+      assert setting.key == uuid
     end
 
     test "no-ops when new_name matches current name" do
@@ -474,30 +451,32 @@ defmodule PhoenixKit.Integration.IntegrationsTest do
       assert {:error, :empty_name} = Integrations.rename_connection(uuid, "   ")
     end
 
-    test "rejects names that violate the connection-name pattern" do
+    test "accepts names with spaces, punctuation, and any character" do
       uuid = setup_conn("google", "personal")
-      # Spaces, slashes, leading punctuation — all rejected
-      assert {:error, :invalid_name} = Integrations.rename_connection(uuid, "my work")
-      assert {:error, :invalid_name} = Integrations.rename_connection(uuid, "-leading-dash")
-      assert {:error, :invalid_name} = Integrations.rename_connection(uuid, "with/slash")
+
+      assert {:ok, %{"name" => "my work"}} = Integrations.rename_connection(uuid, "my work")
+
+      assert {:ok, %{"name" => "-leading-dash"}} =
+               Integrations.rename_connection(uuid, "-leading-dash")
+
+      assert {:ok, %{"name" => "with/slash"}} = Integrations.rename_connection(uuid, "with/slash")
     end
 
-    test "rejects renaming to a name that already exists for the provider" do
+    test "accepts renaming to a name another connection already has" do
       uuid = setup_conn("google", "personal")
       setup_conn("google", "work")
 
-      assert {:error, :already_exists} = Integrations.rename_connection(uuid, "work")
+      assert {:ok, %{"name" => "work"}} = Integrations.rename_connection(uuid, "work")
 
-      # Both rows still present
+      # Both rows still present, both named "work"
       assert length(Integrations.list_connections("google")) == 2
     end
 
-    test "default-named connection can now be renamed (no privileged name)" do
+    test "default-named connection has no privileged status" do
       uuid = setup_conn("google", "default", %{"client_id" => "cid"})
 
       assert {:ok, _} = Integrations.rename_connection(uuid, "primary")
-      assert {:error, :not_configured} = Integrations.get_integration("google:default")
-      assert {:ok, _} = Integrations.get_integration("google:primary")
+      assert {:ok, %{name: "primary"}} = Integrations.get_integration_by_uuid(uuid)
     end
 
     test "returns :not_configured when uuid doesn't resolve" do
@@ -520,12 +499,11 @@ defmodule PhoenixKit.Integration.IntegrationsTest do
       assert_receive {:integration_connection_renamed, "google", "personal", "work"}
     end
 
-    test "does not broadcast on failure" do
+    test "does not broadcast on no-op (same name)" do
       uuid = setup_conn("google", "personal")
-      setup_conn("google", "work")
       :ok = Events.subscribe()
 
-      assert {:error, :already_exists} = Integrations.rename_connection(uuid, "work")
+      assert {:ok, _} = Integrations.rename_connection(uuid, "personal")
 
       refute_receive {:integration_connection_renamed, _, _, _}, 50
     end
@@ -547,16 +525,75 @@ defmodule PhoenixKit.Integration.IntegrationsTest do
       assert conn.data["api_key"] == "test-key"
     end
 
-    test "returns multiple connections sorted with default first" do
-      setup_conn("google", "default", %{"client_id" => "default-id"})
+    test "returns multiple connections sorted by name (case-insensitive)" do
       setup_conn("google", "personal")
       setup_conn("google", "work")
+      setup_conn("google", "Archive")
 
       connections = Integrations.list_connections("google")
-      names = Enum.map(connections, & &1.name)
-      assert hd(names) == "default"
-      assert "personal" in names
-      assert "work" in names
+      assert Enum.map(connections, & &1.name) == ["Archive", "personal", "work"]
+    end
+
+    test "exposes :date_added on each connection map" do
+      uuid = setup_conn("google", "primary")
+
+      [conn] = Integrations.list_connections("google")
+      assert conn.uuid == uuid
+      assert %DateTime{} = conn.date_added
+      # Created within the last few seconds — pins that the field is
+      # the actual row creation time, not a default sentinel.
+      assert DateTime.diff(DateTime.utc_now(), conn.date_added) in 0..5
+    end
+  end
+
+  describe "load_all_connections/1" do
+    test "returns a map keyed by every requested provider" do
+      setup_conn("openrouter", "primary", %{"api_key" => "key"})
+      setup_conn("google", "work")
+      # `aws` requested but never seeded — should still be in the map
+      # with an empty list, so callers don't have to defend against
+      # missing keys.
+      result = Integrations.load_all_connections(["openrouter", "google", "aws"])
+
+      assert Map.keys(result) |> Enum.sort() == ["aws", "google", "openrouter"]
+      assert result["aws"] == []
+      assert length(result["openrouter"]) == 1
+      assert length(result["google"]) == 1
+    end
+
+    test "groups connections under the right provider via JSONB `provider` field" do
+      setup_conn("openrouter", "alpha")
+      setup_conn("openrouter", "bravo")
+      setup_conn("google", "personal")
+
+      result = Integrations.load_all_connections(["openrouter", "google"])
+
+      assert Enum.map(result["openrouter"], & &1.name) == ["alpha", "bravo"]
+      assert Enum.map(result["google"], & &1.name) == ["personal"]
+    end
+
+    test "sorts each provider's connections alphabetically (case-insensitive)" do
+      setup_conn("openrouter", "Zebra")
+      setup_conn("openrouter", "alpha")
+      setup_conn("openrouter", "MIDDLE")
+
+      result = Integrations.load_all_connections(["openrouter"])
+
+      assert Enum.map(result["openrouter"], & &1.name) == ["alpha", "MIDDLE", "Zebra"]
+    end
+
+    test "exposes :date_added on every connection map" do
+      setup_conn("openrouter", "x")
+      setup_conn("google", "y")
+
+      result = Integrations.load_all_connections(["openrouter", "google"])
+
+      assert Enum.all?(result["openrouter"], &match?(%DateTime{}, &1.date_added))
+      assert Enum.all?(result["google"], &match?(%DateTime{}, &1.date_added))
+    end
+
+    test "returns empty map when no providers requested" do
+      assert Integrations.load_all_connections([]) == %{}
     end
   end
 
@@ -863,19 +900,13 @@ defmodule PhoenixKit.Integration.IntegrationsTest do
       # restore. validate_connection should distinguish "credentials
       # missing" (Not configured) from "access_token specifically
       # missing on an otherwise-connected row" (No access token).
-      Settings.update_json_setting_with_module(
-        Integrations.settings_key("google"),
-        %{
-          "provider" => "google",
+      uuid =
+        seed_raw("google", %{
           "auth_type" => "oauth2",
           "client_id" => "id",
           "client_secret" => "secret",
           "status" => "connected"
-        },
-        "integrations"
-      )
-
-      [%{uuid: uuid}] = Integrations.list_connections("google")
+        })
 
       assert {:error, "No access token"} = Integrations.validate_connection(uuid)
     end
@@ -948,7 +979,7 @@ defmodule PhoenixKit.Integration.IntegrationsTest do
 
       # First :ok flips status from "configured" → "connected" → broadcasts.
       :ok = Integrations.record_validation(uuid, :ok)
-      assert_receive {:integration_validated, "openrouter:default", :ok}
+      assert_receive {:integration_validated, "openrouter", :ok}
 
       # Second :ok keeps status at "connected" → no broadcast (but
       # last_validated_at still advances per the test above).
@@ -957,7 +988,7 @@ defmodule PhoenixKit.Integration.IntegrationsTest do
 
       # Switching to error → broadcasts.
       :ok = Integrations.record_validation(uuid, {:error, "boom"})
-      assert_receive {:integration_validated, "openrouter:default", {:error, "boom"}}
+      assert_receive {:integration_validated, "openrouter", {:error, "boom"}}
     end
 
     test "silently no-ops when uuid doesn't resolve" do
@@ -967,91 +998,60 @@ defmodule PhoenixKit.Integration.IntegrationsTest do
   end
 
   # ===========================================================================
-  # Storage-key integrity (regression: corrupted JSONB cannot leak into key)
+  # Storage-shape invariants (post-V113: key = uuid, module = "integrations")
   # ===========================================================================
-  #
-  # Background: a previous bug wrote `"openrouter:default"` into the
-  # JSONB `provider` field, then derived a storage key from that field,
-  # producing `integration:openrouter:default:default`. The fix is
-  # structural: provider+name are sourced from the row's `key` column
-  # only, and JSONB `provider`/`name` are treated as untrusted
-  # duplicates. This block proves the invariant holds.
 
-  describe "storage-key invariant" do
-    test "rename never adds extra colon segments to the storage key" do
+  describe "storage-shape invariant" do
+    test "add_connection produces key == uuid, module == 'integrations'" do
+      {:ok, %{uuid: uuid}} = Integrations.add_connection("openrouter", "anything")
+      setting = PhoenixKit.Settings.Queries.get_setting_by_uuid(uuid)
+      assert setting.key == uuid
+      assert setting.module == "integrations"
+    end
+
+    test "rename never touches the storage key" do
       uuid = setup_conn("openrouter", "primary", %{"api_key" => "k1"})
 
-      # Confirm starting shape: exactly two colons (the prefix +
-      # provider/name separator).
-      [%{key: starting_key}] = list_settings_keys()
-      assert starting_key == "integration:openrouter:primary"
+      starting_key = PhoenixKit.Settings.Queries.get_setting_by_uuid(uuid).key
+      assert starting_key == uuid
 
-      # Rename → still exactly two colons.
       {:ok, _} = Integrations.rename_connection(uuid, "work")
-      [%{key: after_rename}] = list_settings_keys()
-      assert after_rename == "integration:openrouter:work"
+      after_rename = PhoenixKit.Settings.Queries.get_setting_by_uuid(uuid).key
+      assert after_rename == uuid
     end
 
-    test "rename round-trip is idempotent on storage key" do
-      uuid = setup_conn("openrouter", "a", %{"api_key" => "k"})
-
-      {:ok, _} = Integrations.rename_connection(uuid, "b")
-      {:ok, _} = Integrations.rename_connection(uuid, "c")
-      {:ok, _} = Integrations.rename_connection(uuid, "a")
-
-      [%{key: key}] = list_settings_keys()
-      assert key == "integration:openrouter:a"
-    end
-
-    test "save_setup ignores corrupted JSONB provider/name and writes to the canonical key" do
-      # Seed a row whose JSONB body has drifted (simulating the
-      # original bug condition). Then call save_setup via uuid — the
-      # write must land at `integration:openrouter:primary`, NOT at
-      # `integration:openrouter:default:primary` or any other
-      # JSONB-derived key.
+    test "save_setup writes through the row's uuid; name and provider stay in JSONB" do
       uuid = setup_conn("openrouter", "primary")
 
-      [%{uuid: ^uuid, key: original_key}] = list_settings_keys()
-      assert original_key == "integration:openrouter:primary"
+      starting_key = PhoenixKit.Settings.Queries.get_setting_by_uuid(uuid).key
+      assert starting_key == uuid
 
-      # Hand-corrupt the JSONB body to drift away from the storage key.
-      Settings.update_json_setting_with_module(
-        original_key,
-        %{
-          "provider" => "openrouter:default",
-          "name" => "default:primary",
-          "api_key" => "old"
-        },
-        "integrations"
-      )
-
-      # save_setup via uuid: the storage key must remain canonical.
       {:ok, _} = Integrations.save_setup(uuid, %{"api_key" => "new"})
 
-      [%{key: after_save}] = list_settings_keys()
-      assert after_save == "integration:openrouter:primary"
+      setting = PhoenixKit.Settings.Queries.get_setting_by_uuid(uuid)
+      assert setting.key == uuid
 
-      # And the JSONB body's provider/name are now repaired (sourced
-      # from the storage key, not from the previous corrupted body).
       {:ok, %{provider: "openrouter", name: "primary", data: data}} =
         Integrations.get_integration_by_uuid(uuid)
 
       assert data["api_key"] == "new"
     end
-  end
 
-  defp list_settings_keys do
-    require Ecto.Query
+    test "duplicate names coexist — uuids disambiguate" do
+      {:ok, %{uuid: uuid1}} = Integrations.add_connection("openrouter", "work")
+      {:ok, %{uuid: uuid2}} = Integrations.add_connection("openrouter", "work")
 
-    Ecto.Query.from(s in PhoenixKit.Settings.Setting,
-      where: like(s.key, "integration:%"),
-      select: %{uuid: s.uuid, key: s.key}
-    )
-    |> PhoenixKit.RepoHelper.repo().all()
+      assert uuid1 != uuid2
+
+      conns = Integrations.list_connections("openrouter")
+      assert length(conns) == 2
+      assert Enum.all?(conns, &(&1.name == "work"))
+      assert Enum.sort(Enum.map(conns, & &1.uuid)) == Enum.sort([uuid1, uuid2])
+    end
   end
 
   describe "connected?/1 simplified" do
-    test "returns true when default connection has credentials (bare provider)" do
+    test "returns true when a connection of that provider has credentials (bare provider)" do
       setup_conn("openrouter", %{"api_key" => "key"})
       assert Integrations.connected?("openrouter")
     end
@@ -1060,18 +1060,18 @@ defmodule PhoenixKit.Integration.IntegrationsTest do
       refute Integrations.connected?("openrouter")
     end
 
-    test "bare provider key no longer falls back to non-default connections" do
-      # The legacy `find_first_connected/1` fallback was removed once
-      # consumers switched to uuid-based references. A bare provider
-      # call now resolves only against the storage row keyed at
-      # `integration:<provider>:default` — non-default rows are
-      # invisible to bare-provider lookups.
+    test "bare provider lookup returns first-match (sorted by name)" do
+      # Names are no longer unique and no name is privileged. A bare
+      # `Integrations.connected?(provider)` resolves against the
+      # provider's first connection sorted by name (case-insensitive).
+      # This is a legacy-callsite convenience; new code should use
+      # uuid-based references.
       uuid = setup_conn("openrouter", "secondary", %{"api_key" => "secondary-key"})
 
-      refute Integrations.connected?("openrouter")
+      # Only connection of the provider, so bare lookup finds it.
+      assert Integrations.connected?("openrouter")
 
-      # The non-default row IS reachable, but only via its uuid — that's
-      # the only call shape consumer modules should be using now.
+      # The uuid path always works (the canonical shape).
       assert Integrations.connected?(uuid)
     end
   end

--- a/test/integration/media_browser_scope_test.exs
+++ b/test/integration/media_browser_scope_test.exs
@@ -40,10 +40,36 @@ defmodule PhoenixKit.Integration.MediaBrowserScopeTest do
         user_file_checksum: "user-sha256:test-#{n}",
         size: 1024,
         status: "active",
-        folder_uuid: folder_uuid
+        folder_uuid: folder_uuid,
+        # V113 added the `phoenix_kit_files_user_or_parent_check`
+        # CHECK constraint requiring `user_uuid IS NOT NULL OR
+        # parent_file_uuid IS NOT NULL`. Stamp the per-test owner.
+        user_uuid: ensure_user!()
       })
 
     file
+  end
+
+  # Memoised user owner for the file fixtures in this test process.
+  # See scope_test.exs for the rationale — same V113 CHECK constraint
+  # workaround.
+  defp ensure_user! do
+    case Process.get(:test_owner_user_uuid) do
+      nil ->
+        n = System.unique_integer([:positive])
+
+        {:ok, user} =
+          PhoenixKit.Users.Auth.register_user(%{
+            email: "media-browser-scope-test-#{n}@example.com",
+            password: "ValidPassword123!"
+          })
+
+        Process.put(:test_owner_user_uuid, user.uuid)
+        user.uuid
+
+      uuid ->
+        uuid
+    end
   end
 
   defp fake_uuid,

--- a/test/integration/phoenix_kit_web/components/media_browser_test.exs
+++ b/test/integration/phoenix_kit_web/components/media_browser_test.exs
@@ -44,10 +44,36 @@ defmodule PhoenixKitWeb.Components.MediaBrowserTest do
         user_file_checksum: "user-sha256:test-#{n}",
         size: 1024,
         status: "active",
-        folder_uuid: folder_uuid
+        folder_uuid: folder_uuid,
+        # V113 added the `phoenix_kit_files_user_or_parent_check`
+        # CHECK constraint requiring `user_uuid IS NOT NULL OR
+        # parent_file_uuid IS NOT NULL`. Stamp the per-test owner.
+        user_uuid: ensure_user!()
       })
 
     file
+  end
+
+  # Memoised user owner for the file fixtures in this test process.
+  # See `test/integration/storage/scope_test.exs` for the rationale —
+  # same V113 CHECK constraint workaround.
+  defp ensure_user! do
+    case Process.get(:test_owner_user_uuid) do
+      nil ->
+        n = System.unique_integer([:positive])
+
+        {:ok, user} =
+          PhoenixKit.Users.Auth.register_user(%{
+            email: "media-browser-test-#{n}@example.com",
+            password: "ValidPassword123!"
+          })
+
+        Process.put(:test_owner_user_uuid, user.uuid)
+        user.uuid
+
+      uuid ->
+        uuid
+    end
   end
 
   defp fake_uuid do

--- a/test/integration/phoenix_kit_web/live/settings/integrations_test.exs
+++ b/test/integration/phoenix_kit_web/live/settings/integrations_test.exs
@@ -150,6 +150,30 @@ defmodule PhoenixKitWeb.Live.Settings.IntegrationsTest do
       assert html =~ "Please enter a connection name."
     end
 
+    test "blank-name create error preserves typed credential values in the form",
+         %{conn: conn} do
+      # Regression: the create_connection error branches used to only
+      # assign `:error` and forget the typed values. The api_key input
+      # would re-render with value="" — operator sees the error AND a
+      # cleared form, has to retype the key. The fix mirrors the
+      # dry-run path's `:form_values` preservation.
+      {:ok, view, _html} = live(conn, @new_path)
+
+      view
+      |> element("button[phx-value-provider=\"openrouter\"]")
+      |> render_click()
+
+      html =
+        view
+        |> element("form[phx-submit=\"save_form\"]")
+        |> render_submit(%{"name" => "", "api_key" => "sk-typed-but-rejected"})
+
+      # Error surfaced.
+      assert html =~ "Please enter a connection name."
+      # AND the typed api_key survives the round-trip.
+      assert html =~ ~s(value="sk-typed-but-rejected")
+    end
+
     test "Test Connection on /new probes credentials without persisting",
          %{conn: conn} do
       # Pre-condition: no openrouter integration rows exist.
@@ -338,19 +362,22 @@ defmodule PhoenixKitWeb.Live.Settings.IntegrationsTest do
       assert name == "primary"
     end
 
-    test "rename to an existing name surfaces an error", %{conn: conn} do
+    test "rename to a name another connection already has succeeds (duplicates allowed)",
+         %{conn: conn} do
       %{uuid: uuid} = seed_openrouter("personal")
       seed_openrouter("work")
 
       {:ok, view, _html} =
         live(conn, Routes.path("/admin/settings/integrations/#{uuid}"))
 
-      html =
-        view
-        |> element("form[phx-submit=\"save_form\"]")
-        |> render_submit(%{"name" => "work", "api_key" => "sk-test-personal"})
+      view
+      |> element("form[phx-submit=\"save_form\"]")
+      |> render_submit(%{"name" => "work", "api_key" => "sk-test-personal"})
 
-      assert html =~ "already exists"
+      # Both rows now named "work" — disambiguated by uuid.
+      conns = Integrations.list_connections("openrouter")
+      assert length(conns) == 2
+      assert Enum.all?(conns, &(&1.name == "work"))
     end
 
     test "Test Connection uses the inputted api_key, not the stale saved value",

--- a/test/integration/storage/scope_test.exs
+++ b/test/integration/storage/scope_test.exs
@@ -30,10 +30,39 @@ defmodule PhoenixKit.Integration.Storage.ScopeTest do
         user_file_checksum: "user-sha256:test-#{n}",
         size: 1024,
         status: "active",
-        folder_uuid: folder_uuid
+        folder_uuid: folder_uuid,
+        # V113 added the `phoenix_kit_files_user_or_parent_check`
+        # CHECK constraint requiring `user_uuid IS NOT NULL OR
+        # parent_file_uuid IS NOT NULL`. Stamp the per-test owner so
+        # the fixture rows pass.
+        user_uuid: ensure_user!()
       })
 
     file
+  end
+
+  # Memoised user owner for the file fixtures in this test process.
+  # Auth.register_user/1 requires unique emails, so we register once
+  # per test process and reuse the uuid on subsequent calls. The user
+  # itself doesn't matter to the assertions in this file — it exists
+  # only to satisfy the V113 CHECK constraint on `phoenix_kit_files`.
+  defp ensure_user! do
+    case Process.get(:test_owner_user_uuid) do
+      nil ->
+        n = System.unique_integer([:positive])
+
+        {:ok, user} =
+          PhoenixKit.Users.Auth.register_user(%{
+            email: "scope-test-#{n}@example.com",
+            password: "ValidPassword123!"
+          })
+
+        Process.put(:test_owner_user_uuid, user.uuid)
+        user.uuid
+
+      uuid ->
+        uuid
+    end
   end
 
   # Builds: scope → child_a → grandchild

--- a/test/phoenix_kit/integrations/integrations_test.exs
+++ b/test/phoenix_kit/integrations/integrations_test.exs
@@ -7,27 +7,6 @@ defmodule PhoenixKit.Integrations.IntegrationsTest do
 
   alias PhoenixKit.Integrations
 
-  describe "settings_key/1" do
-    test "returns prefixed key with default name" do
-      assert Integrations.settings_key("google") == "integration:google:default"
-      assert Integrations.settings_key("openrouter") == "integration:openrouter:default"
-    end
-
-    test "returns prefixed key with explicit name" do
-      assert Integrations.settings_key("google:personal") == "integration:google:personal"
-
-      assert Integrations.settings_key("openrouter:secondary") ==
-               "integration:openrouter:secondary"
-    end
-  end
-
-  describe "settings_key/1 with names" do
-    test "supports names with spaces and special characters" do
-      assert Integrations.settings_key("google:My Company Drive") ==
-               "integration:google:My Company Drive"
-    end
-  end
-
   describe "validate_connection/1 (no DB)" do
     test "returns error for invalid input" do
       assert {:error, _} = Integrations.validate_connection("")

--- a/test/phoenix_kit/migrations/v114_test.exs
+++ b/test/phoenix_kit/migrations/v114_test.exs
@@ -1,0 +1,291 @@
+defmodule PhoenixKit.Migrations.Postgres.V114Test do
+  @moduledoc """
+  Tests V114's data rewrite from composite-key storage
+  (`integration:<provider>:<name>`) to uuid-only storage (`key = uuid`,
+  provider + name in JSONB).
+
+  V114.up/down can't be invoked outside an `Ecto.Migrator` runner —
+  they rely on `Ecto.Migration.execute/1` which checks for a runner
+  process. Instead, this test runs the same UPDATE statements
+  directly via `Repo.query`, which is what we actually care about:
+  that the rewrite logic picks the right key, fills JSONB correctly,
+  and handles edge cases (legacy V0 keyless shape, idempotence,
+  collision suffixing on rollback).
+
+  The schema change itself is implicitly verified by
+  `test_helper.exs` running every core migration including V114
+  before tests — any test that depends on the new storage shape
+  would fail at boot if V114 hadn't run.
+  """
+
+  use PhoenixKit.DataCase, async: false
+
+  alias PhoenixKit.Test.Repo
+
+  # ---------------------------------------------------------------------------
+  # Helpers
+  # ---------------------------------------------------------------------------
+
+  # Insert a row at an arbitrary key (composite or uuid-shaped) with the
+  # given JSONB body and `module`. Mirrors how a pre-V114 row would have
+  # been written by old `add_connection/3`. JSON is inlined as a literal
+  # so PostgreSQL parses it as a JSONB object directly (passing through
+  # `$N::jsonb` double-encodes via Postgrex's string handling).
+  defp insert_setting!(key, value_json, module) do
+    json_literal = value_json |> Jason.encode!() |> String.replace("'", "''")
+
+    %{rows: [[uuid_bin]]} =
+      Repo.query!(
+        """
+        INSERT INTO phoenix_kit_settings (key, value_json, module, date_added, date_updated)
+        VALUES ($1, '#{json_literal}'::jsonb, $2, NOW(), NOW())
+        RETURNING uuid
+        """,
+        [key, module]
+      )
+
+    Ecto.UUID.cast!(uuid_bin)
+  end
+
+  defp read_row(uuid) do
+    {:ok, dumped} = Ecto.UUID.dump(uuid)
+
+    %{rows: [[key, value_json, module]]} =
+      Repo.query!(
+        "SELECT key, value_json, module FROM phoenix_kit_settings WHERE uuid = $1",
+        [dumped]
+      )
+
+    %{key: key, value_json: value_json, module: module}
+  end
+
+  # Runs V114.up's UPDATE statement verbatim against the current DB.
+  # Mirrors the SQL in `lib/phoenix_kit/migrations/postgres/v114.ex`.
+  defp run_up! do
+    Repo.query!("""
+    UPDATE phoenix_kit_settings AS s
+       SET key = s.uuid::text,
+           module = 'integrations',
+           value_json = COALESCE(s.value_json, '{}'::jsonb)
+                        || jsonb_build_object(
+                             'provider',
+                             COALESCE(
+                               NULLIF(s.value_json->>'provider', ''),
+                               split_part(substring(s.key from 13), ':', 1)
+                             ),
+                             'name',
+                             COALESCE(
+                               NULLIF(s.value_json->>'name', ''),
+                               NULLIF(split_part(substring(s.key from 13), ':', 2), ''),
+                               'default'
+                             )
+                           )
+     WHERE s.key LIKE 'integration:%';
+    """)
+  end
+
+  # Runs V114.down's UPDATE statement verbatim. Reverses the up rewrite,
+  # collision-suffixing on duplicate (provider, name) pairs.
+  defp run_down! do
+    Repo.query!("""
+    WITH ordered AS (
+      SELECT
+        s.uuid,
+        s.value_json->>'provider' AS provider,
+        s.value_json->>'name'     AS name,
+        ROW_NUMBER() OVER (
+          PARTITION BY s.value_json->>'provider', s.value_json->>'name'
+          ORDER BY s.date_added NULLS LAST, s.uuid
+        ) AS rn
+      FROM phoenix_kit_settings s
+      WHERE s.module = 'integrations'
+        AND s.key = s.uuid::text
+    )
+    UPDATE phoenix_kit_settings AS s
+       SET key = 'integration:' || o.provider || ':' ||
+                 CASE
+                   WHEN o.rn = 1 THEN o.name
+                   ELSE o.name || '-' || substring(s.uuid::text from 1 for 8)
+                 END
+      FROM ordered o
+     WHERE s.uuid = o.uuid;
+    """)
+  end
+
+  # ---------------------------------------------------------------------------
+  # V114.up
+  # ---------------------------------------------------------------------------
+
+  describe "V114.up — composite-key → uuid-only rewrite" do
+    test "rewrites integration:<provider>:<name> rows so key = uuid" do
+      uuid =
+        insert_setting!(
+          "integration:openrouter:work",
+          %{"api_key" => "sk-or-test", "status" => "connected"},
+          "integrations"
+        )
+
+      run_up!()
+
+      row = read_row(uuid)
+      assert row.key == uuid
+      assert row.module == "integrations"
+      assert row.value_json["provider"] == "openrouter"
+      assert row.value_json["name"] == "work"
+      # Pre-existing fields preserved.
+      assert row.value_json["api_key"] == "sk-or-test"
+      assert row.value_json["status"] == "connected"
+    end
+
+    test "backfills missing name from key suffix when JSONB lacks 'name'" do
+      uuid = insert_setting!("integration:google:personal", %{}, "integrations")
+
+      run_up!()
+
+      row = read_row(uuid)
+      assert row.value_json["name"] == "personal"
+      assert row.value_json["provider"] == "google"
+    end
+
+    test "preserves an existing JSONB 'name' over the key suffix" do
+      # Edge case: JSONB body has a name that disagrees with the key
+      # (drift from a pre-V114 buggy save). The JSONB value wins —
+      # it's what consumers see at runtime, and rewriting it back to
+      # the key suffix could mask the operator's actual choice.
+      uuid =
+        insert_setting!(
+          "integration:openrouter:slug-from-key",
+          %{"name" => "Display Name", "provider" => "openrouter"},
+          "integrations"
+        )
+
+      run_up!()
+
+      row = read_row(uuid)
+      assert row.value_json["name"] == "Display Name"
+      assert row.value_json["provider"] == "openrouter"
+    end
+
+    test "treats legacy V0 bare-provider key (no :name segment) as 'default'" do
+      # `integration:google` without a `:name` segment was the original
+      # 1-connection-per-provider shape pre-named-connections. Rewrite
+      # should still work — name becomes "default".
+      uuid = insert_setting!("integration:google", %{"client_id" => "cid"}, "integrations")
+
+      run_up!()
+
+      row = read_row(uuid)
+      assert row.key == uuid
+      assert row.value_json["provider"] == "google"
+      assert row.value_json["name"] == "default"
+      assert row.value_json["client_id"] == "cid"
+    end
+
+    test "stamps module='integrations' even if it was missing before" do
+      # Edge: a row pre-dating `@settings_module` stamping might have
+      # NULL module. V114.up should set it during the rewrite so the
+      # new query path (filter by module) finds the row.
+      uuid =
+        insert_setting!("integration:openrouter:old", %{"api_key" => "k"}, nil)
+
+      run_up!()
+
+      row = read_row(uuid)
+      assert row.module == "integrations"
+    end
+
+    test "ignores non-integration rows (key doesn't start with 'integration:')" do
+      # Unrelated settings should not be touched.
+      uuid = insert_setting!("project_title", %{"value" => "My App"}, nil)
+
+      run_up!()
+
+      row = read_row(uuid)
+      assert row.key == "project_title"
+      # Module not stamped (V114 only stamps rows it's actually
+      # rewriting; this row matches no clause).
+      assert row.module == nil
+    end
+
+    test "is idempotent — already-rewritten rows are no-ops on re-run" do
+      uuid =
+        insert_setting!(
+          "integration:openrouter:once",
+          %{"api_key" => "k"},
+          "integrations"
+        )
+
+      run_up!()
+      row_after_first = read_row(uuid)
+
+      run_up!()
+      row_after_second = read_row(uuid)
+
+      assert row_after_first == row_after_second
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # V114.down
+  # ---------------------------------------------------------------------------
+
+  describe "V114.down — uuid-only → composite-key rewrite" do
+    test "rewrites key = uuid back to integration:<provider>:<name>" do
+      # Start in the new shape (key = uuid).
+      uuid =
+        insert_setting!(
+          # Garbage key — will be overwritten by run_up! to equal the row's uuid.
+          "integration:openrouter:will-be-rewritten",
+          %{"provider" => "openrouter", "name" => "work", "api_key" => "k"},
+          "integrations"
+        )
+
+      run_up!()
+      assert read_row(uuid).key == uuid
+
+      run_down!()
+
+      row = read_row(uuid)
+      assert row.key == "integration:openrouter:work"
+    end
+
+    test "suffixes -<short uuid> on (provider, name) collisions" do
+      # Two rows in the new shape with the same provider + name in
+      # JSONB. V114.down has to disambiguate via uuid suffix because
+      # the old shape can't represent duplicates.
+      uuid1 =
+        insert_setting!(
+          "integration:openrouter:placeholder-a",
+          %{"provider" => "openrouter", "name" => "work"},
+          "integrations"
+        )
+
+      uuid2 =
+        insert_setting!(
+          "integration:openrouter:placeholder-b",
+          %{"provider" => "openrouter", "name" => "work"},
+          "integrations"
+        )
+
+      run_up!()
+      run_down!()
+
+      key1 = read_row(uuid1).key
+      key2 = read_row(uuid2).key
+
+      # One row keeps the plain composite key; the other gets a uuid
+      # suffix. Both share the `integration:openrouter:work` prefix.
+      assert key1 != key2
+
+      assert key1 == "integration:openrouter:work" or
+               String.starts_with?(key1, "integration:openrouter:work-")
+
+      assert key2 == "integration:openrouter:work" or
+               String.starts_with?(key2, "integration:openrouter:work-")
+
+      # Exactly one row got the plain key; the other got the suffixed one.
+      plain_keys = Enum.count([key1, key2], &(&1 == "integration:openrouter:work"))
+      assert plain_keys == 1
+    end
+  end
+end

--- a/test/phoenix_kit_web/components/core/integration_picker_test.exs
+++ b/test/phoenix_kit_web/components/core/integration_picker_test.exs
@@ -1,0 +1,650 @@
+defmodule PhoenixKitWeb.Components.Core.IntegrationPickerTest do
+  use ExUnit.Case, async: true
+
+  import Phoenix.LiveViewTest, only: [rendered_to_string: 1]
+  import Phoenix.Component, only: [sigil_H: 2]
+  import PhoenixKitWeb.Components.Core.IntegrationPicker
+
+  # Connection fixture shaped like what `Integrations.list_connections/1`
+  # returns post-V113: `%{uuid, name, data, date_added}` with provider
+  # in JSONB.
+  defp conn_fixture(attrs) do
+    attrs = Map.new(attrs)
+
+    %{
+      uuid: Map.get(attrs, :uuid, "019b669c-3c9d-7256-8ed1-edbc6ae29701"),
+      name: Map.get(attrs, :name, "primary"),
+      data:
+        Map.merge(
+          %{
+            "provider" => Map.get(attrs, :provider, "openrouter"),
+            "name" => Map.get(attrs, :name, "primary"),
+            "status" => "connected"
+          },
+          Map.get(attrs, :data, %{})
+        ),
+      date_added: Map.get(attrs, :date_added, DateTime.utc_now())
+    }
+  end
+
+  # ===========================================================================
+  # Selection check (always rendered, ghosted when unselected)
+  # ===========================================================================
+
+  describe "selection checkmark" do
+    test "renders in primary color when card is selected" do
+      conn = conn_fixture(uuid: "01900000-0000-7000-8000-000000000001")
+
+      assigns = %{conns: [conn], selected: ["01900000-0000-7000-8000-000000000001"]}
+
+      html =
+        rendered_to_string(~H"""
+        <.integration_picker
+          id="picker"
+          connections={@conns}
+          selected={@selected}
+          on_select="select"
+        />
+        """)
+
+      assert html =~ "hero-check-circle-solid"
+      assert html =~ "text-primary"
+    end
+
+    test "renders ghosted (text-base-content/20) when card is unselected" do
+      conn = conn_fixture(uuid: "01900000-0000-7000-8000-000000000002")
+
+      assigns = %{conns: [conn], selected: []}
+
+      html =
+        rendered_to_string(~H"""
+        <.integration_picker id="picker" connections={@conns} selected={@selected} on_select="x" />
+        """)
+
+      # Always renders the icon so the row layout doesn't shift on
+      # pick/unpick — ghosted via a low-contrast colour.
+      assert html =~ "hero-check-circle-solid"
+      assert html =~ "text-base-content/20"
+      refute html =~ "text-primary"
+    end
+  end
+
+  # ===========================================================================
+  # Subtitle priority: external_account_id → masked credential → empty
+  # ===========================================================================
+
+  describe "card subtitle" do
+    test "shows external_account_id when present (OAuth path)" do
+      conn = conn_fixture(data: %{"external_account_id" => "user@gmail.com"})
+
+      assigns = %{conns: [conn]}
+
+      html =
+        rendered_to_string(~H"""
+        <.integration_picker id="p" connections={@conns} on_select="x" />
+        """)
+
+      assert html =~ "user@gmail.com"
+    end
+
+    test "shows masked api_key tail when no external_account_id" do
+      conn = conn_fixture(data: %{"api_key" => "sk-or-v1-very-long-key-1234abcd"})
+
+      assigns = %{conns: [conn]}
+
+      html =
+        rendered_to_string(~H"""
+        <.integration_picker id="p" connections={@conns} on_select="x" />
+        """)
+
+      # first 8 + ellipsis + last 4
+      assert html =~ "sk-or-v1…abcd"
+    end
+
+    test "masks short credentials as `•••` (under 14 chars)" do
+      conn = conn_fixture(data: %{"api_key" => "short-key"})
+
+      assigns = %{conns: [conn]}
+
+      html =
+        rendered_to_string(~H"""
+        <.integration_picker id="p" connections={@conns} on_select="x" />
+        """)
+
+      assert html =~ "•••"
+      # Doesn't leak the actual short value.
+      refute html =~ "short-key"
+    end
+
+    test "masks bot_token like an api_key when present" do
+      conn = conn_fixture(data: %{"bot_token" => "1234567890:ABC-DEF1234-ghIjKlMn"})
+
+      assigns = %{conns: [conn]}
+
+      html =
+        rendered_to_string(~H"""
+        <.integration_picker id="p" connections={@conns} on_select="x" />
+        """)
+
+      # first 8 + ellipsis + last 4
+      assert html =~ "12345678…KlMn"
+    end
+
+    test "masks access_key like an api_key when present" do
+      conn = conn_fixture(data: %{"access_key" => "AKIA1234567890ABCDEFG"})
+
+      assigns = %{conns: [conn]}
+
+      html =
+        rendered_to_string(~H"""
+        <.integration_picker id="p" connections={@conns} on_select="x" />
+        """)
+
+      assert html =~ "AKIA1234…DEFG"
+    end
+
+    test "external_account_id wins over a masked credential" do
+      conn =
+        conn_fixture(
+          data: %{
+            "external_account_id" => "user@example.com",
+            "api_key" => "sk-or-v1-fall-back-ignored"
+          }
+        )
+
+      assigns = %{conns: [conn]}
+
+      html =
+        rendered_to_string(~H"""
+        <.integration_picker id="p" connections={@conns} on_select="x" />
+        """)
+
+      assert html =~ "user@example.com"
+      # api_key tail is NOT rendered as the subtitle.
+      refute html =~ "sk-or-v1…ored"
+    end
+
+    test "renders no subtitle when neither account nor credential exists" do
+      conn = conn_fixture(data: %{"status" => "disconnected"})
+
+      assigns = %{conns: [conn]}
+
+      html =
+        rendered_to_string(~H"""
+        <.integration_picker id="p" connections={@conns} on_select="x" />
+        """)
+
+      # Empty subtitle paragraph isn't rendered — `:if=...` guards it.
+      refute html =~ ~r/<p[^>]*class="text-xs text-base-content\/60 truncate"/
+    end
+  end
+
+  # ===========================================================================
+  # Age line (uses time_ago hook)
+  # ===========================================================================
+
+  describe "age line" do
+    test "renders a <time> element when date_added is set" do
+      conn = conn_fixture(date_added: ~U[2026-05-01 12:00:00Z])
+
+      assigns = %{conns: [conn]}
+
+      html =
+        rendered_to_string(~H"""
+        <.integration_picker id="p" connections={@conns} on_select="x" />
+        """)
+
+      assert html =~ "Created"
+      assert html =~ ~s(phx-hook="TimeAgo")
+      # ISO timestamp passed through as the `datetime` attribute.
+      assert html =~ "2026-05-01"
+    end
+
+    test "omits the age line when date_added is nil" do
+      conn = conn_fixture(date_added: nil)
+
+      assigns = %{conns: [conn]}
+
+      html =
+        rendered_to_string(~H"""
+        <.integration_picker id="p" connections={@conns} on_select="x" />
+        """)
+
+      refute html =~ "Created"
+      refute html =~ ~s(phx-hook="TimeAgo")
+    end
+  end
+
+  # ===========================================================================
+  # Provider def auto-resolution (icon + badge) via Providers.get/1
+  # ===========================================================================
+
+  describe "provider def auto-resolution" do
+    test "renders provider icon + display name in mixed-provider mode (no `provider` attr)" do
+      conn = conn_fixture(provider: "openrouter")
+
+      assigns = %{conns: [conn]}
+
+      html =
+        rendered_to_string(~H"""
+        <.integration_picker id="p" connections={@conns} on_select="x" />
+        """)
+
+      # OpenRouter is registered in PhoenixKit.Integrations.Providers
+      # with both an icon and a display name. With no `provider` attr,
+      # the picker is rendering a mixed list, so the per-card provider
+      # badge IS useful for disambiguation.
+      assert html =~ "OpenRouter"
+    end
+
+    test "hides provider badge when picker is filtered to a single provider" do
+      # When `provider="openrouter"` is set, every visible card is the
+      # same provider — the badge is redundant and the boss flagged
+      # it as visual noise. Confirm it's gone.
+      conn = conn_fixture(provider: "openrouter")
+
+      assigns = %{conns: [conn]}
+
+      html =
+        rendered_to_string(~H"""
+        <.integration_picker
+          id="p"
+          connections={@conns}
+          provider="openrouter"
+          on_select="x"
+        />
+        """)
+
+      # The provider-name badge wrapper isn't rendered. (The provider
+      # icon still is — it's the visual anchor for the card.)
+      refute html =~ ~s(<span class="badge badge-ghost badge-xs shrink-0">)
+      # But the icon resolution still kicks in (registered provider).
+      assert html =~ "hero-sparkles"
+    end
+
+    test "omits icon + badge when provider isn't in the Providers registry" do
+      conn = conn_fixture(provider: "fictional-provider-xyz")
+
+      assigns = %{conns: [conn]}
+
+      html =
+        rendered_to_string(~H"""
+        <.integration_picker id="p" connections={@conns} on_select="x" />
+        """)
+
+      # No registered provider def → no provider badge (the
+      # `<.icon>` block and provider-name `<span class="badge ...">`
+      # are both `:if`-gated on `@provider_def`). The bare provider
+      # string still appears in the card's `data-search-text` attr
+      # (that's fine — search needs to find by raw key too), so we
+      # assert on the rendered badge wrapper specifically.
+      refute html =~ ~s(<span class="badge badge-ghost badge-xs shrink-0">)
+    end
+  end
+
+  # ===========================================================================
+  # Status badge
+  # ===========================================================================
+
+  describe "status badge" do
+    test "Connected badge (green) for status='connected'" do
+      conn = conn_fixture(data: %{"status" => "connected"})
+
+      assigns = %{conns: [conn]}
+
+      html =
+        rendered_to_string(~H"""
+        <.integration_picker id="p" connections={@conns} on_select="x" />
+        """)
+
+      assert html =~ "Connected"
+      assert html =~ "badge-success"
+    end
+
+    test "Auth-failed badge (red) for status='error' — distinguishable from never-tested" do
+      conn =
+        conn_fixture(
+          data: %{"status" => "error", "validation_status" => "error: Invalid credentials"}
+        )
+
+      assigns = %{conns: [conn]}
+
+      html =
+        rendered_to_string(~H"""
+        <.integration_picker id="p" connections={@conns} on_select="x" />
+        """)
+
+      assert html =~ "Auth failed"
+      assert html =~ "badge-error"
+      # The validation message hovers as a title attribute so the
+      # operator can see WHY without leaving the form.
+      assert html =~ ~s(title="error: Invalid credentials")
+    end
+
+    test "Not-tested badge (yellow) for status='configured'" do
+      conn = conn_fixture(data: %{"status" => "configured"})
+
+      assigns = %{conns: [conn]}
+
+      html =
+        rendered_to_string(~H"""
+        <.integration_picker id="p" connections={@conns} on_select="x" />
+        """)
+
+      assert html =~ "Not tested"
+      assert html =~ "badge-warning"
+    end
+
+    test "Not-connected badge (grey) for status='disconnected'" do
+      conn = conn_fixture(data: %{"status" => "disconnected"})
+
+      assigns = %{conns: [conn]}
+
+      html =
+        rendered_to_string(~H"""
+        <.integration_picker id="p" connections={@conns} on_select="x" />
+        """)
+
+      assert html =~ "Not connected"
+      assert html =~ "badge-ghost"
+    end
+
+    test "Not-connected fallback for unknown / nil status" do
+      conn = conn_fixture(data: %{"status" => "wat"})
+
+      assigns = %{conns: [conn]}
+
+      html =
+        rendered_to_string(~H"""
+        <.integration_picker id="p" connections={@conns} on_select="x" />
+        """)
+
+      assert html =~ "Not connected"
+      assert html =~ "badge-ghost"
+    end
+  end
+
+  # ===========================================================================
+  # Filter by provider
+  # ===========================================================================
+
+  describe "filter by provider" do
+    test "renders only connections whose JSONB provider matches" do
+      conns = [
+        conn_fixture(uuid: "01900000-0000-7000-8000-aaaaaaaaaaaa", name: "OR-1", provider: "openrouter"),
+        conn_fixture(uuid: "01900000-0000-7000-8000-bbbbbbbbbbbb", name: "G-1", provider: "google")
+      ]
+
+      assigns = %{conns: conns}
+
+      html =
+        rendered_to_string(~H"""
+        <.integration_picker
+          id="p"
+          connections={@conns}
+          provider="openrouter"
+          on_select="x"
+        />
+        """)
+
+      assert html =~ "OR-1"
+      refute html =~ "G-1"
+    end
+
+    test "with no provider attr, renders all connections" do
+      conns = [
+        conn_fixture(uuid: "01900000-0000-7000-8000-aaaaaaaaaaaa", name: "OR-1", provider: "openrouter"),
+        conn_fixture(uuid: "01900000-0000-7000-8000-bbbbbbbbbbbb", name: "G-1", provider: "google")
+      ]
+
+      assigns = %{conns: conns}
+
+      html =
+        rendered_to_string(~H"""
+        <.integration_picker id="p" connections={@conns} on_select="x" />
+        """)
+
+      assert html =~ "OR-1"
+      assert html =~ "G-1"
+    end
+  end
+
+  # ===========================================================================
+  # Search input visibility
+  # ===========================================================================
+
+  describe "search input" do
+    test "is hidden by default when ≤ 6 connections" do
+      conns =
+        Enum.map(1..6, fn i ->
+          conn_fixture(
+            uuid: "01900000-0000-7000-8000-#{String.pad_leading("#{i}", 12, "0")}",
+            name: "c-#{i}"
+          )
+        end)
+
+      assigns = %{conns: conns}
+
+      html =
+        rendered_to_string(~H"""
+        <.integration_picker id="p" connections={@conns} on_select="x" />
+        """)
+
+      refute html =~ ~s(phx-hook="IntegrationPickerSearch")
+    end
+
+    test "auto-shows when > 6 connections" do
+      conns =
+        Enum.map(1..7, fn i ->
+          conn_fixture(
+            uuid: "01900000-0000-7000-8000-#{String.pad_leading("#{i}", 12, "0")}",
+            name: "c-#{i}"
+          )
+        end)
+
+      assigns = %{conns: conns}
+
+      html =
+        rendered_to_string(~H"""
+        <.integration_picker id="p" connections={@conns} on_select="x" />
+        """)
+
+      assert html =~ ~s(phx-hook="IntegrationPickerSearch")
+    end
+
+    test "respects explicit `searchable: false` even past the auto-show threshold" do
+      conns =
+        Enum.map(1..10, fn i ->
+          conn_fixture(
+            uuid: "01900000-0000-7000-8000-#{String.pad_leading("#{i}", 12, "0")}",
+            name: "c-#{i}"
+          )
+        end)
+
+      assigns = %{conns: conns}
+
+      html =
+        rendered_to_string(~H"""
+        <.integration_picker
+          id="p"
+          connections={@conns}
+          searchable={false}
+          on_select="x"
+        />
+        """)
+
+      refute html =~ ~s(phx-hook="IntegrationPickerSearch")
+    end
+  end
+
+  # ===========================================================================
+  # Empty state
+  # ===========================================================================
+
+  describe "empty state" do
+    test "shows 'No integrations configured.' when no connections" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.integration_picker id="p" connections={[]} on_select="x" />
+        """)
+
+      assert html =~ "No integrations configured."
+    end
+
+    test "renders empty_url link when provided" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.integration_picker
+          id="p"
+          connections={[]}
+          on_select="x"
+          empty_url="/admin/settings/integrations/new"
+        />
+        """)
+
+      assert html =~ "/admin/settings/integrations/new"
+      assert html =~ "Settings"
+    end
+
+    test "with active search, shows 'No integrations match your search.'" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.integration_picker
+          id="p"
+          connections={[]}
+          search="anything"
+          on_select="x"
+        />
+        """)
+
+      assert html =~ "No integrations match your search."
+    end
+  end
+
+  # ===========================================================================
+  # Deleted-integration card (selected uuid no longer in connections)
+  # ===========================================================================
+
+  describe "deleted-integration card" do
+    test "renders warning card when selected uuid is not in connections" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.integration_picker
+          id="p"
+          connections={[]}
+          selected={["01900000-0000-7000-8000-aaaaaaaaaaaa"]}
+          on_select="x"
+        />
+        """)
+
+      assert html =~ "Integration deleted"
+      assert html =~ "Missing"
+    end
+
+    test "doesn't render the deleted card when the selected uuid resolves" do
+      conn = conn_fixture(uuid: "01900000-0000-7000-8000-aaaaaaaaaaaa")
+
+      assigns = %{conn: conn}
+
+      html =
+        rendered_to_string(~H"""
+        <.integration_picker
+          id="p"
+          connections={[@conn]}
+          selected={["01900000-0000-7000-8000-aaaaaaaaaaaa"]}
+          on_select="x"
+        />
+        """)
+
+      refute html =~ "Integration deleted"
+    end
+  end
+
+  # ===========================================================================
+  # Click actions (single vs multi select)
+  # ===========================================================================
+
+  describe "click actions" do
+    test "single-mode unselected card emits action='select'" do
+      conn = conn_fixture(uuid: "01900000-0000-7000-8000-aaaaaaaaaaaa")
+
+      assigns = %{conn: conn}
+
+      html =
+        rendered_to_string(~H"""
+        <.integration_picker
+          id="p"
+          connections={[@conn]}
+          selected={[]}
+          on_select="x"
+        />
+        """)
+
+      assert html =~ ~s(phx-value-action="select")
+    end
+
+    test "single-mode selected card emits action='deselect' so user can clear" do
+      conn = conn_fixture(uuid: "01900000-0000-7000-8000-aaaaaaaaaaaa")
+
+      assigns = %{conn: conn}
+
+      html =
+        rendered_to_string(~H"""
+        <.integration_picker
+          id="p"
+          connections={[@conn]}
+          selected={["01900000-0000-7000-8000-aaaaaaaaaaaa"]}
+          on_select="x"
+        />
+        """)
+
+      assert html =~ ~s(phx-value-action="deselect")
+    end
+
+    test "multi-mode unselected card emits action='add'" do
+      conn = conn_fixture(uuid: "01900000-0000-7000-8000-aaaaaaaaaaaa")
+
+      assigns = %{conn: conn}
+
+      html =
+        rendered_to_string(~H"""
+        <.integration_picker
+          id="p"
+          connections={[@conn]}
+          selected={[]}
+          multiple={true}
+          on_select="x"
+        />
+        """)
+
+      assert html =~ ~s(phx-value-action="add")
+    end
+
+    test "multi-mode selected card emits action='remove'" do
+      conn = conn_fixture(uuid: "01900000-0000-7000-8000-aaaaaaaaaaaa")
+
+      assigns = %{conn: conn}
+
+      html =
+        rendered_to_string(~H"""
+        <.integration_picker
+          id="p"
+          connections={[@conn]}
+          selected={["01900000-0000-7000-8000-aaaaaaaaaaaa"]}
+          multiple={true}
+          on_select="x"
+        />
+        """)
+
+      assert html =~ ~s(phx-value-action="remove")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Quality sweep on the Integrations subsystem and the core
IntegrationPicker / integration_form LV. The architectural change
is **V114** — collapsing the per-row `phoenix_kit_settings.key`
from the composite `integration:<provider>:<name>` shape to just
the row's uuid. Lifts both name restrictions (regex + uniqueness)
that were storage-layout artifacts, not product decisions: any
non-empty string is now a valid connection name, duplicates within
a provider are allowed.

(V113 was occupied upstream by the Tessera migration. This PR's
migration was originally numbered V113 locally; renumbered to
V114 during rebase per the workspace convention.)

### PR follow-up(s)

- `3901bc4c` — Triaged `BeamLabEU/phoenix_kit#526` (selected-card
  indicator on SortableGrid). Two NITPICKs + one IMPROVEMENT-LOW;
  NITPICK #2 (`!important`) was already fixed post-merge in
  `3521fa2f`; the other two are forward-looking notes deferred to
  the existing component-coverage TODO in `AGENTS.md`. FOLLOW_UP.md
  in the standard batch-fix format.

### Quality sweep

**Storage refactor (V114)** — `31ab4ad6` (renumbered post-rebase)

- `add_connection/3`: dropped the `[a-zA-Z0-9][a-zA-Z0-9\-_]*`
  regex AND the per-provider uniqueness check. UUIDv7 is generated
  up-front and embedded directly in both the row's `uuid` column
  and the `key` column.
- `rename_connection/3`: rewrites only the JSONB `name` field. No
  more key column rewrite, no uniqueness check, no regex.
- Read sites (`get_integration_by_uuid/1`, `list_connections/1`,
  `load_all_connections/1`) source provider+name from JSONB; the
  list helpers also expose `:date_added` so UI callers can render
  "Created N ago" without a second lookup.
- `provider:name` string lookups become first-match semantics
  (names aren't unique anymore). Read-shim contract preserved for
  legacy `migrate_legacy/0` callsites.
- `log_activity` takes explicit `(provider, name)` so audit rows
  carry human-readable names — parsing the key would have stamped
  a uuid string into `metadata.connection`.

**Migration (V114)**

- One UPDATE walks every `integration:%`-keyed row, backfills
  missing `value_json -> 'name'` / `'provider'`, ensures `module =
  'integrations'`, and rewrites `key = uuid::text`. Legacy V0-shape
  keys without a `:name` segment fold to `name = "default"`.
- `down/1` rewrites back to composite shape; collision suffix
  `-<8-char uuid>` on duplicate (provider, name) pairs (lossy by
  necessity).
- 9 round-trip tests in `v114_test.exs` covering the up rewrite,
  name backfill, JSONB-name preservation, V0 keyless shape →
  "default", module stamping, non-integration row skip,
  idempotence, and down-side collision suffixing. One real bug
  caught by the test (V0 keyless `integration:google` was being
  treated as `name="google"` instead of `"default"`; fixed via
  `split_part` SQL).

**Form-clear preservation** — `28cb0b59`

- `create_connection` + `save_form_with_rename` error branches
  now preserve `:new_name` + `:form_values` (mirroring the
  existing `test_credentials_dry_run/2` path). Pre-fix, hitting
  `:empty_name` on submit wiped the api_key the operator just
  typed.
- Dropped the dead `:already_exists` / `:invalid_name` error
  branches (those tuples no longer fire post-V114).
- Template: removed the now-incorrect "Letters, digits, hyphens,
  and underscores. Must be unique per provider." hint and the
  ` <provider> Connection` label.

**IntegrationPicker** — `4106ce33`

- Card subtitle: priority `external_account_id` → masked
  credential tail (`first 8 + … + last 4` for any of `api_key` /
  `bot_token` / `access_key`; `•••` for keys under 14 chars).
- Age line under subtitle using shared `<.time_ago>`.
- Status badge: distinct labels + colours for each of the four
  canonical statuses (`connected` → green "Connected",
  `error` → red "Auth failed" with `validation_status` tooltip,
  `configured` → yellow "Not tested", `disconnected` → grey "Not
  connected"). Aligns with the Endpoints list LV's vocabulary.
- Provider icon + display name now auto-resolve via
  `Integrations.Providers.get(data["provider"])` — callers no
  longer have to pre-attach a `:provider` struct. Dead
  `is_map(conn[:provider])` / `is_binary(conn[:provider_key])`
  branches removed.
- Provider-name badge hides when the picker is filtered to a
  single provider (`provider` attr set) — both real callsites do
  this, making the badge redundant.
- Click feedback: `phx-click-loading:opacity-60` +
  `phx-click-loading:pointer-events-none` dims the clicked card +
  blocks rapid re-clicks during the LV round-trip; daisyUI
  `loading-spinner` swaps in for the status badge during the
  same window. 33 new component spec tests.

**C12 sweep findings** — `be9efc43`, `22ee0865`

- `phx-disable-with` added to Save / Test Connection / Disconnect /
  Delete buttons on `integration_form.html.heex`. Pre-fix, a
  double-click + slow network could submit two save requests or
  spawn parallel HTTP probes; `data-confirm` is friendlier UX but
  not a substitute.
- Narrowed `Integrations.validate_connection/2`'s `rescue e ->` to
  three expected exception classes (`DBConnection.OwnershipError`,
  `Postgrex.Error`, `Req.TransportError`). Genuine logic bugs
  (`KeyError`, `MatchError`, etc.) now surface to the supervisor +
  Logger.error instead of getting swallowed under the generic
  "validation failed" message.
- Doc-only security note on `Integrations.authenticated_request/4`
  warning that the attached Bearer token leaks if the caller's
  `url` parameter comes from unvalidated user input. Internal
  callers (`OpenRouterClient`, OAuth refresh, userinfo) are safe;
  the AI module's `Endpoint.validate_base_url/1` schema guard
  covers the operator-supplied case. The doc spells out that new
  callsites that take URLs from anywhere else need their own
  allowlist.

**Permissions `module_label("db")` fix — `0d24c35e`**

- Pre-existing failure on `upstream/dev`: when the external
  `phoenix_kit_db` module isn't loaded (core's own test VM doesn't
  pull in feature modules), `Permissions.module_label("db")` falls
  through to `String.capitalize("db")` = `"Db"`, but the test
  asserts `"DB"` (the registered shape from
  `phoenix_kit_db.permission_metadata/0`).
- `db` was extracted into its own module but core still references
  the key (`phoenix_kit_web/users/auth.ex` keeps a
  `{"db", "/admin/db"}` route). Same pattern as if `"shop"` were
  extracted later: the canonical label / icon / description belong
  in core's `@core_*` maps so the display is correct regardless of
  whether the external module is installed.
- Added three parallel entries (`@core_labels` `"db" => "DB"`,
  `@core_icons` `"db" => "hero-server-stack"`, `@core_descriptions`
  `"db" => "Database explorer and schema inspection"`) mirroring
  `phoenix_kit_db.permission_metadata/0` verbatim — a host app
  loading both core and the external module sees the same values
  regardless of which lookup wins.
- Folded in to keep the post-rebase baseline green at 0 failures.

**Upstream fixture fix — `3c9ca9f5`**

- The rebase brought in upstream's V113 (PR #534, Tessera) which
  added the `phoenix_kit_files_user_or_parent_check` CHECK
  constraint requiring `user_uuid IS NOT NULL OR parent_file_uuid
  IS NOT NULL`. Existing fixtures in `storage/scope_test.exs`,
  `media_browser_scope_test.exs`, and `media_browser_test.exs`
  insert `phoenix_kit_files` rows with neither — fixture pattern
  predates V113. Reproduced on clean `upstream/dev` (`93f242b3`)
  via separate worktree, so confirmed not caused by this PR.
- Fix: each `create_file!/1` now stamps `user_uuid` via a memoised
  `ensure_user!/0` helper that registers an owner user once per
  test process. The user identity is incidental to every
  assertion in these tests; it exists only to satisfy the V113
  CHECK. Folded into this PR rather than a follow-up so the
  baseline `mix test` is clean — otherwise the next sweep would
  be unable to distinguish new regressions from upstream's
  pre-existing red.

## Verification

| Check | Result |
|---|---|
| `mix compile --warnings-as-errors` | clean |
| `mix credo --strict` | same pre-existing counts as upstream/dev (no new findings) |
| Targeted tests on changed files | 162 / 162 pass |
| Full `mix test` | **1229 tests, 0 failures.** The 23 upstream Tessera-fixture failures (introduced by V113's `phoenix_kit_files_user_or_parent_check` CHECK constraint) are fixed in `3c9ca9f5` — each `create_file!/1` fixture stamps `user_uuid` via a memoised `ensure_user!/0` helper. The remaining `Permissions.module_label("db")` failure (which existed on clean `upstream/dev`, unrelated to this PR's primary scope) is fixed in `0d24c35e` — `"db" => "DB"` added to `@core_labels` / `@core_icons` / `@core_descriptions` so core's display is correct even when `phoenix_kit_db` (which registers the same shape) isn't loaded. Targeted tests on this PR's changed files: 162 / 162. |

## Test plan

- [x] V114 migration round-trip + idempotence + edge cases (9 tests)
- [x] `add_connection` accepts spaces / punctuation / duplicates / leading symbols (4 tests)
- [x] `rename_connection` accepts arbitrary names + duplicate targets (5 tests)
- [x] `list_connections` + `load_all_connections` expose `:date_added` (6 tests)
- [x] Form-clear preservation on empty-name create error (1 test)
- [x] IntegrationPicker component spec — subtitle priority + masked
      credential + age + provider auto-resolve + 5 status branches
      + filter-by-provider + search threshold + empty state +
      deleted-card warning + click-action dispatch (33 tests)
- [x] `mix precommit`
- [x] `for i in {1..3}; do mix test --exclude integration; done`
      (stable on non-DB tests)

Renaming V113 → V114 across the migration, the test, the
`@current_version` constant, and the moduledoc changelog entry.
