### PR TITLE
Add V116 migration (parent_uuid on entity_data) + sortable_handle on draggable_list

### DIFF
--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -529,7 +529,26 @@ defmodule PhoenixKit.Migrations.Postgres do
   - Replaces unique index with partial index (slug-mode only, WHERE slug IS NOT NULL)
   - Adds unique index on `(group_uuid, post_date, post_time)` for timestamp-mode posts
 
-  ### V115 - phoenix_kit_annotations table for Etcher-drawn shapes ⚡ LATEST
+  ### V116 - Parent reference on entity_data ⚡ LATEST
+  - Adds nullable self-referential `parent_uuid` column to
+    `phoenix_kit_entity_data` so each data row can point at another row
+    of the same entity as its parent. The feature is a system field on
+    every entity_data row — always present, optional to fill, never
+    removable by the user (does not appear in
+    `entities.fields_definition`).
+  - No `ON DELETE` cascade: parent/child linkage and same-entity scope
+    are managed by the `PhoenixKitEntities.EntityData` context inside a
+    transaction. A DB-level cascade would bypass the soft-delete
+    machinery and the activity log.
+  - Same-entity enforcement (a row's parent must share its
+    `entity_uuid`) is a context-layer responsibility — the self-FK has
+    no view of `entity_uuid`.
+  - B-tree index on `(parent_uuid)` covers the "list children" query
+    used when rendering the WordPress-style indented tree.
+  - Existing rows stay `parent_uuid = NULL` and become roots — no
+    backfill needed.
+
+  ### V115 - phoenix_kit_annotations table for Etcher-drawn shapes
   - Creates `phoenix_kit_annotations` storing user-drawn rectangle /
     circle / polygon / freehand shapes anchored to `phoenix_kit_files`
     rows in image-pixel coordinates. Geometry is JSONB; shape kinds are
@@ -952,7 +971,7 @@ defmodule PhoenixKit.Migrations.Postgres do
   use Ecto.Migration
 
   @initial_version 1
-  @current_version 115
+  @current_version 116
   @default_prefix "public"
 
   @doc false

--- a/lib/phoenix_kit/migrations/postgres/v116.ex
+++ b/lib/phoenix_kit/migrations/postgres/v116.ex
@@ -1,0 +1,102 @@
+defmodule PhoenixKit.Migrations.Postgres.V116 do
+  @moduledoc """
+  V116: Parent reference on entity_data.
+
+  Adds a nullable self-referential `parent_uuid` column on
+  `phoenix_kit_entity_data`, letting each data row point at another row
+  of the same entity as its parent. The feature is a system field on
+  every entity_data row — it is always present, optional to fill, and
+  never removable by the user (it does not appear in
+  `entities.fields_definition`). Existing rows stay `parent_uuid = NULL`
+  and become roots; no backfill needed.
+
+  The column is nullable (roots have no parent) with **no `ON DELETE`**
+  cascade: parent/child linkage and same-entity scope are managed by
+  the `PhoenixKitEntities.EntityData` context, which runs subtree
+  checks inside a transaction. A DB-level cascade would bypass the
+  soft-delete machinery and the activity log.
+
+  Same-entity enforcement (a row's parent must share its `entity_uuid`)
+  is a context-layer responsibility — the self-FK has no view of
+  `entity_uuid`, so the changeset + context perform the lookup before
+  saving.
+
+  A plain b-tree index on `(parent_uuid)` covers the "list children"
+  query used when rendering the WordPress-style indented tree. Existing
+  indexes on `(entity_uuid)` and `(entity_uuid, position)` still cover
+  per-entity listing and manual ordering.
+  """
+
+  use Ecto.Migration
+
+  def up(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+    schema = if prefix == "public", do: "public", else: prefix
+
+    if table_exists?(:phoenix_kit_entity_data, prefix) do
+      # Raw SQL — the Ecto.Migration `references/2` macro targets the
+      # `:id` column by default, but `phoenix_kit_entity_data`'s PK is
+      # `uuid`. Match V103's column-add shape exactly.
+      execute("""
+      DO $$
+      BEGIN
+        IF NOT EXISTS (
+          SELECT FROM information_schema.columns
+          WHERE table_schema = '#{schema}'
+            AND table_name = 'phoenix_kit_entity_data'
+            AND column_name = 'parent_uuid'
+        ) THEN
+          ALTER TABLE #{p}phoenix_kit_entity_data
+            ADD COLUMN parent_uuid UUID
+            REFERENCES #{p}phoenix_kit_entity_data(uuid);
+        END IF;
+      END $$;
+      """)
+
+      execute("""
+      CREATE INDEX IF NOT EXISTS phoenix_kit_entity_data_parent_index
+      ON #{p}phoenix_kit_entity_data (parent_uuid)
+      """)
+    end
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '116'")
+  end
+
+  @doc """
+  Rolls V116 back by dropping the parent index and column.
+
+  **Lossy rollback:** the tree collapses — every row becomes a root and
+  all parent linkage is lost. Back up before rolling back in production.
+  """
+  def down(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    if table_exists?(:phoenix_kit_entity_data, prefix) do
+      execute("DROP INDEX IF EXISTS #{p}phoenix_kit_entity_data_parent_index")
+
+      execute(
+        "ALTER TABLE #{p}phoenix_kit_entity_data DROP COLUMN IF EXISTS parent_uuid"
+      )
+    end
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '115'")
+  end
+
+  defp table_exists?(table_name, prefix) do
+    query = """
+    SELECT EXISTS (
+      SELECT FROM information_schema.tables
+      WHERE table_schema = '#{prefix}'
+      AND table_name = '#{table_name}'
+    )
+    """
+
+    %{rows: [[exists]]} = PhoenixKit.RepoHelper.repo().query!(query)
+    exists
+  end
+
+  defp prefix_str("public"), do: "public."
+  defp prefix_str(prefix), do: "#{prefix}."
+end

--- a/lib/phoenix_kit_web/components/core/draggable_list.ex
+++ b/lib/phoenix_kit_web/components/core/draggable_list.ex
@@ -76,6 +76,11 @@ defmodule PhoenixKitWeb.Components.Core.DraggableList do
   attr :item_class, :string, default: "", doc: "Additional CSS classes for each item wrapper"
   attr :hide_source, :boolean, default: false, doc: "Hide source element on drag start"
 
+  attr :sortable_handle, :string,
+    default: nil,
+    doc:
+      "Optional CSS selector (e.g. `\".pk-drag-handle\"`) that restricts drag initiation to elements matching the selector inside each item. When set, the item wrapper no longer carries the `cursor-grab` styling — the caller is responsible for rendering the handle. Mirrors the workspace's `<.table_default>` `:on_reorder` + `.pk-drag-handle` convention."
+
   attr :draggable, :boolean,
     default: true,
     doc:
@@ -108,13 +113,15 @@ defmodule PhoenixKitWeb.Components.Core.DraggableList do
       data-sortable-event={if @draggable, do: @on_reorder}
       data-sortable-items={if @draggable, do: ".sortable-item"}
       data-sortable-hide-source={if @draggable, do: to_string(@hide_source)}
+      data-sortable-handle={if @draggable, do: @sortable_handle}
       phx-hook={if @draggable, do: "SortableGrid"}
       class={@container_class}
     >
       <%= for item <- @items do %>
         <div
           class={[
-            @draggable && "sortable-item cursor-grab active:cursor-grabbing",
+            @draggable && "sortable-item",
+            @draggable && is_nil(@sortable_handle) && "cursor-grab active:cursor-grabbing",
             @item_class
           ]}
           data-id={@item_id_fn.(item)}


### PR DESCRIPTION
## Summary

Two independent additions on top of the post-V115 upstream:

1. **V116 — `parent_uuid` self-FK on `phoenix_kit_entity_data`** so each
   entity-data row can point at another row of the same entity as its
   parent. System field — always present, optional, never user-removable
   (does not appear in `entities.fields_definition`). Same shape as V103
   (catalogue's nested categories): nullable self-FK, no `ON DELETE`
   cascade, b-tree index on `(parent_uuid)`. Same-entity scope + cycle
   prevention are context-layer responsibilities in
   `phoenix_kit_entities`.

2. **`sortable_handle` attribute on `<.draggable_list>`** so consumers
   can render their own grab handle (e.g. a hover-revealed bars icon)
   instead of making the whole card draggable. Optional, default `nil` —
   backward-compatible with every existing call site. Mirrors the
   `:on_reorder` → `.pk-drag-handle` convention `<.table_default>`
   already ships.

## Companion PR

`BeamLabEU/phoenix_kit_entities` — consumes V116 (`parent_uuid` schema +
context layer) and the new `:sortable_handle` attr (card-view DnD in
`Web.Entities` + `Web.DataNavigator`).

## Verification

- `mix compile` — clean.
- `mix test` — 1230 / 1231 pass (one pre-existing failure in
  `V114Test "N >= 3 collision: exactly one plain key, N-1 distinct
  suffixed keys"` — unrelated to this PR; the `V114.down/1` collision-
  suffix logic ships a duplicate `integration:openrouter:work-<8-char>`
  in the test fixture).
- V116 column add + index follow V103's exact shape; idempotent
  (`IF NOT EXISTS` on both the column and the index).
- `down/1` drops the index then the column; comment marker rewrites
  to '115' on rollback.

## Test plan

- [x] `mix format --check-formatted`
- [x] `mix credo --strict` (no new findings)
- [x] `mix compile --warnings-as-errors`
- [x] `mix test` (1230 of 1231; 1 pre-existing flake noted above)
- [x] `down/1` smoke: marker rewrites to 115, column + index dropped