### PR TITLE
Fix sitemap lastmod regression from PR #539 merge

### DIFF
--- a/lib/modules/sitemap/sources/publishing.ex
+++ b/lib/modules/sitemap/sources/publishing.ex
@@ -166,7 +166,7 @@ defmodule PhoenixKit.Modules.Sitemap.Sources.Publishing do
 
       UrlEntry.new(%{
         loc: url,
-        lastmod: nil,
+        lastmod: latest_post_date(slug, language),
         changefreq: "daily",
         priority: 0.7,
         title: name,
@@ -390,6 +390,20 @@ defmodule PhoenixKit.Modules.Sitemap.Sources.Publishing do
       %{slug: slug} when is_binary(slug) -> format_slug(slug)
       _ -> "Post"
     end
+  end
+
+  # Latest lastmod among published posts in a group (for group listing pages)
+  defp latest_post_date(group_slug, language) do
+    post_language = language || get_default_language()
+
+    @publishing_mod.list_posts(group_slug, post_language)
+    |> Enum.filter(&published?/1)
+    |> Enum.reject(&excluded?/1)
+    |> Enum.map(&get_post_lastmod/1)
+    |> Enum.reject(&is_nil/1)
+    |> Enum.max(Date, fn -> nil end)
+  rescue
+    _ -> nil
   end
 
   defp get_post_lastmod(post) do

--- a/lib/modules/sitemap/sources/static.ex
+++ b/lib/modules/sitemap/sources/static.ex
@@ -199,7 +199,7 @@ defmodule PhoenixKit.Modules.Sitemap.Sources.Static do
 
       UrlEntry.new(%{
         loc: url,
-        lastmod: Date.utc_today(),
+        lastmod: static_lastmod(path),
         changefreq: Map.get(config, "changefreq", "weekly"),
         priority: Map.get(config, "priority", 0.5),
         title: Map.get(config, "title", path),
@@ -224,7 +224,7 @@ defmodule PhoenixKit.Modules.Sitemap.Sources.Static do
 
       UrlEntry.new(%{
         loc: url,
-        lastmod: Date.utc_today(),
+        lastmod: static_lastmod(path),
         changefreq: Map.get(config, "changefreq", "weekly"),
         priority: Map.get(config, "priority", 0.5),
         title: Map.get(config, "title", path),
@@ -236,6 +236,25 @@ defmodule PhoenixKit.Modules.Sitemap.Sources.Static do
       nil
     end
   end
+
+  # For homepage, use the latest published content date across all publishing groups.
+  # For other static pages, use today's date as a reasonable approximation.
+  defp static_lastmod("/") do
+    alias PhoenixKit.Modules.Sitemap.Sources.Publishing
+
+    if Code.ensure_loaded?(Publishing) and function_exported?(Publishing, :collect, 1) do
+      Publishing.collect([])
+      |> Enum.map(& &1.lastmod)
+      |> Enum.reject(&is_nil/1)
+      |> Enum.max(Date, fn -> Date.utc_today() end)
+    else
+      Date.utc_today()
+    end
+  rescue
+    _ -> Date.utc_today()
+  end
+
+  defp static_lastmod(_path), do: Date.utc_today()
 
   # Resolve path from config: explicit path OR via RouteResolver
   defp resolve_path(%{"path" => path}) when is_binary(path) and path != "" do


### PR DESCRIPTION
## Summary

PR #539 (V117 migration) was merged with a silent sitemap regression. The 3-way merge overwrote two sitemap helpers that existed on `upstream/dev` but had been removed long ago on the source fork — restoring them.

## What broke after PR #539

| File | Before merge | After merge |
|---|---|---|
| `lib/modules/sitemap/sources/publishing.ex` | `lastmod: latest_post_date(slug, language)` | `lastmod: nil` |
| `lib/modules/sitemap/sources/static.ex` (lines 202, 227) | `lastmod: static_lastmod(path)` | `lastmod: Date.utc_today()` |
| `defp latest_post_date/2` | present | **deleted** |
| `defp static_lastmod/1` | present | **deleted** |

SEO impact of the regression:
- Publishing group listing pages (`/blog`, `/posts`, …) lost their `<lastmod>` element entirely
- Static homepage `/` now reports `lastmod: today's date` on every sitemap regeneration — a known SEO anti-pattern

## Fix

Restores both files to their state at `0b561d1b` — the last `upstream/dev` commit before the PR #539 merge. Both helper functions (`latest_post_date/2`, `static_lastmod/1`) and their callsites come back.

Original commits that introduced this logic:
- `e7b0ef60` Add lastmod to sitemap group listings and homepage
- `54b9b899` Add lastmod to sitemap router-discovered and static entries

## Test Plan

- [x] `mix compile --warnings-as-errors` clean
- [x] `mix docs` clean
- [x] `mix quality` (credo + dialyzer) clean
- [x] Pre-commit hook passed
- [ ] Verify sitemap XML output on a parent app — group listing pages should emit `<lastmod>` again, homepage `<lastmod>` should reflect latest publishing content rather than today's date

## Context

Detailed pre-merge analysis: `dev_docs/pull_requests/2026/539-v117-document-composition-tables/CLAUDE_REVIEW.md` (already on `dev` via commit `17b3b6e1`) — see section "#1 Undeclared scope: PR also reverted the dynamic-lastmod sitemap logic on dev".