### PR TITLE
Add gettext manifests for projects + comments; global locale sync; avatar dropdown UX

### DIFF
--- a/lib/phoenix_kit_web/comments_gettext_manifest.ex
+++ b/lib/phoenix_kit_web/comments_gettext_manifest.ex
@@ -1,0 +1,70 @@
+defmodule PhoenixKitWeb.CommentsGettextManifest do
+  @moduledoc false
+
+  # Lists translatable strings used by `phoenix_kit_comments` that route via
+  # the shared `PhoenixKitWeb.Gettext` backend. Mirrors the
+  # `legal_gettext_manifest.ex` + `projects_gettext_manifest.ex` pattern —
+  # `mix gettext.extract` only walks core's `lib/`, never deps, so any string
+  # called from `phoenix_kit_comments` via `gettext(...)` against
+  # `PhoenixKitWeb.Gettext` would be missing from `priv/gettext/default.pot`
+  # without this manifest.
+  #
+  # Scope: end-user-facing strings rendered by the public
+  # `CommentsComponent` LiveComponent (the comment thread that mounts on
+  # post/project pages) plus the `data-confirm` shown to commenters on
+  # delete. Admin-settings UI strings under
+  # `lib/phoenix_kit_comments/web/settings*` are intentionally excluded —
+  # the admin panel runs in English.
+  #
+  # ## Refreshing the list
+  #
+  # When `phoenix_kit_comments` adds or renames a translatable string, run
+  # from the comments checkout:
+  #
+  #     grep -hEo 'gettext\("[^"]+' \
+  #       lib/phoenix_kit_comments/web/comments_component.ex \
+  #       lib/phoenix_kit_comments/web/comments_component.html.heex \
+  #     | sort -u
+  #
+  # Then mirror new entries here and run `mix gettext.extract --merge` from
+  # core.
+  #
+  # This module is never called at runtime.
+
+  use Gettext, backend: PhoenixKitWeb.Gettext
+
+  @doc false
+  def __extract__ do
+    [
+      # comments_component.html.heex
+      gettext("Replying to comment"),
+      gettext("Cancel"),
+      gettext("Write a comment..."),
+      gettext("GIF"),
+      gettext("Remove GIF"),
+      gettext("Remove %{name}", name: ""),
+      gettext("Stop recording"),
+      gettext("Attach media"),
+      gettext("Attach media options"),
+      gettext("Image"),
+      gettext("Record"),
+      gettext("Up to %{count} files, max %{size}MB each", count: 0, size: 0),
+      gettext("Giphy picker"),
+      gettext("Search GIFs"),
+      gettext("Search GIFs..."),
+      gettext("GIF results"),
+      gettext("Select GIF %{id}", id: ""),
+      gettext("Type a search term to find GIFs."),
+      gettext("No results."),
+      gettext("Post Comment"),
+      gettext("Sign in to post a comment."),
+      gettext("No comments yet. Be the first to comment!"),
+      # comments_component.ex render_comment
+      gettext("[removed]"),
+      gettext("Unknown"),
+      gettext("Reply"),
+      gettext("Are you sure you want to delete this comment?"),
+      gettext("Save")
+    ]
+  end
+end

--- a/lib/phoenix_kit_web/components/admin_nav.ex
+++ b/lib/phoenix_kit_web/components/admin_nav.ex
@@ -216,7 +216,7 @@ defmodule PhoenixKitWeb.Components.AdminNav do
         <%!-- Dropdown Menu --%>
         <ul
           tabindex="0"
-          class="dropdown-content menu bg-base-100 rounded-box z-[60] w-64 p-2 shadow-xl border border-base-300 mt-3"
+          class="dropdown-content menu bg-base-100 rounded-box z-[60] w-64 p-2 shadow-xl border border-base-300 mt-3 max-h-[calc(100vh-5rem)] overflow-y-auto flex-nowrap"
         >
           <%!-- User Info Header --%>
           <li class="menu-title px-4 py-2">
@@ -261,26 +261,43 @@ defmodule PhoenixKitWeb.Components.AdminNav do
               <span class="text-xs">Language</span>
             </li>
 
-            <%= for language <- @admin_languages do %>
-              <li>
-                <button
-                  type="button"
-                  phx-click="phoenix_kit_set_locale"
-                  phx-value-locale={language.code}
-                  phx-value-url={generate_language_switch_url(@current_path, language.code)}
-                  class={[
-                    "flex items-center gap-3",
-                    if(language.code == @current_locale, do: "active", else: "")
-                  ]}
-                >
-                  <span class="text-lg">{get_language_flag(language.code)}</span>
-                  <span>{language.name}</span>
-                  <%= if language.code == @current_locale do %>
-                    <PhoenixKitWeb.Components.Core.Icons.icon_check class="w-4 h-4 ml-auto" />
-                  <% end %>
-                </button>
-              </li>
-            <% end %>
+            <%!--
+              Independently scrollable language list — caps at ~5 visible rows.
+              Buttons are styled directly (no nested daisyUI <ul class="menu">) so
+              the parent menu doesn't apply submenu indent (16px margin) or
+              li-child padding (12px) that would otherwise force horizontal scroll
+              and leave a weird left indent. `!p-0` resets the menu-child padding
+              the parent <ul> applies to the wrapper <li>'s children.
+            --%>
+            <li class="p-0 !bg-transparent hover:!bg-transparent focus:!bg-transparent">
+              <div class="!p-0 block w-full max-h-60 overflow-y-auto overflow-x-hidden !bg-transparent hover:!bg-transparent focus:!bg-transparent">
+                <%= for language <- @admin_languages do %>
+                  <button
+                    type="button"
+                    phx-click="phoenix_kit_set_locale"
+                    phx-value-locale={language.code}
+                    phx-value-url={generate_language_switch_url(@current_path, language.code)}
+                    class={[
+                      "w-full flex items-center gap-3 rounded-lg px-4 py-2 text-sm",
+                      "focus:outline-none focus-visible:outline-none",
+                      "phx-click-loading:opacity-60 phx-click-loading:pointer-events-none",
+                      if(language.code == @current_locale,
+                        do:
+                          "bg-primary !text-primary-content hover:bg-primary hover:!text-primary-content active:!bg-primary/80",
+                        else:
+                          "!text-base-content hover:bg-base-200 hover:!text-base-content focus:!text-base-content active:!text-base-content active:!bg-base-300"
+                      )
+                    ]}
+                  >
+                    <span class="text-lg">{get_language_flag(language.code)}</span>
+                    <span>{language.name}</span>
+                    <%= if language.code == @current_locale do %>
+                      <PhoenixKitWeb.Components.Core.Icons.icon_check class="w-4 h-4 ml-auto" />
+                    <% end %>
+                  </button>
+                <% end %>
+              </div>
+            </li>
           <% end %>
 
           <div class="divider my-0"></div>

--- a/lib/phoenix_kit_web/components/user_dashboard_nav.ex
+++ b/lib/phoenix_kit_web/components/user_dashboard_nav.ex
@@ -45,7 +45,7 @@ defmodule PhoenixKitWeb.Components.UserDashboardNav do
 
         <ul
           tabindex="0"
-          class="dropdown-content menu bg-base-100 rounded-box z-[60] w-64 p-2 shadow-xl border border-base-300 mt-3"
+          class="dropdown-content menu bg-base-100 rounded-box z-[60] w-64 p-2 shadow-xl border border-base-300 mt-3 max-h-[calc(100vh-5rem)] overflow-y-auto flex-nowrap"
         >
           <li class="menu-title px-4 py-2">
             <div class="flex flex-col gap-1">
@@ -108,17 +108,27 @@ defmodule PhoenixKitWeb.Components.UserDashboardNav do
               <span class="text-xs">Language</span>
             </li>
 
-            <%!-- Scrollable container when there are many languages --%>
-            <div class={[
-              length(user_languages) > 6 && "max-h-48 overflow-y-auto"
-            ]}>
-              <%= for language <- user_languages do %>
-                <li>
+            <%!--
+              Independently scrollable language list — caps at ~5 visible rows.
+              Anchors are styled directly (no nested daisyUI <ul class="menu">) so
+              the parent menu doesn't apply submenu indent or li-child padding
+              that would otherwise force horizontal scroll and leave a weird
+              left indent. See admin_nav.ex for the matching pattern.
+            --%>
+            <li class="p-0 !bg-transparent hover:!bg-transparent focus:!bg-transparent">
+              <div class="!p-0 block w-full max-h-60 overflow-y-auto overflow-x-hidden !bg-transparent hover:!bg-transparent focus:!bg-transparent">
+                <%= for language <- user_languages do %>
                   <a
                     href={generate_language_switch_url(@current_path, language.code)}
                     class={[
-                      "flex items-center gap-3",
-                      if(language.code == @current_locale, do: "active", else: "")
+                      "w-full flex items-center gap-3 rounded-lg px-4 py-2 text-sm",
+                      "focus:outline-none focus-visible:outline-none",
+                      if(language.code == @current_locale,
+                        do:
+                          "bg-primary !text-primary-content hover:bg-primary hover:!text-primary-content active:!bg-primary/80",
+                        else:
+                          "!text-base-content hover:bg-base-200 hover:!text-base-content focus:!text-base-content active:!text-base-content active:!bg-base-300"
+                      )
                     ]}
                   >
                     <span class="text-lg">{get_language_flag(language.code)}</span>
@@ -127,9 +137,9 @@ defmodule PhoenixKitWeb.Components.UserDashboardNav do
                       <PhoenixKitWeb.Components.Core.Icons.icon_check class="w-4 h-4 ml-auto" />
                     <% end %>
                   </a>
-                </li>
-              <% end %>
-            </div>
+                <% end %>
+              </div>
+            </li>
           <% end %>
 
           <div class="divider my-0"></div>

--- a/lib/phoenix_kit_web/projects_gettext_manifest.ex
+++ b/lib/phoenix_kit_web/projects_gettext_manifest.ex
@@ -1,0 +1,57 @@
+defmodule PhoenixKitWeb.ProjectsGettextManifest do
+  @moduledoc false
+
+  # Lists translatable strings used by `phoenix_kit_projects` that route via
+  # the shared `PhoenixKitWeb.Gettext` backend (the "common" bucket per the
+  # hybrid gettext convention — date/month formatting helpers in
+  # `PhoenixKitProjects.L10n` and generic table chrome in
+  # `PhoenixKitProjects.Web.Components.SortableTable`).
+  #
+  # Projects-domain-specific strings stay in `phoenix_kit_projects`' own
+  # `PhoenixKitProjects.Gettext` backend; this manifest only mirrors the
+  # subset that's deliberately shared workspace-wide.
+  #
+  # See `phoenix_kit_projects/dev_docs/i18n_triage.md` for the per-file
+  # bucket assignments and `legal_gettext_manifest.ex` for the same pattern
+  # applied to `phoenix_kit_legal`.
+  #
+  # ## Refreshing the list
+  #
+  # Run from a `phoenix_kit_projects` checkout to confirm the current set:
+  #
+  #     grep -hEo 'gettext\("[^"]+' \
+  #       lib/phoenix_kit_projects/l10n.ex \
+  #       lib/phoenix_kit_projects/web/components/sortable_table.ex \
+  #     | sort -u
+  #
+  # This module is never called at runtime — it exists purely as an
+  # extraction target for `mix gettext.extract`.
+
+  use Gettext, backend: PhoenixKitWeb.Gettext
+
+  @doc false
+  def __extract__ do
+    [
+      # Month abbreviations (PhoenixKitProjects.L10n.short_month/1).
+      gettext("Jan"),
+      gettext("Feb"),
+      gettext("Mar"),
+      gettext("Apr"),
+      gettext("May"),
+      gettext("Jun"),
+      gettext("Jul"),
+      gettext("Aug"),
+      gettext("Sep"),
+      gettext("Oct"),
+      gettext("Nov"),
+      gettext("Dec"),
+      # Date/time format templates (PhoenixKitProjects.L10n).
+      gettext("%{month} %{day}, %{year}", month: "", day: "", year: ""),
+      gettext("%{month} %{day}, %{year} at %{time}", month: "", day: "", year: "", time: ""),
+      gettext("%{month} %{day} %{time}", month: "", day: "", time: ""),
+      # Generic table chrome
+      # (PhoenixKitProjects.Web.Components.SortableTable column headers).
+      gettext("Title")
+    ]
+  end
+end

--- a/lib/phoenix_kit_web/users/auth.ex
+++ b/lib/phoenix_kit_web/users/auth.ex
@@ -716,8 +716,13 @@ defmodule PhoenixKitWeb.Users.Auth do
       user = socket.assigns[:phoenix_kit_current_user]
       full_dialect = DialectMapper.resolve_dialect(locale, user)
 
-      # Update Gettext locale
+      # Update Gettext locale — set both the backend-specific value (for
+      # PhoenixKitWeb.Gettext callers that look it up explicitly) and the
+      # process-global default (so feature modules with their own backends,
+      # e.g. PhoenixKitProjects.Gettext, also pick up the new locale without
+      # needing per-backend wiring).
       Gettext.put_locale(PhoenixKitWeb.Gettext, full_dialect)
+      Gettext.put_locale(full_dialect)
 
       socket
       |> Phoenix.Component.assign(:current_locale_base, locale)
@@ -756,6 +761,7 @@ defmodule PhoenixKitWeb.Users.Auth do
         default_dialect = DialectMapper.resolve_dialect(default_base, user)
 
         Gettext.put_locale(PhoenixKitWeb.Gettext, default_dialect)
+        Gettext.put_locale(default_dialect)
 
         socket
         |> Phoenix.Component.assign(:current_locale_base, default_base)
@@ -813,8 +819,10 @@ defmodule PhoenixKitWeb.Users.Auth do
 
     current_locale = DialectMapper.resolve_dialect(current_locale_base, user)
 
-    # Set Gettext locale for translations
+    # Set Gettext locale for translations (backend-specific + global, so
+    # module backends like PhoenixKitProjects.Gettext sync too).
     Gettext.put_locale(PhoenixKitWeb.Gettext, current_locale)
+    Gettext.put_locale(current_locale)
 
     socket
     |> maybe_manage_scope_subscription(user)
@@ -1759,6 +1767,7 @@ defmodule PhoenixKitWeb.Users.Auth do
           end
 
         Gettext.put_locale(PhoenixKitWeb.Gettext, dialect)
+        Gettext.put_locale(dialect)
 
         conn
         |> assign(:current_locale_base, base)
@@ -1790,6 +1799,7 @@ defmodule PhoenixKitWeb.Users.Auth do
     default_dialect = DialectMapper.resolve_dialect(default_base, current_user)
 
     Gettext.put_locale(PhoenixKitWeb.Gettext, default_dialect)
+    Gettext.put_locale(default_dialect)
 
     # Redirect to clean path so the router matches the correct route
     conn
@@ -1864,6 +1874,7 @@ defmodule PhoenixKitWeb.Users.Auth do
       full_dialect = DialectMapper.resolve_dialect(locale, current_user)
 
       Gettext.put_locale(PhoenixKitWeb.Gettext, full_dialect)
+      Gettext.put_locale(full_dialect)
 
       conn
       |> assign(:current_locale_base, locale)

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -7229,3 +7229,198 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Dimensions"
 msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:35
+#, elixir-autogen, elixir-format
+msgid "Jan"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:36
+#, elixir-autogen, elixir-format
+msgid "Feb"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:37
+#, elixir-autogen, elixir-format
+msgid "Mar"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:38
+#, elixir-autogen, elixir-format
+msgid "Apr"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:39
+#, elixir-autogen, elixir-format
+msgid "May"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:40
+#, elixir-autogen, elixir-format
+msgid "Jun"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:41
+#, elixir-autogen, elixir-format
+msgid "Jul"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:42
+#, elixir-autogen, elixir-format
+msgid "Aug"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:43
+#, elixir-autogen, elixir-format
+msgid "Sep"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:44
+#, elixir-autogen, elixir-format
+msgid "Oct"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:45
+#, elixir-autogen, elixir-format
+msgid "Nov"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:46
+#, elixir-autogen, elixir-format
+msgid "Dec"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:48
+#, elixir-autogen, elixir-format
+msgid "%{month} %{day}, %{year}"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:49
+#, elixir-autogen, elixir-format
+msgid "%{month} %{day}, %{year} at %{time}"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:50
+#, elixir-autogen, elixir-format
+msgid "%{month} %{day} %{time}"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:53
+#, elixir-autogen, elixir-format
+msgid "Title"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:43
+#, elixir-autogen, elixir-format
+msgid "Replying to comment"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:45
+#, elixir-autogen, elixir-format
+msgid "Write a comment..."
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:46
+#, elixir-autogen, elixir-format
+msgid "GIF"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:47
+#, elixir-autogen, elixir-format
+msgid "Remove GIF"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:48
+#, elixir-autogen, elixir-format
+msgid "Remove %{name}"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:49
+#, elixir-autogen, elixir-format
+msgid "Stop recording"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:50
+#, elixir-autogen, elixir-format
+msgid "Attach media"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:51
+#, elixir-autogen, elixir-format
+msgid "Attach media options"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:53
+#, elixir-autogen, elixir-format
+msgid "Record"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:54
+#, elixir-autogen, elixir-format
+msgid "Up to %{count} files, max %{size}MB each"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:55
+#, elixir-autogen, elixir-format
+msgid "Giphy picker"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:56
+#, elixir-autogen, elixir-format
+msgid "Search GIFs"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:57
+#, elixir-autogen, elixir-format
+msgid "Search GIFs..."
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:58
+#, elixir-autogen, elixir-format
+msgid "GIF results"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:59
+#, elixir-autogen, elixir-format
+msgid "Select GIF %{id}"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:60
+#, elixir-autogen, elixir-format
+msgid "Type a search term to find GIFs."
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:61
+#, elixir-autogen, elixir-format
+msgid "No results."
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:62
+#, elixir-autogen, elixir-format
+msgid "Post Comment"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:63
+#, elixir-autogen, elixir-format
+msgid "Sign in to post a comment."
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:64
+#, elixir-autogen, elixir-format
+msgid "No comments yet. Be the first to comment!"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:66
+#, elixir-autogen, elixir-format
+msgid "[removed]"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:68
+#, elixir-autogen, elixir-format
+msgid "Reply"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:69
+#, elixir-autogen, elixir-format
+msgid "Are you sure you want to delete this comment?"
+msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -7228,3 +7228,198 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Dimensions"
 msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:35
+#, elixir-autogen, elixir-format
+msgid "Jan"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:36
+#, elixir-autogen, elixir-format
+msgid "Feb"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:37
+#, elixir-autogen, elixir-format
+msgid "Mar"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:38
+#, elixir-autogen, elixir-format
+msgid "Apr"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:39
+#, elixir-autogen, elixir-format
+msgid "May"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:40
+#, elixir-autogen, elixir-format
+msgid "Jun"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:41
+#, elixir-autogen, elixir-format
+msgid "Jul"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:42
+#, elixir-autogen, elixir-format
+msgid "Aug"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:43
+#, elixir-autogen, elixir-format
+msgid "Sep"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:44
+#, elixir-autogen, elixir-format
+msgid "Oct"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:45
+#, elixir-autogen, elixir-format
+msgid "Nov"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:46
+#, elixir-autogen, elixir-format
+msgid "Dec"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:48
+#, elixir-autogen, elixir-format
+msgid "%{month} %{day}, %{year}"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:49
+#, elixir-autogen, elixir-format
+msgid "%{month} %{day}, %{year} at %{time}"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:50
+#, elixir-autogen, elixir-format
+msgid "%{month} %{day} %{time}"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:53
+#, elixir-autogen, elixir-format
+msgid "Title"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:43
+#, elixir-autogen, elixir-format
+msgid "Replying to comment"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:45
+#, elixir-autogen, elixir-format
+msgid "Write a comment..."
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:46
+#, elixir-autogen, elixir-format
+msgid "GIF"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:47
+#, elixir-autogen, elixir-format
+msgid "Remove GIF"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:48
+#, elixir-autogen, elixir-format
+msgid "Remove %{name}"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:49
+#, elixir-autogen, elixir-format
+msgid "Stop recording"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:50
+#, elixir-autogen, elixir-format
+msgid "Attach media"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:51
+#, elixir-autogen, elixir-format
+msgid "Attach media options"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:53
+#, elixir-autogen, elixir-format
+msgid "Record"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:54
+#, elixir-autogen, elixir-format
+msgid "Up to %{count} files, max %{size}MB each"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:55
+#, elixir-autogen, elixir-format
+msgid "Giphy picker"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:56
+#, elixir-autogen, elixir-format
+msgid "Search GIFs"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:57
+#, elixir-autogen, elixir-format
+msgid "Search GIFs..."
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:58
+#, elixir-autogen, elixir-format
+msgid "GIF results"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:59
+#, elixir-autogen, elixir-format
+msgid "Select GIF %{id}"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:60
+#, elixir-autogen, elixir-format
+msgid "Type a search term to find GIFs."
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:61
+#, elixir-autogen, elixir-format
+msgid "No results."
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:62
+#, elixir-autogen, elixir-format
+msgid "Post Comment"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:63
+#, elixir-autogen, elixir-format
+msgid "Sign in to post a comment."
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:64
+#, elixir-autogen, elixir-format
+msgid "No comments yet. Be the first to comment!"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:66
+#, elixir-autogen, elixir-format
+msgid "[removed]"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:68
+#, elixir-autogen, elixir-format
+msgid "Reply"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:69
+#, elixir-autogen, elixir-format
+msgid "Are you sure you want to delete this comment?"
+msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -7229,3 +7229,198 @@ msgstr "Authorization"
 #, elixir-autogen, elixir-format
 msgid "Dimensions"
 msgstr "Dimensions"
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:35
+#, elixir-autogen, elixir-format
+msgid "Jan"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:36
+#, elixir-autogen, elixir-format
+msgid "Feb"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:37
+#, elixir-autogen, elixir-format
+msgid "Mar"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:38
+#, elixir-autogen, elixir-format
+msgid "Apr"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:39
+#, elixir-autogen, elixir-format
+msgid "May"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:40
+#, elixir-autogen, elixir-format
+msgid "Jun"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:41
+#, elixir-autogen, elixir-format
+msgid "Jul"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:42
+#, elixir-autogen, elixir-format
+msgid "Aug"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:43
+#, elixir-autogen, elixir-format
+msgid "Sep"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:44
+#, elixir-autogen, elixir-format
+msgid "Oct"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:45
+#, elixir-autogen, elixir-format
+msgid "Nov"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:46
+#, elixir-autogen, elixir-format
+msgid "Dec"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:48
+#, elixir-autogen, elixir-format
+msgid "%{month} %{day}, %{year}"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:49
+#, elixir-autogen, elixir-format
+msgid "%{month} %{day}, %{year} at %{time}"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:50
+#, elixir-autogen, elixir-format
+msgid "%{month} %{day} %{time}"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:53
+#, elixir-autogen, elixir-format
+msgid "Title"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:43
+#, elixir-autogen, elixir-format
+msgid "Replying to comment"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:45
+#, elixir-autogen, elixir-format
+msgid "Write a comment..."
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:46
+#, elixir-autogen, elixir-format
+msgid "GIF"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:47
+#, elixir-autogen, elixir-format
+msgid "Remove GIF"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:48
+#, elixir-autogen, elixir-format
+msgid "Remove %{name}"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:49
+#, elixir-autogen, elixir-format
+msgid "Stop recording"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:50
+#, elixir-autogen, elixir-format
+msgid "Attach media"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:51
+#, elixir-autogen, elixir-format
+msgid "Attach media options"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:53
+#, elixir-autogen, elixir-format
+msgid "Record"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:54
+#, elixir-autogen, elixir-format
+msgid "Up to %{count} files, max %{size}MB each"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:55
+#, elixir-autogen, elixir-format
+msgid "Giphy picker"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:56
+#, elixir-autogen, elixir-format
+msgid "Search GIFs"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:57
+#, elixir-autogen, elixir-format
+msgid "Search GIFs..."
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:58
+#, elixir-autogen, elixir-format
+msgid "GIF results"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:59
+#, elixir-autogen, elixir-format
+msgid "Select GIF %{id}"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:60
+#, elixir-autogen, elixir-format
+msgid "Type a search term to find GIFs."
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:61
+#, elixir-autogen, elixir-format
+msgid "No results."
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:62
+#, elixir-autogen, elixir-format
+msgid "Post Comment"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:63
+#, elixir-autogen, elixir-format
+msgid "Sign in to post a comment."
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:64
+#, elixir-autogen, elixir-format
+msgid "No comments yet. Be the first to comment!"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:66
+#, elixir-autogen, elixir-format
+msgid "[removed]"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:68
+#, elixir-autogen, elixir-format
+msgid "Reply"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:69
+#, elixir-autogen, elixir-format
+msgid "Are you sure you want to delete this comment?"
+msgstr ""

--- a/priv/gettext/es/LC_MESSAGES/default.po
+++ b/priv/gettext/es/LC_MESSAGES/default.po
@@ -7237,3 +7237,198 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Dimensions"
 msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:35
+#, elixir-autogen, elixir-format
+msgid "Jan"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:36
+#, elixir-autogen, elixir-format
+msgid "Feb"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:37
+#, elixir-autogen, elixir-format
+msgid "Mar"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:38
+#, elixir-autogen, elixir-format
+msgid "Apr"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:39
+#, elixir-autogen, elixir-format
+msgid "May"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:40
+#, elixir-autogen, elixir-format
+msgid "Jun"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:41
+#, elixir-autogen, elixir-format
+msgid "Jul"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:42
+#, elixir-autogen, elixir-format
+msgid "Aug"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:43
+#, elixir-autogen, elixir-format
+msgid "Sep"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:44
+#, elixir-autogen, elixir-format
+msgid "Oct"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:45
+#, elixir-autogen, elixir-format
+msgid "Nov"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:46
+#, elixir-autogen, elixir-format
+msgid "Dec"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:48
+#, elixir-autogen, elixir-format
+msgid "%{month} %{day}, %{year}"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:49
+#, elixir-autogen, elixir-format
+msgid "%{month} %{day}, %{year} at %{time}"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:50
+#, elixir-autogen, elixir-format
+msgid "%{month} %{day} %{time}"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:53
+#, elixir-autogen, elixir-format
+msgid "Title"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:43
+#, elixir-autogen, elixir-format
+msgid "Replying to comment"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:45
+#, elixir-autogen, elixir-format
+msgid "Write a comment..."
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:46
+#, elixir-autogen, elixir-format
+msgid "GIF"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:47
+#, elixir-autogen, elixir-format
+msgid "Remove GIF"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:48
+#, elixir-autogen, elixir-format
+msgid "Remove %{name}"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:49
+#, elixir-autogen, elixir-format
+msgid "Stop recording"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:50
+#, elixir-autogen, elixir-format
+msgid "Attach media"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:51
+#, elixir-autogen, elixir-format
+msgid "Attach media options"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:53
+#, elixir-autogen, elixir-format
+msgid "Record"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:54
+#, elixir-autogen, elixir-format
+msgid "Up to %{count} files, max %{size}MB each"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:55
+#, elixir-autogen, elixir-format
+msgid "Giphy picker"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:56
+#, elixir-autogen, elixir-format
+msgid "Search GIFs"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:57
+#, elixir-autogen, elixir-format
+msgid "Search GIFs..."
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:58
+#, elixir-autogen, elixir-format
+msgid "GIF results"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:59
+#, elixir-autogen, elixir-format
+msgid "Select GIF %{id}"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:60
+#, elixir-autogen, elixir-format
+msgid "Type a search term to find GIFs."
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:61
+#, elixir-autogen, elixir-format
+msgid "No results."
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:62
+#, elixir-autogen, elixir-format
+msgid "Post Comment"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:63
+#, elixir-autogen, elixir-format
+msgid "Sign in to post a comment."
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:64
+#, elixir-autogen, elixir-format
+msgid "No comments yet. Be the first to comment!"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:66
+#, elixir-autogen, elixir-format
+msgid "[removed]"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:68
+#, elixir-autogen, elixir-format
+msgid "Reply"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:69
+#, elixir-autogen, elixir-format
+msgid "Are you sure you want to delete this comment?"
+msgstr ""

--- a/priv/gettext/et/LC_MESSAGES/default.po
+++ b/priv/gettext/et/LC_MESSAGES/default.po
@@ -7251,3 +7251,198 @@ msgstr "Volitamine"
 #, elixir-autogen, elixir-format
 msgid "Dimensions"
 msgstr "Mõõtmed"
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:35
+#, elixir-autogen, elixir-format
+msgid "Jan"
+msgstr "Jaan"
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:36
+#, elixir-autogen, elixir-format
+msgid "Feb"
+msgstr "Veebr"
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:37
+#, elixir-autogen, elixir-format
+msgid "Mar"
+msgstr "Märts"
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:38
+#, elixir-autogen, elixir-format
+msgid "Apr"
+msgstr "Apr"
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:39
+#, elixir-autogen, elixir-format
+msgid "May"
+msgstr "Mai"
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:40
+#, elixir-autogen, elixir-format
+msgid "Jun"
+msgstr "Juuni"
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:41
+#, elixir-autogen, elixir-format
+msgid "Jul"
+msgstr "Juuli"
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:42
+#, elixir-autogen, elixir-format
+msgid "Aug"
+msgstr "Aug"
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:43
+#, elixir-autogen, elixir-format
+msgid "Sep"
+msgstr "Sept"
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:44
+#, elixir-autogen, elixir-format
+msgid "Oct"
+msgstr "Okt"
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:45
+#, elixir-autogen, elixir-format
+msgid "Nov"
+msgstr "Nov"
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:46
+#, elixir-autogen, elixir-format
+msgid "Dec"
+msgstr "Dets"
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:48
+#, elixir-autogen, elixir-format
+msgid "%{month} %{day}, %{year}"
+msgstr "%{day}. %{month} %{year}"
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:49
+#, elixir-autogen, elixir-format
+msgid "%{month} %{day}, %{year} at %{time}"
+msgstr "%{day}. %{month} %{year} kell %{time}"
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:50
+#, elixir-autogen, elixir-format
+msgid "%{month} %{day} %{time}"
+msgstr "%{day}. %{month} %{time}"
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:53
+#, elixir-autogen, elixir-format
+msgid "Title"
+msgstr "Pealkiri"
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:43
+#, elixir-autogen, elixir-format
+msgid "Replying to comment"
+msgstr "Vastad kommentaarile"
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:45
+#, elixir-autogen, elixir-format
+msgid "Write a comment..."
+msgstr "Kirjuta kommentaar…"
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:46
+#, elixir-autogen, elixir-format
+msgid "GIF"
+msgstr "GIF"
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:47
+#, elixir-autogen, elixir-format
+msgid "Remove GIF"
+msgstr "Eemalda GIF"
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:48
+#, elixir-autogen, elixir-format
+msgid "Remove %{name}"
+msgstr "Eemalda %{name}"
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:49
+#, elixir-autogen, elixir-format
+msgid "Stop recording"
+msgstr "Lõpeta salvestus"
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:50
+#, elixir-autogen, elixir-format
+msgid "Attach media"
+msgstr "Lisa meedia"
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:51
+#, elixir-autogen, elixir-format
+msgid "Attach media options"
+msgstr "Meedia lisamise valikud"
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:53
+#, elixir-autogen, elixir-format
+msgid "Record"
+msgstr "Salvesta"
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:54
+#, elixir-autogen, elixir-format
+msgid "Up to %{count} files, max %{size}MB each"
+msgstr "Kuni %{count} faili, igaüks max %{size} MB"
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:55
+#, elixir-autogen, elixir-format
+msgid "Giphy picker"
+msgstr "Giphy valija"
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:56
+#, elixir-autogen, elixir-format
+msgid "Search GIFs"
+msgstr "Otsi GIFe"
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:57
+#, elixir-autogen, elixir-format
+msgid "Search GIFs..."
+msgstr "Otsi GIFe…"
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:58
+#, elixir-autogen, elixir-format
+msgid "GIF results"
+msgstr "GIF tulemused"
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:59
+#, elixir-autogen, elixir-format
+msgid "Select GIF %{id}"
+msgstr "Vali GIF %{id}"
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:60
+#, elixir-autogen, elixir-format
+msgid "Type a search term to find GIFs."
+msgstr "Sisesta otsisõna GIFide leidmiseks."
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:61
+#, elixir-autogen, elixir-format
+msgid "No results."
+msgstr "Tulemusi pole."
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:62
+#, elixir-autogen, elixir-format
+msgid "Post Comment"
+msgstr "Postita kommentaar"
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:63
+#, elixir-autogen, elixir-format
+msgid "Sign in to post a comment."
+msgstr "Logi sisse kommentaari postitamiseks."
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:64
+#, elixir-autogen, elixir-format
+msgid "No comments yet. Be the first to comment!"
+msgstr "Kommentaare pole veel. Ole esimene!"
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:66
+#, elixir-autogen, elixir-format
+msgid "[removed]"
+msgstr "[eemaldatud]"
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:68
+#, elixir-autogen, elixir-format
+msgid "Reply"
+msgstr "Vasta"
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:69
+#, elixir-autogen, elixir-format
+msgid "Are you sure you want to delete this comment?"
+msgstr "Kas oled kindel, et soovid selle kommentaari kustutada?"

--- a/priv/gettext/fr/LC_MESSAGES/default.po
+++ b/priv/gettext/fr/LC_MESSAGES/default.po
@@ -7229,3 +7229,198 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Dimensions"
 msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:35
+#, elixir-autogen, elixir-format
+msgid "Jan"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:36
+#, elixir-autogen, elixir-format
+msgid "Feb"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:37
+#, elixir-autogen, elixir-format
+msgid "Mar"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:38
+#, elixir-autogen, elixir-format
+msgid "Apr"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:39
+#, elixir-autogen, elixir-format
+msgid "May"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:40
+#, elixir-autogen, elixir-format
+msgid "Jun"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:41
+#, elixir-autogen, elixir-format
+msgid "Jul"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:42
+#, elixir-autogen, elixir-format
+msgid "Aug"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:43
+#, elixir-autogen, elixir-format
+msgid "Sep"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:44
+#, elixir-autogen, elixir-format
+msgid "Oct"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:45
+#, elixir-autogen, elixir-format
+msgid "Nov"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:46
+#, elixir-autogen, elixir-format
+msgid "Dec"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:48
+#, elixir-autogen, elixir-format
+msgid "%{month} %{day}, %{year}"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:49
+#, elixir-autogen, elixir-format
+msgid "%{month} %{day}, %{year} at %{time}"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:50
+#, elixir-autogen, elixir-format
+msgid "%{month} %{day} %{time}"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:53
+#, elixir-autogen, elixir-format
+msgid "Title"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:43
+#, elixir-autogen, elixir-format
+msgid "Replying to comment"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:45
+#, elixir-autogen, elixir-format
+msgid "Write a comment..."
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:46
+#, elixir-autogen, elixir-format
+msgid "GIF"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:47
+#, elixir-autogen, elixir-format
+msgid "Remove GIF"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:48
+#, elixir-autogen, elixir-format
+msgid "Remove %{name}"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:49
+#, elixir-autogen, elixir-format
+msgid "Stop recording"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:50
+#, elixir-autogen, elixir-format
+msgid "Attach media"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:51
+#, elixir-autogen, elixir-format
+msgid "Attach media options"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:53
+#, elixir-autogen, elixir-format
+msgid "Record"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:54
+#, elixir-autogen, elixir-format
+msgid "Up to %{count} files, max %{size}MB each"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:55
+#, elixir-autogen, elixir-format
+msgid "Giphy picker"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:56
+#, elixir-autogen, elixir-format
+msgid "Search GIFs"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:57
+#, elixir-autogen, elixir-format
+msgid "Search GIFs..."
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:58
+#, elixir-autogen, elixir-format
+msgid "GIF results"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:59
+#, elixir-autogen, elixir-format
+msgid "Select GIF %{id}"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:60
+#, elixir-autogen, elixir-format
+msgid "Type a search term to find GIFs."
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:61
+#, elixir-autogen, elixir-format
+msgid "No results."
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:62
+#, elixir-autogen, elixir-format
+msgid "Post Comment"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:63
+#, elixir-autogen, elixir-format
+msgid "Sign in to post a comment."
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:64
+#, elixir-autogen, elixir-format
+msgid "No comments yet. Be the first to comment!"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:66
+#, elixir-autogen, elixir-format
+msgid "[removed]"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:68
+#, elixir-autogen, elixir-format
+msgid "Reply"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:69
+#, elixir-autogen, elixir-format
+msgid "Are you sure you want to delete this comment?"
+msgstr ""

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -7229,3 +7229,198 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Dimensions"
 msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:35
+#, elixir-autogen, elixir-format
+msgid "Jan"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:36
+#, elixir-autogen, elixir-format
+msgid "Feb"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:37
+#, elixir-autogen, elixir-format
+msgid "Mar"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:38
+#, elixir-autogen, elixir-format
+msgid "Apr"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:39
+#, elixir-autogen, elixir-format
+msgid "May"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:40
+#, elixir-autogen, elixir-format
+msgid "Jun"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:41
+#, elixir-autogen, elixir-format
+msgid "Jul"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:42
+#, elixir-autogen, elixir-format
+msgid "Aug"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:43
+#, elixir-autogen, elixir-format
+msgid "Sep"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:44
+#, elixir-autogen, elixir-format
+msgid "Oct"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:45
+#, elixir-autogen, elixir-format
+msgid "Nov"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:46
+#, elixir-autogen, elixir-format
+msgid "Dec"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:48
+#, elixir-autogen, elixir-format
+msgid "%{month} %{day}, %{year}"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:49
+#, elixir-autogen, elixir-format
+msgid "%{month} %{day}, %{year} at %{time}"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:50
+#, elixir-autogen, elixir-format
+msgid "%{month} %{day} %{time}"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:53
+#, elixir-autogen, elixir-format
+msgid "Title"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:43
+#, elixir-autogen, elixir-format
+msgid "Replying to comment"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:45
+#, elixir-autogen, elixir-format
+msgid "Write a comment..."
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:46
+#, elixir-autogen, elixir-format
+msgid "GIF"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:47
+#, elixir-autogen, elixir-format
+msgid "Remove GIF"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:48
+#, elixir-autogen, elixir-format
+msgid "Remove %{name}"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:49
+#, elixir-autogen, elixir-format
+msgid "Stop recording"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:50
+#, elixir-autogen, elixir-format
+msgid "Attach media"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:51
+#, elixir-autogen, elixir-format
+msgid "Attach media options"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:53
+#, elixir-autogen, elixir-format
+msgid "Record"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:54
+#, elixir-autogen, elixir-format
+msgid "Up to %{count} files, max %{size}MB each"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:55
+#, elixir-autogen, elixir-format
+msgid "Giphy picker"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:56
+#, elixir-autogen, elixir-format
+msgid "Search GIFs"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:57
+#, elixir-autogen, elixir-format
+msgid "Search GIFs..."
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:58
+#, elixir-autogen, elixir-format
+msgid "GIF results"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:59
+#, elixir-autogen, elixir-format
+msgid "Select GIF %{id}"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:60
+#, elixir-autogen, elixir-format
+msgid "Type a search term to find GIFs."
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:61
+#, elixir-autogen, elixir-format
+msgid "No results."
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:62
+#, elixir-autogen, elixir-format
+msgid "Post Comment"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:63
+#, elixir-autogen, elixir-format
+msgid "Sign in to post a comment."
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:64
+#, elixir-autogen, elixir-format
+msgid "No comments yet. Be the first to comment!"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:66
+#, elixir-autogen, elixir-format
+msgid "[removed]"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:68
+#, elixir-autogen, elixir-format
+msgid "Reply"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:69
+#, elixir-autogen, elixir-format
+msgid "Are you sure you want to delete this comment?"
+msgstr ""

--- a/priv/gettext/pl/LC_MESSAGES/default.po
+++ b/priv/gettext/pl/LC_MESSAGES/default.po
@@ -7248,3 +7248,198 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Dimensions"
 msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:35
+#, elixir-autogen, elixir-format
+msgid "Jan"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:36
+#, elixir-autogen, elixir-format
+msgid "Feb"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:37
+#, elixir-autogen, elixir-format
+msgid "Mar"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:38
+#, elixir-autogen, elixir-format
+msgid "Apr"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:39
+#, elixir-autogen, elixir-format
+msgid "May"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:40
+#, elixir-autogen, elixir-format
+msgid "Jun"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:41
+#, elixir-autogen, elixir-format
+msgid "Jul"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:42
+#, elixir-autogen, elixir-format
+msgid "Aug"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:43
+#, elixir-autogen, elixir-format
+msgid "Sep"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:44
+#, elixir-autogen, elixir-format
+msgid "Oct"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:45
+#, elixir-autogen, elixir-format
+msgid "Nov"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:46
+#, elixir-autogen, elixir-format
+msgid "Dec"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:48
+#, elixir-autogen, elixir-format
+msgid "%{month} %{day}, %{year}"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:49
+#, elixir-autogen, elixir-format
+msgid "%{month} %{day}, %{year} at %{time}"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:50
+#, elixir-autogen, elixir-format
+msgid "%{month} %{day} %{time}"
+msgstr ""
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:53
+#, elixir-autogen, elixir-format
+msgid "Title"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:43
+#, elixir-autogen, elixir-format
+msgid "Replying to comment"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:45
+#, elixir-autogen, elixir-format
+msgid "Write a comment..."
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:46
+#, elixir-autogen, elixir-format
+msgid "GIF"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:47
+#, elixir-autogen, elixir-format
+msgid "Remove GIF"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:48
+#, elixir-autogen, elixir-format
+msgid "Remove %{name}"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:49
+#, elixir-autogen, elixir-format
+msgid "Stop recording"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:50
+#, elixir-autogen, elixir-format
+msgid "Attach media"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:51
+#, elixir-autogen, elixir-format
+msgid "Attach media options"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:53
+#, elixir-autogen, elixir-format
+msgid "Record"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:54
+#, elixir-autogen, elixir-format
+msgid "Up to %{count} files, max %{size}MB each"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:55
+#, elixir-autogen, elixir-format
+msgid "Giphy picker"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:56
+#, elixir-autogen, elixir-format
+msgid "Search GIFs"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:57
+#, elixir-autogen, elixir-format
+msgid "Search GIFs..."
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:58
+#, elixir-autogen, elixir-format
+msgid "GIF results"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:59
+#, elixir-autogen, elixir-format
+msgid "Select GIF %{id}"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:60
+#, elixir-autogen, elixir-format
+msgid "Type a search term to find GIFs."
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:61
+#, elixir-autogen, elixir-format
+msgid "No results."
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:62
+#, elixir-autogen, elixir-format
+msgid "Post Comment"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:63
+#, elixir-autogen, elixir-format
+msgid "Sign in to post a comment."
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:64
+#, elixir-autogen, elixir-format
+msgid "No comments yet. Be the first to comment!"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:66
+#, elixir-autogen, elixir-format
+msgid "[removed]"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:68
+#, elixir-autogen, elixir-format
+msgid "Reply"
+msgstr ""
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:69
+#, elixir-autogen, elixir-format
+msgid "Are you sure you want to delete this comment?"
+msgstr ""

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -7257,3 +7257,198 @@ msgstr "Авторизация"
 #, elixir-autogen, elixir-format
 msgid "Dimensions"
 msgstr "Размеры"
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:35
+#, elixir-autogen, elixir-format
+msgid "Jan"
+msgstr "Янв"
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:36
+#, elixir-autogen, elixir-format
+msgid "Feb"
+msgstr "Февр"
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:37
+#, elixir-autogen, elixir-format
+msgid "Mar"
+msgstr "Март"
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:38
+#, elixir-autogen, elixir-format
+msgid "Apr"
+msgstr "Апр"
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:39
+#, elixir-autogen, elixir-format
+msgid "May"
+msgstr "Май"
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:40
+#, elixir-autogen, elixir-format
+msgid "Jun"
+msgstr "Июнь"
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:41
+#, elixir-autogen, elixir-format
+msgid "Jul"
+msgstr "Июль"
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:42
+#, elixir-autogen, elixir-format
+msgid "Aug"
+msgstr "Авг"
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:43
+#, elixir-autogen, elixir-format
+msgid "Sep"
+msgstr "Сент"
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:44
+#, elixir-autogen, elixir-format
+msgid "Oct"
+msgstr "Окт"
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:45
+#, elixir-autogen, elixir-format
+msgid "Nov"
+msgstr "Нояб"
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:46
+#, elixir-autogen, elixir-format
+msgid "Dec"
+msgstr "Дек"
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:48
+#, elixir-autogen, elixir-format
+msgid "%{month} %{day}, %{year}"
+msgstr "%{day} %{month} %{year}"
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:49
+#, elixir-autogen, elixir-format
+msgid "%{month} %{day}, %{year} at %{time}"
+msgstr "%{day} %{month} %{year} в %{time}"
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:50
+#, elixir-autogen, elixir-format
+msgid "%{month} %{day} %{time}"
+msgstr "%{day} %{month} %{time}"
+
+#: lib/phoenix_kit_web/projects_gettext_manifest.ex:53
+#, elixir-autogen, elixir-format
+msgid "Title"
+msgstr "Название"
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:43
+#, elixir-autogen, elixir-format
+msgid "Replying to comment"
+msgstr "Ответ на комментарий"
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:45
+#, elixir-autogen, elixir-format
+msgid "Write a comment..."
+msgstr "Напишите комментарий…"
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:46
+#, elixir-autogen, elixir-format
+msgid "GIF"
+msgstr "GIF"
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:47
+#, elixir-autogen, elixir-format
+msgid "Remove GIF"
+msgstr "Удалить GIF"
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:48
+#, elixir-autogen, elixir-format
+msgid "Remove %{name}"
+msgstr "Удалить %{name}"
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:49
+#, elixir-autogen, elixir-format
+msgid "Stop recording"
+msgstr "Остановить запись"
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:50
+#, elixir-autogen, elixir-format
+msgid "Attach media"
+msgstr "Прикрепить медиа"
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:51
+#, elixir-autogen, elixir-format
+msgid "Attach media options"
+msgstr "Параметры прикрепления"
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:53
+#, elixir-autogen, elixir-format
+msgid "Record"
+msgstr "Записать"
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:54
+#, elixir-autogen, elixir-format
+msgid "Up to %{count} files, max %{size}MB each"
+msgstr "До %{count} файлов, каждый до %{size} МБ"
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:55
+#, elixir-autogen, elixir-format
+msgid "Giphy picker"
+msgstr "Выбор Giphy"
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:56
+#, elixir-autogen, elixir-format
+msgid "Search GIFs"
+msgstr "Поиск GIF"
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:57
+#, elixir-autogen, elixir-format
+msgid "Search GIFs..."
+msgstr "Поиск GIF…"
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:58
+#, elixir-autogen, elixir-format
+msgid "GIF results"
+msgstr "Результаты GIF"
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:59
+#, elixir-autogen, elixir-format
+msgid "Select GIF %{id}"
+msgstr "Выбрать GIF %{id}"
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:60
+#, elixir-autogen, elixir-format
+msgid "Type a search term to find GIFs."
+msgstr "Введите запрос для поиска GIF."
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:61
+#, elixir-autogen, elixir-format
+msgid "No results."
+msgstr "Результатов нет."
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:62
+#, elixir-autogen, elixir-format
+msgid "Post Comment"
+msgstr "Опубликовать"
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:63
+#, elixir-autogen, elixir-format
+msgid "Sign in to post a comment."
+msgstr "Войдите, чтобы оставить комментарий."
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:64
+#, elixir-autogen, elixir-format
+msgid "No comments yet. Be the first to comment!"
+msgstr "Комментариев пока нет. Будьте первым!"
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:66
+#, elixir-autogen, elixir-format
+msgid "[removed]"
+msgstr "[удалено]"
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:68
+#, elixir-autogen, elixir-format
+msgid "Reply"
+msgstr "Ответить"
+
+#: lib/phoenix_kit_web/comments_gettext_manifest.ex:69
+#, elixir-autogen, elixir-format
+msgid "Are you sure you want to delete this comment?"
+msgstr "Точно удалить этот комментарий?"


### PR DESCRIPTION
## Summary

Companion to \`BeamLabEU/phoenix_kit_projects#7\`. Three concerns in three commits:

1. **\`projects_gettext_manifest.ex\` + \`comments_gettext_manifest.ex\`** — mirror the \`legal_gettext_manifest\` pattern so \`mix gettext.extract\` records the strings called from \`phoenix_kit_projects\` and \`phoenix_kit_comments\` via the shared \`PhoenixKitWeb.Gettext\` backend. 16 + 27 = 43 new msgids; \`et\` and \`ru\` translations filled. Other locales stay as empty msgstrs to match the existing coverage pattern.

2. **\`auth.ex\` global locale sync** — every \`Gettext.put_locale(PhoenixKitWeb.Gettext, dialect)\` site (6 in total — 3 in the LV on_mount path, 3 in the Plug pipeline) now also calls \`Gettext.put_locale(dialect)\` so module backends like \`PhoenixKitProjects.Gettext\` pick up the locale automatically. Otherwise the two surfaces drift on locale switch — core's strings translate but a module's stay English.

3. **Avatar dropdown UX (\`admin_nav.ex\` + \`user_dashboard_nav.ex\`)** — with 41 locales enabled the menu was spilling off the viewport. Now:
   - Outer \`<ul>\` capped at \`max-h-[calc(100vh-5rem)] overflow-y-auto\`.
   - Language list moves into a single wrapper \`<li class='p-0'>\` containing a \`<div class='max-h-60 overflow-y-auto overflow-x-hidden'>\` with buttons rendered directly (no nested daisyUI \`<ul class='menu'>\`) so the parent menu's submenu-indent / li-child-padding rules don't force horizontal scroll or weird left indent. ~5 visible rows, rest scroll independently.
   - \`!bg-transparent\` + \`!text-base-content\` (and \`!text-primary-content\` on the active button) with hover/focus/active variants override the daisyUI menu rules that would otherwise paint the whole language area dark (\`var(--color-base-content)\`) on hover and flip text color to primary on click. The \`all languages get colored\` and \`text goes white\` bugs Max reported.
   - Click feedback: \`active:!bg-base-300\` for instant mousedown darken + \`phx-click-loading:opacity-60\` so the clicked button dims during the locale-switch request.

## Test plan

- [ ] Compile + Credo + Dialyzer clean.
- [ ] Browser smoke at \`/phoenix_kit/et/admin\` and \`/phoenix_kit/ru/admin\` — verify the avatar dropdown opens, language list scrolls independently with ~5 items visible, clicked language dims briefly while the locale switches, current locale highlighted with primary background + primary-content text.
- [ ] After locale switch, both core's UI strings and \`phoenix_kit_projects\` strings render in the chosen locale (proves the global \`put_locale\` is reaching module backends).
- [ ] Run \`mix gettext.extract --merge --no-fuzzy\` from core and confirm no drift in \`priv/gettext/default.pot\`.