### PR TITLE
V120: Document Creator Category → Type taxonomy migration

### DIFF
--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -529,7 +529,14 @@ defmodule PhoenixKit.Migrations.Postgres do
   - Replaces unique index with partial index (slug-mode only, WHERE slug IS NOT NULL)
   - Adds unique index on `(group_uuid, post_date, post_time)` for timestamp-mode posts
 
-  ### V119 - Trash support for storage folders ⚡ LATEST
+  ### V120 - Document Creator Category → Type taxonomy ⚡ LATEST
+  #
+  # Creates phoenix_kit_doc_categories + phoenix_kit_doc_types, adds
+  # nullable category_uuid/type_uuid FKs to doc templates + documents,
+  # migrates legacy category strings into Category rows, drops the
+  # legacy category string columns.
+
+  ### V119 - Trash support for storage folders
   - Adds `trashed_at TIMESTAMPTZ` to `phoenix_kit_media_folders`,
     mirroring the V99 column on `phoenix_kit_files`. Folders with a
     non-nil `trashed_at` are in the trash bucket and can be restored
@@ -1007,7 +1014,7 @@ defmodule PhoenixKit.Migrations.Postgres do
   use Ecto.Migration
 
   @initial_version 1
-  @current_version 119
+  @current_version 120
   @default_prefix "public"
 
   @doc false

--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -530,11 +530,10 @@ defmodule PhoenixKit.Migrations.Postgres do
   - Adds unique index on `(group_uuid, post_date, post_time)` for timestamp-mode posts
 
   ### V120 - Document Creator Category → Type taxonomy ⚡ LATEST
-  #
-  # Creates phoenix_kit_doc_categories + phoenix_kit_doc_types, adds
-  # nullable category_uuid/type_uuid FKs to doc templates + documents,
-  # migrates legacy category strings into Category rows, drops the
-  # legacy category string columns.
+  - Creates `phoenix_kit_doc_categories` and `phoenix_kit_doc_types` tables.
+  - Adds nullable `category_uuid` / `type_uuid` FK columns to doc templates and documents.
+  - Migrates legacy category strings from templates into `phoenix_kit_doc_categories` rows.
+  - Drops the legacy `category` string columns from templates and presets.
 
   ### V119 - Trash support for storage folders
   - Adds `trashed_at TIMESTAMPTZ` to `phoenix_kit_media_folders`,

--- a/lib/phoenix_kit/migrations/postgres/v120.ex
+++ b/lib/phoenix_kit/migrations/postgres/v120.ex
@@ -21,12 +21,13 @@ defmodule PhoenixKit.Migrations.Postgres.V120 do
   def up(opts) do
     prefix = Map.get(opts, :prefix, "public")
     p = prefix_str(prefix)
+    schema = if prefix == "public", do: "public", else: prefix
 
     create_if_not_exists table(:phoenix_kit_doc_categories,
                            primary_key: false,
                            prefix: prefix
                          ) do
-      add(:uuid, :uuid, primary_key: true)
+      add(:uuid, :uuid, primary_key: true, default: fragment("uuid_generate_v7()"))
       add(:name, :string, null: false)
       add(:description, :text)
       add(:position, :integer, null: false, default: 0)
@@ -43,7 +44,7 @@ defmodule PhoenixKit.Migrations.Postgres.V120 do
                            primary_key: false,
                            prefix: prefix
                          ) do
-      add(:uuid, :uuid, primary_key: true)
+      add(:uuid, :uuid, primary_key: true, default: fragment("uuid_generate_v7()"))
       add(:name, :string, null: false)
       add(:description, :text)
       add(:position, :integer, null: false, default: 0)
@@ -78,7 +79,8 @@ defmodule PhoenixKit.Migrations.Postgres.V120 do
       DO $$ BEGIN
         IF NOT EXISTS (
           SELECT FROM information_schema.columns
-          WHERE table_name = '#{table}' AND column_name = 'category_uuid'
+          WHERE table_schema = '#{schema}'
+            AND table_name = '#{table}' AND column_name = 'category_uuid'
         ) THEN
           ALTER TABLE #{p}#{table}
             ADD COLUMN category_uuid uuid
@@ -86,7 +88,8 @@ defmodule PhoenixKit.Migrations.Postgres.V120 do
         END IF;
         IF NOT EXISTS (
           SELECT FROM information_schema.columns
-          WHERE table_name = '#{table}' AND column_name = 'type_uuid'
+          WHERE table_schema = '#{schema}'
+            AND table_name = '#{table}' AND column_name = 'type_uuid'
         ) THEN
           ALTER TABLE #{p}#{table}
             ADD COLUMN type_uuid uuid
@@ -112,10 +115,12 @@ defmodule PhoenixKit.Migrations.Postgres.V120 do
       legacy text;
       new_uuid uuid;
       pos int := 0;
+      display_name text;
     BEGIN
       IF EXISTS (
         SELECT FROM information_schema.columns
-        WHERE table_name = 'phoenix_kit_doc_templates'
+        WHERE table_schema = '#{schema}'
+          AND table_name = 'phoenix_kit_doc_templates'
           AND column_name = 'category'
       ) THEN
         FOR legacy IN
@@ -123,11 +128,17 @@ defmodule PhoenixKit.Migrations.Postgres.V120 do
           WHERE category IS NOT NULL AND category <> ''
           ORDER BY category
         LOOP
+          -- Map known values explicitly; capitalize first letter for anything else.
+          display_name := CASE lower(legacy)
+            WHEN 'financial' THEN 'Financial'
+            WHEN 'technical' THEN 'Technical'
+            ELSE upper(substr(legacy, 1, 1)) || substr(legacy, 2)
+          END;
           new_uuid := uuid_generate_v7();
           INSERT INTO #{p}phoenix_kit_doc_categories
             (uuid, name, position, status, data, inserted_at, updated_at)
           VALUES
-            (new_uuid, initcap(legacy), pos, 'active', '{}'::jsonb, now(), now());
+            (new_uuid, display_name, pos, 'active', '{}'::jsonb, now(), now());
           UPDATE #{p}phoenix_kit_doc_templates
             SET category_uuid = new_uuid WHERE category = legacy;
           pos := pos + 1;
@@ -150,7 +161,8 @@ defmodule PhoenixKit.Migrations.Postgres.V120 do
     DO $$ BEGIN
       IF EXISTS (
         SELECT FROM information_schema.columns
-        WHERE table_name = 'phoenix_kit_doc_template_presets'
+        WHERE table_schema = '#{schema}'
+          AND table_name = 'phoenix_kit_doc_template_presets'
           AND column_name = 'category'
       ) THEN
         ALTER TABLE #{p}phoenix_kit_doc_template_presets DROP COLUMN category;
@@ -164,13 +176,14 @@ defmodule PhoenixKit.Migrations.Postgres.V120 do
   def down(opts) do
     prefix = Map.get(opts, :prefix, "public")
     p = prefix_str(prefix)
+    schema = if prefix == "public", do: "public", else: prefix
 
     execute(
-      "ALTER TABLE #{p}phoenix_kit_doc_templates ADD COLUMN IF NOT EXISTS category varchar(255)"
+      "ALTER TABLE #{p}phoenix_kit_doc_templates ADD COLUMN IF NOT EXISTS category varchar"
     )
 
     execute(
-      "ALTER TABLE #{p}phoenix_kit_doc_template_presets ADD COLUMN IF NOT EXISTS category varchar(255)"
+      "ALTER TABLE #{p}phoenix_kit_doc_template_presets ADD COLUMN IF NOT EXISTS category varchar"
     )
 
     # Best-effort restore of the legacy string from the category name.
@@ -178,7 +191,8 @@ defmodule PhoenixKit.Migrations.Postgres.V120 do
     DO $$ BEGIN
       IF EXISTS (
         SELECT FROM information_schema.columns
-        WHERE table_name = 'phoenix_kit_doc_categories'
+        WHERE table_schema = '#{schema}'
+          AND table_name = 'phoenix_kit_doc_categories'
       ) THEN
         UPDATE #{p}phoenix_kit_doc_templates t
           SET category = lower(c.name)

--- a/lib/phoenix_kit/migrations/postgres/v120.ex
+++ b/lib/phoenix_kit/migrations/postgres/v120.ex
@@ -35,13 +35,9 @@ defmodule PhoenixKit.Migrations.Postgres.V120 do
       timestamps(type: :utc_datetime)
     end
 
-    create_if_not_exists(
-      index(:phoenix_kit_doc_categories, [:status], prefix: prefix)
-    )
+    create_if_not_exists(index(:phoenix_kit_doc_categories, [:status], prefix: prefix))
 
-    create_if_not_exists(
-      index(:phoenix_kit_doc_categories, [:position], prefix: prefix)
-    )
+    create_if_not_exists(index(:phoenix_kit_doc_categories, [:position], prefix: prefix))
 
     create_if_not_exists table(:phoenix_kit_doc_types,
                            primary_key: false,
@@ -68,17 +64,13 @@ defmodule PhoenixKit.Migrations.Postgres.V120 do
       timestamps(type: :utc_datetime)
     end
 
-    create_if_not_exists(
-      index(:phoenix_kit_doc_types, [:category_uuid], prefix: prefix)
-    )
+    create_if_not_exists(index(:phoenix_kit_doc_types, [:category_uuid], prefix: prefix))
 
     create_if_not_exists(
       index(:phoenix_kit_doc_types, [:category_uuid, :position], prefix: prefix)
     )
 
-    create_if_not_exists(
-      index(:phoenix_kit_doc_types, [:status], prefix: prefix)
-    )
+    create_if_not_exists(index(:phoenix_kit_doc_types, [:status], prefix: prefix))
 
     # FK columns on templates and documents.
     for table <- ["phoenix_kit_doc_templates", "phoenix_kit_doc_documents"] do
@@ -104,21 +96,13 @@ defmodule PhoenixKit.Migrations.Postgres.V120 do
       """)
     end
 
-    create_if_not_exists(
-      index(:phoenix_kit_doc_templates, [:category_uuid], prefix: prefix)
-    )
+    create_if_not_exists(index(:phoenix_kit_doc_templates, [:category_uuid], prefix: prefix))
 
-    create_if_not_exists(
-      index(:phoenix_kit_doc_templates, [:type_uuid], prefix: prefix)
-    )
+    create_if_not_exists(index(:phoenix_kit_doc_templates, [:type_uuid], prefix: prefix))
 
-    create_if_not_exists(
-      index(:phoenix_kit_doc_documents, [:category_uuid], prefix: prefix)
-    )
+    create_if_not_exists(index(:phoenix_kit_doc_documents, [:category_uuid], prefix: prefix))
 
-    create_if_not_exists(
-      index(:phoenix_kit_doc_documents, [:type_uuid], prefix: prefix)
-    )
+    create_if_not_exists(index(:phoenix_kit_doc_documents, [:type_uuid], prefix: prefix))
 
     # Data migration: legacy category strings -> Category rows.
     # Only runs if the legacy column still exists.
@@ -160,9 +144,7 @@ defmodule PhoenixKit.Migrations.Postgres.V120 do
     """)
 
     # Drop legacy string columns.
-    execute(
-      "ALTER TABLE #{p}phoenix_kit_doc_templates DROP COLUMN IF EXISTS category"
-    )
+    execute("ALTER TABLE #{p}phoenix_kit_doc_templates DROP COLUMN IF EXISTS category")
 
     execute("""
     DO $$ BEGIN
@@ -206,21 +188,13 @@ defmodule PhoenixKit.Migrations.Postgres.V120 do
     END $$
     """)
 
-    execute(
-      "ALTER TABLE #{p}phoenix_kit_doc_templates DROP COLUMN IF EXISTS type_uuid"
-    )
+    execute("ALTER TABLE #{p}phoenix_kit_doc_templates DROP COLUMN IF EXISTS type_uuid")
 
-    execute(
-      "ALTER TABLE #{p}phoenix_kit_doc_templates DROP COLUMN IF EXISTS category_uuid"
-    )
+    execute("ALTER TABLE #{p}phoenix_kit_doc_templates DROP COLUMN IF EXISTS category_uuid")
 
-    execute(
-      "ALTER TABLE #{p}phoenix_kit_doc_documents DROP COLUMN IF EXISTS type_uuid"
-    )
+    execute("ALTER TABLE #{p}phoenix_kit_doc_documents DROP COLUMN IF EXISTS type_uuid")
 
-    execute(
-      "ALTER TABLE #{p}phoenix_kit_doc_documents DROP COLUMN IF EXISTS category_uuid"
-    )
+    execute("ALTER TABLE #{p}phoenix_kit_doc_documents DROP COLUMN IF EXISTS category_uuid")
 
     drop_if_exists(table(:phoenix_kit_doc_types, prefix: prefix))
     drop_if_exists(table(:phoenix_kit_doc_categories, prefix: prefix))

--- a/lib/phoenix_kit/migrations/postgres/v120.ex
+++ b/lib/phoenix_kit/migrations/postgres/v120.ex
@@ -1,0 +1,233 @@
+defmodule PhoenixKit.Migrations.Postgres.V120 do
+  @moduledoc """
+  V120: Document Creator Category → Type taxonomy.
+
+  Creates two tables — `phoenix_kit_doc_categories` and
+  `phoenix_kit_doc_types` — and adds nullable `category_uuid` /
+  `type_uuid` FK columns to `phoenix_kit_doc_templates` and
+  `phoenix_kit_doc_documents`.
+
+  Data migration: each distinct non-empty legacy `category` string on
+  templates becomes a Category row; templates are repointed via
+  `category_uuid`; documents inherit their template's category.
+  The legacy `category` string columns on templates and presets are
+  then dropped. `type_uuid` stays NULL everywhere (no Types yet).
+
+  All operations are idempotent.
+  """
+
+  use Ecto.Migration
+
+  def up(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    create_if_not_exists table(:phoenix_kit_doc_categories,
+                           primary_key: false,
+                           prefix: prefix
+                         ) do
+      add(:uuid, :uuid, primary_key: true)
+      add(:name, :string, null: false)
+      add(:description, :text)
+      add(:position, :integer, null: false, default: 0)
+      add(:status, :string, null: false, default: "active")
+      add(:data, :map, null: false, default: %{})
+      timestamps(type: :utc_datetime)
+    end
+
+    create_if_not_exists(
+      index(:phoenix_kit_doc_categories, [:status], prefix: prefix)
+    )
+
+    create_if_not_exists(
+      index(:phoenix_kit_doc_categories, [:position], prefix: prefix)
+    )
+
+    create_if_not_exists table(:phoenix_kit_doc_types,
+                           primary_key: false,
+                           prefix: prefix
+                         ) do
+      add(:uuid, :uuid, primary_key: true)
+      add(:name, :string, null: false)
+      add(:description, :text)
+      add(:position, :integer, null: false, default: 0)
+      add(:status, :string, null: false, default: "active")
+      add(:data, :map, null: false, default: %{})
+
+      add(
+        :category_uuid,
+        references(:phoenix_kit_doc_categories,
+          column: :uuid,
+          type: :uuid,
+          on_delete: :delete_all,
+          prefix: prefix
+        ),
+        null: false
+      )
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create_if_not_exists(
+      index(:phoenix_kit_doc_types, [:category_uuid], prefix: prefix)
+    )
+
+    create_if_not_exists(
+      index(:phoenix_kit_doc_types, [:category_uuid, :position], prefix: prefix)
+    )
+
+    create_if_not_exists(
+      index(:phoenix_kit_doc_types, [:status], prefix: prefix)
+    )
+
+    # FK columns on templates and documents.
+    for table <- ["phoenix_kit_doc_templates", "phoenix_kit_doc_documents"] do
+      execute("""
+      DO $$ BEGIN
+        IF NOT EXISTS (
+          SELECT FROM information_schema.columns
+          WHERE table_name = '#{table}' AND column_name = 'category_uuid'
+        ) THEN
+          ALTER TABLE #{p}#{table}
+            ADD COLUMN category_uuid uuid
+            REFERENCES #{p}phoenix_kit_doc_categories(uuid) ON DELETE SET NULL;
+        END IF;
+        IF NOT EXISTS (
+          SELECT FROM information_schema.columns
+          WHERE table_name = '#{table}' AND column_name = 'type_uuid'
+        ) THEN
+          ALTER TABLE #{p}#{table}
+            ADD COLUMN type_uuid uuid
+            REFERENCES #{p}phoenix_kit_doc_types(uuid) ON DELETE SET NULL;
+        END IF;
+      END $$
+      """)
+    end
+
+    create_if_not_exists(
+      index(:phoenix_kit_doc_templates, [:category_uuid], prefix: prefix)
+    )
+
+    create_if_not_exists(
+      index(:phoenix_kit_doc_templates, [:type_uuid], prefix: prefix)
+    )
+
+    create_if_not_exists(
+      index(:phoenix_kit_doc_documents, [:category_uuid], prefix: prefix)
+    )
+
+    create_if_not_exists(
+      index(:phoenix_kit_doc_documents, [:type_uuid], prefix: prefix)
+    )
+
+    # Data migration: legacy category strings -> Category rows.
+    # Only runs if the legacy column still exists.
+    execute("""
+    DO $$
+    DECLARE
+      legacy text;
+      new_uuid uuid;
+      pos int := 0;
+    BEGIN
+      IF EXISTS (
+        SELECT FROM information_schema.columns
+        WHERE table_name = 'phoenix_kit_doc_templates'
+          AND column_name = 'category'
+      ) THEN
+        FOR legacy IN
+          SELECT DISTINCT category FROM #{p}phoenix_kit_doc_templates
+          WHERE category IS NOT NULL AND category <> ''
+          ORDER BY category
+        LOOP
+          new_uuid := gen_random_uuid();
+          INSERT INTO #{p}phoenix_kit_doc_categories
+            (uuid, name, position, status, data, inserted_at, updated_at)
+          VALUES
+            (new_uuid, initcap(legacy), pos, 'active', '{}'::jsonb, now(), now());
+          UPDATE #{p}phoenix_kit_doc_templates
+            SET category_uuid = new_uuid WHERE category = legacy;
+          pos := pos + 1;
+        END LOOP;
+
+        -- Documents inherit their template's category.
+        UPDATE #{p}phoenix_kit_doc_documents d
+          SET category_uuid = t.category_uuid
+          FROM #{p}phoenix_kit_doc_templates t
+          WHERE d.template_uuid = t.uuid
+            AND t.category_uuid IS NOT NULL;
+      END IF;
+    END $$
+    """)
+
+    # Drop legacy string columns.
+    execute(
+      "ALTER TABLE #{p}phoenix_kit_doc_templates DROP COLUMN IF EXISTS category"
+    )
+
+    execute("""
+    DO $$ BEGIN
+      IF EXISTS (
+        SELECT FROM information_schema.columns
+        WHERE table_name = 'phoenix_kit_doc_template_presets'
+          AND column_name = 'category'
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_doc_template_presets DROP COLUMN category;
+      END IF;
+    END $$
+    """)
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '120'")
+  end
+
+  def down(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    execute(
+      "ALTER TABLE #{p}phoenix_kit_doc_templates ADD COLUMN IF NOT EXISTS category varchar(255)"
+    )
+
+    execute(
+      "ALTER TABLE #{p}phoenix_kit_doc_template_presets ADD COLUMN IF NOT EXISTS category varchar(255)"
+    )
+
+    # Best-effort restore of the legacy string from the category name.
+    execute("""
+    DO $$ BEGIN
+      IF EXISTS (
+        SELECT FROM information_schema.columns
+        WHERE table_name = 'phoenix_kit_doc_categories'
+      ) THEN
+        UPDATE #{p}phoenix_kit_doc_templates t
+          SET category = lower(c.name)
+          FROM #{p}phoenix_kit_doc_categories c
+          WHERE t.category_uuid = c.uuid;
+      END IF;
+    END $$
+    """)
+
+    execute(
+      "ALTER TABLE #{p}phoenix_kit_doc_templates DROP COLUMN IF EXISTS type_uuid"
+    )
+
+    execute(
+      "ALTER TABLE #{p}phoenix_kit_doc_templates DROP COLUMN IF EXISTS category_uuid"
+    )
+
+    execute(
+      "ALTER TABLE #{p}phoenix_kit_doc_documents DROP COLUMN IF EXISTS type_uuid"
+    )
+
+    execute(
+      "ALTER TABLE #{p}phoenix_kit_doc_documents DROP COLUMN IF EXISTS category_uuid"
+    )
+
+    drop_if_exists(table(:phoenix_kit_doc_types, prefix: prefix))
+    drop_if_exists(table(:phoenix_kit_doc_categories, prefix: prefix))
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '119'")
+  end
+
+  defp prefix_str("public"), do: "public."
+  defp prefix_str(prefix), do: "#{prefix}."
+end

--- a/lib/phoenix_kit/migrations/postgres/v120.ex
+++ b/lib/phoenix_kit/migrations/postgres/v120.ex
@@ -123,7 +123,7 @@ defmodule PhoenixKit.Migrations.Postgres.V120 do
           WHERE category IS NOT NULL AND category <> ''
           ORDER BY category
         LOOP
-          new_uuid := gen_random_uuid();
+          new_uuid := uuid_generate_v7();
           INSERT INTO #{p}phoenix_kit_doc_categories
             (uuid, name, position, status, data, inserted_at, updated_at)
           VALUES


### PR DESCRIPTION
## V120 — Document Creator Category → Type taxonomy

Adds migration **V120**, the schema/DB foundation for the Document
Creator's Category → Type hierarchy (module-side work is a separate PR
on `phoenix_kit_document_creator`).

### What V120 does

- Creates `phoenix_kit_doc_categories` and `phoenix_kit_doc_types`
  tables (UUIDv7 PKs, `status` soft-delete, `position` ordering).
- Adds nullable `category_uuid` / `type_uuid` FK columns to
  `phoenix_kit_doc_templates` and `phoenix_kit_doc_documents`
  (`ON DELETE SET NULL`); `doc_types.category_uuid` is
  `ON DELETE CASCADE`.
- Data migration: each distinct legacy `template.category` string
  becomes a `Category` row; templates/documents are repointed via FK;
  the legacy `category` string columns on templates and presets are
  dropped.
- Bumps `@current_version` to 120; idempotent up/down.

### Notes

- Uses `uuid_generate_v7()` for data-migrated rows, per house
  convention (consistent with the schema's UUIDv7 autogenerate).
- No `CHANGELOG.md` / `@version` changes — maintainer-owned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
