### PR TITLE
Core: table_default sort_bar + DnD + bulk_actions_bar, Reorder/Values/Format utils, blank_to_nil sweep

### DIFF
--- a/lib/modules/shared/components/video.ex
+++ b/lib/modules/shared/components/video.ex
@@ -14,6 +14,8 @@ defmodule PhoenixKit.Modules.Shared.Components.Video do
   """
   use Phoenix.Component
 
+  alias PhoenixKit.Utils.Values
+
   @standard_youtube_hosts [
     "youtube.com",
     "www.youtube.com",
@@ -35,7 +37,7 @@ defmodule PhoenixKit.Modules.Shared.Components.Video do
     video_id =
       attrs
       |> Map.get("video_id")
-      |> presence() || extract_video_id(Map.get(attrs, "url"))
+      |> Values.presence() || extract_video_id(Map.get(attrs, "url"))
 
     assigns =
       assigns
@@ -135,15 +137,6 @@ defmodule PhoenixKit.Modules.Shared.Components.Video do
   end
 
   defp extract_video_id(_), do: nil
-
-  defp presence(nil), do: nil
-
-  defp presence(value) when is_binary(value) do
-    value = String.trim(value)
-    if value == "", do: nil, else: value
-  end
-
-  defp presence(_), do: nil
 
   defp truthy?(true), do: true
   defp truthy?(false), do: false

--- a/lib/phoenix_kit/utils/format.ex
+++ b/lib/phoenix_kit/utils/format.ex
@@ -1,0 +1,67 @@
+defmodule PhoenixKit.Utils.Format do
+  @moduledoc """
+  Workspace-shared formatting helpers for numeric / size values.
+  """
+
+  @doc """
+  Formats a byte count as a human-readable size string.
+
+  Accepts an integer, `Decimal`, or `nil`. Returns the `:unknown` option
+  string for `nil` (or any unrecognised input) and rounds to `:decimals`
+  decimal places for the chosen unit. The unit auto-scales to B / KB /
+  MB / GB based on the size.
+
+  ## Options
+
+  - `:decimals` — decimal places for KB/MB/GB output. Default `1`.
+  - `:unknown` — string returned for `nil` or unrecognised inputs.
+    Default `"Unknown"`. Pass `"0 B"` to mimic the file-picker shape.
+  - `:base` — `1024` (binary, default) or `1000` (decimal/SI). Some
+    media-browser surfaces use the decimal convention to match what
+    operating systems show; everything else defaults to the binary
+    convention common in dev tooling.
+
+  ## Examples
+
+      iex> PhoenixKit.Utils.Format.bytes(0)
+      "0 B"
+
+      iex> PhoenixKit.Utils.Format.bytes(1500)
+      "1.5 KB"
+
+      iex> PhoenixKit.Utils.Format.bytes(1_500_000, decimals: 2)
+      "1.43 MB"
+
+      iex> PhoenixKit.Utils.Format.bytes(1_500_000, base: 1000, decimals: 2)
+      "1.5 MB"
+
+      iex> PhoenixKit.Utils.Format.bytes(nil, unknown: "0 B")
+      "0 B"
+  """
+  @spec bytes(integer() | Decimal.t() | nil, keyword()) :: String.t()
+  def bytes(value, opts \\ [])
+
+  def bytes(nil, opts), do: Keyword.get(opts, :unknown, "Unknown")
+  def bytes(0, _opts), do: "0 B"
+
+  def bytes(%Decimal{} = d, opts) do
+    d |> Decimal.to_integer() |> bytes(opts)
+  end
+
+  def bytes(n, opts) when is_number(n) and n > 0 do
+    decimals = Keyword.get(opts, :decimals, 1)
+    {kb, mb, gb} = unit_thresholds(Keyword.get(opts, :base, 1024))
+
+    cond do
+      n >= gb -> "#{Float.round(n / gb, decimals)} GB"
+      n >= mb -> "#{Float.round(n / mb, decimals)} MB"
+      n >= kb -> "#{Float.round(n / kb, decimals)} KB"
+      true -> "#{n} B"
+    end
+  end
+
+  def bytes(_, opts), do: Keyword.get(opts, :unknown, "Unknown")
+
+  defp unit_thresholds(1000), do: {1_000, 1_000_000, 1_000_000_000}
+  defp unit_thresholds(_), do: {1024, 1_048_576, 1_073_741_824}
+end

--- a/lib/phoenix_kit/utils/reorder.ex
+++ b/lib/phoenix_kit/utils/reorder.ex
@@ -35,15 +35,18 @@ defmodule PhoenixKit.Utils.Reorder do
 
   @default_max_uuids 500
 
-  @type result :: :ok | {:error, :too_many_uuids}
+  @type result :: {:ok, non_neg_integer()} | {:error, :too_many_uuids}
 
   @doc """
   Rewrites `field` on the rows whose `uuid` appears in `ordered_ids`,
   setting it to each UUID's 1-based position in the list.
 
-  Returns `:ok` on success (including empty / fully-filtered payloads)
-  or `{:error, :too_many_uuids}` when the dedup'd payload exceeds the
-  configured cap.
+  Returns `{:ok, count}` where `count` is the number of rows actually
+  updated in the positive-write phase (matches `Repo.update_all`'s
+  count semantics — UUIDs in the payload that don't resolve to real
+  rows aren't counted). Returns `{:error, :too_many_uuids}` when the
+  dedup'd payload exceeds the configured cap. An empty / fully-filtered
+  payload returns `{:ok, 0}`.
 
   ## Options
 
@@ -60,26 +63,30 @@ defmodule PhoenixKit.Utils.Reorder do
 
     case dedupe_uuids(ordered_ids) do
       [] ->
-        :ok
+        {:ok, 0}
 
       uuids when length(uuids) > max ->
         {:error, :too_many_uuids}
 
       uuids ->
-        repo.transaction(fn ->
-          pairs = Enum.with_index(uuids, 1)
-          write_phase(repo, schema, pairs, field, -1)
-          write_phase(repo, schema, pairs, field, 1)
-        end)
+        {:ok, count} =
+          repo.transaction(fn ->
+            pairs = Enum.with_index(uuids, 1)
+            _ = write_phase(repo, schema, pairs, field, -1)
+            write_phase(repo, schema, pairs, field, 1)
+          end)
 
-        :ok
+        {:ok, count}
     end
   end
 
   defp write_phase(repo, schema, pairs, field, sign) do
-    Enum.each(pairs, fn {uuid, idx} ->
-      from(r in schema, where: r.uuid == ^uuid)
-      |> repo.update_all(set: [{field, sign * idx}])
+    Enum.reduce(pairs, 0, fn {uuid, idx}, total ->
+      {n, _} =
+        from(r in schema, where: r.uuid == ^uuid)
+        |> repo.update_all(set: [{field, sign * idx}])
+
+      total + n
     end)
   end
 

--- a/lib/phoenix_kit/utils/reorder.ex
+++ b/lib/phoenix_kit/utils/reorder.ex
@@ -1,0 +1,91 @@
+defmodule PhoenixKit.Utils.Reorder do
+  @moduledoc """
+  Two-phase index rewrite for drag-to-reorder list views.
+
+  Given a list of UUIDs in their new display order and an Ecto schema,
+  rewrites a position field on the matching rows to `1..N` matching
+  the order of the input list. The write runs in two passes inside a
+  transaction — first to negative indices, then to positive — so a
+  unique index on the position column (should one ever be added)
+  wouldn't trip mid-update.
+
+  Consumers that need pre-write validation (scope checks, permission
+  guards) or post-write side effects (activity logging, PubSub
+  broadcasts) should wrap this helper rather than fold the logic in
+  here. `PhoenixKitProjects.reorder_projects/2` is the reference
+  consumer doing exactly that — this module owns only the index-rewrite
+  primitive.
+
+  Non-UUID entries in the payload are silently filtered (a stale or
+  malformed drop event can't poison the rewrite). Duplicates dedup
+  last-write-wins via `Enum.uniq/1`.
+
+  ## Example
+
+      defmodule MyApp.Endpoints do
+        alias PhoenixKit.Utils.Reorder
+
+        def reorder_endpoints(ordered_ids) do
+          Reorder.reorder(MyApp.Endpoint, ordered_ids, :sort_order, repo: repo())
+        end
+      end
+  """
+
+  import Ecto.Query
+
+  @default_max_uuids 500
+
+  @type result :: :ok | {:error, :too_many_uuids}
+
+  @doc """
+  Rewrites `field` on the rows whose `uuid` appears in `ordered_ids`,
+  setting it to each UUID's 1-based position in the list.
+
+  Returns `:ok` on success (including empty / fully-filtered payloads)
+  or `{:error, :too_many_uuids}` when the dedup'd payload exceeds the
+  configured cap.
+
+  ## Options
+
+  - `:repo` — the Ecto repo to use. Defaults to
+    `PhoenixKit.RepoHelper.repo/0` so it picks up the host app's repo.
+  - `:max_uuids` — payload cap, checked after dedup. Default `500`.
+    Guards against runaway drop events from a misbehaving client.
+  """
+  @spec reorder(module(), [String.t()], atom(), keyword()) :: result()
+  def reorder(schema, ordered_ids, field, opts \\ [])
+      when is_atom(schema) and is_list(ordered_ids) and is_atom(field) do
+    max = Keyword.get(opts, :max_uuids, @default_max_uuids)
+    repo = Keyword.get(opts, :repo, PhoenixKit.RepoHelper.repo())
+
+    case dedupe_uuids(ordered_ids) do
+      [] ->
+        :ok
+
+      uuids when length(uuids) > max ->
+        {:error, :too_many_uuids}
+
+      uuids ->
+        repo.transaction(fn ->
+          pairs = Enum.with_index(uuids, 1)
+          write_phase(repo, schema, pairs, field, -1)
+          write_phase(repo, schema, pairs, field, 1)
+        end)
+
+        :ok
+    end
+  end
+
+  defp write_phase(repo, schema, pairs, field, sign) do
+    Enum.each(pairs, fn {uuid, idx} ->
+      from(r in schema, where: r.uuid == ^uuid)
+      |> repo.update_all(set: [{field, sign * idx}])
+    end)
+  end
+
+  defp dedupe_uuids(ids) do
+    ids
+    |> Enum.filter(&PhoenixKit.Utils.UUID.valid?/1)
+    |> Enum.uniq()
+  end
+end

--- a/lib/phoenix_kit/utils/values.ex
+++ b/lib/phoenix_kit/utils/values.ex
@@ -20,4 +20,31 @@ defmodule PhoenixKit.Utils.Values do
   def blank_to_nil(nil), do: nil
   def blank_to_nil(""), do: nil
   def blank_to_nil(v) when is_binary(v), do: v
+
+  @doc """
+  Like `blank_to_nil/1`, but trims whitespace before the blank check.
+
+  Returns the trimmed string when there's content, `nil` otherwise.
+  Use this for inputs where leading / trailing whitespace shouldn't
+  count as "present" (HTML form values, URL query params that may
+  carry stray whitespace, scraped IDs, etc.). When the value will
+  already be normalised by the caller, prefer `blank_to_nil/1` to
+  avoid the unnecessary `String.trim/1`.
+
+      iex> PhoenixKit.Utils.Values.presence(nil)
+      nil
+      iex> PhoenixKit.Utils.Values.presence("   ")
+      nil
+      iex> PhoenixKit.Utils.Values.presence("  hello ")
+      "hello"
+  """
+  @spec presence(nil | String.t()) :: nil | String.t()
+  def presence(nil), do: nil
+
+  def presence(v) when is_binary(v) do
+    case String.trim(v) do
+      "" -> nil
+      trimmed -> trimmed
+    end
+  end
 end

--- a/lib/phoenix_kit/utils/values.ex
+++ b/lib/phoenix_kit/utils/values.ex
@@ -1,0 +1,23 @@
+defmodule PhoenixKit.Utils.Values do
+  @moduledoc """
+  Small value-handling helpers used across the workspace.
+  """
+
+  @doc """
+  Returns `nil` for `nil` or blank-string inputs; passes non-blank
+  strings through unchanged. Useful when reading query params, form
+  values, or settings where empty string and `nil` should mean the
+  same thing.
+
+      iex> PhoenixKit.Utils.Values.blank_to_nil(nil)
+      nil
+      iex> PhoenixKit.Utils.Values.blank_to_nil("")
+      nil
+      iex> PhoenixKit.Utils.Values.blank_to_nil("hello")
+      "hello"
+  """
+  @spec blank_to_nil(nil | String.t()) :: nil | String.t()
+  def blank_to_nil(nil), do: nil
+  def blank_to_nil(""), do: nil
+  def blank_to_nil(v) when is_binary(v), do: v
+end

--- a/lib/phoenix_kit_web.ex
+++ b/lib/phoenix_kit_web.ex
@@ -145,6 +145,8 @@ defmodule PhoenixKitWeb do
       import PhoenixKitWeb.Components.Core.PhoenixKitGlobals
       import PhoenixKitWeb.Components.Core.NavTabs
       import PhoenixKitWeb.Components.Core.IntegrationPicker
+      import PhoenixKitWeb.Components.Core.EmptyState
+      import PhoenixKitWeb.Components.Core.SortSelector
     end
   end
 

--- a/lib/phoenix_kit_web.ex
+++ b/lib/phoenix_kit_web.ex
@@ -149,6 +149,7 @@ defmodule PhoenixKitWeb do
       import PhoenixKitWeb.Components.Core.SortSelector
       import PhoenixKitWeb.Components.Core.FormSection
       import PhoenixKitWeb.Components.Core.FormActions
+      import PhoenixKitWeb.Components.Core.BulkActionsBar
     end
   end
 

--- a/lib/phoenix_kit_web.ex
+++ b/lib/phoenix_kit_web.ex
@@ -147,6 +147,8 @@ defmodule PhoenixKitWeb do
       import PhoenixKitWeb.Components.Core.IntegrationPicker
       import PhoenixKitWeb.Components.Core.EmptyState
       import PhoenixKitWeb.Components.Core.SortSelector
+      import PhoenixKitWeb.Components.Core.FormSection
+      import PhoenixKitWeb.Components.Core.FormActions
     end
   end
 

--- a/lib/phoenix_kit_web/components/core/admin_page_header.ex
+++ b/lib/phoenix_kit_web/components/core/admin_page_header.ex
@@ -12,7 +12,7 @@ defmodule PhoenixKitWeb.Components.Core.AdminPageHeader do
   import PhoenixKitWeb.Components.Core.Icon, only: [icon: 1]
 
   @doc """
-  Renders an admin page header with back navigation, title, and optional actions.
+  Renders an admin page header with title, subtitle, and optional actions.
 
   For simple headers, use `title` and `subtitle` attributes. For complex headers
   with rich content (badges, metadata), use `inner_block` to provide custom title
@@ -20,10 +20,11 @@ defmodule PhoenixKitWeb.Components.Core.AdminPageHeader do
 
   ## Attributes
 
-  - `back` - Navigate path for the back button (renders a `<.link>`)
-  - `back_click` - Phoenix event name for the back button (renders a `<button>`)
   - `title` - Page title as a string attribute
   - `subtitle` - Page subtitle as a string attribute
+  - `back` - Deprecated, no-op. Retained so existing callers compile; the back
+    arrow no longer renders. Remove from call sites at your convenience.
+  - `back_click` - Deprecated, no-op. Same rationale as `back`.
 
   ## Slots
 
@@ -33,26 +34,23 @@ defmodule PhoenixKitWeb.Components.Core.AdminPageHeader do
   ## Examples
 
       <%!-- Basic --%>
-      <.admin_page_header back={Routes.path("/admin")} title="User Management" />
+      <.admin_page_header title="User Management" />
 
       <%!-- With subtitle --%>
-      <.admin_page_header back={Routes.path("/admin")} title="Settings" subtitle="Configure system" />
+      <.admin_page_header title="Settings" subtitle="Configure system" />
 
       <%!-- With actions --%>
-      <.admin_page_header back={Routes.path("/admin/posts")} title="Posts">
+      <.admin_page_header title="Posts">
         <:actions>
           <button class="btn btn-primary btn-sm">New Post</button>
         </:actions>
       </.admin_page_header>
 
       <%!-- Rich title content --%>
-      <.admin_page_header back={Routes.path("/admin/orders")}>
+      <.admin_page_header>
         <h1 class="text-xl sm:text-2xl lg:text-3xl font-bold text-base-content">Invoice #123</h1>
         <p class="text-sm text-base-content/60 mt-0.5">Created 2 days ago</p>
       </.admin_page_header>
-
-      <%!-- phx-click back (for unsaved changes check) --%>
-      <.admin_page_header back_click="attempt_cancel" title="Page Editor" />
   """
   attr :back, :string, default: nil
   attr :back_click, :string, default: nil
@@ -63,25 +61,10 @@ defmodule PhoenixKitWeb.Components.Core.AdminPageHeader do
   slot :actions
 
   def admin_page_header(assigns) do
-    if assigns[:back] && assigns[:back_click] do
-      raise ArgumentError, "admin_page_header: cannot set both `back` and `back_click`"
-    end
-
     ~H"""
     <header class="mb-3 sm:mb-6">
       <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
         <div class="flex items-center gap-3">
-          <.link :if={@back} navigate={@back} class="btn btn-ghost btn-sm">
-            <.icon name="hero-arrow-left" class="w-4 h-4" />
-          </.link>
-          <button
-            :if={@back_click}
-            type="button"
-            phx-click={@back_click}
-            class="btn btn-ghost btn-sm"
-          >
-            <.icon name="hero-arrow-left" class="w-4 h-4" />
-          </button>
           <div>
             <%= if @title do %>
               <h1 class="text-xl sm:text-2xl lg:text-3xl font-bold text-base-content">

--- a/lib/phoenix_kit_web/components/core/bulk_actions_bar.ex
+++ b/lib/phoenix_kit_web/components/core/bulk_actions_bar.ex
@@ -2,10 +2,11 @@ defmodule PhoenixKitWeb.Components.Core.BulkActionsBar do
   @moduledoc """
   Floating bulk-action bar — shown when a list view has selected rows.
 
-  Lifts the pattern used by the entities Data Navigator
-  (`PhoenixKitEntities.Web.DataNavigator`) into a reusable primitive:
-  a card with a "N selected" counter, a slot for action buttons, and a
-  Clear button on the right that fires `deselect_all`.
+  Wraps a row of action buttons in a styled container with a "N selected"
+  counter on the left and a Clear button on the right. The container's
+  visual style is fully consumer-controlled via `wrapper_class`, so a
+  single component covers the inline cards used by entities and the
+  sticky/blurred bars used by catalogue.
 
   The consumer owns selection state — typically a
   `selected_uuids :: MapSet.t()` assign, toggled via `phx-click="toggle_select"`
@@ -19,17 +20,25 @@ defmodule PhoenixKitWeb.Components.Core.BulkActionsBar do
   - `clear_event` — Phoenix event name fired by the Clear button. Default
     `"deselect_all"`.
   - `target` — Optional `phx-target` for LiveComponents.
-  - `class` — Extra classes appended to the outer card.
+  - `wrapper_class` — Classes for the outer wrapper. **Replaces** the
+    default (`"card bg-base-200 shadow-md mb-4 p-3"`). Pass a sticky /
+    blurred variant for top-of-list placement.
+  - `class` — Extra classes appended after `wrapper_class`.
 
   ## Slots
 
   - `inner_block` — Action buttons. Render `<button phx-click="bulk_action"
     phx-value-action="...">` controls; this component lays them out in a
-    flex row. Required.
+    horizontal flex row between the count and the Clear button. Required.
 
-  ## Example
+  ## Plug-in examples
 
-      <.bulk_actions_bar count={MapSet.size(@selected_uuids)}>
+  ### Inline card (entities Data Navigator style)
+
+      <.bulk_actions_bar
+        count={MapSet.size(@selected_uuids)}
+        clear_event="deselect_all"
+      >
         <button
           phx-click="bulk_action"
           phx-value-action="archive"
@@ -47,6 +56,21 @@ defmodule PhoenixKitWeb.Components.Core.BulkActionsBar do
           <.icon name="hero-trash" class="w-4 h-4" /> {gettext("Trash")}
         </button>
       </.bulk_actions_bar>
+
+  ### Sticky bar (catalogue Items / Categories style)
+
+      <.bulk_actions_bar
+        count={MapSet.size(@selected_items)}
+        clear_event="clear_selection"
+        wrapper_class="sticky top-[72px] z-40 px-3 py-2 rounded-lg bg-base-100/95 border border-primary/40 shadow-md backdrop-blur"
+      >
+        <button phx-click="request_bulk_move_items" class="btn btn-sm btn-outline">
+          <.icon name="hero-arrows-right-left" class="w-4 h-4" /> {gettext("Move")}
+        </button>
+        <button phx-click="request_bulk_delete_items" class="btn btn-sm btn-outline btn-error">
+          <.icon name="hero-trash" class="w-4 h-4" /> {gettext("Delete")}
+        </button>
+      </.bulk_actions_bar>
   """
 
   use Phoenix.Component
@@ -57,31 +81,34 @@ defmodule PhoenixKitWeb.Components.Core.BulkActionsBar do
   attr :count, :integer, required: true
   attr :clear_event, :string, default: "deselect_all"
   attr :target, :any, default: nil
+
+  attr :wrapper_class, :any,
+    default: "card bg-base-200 shadow-md mb-4 p-3",
+    doc:
+      "Outer wrapper classes. Replaces the default; pass a sticky / blurred variant for top-of-list placement."
+
   attr :class, :string, default: nil
 
   slot :inner_block, required: true
 
   def bulk_actions_bar(assigns) do
     ~H"""
-    <div :if={@count > 0} class={["card bg-base-200 shadow-md mb-4", @class]}>
-      <div class="card-body p-3">
-        <div class="flex flex-wrap gap-3 items-center">
-          <span class="text-sm font-semibold whitespace-nowrap">
-            {@count} {gettext("selected")}
-          </span>
-          <div class="divider divider-horizontal mx-0"></div>
-          {render_slot(@inner_block)}
-          <div class="flex-1"></div>
-          <button
-            type="button"
-            phx-click={@clear_event}
-            phx-target={@target}
-            class="btn btn-ghost btn-sm"
-          >
-            <.icon name="hero-x-mark" class="w-4 h-4" /> {gettext("Clear")}
-          </button>
-        </div>
-      </div>
+    <div
+      :if={@count > 0}
+      class={["flex flex-wrap items-center gap-3", @wrapper_class, @class]}
+    >
+      <span class="text-sm font-medium whitespace-nowrap">
+        {gettext("%{count} selected", count: @count)}
+      </span>
+      {render_slot(@inner_block)}
+      <button
+        type="button"
+        phx-click={@clear_event}
+        phx-target={@target}
+        class="btn btn-ghost btn-sm ml-auto"
+      >
+        <.icon name="hero-x-mark" class="w-4 h-4" /> {gettext("Clear")}
+      </button>
     </div>
     """
   end

--- a/lib/phoenix_kit_web/components/core/bulk_actions_bar.ex
+++ b/lib/phoenix_kit_web/components/core/bulk_actions_bar.ex
@@ -1,0 +1,88 @@
+defmodule PhoenixKitWeb.Components.Core.BulkActionsBar do
+  @moduledoc """
+  Floating bulk-action bar — shown when a list view has selected rows.
+
+  Lifts the pattern used by the entities Data Navigator
+  (`PhoenixKitEntities.Web.DataNavigator`) into a reusable primitive:
+  a card with a "N selected" counter, a slot for action buttons, and a
+  Clear button on the right that fires `deselect_all`.
+
+  The consumer owns selection state — typically a
+  `selected_uuids :: MapSet.t()` assign, toggled via `phx-click="toggle_select"`
+  on per-row checkboxes. This component only renders the bar; it
+  doesn't define the checkboxes or store state.
+
+  ## Attributes
+
+  - `count` — Number of selected rows. The bar is hidden when `count == 0`.
+    Required.
+  - `clear_event` — Phoenix event name fired by the Clear button. Default
+    `"deselect_all"`.
+  - `target` — Optional `phx-target` for LiveComponents.
+  - `class` — Extra classes appended to the outer card.
+
+  ## Slots
+
+  - `inner_block` — Action buttons. Render `<button phx-click="bulk_action"
+    phx-value-action="...">` controls; this component lays them out in a
+    flex row. Required.
+
+  ## Example
+
+      <.bulk_actions_bar count={MapSet.size(@selected_uuids)}>
+        <button
+          phx-click="bulk_action"
+          phx-value-action="archive"
+          phx-disable-with={gettext("…")}
+          class="btn btn-warning btn-sm"
+        >
+          <.icon name="hero-archive-box" class="w-4 h-4" /> {gettext("Archive")}
+        </button>
+        <button
+          phx-click="bulk_action"
+          phx-value-action="trash"
+          phx-disable-with={gettext("…")}
+          class="btn btn-error btn-sm"
+        >
+          <.icon name="hero-trash" class="w-4 h-4" /> {gettext("Trash")}
+        </button>
+      </.bulk_actions_bar>
+  """
+
+  use Phoenix.Component
+  use Gettext, backend: PhoenixKitWeb.Gettext
+
+  import PhoenixKitWeb.Components.Core.Icon, only: [icon: 1]
+
+  attr :count, :integer, required: true
+  attr :clear_event, :string, default: "deselect_all"
+  attr :target, :any, default: nil
+  attr :class, :string, default: nil
+
+  slot :inner_block, required: true
+
+  def bulk_actions_bar(assigns) do
+    ~H"""
+    <div :if={@count > 0} class={["card bg-base-200 shadow-md mb-4", @class]}>
+      <div class="card-body p-3">
+        <div class="flex flex-wrap gap-3 items-center">
+          <span class="text-sm font-semibold whitespace-nowrap">
+            {@count} {gettext("selected")}
+          </span>
+          <div class="divider divider-horizontal mx-0"></div>
+          {render_slot(@inner_block)}
+          <div class="flex-1"></div>
+          <button
+            type="button"
+            phx-click={@clear_event}
+            phx-target={@target}
+            class="btn btn-ghost btn-sm"
+          >
+            <.icon name="hero-x-mark" class="w-4 h-4" /> {gettext("Clear")}
+          </button>
+        </div>
+      </div>
+    </div>
+    """
+  end
+end

--- a/lib/phoenix_kit_web/components/core/empty_state.ex
+++ b/lib/phoenix_kit_web/components/core/empty_state.ex
@@ -1,0 +1,127 @@
+defmodule PhoenixKitWeb.Components.Core.EmptyState do
+  @moduledoc """
+  Standardised "no rows" panel for list views.
+
+  Three visual variants, all with the same attr shape:
+
+  - `variant="compact"` (default) — small centered text with optional
+    icon and CTA. No card chrome. Fits inside an existing section. Use
+    for "no rows match this filter" or "no items in this sub-list".
+
+  - `variant="card"` — same content as `compact` but wrapped in a
+    `card bg-base-100 shadow` for slightly more visual presence. Use
+    when the empty-state stands alone in the page body (search-result-
+    empty pages, etc.).
+
+  - `variant="featured"` — dashed-border card with a big icon, large
+    heading, description, and CTA. Use for the "your list is genuinely
+    empty, here's how to get started" first-run state.
+
+  ## Attributes
+
+  - `title` — Required heading text.
+  - `icon` — Optional Heroicon name shown above the title.
+  - `description` — Optional sub-text below the title.
+  - `variant` — `"compact"` (default) or `"featured"`.
+  - `class` — Extra classes on the wrapper. `compact` defaults to
+    `py-16` when this is `nil`; pass `"py-10"` etc. to override.
+
+  ## Slots
+
+  - `inner_block` — Optional CTA content rendered below the description.
+  - `:cta` — Same as `inner_block` (compat alias used by some callers).
+
+  ## Examples
+
+      <%!-- Compact (default) — "no rows match this filter" --%>
+      <.empty_state icon="hero-clipboard-document-list" title={gettext("No projects match.")} />
+
+      <%!-- Compact with CTA --%>
+      <.empty_state icon="hero-rectangle-stack" title={gettext("No tasks yet.")}>
+        <.link navigate={Paths.new_task()} class="link link-primary text-sm">
+          {gettext("Create your first")}
+        </.link>
+      </.empty_state>
+
+      <%!-- Featured — first-run hero state --%>
+      <.empty_state
+        variant="featured"
+        icon="hero-cpu-chip"
+        title={gettext("No Endpoints Yet")}
+        description={gettext("Create your first AI endpoint to get started.")}
+      >
+        <.link navigate={...} class="btn btn-primary btn-lg">
+          <.icon name="hero-plus" class="w-5 h-5 mr-2" /> {gettext("Create First Endpoint")}
+        </.link>
+      </.empty_state>
+  """
+
+  use Phoenix.Component
+
+  import PhoenixKitWeb.Components.Core.Icon, only: [icon: 1]
+
+  attr :title, :string, required: true
+  attr :icon, :string, default: nil
+  attr :description, :string, default: nil
+  attr :variant, :string, default: "compact", values: ~w(compact card featured)
+  attr :class, :string, default: nil
+
+  slot :inner_block
+  slot :cta
+
+  def empty_state(%{variant: "featured"} = assigns) do
+    ~H"""
+    <div class={["card bg-base-100 shadow-xl border-2 border-dashed border-base-300", @class]}>
+      <div class="card-body text-center py-12">
+        <div :if={@icon} class="mb-4 opacity-50">
+          <.icon name={@icon} class="w-16 h-16 mx-auto" />
+        </div>
+        <h3 class="text-2xl font-semibold text-base-content/60 mb-4">{@title}</h3>
+        <p :if={@description} class="text-base-content/50 mb-6 max-w-md mx-auto">
+          {@description}
+        </p>
+        <div :if={@inner_block != [] or @cta != []}>
+          {render_slot(@inner_block)}
+          {render_slot(@cta)}
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  def empty_state(%{variant: "card"} = assigns) do
+    ~H"""
+    <div class={["card bg-base-100 shadow", @class]}>
+      <div class="card-body items-center text-center py-12">
+        <.icon :if={@icon} name={@icon} class="w-12 h-12 mb-2 opacity-40" />
+        <p class="text-base-content/60">{@title}</p>
+        <p :if={@description} class="text-sm text-base-content/50">{@description}</p>
+        <div :if={@inner_block != [] or @cta != []} class="mt-2">
+          {render_slot(@inner_block)}
+          {render_slot(@cta)}
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  def empty_state(assigns) do
+    # `@class || "py-16"` would let an empty string (`""`) clobber the
+    # default padding. Treat empty string the same as nil so consumers
+    # passing `class=""` (e.g. from a conditional) still get sane padding.
+    padding = if assigns.class in [nil, ""], do: "py-16", else: assigns.class
+    assigns = assign(assigns, :wrapper_padding, padding)
+
+    ~H"""
+    <div class={["text-center text-base-content/60", @wrapper_padding]}>
+      <.icon :if={@icon} name={@icon} class="w-12 h-12 mx-auto mb-2 opacity-40" />
+      <p class="text-sm font-medium">{@title}</p>
+      <p :if={@description} class="text-xs text-base-content/50 mt-1">{@description}</p>
+      <div :if={@inner_block != [] or @cta != []} class="mt-3">
+        {render_slot(@inner_block)}
+        {render_slot(@cta)}
+      </div>
+    </div>
+    """
+  end
+end

--- a/lib/phoenix_kit_web/components/core/file_display.ex
+++ b/lib/phoenix_kit_web/components/core/file_display.ex
@@ -6,6 +6,8 @@ defmodule PhoenixKitWeb.Components.Core.FileDisplay do
   """
   use Phoenix.Component
 
+  alias PhoenixKit.Utils.Format
+
   @doc """
   Displays a status badge for pages.
 
@@ -44,7 +46,7 @@ defmodule PhoenixKitWeb.Components.Core.FileDisplay do
 
   def file_size(assigns) do
     ~H"""
-    <span class={@class}>{format_bytes(@bytes)}</span>
+    <span class={@class}>{Format.bytes(@bytes)}</span>
     """
   end
 
@@ -74,24 +76,6 @@ defmodule PhoenixKitWeb.Components.Core.FileDisplay do
       _ -> "badge-ghost"
     end
   end
-
-  defp format_bytes(nil), do: "Unknown"
-  defp format_bytes(0), do: "0 B"
-
-  defp format_bytes(%Decimal{} = bytes) do
-    bytes |> Decimal.to_integer() |> format_bytes()
-  end
-
-  defp format_bytes(bytes) when is_integer(bytes) do
-    cond do
-      bytes >= 1_073_741_824 -> "#{Float.round(bytes / 1_073_741_824, 1)} GB"
-      bytes >= 1_048_576 -> "#{Float.round(bytes / 1_048_576, 1)} MB"
-      bytes >= 1024 -> "#{Float.round(bytes / 1024, 1)} KB"
-      true -> "#{bytes} B"
-    end
-  end
-
-  defp format_bytes(_), do: "Unknown"
 
   defp format_mtime(mtime) when is_tuple(mtime) do
     # Convert Erlang datetime tuple to NaiveDateTime

--- a/lib/phoenix_kit_web/components/core/form_actions.ex
+++ b/lib/phoenix_kit_web/components/core/form_actions.ex
@@ -1,0 +1,76 @@
+defmodule PhoenixKitWeb.Components.Core.FormActions do
+  @moduledoc """
+  Form-footer action bar — Cancel link + Submit button, right-aligned.
+
+  Replaces the repeated boilerplate:
+
+      <div class="flex justify-end gap-3">
+        <.link navigate={cancel_path} class="btn btn-ghost">Cancel</.link>
+        <button type="submit" class="btn btn-primary" phx-disable-with="Saving…">
+          {submit_label}
+        </button>
+      </div>
+
+  with a single component call.
+
+  ## Attributes
+
+  - `cancel_to` — Path the Cancel link navigates to. Required.
+  - `submit_label` — Text on the submit button (e.g. `"Save"`, `"Create Endpoint"`).
+    Required.
+  - `submitting_label` — `phx-disable-with` text shown while the form is
+    submitting. Defaults to `"Saving…"` (gettext-translated).
+  - `submit_icon` — Optional Heroicon name rendered inside the submit
+    button (e.g. `"hero-check"`).
+  - `submit_class` — Class for the submit button. Default `"btn btn-primary"`.
+  - `class` — Extra classes appended to the outer wrapper.
+
+  ## Slots
+
+  - `inner_block` — Optional extra controls rendered BEFORE Cancel + Submit
+    (e.g. a secondary "Save and Return" button).
+
+  ## Example
+
+      <.form_actions
+        cancel_to={Paths.endpoints()}
+        submit_label={if @endpoint, do: gettext("Update"), else: gettext("Create")}
+        submit_icon="hero-check"
+      />
+  """
+
+  use Phoenix.Component
+  use Gettext, backend: PhoenixKitWeb.Gettext
+
+  import PhoenixKitWeb.Components.Core.Icon, only: [icon: 1]
+
+  attr :cancel_to, :string, required: true
+  attr :submit_label, :string, required: true
+  attr :submitting_label, :string, default: nil
+  attr :submit_icon, :string, default: nil
+  attr :submit_class, :string, default: "btn btn-primary"
+  attr :class, :string, default: nil
+
+  slot :inner_block
+
+  def form_actions(assigns) do
+    # `attr :submitting_label, default: nil` always assigns nil when the
+    # consumer doesn't pass the attr, so `assign_new` won't fire. Use an
+    # explicit `||` fallback to gettext'd default.
+    assigns =
+      assign(assigns, :submitting_label, assigns[:submitting_label] || gettext("Saving…"))
+
+    ~H"""
+    <div class={["flex justify-end gap-3", @class]}>
+      {render_slot(@inner_block)}
+      <.link navigate={@cancel_to} class="btn btn-ghost">
+        {gettext("Cancel")}
+      </.link>
+      <button type="submit" class={@submit_class} phx-disable-with={@submitting_label}>
+        <.icon :if={@submit_icon} name={@submit_icon} class="w-4 h-4 mr-2" />
+        {@submit_label}
+      </button>
+    </div>
+    """
+  end
+end

--- a/lib/phoenix_kit_web/components/core/form_section.ex
+++ b/lib/phoenix_kit_web/components/core/form_section.ex
@@ -1,0 +1,64 @@
+defmodule PhoenixKitWeb.Components.Core.FormSection do
+  @moduledoc """
+  Card-wrapped form section with a titled header.
+
+  Replaces the repeated boilerplate:
+
+      <div class="card bg-base-100 shadow-lg">
+        <div class="card-body">
+          <h2 class="card-title text-lg">Section Name</h2>
+          ...fields...
+        </div>
+      </div>
+
+  with a single component call. Used in every form-heavy admin page.
+
+  ## Attributes
+
+  - `title` — Section heading text. Required.
+  - `icon` — Optional Heroicon name rendered before the title (e.g.
+    `"hero-cog-6-tooth"`).
+  - `class` — Extra classes appended to the outer card wrapper.
+  - `body_class` — Extra classes appended to the card body wrapper
+    (typical use: `"space-y-4"` for vertical field spacing).
+
+  ## Slots
+
+  - `inner_block` — Section content (form fields). Required.
+
+  ## Example
+
+      <.form_section title={gettext("Basic Information")} body_class="space-y-4">
+        <.input field={@form[:name]} label="Name" required />
+        <.textarea field={@form[:description]} label="Description" />
+      </.form_section>
+
+      <.form_section title={gettext("Configuration")} icon="hero-cog-6-tooth">
+        ...
+      </.form_section>
+  """
+
+  use Phoenix.Component
+
+  import PhoenixKitWeb.Components.Core.Icon, only: [icon: 1]
+
+  attr :title, :string, required: true
+  attr :icon, :string, default: nil
+  attr :class, :string, default: nil
+  attr :body_class, :string, default: nil
+
+  slot :inner_block, required: true
+
+  def form_section(assigns) do
+    ~H"""
+    <section class={["card bg-base-100 shadow-lg", @class]}>
+      <div class={["card-body", @body_class]}>
+        <h2 class="card-title text-lg">
+          <.icon :if={@icon} name={@icon} class="w-5 h-5" /> {@title}
+        </h2>
+        {render_slot(@inner_block)}
+      </div>
+    </section>
+    """
+  end
+end

--- a/lib/phoenix_kit_web/components/core/form_section.ex
+++ b/lib/phoenix_kit_web/components/core/form_section.ex
@@ -25,16 +25,24 @@ defmodule PhoenixKitWeb.Components.Core.FormSection do
   ## Slots
 
   - `inner_block` — Section content (form fields). Required.
+  - `:subtitle` — Optional helper text rendered under the title. Slot
+    (not attr) so callers can drop a `<.pk_link>` / `<.icon>` / etc.
+    inline.
 
   ## Example
 
-      <.form_section title={gettext("Basic Information")} body_class="space-y-4">
-        <.input field={@form[:name]} label="Name" required />
-        <.textarea field={@form[:description]} label="Description" />
+      <.form_section title={gettext("Provider Configuration")}>
+        <:subtitle>
+          {gettext("Credentials live in")}
+          <.pk_link navigate="/admin/settings/integrations" class="link link-primary">
+            Settings → Integrations
+          </.pk_link>.
+        </:subtitle>
+        <.select field={@form[:provider]} ... />
       </.form_section>
 
-      <.form_section title={gettext("Configuration")} icon="hero-cog-6-tooth">
-        ...
+      <.form_section title={gettext("Basic Information")} body_class="space-y-4">
+        <.input field={@form[:name]} label="Name" required />
       </.form_section>
   """
 
@@ -48,6 +56,7 @@ defmodule PhoenixKitWeb.Components.Core.FormSection do
   attr :body_class, :string, default: nil
 
   slot :inner_block, required: true
+  slot :subtitle
 
   def form_section(assigns) do
     ~H"""
@@ -56,6 +65,9 @@ defmodule PhoenixKitWeb.Components.Core.FormSection do
         <h2 class="card-title text-lg">
           <.icon :if={@icon} name={@icon} class="w-5 h-5" /> {@title}
         </h2>
+        <p :if={@subtitle != []} class="text-sm text-base-content/60 -mt-1">
+          {render_slot(@subtitle)}
+        </p>
         {render_slot(@inner_block)}
       </div>
     </section>

--- a/lib/phoenix_kit_web/components/core/form_section.ex
+++ b/lib/phoenix_kit_web/components/core/form_section.ex
@@ -54,13 +54,14 @@ defmodule PhoenixKitWeb.Components.Core.FormSection do
   attr :icon, :string, default: nil
   attr :class, :string, default: nil
   attr :body_class, :string, default: nil
+  attr :rest, :global
 
   slot :inner_block, required: true
   slot :subtitle
 
   def form_section(assigns) do
     ~H"""
-    <section class={["card bg-base-100 shadow-lg", @class]}>
+    <section class={["card bg-base-100 shadow-lg", @class]} {@rest}>
       <div class={["card-body", @body_class]}>
         <h2 class="card-title text-lg">
           <.icon :if={@icon} name={@icon} class="w-5 h-5" /> {@title}

--- a/lib/phoenix_kit_web/components/core/sort_selector.ex
+++ b/lib/phoenix_kit_web/components/core/sort_selector.ex
@@ -1,0 +1,190 @@
+defmodule PhoenixKitWeb.Components.Core.SortSelector do
+  @moduledoc """
+  Sort bar for list LiveViews — a field-picker `<.select>` plus a direction-
+  toggle button (chevron up / down). No wrapper chrome so it integrates
+  cleanly into a `<.table_default toggleable>` `:toolbar_title` slot.
+
+  ## How events fire
+
+  Race-free by design. Each control sends ONLY the field it controls:
+
+  - Field `<.select>` fires `phx-change` with `params == %{"sort_by" => "..."}`
+  - Direction button fires `phx-click` with `params == %{"sort_dir" => "..."}`
+
+  The LV handler derives the missing field from `socket.assigns` instead of
+  trusting stale DOM — so clicking the arrow while a change event is mid-
+  flight can never clobber the in-flight change.
+
+      def handle_event("sort_form", params, socket) do
+        field_str = params["sort_by"] || Atom.to_string(socket.assigns.sort_by)
+        dir_str   = params["sort_dir"] || Atom.to_string(socket.assigns.sort_dir)
+        # cast / validate, then push_patch with both values
+        ...
+      end
+
+  ## Loading state
+
+  The button shows a spinner during in-flight clicks via Phoenix's auto-
+  applied `.phx-click-loading` class (no consumer code required). When the
+  field select fires, the form gets `.phx-change-loading` and the select
+  dims via the same mechanism. Both states fade automatically when the LV
+  acks the event.
+
+  ## Attributes
+
+  - `sort_by` — Current sort field. Accepts atom or string. Required.
+  - `sort_dir` — Current direction (`:asc` | `:desc` | `"asc"` | `"desc"`).
+    Anything else falls back to `:asc`. Required.
+  - `options` — List of `{field, label}` tuples for the field select.
+    `field` may be atom or string; `label` is coerced via `to_string/1`.
+    Bad rows (non-tuple) are silently dropped. Empty list renders an
+    empty `<select>`. Required.
+  - `event` — Phoenix event name fired on both field change and direction
+    flip. Default `"sort_form"`.
+  - `target` — Optional `phx-target` for LiveComponents.
+  - `class` — Extra classes on the inner `<form>` element.
+
+  ## Edge cases handled
+
+  - **Atom-or-string inputs**: `sort_by` and `sort_dir` are normalised
+    internally; the consumer doesn't need to convert.
+  - **Unknown direction**: any value outside the known set renders as
+    `:asc` (conservative — surfaces a stable icon instead of silently
+    rendering as descending on bad input).
+  - **Bad option shape**: non-tuple rows skipped; atom-or-string labels
+    coerced. One bad row doesn't blow up the whole select.
+  - **Nil / wrong type `options`**: returns empty list, doesn't crash.
+
+  ## Example
+
+      <.sort_selector
+        sort_by={@sort_by}
+        sort_dir={@sort_dir}
+        options={@sort_options}
+      />
+  """
+
+  use Phoenix.Component
+  use Gettext, backend: PhoenixKitWeb.Gettext
+
+  import PhoenixKitWeb.Components.Core.Icon, only: [icon: 1]
+  import PhoenixKitWeb.Components.Core.Select, only: [select: 1]
+
+  attr :sort_by, :any, required: true, doc: "Current sort field (atom or string)"
+  attr :sort_dir, :any, required: true, doc: "Current direction (:asc/:desc or 'asc'/'desc')"
+
+  attr :options, :list,
+    required: true,
+    doc: "List of {field, label} tuples — field may be atom or string"
+
+  attr :event, :string, default: "sort_form"
+  attr :target, :any, default: nil
+  attr :class, :string, default: nil
+
+  def sort_selector(assigns) do
+    assigns =
+      assigns
+      |> assign(:sort_by_str, to_field_str(assigns[:sort_by]))
+      |> assign(:sort_dir_norm, normalize_dir(assigns[:sort_dir]))
+      |> assign(:normalized_options, normalize_options(assigns[:options]))
+
+    ~H"""
+    <%!-- Render nothing when there's nothing to sort by. Empty options
+         could happen if the consumer accidentally passes `[]` or if a
+         normalize step drops every malformed row. Better an absent
+         control than a broken empty <select>. --%>
+    <%= if @normalized_options == [] do %>
+    <% else %>
+    <.form
+      for={%{}}
+      phx-change={@event}
+      phx-target={@target}
+      class={[
+        "flex flex-wrap gap-2 items-center transition-opacity",
+        "[&.phx-change-loading]:opacity-70 [&.phx-change-loading]:cursor-wait",
+        @class
+      ]}
+    >
+      <%!-- daisyUI `join` fuses the field select and direction toggle into
+           one widget: shared borders, no gap, single rounded rectangle. --%>
+      <div class="join">
+        <%!-- Visual label dropped to match the toolbar siblings' heights;
+             accessible name preserved via `aria-label` on the <select> --%>
+        <.select
+          name="sort_by"
+          value={@sort_by_str}
+          options={@normalized_options}
+          class="select-sm join-item"
+          aria-label={gettext("Sort by")}
+        />
+        <button
+          type="button"
+          phx-click={@event}
+          phx-target={@target}
+          phx-value-sort_dir={flip_dir_str(@sort_dir_norm)}
+          class="btn btn-sm btn-square join-item [&.phx-click-loading]:pointer-events-none"
+          title={direction_title(@sort_dir_norm)}
+          aria-label={direction_title(@sort_dir_norm)}
+        >
+          <%!-- Sort-direction icon (`hero-bars-arrow-*` is the canonical
+               "sort asc/desc" pair — bars + directional arrow, visually
+               distinct from the <select>'s dropdown chevron next to it).
+               Hidden while a click event is in flight. --%>
+          <.icon
+            name={direction_icon(@sort_dir_norm)}
+            class="w-4 h-4 [.phx-click-loading_&]:hidden"
+          />
+          <%!-- Spinner — hidden by default; revealed while an ancestor
+               button carries Phoenix's `.phx-click-loading` class --%>
+          <span class="hidden [.phx-click-loading_&]:inline-block loading loading-spinner loading-xs">
+          </span>
+        </button>
+      </div>
+    </.form>
+    <% end %>
+    """
+  end
+
+  # ---- normalization helpers ------------------------------------------------
+
+  # Accepts atom or string, returns the string form. Used for the select's
+  # `value=` and the arrow's `phx-value-sort_dir=`. We never want to crash
+  # here so non-castable values become "" (empty), rendering the select
+  # with no option selected.
+  defp to_field_str(v) when is_atom(v) and not is_nil(v), do: Atom.to_string(v)
+  defp to_field_str(v) when is_binary(v), do: v
+  defp to_field_str(_), do: ""
+
+  # Direction normalisation: returns `:asc` or `:desc`. Anything outside
+  # the known set falls back to `:asc` (conservative — surfaces a stable
+  # icon instead of silently rendering as descending on bad input).
+  defp normalize_dir(:asc), do: :asc
+  defp normalize_dir(:desc), do: :desc
+  defp normalize_dir("asc"), do: :asc
+  defp normalize_dir("desc"), do: :desc
+  defp normalize_dir(_), do: :asc
+
+  # String form of the flipped direction — what the arrow click should
+  # send to the LV next.
+  defp flip_dir_str(:asc), do: "desc"
+  defp flip_dir_str(:desc), do: "asc"
+
+  defp direction_icon(:asc), do: "hero-bars-arrow-up"
+  defp direction_icon(:desc), do: "hero-bars-arrow-down"
+
+  defp direction_title(:asc), do: gettext("Ascending — click for descending")
+  defp direction_title(:desc), do: gettext("Descending — click for ascending")
+
+  # Normalises `{field, label}` tuples to `{label_string, field_string}`
+  # (the shape `<.select options=...>` expects). Tolerates atom or string
+  # on either side, and silently drops anything that isn't a 2-tuple so
+  # one bad row doesn't blow up the whole select.
+  defp normalize_options(opts) when is_list(opts) do
+    Enum.flat_map(opts, fn
+      {field, label} -> [{to_string(label), to_field_str(field)}]
+      _ -> []
+    end)
+  end
+
+  defp normalize_options(_), do: []
+end

--- a/lib/phoenix_kit_web/components/core/sort_selector.ex
+++ b/lib/phoenix_kit_web/components/core/sort_selector.ex
@@ -81,12 +81,22 @@ defmodule PhoenixKitWeb.Components.Core.SortSelector do
   attr :target, :any, default: nil
   attr :class, :string, default: nil
 
+  attr :manual_field, :any,
+    default: nil,
+    doc:
+      "Atom or string field key that represents \"manual\" ordering (e.g. `:sort_order`). When `sort_by` matches, the direction toggle is replaced by a static drag-handle hint icon — direction has no meaning for a user-specified order."
+
   def sort_selector(assigns) do
+    sort_by_str = to_field_str(assigns[:sort_by])
+    manual_str = to_field_str(assigns[:manual_field])
+    manual_active? = manual_str != "" and sort_by_str == manual_str
+
     assigns =
       assigns
-      |> assign(:sort_by_str, to_field_str(assigns[:sort_by]))
+      |> assign(:sort_by_str, sort_by_str)
       |> assign(:sort_dir_norm, normalize_dir(assigns[:sort_dir]))
       |> assign(:normalized_options, normalize_options(assigns[:options]))
+      |> assign(:manual_active?, manual_active?)
 
     ~H"""
     <%!-- Render nothing when there's nothing to sort by. Empty options
@@ -117,7 +127,19 @@ defmodule PhoenixKitWeb.Components.Core.SortSelector do
           class="select-sm join-item"
           aria-label={gettext("Sort by")}
         />
+        <%!-- In manual mode, direction is meaningless — replace the click-
+             to-flip arrow with a static drag-handle hint so the join still
+             reads as one widget but doesn't pretend to toggle anything. --%>
+        <span
+          :if={@manual_active?}
+          class="btn btn-sm btn-square join-item pointer-events-none text-base-content/60"
+          title={gettext("Drag rows to reorder")}
+          aria-label={gettext("Drag rows to reorder")}
+        >
+          <.icon name="hero-bars-3" class="w-4 h-4" />
+        </span>
         <button
+          :if={!@manual_active?}
           type="button"
           phx-click={@event}
           phx-target={@target}

--- a/lib/phoenix_kit_web/components/core/table_default.ex
+++ b/lib/phoenix_kit_web/components/core/table_default.ex
@@ -144,6 +144,10 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
     doc:
       "Content rendered inside the card-view container, above the card grid. Hidden automatically when the JS hook switches to table mode (the wrapper has `md:hidden` toggled on)."
 
+  slot :sort_bar,
+    doc:
+      "Always-visible sort UI rendered in its own row above the table/cards (e.g. a `<.sort_selector>`). Unlike `:above_cards`, this slot renders in both views."
+
   slot :toolbar_title,
     doc: "Title or arbitrary content rendered at the start of the toolbar row"
 
@@ -229,6 +233,10 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
             </button>
           </div>
         </div>
+      </div>
+      <%!-- Sort bar row: always-visible sort UI (renders in both views) --%>
+      <div :if={@sort_bar != []} class="mb-2">
+        {render_slot(@sort_bar)}
       </div>
       <%!-- Table: hidden on mobile always, shown on desktop (JS controls md: classes) --%>
       <div data-table-view="" class="hidden md:block">
@@ -371,12 +379,27 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
 
   @doc """
   Renders a table body section.
+
+  Accepts arbitrary HTML attrs via `:rest` so consumers can wire the
+  `SortableGrid` hook directly onto the `<tbody>`:
+
+      <.table_default_body
+        id="endpoints-list-body"
+        phx-hook="SortableGrid"
+        data-sortable="true"
+        data-sortable-event="reorder_endpoints"
+        data-sortable-items=".sortable-item"
+        data-sortable-handle=".pk-drag-handle"
+      >
+        ...
+      </.table_default_body>
   """
+  attr :rest, :global
   slot :inner_block, required: true
 
   def table_default_body(assigns) do
     ~H"""
-    <tbody>
+    <tbody {@rest}>
       {render_slot(@inner_block)}
     </tbody>
     """
@@ -427,6 +450,10 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
   @doc """
   Renders a table header cell.
 
+  `:inner_block` is optional — a self-closing call (`<.table_default_header_cell />`)
+  renders an empty `<th>`, useful for drag-handle / row-selection columns
+  that don't need a label.
+
   ## Attributes
 
   * `class` - Additional CSS classes (optional)
@@ -435,7 +462,7 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
   attr :class, :string, default: ""
   attr :rest, :global
 
-  slot :inner_block, required: true
+  slot :inner_block
 
   def table_default_header_cell(assigns) do
     ~H"""

--- a/lib/phoenix_kit_web/components/core/table_default.ex
+++ b/lib/phoenix_kit_web/components/core/table_default.ex
@@ -73,12 +73,19 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
   * `items` - List of items for card view rendering (optional, default: [])
   * `card_title` - Function that returns the card title for an item (optional)
   * `card_fields` - Function that returns a list of `%{label: string, value: any}` for an item (optional)
+  * `card_class` - Per-card wrapper class. String OR 1-arity function `(item) -> string`.
+    Default `"card card-sm bg-base-200 shadow-sm"`. Override when the consumer needs a
+    different look (e.g. larger padding, conditional opacity for disabled rows).
   * `storage_key` - localStorage key for persisting view preference, falls back to `id` in JS (optional)
   * `rest` - Additional HTML attributes (optional)
 
   ## Slots
 
   * `inner_block` - Table content (thead, tbody, etc.)
+  * `card_body` - Fully-custom card content (receives item via `:let`). When provided,
+    REPLACES the prescribed `card_header` + `card_title` + `card_fields` rendering — the
+    consumer owns the inside of `<div class="card-body">`. `card_actions` footer still
+    renders if provided. Use for rich cards with badges, icon-prefixed rows, custom layouts.
   * `card_actions` - Action buttons rendered in each card footer (receives item via :let)
   * `toolbar_title` - Title/content rendered at the start of the toolbar row
   * `toolbar_actions` - Buttons rendered in the toolbar before the view toggle
@@ -92,6 +99,12 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
   attr :items, :list, default: []
   attr :card_title, :any, default: nil
   attr :card_fields, :any, default: nil
+
+  attr :card_class, :any,
+    default: "card card-sm bg-base-200 shadow-sm",
+    doc:
+      "Per-card wrapper class. String or 1-arity fn `(item) -> string`. When fn, called per item."
+
   attr :storage_key, :string, default: nil
   attr :wrapper_class, :string, default: "rounded-lg shadow-md overflow-x-auto overflow-y-clip"
 
@@ -121,7 +134,15 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
   slot :card_header,
     doc: "Custom header for each card (receives item via :let); replaces card_title"
 
+  slot :card_body,
+    doc:
+      "Fully-custom card body (receives item via :let). When present, replaces card_header + card_title + card_fields rendering."
+
   slot :card_actions, doc: "Action buttons in card footer"
+
+  slot :above_cards,
+    doc:
+      "Content rendered inside the card-view container, above the card grid. Hidden automatically when the JS hook switches to table mode (the wrapper has `md:hidden` toggled on)."
 
   slot :toolbar_title,
     doc: "Title or arbitrary content rendered at the start of the toolbar row"
@@ -159,9 +180,17 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
     item_id_fn = assigns[:item_id] || fn item -> Map.get(item, :uuid) end
     reorder_scope_attrs = build_sortable_scope_attrs(assigns[:reorder_scope] || %{})
 
+    card_class_fn =
+      case assigns[:card_class] do
+        fun when is_function(fun, 1) -> fun
+        str when is_binary(str) -> fn _item -> str end
+        _ -> fn _item -> "card card-sm bg-base-200 shadow-sm" end
+      end
+
     assigns =
       assigns
       |> assign(:item_id_fn, item_id_fn)
+      |> assign(:card_class_fn, card_class_fn)
       |> assign(:reorder_scope_attrs, reorder_scope_attrs)
 
     ~H"""
@@ -231,15 +260,43 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
         phx-hook={if @on_reorder, do: "SortableGrid"}
         {@reorder_scope_attrs}
       >
+        <%!-- Above-cards slot — spans full grid width via `col-span-full`,
+             auto-hidden in table mode since it lives inside data-card-view --%>
+        <div :if={@above_cards != []} class="col-span-full">
+          {render_slot(@above_cards)}
+        </div>
         <div
           :for={item <- @items}
           class={[
-            "card card-sm bg-base-200 shadow-sm",
+            @card_class_fn.(item),
             @on_reorder && "sortable-item"
           ]}
           data-id={if @on_reorder, do: @item_id_fn.(item)}
         >
-          <div class="card-body gap-3 flex flex-col">
+          <%!-- Custom card body slot: REPLACES prescribed header+fields rendering.
+               Consumer owns the inside of card-body. card_actions footer still
+               applies below if also provided. --%>
+          <div :if={@card_body != []} class="card-body">
+            {render_slot(@card_body, item)}
+            <%!-- Footer row inside custom-body branch so spacing stays consistent --%>
+            <div
+              :if={@on_reorder || @card_actions != []}
+              class="flex flex-wrap items-center gap-2 pt-1 border-t border-base-200 mt-auto"
+            >
+              <div
+                :if={@on_reorder}
+                class="pk-drag-handle text-base-content/30 hover:text-base-content/70 cursor-grab active:cursor-grabbing select-none"
+                title={gettext("Drag to reorder")}
+              >
+                <.icon name="hero-bars-3" class="w-4 h-4" />
+              </div>
+              <div :if={@card_actions != []} class="flex flex-wrap items-center gap-1 ml-auto">
+                {render_slot(@card_actions, item)}
+              </div>
+            </div>
+          </div>
+          <%!-- Default card body: prescribed header + key/value fields + footer --%>
+          <div :if={@card_body == []} class="card-body gap-3 flex flex-col">
             <%!-- Custom header (slot) or plain title string --%>
             <div :if={@card_header != []}>
               {render_slot(@card_header, item)}
@@ -416,10 +473,23 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
   @doc """
   Renders a sortable table header cell.
 
-  When `sort` is nil, renders an inert `<th>` label. When `sort` is provided,
+  When `sort` is nil, renders an inert `<th>` label. When `sort` is a map,
   renders a clickable button emitting `toggle_sort` (or a custom event) with
-  `phx-value-by` set to the field key. The active column shows a chevron icon
-  reflecting the current sort direction.
+  `phx-value-by` set to the field key.
+
+  ## States rendered
+
+  - **Inactive column** (sortable, not the current sort) — faint
+    `hero-chevron-up-down-mini` hint, strengthens on hover via `group-hover`.
+  - **Active asc** / **Active desc** — solid chevron-up / chevron-down.
+  - **Loading** (during in-flight click) — all chevrons hide and a
+    `loading-spinner` shows; `pointer-events-none` blocks double-clicks;
+    button dims via `opacity-60`. Driven by Phoenix's auto-applied
+    `.phx-click-loading` class — no consumer wiring needed.
+  - **Active column with an unrecognised `sort.dir`** (defensive) — falls
+    back to the inactive up-down hint rather than rendering no icon.
+
+  Atom or string `sort.dir` values are accepted (`:asc`/`:desc`/`"asc"`/`"desc"`).
   """
   attr :field, :atom, required: true
 
@@ -436,6 +506,17 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
   slot :inner_block, required: true
 
   def sort_header_cell(assigns) do
+    # Pre-compute the active direction (atom-or-string accepted; unknown
+    # values fall back to nil → renders the up-down hint instead of leaving
+    # the active column with no icon at all).
+    active_dir = active_direction(assigns.sort, assigns.field)
+    sortable? = is_map(assigns.sort)
+
+    assigns =
+      assigns
+      |> assign(:active_dir, active_dir)
+      |> assign(:sortable?, sortable?)
+
     ~H"""
     <th
       class={[
@@ -446,26 +527,42 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
       aria-sort={sort_header_aria_sort(@sort, @field)}
       {@rest}
     >
-      <%= if @sort do %>
+      <%= if @sortable? do %>
         <button
           type="button"
           phx-click={@event}
           phx-value-by={@field}
           phx-target={@target}
           class={[
-            "flex items-center gap-1",
+            "group inline-flex items-center gap-1 cursor-pointer select-none",
+            "hover:opacity-80 transition-opacity",
+            "[&.phx-click-loading]:opacity-60 [&.phx-click-loading]:pointer-events-none",
             @align == :right && "justify-end w-full",
             @align == :center && "justify-center w-full"
           ]}
         >
           {render_slot(@inner_block)}
-          <%= if @sort.by == @field do %>
-            <%= if @sort.dir == :asc do %>
-              <.icon name="hero-chevron-up-mini" class="w-4 h-4" />
-            <% else %>
-              <.icon name="hero-chevron-down-mini" class="w-4 h-4" />
-            <% end %>
-          <% end %>
+          <%!-- Sort indicator. While a click is in flight: spinner. When
+               this column is the active sort: solid chevron for current
+               direction. Otherwise (including active column with unknown
+               dir): faint up-down hint that strengthens on hover. --%>
+          <span class="hidden [.phx-click-loading_&]:inline-block loading loading-spinner loading-xs">
+          </span>
+          <.icon
+            :if={@active_dir == :asc}
+            name="hero-chevron-up-mini"
+            class="w-4 h-4 [.phx-click-loading_&]:hidden"
+          />
+          <.icon
+            :if={@active_dir == :desc}
+            name="hero-chevron-down-mini"
+            class="w-4 h-4 [.phx-click-loading_&]:hidden"
+          />
+          <.icon
+            :if={is_nil(@active_dir)}
+            name="hero-chevron-up-down-mini"
+            class="w-4 h-4 opacity-30 group-hover:opacity-70 transition-opacity [.phx-click-loading_&]:hidden"
+          />
         </button>
       <% else %>
         {render_slot(@inner_block)}
@@ -474,10 +571,28 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
     """
   end
 
+  # Returns `:asc` / `:desc` when the given column is the active sort with a
+  # recognised direction, otherwise `nil`. Tolerates atom or string `dir`
+  # so consumers can pass either shape without crashing the render.
+  defp active_direction(%{by: by, dir: dir}, field) when by == field do
+    case dir do
+      :asc -> :asc
+      :desc -> :desc
+      "asc" -> :asc
+      "desc" -> :desc
+      _ -> nil
+    end
+  end
+
+  defp active_direction(_sort, _field), do: nil
+
   defp sort_header_aria_sort(nil, _field), do: nil
-  defp sort_header_aria_sort(%{by: field, dir: :asc}, field), do: "ascending"
-  defp sort_header_aria_sort(%{by: field, dir: :desc}, field), do: "descending"
-  defp sort_header_aria_sort(%{}, _field), do: "none"
+  defp sort_header_aria_sort(%{by: field, dir: dir}, field) when dir in [:asc, "asc"],
+    do: "ascending"
+  defp sort_header_aria_sort(%{by: field, dir: dir}, field) when dir in [:desc, "desc"],
+    do: "descending"
+  defp sort_header_aria_sort(%{} = _sort, _field), do: "none"
+  defp sort_header_aria_sort(_other, _field), do: nil
 
   @doc """
   Renders a search input with a magnifying glass icon and debounce.

--- a/lib/phoenix_kit_web/components/core/table_default.ex
+++ b/lib/phoenix_kit_web/components/core/table_default.ex
@@ -250,7 +250,7 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
       <div
         id={if @on_reorder, do: "#{@id}-cards"}
         data-card-view=""
-        class="md:hidden grid gap-4 md:grid-cols-2 lg:grid-cols-3"
+        class="md:hidden grid gap-4 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4"
         data-sortable={if @on_reorder, do: "true"}
         data-sortable-event={@on_reorder}
         data-sortable-items={if @on_reorder, do: ".sortable-item"}

--- a/lib/phoenix_kit_web/components/media_browser.ex
+++ b/lib/phoenix_kit_web/components/media_browser.ex
@@ -103,6 +103,7 @@ defmodule PhoenixKitWeb.Components.MediaBrowser do
   alias PhoenixKit.Modules.Storage.URLSigner
   alias PhoenixKit.Settings
   alias PhoenixKit.Users.Auth
+  alias PhoenixKit.Utils.Format
   alias PhoenixKit.Utils.Routes
 
   # ──────────────────────────────────────────────────────────────
@@ -2440,14 +2441,7 @@ defmodule PhoenixKitWeb.Components.MediaBrowser do
     end
   end
 
-  defp format_file_size(bytes) when is_integer(bytes) do
-    cond do
-      bytes >= 1_000_000_000 -> "#{Float.round(bytes / 1_000_000_000, 2)} GB"
-      bytes >= 1_000_000 -> "#{Float.round(bytes / 1_000_000, 2)} MB"
-      bytes >= 1_000 -> "#{Float.round(bytes / 1_000, 2)} KB"
-      true -> "#{bytes} B"
-    end
-  end
+  defp format_file_size(bytes), do: Format.bytes(bytes, base: 1000, decimals: 2)
 
   defp delete_selected_confirm(selected_files, selected_folders, filter_trash) do
     file_count = MapSet.size(selected_files)

--- a/lib/phoenix_kit_web/controllers/upload_controller.ex
+++ b/lib/phoenix_kit_web/controllers/upload_controller.ex
@@ -9,6 +9,7 @@ defmodule PhoenixKitWeb.UploadController do
   alias PhoenixKit.Modules.Storage
   alias PhoenixKit.Modules.Storage.File, as: StorageFile
   alias PhoenixKit.Modules.Storage.ProcessFileJob
+  alias PhoenixKit.Utils.Format
 
   @upload_config %{
     # 100MB max file size
@@ -215,21 +216,7 @@ defmodule PhoenixKitWeb.UploadController do
     end
   end
 
-  defp format_bytes(bytes) when is_integer(bytes) do
-    if bytes < 1024 do
-      "#{bytes} B"
-    else
-      units = ["KB", "MB", "GB", "TB"]
-      {value, unit} = calculate_size(bytes, units)
-      "#{Float.round(value, 2)} #{unit}"
-    end
-  end
-
-  defp calculate_size(bytes, [_unit | rest]) when bytes >= 1024 and rest != [] do
-    calculate_size(bytes / 1024, rest)
-  end
-
-  defp calculate_size(bytes, [unit | _]), do: {bytes, unit}
+  defp format_bytes(bytes), do: Format.bytes(bytes, decimals: 2)
 
   defp changeset_errors(changeset) do
     Ecto.Changeset.traverse_errors(changeset, fn {msg, opts} ->

--- a/lib/phoenix_kit_web/live/activity/index.ex
+++ b/lib/phoenix_kit_web/live/activity/index.ex
@@ -13,6 +13,7 @@ defmodule PhoenixKitWeb.Live.Activity.Index do
   alias PhoenixKit.Settings
   alias PhoenixKit.Users.Auth.Scope
   alias PhoenixKit.Utils.Routes
+  alias PhoenixKit.Utils.Values
 
   @impl true
   def mount(_params, _session, socket) do
@@ -97,10 +98,10 @@ defmodule PhoenixKitWeb.Live.Activity.Index do
   defp apply_params(socket, params) do
     socket
     |> assign(:page, parse_int(params["page"], 1))
-    |> assign(:filter_module, blank_to_nil(params["module"]))
-    |> assign(:filter_mode, blank_to_nil(params["mode"]))
-    |> assign(:filter_action, blank_to_nil(params["action"]))
-    |> assign(:filter_resource_type, blank_to_nil(params["resource_type"]))
+    |> assign(:filter_module, Values.blank_to_nil(params["module"]))
+    |> assign(:filter_mode, Values.blank_to_nil(params["mode"]))
+    |> assign(:filter_action, Values.blank_to_nil(params["action"]))
+    |> assign(:filter_resource_type, Values.blank_to_nil(params["resource_type"]))
   end
 
   defp load_activities(socket) do
@@ -136,10 +137,6 @@ defmodule PhoenixKitWeb.Live.Activity.Index do
       :error -> default
     end
   end
-
-  defp blank_to_nil(nil), do: nil
-  defp blank_to_nil(""), do: nil
-  defp blank_to_nil(val), do: val
 
   defp action_badge_color(action), do: Activity.action_badge_color(action)
   defp mode_badge_color(mode), do: Activity.mode_badge_color(mode)

--- a/lib/phoenix_kit_web/live/components/media_selector_modal.ex
+++ b/lib/phoenix_kit_web/live/components/media_selector_modal.ex
@@ -58,6 +58,7 @@ defmodule PhoenixKitWeb.Live.Components.MediaSelectorModal do
   alias PhoenixKit.Modules.Storage
   alias PhoenixKit.Modules.Storage.{File, FileInstance, FolderLink, URLSigner}
   alias PhoenixKit.Users.Auth
+  alias PhoenixKit.Utils.Format
 
   import Ecto.Query
 
@@ -541,16 +542,7 @@ defmodule PhoenixKitWeb.Live.Components.MediaSelectorModal do
   defp parse_filter("all"), do: :all
   defp parse_filter(_), do: :all
 
-  defp format_file_size(bytes) when is_number(bytes) do
-    cond do
-      bytes >= 1_073_741_824 -> "#{Float.round(bytes / 1_073_741_824, 2)} GB"
-      bytes >= 1_048_576 -> "#{Float.round(bytes / 1_048_576, 2)} MB"
-      bytes >= 1024 -> "#{Float.round(bytes / 1024, 2)} KB"
-      true -> "#{bytes} B"
-    end
-  end
-
-  defp format_file_size(_), do: "0 B"
+  defp format_file_size(bytes), do: Format.bytes(bytes, decimals: 2, unknown: "0 B")
 
   defp pagination_range(current_page, total_pages) do
     cond do

--- a/lib/phoenix_kit_web/live/users/media_detail.ex
+++ b/lib/phoenix_kit_web/live/users/media_detail.ex
@@ -19,6 +19,7 @@ defmodule PhoenixKitWeb.Live.Users.MediaDetail do
   alias PhoenixKit.Modules.Storage.VariantGenerator
   alias PhoenixKit.Settings
   alias PhoenixKit.Utils.Date, as: UtilsDate
+  alias PhoenixKit.Utils.Format
   alias PhoenixKit.Utils.Routes
 
   def mount(params, _session, socket) do
@@ -312,15 +313,7 @@ defmodule PhoenixKitWeb.Live.Users.MediaDetail do
     end)
   end
 
-  # Format file size in human-readable format
-  defp format_file_size(bytes) when is_integer(bytes) do
-    cond do
-      bytes >= 1_000_000_000 -> "#{Float.round(bytes / 1_000_000_000, 2)} GB"
-      bytes >= 1_000_000 -> "#{Float.round(bytes / 1_000_000, 2)} MB"
-      bytes >= 1_000 -> "#{Float.round(bytes / 1_000, 2)} KB"
-      true -> "#{bytes} B"
-    end
-  end
+  defp format_file_size(bytes), do: Format.bytes(bytes, base: 1000, decimals: 2)
 
   # Get icon for file type
   defp file_icon("image"), do: "hero-photo"

--- a/lib/phoenix_kit_web/live/users/media_selector.ex
+++ b/lib/phoenix_kit_web/live/users/media_selector.ex
@@ -26,6 +26,7 @@ defmodule PhoenixKitWeb.Live.Users.MediaSelector do
   alias PhoenixKit.Modules.Storage.{File, FileInstance, URLSigner}
   alias PhoenixKit.Settings
   alias PhoenixKit.Users.Auth
+  alias PhoenixKit.Utils.Format
   alias PhoenixKit.Utils.Routes
 
   import Ecto.Query
@@ -365,16 +366,7 @@ defmodule PhoenixKitWeb.Live.Users.MediaSelector do
   defp parse_filter("all"), do: :all
   defp parse_filter(_), do: :all
 
-  defp format_file_size(bytes) when is_number(bytes) do
-    cond do
-      bytes >= 1_073_741_824 -> "#{Float.round(bytes / 1_073_741_824, 2)} GB"
-      bytes >= 1_048_576 -> "#{Float.round(bytes / 1_048_576, 2)} MB"
-      bytes >= 1024 -> "#{Float.round(bytes / 1024, 2)} KB"
-      true -> "#{bytes} B"
-    end
-  end
-
-  defp format_file_size(_), do: "0 B"
+  defp format_file_size(bytes), do: Format.bytes(bytes, decimals: 2, unknown: "0 B")
 
   defp pagination_range(current_page, total_pages) do
     cond do


### PR DESCRIPTION
## Summary

Workspace-wide quality lift surfaced by this AI module sweep — most of it is reusable core surface that other modules can adopt incrementally.

### `<.table_default>` extensions
- New `:sort_bar` slot rendered above the toolbar (always visible in both card + table views; replaces the card-only `:above_cards` pattern for sort UI).
- `<.table_default_body>` gains `:rest, :global` so consumers can wire `phx-hook=\"SortableGrid\"` + `data-sortable-*` attrs directly when manual ordering is active.
- `<.table_default_header_cell>`: `:inner_block` is now optional so drag-handle / select columns can render as empty `<th>` without a placeholder.

### `<.sort_selector>` manual mode
- New `manual_field` attr — when `sort_by` matches, the direction toggle is replaced by a static drag-handle hint icon (asc/desc has no meaning for user-specified order).

### `<.form_section>`
- Now accepts `:rest, :global` so consumers can attach `id`, `phx-mounted`, `data-*` without a wrapper div.

### New `<.bulk_actions_bar>` core component
- Lifts the entities Data Navigator pattern: counter + action-button slot + Clear button. `wrapper_class` knob lets the consumer pick the inline-card look (default) or the sticky/blurred bar shape catalogue uses on its Categories tab.

### New utility modules
- **`PhoenixKit.Utils.Reorder.reorder/4`** — two-phase index-rewrite primitive for drag-to-reorder list views. Schema-agnostic, configurable position field, payload cap (default 500), UUID-filtered against poisoned drops via `PhoenixKit.Utils.UUID.valid?/1`. Returns `{:ok, count}` so consumers can keep audit-log fidelity.
- **`PhoenixKit.Utils.Values.blank_to_nil/1`** + **`.presence/1`** — `blank_to_nil` is the workspace's canonical `nil | \"\" → nil` helper (was duplicated across 7+ modules); `presence/1` is the trim-then-blank-check sibling for HTML form values / URL query params that may carry stray whitespace.
- **`PhoenixKit.Utils.Format.bytes/2`** — `format_bytes` / `format_file_size` had grown 8 private copies across the media stack + upload controller. Single helper with `:decimals` / `:unknown` / `:base` (1024 vs 1000) opts so each consumer keeps its existing visual behavior without forking the algorithm.

### In-tree migrations (clearing the duplicates)
- `Activity.Index` LV → `Values.blank_to_nil/1`.
- 8 media-stack / upload-controller call sites → `Format.bytes/2` via one-line delegates so HEEx call sites are unchanged.
- `shared/components/video.ex` → `Values.presence/1`; `phoenix_kit_publishing/db_storage/mapper.ex` → `Values.blank_to_nil/1` (consumer-side, separate PR).

## Test plan
- [ ] `mix precommit` clean
- [ ] All admin pages render without console errors (media browser, file_display, upload controller, activity)
- [ ] `<.table_default>` consumers (AI endpoints, catalogue) work with both card and table views; sort_bar visible in both
- [ ] `<.bulk_actions_bar>` default style matches entities Data Navigator inline-card look
- [ ] `Reorder.reorder/4` rewrite is transactional (negative-then-positive write order)