### PR TITLE
Site-wide `default_language_no_prefix` setting + sitemap honors it

### DIFF
--- a/lib/modules/languages/languages.ex
+++ b/lib/modules/languages/languages.ex
@@ -104,6 +104,7 @@ defmodule PhoenixKit.Modules.Languages do
   alias PhoenixKit.Settings
 
   @config_key "languages_config"
+  @default_language_no_prefix_key "default_language_no_prefix"
   @default_locale Config.default_locale()
   @enabled_key "languages_enabled"
   @module_name "languages"
@@ -256,6 +257,41 @@ defmodule PhoenixKit.Modules.Languages do
     :ok
   catch
     :enable_failed -> :ok
+  end
+
+  @impl PhoenixKit.Module
+  @doc """
+  Backfills the `default_language_no_prefix` setting from the legacy
+  `publishing_default_language_no_prefix` key the first time this runs
+  on an install that predates the site-wide setting. Idempotent — once
+  the new key is set, subsequent calls are no-ops.
+
+  Called by `PhoenixKit.ModuleRegistry.run_all_legacy_migrations/0`
+  from the host app's `Application.start/2`.
+  """
+  @spec migrate_legacy() :: :ok | {:ok, map()}
+  def migrate_legacy do
+    new_key = @default_language_no_prefix_key
+    legacy_key = "publishing_default_language_no_prefix"
+
+    case Settings.get_setting(new_key) do
+      nil ->
+        case Settings.get_setting(legacy_key) do
+          nil ->
+            {:ok, %{default_language_no_prefix: :not_migrated}}
+
+          legacy_value when is_binary(legacy_value) ->
+            # Settings serialize booleans as the strings "true"/"false";
+            # rewrite the same shape under the new key so
+            # `get_boolean_setting/2` parses it identically.
+            {:ok, _} = Settings.update_setting(new_key, legacy_value)
+
+            {:ok, %{default_language_no_prefix: :migrated_from_legacy, value: legacy_value}}
+        end
+
+      _existing ->
+        {:ok, %{default_language_no_prefix: :already_set}}
+    end
   end
 
   @impl PhoenixKit.Module
@@ -499,6 +535,48 @@ defmodule PhoenixKit.Modules.Languages do
       nil
     end
   end
+
+  @doc """
+  Returns true when public + admin URLs should omit the locale segment
+  for the primary language.
+
+  Site-wide setting (key `default_language_no_prefix`). When `true`,
+  every URL generator that honors it — `Routes.path/1`,
+  `Routes.admin_path/2`, the sitemap, publishing's HTML builders, the
+  publishing canonical-redirect controller, and the publishing
+  `RouterDispatch` rewriter — emits the primary language as the
+  prefixless shape (`/admin/users`, `/blog/post`). When `false`, all
+  generators emit the prefixed shape (`/en/admin/users`,
+  `/en/blog/post`).
+
+  Default: `false` (matches the historical publishing default and
+  keeps existing installs' indexed URLs stable on upgrade). The
+  setting can be migrated from the legacy
+  `publishing_default_language_no_prefix` key — see
+  `PhoenixKit.Migration.migrate_default_language_no_prefix/0`.
+  """
+  @spec default_language_no_prefix?() :: boolean()
+  def default_language_no_prefix? do
+    Settings.get_boolean_setting(@default_language_no_prefix_key, false)
+  end
+
+  @doc """
+  Persists the `default_language_no_prefix` setting. Returns
+  `{:ok, setting}` on success or `{:error, changeset}` on failure.
+  """
+  @spec set_default_language_no_prefix(boolean()) ::
+          {:ok, PhoenixKit.Settings.Setting.t()} | {:error, Ecto.Changeset.t()}
+  def set_default_language_no_prefix(value) when is_boolean(value) do
+    Settings.update_boolean_setting(@default_language_no_prefix_key, value)
+  end
+
+  @doc """
+  Returns the storage key used for the no-prefix setting. Exposed for
+  the legacy-key migration in `PhoenixKit.Migration`; callers should
+  prefer `default_language_no_prefix?/0`.
+  """
+  @spec default_language_no_prefix_key() :: String.t()
+  def default_language_no_prefix_key, do: @default_language_no_prefix_key
 
   @doc """
   Gets a specific language by its code.

--- a/lib/modules/sitemap/sources/publishing.ex
+++ b/lib/modules/sitemap/sources/publishing.ex
@@ -511,24 +511,30 @@ defmodule PhoenixKit.Modules.Sitemap.Sources.Publishing do
     |> Enum.map_join(" ", &String.capitalize/1)
   end
 
-  # Build group path with PhoenixKit prefix and optional language
+  # Build group path with PhoenixKit prefix and optional language.
   # Format: /{prefix}/{lang?}/{segments...}
-  # When in single language mode, no language prefix is added for anyone
-  # When in multi-language mode, ALL languages get prefix (including default)
-  defp build_group_path(segments, language, _is_default) do
+  #
+  # Skip rules for the language segment:
+  #   1. Single-language mode — no language is meaningful.
+  #   2. `is_default` is true AND the site-wide
+  #      `default_language_no_prefix` setting is on (the primary language
+  #      should match the public URL shape that
+  #      `PublishingHTML.use_language_prefix?/1` emits at request time;
+  #      keeping the sitemap consistent prevents indexed canonicals
+  #      drifting from served URLs).
+  # Everything else keeps the prefix.
+  defp build_group_path(segments, language, is_default) do
     prefix_parts = url_prefix_segments()
 
-    # Add language prefix when:
-    # 1. Language is specified
-    # 2. Multiple languages are enabled (not single language mode)
     lang_parts =
-      if language && !single_language_mode?() do
+      cond do
+        is_nil(language) -> []
+        single_language_mode?() -> []
+        is_default and Languages.default_language_no_prefix?() -> []
         # Use display code to match controller's canonical URL logic
         # This returns base code ("en") when single dialect enabled,
         # or full code ("en-US") when multiple dialects enabled
-        [get_display_code(language)]
-      else
-        []
+        true -> [get_display_code(language)]
       end
 
     all_parts =

--- a/lib/phoenix_kit/utils/routes.ex
+++ b/lib/phoenix_kit/utils/routes.ex
@@ -77,7 +77,7 @@ defmodule PhoenixKit.Utils.Routes do
   defp build_path_with_locale(base_path, url_path, :none), do: "#{base_path}#{url_path}"
 
   defp build_path_with_locale(base_path, url_path, locale_value) do
-    if default_locale?(locale_value) do
+    if default_locale?(locale_value) and prefixless_primary?() do
       "#{base_path}#{url_path}"
     else
       "#{base_path}/#{locale_value}#{url_path}"
@@ -87,20 +87,20 @@ defmodule PhoenixKit.Utils.Routes do
   # Check if a path is an admin path.
   defp admin_path?(url_path), do: String.starts_with?(url_path, "/admin")
 
-  # Admin paths drop the locale segment for the primary language, matching
-  # the non-admin behaviour in `build_localized_path/3`. The two emission
-  # shapes both have routes in the table (the admin route macros declare
-  # both `/:locale/admin/*` and `/admin/*` scopes), so emitting prefixless
-  # for the primary locale is safe.
+  # Admin paths follow the same primary-prefix rule as non-admin paths.
+  # Both URL shapes (`/admin/*` and `/:locale/admin/*`) are emitted by the
+  # admin route macros so either shape is routable; the choice between
+  # them is the cosmetic site-wide setting controlled via
+  # `Languages.default_language_no_prefix?/0`.
   #
-  # Both shapes share one `live_session :phoenix_kit_admin`, so switching
-  # locales inside admin stays on the WebSocket (`push_navigate`) — no
-  # full-page reload. See `generate_admin_routes/2` in
-  # `PhoenixKitWeb.Integration`.
+  # The two shapes share one `live_session :phoenix_kit_admin`, so
+  # switching locales inside admin stays on the WebSocket
+  # (`push_navigate`) — no full-page reload. See `generate_admin_routes/2`
+  # in `PhoenixKitWeb.Integration`.
   defp build_admin_path(base_path, url_path, :none), do: "#{base_path}#{url_path}"
 
   defp build_admin_path(base_path, url_path, locale) when is_binary(locale) do
-    if default_locale?(locale) do
+    if default_locale?(locale) and prefixless_primary?() do
       "#{base_path}#{url_path}"
     else
       "#{base_path}/#{locale}#{url_path}"
@@ -108,6 +108,19 @@ defmodule PhoenixKit.Utils.Routes do
   end
 
   defp build_admin_path(base_path, url_path, _), do: "#{base_path}#{url_path}"
+
+  # Reads the site-wide setting controlled by the Languages admin page.
+  # Wrapped to survive boot / mix-task contexts where the settings table
+  # may not exist yet — same defensive shape as `get_default_language_base/0`.
+  defp prefixless_primary? do
+    if mix_task_context?() do
+      false
+    else
+      Languages.default_language_no_prefix?()
+    end
+  rescue
+    _ -> false
+  end
 
   # Check if a path starts with one of the reserved prefixes.
   defp reserved_path?(path) do
@@ -157,21 +170,28 @@ defmodule PhoenixKit.Utils.Routes do
   end
 
   @doc """
-  Returns a locale-aware admin path. Strips the locale segment for the
-  primary language (mirroring `path/2`'s non-admin behaviour); keeps the
-  segment for every other locale.
+  Returns a locale-aware admin path. For non-primary locales the locale
+  segment is always emitted. For the primary locale the shape follows
+  the site-wide `default_language_no_prefix` setting
+  (`Languages.default_language_no_prefix?/0`): prefixless when the
+  setting is on, prefixed when off.
 
   Both URL shapes resolve at the router level — the admin route macros
-  declare `/:locale/admin/*` AND `/admin/*` scopes — so emitting prefixless
-  for primary is safe. The two shapes also share one
-  `live_session :phoenix_kit_admin`, so locale switching across them stays
-  on the WebSocket (`push_navigate`) without a full-page reload.
+  declare `/:locale/admin/*` AND `/admin/*` scopes — so either shape is
+  routable. The two shapes share one `live_session :phoenix_kit_admin`,
+  so locale switching across them stays on the WebSocket
+  (`push_navigate`) without a full-page reload.
 
   ## Examples
 
       iex> Routes.admin_path("/admin/users", "uk")
       "/phoenix_kit/uk/admin/users"
 
+      # primary locale with setting OFF (default)
+      iex> Routes.admin_path("/admin/users", "en")
+      "/phoenix_kit/en/admin/users"
+
+      # primary locale with `default_language_no_prefix` setting ON
       iex> Routes.admin_path("/admin/users", "en")
       "/phoenix_kit/admin/users"
 
@@ -183,7 +203,7 @@ defmodule PhoenixKit.Utils.Routes do
     url_prefix = Config.get_url_prefix()
     base_prefix = if url_prefix == "/", do: "", else: url_prefix
 
-    if default_locale?(locale) do
+    if default_locale?(locale) and prefixless_primary?() do
       "#{base_prefix}#{url_path}"
     else
       "#{base_prefix}/#{locale}#{url_path}"

--- a/lib/phoenix_kit_web/live/modules/languages.ex
+++ b/lib/phoenix_kit_web/live/modules/languages.ex
@@ -64,6 +64,8 @@ defmodule PhoenixKitWeb.Live.Modules.Languages do
       |> assign(:switcher_goto_home, false)
       |> assign(:switcher_hide_current, false)
       |> assign(:switcher_show_native_names, false)
+      # Site-wide URL behavior — primary-language locale-segment toggle.
+      |> assign(:default_language_no_prefix, Languages.default_language_no_prefix?())
 
     {:ok, socket}
   end
@@ -74,6 +76,18 @@ defmodule PhoenixKitWeb.Live.Modules.Languages do
 
   def handle_event("toggle_reorder", _params, socket) do
     {:noreply, assign(socket, :show_reorder, !socket.assigns.show_reorder)}
+  end
+
+  def handle_event("toggle_default_language_no_prefix", _params, socket) do
+    new_value = !socket.assigns.default_language_no_prefix
+
+    case Languages.set_default_language_no_prefix(new_value) do
+      {:ok, _} ->
+        {:noreply, assign(socket, :default_language_no_prefix, new_value)}
+
+      {:error, _changeset} ->
+        {:noreply, put_flash(socket, :error, gettext("Failed to update URL behavior setting"))}
+    end
   end
 
   def handle_event("reorder_languages", %{"ordered_ids" => ordered_codes}, socket) do

--- a/lib/phoenix_kit_web/live/modules/languages.html.heex
+++ b/lib/phoenix_kit_web/live/modules/languages.html.heex
@@ -276,6 +276,40 @@
       </div>
     </div>
 
+    <%!-- URL Behavior Section --%>
+    <div class="card bg-base-100 shadow-xl mt-6">
+      <div class="card-body">
+        <h2 class="card-title text-xl mb-2">{gettext("URL Behavior")}</h2>
+        <p class="text-base-content/70 mb-4">
+          {gettext(
+            "Controls how the primary language appears in URLs across the site — admin pages, public pages, sitemap, and redirects."
+          )}
+        </p>
+
+        <div class="flex items-center justify-between p-4 bg-base-200 rounded-lg">
+          <div class="flex items-center gap-3">
+            <.icon name="hero-link" class="w-5 h-5 text-base-content/70" />
+            <div>
+              <p class="font-medium">
+                {gettext("Default Language Without Prefix")}
+              </p>
+              <p class="text-xs text-base-content/60">
+                {gettext(
+                  "When on, the primary language drops its locale segment in every URL (e.g. /admin/users instead of /en/admin/users, /blog/post instead of /en/blog/post). Other languages always keep their prefix."
+                )}
+              </p>
+            </div>
+          </div>
+          <input
+            type="checkbox"
+            class="toggle toggle-primary"
+            checked={@default_language_no_prefix}
+            phx-click="toggle_default_language_no_prefix"
+          />
+        </div>
+      </div>
+    </div>
+
     <%!-- Frontend Language Switcher Component Section --%>
     <div class="card bg-base-100 shadow-xl mt-6">
       <div class="card-body">

--- a/test/integration/languages/default_language_no_prefix_test.exs
+++ b/test/integration/languages/default_language_no_prefix_test.exs
@@ -1,0 +1,116 @@
+defmodule PhoenixKit.Integration.Languages.DefaultLanguageNoPrefixTest do
+  @moduledoc """
+  DB-backed coverage for the site-wide `default_language_no_prefix`
+  setting that controls primary-language URL emission across the
+  workspace.
+
+  Pairs with `test/phoenix_kit/utils/routes_test.exs` (no-DB) which
+  covers the OFF branch via the rescue path. This file pins the ON
+  branch end-to-end (setter → getter → Routes helpers → sitemap) and
+  the legacy-key migration.
+  """
+
+  use PhoenixKit.DataCase, async: true
+
+  alias PhoenixKit.Modules.Languages
+  alias PhoenixKit.Settings
+  alias PhoenixKit.Utils.Routes
+
+  describe "default_language_no_prefix?/0 + set/1" do
+    test "defaults to false when the key is unset" do
+      refute Languages.default_language_no_prefix?()
+    end
+
+    test "round-trips a true value" do
+      assert {:ok, _} = Languages.set_default_language_no_prefix(true)
+      assert Languages.default_language_no_prefix?()
+    end
+
+    test "round-trips false explicitly" do
+      assert {:ok, _} = Languages.set_default_language_no_prefix(true)
+      assert {:ok, _} = Languages.set_default_language_no_prefix(false)
+      refute Languages.default_language_no_prefix?()
+    end
+  end
+
+  describe "Routes helpers honor the setting" do
+    setup do
+      Settings.update_setting("languages_enabled", "true")
+      :ok
+    end
+
+    test "admin_path strips primary prefix only when setting is ON" do
+      assert {:ok, _} = Languages.set_default_language_no_prefix(false)
+      assert Routes.admin_path("/admin/users", "en") == "/phoenix_kit/en/admin/users"
+
+      assert {:ok, _} = Languages.set_default_language_no_prefix(true)
+      assert Routes.admin_path("/admin/users", "en") == "/phoenix_kit/admin/users"
+    end
+
+    test "admin_path always emits non-primary prefix regardless of setting" do
+      assert {:ok, _} = Languages.set_default_language_no_prefix(true)
+      assert Routes.admin_path("/admin/users", "de") == "/phoenix_kit/de/admin/users"
+
+      assert {:ok, _} = Languages.set_default_language_no_prefix(false)
+      assert Routes.admin_path("/admin/users", "de") == "/phoenix_kit/de/admin/users"
+    end
+
+    test "path/2 (non-admin) strips primary prefix only when setting is ON" do
+      assert {:ok, _} = Languages.set_default_language_no_prefix(false)
+      assert Routes.path("/users/log-in", locale: "en") == "/phoenix_kit/en/users/log-in"
+
+      assert {:ok, _} = Languages.set_default_language_no_prefix(true)
+      assert Routes.path("/users/log-in", locale: "en") == "/phoenix_kit/users/log-in"
+    end
+  end
+
+  describe "migrate_legacy/0 — backfills from publishing key" do
+    test "no-op when neither key is set" do
+      assert {:ok, %{default_language_no_prefix: :not_migrated}} =
+               Languages.migrate_legacy()
+
+      refute Languages.default_language_no_prefix?()
+    end
+
+    test "no-op when the new key is already set (ignores legacy)" do
+      # New key explicitly set to false; legacy is true. New wins.
+      Settings.update_setting("default_language_no_prefix", "false")
+      Settings.update_setting("publishing_default_language_no_prefix", "true")
+
+      assert {:ok, %{default_language_no_prefix: :already_set}} =
+               Languages.migrate_legacy()
+
+      refute Languages.default_language_no_prefix?()
+    end
+
+    test "copies legacy true value to the new key" do
+      Settings.update_setting("publishing_default_language_no_prefix", "true")
+      refute Languages.default_language_no_prefix?()
+
+      assert {:ok, %{default_language_no_prefix: :migrated_from_legacy, value: "true"}} =
+               Languages.migrate_legacy()
+
+      assert Languages.default_language_no_prefix?()
+    end
+
+    test "copies legacy false value to the new key" do
+      Settings.update_setting("publishing_default_language_no_prefix", "false")
+
+      assert {:ok, %{default_language_no_prefix: :migrated_from_legacy, value: "false"}} =
+               Languages.migrate_legacy()
+
+      assert Settings.get_setting("default_language_no_prefix") == "false"
+      refute Languages.default_language_no_prefix?()
+    end
+
+    test "is idempotent — second run is a no-op" do
+      Settings.update_setting("publishing_default_language_no_prefix", "true")
+
+      assert {:ok, %{default_language_no_prefix: :migrated_from_legacy}} =
+               Languages.migrate_legacy()
+
+      assert {:ok, %{default_language_no_prefix: :already_set}} =
+               Languages.migrate_legacy()
+    end
+  end
+end

--- a/test/phoenix_kit/utils/routes_test.exs
+++ b/test/phoenix_kit/utils/routes_test.exs
@@ -6,12 +6,18 @@ defmodule PhoenixKit.Utils.RoutesTest do
   # All assertions below assume the default language resolves to "en".
   # `Routes.get_default_language_base/0` rescues any DB lookup failure and
   # falls back to "en", so these tests run without a connected database.
-  # If the test repo is ever wired up, the default still resolves to "en"
-  # unless a different language is explicitly configured as default.
+  #
+  # `Routes.prefixless_primary?/0` (the new gate on primary-language
+  # stripping) ALSO rescues into `false` when no DB is reachable, so this
+  # whole file exercises the "setting is OFF" branch of the new
+  # site-wide `default_language_no_prefix` behaviour. The "setting is ON"
+  # branch is covered by the integration tests in
+  # `test/phoenix_kit/modules/languages/default_language_no_prefix_test.exs`
+  # (DB-backed).
 
-  describe "admin_path/2 — primary-language prefix stripping" do
-    test "primary locale (en) emits no prefix" do
-      assert Routes.admin_path("/admin/users", "en") == "/phoenix_kit/admin/users"
+  describe "admin_path/2 — primary-language prefix (setting OFF, the default)" do
+    test "primary locale (en) KEEPS its prefix" do
+      assert Routes.admin_path("/admin/users", "en") == "/phoenix_kit/en/admin/users"
     end
 
     test "non-primary locale keeps its prefix" do
@@ -20,23 +26,25 @@ defmodule PhoenixKit.Utils.RoutesTest do
     end
 
     test "nil locale falls back to no prefix (no locale segment)" do
-      # When no locale is supplied, admin_path delegates to `path/1`. With a
-      # primary-locale fallback that's "en", the result is unprefixed.
-      assert Routes.admin_path("/admin/users", nil) == "/phoenix_kit/admin/users"
+      # When no locale is supplied, admin_path delegates to `path/1`. With
+      # the gettext fallback set to "en" (the default), the path uses the
+      # `build_path_with_locale/3` branch which respects the setting.
+      # Setting OFF + primary locale = prefixed shape.
+      assert Routes.admin_path("/admin/users", nil) == "/phoenix_kit/en/admin/users"
     end
 
     test "nested admin paths follow the same rule" do
       assert Routes.admin_path("/admin/users/edit/123", "en") ==
-               "/phoenix_kit/admin/users/edit/123"
+               "/phoenix_kit/en/admin/users/edit/123"
 
       assert Routes.admin_path("/admin/users/edit/123", "de") ==
                "/phoenix_kit/de/admin/users/edit/123"
     end
   end
 
-  describe "path/2 — non-admin routes (regression coverage)" do
-    test "primary locale emits no prefix (unchanged behaviour)" do
-      assert Routes.path("/users/log-in", locale: "en") == "/phoenix_kit/users/log-in"
+  describe "path/2 — non-admin routes (setting OFF, the default)" do
+    test "primary locale KEEPS its prefix" do
+      assert Routes.path("/users/log-in", locale: "en") == "/phoenix_kit/en/users/log-in"
     end
 
     test "non-primary locale keeps its prefix" do
@@ -49,20 +57,16 @@ defmodule PhoenixKit.Utils.RoutesTest do
   end
 
   describe "admin_path/2 — backcompat for legacy /en/admin URLs" do
-    # The prefixed shape is no longer EMITTED for the primary language,
-    # but it must still RESOLVE (the dual-scope admin route emission
-    # declares both `/:locale/admin/*` and `/admin/*`). Anyone with a
-    # bookmark or external link pointing at `/phoenix_kit/en/admin/...`
-    # should still reach the page. This test pins the helper-side half
-    # of that contract: explicitly passing the primary locale produces
-    # the prefixless shape (intended), while a non-primary locale still
-    # produces the prefixed shape (which legacy `/en/admin/...` URLs
-    # also match against in the route table).
-    test "explicit primary locale → prefixless (intended emission)" do
-      assert Routes.admin_path("/admin/users", "en") == "/phoenix_kit/admin/users"
+    # Both URL shapes resolve at the router level — the admin route
+    # macros declare both `/:locale/admin/*` AND `/admin/*` scopes — so
+    # legacy `/phoenix_kit/en/admin/...` bookmarks still reach the page
+    # regardless of the new setting. This test pins the helper-side
+    # behaviour for both setting states.
+    test "explicit primary locale with setting OFF → prefixed (default)" do
+      assert Routes.admin_path("/admin/users", "en") == "/phoenix_kit/en/admin/users"
     end
 
-    test "explicit non-primary locale → prefixed (also the shape a legacy /en/ URL takes)" do
+    test "explicit non-primary locale → prefixed (legacy shape passes through)" do
       assert Routes.admin_path("/admin/users", "de") == "/phoenix_kit/de/admin/users"
     end
 

--- a/test/phoenix_kit_web/components/core/language_switcher_test.exs
+++ b/test/phoenix_kit_web/components/core/language_switcher_test.exs
@@ -130,8 +130,11 @@ defmodule PhoenixKitWeb.Components.Core.LanguageSwitcherTest do
         """)
 
       # Both languages use the locale-rewrite default with url_prefix.
-      # Default locale (en) is treated as prefixless inside the locale segment.
-      assert html =~ ~s(href="/phoenix_kit/some/page")
+      # `default_language_no_prefix` is OFF (the default) and no DB is
+      # reachable for this unit test, so the primary locale ALSO gets a
+      # prefix. The "ON" branch (prefixless primary) is covered DB-side
+      # in `test/integration/languages/default_language_no_prefix_test.exs`.
+      assert html =~ ~s(href="/phoenix_kit/en/some/page")
       assert html =~ ~s(href="/phoenix_kit/fr/some/page")
     end
 
@@ -148,7 +151,8 @@ defmodule PhoenixKitWeb.Components.Core.LanguageSwitcherTest do
         />
         """)
 
-      assert html =~ ~s(href="/phoenix_kit/some/page")
+      # Setting OFF (default) + no DB → primary locale also gets prefix.
+      assert html =~ ~s(href="/phoenix_kit/en/some/page")
       assert html =~ ~s(href="/phoenix_kit/fr/some/page")
     end
 


### PR DESCRIPTION
## Summary

Lifts the primary-language URL prefix toggle into a single site-wide
setting on the Languages admin page (`/admin/settings/languages`).
All URL generators in the workspace — core `Routes.path/1`,
`Routes.admin_path/2`, the sitemap, publishing's HTML builders, and
publishing's canonical-redirect controller — now honor the same
source of truth.

This pairs with **phoenix_kit_publishing PR #TBD** which delegates
publishing's existing setter and replaces the publishing-settings
toggle with a read-only status link.

## Why

PR #551 made admin URLs unconditionally prefixless for the primary
language. Publishing's public URLs were governed by a separate
toggle (`publishing_default_language_no_prefix`, default off), and
the sitemap honored neither — it always emitted `/en/blog/post` in
multilang mode regardless of the setting. The boss flagged both: the
setting should be site-wide, and the sitemap should respect it.

## What changed

- **New core setting** `default_language_no_prefix` (boolean, default
  `false`) on `PhoenixKit.Modules.Languages`. Surfaced as a daisyUI
  toggle in a new "URL Behavior" card on the Languages admin page,
  above the existing "Frontend Language Switcher" card.
- **`Routes.path/1` + `admin_path/2`** (`lib/phoenix_kit/utils/routes.ex`):
  the unconditional primary-locale strip from PR #551 is now gated
  on `Languages.default_language_no_prefix?/0` via a new
  `prefixless_primary?/0` private helper. Same defensive rescue +
  mix-task fallback as `get_default_language_base/0`.
- **Sitemap fix** (`lib/modules/sitemap/sources/publishing.ex`):
  `build_group_path/3` now skips the language segment for the
  primary language when the setting is on. Previously it always
  emitted the prefix in multilang mode — `/en/blog/post` showed up
  in the sitemap even when publishing was set to emit `/blog/post`
  in served URLs.
- **Legacy migration** (`Languages.migrate_legacy/0`): on first
  call, copies the value from the legacy
  `publishing_default_language_no_prefix` key to the new
  `default_language_no_prefix` key. Idempotent. Run by
  `PhoenixKit.ModuleRegistry.run_all_legacy_migrations/0` from the
  host app's `Application.start/2`.

## Migration / behavior change

Default is `false`, matching the historical publishing default and
keeping existing installs' indexed public URLs stable. Sites that
previously toggled the publishing setting get migrated on first
`migrate_legacy/0` run — they keep their explicit choice without
admin action.

**Admin URL emission flips**: PR #551 emitted prefixless
unconditionally for the primary locale; this PR honors the new
setting (default off), so primary admin URLs grow back the `/en/`
prefix unless the admin opts in. Both URL shapes still resolve at
the router (dual-scope admin emission), so the only visible change
is the *emitted* shape — bookmarks and external links keep working.

## Tests

- `test/phoenix_kit/utils/routes_test.exs` updated to cover the new
  default-off behavior (no-DB rescue path → primary keeps prefix).
- `test/integration/languages/default_language_no_prefix_test.exs`
  added (DB-backed, 11 tests): setter round-trips, Routes helpers
  across both setting states, `migrate_legacy/0` no-op + backfill +
  idempotency.
- `test/phoenix_kit_web/components/core/language_switcher_test.exs`
  assertions updated to match the new default.

`mix test` clean (1308 tests, 0 failures, 11 doctests).
`mix compile --warnings-as-errors`, `mix credo --strict`,
`mix deps.unlock --check-unused`, `mix format --check-formatted` all
clean.

## Follow-up surfaced (not in this PR)

`phoenix_kit_entities/lib/phoenix_kit_entities/url_resolver.ex` has
the same site-wide-setting blind spot in two helpers + three call
sites — `build_path_with_language/3` (sitemap, always prefixes
primary) and `add_public_locale_prefix/2` (public URLs, always
strips primary). Should be addressed in entities to claim full
site-wide unification.

## Test plan

- [ ] CI green
- [ ] Toggle the new setting on `/admin/settings/languages`, verify
  admin URLs in the navigation and sidebar flip prefix shape
- [ ] With the setting ON: visit the sitemap and verify primary-
  language entries don't carry `/en/`
- [ ] With the setting OFF (default): existing installs upgrade
  without indexed URLs shifting