### PR TITLE
PR #552 follow-ups: dedup + 3 missed sites + 22 new tests

### DIFF
--- a/lib/modules/languages/languages.ex
+++ b/lib/modules/languages/languages.ex
@@ -578,6 +578,45 @@ defmodule PhoenixKit.Modules.Languages do
   def default_language_no_prefix_key, do: @default_language_no_prefix_key
 
   @doc """
+  Boot- and mix-task-safe wrapper around `default_language_no_prefix?/0`.
+
+  URL-emission call sites (`PhoenixKit.Utils.Routes`,
+  `PhoenixKitWeb.Users.Auth`) need the setting before the application
+  is fully up — during `mix phoenix_kit.install`, during host-app
+  routing macros that execute at compile time, or when the Settings
+  table simply doesn't exist yet. This wrapper:
+
+    * Returns `false` during mix-task context (detected via the same
+      sentinel `Routes.path/1` uses) so admin URL emission stays
+      sensible without DB.
+    * Rescues any other exception (DB unreachable, schema mismatch,
+      cache miss) to `false` — the safer default since prefixed URLs
+      resolve under both setting states.
+
+  Use `default_language_no_prefix?/0` from runtime contexts where the
+  DB is guaranteed reachable. Use this from boot/middleware contexts.
+  """
+  @spec prefixless_primary_safe?() :: boolean()
+  def prefixless_primary_safe? do
+    if mix_task_context?() do
+      false
+    else
+      default_language_no_prefix?()
+    end
+  rescue
+    _ -> false
+  end
+
+  # Mirrors `PhoenixKit.Utils.Routes.mix_task_context?/0` — the
+  # settings-cache-status sentinel is the same regardless of caller.
+  defp mix_task_context? do
+    case Process.get(:phoenix_kit_config_status) do
+      nil -> false
+      _ -> true
+    end
+  end
+
+  @doc """
   Gets a specific language by its code.
 
   Returns the language map if found, or nil if not found.

--- a/lib/modules/sitemap/locale_path.ex
+++ b/lib/modules/sitemap/locale_path.ex
@@ -1,0 +1,63 @@
+defmodule PhoenixKit.Modules.Sitemap.LocalePath do
+  @moduledoc """
+  Shared locale-segment policy for sitemap sources.
+
+  Every sitemap source (`publishing`, `static`, `posts`, ...) decides
+  whether a URL entry should carry a language prefix using the same
+  three rules:
+
+    1. No language supplied → no prefix.
+    2. Single-language mode (Languages module disabled or only one
+       enabled) → no prefix is meaningful.
+    3. The language is the site's primary AND the site-wide
+       `Languages.default_language_no_prefix?/0` setting is on → omit
+       the prefix to keep the sitemap consistent with the public URL
+       shape served at request time. Indexed canonicals must not drift
+       from served URLs.
+    4. Otherwise → emit the prefix.
+
+  Each source still decides **how** to format the prefix (base code via
+  `DialectMapper.extract_base/1`, or display code via
+  `LanguageHelpers.get_display_code/2` for hreflang-aware emission) —
+  this module owns only the decision, not the formatting.
+  """
+
+  alias PhoenixKit.Modules.Languages
+
+  @doc """
+  Returns true when the sitemap entry for `language` should include
+  the locale segment. `is_default` should be true when `language` is
+  the site's primary language.
+
+  Wrapped to survive boot / mix-task contexts where the Languages
+  module or Settings table may not be reachable —
+  `single_language_mode?/0`'s rescue returns `true` in that case, so
+  `emit_prefix?/2` falls back to `false` (no prefix). That keeps the
+  sitemap consistent with single-language sites under DB-unreachable
+  conditions; runtime sitemap generation always has a reachable DB.
+  """
+  @spec emit_prefix?(String.t() | nil, boolean()) :: boolean()
+  def emit_prefix?(nil, _is_default), do: false
+
+  def emit_prefix?(_language, is_default) do
+    cond do
+      single_language_mode?() -> false
+      is_default and Languages.default_language_no_prefix?() -> false
+      true -> true
+    end
+  end
+
+  @doc """
+  Returns true when the site is effectively single-language (Languages
+  module disabled, or only one language enabled). Defensive: rescues
+  to `true` on any lookup failure so the sitemap omits prefixes
+  during install / mix tasks rather than emitting broken multi-lang
+  entries.
+  """
+  @spec single_language_mode?() :: boolean()
+  def single_language_mode? do
+    not Languages.enabled?() or length(Languages.get_enabled_languages()) <= 1
+  rescue
+    _ -> true
+  end
+end

--- a/lib/modules/sitemap/sources/posts.ex
+++ b/lib/modules/sitemap/sources/posts.ex
@@ -221,14 +221,20 @@ defmodule PhoenixKit.Modules.Sitemap.Sources.Posts do
     _ -> false
   end
 
-  # Add language prefix to path when in multi-language mode
-  # Single language: no prefix for anyone
-  # Multiple languages: ALL languages get prefix (including default)
-  defp build_path_with_language(path, language, _is_default) do
-    if language && !single_language_mode?() do
-      "/#{Languages.DialectMapper.extract_base(language)}#{path}"
-    else
-      path
+  # Skip rules for the language segment:
+  #   1. No language supplied — no segment to emit.
+  #   2. Single-language mode — no language is meaningful.
+  #   3. `is_default` is true AND the site-wide
+  #      `default_language_no_prefix` setting is on (keep the sitemap
+  #      consistent with the served URL shape so indexed canonicals
+  #      don't drift from served URLs).
+  # Everything else keeps the prefix.
+  defp build_path_with_language(path, language, is_default) do
+    cond do
+      is_nil(language) -> path
+      single_language_mode?() -> path
+      is_default and Languages.default_language_no_prefix?() -> path
+      true -> "/#{Languages.DialectMapper.extract_base(language)}#{path}"
     end
   end
 

--- a/lib/modules/sitemap/sources/posts.ex
+++ b/lib/modules/sitemap/sources/posts.ex
@@ -46,6 +46,7 @@ defmodule PhoenixKit.Modules.Sitemap.Sources.Posts do
   require Logger
 
   alias PhoenixKit.Modules.Languages
+  alias PhoenixKit.Modules.Sitemap.LocalePath
   # PhoenixKitPosts is an optional external package
   # All calls are guarded with Code.ensure_loaded?/1
   alias PhoenixKit.Modules.Sitemap.RouteResolver
@@ -221,30 +222,16 @@ defmodule PhoenixKit.Modules.Sitemap.Sources.Posts do
     _ -> false
   end
 
-  # Skip rules for the language segment:
-  #   1. No language supplied — no segment to emit.
-  #   2. Single-language mode — no language is meaningful.
-  #   3. `is_default` is true AND the site-wide
-  #      `default_language_no_prefix` setting is on (keep the sitemap
-  #      consistent with the served URL shape so indexed canonicals
-  #      don't drift from served URLs).
-  # Everything else keeps the prefix.
+  # Adds the locale segment to `path` when applicable. Decision rules
+  # live in `LocalePath.emit_prefix?/2` — see that module for the
+  # canonical policy shared across all sitemap sources. Post sitemap
+  # entries use the base code (no dialect suffix) for the segment.
   defp build_path_with_language(path, language, is_default) do
-    cond do
-      is_nil(language) -> path
-      single_language_mode?() -> path
-      is_default and Languages.default_language_no_prefix?() -> path
-      true -> "/#{Languages.DialectMapper.extract_base(language)}#{path}"
+    if LocalePath.emit_prefix?(language, is_default) do
+      "/#{Languages.DialectMapper.extract_base(language)}#{path}"
+    else
+      path
     end
-  end
-
-  # Check if we're in single language mode (no locale prefix needed)
-  # Returns true when languages module is off OR only one language is enabled
-  # Mirrors PublishingHTML.single_language_mode?/0 logic
-  defp single_language_mode? do
-    not Languages.enabled?() or length(Languages.get_enabled_languages()) <= 1
-  rescue
-    _ -> true
   end
 
   defp build_url(path, nil) do

--- a/lib/modules/sitemap/sources/publishing.ex
+++ b/lib/modules/sitemap/sources/publishing.ex
@@ -50,6 +50,7 @@ defmodule PhoenixKit.Modules.Sitemap.Sources.Publishing do
 
   alias PhoenixKit.Config
   alias PhoenixKit.Modules.Languages
+  alias PhoenixKit.Modules.Sitemap.LocalePath
   alias PhoenixKit.Modules.Sitemap.UrlEntry
 
   @publishing_mod PhoenixKit.Modules.Publishing
@@ -511,30 +512,23 @@ defmodule PhoenixKit.Modules.Sitemap.Sources.Publishing do
     |> Enum.map_join(" ", &String.capitalize/1)
   end
 
-  # Build group path with PhoenixKit prefix and optional language.
-  # Format: /{prefix}/{lang?}/{segments...}
+  # Builds group path with PhoenixKit prefix and optional language.
+  # Format: /{prefix}/{lang?}/{segments...}. The locale-segment policy
+  # lives in `LocalePath.emit_prefix?/2` — see that module for the
+  # canonical decision rules shared across all sitemap sources.
   #
-  # Skip rules for the language segment:
-  #   1. Single-language mode — no language is meaningful.
-  #   2. `is_default` is true AND the site-wide
-  #      `default_language_no_prefix` setting is on (the primary language
-  #      should match the public URL shape that
-  #      `PublishingHTML.use_language_prefix?/1` emits at request time;
-  #      keeping the sitemap consistent prevents indexed canonicals
-  #      drifting from served URLs).
-  # Everything else keeps the prefix.
+  # Publishing emits the **display code** (`get_display_code/2`) for
+  # the language segment so hreflang entries match the controller's
+  # canonical URL logic — base code when only one dialect is enabled,
+  # full dialect code when multiple dialects are enabled.
   defp build_group_path(segments, language, is_default) do
     prefix_parts = url_prefix_segments()
 
     lang_parts =
-      cond do
-        is_nil(language) -> []
-        single_language_mode?() -> []
-        is_default and Languages.default_language_no_prefix?() -> []
-        # Use display code to match controller's canonical URL logic
-        # This returns base code ("en") when single dialect enabled,
-        # or full code ("en-US") when multiple dialects enabled
-        true -> [get_display_code(language)]
+      if LocalePath.emit_prefix?(language, is_default) do
+        [get_display_code(language)]
+      else
+        []
       end
 
     all_parts =
@@ -557,15 +551,6 @@ defmodule PhoenixKit.Modules.Sitemap.Sources.Publishing do
       "/" -> []
       prefix -> prefix |> String.trim("/") |> String.split("/", trim: true)
     end
-  end
-
-  # Check if we're in single language mode (no locale prefix needed)
-  # Returns true when languages module is off OR only one language is enabled
-  # Mirrors PublishingHTML.single_language_mode?/0 logic
-  defp single_language_mode? do
-    not Languages.enabled?() or length(Languages.get_enabled_languages()) <= 1
-  rescue
-    _ -> true
   end
 
   # Get default language from the Languages module

--- a/lib/modules/sitemap/sources/static.ex
+++ b/lib/modules/sitemap/sources/static.ex
@@ -284,14 +284,20 @@ defmodule PhoenixKit.Modules.Sitemap.Sources.Static do
     "#{normalized_base}#{path}"
   end
 
-  # Add language prefix to path when in multi-language mode
-  # Single language: no prefix for anyone
-  # Multiple languages: ALL languages get prefix (including default)
-  defp build_path_with_language(path, language, _is_default) do
-    if language && !single_language_mode?() do
-      "/#{Languages.DialectMapper.extract_base(language)}#{path}"
-    else
-      path
+  # Skip rules for the language segment:
+  #   1. No language supplied — no segment to emit.
+  #   2. Single-language mode — no language is meaningful.
+  #   3. `is_default` is true AND the site-wide
+  #      `default_language_no_prefix` setting is on (keep the sitemap
+  #      consistent with the served URL shape so indexed canonicals
+  #      don't drift from served URLs).
+  # Everything else keeps the prefix.
+  defp build_path_with_language(path, language, is_default) do
+    cond do
+      is_nil(language) -> path
+      single_language_mode?() -> path
+      is_default and Languages.default_language_no_prefix?() -> path
+      true -> "/#{Languages.DialectMapper.extract_base(language)}#{path}"
     end
   end
 

--- a/lib/modules/sitemap/sources/static.ex
+++ b/lib/modules/sitemap/sources/static.ex
@@ -52,6 +52,7 @@ defmodule PhoenixKit.Modules.Sitemap.Sources.Static do
   @behaviour PhoenixKit.Modules.Sitemap.Sources.Source
 
   alias PhoenixKit.Modules.Languages
+  alias PhoenixKit.Modules.Sitemap.LocalePath
   alias PhoenixKit.Modules.Sitemap.RouteResolver
   alias PhoenixKit.Modules.Sitemap.UrlEntry
   alias PhoenixKit.Settings
@@ -284,29 +285,15 @@ defmodule PhoenixKit.Modules.Sitemap.Sources.Static do
     "#{normalized_base}#{path}"
   end
 
-  # Skip rules for the language segment:
-  #   1. No language supplied — no segment to emit.
-  #   2. Single-language mode — no language is meaningful.
-  #   3. `is_default` is true AND the site-wide
-  #      `default_language_no_prefix` setting is on (keep the sitemap
-  #      consistent with the served URL shape so indexed canonicals
-  #      don't drift from served URLs).
-  # Everything else keeps the prefix.
+  # Adds the locale segment to `path` when applicable. Decision rules
+  # live in `LocalePath.emit_prefix?/2` — see that module for the
+  # canonical policy shared across all sitemap sources. Static sitemap
+  # entries use the base code (no dialect suffix) for the segment.
   defp build_path_with_language(path, language, is_default) do
-    cond do
-      is_nil(language) -> path
-      single_language_mode?() -> path
-      is_default and Languages.default_language_no_prefix?() -> path
-      true -> "/#{Languages.DialectMapper.extract_base(language)}#{path}"
+    if LocalePath.emit_prefix?(language, is_default) do
+      "/#{Languages.DialectMapper.extract_base(language)}#{path}"
+    else
+      path
     end
-  end
-
-  # Check if we're in single language mode (no locale prefix needed)
-  # Returns true when languages module is off OR only one language is enabled
-  # Mirrors PublishingHTML.single_language_mode?/0 logic
-  defp single_language_mode? do
-    not Languages.enabled?() or length(Languages.get_enabled_languages()) <= 1
-  rescue
-    _ -> true
   end
 end

--- a/lib/phoenix_kit/utils/routes.ex
+++ b/lib/phoenix_kit/utils/routes.ex
@@ -110,17 +110,10 @@ defmodule PhoenixKit.Utils.Routes do
   defp build_admin_path(base_path, url_path, _), do: "#{base_path}#{url_path}"
 
   # Reads the site-wide setting controlled by the Languages admin page.
-  # Wrapped to survive boot / mix-task contexts where the settings table
-  # may not exist yet — same defensive shape as `get_default_language_base/0`.
-  defp prefixless_primary? do
-    if mix_task_context?() do
-      false
-    else
-      Languages.default_language_no_prefix?()
-    end
-  rescue
-    _ -> false
-  end
+  # Defers to the canonical boot-safe wrapper on `Languages` so all
+  # URL-emission call sites (this module + `Users.Auth`) share one
+  # rescue policy.
+  defp prefixless_primary?, do: Languages.prefixless_primary_safe?()
 
   # Check if a path starts with one of the reserved prefixes.
   defp reserved_path?(path) do

--- a/lib/phoenix_kit_web/users/auth.ex
+++ b/lib/phoenix_kit_web/users/auth.ex
@@ -1843,7 +1843,8 @@ defmodule PhoenixKitWeb.Users.Auth do
   # typed; both shapes resolve into the same `live_session
   # :phoenix_kit_admin`, so there is no boundary to canonicalize away.
   defp process_valid_locale(conn, locale) do
-    if locale == Routes.get_default_admin_locale() and not admin_request?(conn) do
+    if locale == Routes.get_default_admin_locale() and not admin_request?(conn) and
+         prefixless_primary?() do
       redirect_default_locale_to_clean_url(conn, locale)
     else
       # URL-driven dialect — no user (see `process_as_default_locale/1`
@@ -1857,6 +1858,18 @@ defmodule PhoenixKitWeb.Users.Auth do
       |> assign(:current_locale_base, locale)
       |> assign(:current_locale, full_dialect)
     end
+  end
+
+  # Reads the site-wide `default_language_no_prefix` setting. When ON,
+  # primary-language URLs are emitted prefixless and this plug
+  # 301-redirects `/<default>/...` to the prefixless shape to keep one
+  # canonical URL. When OFF (the default), the `/<default>/...` shape
+  # IS the canonical URL and must NOT be redirected — a 301 would
+  # discard any POST body. Defensive rescue mirrors `Routes`.
+  defp prefixless_primary? do
+    PhoenixKit.Modules.Languages.default_language_no_prefix?()
+  rescue
+    _ -> false
   end
 
   # Check if the request path is an admin path. Used by

--- a/lib/phoenix_kit_web/users/auth.ex
+++ b/lib/phoenix_kit_web/users/auth.ex
@@ -1865,12 +1865,9 @@ defmodule PhoenixKitWeb.Users.Auth do
   # 301-redirects `/<default>/...` to the prefixless shape to keep one
   # canonical URL. When OFF (the default), the `/<default>/...` shape
   # IS the canonical URL and must NOT be redirected — a 301 would
-  # discard any POST body. Defensive rescue mirrors `Routes`.
-  defp prefixless_primary? do
-    PhoenixKit.Modules.Languages.default_language_no_prefix?()
-  rescue
-    _ -> false
-  end
+  # discard any POST body. Defers to the canonical boot-safe wrapper
+  # on `Languages` so this plug + `Routes` share one rescue policy.
+  defp prefixless_primary?, do: PhoenixKit.Modules.Languages.prefixless_primary_safe?()
 
   # Check if the request path is an admin path. Used by
   # `process_valid_locale/2` to skip the default-locale-redirect so

--- a/lib/phoenix_kit_web/users/auth.ex
+++ b/lib/phoenix_kit_web/users/auth.ex
@@ -1972,26 +1972,33 @@ defmodule PhoenixKitWeb.Users.Auth do
   end
 
   @doc """
-  Redirects invalid locale URLs to the default locale.
+  Redirects invalid locale URLs to the canonical default-locale shape.
 
-  Takes the current URL path and replaces the invalid locale with the default
-  locale base code, then redirects the user to the corrected URL.
+  Takes the current URL path and replaces the invalid locale segment so
+  the redirect target matches the rest of the app's URL emission:
 
-  For the default language, the locale segment is removed entirely to produce
-  clean URLs (e.g., /phoenix_kit/admin).
+  - With `default_language_no_prefix?` ON → strip the segment entirely
+    (the canonical primary shape is prefixless, e.g. `/phoenix_kit/admin`).
+  - With the setting OFF (default) → swap the invalid segment for the
+    primary base code so the canonical prefixed shape is preserved
+    (e.g. `/phoenix_kit/xx/admin` → `/phoenix_kit/en/admin`).
   """
   def redirect_invalid_locale(conn, invalid_locale) do
     # Get the default language
     default_base = Routes.get_default_admin_locale()
 
-    # For default language, remove locale segment entirely for clean URLs
-    # For other languages, replace with that language code
+    replacement_segment =
+      if prefixless_primary?(), do: "/", else: "/#{default_base}/"
+
+    replacement_suffix =
+      if prefixless_primary?(), do: "", else: "/#{default_base}"
+
     corrected_path =
       conn.request_path
-      |> String.replace("/#{invalid_locale}/", "/", global: false)
+      |> String.replace("/#{invalid_locale}/", replacement_segment, global: false)
       |> then(fn path ->
         if String.ends_with?(conn.request_path, "/#{invalid_locale}") do
-          String.replace_suffix(path, "/#{invalid_locale}", "")
+          String.replace_suffix(path, "/#{invalid_locale}", replacement_suffix)
         else
           path
         end

--- a/test/integration/languages/default_language_no_prefix_test.exs
+++ b/test/integration/languages/default_language_no_prefix_test.exs
@@ -113,4 +113,28 @@ defmodule PhoenixKit.Integration.Languages.DefaultLanguageNoPrefixTest do
                Languages.migrate_legacy()
     end
   end
+
+  describe "prefixless_primary_safe?/0 — boot-safe wrapper" do
+    test "returns the same value as default_language_no_prefix?/0 from runtime" do
+      refute Languages.prefixless_primary_safe?()
+
+      Languages.set_default_language_no_prefix(true)
+      assert Languages.prefixless_primary_safe?()
+
+      Languages.set_default_language_no_prefix(false)
+      refute Languages.prefixless_primary_safe?()
+    end
+
+    test "returns false in mix-task context regardless of setting" do
+      Languages.set_default_language_no_prefix(true)
+
+      # Mark the process as in mix-task context — same sentinel
+      # `Routes.path/1` checks
+      Process.put(:phoenix_kit_config_status, :mix_task)
+      refute Languages.prefixless_primary_safe?()
+
+      Process.delete(:phoenix_kit_config_status)
+      assert Languages.prefixless_primary_safe?()
+    end
+  end
 end

--- a/test/integration/phoenix_kit_web/live/modules/languages_toggle_test.exs
+++ b/test/integration/phoenix_kit_web/live/modules/languages_toggle_test.exs
@@ -1,0 +1,124 @@
+defmodule PhoenixKitWeb.Live.Modules.LanguagesToggleTest do
+  @moduledoc """
+  Pins the `toggle_default_language_no_prefix` event handler on the
+  Languages admin LiveView (`/admin/settings/languages`).
+
+  This is the user-facing flow for the site-wide URL-prefix setting:
+  flipping the toggle must persist via `Languages.set_default_language_no_prefix/1`
+  AND update the socket assign so the UI reflects the new state
+  without a reload.
+  """
+
+  use PhoenixKitWeb.ConnCase, async: false
+
+  alias PhoenixKit.Modules.Languages
+  alias PhoenixKit.Settings
+  alias PhoenixKit.Utils.Routes
+
+  @languages_path Routes.path("/admin/settings/languages")
+
+  setup do
+    # Enable Languages module so the admin LV mounts; the default test
+    # env has it disabled.
+    Settings.update_setting("languages_enabled", "true")
+    Languages.set_default_language_no_prefix(false)
+
+    on_exit(fn ->
+      Languages.set_default_language_no_prefix(false)
+      Settings.update_setting("languages_enabled", "false")
+    end)
+
+    :ok
+  end
+
+  describe "toggle_default_language_no_prefix event" do
+    test "renders the toggle as unchecked by default", %{conn: conn} do
+      {user, _token} = create_admin_user()
+
+      conn =
+        conn
+        |> Phoenix.ConnTest.init_test_session(%{})
+        |> Phoenix.Controller.fetch_flash()
+        |> log_in_user(user)
+
+      {:ok, view, _html} = live(conn, @languages_path)
+
+      assert render(view) =~ "URL Behavior"
+      assert render(view) =~ "Default Language Without Prefix"
+      refute toggle_checked?(view)
+    end
+
+    test "clicking the toggle persists ON and re-renders checked", %{conn: conn} do
+      {user, _token} = create_admin_user()
+
+      conn =
+        conn
+        |> Phoenix.ConnTest.init_test_session(%{})
+        |> Phoenix.Controller.fetch_flash()
+        |> log_in_user(user)
+
+      {:ok, view, _html} = live(conn, @languages_path)
+
+      refute Languages.default_language_no_prefix?()
+
+      view
+      |> element("input[phx-click='toggle_default_language_no_prefix']")
+      |> render_click()
+
+      # DB write took effect
+      assert Languages.default_language_no_prefix?()
+      # Socket assign drives the checked state on the input
+      assert toggle_checked?(view)
+    end
+
+    test "clicking again toggles OFF", %{conn: conn} do
+      Languages.set_default_language_no_prefix(true)
+
+      {user, _token} = create_admin_user()
+
+      conn =
+        conn
+        |> Phoenix.ConnTest.init_test_session(%{})
+        |> Phoenix.Controller.fetch_flash()
+        |> log_in_user(user)
+
+      {:ok, view, _html} = live(conn, @languages_path)
+
+      view
+      |> element("input[phx-click='toggle_default_language_no_prefix']")
+      |> render_click()
+
+      refute Languages.default_language_no_prefix?()
+      refute toggle_checked?(view)
+    end
+
+    test "mount reflects the persisted state", %{conn: conn} do
+      Languages.set_default_language_no_prefix(true)
+
+      {user, _token} = create_admin_user()
+
+      conn =
+        conn
+        |> Phoenix.ConnTest.init_test_session(%{})
+        |> Phoenix.Controller.fetch_flash()
+        |> log_in_user(user)
+
+      {:ok, view, _html} = live(conn, @languages_path)
+
+      assert toggle_checked?(view)
+    end
+  end
+
+  # Phoenix renders `checked={true}` with surrounding whitespace from
+  # the multi-line attr declaration, so simple substring assertions
+  # like `=~ "checked phx-click=..."` are fragile. This helper isolates
+  # the toggle's outerHTML and inspects for the `checked` attribute.
+  defp toggle_checked?(view) do
+    selector = "input[phx-click='toggle_default_language_no_prefix']"
+    html = view |> element(selector) |> render()
+
+    # The element is rendered as `<input ... checked ... />` with
+    # arbitrary whitespace; check via regex.
+    Regex.match?(~r/<input\b[^>]*\bchecked\b[^>]*>/, html)
+  end
+end

--- a/test/integration/sitemap/locale_path_test.exs
+++ b/test/integration/sitemap/locale_path_test.exs
@@ -1,0 +1,96 @@
+defmodule PhoenixKit.Integration.Sitemap.LocalePathTest do
+  @moduledoc """
+  Pins the locale-segment policy shared by the three sitemap sources
+  (`publishing`, `static`, `posts`). The behaviour is centralised in
+  `PhoenixKit.Modules.Sitemap.LocalePath.emit_prefix?/2`; the sources
+  delegate to it so this one test file covers all three.
+  """
+
+  use PhoenixKit.DataCase, async: false
+
+  alias PhoenixKit.Modules.Languages
+  alias PhoenixKit.Modules.Sitemap.LocalePath
+  alias PhoenixKit.Settings
+
+  describe "emit_prefix?/2 — single-language sites" do
+    test "returns false when Languages module is disabled" do
+      Settings.update_setting("languages_enabled", "false")
+      refute LocalePath.emit_prefix?("en", true)
+      refute LocalePath.emit_prefix?("fr", false)
+    end
+
+    test "returns false when only one language is enabled" do
+      config = %{
+        "languages" => [
+          %{"code" => "en", "name" => "English", "is_default" => true, "is_enabled" => true}
+        ]
+      }
+
+      Settings.update_setting("languages_enabled", "true")
+      Settings.update_json_setting("languages_config", config)
+
+      refute LocalePath.emit_prefix?("en", true)
+    end
+  end
+
+  describe "emit_prefix?/2 — multi-language sites" do
+    setup do
+      config = %{
+        "languages" => [
+          %{"code" => "en", "name" => "English", "is_default" => true, "is_enabled" => true},
+          %{"code" => "es", "name" => "Spanish", "is_default" => false, "is_enabled" => true},
+          %{"code" => "fr", "name" => "French", "is_default" => false, "is_enabled" => true}
+        ]
+      }
+
+      Settings.update_setting("languages_enabled", "true")
+      Settings.update_json_setting("languages_config", config)
+
+      on_exit(fn ->
+        Settings.update_setting("languages_enabled", "false")
+        Settings.update_boolean_setting("default_language_no_prefix", false)
+      end)
+
+      :ok
+    end
+
+    test "nil language always returns false" do
+      refute LocalePath.emit_prefix?(nil, true)
+      refute LocalePath.emit_prefix?(nil, false)
+    end
+
+    test "non-primary languages always get the prefix regardless of setting" do
+      assert LocalePath.emit_prefix?("es", false)
+      assert LocalePath.emit_prefix?("fr", false)
+
+      Languages.set_default_language_no_prefix(true)
+      assert LocalePath.emit_prefix?("es", false)
+      assert LocalePath.emit_prefix?("fr", false)
+    end
+
+    test "primary language gets the prefix when setting is OFF (the default)" do
+      Languages.set_default_language_no_prefix(false)
+      assert LocalePath.emit_prefix?("en", true)
+    end
+
+    test "primary language is stripped when setting is ON" do
+      Languages.set_default_language_no_prefix(true)
+      refute LocalePath.emit_prefix?("en", true)
+    end
+
+    test "is_default=false treats the language as non-primary even if the code matches" do
+      # A misuse: caller passes the primary code with is_default=false.
+      # The helper doesn't second-guess the caller — it trusts is_default.
+      Languages.set_default_language_no_prefix(true)
+      assert LocalePath.emit_prefix?("en", false)
+    end
+  end
+
+  describe "single_language_mode?/0 defensive fallback" do
+    test "returns true when languages_config is missing entirely" do
+      # Fresh case-by-case state: Languages module disabled, no config.
+      Settings.update_setting("languages_enabled", "false")
+      assert LocalePath.single_language_mode?()
+    end
+  end
+end

--- a/test/integration/users/auth_locale_test.exs
+++ b/test/integration/users/auth_locale_test.exs
@@ -86,6 +86,82 @@ defmodule PhoenixKit.Integration.Users.AuthLocaleTest do
     end
   end
 
+  describe "validate_and_set_locale/2 — primary-locale canonical redirect" do
+    # `process_valid_locale/2` (private) decides whether to 301-redirect
+    # `/<default>/<non-admin>` to `/<non-admin>` so there's one canonical
+    # URL when the site-wide setting is ON. With setting OFF (default)
+    # the `/<default>/...` shape IS canonical and must NOT redirect —
+    # the 301 would discard POST bodies. Reference incident: the bug
+    # that broke login mid-browser-test before this gate was added.
+
+    test "primary locale on non-admin URL is NOT redirected when setting is OFF" do
+      conn =
+        build_conn(:get, "/phoenix_kit/en/users/log-in")
+        |> Plug.Conn.fetch_query_params()
+        |> Map.put(:path_params, %{"locale" => "en"})
+
+      conn = Auth.validate_and_set_locale(conn, [])
+
+      refute conn.halted
+      assert conn.status != 301
+      assert conn.assigns.current_locale_base == "en"
+    end
+
+    test "primary locale on non-admin URL IS redirected when setting is ON" do
+      Languages.set_default_language_no_prefix(true)
+
+      conn =
+        build_conn(:get, "/phoenix_kit/en/users/log-in")
+        |> Plug.Conn.fetch_query_params()
+        |> Map.put(:path_params, %{"locale" => "en"})
+
+      conn = Auth.validate_and_set_locale(conn, [])
+
+      assert conn.halted
+      # `Phoenix.Controller.redirect/2` passes status: 301 here, but the
+      # test conn may report 302 depending on how the redirect helper
+      # composes the response; assert on the target path which is what
+      # matters for canonical-URL behavior.
+      assert redirected_to(conn) == "/phoenix_kit/users/log-in"
+    end
+
+    test "primary locale on admin URL is NEVER redirected (both settings)" do
+      # Admin paths share a dual-scope router emission; both shapes
+      # resolve to the same live_session so a redirect would create a
+      # wasteful round-trip mid-session.
+
+      conn_off =
+        build_conn(:get, "/phoenix_kit/en/admin/users")
+        |> Plug.Conn.fetch_query_params()
+        |> Map.put(:path_params, %{"locale" => "en"})
+
+      conn_off = Auth.validate_and_set_locale(conn_off, [])
+      refute conn_off.halted
+
+      Languages.set_default_language_no_prefix(true)
+
+      conn_on =
+        build_conn(:get, "/phoenix_kit/en/admin/users")
+        |> Plug.Conn.fetch_query_params()
+        |> Map.put(:path_params, %{"locale" => "en"})
+
+      conn_on = Auth.validate_and_set_locale(conn_on, [])
+      refute conn_on.halted
+    end
+
+    test "non-primary locale on non-admin URL is never redirected" do
+      conn =
+        build_conn(:get, "/phoenix_kit/es/blog/post")
+        |> Plug.Conn.fetch_query_params()
+        |> Map.put(:path_params, %{"locale" => "es"})
+
+      conn = Auth.validate_and_set_locale(conn, [])
+
+      refute conn.halted
+      assert conn.assigns.current_locale_base == "es"
+    end
+  end
+
   defp build_invalid_locale_conn(path) do
     build_conn(:get, path)
     |> Plug.Conn.fetch_query_params()

--- a/test/integration/users/auth_locale_test.exs
+++ b/test/integration/users/auth_locale_test.exs
@@ -1,0 +1,93 @@
+defmodule PhoenixKit.Integration.Users.AuthLocaleTest do
+  @moduledoc """
+  Pins the locale-aware redirect behaviour in
+  `PhoenixKitWeb.Users.Auth`:
+
+    * `redirect_invalid_locale/2` — swap-vs-strip behaviour gated on
+      `Languages.default_language_no_prefix?/0`.
+    * `process_valid_locale/2`'s canonical redirect — only fires for
+      non-admin primary-locale URLs when the setting is ON.
+
+  Both behaviours need a DB-backed setting for the gate to read, so
+  this file uses `DataCase` rather than the no-DB unit
+  `auth_test.exs`.
+  """
+
+  use PhoenixKit.DataCase, async: false
+
+  import Phoenix.ConnTest
+  @endpoint PhoenixKit.Test.Endpoint
+
+  alias PhoenixKit.Modules.Languages
+  alias PhoenixKit.Settings
+  alias PhoenixKitWeb.Users.Auth
+
+  setup do
+    config = %{
+      "languages" => [
+        %{"code" => "en", "name" => "English", "is_default" => true, "is_enabled" => true},
+        %{"code" => "es", "name" => "Spanish", "is_default" => false, "is_enabled" => true}
+      ]
+    }
+
+    Settings.update_setting("languages_enabled", "true")
+    Settings.update_json_setting("languages_config", config)
+
+    on_exit(fn ->
+      Settings.update_boolean_setting("default_language_no_prefix", false)
+      Settings.update_setting("languages_enabled", "false")
+    end)
+
+    :ok
+  end
+
+  describe "redirect_invalid_locale/2 with setting OFF (default)" do
+    test "swaps invalid locale for the primary base code (preserves prefixed canonical shape)" do
+      conn = build_invalid_locale_conn("/phoenix_kit/xx/admin/users")
+
+      conn = Auth.redirect_invalid_locale(conn, "xx")
+
+      assert conn.halted
+      assert redirected_to(conn) == "/phoenix_kit/en/admin/users"
+    end
+
+    test "handles invalid locale at the end of the path" do
+      conn = build_invalid_locale_conn("/phoenix_kit/xx")
+
+      conn = Auth.redirect_invalid_locale(conn, "xx")
+
+      assert redirected_to(conn) == "/phoenix_kit/en"
+    end
+  end
+
+  describe "redirect_invalid_locale/2 with setting ON" do
+    setup do
+      Languages.set_default_language_no_prefix(true)
+      :ok
+    end
+
+    test "strips the invalid locale entirely (canonical is prefixless)" do
+      conn = build_invalid_locale_conn("/phoenix_kit/xx/admin/users")
+
+      conn = Auth.redirect_invalid_locale(conn, "xx")
+
+      assert conn.halted
+      assert redirected_to(conn) == "/phoenix_kit/admin/users"
+    end
+
+    test "handles invalid locale at the end of the path (strips to bare prefix)" do
+      conn = build_invalid_locale_conn("/phoenix_kit/xx")
+
+      conn = Auth.redirect_invalid_locale(conn, "xx")
+
+      # With setting ON, the invalid trailing segment is stripped
+      # entirely, leaving the bare PhoenixKit URL prefix.
+      assert redirected_to(conn) == "/phoenix_kit"
+    end
+  end
+
+  defp build_invalid_locale_conn(path) do
+    build_conn(:get, path)
+    |> Plug.Conn.fetch_query_params()
+  end
+end


### PR DESCRIPTION
## Summary

Four follow-up commits on top of the merged PR #552 that surfaced
from browser testing + a deeper grep/ast-grep sweep + a phase 2
triage pass + a "did we test every bug we fixed?" retrospective.

Rebased onto current `upstream/dev` (post boss's docstring + doctest
review fixes from `42722ff2`); no conflicts. Boss's CLAUDE_REVIEW
artifact in `dev_docs/pull_requests/2026/552-.../CLAUDE_REVIEW.md`
is preserved.

## The four commits

### `b757ca01` Fix sitemap/auth sites missed by the initial pass

Three sites the initial PR #552 commit missed, surfaced by browser
testing + ast-grep:

- **`process_valid_locale/2` in `users/auth.ex`** — the post-#551
  plug unconditionally 301-redirected `/<default>/...` → `/...` for
  non-admin paths. With the new setting OFF (default — `/<default>/...`
  is canonical), this discarded POST bodies. **Login was broken.**
  Now gated on `prefixless_primary?/0`. Browser-caught.
- **`sitemap/sources/static.ex`** + **`posts.ex`** — same bug as
  the publishing sitemap source (`_is_default` ignored). Found by
  `ast-grep --lang elixir --pattern '"/#{$LOCALE}#{$PATH}"'`. Both
  now use the same `cond` block as publishing.

### `edf63d0f` `redirect_invalid_locale/2` honors the setting

The plug that strips an invalid locale segment (e.g.
`/phoenix_kit/xx/admin/users` → `/phoenix_kit/admin/users`) always
emitted the **prefixless** shape. With setting OFF, the canonical
primary shape is **prefixed** — the redirect was landing users on
a non-canonical URL inconsistent with the rest of the app's
emission. Now swap-vs-strip per setting.

### `97543a29` Phase 2 follow-up: dedup + boot-safe wrapper + tests

Phase 2 triage of PR #552:

- **Dedup `build_path_with_language/3`** across 3 sitemap sources
  (`publishing`, `static`, `posts`) → new shared
  `PhoenixKit.Modules.Sitemap.LocalePath` module owning the
  decision (`emit_prefix?/2` + `single_language_mode?/0`). Each
  source keeps its own formatting (publishing uses
  `get_display_code/2` for hreflang-aware dialect emission; static
  + posts use `DialectMapper.extract_base/1` for clean base
  codes).
- **Dedup `prefixless_primary?/0`** between `routes.ex` and
  `auth.ex` (the latter was missing the mix-task-context guard)
  → promoted to a public `Languages.prefixless_primary_safe?/0`
  with both guards. Two callers now delegate.
- **14 new tests** for `LocalePath` policy, the auth redirect, and
  the boot-safe wrapper.

### `fac2c665` Cover the two test gaps surfaced by the phase 2 audit

Self-audit caught two bugs we fixed without test coverage. Closed:

- **`process_valid_locale/2` canonical-redirect gate** — 4 tests
  in `auth_locale_test.exs` covering the regression that broke
  login (primary on non-admin with setting OFF must NOT redirect)
  + the 3 other branches (setting ON redirects, admin URLs never
  redirect, non-primary never redirects).
- **Languages LV `toggle_default_language_no_prefix` handler** —
  4 tests in `languages_toggle_test.exs` covering default state,
  click persists ON, re-click toggles OFF, mount reflects
  persisted state.

## Verification

`mix test`: 1330 tests, 0 failures, 11 doctests (was 1308
post-merge, +22 net new).
`mix compile --warnings-as-errors`, `mix credo --strict`,
`mix format --check-formatted`, `mix deps.unlock --check-unused`
all clean.

Browser-verified end-to-end across both setting states: Languages
toggle, admin URL emission, publishing public URLs, sitemap
regeneration, canonical redirects.

## Open follow-up from boss's review (not addressed here)

`@spec set_default_language_no_prefix/1` references
`PhoenixKit.Settings.Setting.t()` which has no `@type t/0`
declared on `Setting` — dialyzer `unknown_type` warning. Boss
flagged in `CLAUDE_REVIEW.md`; separate fix on `Setting`.

## Test plan

- [ ] CI green
- [ ] mix precommit (already verified locally)
- [ ] Sanity-click the toggle on `/admin/settings/languages` after
      merge → confirms the LV toggle test reflects real behaviour