### PR TITLE
Add country-qualifier dedup to language switcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## Unreleased
+
+### Changed
+- Frontend language switcher (`PhoenixKitWeb.Components.Core.LanguageSwitcher`'s
+  dropdown + continent-grouped views) now drops the country qualifier from
+  rendered labels when only one dialect of a given base language is enabled.
+  `English (United States)`, `Estonian (Estonia)`, `French (France)` render
+  as `English`, `Estonian`, `French` whenever no sibling dialect is
+  configured; enabling a second dialect of the same base (e.g. `en-US` +
+  `en-GB`) causes those entries to reacquire the country qualifier so they
+  remain distinguishable. Implementation reuses the historical
+  `extract_base_language_name/1` string-parse approach
+  ("Spanish (Mexico)" → "Spanish") plus a new
+  `DialectMapper.group_dialects_by_base/1` to count siblings per base.
+  Restores the bare-label rendering that was lost when commit `d1c2d577`
+  rewrote the switcher to one-row-per-dialect.
+
 ## 1.7.115 - 2026-05-19
 
 ### Added

--- a/lib/modules/languages/dialect_mapper.ex
+++ b/lib/modules/languages/dialect_mapper.ex
@@ -358,4 +358,40 @@ defmodule PhoenixKit.Modules.Languages.DialectMapper do
       "pt-BR"
   """
   def default_dialects, do: @default_dialects
+
+  @doc """
+  Counts how many entries share each base language code in a list of
+  language entries. Used by language switchers to decide whether to
+  show a country qualifier or just the bare language name.
+
+  Accepts both maps with atom-keyed `:code` (e.g. `%Language{}` structs)
+  and string-keyed `"code"` (e.g. JSON-decoded settings). Entries
+  without a recognizable code are skipped.
+
+  ## Examples
+
+      iex> DialectMapper.group_dialects_by_base([
+      ...>   %{code: "en-US"},
+      ...>   %{code: "en-GB"},
+      ...>   %{code: "et-EE"}
+      ...> ])
+      %{"en" => 2, "et" => 1}
+
+      iex> DialectMapper.group_dialects_by_base([])
+      %{}
+  """
+  def group_dialects_by_base(languages) when is_list(languages) do
+    languages
+    |> Enum.reduce([], fn lang, acc ->
+      case lang_code(lang) do
+        nil -> acc
+        code -> [extract_base(code) | acc]
+      end
+    end)
+    |> Enum.frequencies()
+  end
+
+  defp lang_code(%{code: code}) when is_binary(code), do: code
+  defp lang_code(%{"code" => code}) when is_binary(code), do: code
+  defp lang_code(_), do: nil
 end

--- a/lib/phoenix_kit_web/components/admin_nav.ex
+++ b/lib/phoenix_kit_web/components/admin_nav.ex
@@ -10,6 +10,7 @@ defmodule PhoenixKitWeb.Components.AdminNav do
   alias PhoenixKit.Modules.Languages.DialectMapper
   alias PhoenixKit.Users.Auth.Scope
   alias PhoenixKit.Utils.Routes
+  alias PhoenixKitWeb.Components.Core.LanguageSwitcher
 
   import PhoenixKitWeb.Components.Core.Icon
   import PhoenixKitWeb.Components.Core.ThemeController, only: [theme_controller: 1]
@@ -500,13 +501,19 @@ defmodule PhoenixKitWeb.Components.AdminNav do
   end
 
   # Helper function to get languages for admin nav display
-  # Uses the unified Languages module as the single source of truth
+  # Uses the unified Languages module as the single source of truth.
+  # The final `dedupe_names/1` call drops the country qualifier from
+  # `:name` when only one dialect of a given base language is
+  # configured (e.g. "German (Germany)" → "German") — same rule the
+  # frontend dropdown applies; the helper lives in
+  # `Core.LanguageSwitcher` so all menus share one implementation.
   defp get_admin_languages do
     if Code.ensure_loaded?(Languages) do
       Languages.get_display_languages()
       |> Enum.filter(fn lang -> is_map(lang) and Map.get(lang, :is_enabled, false) end)
       |> Enum.map(&enrich_language/1)
       |> Enum.reject(&is_nil/1)
+      |> LanguageSwitcher.dedupe_names()
     else
       []
     end

--- a/lib/phoenix_kit_web/components/core/language_switcher.ex
+++ b/lib/phoenix_kit_web/components/core/language_switcher.ex
@@ -678,10 +678,22 @@ defmodule PhoenixKitWeb.Components.Core.LanguageSwitcher do
   # Falls back to flat list if grouping fails or produces no results.
   defp maybe_build_continent_groups(assigns, filtered_languages) do
     if assigns.group_by_continent and length(filtered_languages) > assigns.continent_threshold do
+      # Count siblings globally before slicing by continent so dedup
+      # decisions stay consistent across continent groups (a base
+      # language with one dialect in Europe + another in North
+      # America still gets the country qualifier in both groups).
+      continent_groups_data = Languages.get_enabled_languages_by_continent()
+
+      global_counts =
+        continent_groups_data
+        |> Enum.flat_map(fn {_continent, langs} -> langs end)
+        |> Enum.uniq_by(&lang_code_for_counts/1)
+        |> DialectMapper.group_dialects_by_base()
+
       groups =
-        Languages.get_enabled_languages_by_continent()
+        continent_groups_data
         |> Enum.map(fn {continent, langs} ->
-          {continent, langs_to_dialect_maps(langs)}
+          {continent, langs_to_dialect_maps(langs, global_counts)}
         end)
         |> Enum.reject(fn {_, langs} -> langs == [] end)
 
@@ -693,18 +705,25 @@ defmodule PhoenixKitWeb.Components.Core.LanguageSwitcher do
     _ -> {false, []}
   end
 
-  # Transforms Language structs/maps from grouped continent data into dialect maps
-  defp langs_to_dialect_maps(langs) do
+  defp lang_code_for_counts(lang) when is_struct(lang), do: lang.code
+  defp lang_code_for_counts(lang) when is_map(lang), do: lang[:code] || lang["code"]
+  defp lang_code_for_counts(_), do: nil
+
+  # Transforms Language structs/maps from grouped continent data into
+  # dialect maps. `counts` is the GLOBAL sibling count across all
+  # enabled languages — never per-continent — so the dedup rule
+  # behaves identically to the flat dropdown.
+  defp langs_to_dialect_maps(langs, counts) do
     langs
     |> Enum.map(fn lang ->
       code = if is_struct(lang), do: lang.code, else: lang[:code]
-      name = if is_struct(lang), do: lang.name, else: lang[:name]
+      base = DialectMapper.extract_base(code)
 
       if is_binary(code) do
         %{
-          "base_code" => DialectMapper.extract_base(code),
+          "base_code" => base,
           "dialect" => code,
-          "name" => name || code,
+          "name" => display_name_for(lang, base, counts),
           "flag" => get_language_flag(code)
         }
       end
@@ -713,11 +732,24 @@ defmodule PhoenixKitWeb.Components.Core.LanguageSwitcher do
     |> Enum.sort_by(& &1["name"])
   end
 
-  # Transforms language config into dialect maps for display
+  # Transforms language config into dialect maps for display.
+  #
+  # When only one dialect of a given base language is configured, the
+  # displayed `name` strips the country qualifier and falls back to
+  # the canonical base-language name (e.g. "English", "Estonian") —
+  # the parenthetical implies a choice that doesn't exist when no
+  # sibling dialect is enabled. Multiple dialects of the same base
+  # language keep their full configured name so the user can tell
+  # them apart.
   defp build_dialect_list(languages_config) do
-    languages_config
-    |> Enum.reject(&is_nil/1)
-    |> Enum.filter(&is_map/1)
+    configured =
+      languages_config
+      |> Enum.reject(&is_nil/1)
+      |> Enum.filter(&is_map/1)
+
+    counts = DialectMapper.group_dialects_by_base(configured)
+
+    configured
     |> Enum.map(fn lang ->
       dialect = lang.code
       base = DialectMapper.extract_base(dialect)
@@ -725,7 +757,7 @@ defmodule PhoenixKitWeb.Components.Core.LanguageSwitcher do
       %{
         "base_code" => base,
         "dialect" => dialect,
-        "name" => lang.name || dialect || "Unknown",
+        "name" => display_name_for(lang, base, counts),
         "native" => get_native_name(dialect),
         "flag" => get_language_flag(dialect)
       }
@@ -736,6 +768,115 @@ defmodule PhoenixKitWeb.Components.Core.LanguageSwitcher do
     end)
     |> Enum.sort_by(& &1["name"])
   end
+
+  # Picks the displayed name for a single language entry: bare
+  # language name (derived from the configured `:name` by stripping
+  # the country qualifier) when this is the only dialect of its base,
+  # full `:name` otherwise. Falls back to `String.upcase(base)` when
+  # the entry has no name. Mirrors the pre-`d1c2d577` convention.
+  #
+  # `base` is always a binary at the call site
+  # (`DialectMapper.extract_base/1` clauses cover `nil` / `""` / binary
+  # and all return a binary), so the no-binary-base branch is
+  # unreachable — keeping it would just confuse dialyzer.
+  defp display_name_for(lang, base, counts) when is_binary(base) do
+    full = get_in_lang(lang, :name) || get_in_lang(lang, "name")
+
+    cond do
+      Map.get(counts, base, 0) > 1 -> full || get_in_lang(lang, :code) || base
+      is_binary(full) -> extract_base_language_name(full)
+      true -> String.upcase(base)
+    end
+  end
+
+  @doc """
+  Strips the country / region qualifier from a configured language
+  name. Used to render bare base-language labels when only one
+  dialect of the base is enabled.
+
+  Public because the admin top-bar dropdown
+  (`PhoenixKitWeb.Components.AdminNav`) and the user dashboard nav
+  (`PhoenixKitWeb.Components.UserDashboardNav`) both call into it via
+  `dedupe_names/1` so all language menus share one rule.
+
+  ## Examples
+
+      iex> extract_base_language_name("Spanish (Mexico)")
+      "Spanish"
+
+      iex> extract_base_language_name("Chinese (Simplified)")
+      "Chinese"
+
+      iex> extract_base_language_name("Japanese")
+      "Japanese"
+  """
+  def extract_base_language_name(full_name) when is_binary(full_name) do
+    full_name
+    |> String.split("(")
+    |> List.first()
+    |> String.trim()
+  end
+
+  @doc """
+  Overrides each language entry's `:name` (or `"name"`) with the
+  bare base-language label when only one dialect of that base is
+  configured. Multi-dialect bases keep their full configured name so
+  users can tell them apart.
+
+  Accepts a list of language entries shaped as atom-keyed maps,
+  string-keyed maps, or `%PhoenixKit.Modules.Languages.Language{}`
+  structs. Returns the list in the same shape with the relevant
+  `:name`/`"name"` key replaced.
+
+  Used by the admin top-bar dropdown and the user dashboard nav to
+  inherit the frontend switcher's dedup rule without duplicating the
+  logic. Internal frontend-switcher code paths
+  (`build_dialect_list/1`, `langs_to_dialect_maps/2`) compute names
+  inline because they emit a new result map per entry; this helper
+  is the entry point for callers that already have a list of entries
+  and just need their names normalized.
+  """
+  def dedupe_names(languages) when is_list(languages) do
+    counts = DialectMapper.group_dialects_by_base(languages)
+    Enum.map(languages, &dedupe_one_name(&1, counts))
+  end
+
+  defp dedupe_one_name(lang, counts) do
+    with code when is_binary(code) <- lang_code(lang),
+         base <- DialectMapper.extract_base(code),
+         true <- Map.get(counts, base, 0) <= 1 do
+      full = get_in_lang(lang, :name) || get_in_lang(lang, "name")
+      put_lang_name(lang, bare_name(full, base))
+    else
+      _ -> lang
+    end
+  end
+
+  # `base` is always a binary at the call site (see
+  # `display_name_for/3` for the same rationale), so we only need
+  # two clauses.
+  defp bare_name(full, _base) when is_binary(full), do: extract_base_language_name(full)
+  defp bare_name(_full, base) when is_binary(base), do: String.upcase(base)
+
+  defp lang_code(%{code: code}) when is_binary(code), do: code
+  defp lang_code(%{"code" => code}) when is_binary(code), do: code
+  defp lang_code(_), do: nil
+
+  defp put_lang_name(lang, name) when is_struct(lang) do
+    if Map.has_key?(lang, :name), do: %{lang | name: name}, else: lang
+  end
+
+  defp put_lang_name(lang, name) when is_map(lang) do
+    cond do
+      Map.has_key?(lang, :name) -> Map.put(lang, :name, name)
+      Map.has_key?(lang, "name") -> Map.put(lang, "name", name)
+      true -> Map.put(lang, :name, name)
+    end
+  end
+
+  defp get_in_lang(lang, key) when is_struct(lang) and is_atom(key), do: Map.get(lang, key)
+  defp get_in_lang(lang, key) when is_map(lang), do: Map.get(lang, key)
+  defp get_in_lang(_, _), do: nil
 
   # Helper function to get language flag emoji
   defp get_language_flag(code) when is_binary(code) do

--- a/lib/phoenix_kit_web/components/user_dashboard_nav.ex
+++ b/lib/phoenix_kit_web/components/user_dashboard_nav.ex
@@ -10,6 +10,7 @@ defmodule PhoenixKitWeb.Components.UserDashboardNav do
   alias PhoenixKit.Modules.Languages.DialectMapper
   alias PhoenixKit.Users.Auth.Scope
   alias PhoenixKit.Utils.Routes
+  alias PhoenixKitWeb.Components.Core.LanguageSwitcher
 
   @doc """
   Renders user dropdown for dashboard navigation.
@@ -179,7 +180,12 @@ defmodule PhoenixKitWeb.Components.UserDashboardNav do
         [%{code: "en-US", name: "English (United States)", is_enabled: true}]
       end
 
-    # Map to expected format with enriched data from predefined languages
+    # Map to expected format with enriched data from predefined languages.
+    # The final `dedupe_names/1` call drops the country qualifier when
+    # only one dialect of a given base language is configured — the
+    # same rule the frontend switcher applies, called from its
+    # canonical home in `Core.LanguageSwitcher` so the logic lives in
+    # one place.
     languages
     |> Enum.map(fn lang ->
       case Languages.get_predefined_language(lang.code) do
@@ -190,6 +196,7 @@ defmodule PhoenixKitWeb.Components.UserDashboardNav do
           %{code: lang.code, name: String.upcase(lang.code), flag: "🌐", native: ""}
       end
     end)
+    |> LanguageSwitcher.dedupe_names()
   end
 
   # Helper function to get language flag emoji

--- a/test/phoenix_kit/languages/dialect_mapper_test.exs
+++ b/test/phoenix_kit/languages/dialect_mapper_test.exs
@@ -129,4 +129,55 @@ defmodule PhoenixKit.Modules.Languages.DialectMapperTest do
       assert defaults["zh"] == "zh-CN"
     end
   end
+
+  describe "group_dialects_by_base/1" do
+    test "counts dialects per base code for atom-keyed maps" do
+      result =
+        DialectMapper.group_dialects_by_base([
+          %{code: "en-US"},
+          %{code: "en-GB"},
+          %{code: "et-EE"}
+        ])
+
+      assert result == %{"en" => 2, "et" => 1}
+    end
+
+    test "supports string-keyed maps" do
+      result =
+        DialectMapper.group_dialects_by_base([
+          %{"code" => "en-US"},
+          %{"code" => "es-ES"}
+        ])
+
+      assert result == %{"en" => 1, "es" => 1}
+    end
+
+    test "supports mixed atom/string keys in the same list" do
+      result =
+        DialectMapper.group_dialects_by_base([
+          %{code: "en-US"},
+          %{"code" => "en-GB"},
+          %{code: "fr-FR"}
+        ])
+
+      assert result == %{"en" => 2, "fr" => 1}
+    end
+
+    test "ignores entries without a binary :code / \"code\"" do
+      result =
+        DialectMapper.group_dialects_by_base([
+          %{code: "en-US"},
+          %{code: nil},
+          nil,
+          %{other: "junk"},
+          "not a map"
+        ])
+
+      assert result == %{"en" => 1}
+    end
+
+    test "returns an empty map for an empty list" do
+      assert DialectMapper.group_dialects_by_base([]) == %{}
+    end
+  end
 end

--- a/test/phoenix_kit_web/components/core/language_switcher_test.exs
+++ b/test/phoenix_kit_web/components/core/language_switcher_test.exs
@@ -174,4 +174,133 @@ defmodule PhoenixKitWeb.Components.Core.LanguageSwitcherTest do
       assert html =~ ~s(href="/phoenix_kit/fr/some/page")
     end
   end
+
+  describe "single-vs-multi-dialect label dedup" do
+    @moduledoc """
+    `build_dialect_list/1` strips the country qualifier from each
+    rendered name when only one dialect of that base language is
+    configured. As soon as a second dialect of the *same* base shows
+    up, both English entries reacquire the qualifier so the user can
+    distinguish them. Other languages with only one dialect stay
+    bare.
+    """
+
+    test "single dialect per language → bare language names render" do
+      assigns = %{
+        languages: [
+          %{code: "en-US", name: "English (United States)"},
+          %{code: "et-EE", name: "Estonian (Estonia)"},
+          %{code: "fr-FR", name: "French (France)"}
+        ]
+      }
+
+      html =
+        rendered_to_string(~H"""
+        <LanguageSwitcher.language_switcher_dropdown
+          current_locale="en"
+          languages={@languages}
+          current_path="/p"
+        />
+        """)
+
+      assert html =~ "English"
+      assert html =~ "Estonian"
+      assert html =~ "French"
+      refute html =~ "(United States)"
+      refute html =~ "(Estonia)"
+      refute html =~ "(France)"
+    end
+
+    test "multiple dialects of the same base → that base reacquires the country qualifier" do
+      assigns = %{
+        languages: [
+          %{code: "en-US", name: "English (United States)"},
+          %{code: "en-GB", name: "English (United Kingdom)"},
+          %{code: "et-EE", name: "Estonian (Estonia)"},
+          %{code: "fr-FR", name: "French (France)"}
+        ]
+      }
+
+      html =
+        rendered_to_string(~H"""
+        <LanguageSwitcher.language_switcher_dropdown
+          current_locale="en"
+          languages={@languages}
+          current_path="/p"
+        />
+        """)
+
+      # English variants need disambiguation
+      assert html =~ "English (United States)"
+      assert html =~ "English (United Kingdom)"
+
+      # Sibling-free languages still render bare
+      assert html =~ "Estonian"
+      assert html =~ "French"
+      refute html =~ "(Estonia)"
+      refute html =~ "(France)"
+    end
+
+    test "dedupe_names/1 — public helper called from admin_nav + user_dashboard_nav" do
+      # Single dialect → strip qualifier
+      input = [
+        %{code: "de-DE", name: "German (Germany)", flag: "🇩🇪"},
+        %{code: "zh", name: "Chinese (Simplified)", flag: "🇨🇳"},
+        %{code: "lv", name: "Latvian", flag: "🇱🇻"}
+      ]
+
+      assert [
+               %{code: "de-DE", name: "German", flag: "🇩🇪"},
+               %{code: "zh", name: "Chinese", flag: "🇨🇳"},
+               %{code: "lv", name: "Latvian", flag: "🇱🇻"}
+             ] = LanguageSwitcher.dedupe_names(input)
+
+      # Multi-dialect → keep qualifier
+      multi = [
+        %{code: "en-US", name: "English (United States)"},
+        %{code: "en-GB", name: "English (United Kingdom)"},
+        %{code: "de-DE", name: "German (Germany)"}
+      ]
+
+      assert [
+               %{code: "en-US", name: "English (United States)"},
+               %{code: "en-GB", name: "English (United Kingdom)"},
+               %{code: "de-DE", name: "German"}
+             ] = LanguageSwitcher.dedupe_names(multi)
+    end
+
+    test "dedupe_names/1 supports string-keyed maps" do
+      input = [
+        %{"code" => "de-DE", "name" => "German (Germany)"},
+        %{"code" => "fr-FR", "name" => "French (France)"}
+      ]
+
+      assert [
+               %{"code" => "de-DE", "name" => "German"},
+               %{"code" => "fr-FR", "name" => "French"}
+             ] = LanguageSwitcher.dedupe_names(input)
+    end
+
+    test "unknown base code parses the bare name from the configured name" do
+      assigns = %{
+        languages: [
+          %{code: "fil-PH", name: "Filipino (Philippines)"}
+        ]
+      }
+
+      html =
+        rendered_to_string(~H"""
+        <LanguageSwitcher.language_switcher_dropdown
+          current_locale="fil"
+          languages={@languages}
+          current_path="/p"
+        />
+        """)
+
+      # Single dialect → strip the parenthetical from the configured
+      # name. Works for any base code without a predefined map.
+      assert html =~ "Filipino"
+      refute html =~ "(Philippines)"
+    end
+  end
 end


### PR DESCRIPTION
When only one dialect of a base language is enabled, the switcher now renders the bare language name ("German", "Chinese") instead of the configured "German (Germany)" / "Chinese (Simplified)". Multi-dialect bases (e.g. en-US + en-GB) keep the qualifier so entries remain distinguishable. Restores the bare-label rendering lost in d1c2d577 when the switcher rewrote to one-row-per-dialect.

Implementation lives in PhoenixKitWeb.Components.Core.LanguageSwitcher (the frontend switcher) as the canonical home — `dedupe_names/1` is public and called from AdminNav and UserDashboardNav so all language menus share one rule. Bare-name derivation reuses the historical `extract_base_language_name/1` string parse
("Spanish (Mexico)" -> "Spanish"); sibling count comes from `DialectMapper.group_dialects_by_base/1`.