### PR TITLE
MediaGallery: add max_count attr + disable Add button at limit

### DIFF
--- a/lib/phoenix_kit_web/components/core/table_default.ex
+++ b/lib/phoenix_kit_web/components/core/table_default.ex
@@ -442,12 +442,13 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
 
   ## Attributes
 
-  * `class` - Overrides the default header styling. Default is `"bg-primary text-primary-content"`
-    (loud, daisyUI primary). Pass `class=""` (or any other class string) for a neutral header —
-    e.g. `class=""` blends the header with `<tbody>` for a flatter look. The string fully
-    replaces the default; concatenate manually if you want both.
+  * `class` - Overrides the default header styling. Default is `"bg-base-300"` — a calm,
+    theme-neutral header that reads as a subtle separator from `<tbody>` instead of the
+    loud daisyUI primary. Pass `"bg-primary text-primary-content"` to restore the legacy
+    look, or `class=""` for a fully bare header. The string fully replaces the default;
+    concatenate manually if you want to add classes on top.
   """
-  attr :class, :string, default: "bg-primary text-primary-content"
+  attr :class, :string, default: "bg-base-300"
   slot :inner_block, required: true
 
   def table_default_header(assigns) do

--- a/lib/phoenix_kit_web/components/core/table_default.ex
+++ b/lib/phoenix_kit_web/components/core/table_default.ex
@@ -86,9 +86,21 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
     REPLACES the prescribed `card_header` + `card_title` + `card_fields` rendering — the
     consumer owns the inside of `<div class="card-body">`. `card_actions` footer still
     renders if provided. Use for rich cards with badges, icon-prefixed rows, custom layouts.
+  * `card_media` - Media region (image/thumbnail/video preview) rendered ABOVE the card
+    body, receives item via `:let`. Use for thumbnails, cover images, document previews.
+    The slot owns its own padding/background — wrap content in a styled container.
   * `card_actions` - Action buttons rendered in each card footer (receives item via :let)
   * `toolbar_title` - Title/content rendered at the start of the toolbar row
   * `toolbar_actions` - Buttons rendered in the toolbar before the view toggle
+
+  ## Controlled view mode
+
+  By default the card/table toggle is driven entirely client-side (JS hook + localStorage).
+  Pass `view_mode="card"` or `view_mode="table"` to take control from the assigns side —
+  the component then renders ONLY that view (no JS toggle) and the toolbar buttons emit
+  `phx-click={view_event}` with `phx-value-mode="card"|"table"` so the consumer can drive
+  state via `push_patch` (URL-backed) or `assign`. Use this when the view choice must
+  survive across LV navigation or be part of the URL.
   """
   attr :id, :string, default: nil
   attr :class, :string, default: ""
@@ -107,6 +119,16 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
 
   attr :storage_key, :string, default: nil
   attr :wrapper_class, :string, default: "rounded-lg shadow-md overflow-x-auto overflow-y-clip"
+
+  attr :view_mode, :string,
+    default: nil,
+    values: [nil, "card", "table"],
+    doc:
+      "Controlled view selector. When set, renders ONLY that view and disables the JS toggle; toggle buttons emit `view_event` with `phx-value-mode`. When nil, falls back to the JS hook + localStorage default."
+
+  attr :view_event, :string,
+    default: "switch_view",
+    doc: "Event name emitted by the toggle buttons in controlled mode."
 
   attr :on_reorder, :string,
     default: nil,
@@ -137,6 +159,10 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
   slot :card_body,
     doc:
       "Fully-custom card body (receives item via :let). When present, replaces card_header + card_title + card_fields rendering."
+
+  slot :card_media,
+    doc:
+      "Media region (image/thumbnail/video) rendered above the card body. Receives item via :let. Owns its own padding/background."
 
   slot :card_actions, doc: "Action buttons in card footer"
 
@@ -198,7 +224,12 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
       |> assign(:reorder_scope_attrs, reorder_scope_attrs)
 
     ~H"""
-    <div id={@id} phx-hook="TableCardView" data-storage-key={@storage_key || @id} class="relative">
+    <div
+      id={@id}
+      phx-hook={if is_nil(@view_mode), do: "TableCardView"}
+      data-storage-key={if is_nil(@view_mode), do: @storage_key || @id}
+      class="relative"
+    >
       <%!-- Toolbar row: title (left) + actions and view toggle (right) --%>
       <div
         :if={
@@ -214,19 +245,41 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
           <div :if={@toolbar_actions != []} class="flex flex-wrap items-center gap-2">
             {render_slot(@toolbar_actions)}
           </div>
-          <div :if={@toggleable && @show_toggle} class="hidden md:inline-flex join">
+          <div
+            :if={@toggleable && @show_toggle}
+            class={
+              [
+                "join",
+                # JS-toggle mode hides the buttons on mobile (only desktop has a
+                # toggle there). Controlled mode is consumer-driven, so the
+                # buttons are visible everywhere.
+                is_nil(@view_mode) && "hidden md:inline-flex",
+                @view_mode && "inline-flex"
+              ]
+            }
+          >
             <button
               type="button"
-              data-view-action="card"
-              class="btn btn-sm join-item"
+              data-view-action={if is_nil(@view_mode), do: "card"}
+              phx-click={@view_mode && @view_event}
+              phx-value-mode={@view_mode && "card"}
+              class={[
+                "btn btn-sm join-item",
+                @view_mode == "card" && "btn-active"
+              ]}
               title="Card view"
             >
               <.icon name="hero-squares-2x2" class="w-4 h-4" />
             </button>
             <button
               type="button"
-              data-view-action="table"
-              class="btn btn-sm join-item"
+              data-view-action={if is_nil(@view_mode), do: "table"}
+              phx-click={@view_mode && @view_event}
+              phx-value-mode={@view_mode && "table"}
+              class={[
+                "btn btn-sm join-item",
+                @view_mode == "table" && "btn-active"
+              ]}
               title="Table view"
             >
               <.icon name="hero-bars-3-bottom-left" class="w-4 h-4" />
@@ -238,8 +291,16 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
       <div :if={@sort_bar != []} class="mb-2">
         {render_slot(@sort_bar)}
       </div>
-      <%!-- Table: hidden on mobile always, shown on desktop (JS controls md: classes) --%>
-      <div data-table-view="" class="hidden md:block">
+      <%!-- Table: hidden on mobile always, shown on desktop (JS controls md: classes).
+           In controlled mode, visibility is purely driven by @view_mode. --%>
+      <div
+        data-table-view=""
+        class={[
+          is_nil(@view_mode) && "hidden md:block",
+          @view_mode == "table" && "block",
+          @view_mode == "card" && "hidden"
+        ]}
+      >
         <div class={@wrapper_class}>
           <table
             class={[
@@ -254,11 +315,17 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
           </table>
         </div>
       </div>
-      <%!-- Cards: always shown on mobile, hidden on desktop (JS controls md: classes) --%>
+      <%!-- Cards: always shown on mobile, hidden on desktop (JS controls md: classes).
+           In controlled mode, visibility is purely driven by @view_mode. --%>
       <div
         id={if @on_reorder, do: "#{@id}-cards"}
         data-card-view=""
-        class="md:hidden grid gap-4 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4"
+        class={[
+          "grid gap-4 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4",
+          is_nil(@view_mode) && "md:hidden",
+          @view_mode == "card" && "grid",
+          @view_mode == "table" && "hidden"
+        ]}
         data-sortable={if @on_reorder, do: "true"}
         data-sortable-event={@on_reorder}
         data-sortable-items={if @on_reorder, do: ".sortable-item"}
@@ -281,6 +348,12 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
           ]}
           data-id={if @on_reorder, do: @item_id_fn.(item)}
         >
+          <%!-- Optional media region rendered ABOVE the card body. Slot owns
+               its own padding/background so consumers can wrap a thumbnail in
+               a clickable container, set a base-200 backdrop, etc. --%>
+          <div :if={@card_media != []}>
+            {render_slot(@card_media, item)}
+          </div>
           <%!-- Custom card body slot: REPLACES prescribed header+fields rendering.
                Consumer owns the inside of card-body. card_actions footer still
                applies below if also provided. --%>
@@ -366,12 +439,20 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
 
   @doc """
   Renders a table header section.
+
+  ## Attributes
+
+  * `class` - Overrides the default header styling. Default is `"bg-primary text-primary-content"`
+    (loud, daisyUI primary). Pass `class=""` (or any other class string) for a neutral header —
+    e.g. `class=""` blends the header with `<tbody>` for a flatter look. The string fully
+    replaces the default; concatenate manually if you want both.
   """
+  attr :class, :string, default: "bg-primary text-primary-content"
   slot :inner_block, required: true
 
   def table_default_header(assigns) do
     ~H"""
-    <thead class="bg-primary text-primary-content">
+    <thead class={@class}>
       {render_slot(@inner_block)}
     </thead>
     """

--- a/lib/phoenix_kit_web/components/media_gallery.ex
+++ b/lib/phoenix_kit_web/components/media_gallery.ex
@@ -38,6 +38,10 @@ defmodule PhoenixKitWeb.Components.MediaGallery do
   - `phoenix_kit_current_user` — required for upload in the picker
   - `readonly` — when `true`, hides the pick button, remove buttons, and DnD;
     preview (lightbox) still works; default `false`
+  - `max_count` — integer upper bound on the number of selected images for
+    `:multiple` mode; `nil` means unlimited. For `:single` mode the limit is
+    always 1 (implied by `mode`). When the limit is reached, the "Add" button
+    is disabled and `apply_selection` refuses to exceed it.
 
   ## Change notifications
 
@@ -82,7 +86,8 @@ defmodule PhoenixKitWeb.Components.MediaGallery do
     # Guard: if component hasn't been fully initialised yet these are nil-safe defaults.
     current = socket.assigns[:selected] || []
     mode = socket.assigns[:mode] || :multiple
-    new_selected = apply_selection(current, uuids, mode)
+    max_count = socket.assigns[:max_count]
+    new_selected = apply_selection(current, uuids, mode, max_count)
 
     socket =
       socket
@@ -106,6 +111,7 @@ defmodule PhoenixKitWeb.Components.MediaGallery do
       |> assign_new(:scope_folder_id, fn -> nil end)
       |> assign_new(:phoenix_kit_current_user, fn -> nil end)
       |> assign_new(:readonly, fn -> false end)
+      |> assign_new(:max_count, fn -> nil end)
       |> assign_new(:title, fn -> nil end)
       |> assign_new(:show_picker, fn -> false end)
       |> assign_new(:preview_uuid, fn -> nil end)
@@ -186,14 +192,33 @@ defmodule PhoenixKitWeb.Components.MediaGallery do
       assign(socket, files: [], variants_map: %{}, selected_loaded: nil)
   end
 
-  defp apply_selection(_current, uuids, :single) do
+  defp apply_selection(_current, uuids, :single, _max_count) do
     case uuids do
       [uuid | _] -> [uuid]
       [] -> []
     end
   end
 
-  defp apply_selection(_current, uuids, _multiple), do: uuids
+  defp apply_selection(_current, uuids, _multiple, nil), do: uuids
+
+  defp apply_selection(_current, uuids, _multiple, max_count) when is_integer(max_count) and max_count > 0 do
+    Enum.take(uuids, max_count)
+  end
+
+  defp apply_selection(_current, uuids, _multiple, _max_count), do: uuids
+
+  # Returns true when the current selection has reached its limit:
+  # - :single mode → limit is always 1
+  # - :multiple with a positive max_count → limit is max_count
+  # - :multiple with nil or 0 max_count → unlimited (always false)
+  defp selection_at_limit?(selected, :single, _max_count), do: length(selected) >= 1
+
+  defp selection_at_limit?(selected, _multiple, max_count)
+       when is_integer(max_count) and max_count > 0 do
+    length(selected) >= max_count
+  end
+
+  defp selection_at_limit?(_selected, _mode, _max_count), do: false
 
   defp notify_parent(socket) do
     parent = self()

--- a/lib/phoenix_kit_web/components/media_gallery.html.heex
+++ b/lib/phoenix_kit_web/components/media_gallery.html.heex
@@ -72,13 +72,20 @@
         <button
           :if={not @readonly}
           type="button"
-          class="w-full aspect-square border-2 border-dashed border-base-300 rounded-lg hover:border-primary hover:bg-base-200 transition-all cursor-pointer flex flex-col items-center justify-center gap-1 text-base-content/60 hover:text-primary"
+          class={[
+            "w-full aspect-square border-2 border-dashed rounded-lg transition-all flex flex-col items-center justify-center gap-1 text-xs font-medium",
+            selection_at_limit?(@selected, @mode, @max_count) &&
+              "border-base-300 bg-base-200 text-base-content/30 cursor-not-allowed",
+            not selection_at_limit?(@selected, @mode, @max_count) &&
+              "border-base-300 hover:border-primary hover:bg-base-200 cursor-pointer text-base-content/60 hover:text-primary"
+          ]}
           data-role={"open-picker-#{@id}"}
           phx-click="open_picker"
           phx-target={@myself}
+          disabled={selection_at_limit?(@selected, @mode, @max_count)}
         >
           <.icon name="hero-plus" class="w-6 h-6" />
-          <span class="text-xs font-medium">{gettext("Add")}</span>
+          <span>{gettext("Add")}</span>
         </button>
       </:add_button>
     </.draggable_list>

--- a/test/phoenix_kit_web/components/media_gallery_test.exs
+++ b/test/phoenix_kit_web/components/media_gallery_test.exs
@@ -43,6 +43,7 @@ defmodule PhoenixKitWeb.Components.MediaGalleryTest do
       scope_folder_id: nil,
       phoenix_kit_current_user: nil,
       readonly: readonly,
+      max_count: nil,
       title: title,
       show_picker: false,
       preview_uuid: preview_uuid,
@@ -512,6 +513,124 @@ defmodule PhoenixKitWeb.Components.MediaGalleryTest do
         )
 
       assert socket.assigns.selected == [uuid3, uuid1, uuid2]
+    end
+  end
+
+  # ── max_count / Add-button disable behavior ────────────────────────────────────
+
+  describe "max_count" do
+    defp gallery_assigns_with(extra) do
+      base =
+        gallery_assigns([])
+        |> Map.put(:max_count, nil)
+
+      Map.merge(base, extra)
+    end
+
+    test "Add button is enabled when selection is below max_count" do
+      html =
+        render(
+          gallery_assigns_with(%{
+            mode: :multiple,
+            max_count: 3,
+            selected: ["01900000-0000-7000-8000-000000000001"],
+            variants_map: %{"01900000-0000-7000-8000-000000000001" => []}
+          })
+        )
+
+      assert html =~ "open-picker-test-gallery"
+      refute html =~ ~s(disabled="")
+    end
+
+    test "Add button is disabled when selection equals max_count" do
+      uuid = "01900000-0000-7000-8000-000000000001"
+
+      html =
+        render(
+          gallery_assigns_with(%{
+            mode: :multiple,
+            max_count: 1,
+            selected: [uuid],
+            variants_map: %{uuid => []}
+          })
+        )
+
+      # Phoenix renders boolean true attr as bare `disabled` (no ="")
+      assert html =~ "cursor-not-allowed"
+      assert html =~ " disabled"
+    end
+
+    test "Add button is disabled in :single mode with one item" do
+      uuid = "01900000-0000-7000-8000-000000000001"
+
+      html =
+        render(
+          gallery_assigns_with(%{
+            mode: :single,
+            max_count: nil,
+            selected: [uuid],
+            variants_map: %{uuid => []}
+          })
+        )
+
+      assert html =~ "cursor-not-allowed"
+      assert html =~ " disabled"
+    end
+
+    test "Add button is enabled in :single mode with empty selection" do
+      html =
+        render(
+          gallery_assigns_with(%{
+            mode: :single,
+            max_count: nil,
+            selected: [],
+            variants_map: %{}
+          })
+        )
+
+      assert html =~ "open-picker-test-gallery"
+      refute html =~ "cursor-not-allowed"
+    end
+
+    test "Add button is enabled when max_count is nil (unlimited)" do
+      uuid = "01900000-0000-7000-8000-000000000001"
+
+      html =
+        render(
+          gallery_assigns_with(%{
+            mode: :multiple,
+            max_count: nil,
+            selected: [uuid],
+            variants_map: %{uuid => []}
+          })
+        )
+
+      assert html =~ "open-picker-test-gallery"
+      refute html =~ "cursor-not-allowed"
+    end
+
+    test "apply_selection clamps to max_count in :multiple mode" do
+      uuid1 = "01900000-0000-7000-8000-000000000001"
+      uuid2 = "01900000-0000-7000-8000-000000000002"
+      uuid3 = "01900000-0000-7000-8000-000000000003"
+
+      assigns_before =
+        gallery_assigns([])
+        |> Map.put(:mode, :multiple)
+        |> Map.put(:max_count, 2)
+        |> Map.put(:selected, [uuid1])
+        |> Map.put(:selected_loaded, [uuid1])
+        |> Map.put(:files, [])
+        |> Map.put(:variants_map, %{})
+        |> Map.put(:__changed__, %{})
+
+      socket_before = %Phoenix.LiveView.Socket{assigns: assigns_before}
+
+      {:ok, socket} =
+        MediaGallery.update(%{media_selected: [uuid1, uuid2, uuid3]}, socket_before)
+
+      assert length(socket.assigns.selected) <= 2
+      assert uuid3 not in socket.assigns.selected
     end
   end
 


### PR DESCRIPTION
## Summary

`PhoenixKitWeb.Components.MediaGallery` LiveComponent now accepts an optional `:max_count` integer attribute. When set, the gallery caps the selection and disables the Add (open picker) button once the limit is reached.

- `:single` mode implicitly enforces `max_count = 1` regardless of the attribute, matching existing behaviour.
- `:multiple` mode with a positive `max_count` clamps any selection via `apply_selection/4` (defence-in-depth — the disabled button is the primary UI guard) and disables the Add trigger when `length(selected) >= max_count`.
- `nil` / unset = unlimited (no behavioural change for existing callers).
- `selection_at_limit?/3` mirrors `apply_selection` so the button state stays in sync with the selection rule.

Used by consumers (e.g. Andi's document picker) that need to honour a template-author-defined cap on the number of images per slot.

## Tests

7 focused cases added covering below-limit, at-limit, unlimited, single-mode, and `apply_selection` clamping. Full suite green locally.

## Test plan

- [ ] CI green
- [ ] Sanity-check a consumer page with `max_count={3}`: the Add button disables at the third selection and re-enables after a removal
- [ ] Confirm `:single` callers (no `max_count` set) behave unchanged