### PR TITLE
Reject empty fields map in AI Translation.translate_fields/6

### DIFF
--- a/lib/modules/ai/translation.ex
+++ b/lib/modules/ai/translation.ex
@@ -124,11 +124,23 @@ defmodule PhoenixKit.Modules.AI.Translation do
     # not an input-shape question — fail fast on bad args either way.
     with :ok <- validate_uuid(endpoint_uuid, :no_endpoint),
          :ok <- validate_uuid(prompt_uuid, :missing_prompt),
+         :ok <- validate_non_empty(fields),
          :ok <- validate_unique_markers(Map.keys(fields)),
          :ok <- ensure_available() do
       do_translate(endpoint_uuid, prompt_uuid, source_lang, target_lang, fields, opts)
     end
   end
+
+  # Short-circuit before dispatching to the AI plugin — an empty
+  # `fields` map would render a prompt with no field variables, spend
+  # real tokens on a `PhoenixKitAI.ask_with_prompt/4` call, and then
+  # fail downstream in `parse_response/2` with `:no_markers`. Cheap to
+  # reject up front. The error sentinel mirrors `parse_response/2`'s
+  # shape so callers don't have to branch on a new error class.
+  defp validate_non_empty(fields) when map_size(fields) == 0,
+    do: {:error, {:parse_error, :no_markers}}
+
+  defp validate_non_empty(_fields), do: :ok
 
   defp validate_uuid(value, error) when is_binary(value) do
     if String.trim(value) == "", do: {:error, error}, else: :ok

--- a/test/phoenix_kit/modules/ai/translation_test.exs
+++ b/test/phoenix_kit/modules/ai/translation_test.exs
@@ -16,7 +16,7 @@ defmodule PhoenixKit.Modules.AI.TranslationTest do
   alias PhoenixKit.Modules.AI.Translation
 
   describe "translate_fields/6 — argument validation runs before plugin check" do
-    # Validation order is `endpoint → prompt → unique-markers → plugin-available`.
+    # Validation order is `endpoint → prompt → non-empty → unique-markers → plugin-available`.
     # Tests below assume PhoenixKitAI is NOT loaded in core's CI; the
     # input-validation errors must still surface so callers can unit-test
     # them without a configured plugin.

--- a/test/phoenix_kit/modules/ai/translation_test.exs
+++ b/test/phoenix_kit/modules/ai/translation_test.exs
@@ -46,6 +46,17 @@ defmodule PhoenixKit.Modules.AI.TranslationTest do
                Translation.translate_fields("ep", "  ", "en", "es", %{"a" => "b"})
     end
 
+    test "empty fields map → :no_markers (rejected before plugin call)" do
+      # Empty `fields` would render a prompt with no field variables,
+      # spend tokens on a `PhoenixKitAI.ask_with_prompt/4` call, and
+      # only fail downstream in `parse_response/2`. Reject up front so
+      # a caller bug doesn't burn a request. Sentinel matches the
+      # `parse_response/2` shape (`{:parse_error, :no_markers}`) so
+      # callers can branch on a single class.
+      assert {:error, {:parse_error, :no_markers}} =
+               Translation.translate_fields("ep", "p", "en", "es", %{})
+    end
+
     test "two fields that normalise to the same marker → duplicate_markers error" do
       # `foo-bar` and `foo_bar` both upcase + non-alnum-collapse to `FOO_BAR`.
       # Without this rejection, the parser would silently overwrite one


### PR DESCRIPTION
## Summary

Follow-up to PR #557 — boss's CLAUDE_REVIEW left this NITPICK as my call.

`Translation.translate_fields/6` previously accepted an empty `fields` map (`is_map/1` + `validate_unique_markers([])` both pass), then rendered a prompt with no field variables, called `PhoenixKitAI.ask_with_prompt/4` (real token spend), and only failed downstream in `parse_response/2` with `{:parse_error, :no_markers}`.

This adds a `validate_non_empty/1` guard before the unique-markers check so an empty `fields` map is rejected up front. Same `{:error, {:parse_error, :no_markers}}` sentinel as the downstream parser — callers don't have to branch on a new error class.

## Test plan

- [x] New test `"empty fields map → :no_markers (rejected before plugin call)"` in `translation_test.exs`
- [x] All 17 existing translation tests still pass
- [x] `mix format` clean
- [x] `mix credo --strict` clean

## Diff size

+23 / -0 across `lib/modules/ai/translation.ex` and the matching test file.