### PR TITLE
Fix submit button overflow on auth form cards (fieldset min-width)

### DIFF
--- a/lib/phoenix_kit_web/users/confirmation.html.heex
+++ b/lib/phoenix_kit_web/users/confirmation.html.heex
@@ -5,7 +5,7 @@
 >
   <h1 class="text-2xl font-bold text-center mb-6">Confirm Account</h1>
   <.form for={@form} id="confirmation_form" phx-submit="confirm_account">
-    <fieldset class="fieldset">
+    <fieldset class="fieldset min-w-0">
       <legend class="fieldset-legend sr-only">Account Confirmation</legend>
       <input type="hidden" name={@form[:token].name} value={@form[:token].value} />
       <button

--- a/lib/phoenix_kit_web/users/confirmation_instructions.html.heex
+++ b/lib/phoenix_kit_web/users/confirmation_instructions.html.heex
@@ -10,7 +10,7 @@
     We'll send a new confirmation link to your inbox
   </p>
   <.form for={@form} id="resend_confirmation_form" phx-submit="send_instructions">
-    <fieldset class="fieldset">
+    <fieldset class="fieldset min-w-0">
       <legend class="fieldset-legend sr-only">Resend Confirmation</legend>
       <.input field={@form[:email]} type="email" placeholder="Email" required />
       <button

--- a/lib/phoenix_kit_web/users/forgot_password.html.heex
+++ b/lib/phoenix_kit_web/users/forgot_password.html.heex
@@ -8,7 +8,7 @@
     We'll send a password reset link to your inbox
   </p>
   <.form for={@form} id="reset_password_form" phx-submit="send_email">
-    <fieldset class="fieldset">
+    <fieldset class="fieldset min-w-0">
       <legend class="fieldset-legend sr-only">Reset Password</legend>
       <.input field={@form[:email]} type="email" placeholder="Email" required />
       <button

--- a/lib/phoenix_kit_web/users/login.html.heex
+++ b/lib/phoenix_kit_web/users/login.html.heex
@@ -13,7 +13,7 @@
     phx-update="ignore"
   >
     <input :if={@return_to} type="hidden" name="user[return_to]" value={@return_to} />
-    <fieldset class="fieldset">
+    <fieldset class="fieldset min-w-0">
       <legend class="fieldset-legend sr-only">{gettext("Login with Password")}</legend>
 
       <label class="label" for="user_email_or_username">

--- a/lib/phoenix_kit_web/users/magic_link.html.heex
+++ b/lib/phoenix_kit_web/users/magic_link.html.heex
@@ -14,7 +14,15 @@
     phx-submit="send_magic_link"
     phx-change="validate"
   >
-    <fieldset class="fieldset">
+    <%!--
+      `min-w-0` overrides the browser-default `min-width: min-content`
+      on <fieldset>, which would otherwise let the fieldset grow past
+      its parent <form>'s width whenever a child has a longer
+      intrinsic width (the icon + "Send Magic Link →" content). With
+      `min-w-0` the fieldset honors the form's flex container width,
+      so the `w-full` submit button no longer overflows the card.
+    --%>
+    <fieldset class="fieldset min-w-0">
       <legend class="fieldset-legend sr-only">Magic Link Authentication</legend>
 
       <div :if={@error} class="alert alert-error text-sm mb-4">
@@ -36,10 +44,20 @@
         required
       />
 
+      <%!--
+        No `phx-disable-with` here: the `@loading` branch already
+        swaps the button to the spinner + "Sending magic link…"
+        state on submit, and the two mechanisms conflict — when
+        both fire on the same submit Phoenix LV's diff merger
+        injects a stray empty `<svg data-phx-skip>` into the button
+        (~183px wide) from the success-alert icon below, which then
+        forces the text to wrap onto 3 lines and look broken.
+        `min-w-0` + `max-w-full` belt-and-suspenders against the
+        fieldset overflow bug.
+      --%>
       <button
         type="submit"
-        phx-disable-with="Sending magic link..."
-        class="btn btn-primary w-full mt-4 transition-all hover:scale-[1.02] active:scale-[0.98]"
+        class="btn btn-primary w-full max-w-full min-w-0 mt-4 transition-all hover:scale-[1.02] active:scale-[0.98]"
         disabled={@loading || @sent}
       >
         <%= if @loading do %>

--- a/lib/phoenix_kit_web/users/reset_password.html.heex
+++ b/lib/phoenix_kit_web/users/reset_password.html.heex
@@ -10,7 +10,7 @@
     phx-submit="reset_password"
     phx-change="validate"
   >
-    <fieldset class="fieldset">
+    <fieldset class="fieldset min-w-0">
       <legend class="fieldset-legend sr-only">Reset Password</legend>
       <.error :if={@form.errors != []}>
         Oops, something went wrong! Please check the errors below.


### PR DESCRIPTION
## Summary

Surfaced while testing the projects-side AI Translate work — the magic-link form's submit button visibly **stuck out past the card on the right** after submit, with text wrapping awkwardly across three lines.

Two root causes, both fixed:

### 1. `<fieldset>` browser-default min-width

`<fieldset>` carries a browser-default `min-width: min-content`. When a long-content child (the icon + `Send Magic Link →` button) had a wider intrinsic size than the form, the fieldset grew past the form's width, and the button's `w-full` honored the wider fieldset — overflowing ~100px past the card edge.

**Fix**: `min-w-0` on the fieldset. Two of eight auth forms (`magic_link_registration`, `registration`) **already had this exact fix** — someone hit this bug class before and patched those two but missed the other six. Applied uniformly across all six remaining: `confirmation`, `confirmation_instructions`, `forgot_password`, `login`, `magic_link`, `reset_password`.

### 2. `phx-disable-with` ↔ `@loading` branch collision (magic-link only)

The magic-link form had both `phx-disable-with="Sending magic link..."` AND an `<%= if @loading do %>` branch in the button content. Both mechanisms swap the button content on submit. The double-swap confused Phoenix LV's diff merger, which injected a stray empty `<svg data-phx-skip>` element from the post-submit success-alert icon **into the button** (default SVG dims = 300×150, computed to ~183×150 in this layout). That squeezed the real text to wrap onto three lines.

**Fix**: dropped `phx-disable-with`. The `@loading` branch already renders the spinner + "Sending magic link..." state. Also added `min-w-0 max-w-full` to the button itself as belt-and-suspenders.

## Test plan

Verified in Chrome at `/phoenix_kit/users/magic-link`:

- [x] Initial render: button is exactly form-width (336px), text on one line
- [x] Post-submit: button stays form-width, `"✉ Send Magic Link →"` still on one line in disabled state
- [x] Success alert renders cleanly below the button
- [x] No phantom `<svg data-phx-skip>` in the button DOM
- [x] No JS console errors