### PR TITLE
table_default card_grid_class, MediaGallery hide-Add-at-limit, draggable_list responsive cols

### DIFF
--- a/lib/phoenix_kit_web/components/core/draggable_list.ex
+++ b/lib/phoenix_kit_web/components/core/draggable_list.ex
@@ -84,7 +84,10 @@ defmodule PhoenixKitWeb.Components.Core.DraggableList do
 
   attr :on_reorder, :string, required: true, doc: "Event name to send on reorder"
   attr :layout, :atom, default: :grid, values: [:grid, :list], doc: "Layout mode"
-  attr :cols, :integer, default: 4, doc: "Number of grid columns (only for layout={:grid})"
+  attr :cols, :any,
+    default: 4,
+    doc:
+      "Grid columns (only for layout={:grid}). Either an integer 1..6 (mapped to a static `grid-cols-N`), or a string of Tailwind grid-column classes used verbatim — e.g. `\"grid-cols-4 lg:grid-cols-6 2xl:grid-cols-8\"` — for a responsive grid. The string form must be a literal in a Tailwind-scanned source so the classes are compiled."
   attr :gap, :string, default: "gap-2", doc: "Gap between items (Tailwind class)"
   attr :class, :string, default: "", doc: "Additional CSS classes for the container"
   attr :item_class, :string, default: "", doc: "Additional CSS classes for each item wrapper"
@@ -159,7 +162,10 @@ defmodule PhoenixKitWeb.Components.Core.DraggableList do
     """
   end
 
-  # Map column count to Tailwind class (must be static for Tailwind to recognize)
+  # Map column count to Tailwind class (must be static for Tailwind to recognize).
+  # A string is taken verbatim so consumers can pass responsive grid-column
+  # classes (e.g. "grid-cols-4 lg:grid-cols-6 3xl:grid-cols-8").
+  defp cols_to_class(cols) when is_binary(cols), do: cols
   defp cols_to_class(1), do: "grid-cols-1"
   defp cols_to_class(2), do: "grid-cols-2"
   defp cols_to_class(3), do: "grid-cols-3"

--- a/lib/phoenix_kit_web/components/core/table_default.ex
+++ b/lib/phoenix_kit_web/components/core/table_default.ex
@@ -120,6 +120,11 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
   attr :storage_key, :string, default: nil
   attr :wrapper_class, :string, default: "rounded-lg shadow-md overflow-x-auto overflow-y-clip"
 
+  attr :card_grid_class, :string,
+    default: "gap-4 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4",
+    doc:
+      "Layout classes for the card-view grid (column density, gaps). Must NOT include a `display` utility (`grid`/`hidden`) — the component sets `display` per view-mode branch so controlled table mode can emit `hidden` cleanly. Override to change column count, e.g. a denser `gap-4 grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5`."
+
   attr :view_mode, :string,
     default: nil,
     values: [nil, "card", "table"],
@@ -325,7 +330,7 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
             # Layout-only classes (no `display`) are always safe; the `display`
             # utility is set per-branch so controlled "table" mode emits only
             # `hidden` — no reliance on Tailwind's hidden-beats-grid source order.
-            "gap-4 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4",
+            @card_grid_class,
             is_nil(@view_mode) && "grid md:hidden",
             @view_mode == "card" && "grid",
             @view_mode == "table" && "hidden"

--- a/lib/phoenix_kit_web/components/media_gallery.ex
+++ b/lib/phoenix_kit_web/components/media_gallery.ex
@@ -40,8 +40,8 @@ defmodule PhoenixKitWeb.Components.MediaGallery do
     preview (lightbox) still works; default `false`
   - `max_count` — integer upper bound on the number of selected images for
     `:multiple` mode; `nil` means unlimited. For `:single` mode the limit is
-    always 1 (implied by `mode`). When the limit is reached, the "Add" button
-    is disabled and `apply_selection` refuses to exceed it.
+    always 1 (implied by `mode`). When the limit is reached, the "Add" tile is
+    hidden entirely (not just disabled) and `apply_selection` refuses to exceed it.
 
   ## Change notifications
 

--- a/lib/phoenix_kit_web/components/media_gallery.ex
+++ b/lib/phoenix_kit_web/components/media_gallery.ex
@@ -27,8 +27,10 @@ defmodule PhoenixKitWeb.Components.MediaGallery do
   - `title` — optional heading above the gallery
   - `selected` — ordered list of file UUIDs (current selection); default `[]`
   - `mode` — `:single` or `:multiple` (default `:multiple`)
-  - `cols` — number of grid columns for the thumbnail layout (1..6, default `4`).
-    Plumbed straight through to `<.draggable_list>`.
+  - `cols` — grid columns for the thumbnail layout (default `4`). Either an
+    integer 1..6, or a string of Tailwind grid-column classes for a responsive
+    grid (e.g. `"grid-cols-4 lg:grid-cols-6 2xl:grid-cols-8"`). Plumbed straight
+    through to `<.draggable_list>`.
   - `featured_first` — when `true`, the first item in `:selected` renders a
     "Featured" badge in the top-left corner. Matches the
     `phoenix_kit_posts` post-creation convention where the first image is the

--- a/lib/phoenix_kit_web/components/media_gallery.html.heex
+++ b/lib/phoenix_kit_web/components/media_gallery.html.heex
@@ -68,11 +68,11 @@
         </div>
       </:item>
 
-      <:add_button>
-        <%!-- Add tile is omitted entirely once the selection reaches its limit
-             (instead of rendering a disabled tile) so it simply disappears. --%>
+      <%!-- Add tile is omitted entirely (the slot itself is conditional) once the
+           selection reaches its limit, so draggable_list renders no trailing cell
+           at all — not even an empty wrapper. --%>
+      <:add_button :if={not @readonly and not selection_at_limit?(@selected, @mode, @max_count)}>
         <button
-          :if={not @readonly and not selection_at_limit?(@selected, @mode, @max_count)}
           type="button"
           class="w-full aspect-square border-2 border-dashed rounded-lg transition-all flex flex-col items-center justify-center gap-1 text-xs font-medium border-base-300 hover:border-primary hover:bg-base-200 cursor-pointer text-base-content/60 hover:text-primary"
           data-role={"open-picker-#{@id}"}

--- a/lib/phoenix_kit_web/components/media_gallery.html.heex
+++ b/lib/phoenix_kit_web/components/media_gallery.html.heex
@@ -69,20 +69,15 @@
       </:item>
 
       <:add_button>
+        <%!-- Add tile is omitted entirely once the selection reaches its limit
+             (instead of rendering a disabled tile) so it simply disappears. --%>
         <button
-          :if={not @readonly}
+          :if={not @readonly and not selection_at_limit?(@selected, @mode, @max_count)}
           type="button"
-          class={[
-            "w-full aspect-square border-2 border-dashed rounded-lg transition-all flex flex-col items-center justify-center gap-1 text-xs font-medium",
-            selection_at_limit?(@selected, @mode, @max_count) &&
-              "border-base-300 bg-base-200 text-base-content/30 cursor-not-allowed",
-            not selection_at_limit?(@selected, @mode, @max_count) &&
-              "border-base-300 hover:border-primary hover:bg-base-200 cursor-pointer text-base-content/60 hover:text-primary"
-          ]}
+          class="w-full aspect-square border-2 border-dashed rounded-lg transition-all flex flex-col items-center justify-center gap-1 text-xs font-medium border-base-300 hover:border-primary hover:bg-base-200 cursor-pointer text-base-content/60 hover:text-primary"
           data-role={"open-picker-#{@id}"}
           phx-click="open_picker"
           phx-target={@myself}
-          disabled={selection_at_limit?(@selected, @mode, @max_count)}
         >
           <.icon name="hero-plus" class="w-6 h-6" />
           <span>{gettext("Add")}</span>


### PR DESCRIPTION
## Summary

Three additive, backwards-compatible changes to core components, driven by the Document Creator image-picker work:

- **`table_default` `card_grid_class` attr** — lets consumers override the card-view grid density (column count, gaps) without touching the per-view-mode `display` utility the component sets itself. Default keeps the previous 1/2/3/4-col layout. The value must NOT carry a `display` class (`grid`/`hidden`) so controlled table mode keeps emitting only `hidden` — preserving the source-order-independent fix from the post-#556 follow-up.
- **`MediaGallery` hides the Add tile at the selection limit** — when the selection reaches `max_count` (or 1 in `:single` mode) the Add tile is omitted entirely instead of rendered as a disabled, greyed-out tile.
- **`draggable_list` `cols` accepts a responsive class string** — `cols` now takes either an integer (1..6, mapped to a static `grid-cols-N` as before) or a string of Tailwind grid-column classes used verbatim, e.g. `"grid-cols-4 lg:grid-cols-6 2xl:grid-cols-8"`, so consumers can render a responsive thumbnail grid. `MediaGallery` plumbs the value straight through.

All three preserve existing behavior for current call sites (defaults unchanged; integer `cols` callers unaffected).

## Test plan

- [ ] Existing `<.table_default>` / `<.draggable_list>` / `<.MediaGallery>` usages render unchanged
- [ ] `card_grid_class` overrides density without breaking controlled table-mode hiding
- [ ] MediaGallery Add tile disappears at the limit and returns when an item is removed
- [ ] `draggable_list` with a responsive `cols` string renders a responsive grid (verify the larger-breakpoint column count actually wins — class must cascade after smaller breakpoints)