### PR TITLE
Fix parse_response/2 marker leak + drive handle_ai_response/2 via real test

### DIFF
--- a/lib/modules/ai/translation.ex
+++ b/lib/modules/ai/translation.ex
@@ -217,30 +217,30 @@ defmodule PhoenixKit.Modules.AI.Translation do
 
   # `PhoenixKitAI.ask_with_prompt/4` returns the full OpenAI-shaped
   # response map (`%{"choices" => [%{"message" => %{"content" => "..."}}]}`),
-  # not a raw string. Reach for `PhoenixKitAI.Completion.extract_content/1`
-  # to pull the assistant's content out — same helper publishing's
-  # `TranslatePostWorker` already uses for its post-translate AI call.
-  # Older versions of the plugin (or test stubs) may still return a
-  # plain binary; the second clause keeps that working.
-  @compile {:no_warn_undefined, [{PhoenixKitAI.Completion, :extract_content, 1}]}
-  defp handle_ai_response(response, fields) when is_map(response) do
-    case PhoenixKitAI.Completion.extract_content(response) do
-      {:ok, content} when is_binary(content) ->
-        parse_response(content, Map.keys(fields))
+  # not a raw string. We extract the assistant's content inline rather
+  # than via `PhoenixKitAI.Completion.extract_content/1` so the helper
+  # has no cross-module dep on the optional plugin — works in core's
+  # test env (plugin absent) and any host (plugin present, any
+  # version). The shape is OpenAI-standard so the inline match is
+  # stable.
+  #
+  # Older plugin versions (or test stubs) may still return a plain
+  # binary; the second clause keeps that path working.
 
-      {:ok, _other} ->
-        {:error, {:ai_error, {:unexpected_response, response}}}
-
-      {:error, reason} ->
-        {:error, {:ai_error, reason}}
-    end
+  @doc false
+  # Public-for-testing entry point so the OpenAI-shape extraction can
+  # be unit-tested without spinning up the live `PhoenixKitAI`
+  # plugin. Production callers go through `do_translate/6`.
+  def handle_ai_response(%{"choices" => [%{"message" => %{"content" => content}} | _]}, fields)
+      when is_binary(content) do
+    parse_response(content, Map.keys(fields))
   end
 
-  defp handle_ai_response(response, fields) when is_binary(response) do
+  def handle_ai_response(response, fields) when is_binary(response) do
     parse_response(response, Map.keys(fields))
   end
 
-  defp handle_ai_response(other, _fields) do
+  def handle_ai_response(other, _fields) do
     {:error, {:ai_error, {:unexpected_response, other}}}
   end
 

--- a/lib/modules/ai/translation.ex
+++ b/lib/modules/ai/translation.ex
@@ -306,13 +306,22 @@ defmodule PhoenixKit.Modules.AI.Translation do
   # Pulls the text between `---MARKER---` and the next `---OTHER---`
   # marker (or end-of-string). Returns nil when the marker isn't
   # present.
-  defp extract_section(body, marker, all_markers) do
-    others = for {_, m} <- all_markers, m != marker, do: Regex.escape(m)
-    boundary = if others == [], do: ~s|\\z|, else: "---(?:#{Enum.join(others, "|")})---"
-    # `i` flag: markers are normalised to uppercase by `marker/1`, but a model
-    # may emit them lowercased (`---title---`). Case-insensitive matching keeps
-    # the documented "case-insensitive marker matching" contract honest.
-    pattern = ~r/---#{Regex.escape(marker)}---\s*\n?(.+?)(?=#{boundary}|\z)/si
+  defp extract_section(body, marker, _all_markers) do
+    # Boundary matches ANY `---<NAME>---` marker, not just the
+    # requested-field markers. Without that, an AI that emits a
+    # marker the caller didn't ask for (e.g. an extra `---TITLE---`
+    # because the prompt template referenced `{{title}}` with no
+    # variable bound, leaving the literal text in the rendered
+    # prompt) gets that block's content rolled into the previous
+    # requested field. The marker name pattern intentionally accepts
+    # the same character class `marker/1` normalises field names
+    # into: uppercase letters, digits, underscores.
+    #
+    # `i` flag: markers are normalised to uppercase by `marker/1`,
+    # but a model may emit them lowercased (`---title---`). Case-
+    # insensitive matching keeps the documented "case-insensitive
+    # marker matching" contract honest.
+    pattern = ~r/---#{Regex.escape(marker)}---\s*\n?(.+?)(?=---[A-Z0-9_]+---|\z)/si
 
     case Regex.run(pattern, body) do
       [_, value] -> String.trim(value)

--- a/test/phoenix_kit/modules/ai/translation_test.exs
+++ b/test/phoenix_kit/modules/ai/translation_test.exs
@@ -172,6 +172,31 @@ defmodule PhoenixKit.Modules.AI.TranslationTest do
       refute "title" in missing
     end
 
+    test "unrequested markers in the response don't leak into adjacent fields" do
+      # A model that emits a marker the caller didn't ask for (e.g.
+      # `---TITLE---` here, but the caller only requested `name` +
+      # `description`) used to silently roll the unrequested block's
+      # content into the preceding requested field. Surfaced on a
+      # real deepseek-v3.2 translation where the prompt template
+      # referenced `{{title}}` literally — the AI emitted a
+      # `---TITLE---{{title}}` block and the parser appended it
+      # to `---NAME---`'s capture.
+      response = """
+      ---NAME---
+      Mitarbeiter-Onboarding
+      ---TITLE---
+      {{title}}
+      ---DESCRIPTION---
+      Standardablauf für den ersten Tag und die erste Woche.
+      """
+
+      assert {:ok, fields} = Translation.parse_response(response, ["name", "description"])
+      assert fields["name"] == "Mitarbeiter-Onboarding"
+      refute fields["name"] =~ "TITLE"
+      refute fields["name"] =~ "title"
+      assert fields["description"] =~ "Standardablauf"
+    end
+
     test "returns :no_markers when nothing matches at all" do
       response = "just some markdown\n\n# header"
 

--- a/test/phoenix_kit/modules/ai/translation_test.exs
+++ b/test/phoenix_kit/modules/ai/translation_test.exs
@@ -73,11 +73,15 @@ defmodule PhoenixKit.Modules.AI.TranslationTest do
       assert "FOO_BAR" in dupes
     end
 
-    test "handles OpenAI-shaped response map (extract_content path)" do
-      # `PhoenixKitAI.ask_with_prompt/4` returns the full OpenAI
-      # response map, not a raw string. The helper now reaches into
-      # `choices[0].message.content`. Directly exercises the
-      # extract-and-parse path via `parse_response/2`.
+    test "handle_ai_response/2 unwraps OpenAI-shaped response map" do
+      # Drives the actual code path that was broken pre-fix:
+      # `ask_with_prompt/4` returns the full OpenAI response map,
+      # not a raw string. The helper must reach into
+      # `choices[0].message.content` (via
+      # `PhoenixKitAI.Completion.extract_content/1`) before passing
+      # through to `parse_response/2`. The previous test asserted
+      # only on `parse_response/2` directly and would have passed
+      # against the broken implementation.
       response_map = %{
         "choices" => [
           %{
@@ -90,12 +94,20 @@ defmodule PhoenixKit.Modules.AI.TranslationTest do
       }
 
       assert {:ok, %{"title" => "Hola", "body" => "Mundo"}} =
-               Translation.parse_response(
-                 response_map["choices"]
-                 |> List.first()
-                 |> get_in(["message", "content"]),
-                 ["title", "body"]
-               )
+               Translation.handle_ai_response(response_map, %{
+                 "title" => "Hello",
+                 "body" => "World"
+               })
+    end
+
+    test "handle_ai_response/2 also accepts raw binary (test stub / legacy)" do
+      assert {:ok, %{"title" => "Hola"}} =
+               Translation.handle_ai_response("---TITLE---\nHola", %{"title" => "Hello"})
+    end
+
+    test "handle_ai_response/2 returns :ai_error for malformed shape" do
+      assert {:error, {:ai_error, {:unexpected_response, _}}} =
+               Translation.handle_ai_response(:not_a_response, %{"a" => "b"})
     end
 
     test "valid inputs + missing plugin → :ai_not_installed" do


### PR DESCRIPTION
## Summary

Follow-up to PR #560 — two commits that landed on `mdon/fix-translation-response-shape` after the merge.

### 1. Parser marker-leak bug (real bug, present on `dev` today)

`parse_response/2`'s field-capture boundary regex only terminated at REQUESTED markers. A model that emits a marker the caller didn't ask for silently rolls that block's content into the previous requested field.

**Real-world trigger:** projects-side prompt template referenced `{{title}}` literally (no `title` variable bound for a template resource that only has name + description), so the AI emitted `---TITLE---{{title}}` between `---NAME---` and `---DESCRIPTION---`. The parser, asked for only `name` and `description`, returned name as `"Mitarbeiter-Onboarding---TITLE---{{title}}"` — corrupted.

**Fix:** widen the boundary regex to terminate at any `---[A-Z0-9_]+---` marker (the character class matches what `marker/1` already produces). Unrequested markers' content is dropped silently — they're not in the requested fields list, so the caller never gets them either way.

Verified end-to-end against real deepseek-v3.2: DE-DE and FR-FR translations of the Employee onboarding template were clean after this fix, dirty before.

### 2. `handle_ai_response/2` testability

Codex final-review of #560 caught that the original "OpenAI-shaped response map" test manually extracted `message.content` and only drove `parse_response/2` directly — it would still have passed against the pre-fix broken implementation. Reworked:

- Promoted `handle_ai_response/2` from `defp` to `@doc false def` so unit tests can drive it directly.
- Replaced the cross-module `PhoenixKitAI.Completion.extract_content/1` call with an inline pattern-match on the OpenAI shape. Drops the cross-module dep — works in core's test env (plugin absent) and any host (plugin present, any version).

## Test plan

- [x] New regression test pins the unrequested-marker boundary behaviour
- [x] New `handle_ai_response/2` tests cover the OpenAI map / raw binary / malformed shape branches
- [x] All 21 translation tests pass
- [x] `mix credo --strict` clean