### PR TITLE
Pin Translation.translate_fields/6 validation order with a regression test

### DIFF
--- a/test/phoenix_kit/modules/ai/translation_test.exs
+++ b/test/phoenix_kit/modules/ai/translation_test.exs
@@ -104,6 +104,39 @@ defmodule PhoenixKit.Modules.AI.TranslationTest do
       assert {:error, :ai_not_installed} =
                Translation.translate_fields("ep", "p", "en", "es", %{"a" => "b"})
     end
+
+    test "validation order: endpoint > prompt > non-empty > unique-markers > plugin" do
+      # Pin the documented validation order. Each test below stacks
+      # multiple input violations and asserts which one wins — if a
+      # future refactor accidentally reorders the validation chain
+      # (e.g. moves `validate_non_empty` before `validate_uuid`),
+      # these regressions catch it.
+
+      # Empty endpoint wins over empty fields, dup markers, missing plugin.
+      assert {:error, :no_endpoint} =
+               Translation.translate_fields("", "", "en", "es", %{})
+
+      # Endpoint present, empty prompt wins over empty fields + dups.
+      assert {:error, :missing_prompt} =
+               Translation.translate_fields("ep", "", "en", "es", %{})
+
+      # Endpoint + prompt present, empty fields wins over duplicate
+      # markers — the empty-fields check happens BEFORE
+      # validate_unique_markers, which is the cheaper rejection
+      # (avoids iterating Map.keys over an empty map for nothing).
+      assert {:error, {:parse_error, :no_markers}} =
+               Translation.translate_fields("ep", "p", "en", "es", %{})
+
+      # Endpoint + prompt + non-empty fields, dup markers reject.
+      assert {:error, {:parse_error, {:duplicate_markers, _}}} =
+               Translation.translate_fields(
+                 "ep",
+                 "p",
+                 "en",
+                 "es",
+                 %{"foo-bar" => "a", "foo_bar" => "b"}
+               )
+    end
   end
 
   describe "parse_response/2 — structured `---FIELD---` markers" do

--- a/test/phoenix_kit/modules/ai/translation_test.exs
+++ b/test/phoenix_kit/modules/ai/translation_test.exs
@@ -112,18 +112,17 @@ defmodule PhoenixKit.Modules.AI.TranslationTest do
       # (e.g. moves `validate_non_empty` before `validate_uuid`),
       # these regressions catch it.
 
-      # Empty endpoint wins over empty fields, dup markers, missing plugin.
+      # Empty endpoint wins over empty fields + missing plugin.
       assert {:error, :no_endpoint} =
                Translation.translate_fields("", "", "en", "es", %{})
 
-      # Endpoint present, empty prompt wins over empty fields + dups.
+      # Endpoint present, empty prompt wins over empty fields.
       assert {:error, :missing_prompt} =
                Translation.translate_fields("ep", "", "en", "es", %{})
 
-      # Endpoint + prompt present, empty fields wins over duplicate
-      # markers — the empty-fields check happens BEFORE
-      # validate_unique_markers, which is the cheaper rejection
-      # (avoids iterating Map.keys over an empty map for nothing).
+      # Endpoint + prompt present, empty fields wins before
+      # validate_unique_markers gets to iterate Map.keys over a
+      # zero-element map for nothing.
       assert {:error, {:parse_error, :no_markers}} =
                Translation.translate_fields("ep", "p", "en", "es", %{})
 


### PR DESCRIPTION
## Summary

Follow-up to PR #558 — codex flagged that the documented validation
order (`endpoint → prompt → non-empty → unique-markers → plugin-
available`) wasn't pinned by any test. A future refactor that
reorders the `with` chain would change caller-facing precedence
without any test catching it.

Added a regression test that stacks multiple input violations and
asserts which one wins:

- empty endpoint vs empty fields → `:no_endpoint` (endpoint wins)
- empty prompt vs empty fields → `:missing_prompt` (prompt wins)
- valid endpoint+prompt + empty fields → `:no_markers`
- valid endpoint+prompt+fields + dup markers → `{:duplicate_markers, _}`

Plus a comment-only tidy on the existing describe block (the order
list there was stale after #558 inserted `validate_non_empty`).

These two commits landed on my fork's branch **after** #558 was
merged, so they didn't make it into upstream/dev. Opening as a
separate small PR.

## Test plan

- [x] 19/0 tests
- [x] No production-code change — test + comment only