### PR TITLE
Trim implementation-detail comments in magic_link.html.heex

### DIFF
--- a/lib/phoenix_kit_web/users/magic_link.html.heex
+++ b/lib/phoenix_kit_web/users/magic_link.html.heex
@@ -14,14 +14,8 @@
     phx-submit="send_magic_link"
     phx-change="validate"
   >
-    <%!--
-      `min-w-0` overrides the browser-default `min-width: min-content`
-      on <fieldset>, which would otherwise let the fieldset grow past
-      its parent <form>'s width whenever a child has a longer
-      intrinsic width (the icon + "Send Magic Link →" content). With
-      `min-w-0` the fieldset honors the form's flex container width,
-      so the `w-full` submit button no longer overflows the card.
-    --%>
+    <%!-- `min-w-0` overrides <fieldset>'s default `min-width: min-content`
+         so a long-content child doesn't push the form past the card. --%>
     <fieldset class="fieldset min-w-0">
       <legend class="fieldset-legend sr-only">Magic Link Authentication</legend>
 
@@ -44,17 +38,10 @@
         required
       />
 
-      <%!--
-        No `phx-disable-with` here: the `@loading` branch already
-        swaps the button to the spinner + "Sending magic link…"
-        state on submit, and the two mechanisms conflict — when
-        both fire on the same submit Phoenix LV's diff merger
-        injects a stray empty `<svg data-phx-skip>` into the button
-        (~183px wide) from the success-alert icon below, which then
-        forces the text to wrap onto 3 lines and look broken.
-        `min-w-0` + `max-w-full` belt-and-suspenders against the
-        fieldset overflow bug.
-      --%>
+      <%!-- `@loading` already swaps the button content; redundant
+           `phx-disable-with` was removed because the double swap
+           broke the DOM merge. `min-w-0 max-w-full` belt-and-
+           suspenders for the fieldset overflow fix. --%>
       <button
         type="submit"
         class="btn btn-primary w-full max-w-full min-w-0 mt-4 transition-all hover:scale-[1.02] active:scale-[0.98]"


### PR DESCRIPTION
## Summary

Codex final-review CONCERN from PR #559: the long inline comments
explaining the `data-phx-skip` / 183px / form-ownership root causes
in `magic_link.html.heex` belong in the PR description, not in
templates where they'll age out faster than the fix.

Kept short comments naming the root rules ("fieldset default
min-width", "double-swap broke the DOM merge") so a future edit
sees the intent without the wall of text.

## Notes

- HTML-template-only change. No logic touched.
- Surfaced during PR #559 review; landed late and got orphaned
  on the merged branch. This PR re-applies it cleanly off
  `upstream/dev`.
- The fix in PR #559 (`min-w-0` on `<fieldset>` + removed
  `phx-disable-with` to avoid double-swap DOM conflict) remains
  in place; only the explanatory comments are trimmed.

## Test plan

- [x] `mix compile` clean
- [x] `mix format --check-formatted` clean on the touched file
- [ ] Visual check at `/phoenix_kit/users/log-in/magic-link` —
      submit button still fills the card, no overflow