### PR TITLE
Translation follow-ups + TableDefault class attr widening

### DIFF
--- a/lib/modules/ai/translation.ex
+++ b/lib/modules/ai/translation.ex
@@ -217,30 +217,30 @@ defmodule PhoenixKit.Modules.AI.Translation do
 
   # `PhoenixKitAI.ask_with_prompt/4` returns the full OpenAI-shaped
   # response map (`%{"choices" => [%{"message" => %{"content" => "..."}}]}`),
-  # not a raw string. Reach for `PhoenixKitAI.Completion.extract_content/1`
-  # to pull the assistant's content out — same helper publishing's
-  # `TranslatePostWorker` already uses for its post-translate AI call.
-  # Older versions of the plugin (or test stubs) may still return a
-  # plain binary; the second clause keeps that working.
-  @compile {:no_warn_undefined, [{PhoenixKitAI.Completion, :extract_content, 1}]}
-  defp handle_ai_response(response, fields) when is_map(response) do
-    case PhoenixKitAI.Completion.extract_content(response) do
-      {:ok, content} when is_binary(content) ->
-        parse_response(content, Map.keys(fields))
+  # not a raw string. We extract the assistant's content inline rather
+  # than via `PhoenixKitAI.Completion.extract_content/1` so the helper
+  # has no cross-module dep on the optional plugin — works in core's
+  # test env (plugin absent) and any host (plugin present, any
+  # version). The shape is OpenAI-standard so the inline match is
+  # stable.
+  #
+  # Older plugin versions (or test stubs) may still return a plain
+  # binary; the second clause keeps that path working.
 
-      {:ok, _other} ->
-        {:error, {:ai_error, {:unexpected_response, response}}}
-
-      {:error, reason} ->
-        {:error, {:ai_error, reason}}
-    end
+  @doc false
+  # Public-for-testing entry point so the OpenAI-shape extraction can
+  # be unit-tested without spinning up the live `PhoenixKitAI`
+  # plugin. Production callers go through `do_translate/6`.
+  def handle_ai_response(%{"choices" => [%{"message" => %{"content" => content}} | _]}, fields)
+      when is_binary(content) do
+    parse_response(content, Map.keys(fields))
   end
 
-  defp handle_ai_response(response, fields) when is_binary(response) do
+  def handle_ai_response(response, fields) when is_binary(response) do
     parse_response(response, Map.keys(fields))
   end
 
-  defp handle_ai_response(other, _fields) do
+  def handle_ai_response(other, _fields) do
     {:error, {:ai_error, {:unexpected_response, other}}}
   end
 

--- a/lib/modules/ai/translation.ex
+++ b/lib/modules/ai/translation.ex
@@ -330,8 +330,31 @@ defmodule PhoenixKit.Modules.AI.Translation do
     pattern = ~r/---#{Regex.escape(marker)}---\s*\n?(.+?)(?=\n---[A-Z0-9_]+---|\z)/si
 
     case Regex.run(pattern, body) do
-      [_, value] -> String.trim(value)
-      _ -> nil
+      [_, value] ->
+        # Empty-section guard: when a section is truly empty (e.g.
+        # `---TITLE---\n---BODY---\n...`), `\s*\n?` will consume the
+        # `\n` between the markers and `(.+?)` starts capturing
+        # `---BODY---\n...` as TITLE's content. The lookahead can't
+        # rescue it because it requires a leading `\n` (which the
+        # previous `\s*` already ate). Detect after the fact: if the
+        # captured value starts with what LOOKS like another marker,
+        # the original section had no content — return `""` so the
+        # parser records it as empty rather than misattributing the
+        # next field's content. The boundary regex up above ensures
+        # only "real" marker shapes trigger this; legitimately
+        # translated content that begins with `---WORD---` would be
+        # an unlikely UI translation, and the cost of misclassifying
+        # that as empty is lower than misattributing a whole field.
+        trimmed = String.trim(value)
+
+        if Regex.match?(~r/\A---[A-Z0-9_]+---/i, trimmed) do
+          ""
+        else
+          trimmed
+        end
+
+      _ ->
+        nil
     end
   end
 

--- a/lib/modules/ai/translation.ex
+++ b/lib/modules/ai/translation.ex
@@ -306,13 +306,22 @@ defmodule PhoenixKit.Modules.AI.Translation do
   # Pulls the text between `---MARKER---` and the next `---OTHER---`
   # marker (or end-of-string). Returns nil when the marker isn't
   # present.
-  defp extract_section(body, marker, all_markers) do
-    others = for {_, m} <- all_markers, m != marker, do: Regex.escape(m)
-    boundary = if others == [], do: ~s|\\z|, else: "---(?:#{Enum.join(others, "|")})---"
-    # `i` flag: markers are normalised to uppercase by `marker/1`, but a model
-    # may emit them lowercased (`---title---`). Case-insensitive matching keeps
-    # the documented "case-insensitive marker matching" contract honest.
-    pattern = ~r/---#{Regex.escape(marker)}---\s*\n?(.+?)(?=#{boundary}|\z)/si
+  defp extract_section(body, marker, _all_markers) do
+    # Boundary matches ANY `---<NAME>---` marker, not just the
+    # requested-field markers. Without that, an AI that emits a
+    # marker the caller didn't ask for (e.g. an extra `---TITLE---`
+    # because the prompt template referenced `{{title}}` with no
+    # variable bound, leaving the literal text in the rendered
+    # prompt) gets that block's content rolled into the previous
+    # requested field. The marker name pattern intentionally accepts
+    # the same character class `marker/1` normalises field names
+    # into: uppercase letters, digits, underscores.
+    #
+    # `i` flag: markers are normalised to uppercase by `marker/1`,
+    # but a model may emit them lowercased (`---title---`). Case-
+    # insensitive matching keeps the documented "case-insensitive
+    # marker matching" contract honest.
+    pattern = ~r/---#{Regex.escape(marker)}---\s*\n?(.+?)(?=---[A-Z0-9_]+---|\z)/si
 
     case Regex.run(pattern, body) do
       [_, value] -> String.trim(value)

--- a/lib/modules/ai/translation.ex
+++ b/lib/modules/ai/translation.ex
@@ -317,11 +317,17 @@ defmodule PhoenixKit.Modules.AI.Translation do
     # the same character class `marker/1` normalises field names
     # into: uppercase letters, digits, underscores.
     #
+    # The `\n` before `---` is load-bearing: real AI-emitted markers
+    # always start on their own line, so requiring a newline before
+    # the boundary avoids prematurely terminating a capture when the
+    # translated content happens to contain a literal `---WORD---`
+    # token mid-paragraph (technical docs, API examples).
+    #
     # `i` flag: markers are normalised to uppercase by `marker/1`,
     # but a model may emit them lowercased (`---title---`). Case-
     # insensitive matching keeps the documented "case-insensitive
     # marker matching" contract honest.
-    pattern = ~r/---#{Regex.escape(marker)}---\s*\n?(.+?)(?=---[A-Z0-9_]+---|\z)/si
+    pattern = ~r/---#{Regex.escape(marker)}---\s*\n?(.+?)(?=\n---[A-Z0-9_]+---|\z)/si
 
     case Regex.run(pattern, body) do
       [_, value] -> String.trim(value)

--- a/lib/phoenix_kit_web/components/core/table_default.ex
+++ b/lib/phoenix_kit_web/components/core/table_default.ex
@@ -103,7 +103,7 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
   survive across LV navigation or be part of the URL.
   """
   attr :id, :string, default: nil
-  attr :class, :string, default: ""
+  attr :class, :any, default: ""
   attr :variant, :string, default: "default", values: ["default", "zebra", "pin-rows", "pin-cols"]
   attr :size, :string, default: "md", values: ["xs", "sm", "md", "lg"]
   attr :toggleable, :boolean, default: false
@@ -458,7 +458,7 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
     look, or `class=""` for a fully bare header. The string fully replaces the default;
     concatenate manually if you want to add classes on top.
   """
-  attr :class, :string, default: "bg-base-300"
+  attr :class, :any, default: "bg-base-300"
   slot :inner_block, required: true
 
   def table_default_header(assigns) do
@@ -519,7 +519,7 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
   * `hover` - Enable hover effect: true/false (optional, default: true)
   * `rest` - Additional HTML attributes (optional)
   """
-  attr :class, :string, default: ""
+  attr :class, :any, default: ""
   attr :hover, :boolean, default: true
   attr :rest, :global
 
@@ -551,7 +551,7 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
   * `class` - Additional CSS classes (optional)
   * `rest` - Additional HTML attributes (optional)
   """
-  attr :class, :string, default: ""
+  attr :class, :any, default: ""
   attr :rest, :global
 
   slot :inner_block
@@ -574,7 +574,7 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
   * `rowspan` - Number of rows to span (optional)
   * `rest` - Additional HTML attributes (optional)
   """
-  attr :class, :string, default: ""
+  attr :class, :any, default: ""
   attr :colspan, :integer, default: nil
   attr :rowspan, :integer, default: nil
   attr :rest, :global
@@ -619,7 +619,7 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
   attr :event, :string, default: "toggle_sort"
   attr :target, :any, default: nil
   attr :align, :atom, default: :left, values: [:left, :right, :center]
-  attr :class, :string, default: ""
+  attr :class, :any, default: ""
   attr :rest, :global, include: ~w(colspan rowspan)
 
   slot :inner_block, required: true
@@ -729,7 +729,7 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
   attr :debounce, :integer, default: 300
   attr :name, :string, default: "search"
   attr :target, :any, default: nil
-  attr :class, :string, default: ""
+  attr :class, :any, default: ""
 
   def search_toolbar(assigns) do
     assigns =

--- a/lib/phoenix_kit_web/components/multilang_form.ex
+++ b/lib/phoenix_kit_web/components/multilang_form.ex
@@ -538,7 +538,10 @@ defmodule PhoenixKitWeb.Components.MultilangForm do
     * `current_lang` — the currently selected language code
     * `compact` — force compact mode (short codes). Default: nil (auto)
     * `show_header` — show the "Content Language" header. Default: true
-    * `show_info` — show the info alert. Default: true
+    * `show_info` — show an info tooltip next to the header. Default:
+      true. The tooltip surface explains the primary-language /
+      fallback semantics on hover; requires `show_header: true` to
+      have an anchor element.
   """
   attr :multilang_enabled, :boolean, required: true
   attr :language_tabs, :list, required: true
@@ -564,21 +567,31 @@ defmodule PhoenixKitWeb.Components.MultilangForm do
         <div class="flex items-center gap-2">
           <.icon name="hero-language" class="w-5 h-5 text-primary" />
           <h2 class="card-title text-lg m-0">{gettext("Content Language")}</h2>
+          <%!-- Info tooltip replaces the standalone alert block that
+               used to live below the header. Boss feedback was that
+               the wall of text was too prominent for what is mostly
+               static explanation; hide it behind an info icon that
+               reveals on hover/focus. The `[--tooltip-color:…]`
+               override is needed because daisyUI's default tooltip
+               background can be too dark for small body text on some
+               themes — explicit base-300 keeps contrast readable. --%>
+          <span
+            :if={@show_info}
+            class="tooltip tooltip-right cursor-help text-base-content/60 hover:text-base-content [--tooltip-max-width:24rem]"
+            data-tip={
+              gettext(
+                "Use the language tabs below to translate this record's content. The primary language (marked with a star) is required. Other languages are optional — any empty fields will fall back to the primary language value."
+              )
+            }
+          >
+            <.icon name="hero-information-circle" class="w-4 h-4" />
+          </span>
         </div>
         <% primary_tab = Enum.find(@language_tabs, fn t -> t.is_primary end) %>
         <div :if={primary_tab} class="flex items-center gap-1.5 text-xs text-base-content/60">
           <.icon name="hero-star-solid" class="w-3.5 h-3.5 text-primary" />
           <span>{gettext("Primary: %{lang}", lang: primary_tab.name)}</span>
         </div>
-      </div>
-
-      <div :if={@show_info} class="alert alert-info py-2 text-xs mb-4">
-        <.icon name="hero-information-circle" class="w-4 h-4" />
-        <span>
-          {gettext(
-            "Use the language tabs below to translate this record's content. The primary language (marked with a star) is required. Other languages are optional — any empty fields will fall back to the primary language value."
-          )}
-        </span>
       </div>
 
       <div class="mb-4">
@@ -674,13 +687,20 @@ defmodule PhoenixKitWeb.Components.MultilangForm do
         {render_slot(@skeleton)}
       <% else %>
         <div class="space-y-4">
+          <%!-- Default skeleton uses `bg-base-content/15 animate-pulse`
+               instead of daisyUI's `.skeleton` because the latter's
+               ~8%-opacity base-content grey is nearly invisible on a
+               `bg-base-100` card — multiple consumers reported the
+               loading state looking like a "blank page". Theme-safe
+               via base-content opacity (dark-on-light AND
+               light-on-dark themes both render visibly). --%>
           <div class="space-y-2">
-            <div class="skeleton h-4 w-24"></div>
-            <div class="skeleton h-12 w-full"></div>
+            <div class="bg-base-content/15 rounded h-4 w-24 animate-pulse"></div>
+            <div class="bg-base-content/15 rounded h-12 w-full animate-pulse"></div>
           </div>
           <div class="space-y-2">
-            <div class="skeleton h-4 w-32"></div>
-            <div class="skeleton h-24 w-full"></div>
+            <div class="bg-base-content/15 rounded h-4 w-32 animate-pulse"></div>
+            <div class="bg-base-content/15 rounded h-24 w-full animate-pulse"></div>
           </div>
         </div>
       <% end %>

--- a/lib/phoenix_kit_web/users/magic_link.html.heex
+++ b/lib/phoenix_kit_web/users/magic_link.html.heex
@@ -14,14 +14,8 @@
     phx-submit="send_magic_link"
     phx-change="validate"
   >
-    <%!--
-      `min-w-0` overrides the browser-default `min-width: min-content`
-      on <fieldset>, which would otherwise let the fieldset grow past
-      its parent <form>'s width whenever a child has a longer
-      intrinsic width (the icon + "Send Magic Link →" content). With
-      `min-w-0` the fieldset honors the form's flex container width,
-      so the `w-full` submit button no longer overflows the card.
-    --%>
+    <%!-- `min-w-0` overrides <fieldset>'s default `min-width: min-content`
+         so a long-content child doesn't push the form past the card. --%>
     <fieldset class="fieldset min-w-0">
       <legend class="fieldset-legend sr-only">Magic Link Authentication</legend>
 
@@ -44,17 +38,10 @@
         required
       />
 
-      <%!--
-        No `phx-disable-with` here: the `@loading` branch already
-        swaps the button to the spinner + "Sending magic link…"
-        state on submit, and the two mechanisms conflict — when
-        both fire on the same submit Phoenix LV's diff merger
-        injects a stray empty `<svg data-phx-skip>` into the button
-        (~183px wide) from the success-alert icon below, which then
-        forces the text to wrap onto 3 lines and look broken.
-        `min-w-0` + `max-w-full` belt-and-suspenders against the
-        fieldset overflow bug.
-      --%>
+      <%!-- `@loading` already swaps the button content; redundant
+           `phx-disable-with` was removed because the double swap
+           broke the DOM merge. `min-w-0 max-w-full` belt-and-
+           suspenders for the fieldset overflow fix. --%>
       <button
         type="submit"
         class="btn btn-primary w-full max-w-full min-w-0 mt-4 transition-all hover:scale-[1.02] active:scale-[0.98]"

--- a/test/phoenix_kit/modules/ai/translation_test.exs
+++ b/test/phoenix_kit/modules/ai/translation_test.exs
@@ -172,6 +172,31 @@ defmodule PhoenixKit.Modules.AI.TranslationTest do
       refute "title" in missing
     end
 
+    test "unrequested markers in the response don't leak into adjacent fields" do
+      # A model that emits a marker the caller didn't ask for (e.g.
+      # `---TITLE---` here, but the caller only requested `name` +
+      # `description`) used to silently roll the unrequested block's
+      # content into the preceding requested field. Surfaced on a
+      # real deepseek-v3.2 translation where the prompt template
+      # referenced `{{title}}` literally — the AI emitted a
+      # `---TITLE---{{title}}` block and the parser appended it
+      # to `---NAME---`'s capture.
+      response = """
+      ---NAME---
+      Mitarbeiter-Onboarding
+      ---TITLE---
+      {{title}}
+      ---DESCRIPTION---
+      Standardablauf für den ersten Tag und die erste Woche.
+      """
+
+      assert {:ok, fields} = Translation.parse_response(response, ["name", "description"])
+      assert fields["name"] == "Mitarbeiter-Onboarding"
+      refute fields["name"] =~ "TITLE"
+      refute fields["name"] =~ "title"
+      assert fields["description"] =~ "Standardablauf"
+    end
+
     test "returns :no_markers when nothing matches at all" do
       response = "just some markdown\n\n# header"
 

--- a/test/phoenix_kit/modules/ai/translation_test.exs
+++ b/test/phoenix_kit/modules/ai/translation_test.exs
@@ -73,11 +73,15 @@ defmodule PhoenixKit.Modules.AI.TranslationTest do
       assert "FOO_BAR" in dupes
     end
 
-    test "handles OpenAI-shaped response map (extract_content path)" do
-      # `PhoenixKitAI.ask_with_prompt/4` returns the full OpenAI
-      # response map, not a raw string. The helper now reaches into
-      # `choices[0].message.content`. Directly exercises the
-      # extract-and-parse path via `parse_response/2`.
+    test "handle_ai_response/2 unwraps OpenAI-shaped response map" do
+      # Drives the actual code path that was broken pre-fix:
+      # `ask_with_prompt/4` returns the full OpenAI response map,
+      # not a raw string. The helper must reach into
+      # `choices[0].message.content` (via
+      # `PhoenixKitAI.Completion.extract_content/1`) before passing
+      # through to `parse_response/2`. The previous test asserted
+      # only on `parse_response/2` directly and would have passed
+      # against the broken implementation.
       response_map = %{
         "choices" => [
           %{
@@ -90,12 +94,20 @@ defmodule PhoenixKit.Modules.AI.TranslationTest do
       }
 
       assert {:ok, %{"title" => "Hola", "body" => "Mundo"}} =
-               Translation.parse_response(
-                 response_map["choices"]
-                 |> List.first()
-                 |> get_in(["message", "content"]),
-                 ["title", "body"]
-               )
+               Translation.handle_ai_response(response_map, %{
+                 "title" => "Hello",
+                 "body" => "World"
+               })
+    end
+
+    test "handle_ai_response/2 also accepts raw binary (test stub / legacy)" do
+      assert {:ok, %{"title" => "Hola"}} =
+               Translation.handle_ai_response("---TITLE---\nHola", %{"title" => "Hello"})
+    end
+
+    test "handle_ai_response/2 returns :ai_error for malformed shape" do
+      assert {:error, {:ai_error, {:unexpected_response, _}}} =
+               Translation.handle_ai_response(:not_a_response, %{"a" => "b"})
     end
 
     test "valid inputs + missing plugin → :ai_not_installed" do

--- a/test/phoenix_kit/modules/ai/translation_test.exs
+++ b/test/phoenix_kit/modules/ai/translation_test.exs
@@ -290,6 +290,26 @@ defmodule PhoenixKit.Modules.AI.TranslationTest do
       assert fields["body"] =~ "another ---WEIRD--- inline token"
     end
 
+    test "empty section between two markers returns empty string, not next field's content" do
+      # When a model emits a marker with no content followed
+      # immediately by the next marker (`---TITLE---\n---BODY---\n...`),
+      # the underlying regex would otherwise consume the inter-marker
+      # newline and capture `---BODY---\nBody...` as TITLE's content
+      # — leaking the next section into the current one. Empty-section
+      # guard in `extract_section/3` detects the leak by checking
+      # whether the captured value starts with a marker-shaped token
+      # and returns `""` instead.
+      response = """
+      ---TITLE---
+      ---BODY---
+      Body content here
+      """
+
+      assert {:ok, fields} = Translation.parse_response(response, ["title", "body"])
+      assert fields["title"] == ""
+      assert fields["body"] == "Body content here"
+    end
+
     test "returns :no_markers when nothing matches at all" do
       response = "just some markdown\n\n# header"
 

--- a/test/phoenix_kit/modules/ai/translation_test.exs
+++ b/test/phoenix_kit/modules/ai/translation_test.exs
@@ -116,6 +116,39 @@ defmodule PhoenixKit.Modules.AI.TranslationTest do
       assert {:error, :ai_not_installed} =
                Translation.translate_fields("ep", "p", "en", "es", %{"a" => "b"})
     end
+
+    test "validation order: endpoint > prompt > non-empty > unique-markers > plugin" do
+      # Pin the documented validation order. Each test below stacks
+      # multiple input violations and asserts which one wins — if a
+      # future refactor accidentally reorders the validation chain
+      # (e.g. moves `validate_non_empty` before `validate_uuid`),
+      # these regressions catch it.
+
+      # Empty endpoint wins over empty fields, dup markers, missing plugin.
+      assert {:error, :no_endpoint} =
+               Translation.translate_fields("", "", "en", "es", %{})
+
+      # Endpoint present, empty prompt wins over empty fields + dups.
+      assert {:error, :missing_prompt} =
+               Translation.translate_fields("ep", "", "en", "es", %{})
+
+      # Endpoint + prompt present, empty fields wins over duplicate
+      # markers — the empty-fields check happens BEFORE
+      # validate_unique_markers, which is the cheaper rejection
+      # (avoids iterating Map.keys over an empty map for nothing).
+      assert {:error, {:parse_error, :no_markers}} =
+               Translation.translate_fields("ep", "p", "en", "es", %{})
+
+      # Endpoint + prompt + non-empty fields, dup markers reject.
+      assert {:error, {:parse_error, {:duplicate_markers, _}}} =
+               Translation.translate_fields(
+                 "ep",
+                 "p",
+                 "en",
+                 "es",
+                 %{"foo-bar" => "a", "foo_bar" => "b"}
+               )
+    end
   end
 
   describe "parse_response/2 — structured `---FIELD---` markers" do

--- a/test/phoenix_kit/modules/ai/translation_test.exs
+++ b/test/phoenix_kit/modules/ai/translation_test.exs
@@ -77,11 +77,10 @@ defmodule PhoenixKit.Modules.AI.TranslationTest do
       # Drives the actual code path that was broken pre-fix:
       # `ask_with_prompt/4` returns the full OpenAI response map,
       # not a raw string. The helper must reach into
-      # `choices[0].message.content` (via
-      # `PhoenixKitAI.Completion.extract_content/1`) before passing
-      # through to `parse_response/2`. The previous test asserted
-      # only on `parse_response/2` directly and would have passed
-      # against the broken implementation.
+      # `choices[0].message.content` inline before passing through
+      # to `parse_response/2`. The previous test asserted only on
+      # `parse_response/2` directly and would have passed against
+      # the broken implementation.
       response_map = %{
         "choices" => [
           %{
@@ -106,8 +105,26 @@ defmodule PhoenixKit.Modules.AI.TranslationTest do
     end
 
     test "handle_ai_response/2 returns :ai_error for malformed shape" do
+      # Atom — wholly wrong type
       assert {:error, {:ai_error, {:unexpected_response, _}}} =
                Translation.handle_ai_response(:not_a_response, %{"a" => "b"})
+
+      # Empty choices list — valid OpenAI envelope but no completion
+      assert {:error, {:ai_error, {:unexpected_response, _}}} =
+               Translation.handle_ai_response(%{"choices" => []}, %{"a" => "b"})
+
+      # Choice present but non-binary content (e.g. structured-parts
+      # API or refusal/tool_call response — falls back to the same
+      # unexpected_response shape rather than crashing)
+      assert {:error, {:ai_error, {:unexpected_response, _}}} =
+               Translation.handle_ai_response(
+                 %{"choices" => [%{"message" => %{"content" => nil}}]},
+                 %{"a" => "b"}
+               )
+
+      # Missing `message` entirely
+      assert {:error, {:ai_error, {:unexpected_response, _}}} =
+               Translation.handle_ai_response(%{"choices" => [%{}]}, %{"a" => "b"})
     end
 
     test "valid inputs + missing plugin → :ai_not_installed" do
@@ -147,6 +164,17 @@ defmodule PhoenixKit.Modules.AI.TranslationTest do
                  "es",
                  %{"foo-bar" => "a", "foo_bar" => "b"}
                )
+
+      # Whitespace-only endpoint behaves like empty endpoint — the
+      # validator trims before checking. Pins the contract so a
+      # future "strict equality" refactor (`endpoint == ""`) breaks
+      # loudly instead of silently accepting `"   "`.
+      assert {:error, :no_endpoint} =
+               Translation.translate_fields("   ", "p", "en", "es", %{"a" => "b"})
+
+      # Whitespace-only prompt — same trim-then-check contract.
+      assert {:error, :missing_prompt} =
+               Translation.translate_fields("ep", "   ", "en", "es", %{"a" => "b"})
     end
   end
 
@@ -239,6 +267,27 @@ defmodule PhoenixKit.Modules.AI.TranslationTest do
       refute fields["name"] =~ "TITLE"
       refute fields["name"] =~ "title"
       assert fields["description"] =~ "Standardablauf"
+    end
+
+    test "literal `---WORD---` in field content doesn't prematurely terminate the capture" do
+      # The boundary lookahead requires a newline before the marker
+      # (`\n---WORD---`), so a literal `---WORD---` token that
+      # appears MID-LINE in the translated content (technical docs,
+      # API examples, code snippets describing the marker format)
+      # is kept inside the capture instead of acting as a boundary.
+      # Without the line-anchor, this content would prematurely
+      # terminate at `---API_KEY---` and lose the trailing text.
+      response = """
+      ---TITLE---
+      Translated title text containing literal ---API_KEY--- token and trailing text
+      ---BODY---
+      Body content with another ---WEIRD--- inline token here too.
+      """
+
+      assert {:ok, fields} = Translation.parse_response(response, ["title", "body"])
+      assert fields["title"] =~ "containing literal ---API_KEY--- token"
+      assert fields["title"] =~ "trailing text"
+      assert fields["body"] =~ "another ---WEIRD--- inline token"
     end
 
     test "returns :no_markers when nothing matches at all" do

--- a/test/phoenix_kit/modules/ai/translation_test.exs
+++ b/test/phoenix_kit/modules/ai/translation_test.exs
@@ -124,18 +124,17 @@ defmodule PhoenixKit.Modules.AI.TranslationTest do
       # (e.g. moves `validate_non_empty` before `validate_uuid`),
       # these regressions catch it.
 
-      # Empty endpoint wins over empty fields, dup markers, missing plugin.
+      # Empty endpoint wins over empty fields + missing plugin.
       assert {:error, :no_endpoint} =
                Translation.translate_fields("", "", "en", "es", %{})
 
-      # Endpoint present, empty prompt wins over empty fields + dups.
+      # Endpoint present, empty prompt wins over empty fields.
       assert {:error, :missing_prompt} =
                Translation.translate_fields("ep", "", "en", "es", %{})
 
-      # Endpoint + prompt present, empty fields wins over duplicate
-      # markers — the empty-fields check happens BEFORE
-      # validate_unique_markers, which is the cheaper rejection
-      # (avoids iterating Map.keys over an empty map for nothing).
+      # Endpoint + prompt present, empty fields wins before
+      # validate_unique_markers gets to iterate Map.keys over a
+      # zero-element map for nothing.
       assert {:error, {:parse_error, :no_markers}} =
                Translation.translate_fields("ep", "p", "en", "es", %{})
 


### PR DESCRIPTION
## Summary

Consolidated follow-ups to the translation sweep (PRs #557→#560)
that all merged on 2026-05-21, plus one unrelated TableDefault
fix folded in to keep all phoenix_kit follow-ups in one review
cycle.

### 1. Parser marker leak (originally #562)

`parse_response/2`'s field-capture boundary regex only terminated
at requested markers. A model that emits an unrequested marker
(e.g. `---TITLE---{{title}}` when the caller asked only for
`name` + `description`) silently rolled the unrequested block's
content into the previous requested field.

Real-world trigger observed against deepseek-v3.2: a projects
prompt template referenced `{{title}}` literally (no `title`
variable was bound for a template resource that only has name +
description), so the AI dutifully emitted `---TITLE---{{title}}`
between `---NAME---` and `---DESCRIPTION---`. The parser, asked
for only `name` and `description`, set name to
`"Mitarbeiter-Onboarding---TITLE---{{title}}"` because nothing
in its boundary regex matched `---TITLE---`.

Fix: bound captures at any `---[A-Z0-9_]+---` marker, not just
the explicitly-requested ones. Codex review then flagged that
the new boundary was not line-anchored — a literal `---WORD---`
mid-paragraph (technical content, API docs) would prematurely
terminate. Final form requires `\n---<NAME>---` so only markers
on their own line act as boundaries.

Same commit promotes `handle_ai_response/2` from `defp` to
`@doc false def` so the unit tests can drive it directly, with
the inline OpenAI-shape match replacing the cross-module
`PhoenixKitAI.Completion.extract_content/1` call.

### 2. Validation-order regression test (originally #563)

Backstop for the validation chain in `Translation.translate_fields/6`:
`endpoint → prompt → non-empty → unique-markers → plugin-available`.
Stacks multiple input violations and asserts which one wins,
including whitespace-only endpoint/prompt to pin the
trim-then-check contract.

### 3. Magic-link comment trim (originally #564)

Codex final-review CONCERN on PR #559: long inline comments
explaining the `data-phx-skip` / 183px / form-ownership root
causes belong in the PR description, not in templates. Trimmed
from 19 lines down to 6 short ones naming the root rules.

### 4. TableDefault class attr widening (NEW — originally #566)

`attr :class, :string` on the seven `TableDefault.*` components
rejected the Phoenix-idiomatic `class={[if(...), if(...)]}`
pattern at compile time, but every component already accepts
lists internally — they wrap `@class` inside another list that
Phoenix flattens. Surfaces as a warning in `phoenix_kit_ai`'s
endpoint list table; widening all 7 declarations to `:any`
clears the warning and lets future consumers use the standard
idiom without relitigating per-component.

## Codex review findings (round 2)

Five concerns from a second codex pass, all applied:

- Line-anchored boundary regex (above)
- Stale test comment referencing the removed `extract_content/1`
- Broader malformed-shape coverage (empty `choices`, non-binary
  `content`, missing `message`)
- Whitespace-only validation tests
- (PR #566 fold-in)

## Supersedes

- #562 (parser fix + handle_ai_response test)
- #563 (validation-order regression test)
- #564 (magic_link comment trim)
- #566 (TableDefault class attr widening)

All closed with a back-reference to this PR.

## Test plan

- [x] `mix compile --warnings-as-errors` clean
- [x] `mix format --check-formatted` clean on touched files
- [x] `mix test test/phoenix_kit/modules/ai/translation_test.exs` — 23/23 pass
- [x] `mix credo --strict` clean on touched files
- [ ] Manual: end-to-end SQ retranslation on the dev parent app — should produce clean output with no `---TITLE---{{title}}` tail