### PR TITLE
Widen TableDefault class attr to :any so class={[...]} idiom works

### DIFF
--- a/lib/phoenix_kit_web/components/core/table_default.ex
+++ b/lib/phoenix_kit_web/components/core/table_default.ex
@@ -103,7 +103,7 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
   survive across LV navigation or be part of the URL.
   """
   attr :id, :string, default: nil
-  attr :class, :string, default: ""
+  attr :class, :any, default: ""
   attr :variant, :string, default: "default", values: ["default", "zebra", "pin-rows", "pin-cols"]
   attr :size, :string, default: "md", values: ["xs", "sm", "md", "lg"]
   attr :toggleable, :boolean, default: false
@@ -458,7 +458,7 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
     look, or `class=""` for a fully bare header. The string fully replaces the default;
     concatenate manually if you want to add classes on top.
   """
-  attr :class, :string, default: "bg-base-300"
+  attr :class, :any, default: "bg-base-300"
   slot :inner_block, required: true
 
   def table_default_header(assigns) do
@@ -519,7 +519,7 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
   * `hover` - Enable hover effect: true/false (optional, default: true)
   * `rest` - Additional HTML attributes (optional)
   """
-  attr :class, :string, default: ""
+  attr :class, :any, default: ""
   attr :hover, :boolean, default: true
   attr :rest, :global
 
@@ -551,7 +551,7 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
   * `class` - Additional CSS classes (optional)
   * `rest` - Additional HTML attributes (optional)
   """
-  attr :class, :string, default: ""
+  attr :class, :any, default: ""
   attr :rest, :global
 
   slot :inner_block
@@ -574,7 +574,7 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
   * `rowspan` - Number of rows to span (optional)
   * `rest` - Additional HTML attributes (optional)
   """
-  attr :class, :string, default: ""
+  attr :class, :any, default: ""
   attr :colspan, :integer, default: nil
   attr :rowspan, :integer, default: nil
   attr :rest, :global
@@ -619,7 +619,7 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
   attr :event, :string, default: "toggle_sort"
   attr :target, :any, default: nil
   attr :align, :atom, default: :left, values: [:left, :right, :center]
-  attr :class, :string, default: ""
+  attr :class, :any, default: ""
   attr :rest, :global, include: ~w(colspan rowspan)
 
   slot :inner_block, required: true
@@ -729,7 +729,7 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
   attr :debounce, :integer, default: 300
   attr :name, :string, default: "search"
   attr :target, :any, default: nil
-  attr :class, :string, default: ""
+  attr :class, :any, default: ""
 
   def search_toolbar(assigns) do
     assigns =


### PR DESCRIPTION
## Summary

The seven `attr :class, :string` declarations on the
`PhoenixKitWeb.Components.Core.TableDefault.*` family reject
Phoenix-idiomatic `class={[...]}` at compile time, but every
component already accepts lists internally — they wrap `@class`
inside another list that Phoenix flattens. The `:string` declaration
is a stale guard from before the internal usage settled.

Surfaced when `phoenix_kit_ai`'s endpoint list table uses a
conditional-class list:

```
warning: attribute "class" in component
PhoenixKitWeb.Components.Core.TableDefault.table_default_row/1
must be a :string, got: [if !endpoint.enabled do "opacity-60" end, ...]
    endpoints.html.heex:241
```

Fix applied uniformly to all seven components in the file
(`table_default/1`, `table_default_header/1`, `table_default_row/1`,
`table_default_body/1`, `table_default_cell/1`,
`table_default_header_cell/1`, `table_default_search/1`) so future
consumers don't relitigate the same warning per-component. Defaults
unchanged (still string literals).

## Notes

- No behavior change for existing callers passing strings.
- New behavior: `class={[...]}` and `class={["a", false, "b"]}` now
  compile cleanly, with Phoenix's standard nil/false filtering and
  flattening applied at render time.

## Test plan

- [x] `mix compile --warnings-as-errors` clean
- [x] `mix format --check-formatted` clean
- [x] `mix credo --strict` clean on touched file