### PR TITLE
Modal-to-native-dialog: PkDialog + BulkSelect + list-UI toolkit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,22 @@ A corrupted JSONB `provider`/`name` cannot leak into a new key — no public wri
 - `<.input>` also has `wrapper_class` → goes to the outer `<div phx-feedback-for>`. (Aligned with Phoenix 1.7 generator: `class` → input element, not wrapper.)
 - Prefer FormField binding: `<.input field={@form[:email]} type="email" label="Email" />`. Raw `name=`/`value=` still works for dynamic field names.
 
+## Core List-UI Components
+
+The canonical toolkit for admin list views — DnD reorder, bulk-select, sort, strategy reorder, load-more pagination. All live in `lib/phoenix_kit_web/components/core/`. Reference call sites: `phoenix_kit_projects`' `projects_live.ex` / `tasks_live.ex` / `templates_live.ex`.
+
+**Sortable** — `<.sortable_tbody enabled={…} event="reorder_x" id="…">` + `<.sortable_row item_id={uuid}>`. Replaces the bespoke `<tbody phx-hook="SortableGrid" data-sortable-* …>` boilerplate. `enabled={false}` omits the hook so DnD turns off cleanly when sort_by ≠ position. Pair with `<.drag_handle_cell>` + `<.drag_handle_header_cell>` (in `table_default.ex`) — those render the grip icon and the `.pk-drag-handle` selector the SortableGrid hook reads. Rows inherit a `group` Tailwind marker so the handle can hide-until-row-hover via `group-hover:`.
+
+**BulkSelect** — `<.bulk_select_scope id="…" total_count={…}>` wraps the table and attaches the `BulkSelectScope` JS hook (in `priv/static/assets/phoenix_kit.js`). Selection lives client-side; the hook reads it at action-button-click time and pushes `%{"uuids" => […]}` to the LV. Three children: `<.bulk_select_header_cell>` (tri-state checkbox), `<.bulk_select_cell value={uuid}>` (per-row), and `<.bulk_actions_toolbar on_open_reorder="…" on_bulk_delete={…} reorder_dialog_id={…}>` (the floating toolbar with Reorder / Delete / Clear). Optional `reorder_dialog_id` wires instant client-side dialog open (skip the LV round-trip) when paired with a kept-in-DOM `<.reorder_modal>`. Consumer LVs collapse 0–1 captured uuids to `:all` in `open_reorder_modal` — a single-row "reorder" is a no-op and the bulk-toolbar label reads "Reorder all" in that state.
+
+**ReorderModal** — `<.reorder_modal show on_close on_apply selected_count total_count strategies={[{value, label}…]} noun_singular noun_plural>` renders a strategy-picker dialog. Wraps `<.modal keep_in_dom={true}>` so the toolbar's `data-bulk-opens-dialog` can open it locally. The consumer LV owns the strategy whitelist (use a hardcoded `%{"name_asc" => :name_asc, …}` map for string→atom — never `String.to_existing_atom` on attacker input). Apply button carries `phx-disable-with` automatically.
+
+**Modal — `keep_in_dom` mode** — `<.modal keep_in_dom>` renders the `<dialog>` regardless of `@show`; visibility flips via `data-show` and the `PkDialog` hook calls `showModal()/close()`. Suits modals whose inner block is static (strategy picker, confirmation with fixed copy). Default conditional render is preserved for forms whose `@form` is `nil` until opened. **Pass an explicit `id=` when using `keep_in_dom`** — the auto-derived id (`pk-modal-<on_close>`) collides if two kept-in-DOM modals share the same close-event name.
+
+**SortSelector** — `<.sort_selector sort_by sort_dir options manual_field>` is the field-picker `<.select>` + direction-toggle button used in toolbars. Race-free by design: the select sends only `sort_by`, the arrow sends only `sort_dir`; the LV handler derives the missing half from `socket.assigns`. `manual_field={:position}` hides the direction toggle when the manual-order field is active (direction is meaningless when each row has a user-specified position).
+
+**Pagination — `<.load_more>`** — `<.load_more loaded={length(@items)} total={@total_count} on_load_more="load_more" noun_plural="…">` renders a status line + Load more button. Hides entirely at `total=0`; button hides at `loaded>=total`. Suits embeddable LVs (no URL state) and DnD-aware lists where rows append (don't replace) on each click — selection persists across loads because rows stay in the DOM. Page-numbered `<.pagination>` is the alternative for standalone admin pages with deep-linkable state.
+
 ## Multilang Form Components
 
 `PhoenixKitWeb.Components.MultilangForm` — `<.multilang_tabs>`, `<.multilang_fields_wrapper>`, `<.translatable_field>`, plus helpers `mount_multilang/1`, `handle_switch_language/2`, `merge_translatable_params/4`. Forms `import` it and call `mount_multilang(socket)` in `mount/3`.
@@ -392,11 +408,11 @@ Workspace-tracked items not ready for inline `# TODO` in `lib/`.
 
 ### Component test coverage for `phoenix_kit_web/components/core/`
 
-`test/phoenix_kit_web/components/core/` doesn't exist yet. Components needing `Phoenix.LiveViewTest`-style coverage:
+Partial coverage exists in `test/phoenix_kit_web/components/core/` — written for the modal-to-native-dialog sweep. Remaining gaps:
 
 - `<.draggable_list>` — three-axis coverage: (a) `:draggable=false` → no SortableJS hook, no `cursor-grab`; (b) `:draggable=true, :sortable_handle=nil` → SortableJS hook + full-item `cursor-grab`; (c) `:draggable=true, :sortable_handle=".pk-drag-handle"` → SortableJS hook + `data-sortable-handle` attribute set, **no** `cursor-grab` on the item wrapper (caller's responsibility). All three branches need rendered-HTML asserts.
-- `<.table_default>` — `:on_reorder` / `:reorder_scope` / `:reorder_group` / `:item_id` wire card-view as sortable target. Both branches need to pin `phx-hook="SortableGrid"`, `data-sortable-*`, `data-id`, `class="sortable-item"`, drag-handle footer.
+- `<.table_default>` card-view branch — `:on_reorder` / `:reorder_scope` / `:reorder_group` / `:item_id` wire card-view as sortable target. Need to pin `phx-hook="SortableGrid"`, `data-sortable-*`, `data-id`, `class="sortable-item"`, drag-handle footer.
 - `<.input>`, `<.select>`, `<.textarea>`, `<.checkbox>` — inline error rendering, daisyUI variant classes, FormField vs raw `name=`/`value=` dispatch.
-- `<.flash>`, `<.modal>` if complexity has grown.
+- `<.flash>` if complexity has grown.
 
-Surfaced 2026-05-02 by C12 triage during V108 / DnD core work. Out of scope for that PR; fold into a future component-coverage sweep.
+Surfaced 2026-05-02 by C12 triage during V108 / DnD core work. Partially closed 2026-05-23 (`bulk_select`, `sortable`, `reorder_modal`, `load_more`, `sort_selector`, `modal` keep_in_dom, `table_default` row + drag_handle). Fold the rest into a future component-coverage sweep.

--- a/dev_docs/pull_requests/2026/550-fresco-0.5-etcher-0.3-migration/FOLLOW_UP.md
+++ b/dev_docs/pull_requests/2026/550-fresco-0.5-etcher-0.3-migration/FOLLOW_UP.md
@@ -1,0 +1,29 @@
+# Follow-up — PR #550 (Fresco 0.5 + Etcher 0.3 migration / annotations)
+
+## Fixed (pre-existing — verified, no new work needed)
+
+- ~~**BUG-MEDIUM** — V121 constraint guard ignored table prefix/schema.~~ Fixed in commit `5198eb3d` ("Fix annotation migration + persistence issues from PR #550 review"). `lib/phoenix_kit/migrations/postgres/v121.ex:10-22` now uses unconditional `DROP IF EXISTS` immediately before each `ADD`.
+- ~~**IMPROVEMENT-MEDIUM** — `:uuid` was castable on update.~~ Fixed in the same commit (`5198eb3d`). `lib/phoenix_kit/annotations/annotations.ex:212` strips `:uuid` from attrs before changeset on update via `Map.drop(attrs, [:uuid, "uuid"])`.
+- ~~**IMPROVEMENT-MEDIUM** — `sync_annotations/3` re-UPDATEd unchanged annotations.~~ Fixed in `5198eb3d`. `lib/phoenix_kit_web/components/media_canvas_viewer.ex:166,243` implements an `annotation_unchanged?/2` dirty-check on geometry/style/kind; lines 218-233 gate the reload on `wrote? or to_delete != []`.
+
+## N/A
+
+- **IMPROVEMENT-LOW** — Hard-delete of linked comments bypasses context. Intentional design — the annotation/comment relationship is one-way (annotation owns; comments back-reference via `metadata.annotation_uuid`), documented in `lib/phoenix_kit/annotations/annotation.ex:10-18` moduledoc.
+
+## Fixed (Batch 1 — 2026-05-25)
+
+- ~~**NITPICK** — `creator_uuid` adapter-writable.~~ Added `:creator_uuid` to the `--` exclusion list in `@adapter_writable_fields` at `lib/phoenix_kit/annotations/annotation.ex:62`. Mirrors `:file_uuid`'s exclusion — the adapter resolves the creator from actor opts server-side, so a forged event payload can't claim authorship.
+
+## Files touched
+
+| File | Change |
+|------|--------|
+| `lib/phoenix_kit/annotations/annotation.ex` | Excluded `:creator_uuid` from adapter-writable whitelist |
+
+## Verification
+
+- `mix compile --warnings-as-errors` clean (via `phoenix_kit_parent`)
+
+## Open
+
+None.

--- a/dev_docs/pull_requests/2026/552-site-wide-default-language-no-prefix/FOLLOW_UP.md
+++ b/dev_docs/pull_requests/2026/552-site-wide-default-language-no-prefix/FOLLOW_UP.md
@@ -1,0 +1,19 @@
+# Follow-up — PR #552 (site-wide `default_language_no_prefix` setting)
+
+## No findings
+
+All findings from `CLAUDE_REVIEW.md` were resolved in post-merge follow-up commits before this triage. Re-verified against current code (`modal-to-native-dialog` branch) on 2026-05-25.
+
+## Fixed (pre-existing — verified, no new work needed)
+
+- ~~**BUG-MEDIUM** — Dead `@see` reference in docstring.~~ Fixed in commit `42722ff2` ("Fix docstring + doctest follow-ups from PR #552 review"). `lib/modules/languages/languages.ex:555` now correctly references `migrate_legacy/0`.
+- ~~**IMPROVEMENT-MEDIUM** — `admin_path/2` doctest would fail if evaluated.~~ Fixed in `42722ff2`. `lib/phoenix_kit/utils/routes.ex:180-194` splits deterministic examples (under `## Examples` with `iex>`) from setting-dependent ones (`#=>` markers outside doctests).
+- ~~**BUG-LOW** — `@spec set_default_language_no_prefix/1` referenced undefined `Setting.t()`.~~ Fixed in commit `0b6ec6ff` ("Add `@type t/0` to `PhoenixKit.Settings.Setting`"). `lib/phoenix_kit/settings/setting.ex:99-107` now declares the type.
+
+## N/A
+
+- **NITPICK** — Free-floating comments inside `cond` clauses. Resolved by the dedup in PR #554 — sitemap sources now delegate to `LocalePath.emit_prefix?/2`, which uses module-level policy (no inline comments).
+
+## Open
+
+None.

--- a/dev_docs/pull_requests/2026/554-pr552-followups-dedup-locale-path/FOLLOW_UP.md
+++ b/dev_docs/pull_requests/2026/554-pr552-followups-dedup-locale-path/FOLLOW_UP.md
@@ -1,0 +1,28 @@
+# Follow-up — PR #554 (PR #552 follow-ups + locale-path dedup)
+
+## Fixed (Batch 1 — 2026-05-25)
+
+- ~~**IMPROVEMENT-MEDIUM** — `redirect_invalid_locale/2` called `prefixless_primary?()` twice.~~ `lib/phoenix_kit_web/users/auth.ex:1987-1994` now reads the flag once and destructures the segment/suffix pair. Beyond the minor perf win, the single read eliminates a torn-read risk if a concurrent setting flip lands between the two evaluations.
+- ~~**IMPROVEMENT-MEDIUM** — `LocalePath` moduledoc said "three rules", listed four.~~ `lib/modules/sitemap/locale_path.ex:7` now reads "four rules:" to match the numbered list below.
+- ~~**NITPICK** — `auth_locale_test.exs` mixed setter styles in cleanup.~~ `test/integration/users/auth_locale_test.exs:36-42` `on_exit` now uses `Languages.set_default_language_no_prefix(false)` (mirroring the `setup` block in the `setting ON` describe), so any future cache/invalidation logic the typed setter wires up runs in cleanup too.
+
+## Partially fixed (intentional residue documented)
+
+- **NITPICK** — `prefixless_primary_safe?()` duplicates the `mix_task_context?()` sentinel. The original review acknowledged this is intentional ("settings-cache-status sentinel is the same regardless of caller"). Left as-is — restating ≠ wrong, and consolidation is a future call.
+- **NITPICK** — `LocalePath.emit_prefix?(nil, _)` rationale is in the moduledoc, not inline. The function's `nil` clause at `lib/modules/sitemap/locale_path.ex:40` is documented in moduledoc rule 1 ("No language supplied → no prefix"). Future callers passing `nil` as "use site default" would not find the explanation right at the clause, but the moduledoc carries it. Left as-is to avoid duplicating the rule across two places that could drift.
+
+## Files touched
+
+| File | Change |
+|------|--------|
+| `lib/phoenix_kit_web/users/auth.ex` | Single read + tuple destructure in `redirect_invalid_locale/2` |
+| `lib/modules/sitemap/locale_path.ex` | Moduledoc rule count: "three" → "four" |
+| `test/integration/users/auth_locale_test.exs` | `on_exit` cleanup uses `Languages.set_default_language_no_prefix/1` |
+
+## Verification
+
+- `mix compile --warnings-as-errors` clean (via `phoenix_kit_parent`)
+
+## Open
+
+None.

--- a/dev_docs/pull_requests/2026/557-ai-translation-language-switcher-ai-translate/FOLLOW_UP.md
+++ b/dev_docs/pull_requests/2026/557-ai-translation-language-switcher-ai-translate/FOLLOW_UP.md
@@ -1,0 +1,20 @@
+# Follow-up — PR #557 (AI translation language switcher + ai_translate)
+
+## No findings
+
+All review items either fixed pre-existing via post-merge follow-up commits or rolled into PR #558. Re-verified against current code (`modal-to-native-dialog` branch) on 2026-05-25.
+
+## Fixed (pre-existing — verified, no new work needed)
+
+- ~~**BUG-HIGH** — Dialyzer failed on `PhoenixKitAI.ask_with_prompt/4`.~~ Resolved post-merge by adding `{"lib/modules/ai/translation.ex", :unknown_function}` to `.dialyzer_ignore.exs:85` (the compile-time `Code.ensure_loaded?/1` guard at `translation.ex:72` masks the function from dialyzer's view, hence the ignore).
+- ~~**NITPICK** — Bulk-handler doc example re-enqueued in-flight jobs.~~ `lib/modules/ai/language_switcher.ex:170` now says "enqueue one job per *actionable* (missing minus in_flight) language".
+- ~~**NITPICK** — Case-insensitive marker regex missing `i` flag.~~ Fixed in commit `2d0a3660` — `lib/modules/ai/translation.ex:346` now has `/si` flags.
+
+## N/A
+
+- **IMPROVEMENT-MEDIUM** — `completed` key documented but unused. The misleading key was doc-dropped post-merge; `language_switcher.ex:147` no longer lists it in the shape.
+- **NITPICK** — Empty `fields` map wastes AI request. Scope of PR #558.
+
+## Open
+
+None.

--- a/dev_docs/pull_requests/2026/558-ai-translation-empty-fields-guard/FOLLOW_UP.md
+++ b/dev_docs/pull_requests/2026/558-ai-translation-empty-fields-guard/FOLLOW_UP.md
@@ -1,0 +1,17 @@
+# Follow-up — PR #558 (AI translation empty-fields guard)
+
+## No findings
+
+The core fix from `CLAUDE_REVIEW.md` was the scope of this PR itself and shipped. The one residual NITPICK is documented as acceptable in the review. Re-verified on 2026-05-25.
+
+## Fixed (pre-existing — verified, no new work needed)
+
+- ~~**Core fix** — `translate_fields/6` rejected empty `fields` map up front.~~ `lib/modules/ai/translation.ex:140-143` has the `validate_non_empty/1` guard in the `with` chain.
+
+## Skipped (with rationale)
+
+- **NITPICK** — Error category for empty input uses `:parse_error` rather than a dedicated `:empty_fields`. `translation.ex:141` returns `{:error, {:parse_error, :no_markers}}`. The review documented this as an intentional taxonomy choice — "reusing the sentinel so callers already handling this branch catch it too" — and that reasoning still holds. Splitting would force every caller to handle a second arm with no behavioural difference.
+
+## Open
+
+None.

--- a/dev_docs/pull_requests/2026/559-fix-auth-form-fieldset-overflow/FOLLOW_UP.md
+++ b/dev_docs/pull_requests/2026/559-fix-auth-form-fieldset-overflow/FOLLOW_UP.md
@@ -1,0 +1,27 @@
+# Follow-up — PR #559 (auth form fieldset overflow fix)
+
+## Fixed (pre-existing — verified, no new work needed)
+
+- ~~**Core fix** — `min-w-0` on auth form fieldsets.~~ All 8 forms verified (`confirmation`, `confirmation_instructions`, `forgot_password`, `login`, `magic_link`, `magic_link_registration`, `registration`, `reset_password`) carry `min-w-0` on their fieldset.
+- ~~**Core fix** — `phx-disable-with` removed from magic_link button.~~ `lib/phoenix_kit_web/users/magic_link.html.heex:45-56` now relies on the LV's `@loading` assign + `disabled={@loading || @sent}` + `min-w-0 max-w-full` for overflow protection. `handle_event` sets `loading: true` before the `start_async` (line 68 of `.ex`).
+- ~~**NITPICK** — `magic_link_registration_request` had dead `@loading` branch.~~ Resolved in commits `34c494ad` + `84e7e2fb`; handler converted to `start_async` matching `magic_link.ex`. Both pages now consistent.
+
+## Fixed (Batch 1 — 2026-05-25)
+
+- ~~**NITPICK** — Fieldset class consistency (`w-full`).~~ Removed `w-full` from `registration.html.heex:28` and `magic_link_registration.html.heex:23` so the class shape now matches the other six forms (`class="fieldset min-w-0"`). Visually identical (parent stretches the form anyway), but the unified class string removes a future-grep gotcha.
+
+## Files touched
+
+| File | Change |
+|------|--------|
+| `lib/phoenix_kit_web/users/registration.html.heex` | Dropped `w-full` from fieldset class |
+| `lib/phoenix_kit_web/users/magic_link_registration.html.heex` | Same |
+
+## Verification
+
+- `mix compile --warnings-as-errors` clean (via `phoenix_kit_parent`)
+- Visual: the two registration forms render at the same width as before (parent `align-items: stretch` provides the full width)
+
+## Open
+
+None.

--- a/dev_docs/pull_requests/2026/565-translation-followups-tabledefault-class-attr/FOLLOW_UP.md
+++ b/dev_docs/pull_requests/2026/565-translation-followups-tabledefault-class-attr/FOLLOW_UP.md
@@ -1,0 +1,53 @@
+# PR #565 — Follow-up
+
+PR is merged into `dev` (merge commit `2a12a536`, version bump landed in
+`babaa68d` → 1.7.117 then `a140dc20` → 1.7.118 then `babaa68d` → 1.7.119).
+Companion `CLAUDE_REVIEW.md` in this folder.
+
+## Fixed (post-merge, on `dev`)
+
+- **NITPICK #2 (empty-section asymmetry — trailing-empty marker).**
+  `(.+?)` → `(.*?)` in `extract_section/3` so a present-but-empty
+  *trailing* marker (`...\n---BODY---` at end-of-string) captures `""`
+  — matching how an empty *middle* section already resolves via the
+  marker-shape post-process guard — instead of failing the regex floor
+  and getting reported in `missing_fields`. An entirely absent marker
+  still returns `nil` → `missing_fields`, so the "model forgot a
+  marker" signal is preserved. Greedy `\s*` always eats the newline
+  before an inter-marker boundary, so the empty match only succeeds at
+  `\z` — no risk to mid-document fields with content. (commit `79f6dc5e`)
+- **MEDIUM (extraction divergence).** Added a `KEEP IN SYNC` comment
+  at the inline OpenAI extract pointing to
+  `PhoenixKitAI.Completion.extract_content/1`, so the deliberate
+  second source of truth doesn't silently drift. (commit `79f6dc5e`)
+- **Two regression tests** pinning the asymmetry fix:
+  trailing-empty → `""`, absent-trailing → `missing_fields`. (commit
+  `79f6dc5e`)
+
+## Skipped (with rationale)
+
+- **NITPICK #3 (`show_info` should be gated on `show_header`).** The
+  info tooltip annotates the header title and has no sensible anchor
+  without a visible header. Rendering a floating tooltip with no
+  anchor would be worse UX than no tooltip. Resolution: documentation,
+  not code. Already noted in the docstring's `show_info` description.
+
+## Files touched
+
+| File | Change |
+| --- | --- |
+| `lib/modules/ai/translation.ex` | `(.+?)` → `(.*?)`; added `KEEP IN SYNC` comment |
+| `test/phoenix_kit/modules/ai/translation_test.exs` | +2 regression tests |
+| `dev_docs/pull_requests/2026/565-translation-followups-tabledefault-class-attr/CLAUDE_REVIEW.md` | Updated with applied fixes + skip rationale |
+
+## Verification
+
+- `mix compile --warnings-as-errors` — clean
+- `mix format --check-formatted` — clean
+- `mix credo --strict` — no issues
+- `mix dialyzer` — 0 errors, 163/163 ignores match
+- `mix test test/phoenix_kit/modules/ai/translation_test.exs` — 26/26 pass
+
+## Open
+
+None.

--- a/lib/modules/sitemap/locale_path.ex
+++ b/lib/modules/sitemap/locale_path.ex
@@ -4,7 +4,7 @@ defmodule PhoenixKit.Modules.Sitemap.LocalePath do
 
   Every sitemap source (`publishing`, `static`, `posts`, ...) decides
   whether a URL entry should carry a language prefix using the same
-  three rules:
+  four rules:
 
     1. No language supplied → no prefix.
     2. Single-language mode (Languages module disabled or only one

--- a/lib/phoenix_kit/annotations/annotation.ex
+++ b/lib/phoenix_kit/annotations/annotation.ex
@@ -58,8 +58,11 @@ defmodule PhoenixKit.Annotations.Annotation do
   # Fields the storage adapter is allowed to accept from event payloads.
   # `file_uuid` is set server-side from `target_uuid`, not by the client,
   # so it's excluded here — the adapter's `create/1` puts it on the
-  # changeset after the whitelist filter.
-  @adapter_writable_fields @cast_fields -- [:file_uuid]
+  # changeset after the whitelist filter. `creator_uuid` is set server-
+  # side from the actor (`adapter`'s `create/1` resolves it from the
+  # actor opts), so it's excluded for the same reason — a forged event
+  # payload shouldn't be able to claim authorship.
+  @adapter_writable_fields @cast_fields -- [:file_uuid, :creator_uuid]
 
   @doc false
   def changeset(annotation, attrs) do

--- a/lib/phoenix_kit_web.ex
+++ b/lib/phoenix_kit_web.ex
@@ -126,6 +126,8 @@ defmodule PhoenixKitWeb do
       import PhoenixKitWeb.Components.Core.TableDefault
       import PhoenixKitWeb.Components.Core.TableRowMenu
       import PhoenixKitWeb.Components.Core.BulkSelect
+      import PhoenixKitWeb.Components.Core.Sortable
+      import PhoenixKitWeb.Components.Core.ReorderModal
       import PhoenixKitWeb.Components.Core.OAuthUtils
       import PhoenixKitWeb.Components.Core.OAuthProvider
       import PhoenixKitWeb.Components.Core.OAuthCheckbox

--- a/lib/phoenix_kit_web.ex
+++ b/lib/phoenix_kit_web.ex
@@ -125,6 +125,7 @@ defmodule PhoenixKitWeb do
       import PhoenixKitWeb.Components.Core.NumberFormatter
       import PhoenixKitWeb.Components.Core.TableDefault
       import PhoenixKitWeb.Components.Core.TableRowMenu
+      import PhoenixKitWeb.Components.Core.BulkSelect
       import PhoenixKitWeb.Components.Core.OAuthUtils
       import PhoenixKitWeb.Components.Core.OAuthProvider
       import PhoenixKitWeb.Components.Core.OAuthCheckbox

--- a/lib/phoenix_kit_web/components/core/bulk_select.ex
+++ b/lib/phoenix_kit_web/components/core/bulk_select.ex
@@ -1,74 +1,73 @@
 defmodule PhoenixKitWeb.Components.Core.BulkSelect do
   @moduledoc """
-  Bulk-select toolkit that composes with `<.table_default>`. Three
-  function components, all opt-in — the consumer decides whether to
-  render them and what events they emit.
+  Bulk-select toolkit for admin tables, **client-side**. The selection
+  lives in the browser; the server only learns about it at action time
+  (when the user clicks an action button) via the `BulkSelectScope`
+  JS hook. This makes per-checkbox toggles feel instant — no LV
+  round-trip on every click.
 
-    * `<.bulk_select_header_cell>` — drops into the table header in
-      place of a `<.table_default_header_cell>`. Renders a tri-state
-      checkbox via the `PkCheckboxIndeterminate` JS hook. State:
+  Three function components compose with `<.table_default>`, plus a
+  wrapper element with the hook attached.
 
-        0 selected      → unchecked
-        partial         → indeterminate (—)
-        all selected    → checked
+    * `<.bulk_select_scope>` — opens an inline-styled wrapper with
+      `phx-hook="BulkSelectScope"`. Everything inside (header cell,
+      row cells, toolbar buttons) participates in the same selection
+      set. Pass `total_count` so the hook knows when "all" is checked.
 
-      Clicking always emits `on_toggle`; the LV handler picks "all"
-      or "none" based on current state.
+    * `<.bulk_select_header_cell>` — the header checkbox. Tri-state
+      (unchecked / indeterminate / checked) is managed by the hook.
 
-    * `<.bulk_select_cell>` — drops into each row in place of a
-      `<.table_default_cell>`. Renders a per-row checkbox bound to a
-      uuid value.
+    * `<.bulk_select_cell>` — per-row checkbox bound to a UUID value.
 
-    * `<.bulk_actions_toolbar>` — floating toolbar rendered ABOVE the
-      table (sibling to `<.table_default>`, not nested). Shows the
-      selection count + actions (Reorder, Delete, Clear). Reorder and
-      Delete are gated by `allow_reorder_all` / `allow_delete` so
-      consumers can hide them when they don't apply.
-
-  Per-row checkboxes are consumer-wired (the row content varies per
-  module). The header cell + toolbar are reusable shells.
+    * `<.bulk_actions_toolbar>` — the toolbar above the table. Buttons
+      with `data-bulk-action` dispatch LV events with the selected
+      UUIDs in the `{uuids: [...]}` payload.
 
   ## Example
 
-      <.table_default id="projects-list" size="sm">
-        <.table_default_header>
-          <.table_default_row>
-            <.bulk_select_header_cell
-              :if={@bulk_enabled?}
-              id="projects-select-all"
-              selected_count={MapSet.size(@selected_uuids)}
-              total_count={length(@projects)}
-              on_toggle="toggle_select_all"
-              aria_label={gettext("Select all projects")}
-            />
-            <.table_default_header_cell>Name</.table_default_header_cell>
-            ...
-          </.table_default_row>
-        </.table_default_header>
-        <tbody>
-          <.table_default_row :for={p <- @projects}>
-            <.bulk_select_cell
-              :if={@bulk_enabled?}
-              value={p.uuid}
-              checked={MapSet.member?(@selected_uuids, p.uuid)}
-              on_toggle="toggle_select"
-            />
-            <.table_default_cell>{p.name}</.table_default_cell>
-            ...
-          </.table_default_row>
-        </tbody>
-      </.table_default>
+      <.bulk_select_scope id="projects-bulk" total_count={length(@projects)}>
+        <.bulk_actions_toolbar
+          on_open_reorder="open_reorder_modal"
+          on_clear_selection="clear"
+          noun_singular={gettext("project")}
+          noun_plural={gettext("projects")}
+        />
 
-      <.bulk_actions_toolbar
-        :if={@bulk_enabled? and @projects != []}
-        selected_count={MapSet.size(@selected_uuids)}
-        total_count={length(@projects)}
-        on_open_reorder="open_reorder_modal"
-        on_bulk_delete="bulk_delete"
-        on_clear_selection="clear_selection"
-        noun_plural={gettext("projects")}
-        allow_delete={false}
-      />
+        <.table_default id="projects-list" size="sm">
+          <.table_default_header>
+            <.table_default_row>
+              <.bulk_select_header_cell
+                id="projects-select-all"
+                aria_label={gettext("Select all projects")}
+              />
+              <.table_default_header_cell>Name</.table_default_header_cell>
+              ...
+            </.table_default_row>
+          </.table_default_header>
+          <tbody>
+            <.table_default_row :for={p <- @projects}>
+              <.bulk_select_cell value={p.uuid} />
+              <.table_default_cell>{p.name}</.table_default_cell>
+              ...
+            </.table_default_row>
+          </tbody>
+        </.table_default>
+      </.bulk_select_scope>
+
+  The consumer LV handles `on_open_reorder` (etc.) with a payload of
+  `%{"uuids" => uuids}`:
+
+      def handle_event("open_reorder_modal", %{"uuids" => uuids}, socket) do
+        {:noreply, assign(socket, show_reorder_modal: true, captured_uuids: uuids)}
+      end
+
+  ## Why client-side
+
+  Server-side selection (each click is a `phx-click` round-trip)
+  forces a re-render with every toggle, which feels laggy at any
+  meaningful network latency. Bulk-select is a high-frequency UI
+  interaction where the server only needs to know the selection at
+  the moment it acts on it — making the client the natural owner.
   """
 
   use Phoenix.Component
@@ -77,13 +76,33 @@ defmodule PhoenixKitWeb.Components.Core.BulkSelect do
   import PhoenixKitWeb.Components.Core.Icon, only: [icon: 1]
 
   @doc """
-  Header checkbox cell — drop-in replacement for `<.table_default_header_cell>`
-  in the bulk-select column.
+  Opens a bulk-select scope. Everything inside this wrapper
+  participates in the same selection set.
   """
   attr :id, :string, required: true
-  attr :selected_count, :integer, required: true
   attr :total_count, :integer, required: true
-  attr :on_toggle, :string, required: true
+  attr :class, :string, default: ""
+  slot :inner_block, required: true
+
+  def bulk_select_scope(assigns) do
+    ~H"""
+    <div
+      id={@id}
+      class={@class}
+      phx-hook="BulkSelectScope"
+      data-bulk-total={@total_count}
+    >
+      {render_slot(@inner_block)}
+    </div>
+    """
+  end
+
+  @doc """
+  Header checkbox cell — drop-in replacement for `<.table_default_header_cell>`
+  in the bulk-select column. The `BulkSelectScope` hook drives its
+  checked / indeterminate state based on the current selection.
+  """
+  attr :id, :string, required: true
   attr :aria_label, :string, default: "Toggle select all"
   attr :class, :string, default: "w-8"
 
@@ -94,10 +113,7 @@ defmodule PhoenixKitWeb.Components.Core.BulkSelect do
         type="checkbox"
         id={@id}
         class="checkbox checkbox-sm"
-        checked={@selected_count > 0 and @selected_count == @total_count}
-        data-indeterminate={to_string(@selected_count > 0 and @selected_count < @total_count)}
-        phx-hook="PkCheckboxIndeterminate"
-        phx-click={@on_toggle}
+        data-bulk-role="select-all"
         aria-label={@aria_label}
       />
     </th>
@@ -105,13 +121,11 @@ defmodule PhoenixKitWeb.Components.Core.BulkSelect do
   end
 
   @doc """
-  Per-row checkbox cell — drop-in replacement for `<.table_default_cell>`
-  in the bulk-select column. The `value` is forwarded as `phx-value-uuid`
-  so the LV handler can identify which row was toggled.
+  Per-row checkbox cell. The `value` is captured into the selection
+  set when checked; it's the identifier the server receives in
+  `{uuids: [...]}` when an action fires.
   """
   attr :value, :string, required: true
-  attr :checked, :boolean, required: true
-  attr :on_toggle, :string, required: true
   attr :class, :string, default: "w-8"
 
   def bulk_select_cell(assigns) do
@@ -120,91 +134,85 @@ defmodule PhoenixKitWeb.Components.Core.BulkSelect do
       <input
         type="checkbox"
         class="checkbox checkbox-sm"
-        checked={@checked}
-        phx-click={@on_toggle}
-        phx-value-uuid={@value}
+        data-bulk-role="row"
+        data-uuid={@value}
       />
     </td>
     """
   end
 
   @doc """
-  Floating toolbar above a bulk-selectable table. Shows selection count +
-  actions. Renders when bulk mode is engaged on the consumer side (this
-  component doesn't gate visibility — wrap with `:if={@bulk_enabled?}` or
-  similar).
+  Floating toolbar above the table. Built-in actions: Reorder, Delete,
+  Clear. Each button is opt-in via flags / event-name attrs. Toolbar
+  always renders; the count text + button labels + visibility update
+  live as the user toggles checkboxes.
 
-  Built-in actions: Reorder, Delete, Clear. Each is opt-in via flags so
-  consumers can hide the buttons they don't need. The actions emit the
-  events the consumer wires up — this component owns layout only.
-
-  When `selected_count == 0`, only Reorder-all is shown (Delete + Clear
-  hide). When > 0, Reorder flips to "Reorder selected" and Delete + Clear
-  become visible.
+  Reorder is mandatory (`on_open_reorder` is required). Delete and
+  Clear are optional.
   """
-  attr :selected_count, :integer, required: true
-  attr :total_count, :integer, required: true
-
-  attr :on_open_reorder, :string, required: true
-  attr :on_clear_selection, :string, required: true
+  attr :on_open_reorder, :string,
+    required: true,
+    doc: "Event pushed when the Reorder button is clicked. Receives `%{\"uuids\" => uuids}`."
 
   attr :on_bulk_delete, :string,
     default: nil,
-    doc:
-      "Only required when allow_delete is true. Left nil otherwise so callers don't have to wire a dead event."
+    doc: "Event pushed when Delete is clicked. Required if `allow_delete` is true."
 
+  attr :noun_singular, :string, default: "item"
   attr :noun_plural, :string, default: "items"
-  attr :allow_reorder_all, :boolean, default: true
   attr :allow_delete, :boolean, default: true
 
   def bulk_actions_toolbar(assigns) do
+    # `%{count}` is substituted by the BulkSelectScope JS hook at run
+    # time, not at render time. `gettext_noop` marks the strings for
+    # POT extraction without trying to bind `count` here (which would
+    # raise a "missing Gettext bindings" warning).
+    assigns =
+      assigns
+      |> assign(:reorder_empty_label, gettext("Reorder all"))
+      |> assign(:reorder_selected_label, gettext_noop("Reorder %{count} selected"))
+      |> assign(:no_selection_label, gettext("No selection"))
+      |> assign(:selected_text_template, gettext_noop("%{count} selected"))
+      |> assign(:delete_label, gettext("Delete"))
+      |> assign(:clear_label, gettext("Clear"))
+
     ~H"""
     <div class="flex items-center gap-3 bg-base-200 rounded-lg px-3 py-2 text-sm">
       <span class="text-base-content/70">
-        <%= if @selected_count > 0 do %>
-          {gettext("%{count} selected", count: @selected_count)}
-        <% else %>
-          {gettext("No selection")}
-        <% end %>
+        <span data-bulk-show="no-selection">{@no_selection_label}</span>
+        <span data-bulk-show="has-selection" data-bulk-text-template={@selected_text_template}>
+          0
+        </span>
       </span>
 
       <div class="flex items-center gap-2 ml-auto">
         <button
-          :if={@allow_reorder_all or @selected_count > 0}
           type="button"
           class="btn btn-sm btn-ghost"
-          phx-click={@on_open_reorder}
-          disabled={@total_count == 0}
+          data-bulk-action={@on_open_reorder}
+          data-bulk-label-empty={@reorder_empty_label}
+          data-bulk-label-selected={@reorder_selected_label}
         >
-          <.icon name="hero-arrows-up-down" class="w-4 h-4" />
-          {if @selected_count > 0,
-            do: gettext("Reorder selected"),
-            else: gettext("Reorder all")}
+          <.icon name="hero-arrows-up-down" class="w-4 h-4" /> {@reorder_empty_label}
         </button>
 
         <button
-          :if={@allow_delete and @selected_count > 0}
+          :if={@allow_delete and @on_bulk_delete}
           type="button"
           class="btn btn-sm btn-ghost text-error"
-          phx-click={@on_bulk_delete}
-          data-confirm={
-            gettext("Delete %{count} selected %{noun}? This cannot be undone.",
-              count: @selected_count,
-              noun: @noun_plural
-            )
-          }
+          data-bulk-action={@on_bulk_delete}
+          data-bulk-show="has-selection"
         >
-          <.icon name="hero-trash" class="w-4 h-4" />
-          {gettext("Delete")}
+          <.icon name="hero-trash" class="w-4 h-4" /> {@delete_label}
         </button>
 
         <button
-          :if={@selected_count > 0}
           type="button"
           class="btn btn-sm btn-ghost"
-          phx-click={@on_clear_selection}
+          data-bulk-clear="true"
+          data-bulk-show="has-selection"
         >
-          {gettext("Clear")}
+          {@clear_label}
         </button>
       </div>
     </div>

--- a/lib/phoenix_kit_web/components/core/bulk_select.ex
+++ b/lib/phoenix_kit_web/components/core/bulk_select.ex
@@ -162,38 +162,35 @@ defmodule PhoenixKitWeb.Components.Core.BulkSelect do
   attr :noun_plural, :string, default: "items"
   attr :allow_delete, :boolean, default: true
 
+  attr :reorder_gate, :atom,
+    default: :always,
+    values: [:always, :multi],
+    doc:
+      "When `:always`, the Reorder button is visible at any selection count (label flips between 'Reorder all' at 0 and 'Reorder N selected' at N>0). When `:multi`, the button is hidden unless count > 1 — useful when the surrounding context doesn't have a meaningful 'reorder all' interpretation (e.g. the list is currently sorted by name, not the manual position field)."
+
+  slot :leading,
+    doc:
+      "Content rendered on the left of the toolbar before the action buttons. Common use: tuck a sort selector in here so the toolbar reads as one widget."
+
   def bulk_actions_toolbar(assigns) do
-    # `%{count}` is substituted by the BulkSelectScope JS hook at run
-    # time, not at render time. `gettext_noop` marks the strings for
-    # POT extraction without trying to bind `count` here (which would
-    # raise a "missing Gettext bindings" warning).
     assigns =
       assigns
       |> assign(:reorder_empty_label, gettext("Reorder all"))
       |> assign(:reorder_selected_label, gettext_noop("Reorder %{count} selected"))
-      |> assign(:selected_text_template, gettext_noop("%{count} selected"))
       |> assign(:delete_label, gettext("Delete"))
       |> assign(:clear_label, gettext("Clear"))
 
     ~H"""
-    <div class="flex items-center gap-3 bg-base-200 rounded-lg px-3 py-2 text-sm">
-      <%!-- Count text shows only when a selection exists. Empty
-           selection state has no left-side text — the action buttons
-           pin to the right via ml-auto on the action group. --%>
-      <span
-        data-bulk-show="has-selection"
-        data-bulk-text-template={@selected_text_template}
-        class="text-base-content/70"
-      >
-        0
-      </span>
+    <div class="flex flex-wrap items-center gap-3 bg-base-200 rounded-lg px-3 py-2 text-sm">
+      {render_slot(@leading)}
 
       <div class="flex items-center gap-2 ml-auto">
         <button
           type="button"
           class="btn btn-sm btn-ghost"
           data-bulk-action={@on_open_reorder}
-          data-bulk-label-empty={@reorder_empty_label}
+          data-bulk-show={if @reorder_gate == :multi, do: "has-multiple"}
+          data-bulk-label-empty={if @reorder_gate == :always, do: @reorder_empty_label}
           data-bulk-label-selected={@reorder_selected_label}
         >
           <.icon name="hero-arrows-up-down" class="w-4 h-4" /> {@reorder_empty_label}

--- a/lib/phoenix_kit_web/components/core/bulk_select.ex
+++ b/lib/phoenix_kit_web/components/core/bulk_select.ex
@@ -166,7 +166,7 @@ defmodule PhoenixKitWeb.Components.Core.BulkSelect do
     default: :always,
     values: [:always, :multi],
     doc:
-      "When `:always`, the Reorder button is visible at count 0 (label: 'Reorder all') or > 1 ('Reorder N selected'); hidden at count = 1 because a single-row reorder is a no-op. When `:multi`, hidden unless count > 1 — useful when the surrounding context has no meaningful 'reorder all' interpretation (e.g. the list is currently sorted by name, not the manual position field)."
+      "When `:always`, the Reorder button is always visible — label is 'Reorder all' when 0–1 rows are selected, 'Reorder N selected' when 2+. (A one-row reorder is a no-op, so we keep the 'Reorder all' label there; the consumer LV normalises 1-uuid scopes to :all when applying.) When `:multi`, hidden unless count > 1 — useful when the surrounding context has no meaningful 'reorder all' interpretation (e.g. the list is currently sorted by name, not the manual position field)."
 
   slot :leading,
     doc:
@@ -189,12 +189,7 @@ defmodule PhoenixKitWeb.Components.Core.BulkSelect do
           type="button"
           class="btn btn-sm btn-ghost"
           data-bulk-action={@on_open_reorder}
-          data-bulk-show={
-            case @reorder_gate do
-              :multi -> "has-multiple"
-              :always -> "not-single"
-            end
-          }
+          data-bulk-show={if @reorder_gate == :multi, do: "has-multiple"}
           data-bulk-label-empty={if @reorder_gate == :always, do: @reorder_empty_label}
           data-bulk-label-selected={@reorder_selected_label}
         >

--- a/lib/phoenix_kit_web/components/core/bulk_select.ex
+++ b/lib/phoenix_kit_web/components/core/bulk_select.ex
@@ -171,18 +171,21 @@ defmodule PhoenixKitWeb.Components.Core.BulkSelect do
       assigns
       |> assign(:reorder_empty_label, gettext("Reorder all"))
       |> assign(:reorder_selected_label, gettext_noop("Reorder %{count} selected"))
-      |> assign(:no_selection_label, gettext("No selection"))
       |> assign(:selected_text_template, gettext_noop("%{count} selected"))
       |> assign(:delete_label, gettext("Delete"))
       |> assign(:clear_label, gettext("Clear"))
 
     ~H"""
     <div class="flex items-center gap-3 bg-base-200 rounded-lg px-3 py-2 text-sm">
-      <span class="text-base-content/70">
-        <span data-bulk-show="no-selection">{@no_selection_label}</span>
-        <span data-bulk-show="has-selection" data-bulk-text-template={@selected_text_template}>
-          0
-        </span>
+      <%!-- Count text shows only when a selection exists. Empty
+           selection state has no left-side text — the action buttons
+           pin to the right via ml-auto on the action group. --%>
+      <span
+        data-bulk-show="has-selection"
+        data-bulk-text-template={@selected_text_template}
+        class="text-base-content/70"
+      >
+        0
       </span>
 
       <div class="flex items-center gap-2 ml-auto">

--- a/lib/phoenix_kit_web/components/core/bulk_select.ex
+++ b/lib/phoenix_kit_web/components/core/bulk_select.ex
@@ -185,6 +185,12 @@ defmodule PhoenixKitWeb.Components.Core.BulkSelect do
       {render_slot(@leading)}
 
       <div class="flex items-center gap-2 ml-auto">
+        <%!-- Elements that hide-on-zero-selection carry an inline
+             `display: none` from the server so they don't flash
+             visible during the gap between first paint and the
+             BulkSelectScope hook's first _sync(). The hook
+             overrides this inline style when count crosses the
+             threshold. --%>
         <button
           type="button"
           class="btn btn-sm btn-ghost"
@@ -192,6 +198,7 @@ defmodule PhoenixKitWeb.Components.Core.BulkSelect do
           data-bulk-show={if @reorder_gate == :multi, do: "has-multiple"}
           data-bulk-label-empty={if @reorder_gate == :always, do: @reorder_empty_label}
           data-bulk-label-selected={@reorder_selected_label}
+          style={if @reorder_gate == :multi, do: "display: none;"}
         >
           <.icon name="hero-arrows-up-down" class="w-4 h-4" /> {@reorder_empty_label}
         </button>
@@ -202,6 +209,7 @@ defmodule PhoenixKitWeb.Components.Core.BulkSelect do
           class="btn btn-sm btn-ghost text-error"
           data-bulk-action={@on_bulk_delete}
           data-bulk-show="has-selection"
+          style="display: none;"
         >
           <.icon name="hero-trash" class="w-4 h-4" /> {@delete_label}
         </button>
@@ -211,6 +219,7 @@ defmodule PhoenixKitWeb.Components.Core.BulkSelect do
           class="btn btn-sm btn-ghost"
           data-bulk-clear="true"
           data-bulk-show="has-selection"
+          style="display: none;"
         >
           {@clear_label}
         </button>

--- a/lib/phoenix_kit_web/components/core/bulk_select.ex
+++ b/lib/phoenix_kit_web/components/core/bulk_select.ex
@@ -166,7 +166,7 @@ defmodule PhoenixKitWeb.Components.Core.BulkSelect do
     default: :always,
     values: [:always, :multi],
     doc:
-      "When `:always`, the Reorder button is visible at any selection count (label flips between 'Reorder all' at 0 and 'Reorder N selected' at N>0). When `:multi`, the button is hidden unless count > 1 — useful when the surrounding context doesn't have a meaningful 'reorder all' interpretation (e.g. the list is currently sorted by name, not the manual position field)."
+      "When `:always`, the Reorder button is visible at count 0 (label: 'Reorder all') or > 1 ('Reorder N selected'); hidden at count = 1 because a single-row reorder is a no-op. When `:multi`, hidden unless count > 1 — useful when the surrounding context has no meaningful 'reorder all' interpretation (e.g. the list is currently sorted by name, not the manual position field)."
 
   slot :leading,
     doc:
@@ -189,7 +189,12 @@ defmodule PhoenixKitWeb.Components.Core.BulkSelect do
           type="button"
           class="btn btn-sm btn-ghost"
           data-bulk-action={@on_open_reorder}
-          data-bulk-show={if @reorder_gate == :multi, do: "has-multiple"}
+          data-bulk-show={
+            case @reorder_gate do
+              :multi -> "has-multiple"
+              :always -> "not-single"
+            end
+          }
           data-bulk-label-empty={if @reorder_gate == :always, do: @reorder_empty_label}
           data-bulk-label-selected={@reorder_selected_label}
         >

--- a/lib/phoenix_kit_web/components/core/bulk_select.ex
+++ b/lib/phoenix_kit_web/components/core/bulk_select.ex
@@ -168,6 +168,11 @@ defmodule PhoenixKitWeb.Components.Core.BulkSelect do
     doc:
       "When `:always`, the Reorder button is always visible — label is 'Reorder all' when 0–1 rows are selected, 'Reorder N selected' when 2+. (A one-row reorder is a no-op, so we keep the 'Reorder all' label there; the consumer LV normalises 1-uuid scopes to :all when applying.) When `:multi`, hidden unless count > 1 — useful when the surrounding context has no meaningful 'reorder all' interpretation (e.g. the list is currently sorted by name, not the manual position field)."
 
+  attr :reorder_dialog_id, :string,
+    default: nil,
+    doc:
+      "Optional id of a kept-in-DOM reorder modal (e.g. `\"reorder-modal\"`). When set, the Reorder button opens that dialog locally via the BulkSelectScope hook BEFORE pushing `on_open_reorder`, so the modal appears instantly without waiting for the LV round-trip. Pair with `<.reorder_modal>` (which sets `keep_in_dom={true}` on its inner `<.modal>`). Omit to fall back to the round-trip-open flow used by conditionally-rendered modals."
+
   slot :leading,
     doc:
       "Content rendered on the left of the toolbar before the action buttons. Common use: tuck a sort selector in here so the toolbar reads as one widget."
@@ -195,6 +200,7 @@ defmodule PhoenixKitWeb.Components.Core.BulkSelect do
           type="button"
           class="btn btn-sm btn-ghost"
           data-bulk-action={@on_open_reorder}
+          data-bulk-opens-dialog={@reorder_dialog_id}
           data-bulk-show={if @reorder_gate == :multi, do: "has-multiple"}
           data-bulk-label-empty={if @reorder_gate == :always, do: @reorder_empty_label}
           data-bulk-label-selected={@reorder_selected_label}

--- a/lib/phoenix_kit_web/components/core/bulk_select.ex
+++ b/lib/phoenix_kit_web/components/core/bulk_select.ex
@@ -146,8 +146,12 @@ defmodule PhoenixKitWeb.Components.Core.BulkSelect do
   attr :total_count, :integer, required: true
 
   attr :on_open_reorder, :string, required: true
-  attr :on_bulk_delete, :string, required: true
   attr :on_clear_selection, :string, required: true
+
+  attr :on_bulk_delete, :string,
+    default: nil,
+    doc:
+      "Only required when allow_delete is true. Left nil otherwise so callers don't have to wire a dead event."
 
   attr :noun_plural, :string, default: "items"
   attr :allow_reorder_all, :boolean, default: true

--- a/lib/phoenix_kit_web/components/core/bulk_select.ex
+++ b/lib/phoenix_kit_web/components/core/bulk_select.ex
@@ -1,0 +1,209 @@
+defmodule PhoenixKitWeb.Components.Core.BulkSelect do
+  @moduledoc """
+  Bulk-select toolkit that composes with `<.table_default>`. Three
+  function components, all opt-in — the consumer decides whether to
+  render them and what events they emit.
+
+    * `<.bulk_select_header_cell>` — drops into the table header in
+      place of a `<.table_default_header_cell>`. Renders a tri-state
+      checkbox via the `PkCheckboxIndeterminate` JS hook. State:
+
+        0 selected      → unchecked
+        partial         → indeterminate (—)
+        all selected    → checked
+
+      Clicking always emits `on_toggle`; the LV handler picks "all"
+      or "none" based on current state.
+
+    * `<.bulk_select_cell>` — drops into each row in place of a
+      `<.table_default_cell>`. Renders a per-row checkbox bound to a
+      uuid value.
+
+    * `<.bulk_actions_toolbar>` — floating toolbar rendered ABOVE the
+      table (sibling to `<.table_default>`, not nested). Shows the
+      selection count + actions (Reorder, Delete, Clear). Reorder and
+      Delete are gated by `allow_reorder_all` / `allow_delete` so
+      consumers can hide them when they don't apply.
+
+  Per-row checkboxes are consumer-wired (the row content varies per
+  module). The header cell + toolbar are reusable shells.
+
+  ## Example
+
+      <.table_default id="projects-list" size="sm">
+        <.table_default_header>
+          <.table_default_row>
+            <.bulk_select_header_cell
+              :if={@bulk_enabled?}
+              id="projects-select-all"
+              selected_count={MapSet.size(@selected_uuids)}
+              total_count={length(@projects)}
+              on_toggle="toggle_select_all"
+              aria_label={gettext("Select all projects")}
+            />
+            <.table_default_header_cell>Name</.table_default_header_cell>
+            ...
+          </.table_default_row>
+        </.table_default_header>
+        <tbody>
+          <.table_default_row :for={p <- @projects}>
+            <.bulk_select_cell
+              :if={@bulk_enabled?}
+              value={p.uuid}
+              checked={MapSet.member?(@selected_uuids, p.uuid)}
+              on_toggle="toggle_select"
+            />
+            <.table_default_cell>{p.name}</.table_default_cell>
+            ...
+          </.table_default_row>
+        </tbody>
+      </.table_default>
+
+      <.bulk_actions_toolbar
+        :if={@bulk_enabled? and @projects != []}
+        selected_count={MapSet.size(@selected_uuids)}
+        total_count={length(@projects)}
+        on_open_reorder="open_reorder_modal"
+        on_bulk_delete="bulk_delete"
+        on_clear_selection="clear_selection"
+        noun_plural={gettext("projects")}
+        allow_delete={false}
+      />
+  """
+
+  use Phoenix.Component
+  use Gettext, backend: PhoenixKitWeb.Gettext
+
+  import PhoenixKitWeb.Components.Core.Icon, only: [icon: 1]
+
+  @doc """
+  Header checkbox cell — drop-in replacement for `<.table_default_header_cell>`
+  in the bulk-select column.
+  """
+  attr :id, :string, required: true
+  attr :selected_count, :integer, required: true
+  attr :total_count, :integer, required: true
+  attr :on_toggle, :string, required: true
+  attr :aria_label, :string, default: "Toggle select all"
+  attr :class, :string, default: "w-8"
+
+  def bulk_select_header_cell(assigns) do
+    ~H"""
+    <th class={@class}>
+      <input
+        type="checkbox"
+        id={@id}
+        class="checkbox checkbox-sm"
+        checked={@selected_count > 0 and @selected_count == @total_count}
+        data-indeterminate={to_string(@selected_count > 0 and @selected_count < @total_count)}
+        phx-hook="PkCheckboxIndeterminate"
+        phx-click={@on_toggle}
+        aria-label={@aria_label}
+      />
+    </th>
+    """
+  end
+
+  @doc """
+  Per-row checkbox cell — drop-in replacement for `<.table_default_cell>`
+  in the bulk-select column. The `value` is forwarded as `phx-value-uuid`
+  so the LV handler can identify which row was toggled.
+  """
+  attr :value, :string, required: true
+  attr :checked, :boolean, required: true
+  attr :on_toggle, :string, required: true
+  attr :class, :string, default: "w-8"
+
+  def bulk_select_cell(assigns) do
+    ~H"""
+    <td class={@class}>
+      <input
+        type="checkbox"
+        class="checkbox checkbox-sm"
+        checked={@checked}
+        phx-click={@on_toggle}
+        phx-value-uuid={@value}
+      />
+    </td>
+    """
+  end
+
+  @doc """
+  Floating toolbar above a bulk-selectable table. Shows selection count +
+  actions. Renders when bulk mode is engaged on the consumer side (this
+  component doesn't gate visibility — wrap with `:if={@bulk_enabled?}` or
+  similar).
+
+  Built-in actions: Reorder, Delete, Clear. Each is opt-in via flags so
+  consumers can hide the buttons they don't need. The actions emit the
+  events the consumer wires up — this component owns layout only.
+
+  When `selected_count == 0`, only Reorder-all is shown (Delete + Clear
+  hide). When > 0, Reorder flips to "Reorder selected" and Delete + Clear
+  become visible.
+  """
+  attr :selected_count, :integer, required: true
+  attr :total_count, :integer, required: true
+
+  attr :on_open_reorder, :string, required: true
+  attr :on_bulk_delete, :string, required: true
+  attr :on_clear_selection, :string, required: true
+
+  attr :noun_plural, :string, default: "items"
+  attr :allow_reorder_all, :boolean, default: true
+  attr :allow_delete, :boolean, default: true
+
+  def bulk_actions_toolbar(assigns) do
+    ~H"""
+    <div class="flex items-center gap-3 bg-base-200 rounded-lg px-3 py-2 text-sm">
+      <span class="text-base-content/70">
+        <%= if @selected_count > 0 do %>
+          {gettext("%{count} selected", count: @selected_count)}
+        <% else %>
+          {gettext("No selection")}
+        <% end %>
+      </span>
+
+      <div class="flex items-center gap-2 ml-auto">
+        <button
+          :if={@allow_reorder_all or @selected_count > 0}
+          type="button"
+          class="btn btn-sm btn-ghost"
+          phx-click={@on_open_reorder}
+          disabled={@total_count == 0}
+        >
+          <.icon name="hero-arrows-up-down" class="w-4 h-4" />
+          {if @selected_count > 0,
+            do: gettext("Reorder selected"),
+            else: gettext("Reorder all")}
+        </button>
+
+        <button
+          :if={@allow_delete and @selected_count > 0}
+          type="button"
+          class="btn btn-sm btn-ghost text-error"
+          phx-click={@on_bulk_delete}
+          data-confirm={
+            gettext("Delete %{count} selected %{noun}? This cannot be undone.",
+              count: @selected_count,
+              noun: @noun_plural
+            )
+          }
+        >
+          <.icon name="hero-trash" class="w-4 h-4" />
+          {gettext("Delete")}
+        </button>
+
+        <button
+          :if={@selected_count > 0}
+          type="button"
+          class="btn btn-sm btn-ghost"
+          phx-click={@on_clear_selection}
+        >
+          {gettext("Clear")}
+        </button>
+      </div>
+    </div>
+    """
+  end
+end

--- a/lib/phoenix_kit_web/components/core/modal.ex
+++ b/lib/phoenix_kit_web/components/core/modal.ex
@@ -88,16 +88,28 @@ defmodule PhoenixKitWeb.Components.Core.Modal do
   slot :actions
 
   def modal(assigns) do
+    # `phx-hook` requires a unique id on the element. Derive one from the
+    # on_close event name when the consumer hasn't passed an explicit id —
+    # different modals on the same page typically wire different on_close
+    # events, so this stays stable AND unique. Two modals sharing the same
+    # on_close would collide, which is rare enough to let the consumer hit
+    # and fix by passing an explicit id.
+    assigns =
+      assign_new(assigns, :resolved_id, fn ->
+        assigns[:id] || "pk-modal-#{assigns.on_close}"
+      end)
+
     ~H"""
     <%= if @show do %>
-      <div
-        id={@id}
-        class="modal modal-open"
+      <dialog
+        id={@resolved_id}
+        class="modal"
+        phx-hook="PkDialog"
+        data-close-event={@on_close}
+        data-closeable={to_string(@closeable)}
         role="dialog"
         aria-modal="true"
-        aria-labelledby={@id && "#{@id}-title"}
-        phx-window-keydown={@closeable && @on_close}
-        phx-key={@closeable && "Escape"}
+        aria-labelledby={"#{@resolved_id}-title"}
       >
         <div class={[
           "modal-box flex flex-col",
@@ -107,7 +119,7 @@ defmodule PhoenixKitWeb.Components.Core.Modal do
           <%!-- Title --%>
           <%= if @title != [] do %>
             <h3
-              id={@id && "#{@id}-title"}
+              id={"#{@resolved_id}-title"}
               class="font-bold text-lg mb-4 flex items-center gap-2 flex-shrink-0"
             >
               {render_slot(@title)}
@@ -129,15 +141,7 @@ defmodule PhoenixKitWeb.Components.Core.Modal do
             </div>
           <% end %>
         </div>
-
-        <%!-- Backdrop --%>
-        <div
-          class={["modal-backdrop bg-base-content/50", @backdrop_class]}
-          phx-click={@closeable && @on_close}
-          aria-hidden="true"
-        >
-        </div>
-      </div>
+      </dialog>
     <% end %>
     """
   end

--- a/lib/phoenix_kit_web/components/core/modal.ex
+++ b/lib/phoenix_kit_web/components/core/modal.ex
@@ -83,6 +83,11 @@ defmodule PhoenixKitWeb.Components.Core.Modal do
   attr :backdrop_class, :string, default: ""
   attr :closeable, :boolean, default: true
 
+  attr :keep_in_dom, :boolean,
+    default: false,
+    doc:
+      "When `true`, the `<dialog>` element is rendered into the DOM regardless of `@show`. Visibility is driven by the `PkDialog` hook (showModal/close) via the `data-show` attribute. Suits modals whose inner content doesn't depend on context-conditional assigns (e.g. a strategy picker with a fixed list) and that benefit from instant client-side open — a trigger button can call `dialog.showModal()` locally without waiting for the server round-trip. Default is conditional rendering for backwards compat with consumers whose inner block crashes when `@show` is false (e.g. forms reading from a `nil` `@form`)."
+
   slot :title
   slot :inner_block, required: true
   slot :actions
@@ -100,11 +105,12 @@ defmodule PhoenixKitWeb.Components.Core.Modal do
       end)
 
     ~H"""
-    <%= if @show do %>
+    <%= if @show or @keep_in_dom do %>
       <dialog
         id={@resolved_id}
         class="modal"
         phx-hook="PkDialog"
+        data-show={to_string(@show)}
         data-close-event={@on_close}
         data-closeable={to_string(@closeable)}
         role="dialog"

--- a/lib/phoenix_kit_web/components/core/modal.ex
+++ b/lib/phoenix_kit_web/components/core/modal.ex
@@ -86,7 +86,7 @@ defmodule PhoenixKitWeb.Components.Core.Modal do
   attr :keep_in_dom, :boolean,
     default: false,
     doc:
-      "When `true`, the `<dialog>` element is rendered into the DOM regardless of `@show`. Visibility is driven by the `PkDialog` hook (showModal/close) via the `data-show` attribute. Suits modals whose inner content doesn't depend on context-conditional assigns (e.g. a strategy picker with a fixed list) and that benefit from instant client-side open — a trigger button can call `dialog.showModal()` locally without waiting for the server round-trip. Default is conditional rendering for backwards compat with consumers whose inner block crashes when `@show` is false (e.g. forms reading from a `nil` `@form`)."
+      "When `true`, the `<dialog>` element is rendered into the DOM regardless of `@show`. Visibility is driven by the `PkDialog` hook (showModal/close) via the `data-show` attribute. Suits modals whose inner content doesn't depend on context-conditional assigns (e.g. a strategy picker with a fixed list) and that benefit from instant client-side open — a trigger button can call `dialog.showModal()` locally without waiting for the server round-trip. Default is conditional rendering for backwards compat with consumers whose inner block crashes when `@show` is false (e.g. forms reading from a `nil` `@form`). **ID collision risk:** kept-in-DOM modals persist across LV renders, so an auto-derived id (from `on_close`) is far more likely to collide with a sibling modal sharing the same close event. Pass an explicit `id=` when using `keep_in_dom` to be safe."
 
   slot :title
   slot :inner_block, required: true

--- a/lib/phoenix_kit_web/components/core/pagination.ex
+++ b/lib/phoenix_kit_web/components/core/pagination.ex
@@ -3,9 +3,22 @@ defmodule PhoenixKitWeb.Components.Core.Pagination do
   Pagination components for list views in PhoenixKit.
 
   Provides pagination controls and information display following daisyUI design patterns.
+
+  Two flavours:
+
+    * Page-numbered (`<.pagination>`, `<.pagination_controls>`,
+      `<.pagination_info>`) — URL-param driven, suits standalone admin
+      pages with deep-linkable state.
+
+    * Load-more (`<.load_more>`) — click-driven LV event that grows
+      the loaded set in place. Suits embeddable LVs (no URL routing),
+      lists with DnD reorder (rows append, don't replace), and lists
+      with client-side bulk-select (selection persists across loads
+      because rows stay in the DOM).
   """
 
   use Phoenix.Component
+  use Gettext, backend: PhoenixKitWeb.Gettext
 
   @doc """
   Displays pagination controls with page numbers and navigation buttons.
@@ -159,6 +172,65 @@ defmodule PhoenixKitWeb.Components.Core.Pagination do
         </div>
       </div>
     <% end %>
+    """
+  end
+
+  @doc """
+  Load-more footer for incrementally-loaded lists.
+
+  Renders a centered "Showing N of M %{noun}" line and a "Load more"
+  button (hidden when `loaded >= total`). Clicking the button emits
+  the LV event named in `on_load_more`.
+
+  Suited for embeddable LVs where URL-param pagination isn't an
+  option, lists with DnD reorder (rows append rather than navigate
+  away), and lists with client-side bulk-select (selection persists
+  because the DOM grows, it doesn't get replaced).
+
+  ## Attributes
+
+  - `loaded` — number of rows currently rendered (required)
+  - `total` — total rows matching the current filter/sort (required)
+  - `on_load_more` — LV event name pushed on button click
+    (default `"load_more"`)
+  - `noun_plural` — used in the "Showing N of M %{noun}" line
+    (default `"items"`)
+  - `class` — additional classes on the outer wrapper
+
+  ## Example
+
+      <.load_more
+        loaded={length(@projects)}
+        total={@total_count}
+        on_load_more="load_more"
+        noun_plural={gettext("projects")}
+      />
+  """
+  attr :loaded, :integer, required: true
+  attr :total, :integer, required: true
+  attr :on_load_more, :string, default: "load_more"
+  attr :noun_plural, :string, default: "items"
+  attr :class, :string, default: ""
+
+  def load_more(assigns) do
+    ~H"""
+    <div :if={@total > 0} class={["flex flex-col items-center gap-2 p-4", @class]}>
+      <p class="text-sm text-base-content/60">
+        {gettext("Showing %{loaded} of %{total} %{noun}",
+          loaded: @loaded,
+          total: @total,
+          noun: @noun_plural
+        )}
+      </p>
+      <button
+        :if={@loaded < @total}
+        type="button"
+        class="btn btn-sm"
+        phx-click={@on_load_more}
+      >
+        {gettext("Load more")}
+      </button>
+    </div>
     """
   end
 

--- a/lib/phoenix_kit_web/components/core/pagination.ex
+++ b/lib/phoenix_kit_web/components/core/pagination.ex
@@ -227,6 +227,7 @@ defmodule PhoenixKitWeb.Components.Core.Pagination do
         type="button"
         class="btn btn-sm"
         phx-click={@on_load_more}
+        phx-disable-with={gettext("Loading…")}
       >
         {gettext("Load more")}
       </button>

--- a/lib/phoenix_kit_web/components/core/reorder_modal.ex
+++ b/lib/phoenix_kit_web/components/core/reorder_modal.ex
@@ -1,0 +1,116 @@
+defmodule PhoenixKitWeb.Components.Core.ReorderModal do
+  @moduledoc """
+  Modal that lets the user pick a sort strategy for a bulk reorder.
+
+  Wraps core's `<.modal>` and renders radio buttons for each strategy
+  the consumer LV passes in. The scope label tells the user up front
+  whether the apply will rewrite "all N rows" or "the M selected rows"
+  so they see the consequence before clicking Apply.
+
+  Strategies are domain-specific (projects sort by `name`, tasks by
+  `title`, ai endpoints by `priority`, etc.) so the consumer owns
+  the strategy list — the modal is just shell + radio UI.
+
+  ## Example
+
+      <.reorder_modal
+        show={@show_reorder}
+        on_close="close_reorder"
+        on_apply="apply_reorder"
+        selected_count={length(@captured_uuids)}
+        total_count={length(@projects)}
+        strategies={[
+          {"name_asc", gettext("A → Z by name")},
+          {"name_desc", gettext("Z → A by name")},
+          {"created_desc", gettext("Newest first")},
+          {"created_asc", gettext("Oldest first")},
+          {"reverse", gettext("Reverse current order")}
+        ]}
+        noun_singular={gettext("project")}
+        noun_plural={gettext("projects")}
+      />
+
+  The Apply button submits the form, which emits `on_apply` with
+  `%{"strategy" => <value>}` — `value` is the first element of each
+  `{value, label}` tuple. `required` on the radios blocks empty
+  submits at the browser level; the consumer LV should still guard
+  against bad strategy strings server-side (whitelist + fallback
+  clause).
+  """
+  use Phoenix.Component
+  use Gettext, backend: PhoenixKitWeb.Gettext
+
+  import PhoenixKitWeb.Components.Core.Modal, only: [modal: 1]
+  import PhoenixKitWeb.Components.Core.Icon, only: [icon: 1]
+
+  attr :show, :boolean, required: true
+  attr :on_close, :string, required: true
+  attr :on_apply, :string, required: true
+  attr :selected_count, :integer, default: 0
+  attr :total_count, :integer, required: true
+
+  attr :strategies, :list,
+    required: true,
+    doc: "List of `{value :: String.t(), label :: String.t()}` tuples."
+
+  attr :noun_singular, :string, default: "item"
+  attr :noun_plural, :string, default: "items"
+  attr :id, :string, default: "reorder-modal"
+
+  def reorder_modal(assigns) do
+    ~H"""
+    <.modal show={@show} on_close={@on_close} id={@id} max_width="md">
+      <:title>
+        <.icon name="hero-arrows-up-down" class="w-5 h-5 text-primary" />
+        {gettext("Reorder")}
+      </:title>
+
+      <div class="space-y-3">
+        <p class="text-sm text-base-content/70">
+          {scope_label(@selected_count, @total_count, @noun_singular, @noun_plural)}
+        </p>
+
+        <form id={"#{@id}-form"} phx-submit={@on_apply} class="space-y-2">
+          <label
+            :for={{value, label} <- @strategies}
+            class="flex items-center gap-3 p-2 rounded hover:bg-base-200 cursor-pointer"
+          >
+            <input
+              type="radio"
+              name="strategy"
+              value={value}
+              required
+              class="radio radio-sm radio-primary"
+            />
+            <span class="text-sm">{label}</span>
+          </label>
+        </form>
+      </div>
+
+      <:actions>
+        <button type="button" class="btn btn-ghost" phx-click={@on_close}>
+          {gettext("Cancel")}
+        </button>
+        <button type="submit" form={"#{@id}-form"} class="btn btn-primary">
+          {gettext("Apply")}
+        </button>
+      </:actions>
+    </.modal>
+    """
+  end
+
+  defp scope_label(0, total, _singular, plural) do
+    gettext("Reorder all %{count} %{noun}.", count: total, noun: plural)
+  end
+
+  defp scope_label(1, _total, singular, _plural) do
+    gettext("Reorder the 1 selected %{noun} (other rows stay in place).", noun: singular)
+  end
+
+  defp scope_label(n, _total, _singular, plural) do
+    gettext("Reorder the %{count} selected %{noun} (other rows stay in place).",
+      count: n,
+      noun: plural
+    )
+  end
+end

--- a/lib/phoenix_kit_web/components/core/reorder_modal.ex
+++ b/lib/phoenix_kit_web/components/core/reorder_modal.ex
@@ -59,7 +59,7 @@ defmodule PhoenixKitWeb.Components.Core.ReorderModal do
 
   def reorder_modal(assigns) do
     ~H"""
-    <.modal show={@show} on_close={@on_close} id={@id} max_width="md">
+    <.modal show={@show} on_close={@on_close} id={@id} max_width="md" keep_in_dom>
       <:title>
         <.icon name="hero-arrows-up-down" class="w-5 h-5 text-primary" />
         {gettext("Reorder")}

--- a/lib/phoenix_kit_web/components/core/reorder_modal.ex
+++ b/lib/phoenix_kit_web/components/core/reorder_modal.ex
@@ -91,7 +91,12 @@ defmodule PhoenixKitWeb.Components.Core.ReorderModal do
         <button type="button" class="btn btn-ghost" phx-click={@on_close}>
           {gettext("Cancel")}
         </button>
-        <button type="submit" form={"#{@id}-form"} class="btn btn-primary">
+        <button
+          type="submit"
+          form={"#{@id}-form"}
+          class="btn btn-primary"
+          phx-disable-with={gettext("Applying…")}
+        >
           {gettext("Apply")}
         </button>
       </:actions>

--- a/lib/phoenix_kit_web/components/core/sort_selector.ex
+++ b/lib/phoenix_kit_web/components/core/sort_selector.ex
@@ -84,7 +84,7 @@ defmodule PhoenixKitWeb.Components.Core.SortSelector do
   attr :manual_field, :any,
     default: nil,
     doc:
-      "Atom or string field key that represents \"manual\" ordering (e.g. `:sort_order`). When `sort_by` matches, the direction toggle is replaced by a static drag-handle hint icon — direction has no meaning for a user-specified order."
+      "Atom or string field key that represents \"manual\" ordering (e.g. `:sort_order`). When `sort_by` matches, the direction toggle is hidden — direction has no meaning for a user-specified order, and the drag handles on each row are themselves the affordance for reordering."
 
   def sort_selector(assigns) do
     sort_by_str = to_field_str(assigns[:sort_by])
@@ -127,17 +127,10 @@ defmodule PhoenixKitWeb.Components.Core.SortSelector do
             class="select-sm join-item"
             aria-label={gettext("Sort by")}
           />
-          <%!-- In manual mode, direction is meaningless — replace the click-
-             to-flip arrow with a static drag-handle hint so the join still
-             reads as one widget but doesn't pretend to toggle anything. --%>
-          <span
-            :if={@manual_active?}
-            class="btn btn-sm btn-square join-item pointer-events-none text-base-content/60"
-            title={gettext("Drag rows to reorder")}
-            aria-label={gettext("Drag rows to reorder")}
-          >
-            <.icon name="hero-bars-3" class="w-4 h-4" />
-          </span>
+          <%!-- In manual mode, direction is meaningless — the row drag
+             handles are the affordance, and a separate indicator here
+             would be visual noise. The direction button is hidden
+             entirely; the dropdown alone communicates "manual" mode. --%>
           <button
             :if={!@manual_active?}
             type="button"

--- a/lib/phoenix_kit_web/components/core/sortable.ex
+++ b/lib/phoenix_kit_web/components/core/sortable.ex
@@ -1,0 +1,116 @@
+defmodule PhoenixKitWeb.Components.Core.Sortable do
+  @moduledoc """
+  Table-view DnD reorder helpers that compose with `<.table_default>`.
+
+  Two components, both thin wrappers around HTML primitives that
+  encode the conventions the `SortableGrid` JS hook expects:
+
+    * `<.sortable_tbody>` — replaces the raw `<tbody>` that DnD-
+      enabled tables previously had to spell out (with the
+      `phx-hook`, `data-sortable`, `data-sortable-items`,
+      `data-sortable-handle` and `data-sortable-event` attrs). When
+      `enabled` is false, renders a plain `<tbody>` without any of
+      the hook wiring — convenient for views where sort mode toggles
+      DnD on/off (e.g. only enable drag when sorted by the manual
+      position field).
+
+    * `<.sortable_row>` — replaces `<.table_default_row>` for rows
+      that participate in DnD. Adds the `sortable-item` class +
+      `data-id` attr that the hook reads to identify each row. The
+      consumer's own classes still pass through via `:class`.
+
+  The hardcoded selectors (`.sortable-item` for items, `.pk-drag-handle`
+  for the handle) match the conventions used by `<.drag_handle_cell>`
+  and across every other DnD-enabled list in the workspace.
+
+  ## Example
+
+      <.table_default id="projects-list" size="sm">
+        <.table_default_header>
+          <.table_default_row>
+            <.drag_handle_header_cell :if={@draggable?} />
+            <.table_default_header_cell>Name</.table_default_header_cell>
+            ...
+          </.table_default_row>
+        </.table_default_header>
+
+        <.sortable_tbody
+          id="projects-list-body"
+          enabled={@draggable?}
+          event="reorder_projects"
+        >
+          <.sortable_row :for={p <- @projects} item_id={p.uuid}>
+            <.drag_handle_cell :if={@draggable?} />
+            <.table_default_cell>{p.name}</.table_default_cell>
+            ...
+          </.sortable_row>
+        </.sortable_tbody>
+      </.table_default>
+
+  The matching LV handler reads `%{"ordered_ids" => uuids, "moved_id" => uuid}`:
+
+      def handle_event("reorder_projects", %{"ordered_ids" => ids} = params, socket)
+          when is_list(ids) do
+        ...
+      end
+  """
+  use Phoenix.Component
+
+  @doc """
+  `<tbody>` configured for SortableGrid-driven DnD.
+
+  When `enabled` is false, the hook attaches are omitted — the
+  consumer's table renders identically but without drag behavior.
+  Useful for view modes where the rendered order doesn't reflect
+  the manual position field (e.g. sort-by-name views), since
+  dragging in that state would write inconsistent positions.
+  """
+  attr :id, :string, required: true
+  attr :enabled, :boolean, default: true
+  attr :event, :string, required: true, doc: "LV event name pushed when the user drops a row."
+
+  attr :rest, :global
+
+  slot :inner_block, required: true
+
+  def sortable_tbody(assigns) do
+    ~H"""
+    <tbody
+      id={@id}
+      phx-hook={if @enabled, do: "SortableGrid"}
+      data-sortable={if @enabled, do: "true"}
+      data-sortable-event={@event}
+      data-sortable-items=".sortable-item"
+      data-sortable-handle=".pk-drag-handle"
+      {@rest}
+    >
+      {render_slot(@inner_block)}
+    </tbody>
+    """
+  end
+
+  @doc """
+  `<tr>` that participates in DnD reordering.
+
+  Wraps `<.table_default_row>` with the conventions SortableGrid
+  needs: `sortable-item` class and `data-id` attr. Consumer classes
+  pass through alongside.
+  """
+  attr :item_id, :string, required: true
+  attr :class, :any, default: ""
+  attr :rest, :global
+
+  slot :inner_block, required: true
+
+  def sortable_row(assigns) do
+    ~H"""
+    <PhoenixKitWeb.Components.Core.TableDefault.table_default_row
+      class={["sortable-item", @class]}
+      data-id={@item_id}
+      {@rest}
+    >
+      {render_slot(@inner_block)}
+    </PhoenixKitWeb.Components.Core.TableDefault.table_default_row>
+    """
+  end
+end

--- a/lib/phoenix_kit_web/components/core/table_default.ex
+++ b/lib/phoenix_kit_web/components/core/table_default.ex
@@ -534,6 +534,11 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
     ~H"""
     <tr
       class={[
+        # `group` is a Tailwind marker so descendants can use
+        # `group-hover:*` selectors. Required by `<.drag_handle_cell>`'s
+        # hide-until-hover behavior; benign for rows that don't have any
+        # group-hover-styled children.
+        "group",
         if(@hover, do: "hover", else: ""),
         @class
       ]}
@@ -591,6 +596,67 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
     <td class={@class} colspan={@colspan} rowspan={@rowspan} {@rest}>
       {render_slot(@inner_block)}
     </td>
+    """
+  end
+
+  @doc """
+  Drag-handle cell for table-view DnD reorder.
+
+  Renders a `<td>` containing the `hero-bars-3` grip icon, with the
+  classes the SortableGrid hook needs to find it (`.pk-drag-handle`)
+  plus the canonical hide-until-hover behavior used elsewhere in the
+  codebase (catalogue category rows, entities card view, etc.):
+
+    * Default: `opacity-0` — icon is invisible.
+    * Row hover: `group-hover:opacity-100` — icon fades in.
+
+  Requires the enclosing `<.table_default_row>` to carry the `group`
+  marker class — which it does by default, so consumers don't have
+  to wire anything beyond placing this cell + the matching
+  `<.drag_handle_header_cell>` in the header.
+
+  Pair this with a `<tbody phx-hook="SortableGrid">` setup (see the
+  `<.table_default>` moduledoc / phoenix_kit_projects reference call
+  sites). The cell only renders the affordance — the hook owns the
+  drag mechanics.
+  """
+  attr :class, :any, default: "w-8"
+  attr :title, :string, default: nil
+  attr :rest, :global
+
+  def drag_handle_cell(assigns) do
+    assigns = assign_new(assigns, :title, fn -> gettext("Drag to reorder") end)
+
+    ~H"""
+    <td
+      class={[
+        "pk-drag-handle cursor-grab active:cursor-grabbing",
+        "text-base-content/30 opacity-0 group-hover:opacity-100 transition-opacity",
+        @class
+      ]}
+      title={@title}
+      {@rest}
+    >
+      <.icon name="hero-bars-3" class="w-4 h-4" />
+    </td>
+    """
+  end
+
+  @doc """
+  Empty `<th>` sized to match the drag-handle column. Sits in the
+  header row alongside `<.bulk_select_header_cell>` and the regular
+  `<.table_default_header_cell>`s.
+
+  Separate component (rather than a bare `<.table_default_header_cell class="w-8" />`)
+  so the intent is obvious at the call site, and the width default
+  matches `<.drag_handle_cell>`'s without consumers having to keep
+  them in sync.
+  """
+  attr :class, :any, default: "w-8"
+
+  def drag_handle_header_cell(assigns) do
+    ~H"""
+    <th class={@class}></th>
     """
   end
 

--- a/lib/phoenix_kit_web/components/core/table_default.ex
+++ b/lib/phoenix_kit_web/components/core/table_default.ex
@@ -533,15 +533,17 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
   def table_default_row(assigns) do
     ~H"""
     <tr
-      class={[
-        # `group` is a Tailwind marker so descendants can use
-        # `group-hover:*` selectors. Required by `<.drag_handle_cell>`'s
-        # hide-until-hover behavior; benign for rows that don't have any
-        # group-hover-styled children.
-        "group",
-        if(@hover, do: "hover", else: ""),
-        @class
-      ]}
+      class={
+        [
+          # `group` is a Tailwind marker so descendants can use
+          # `group-hover:*` selectors. Required by `<.drag_handle_cell>`'s
+          # hide-until-hover behavior; benign for rows that don't have any
+          # group-hover-styled children.
+          "group",
+          if(@hover, do: "hover", else: ""),
+          @class
+        ]
+      }
       {@rest}
     >
       {render_slot(@inner_block)}
@@ -625,7 +627,11 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
   attr :rest, :global
 
   def drag_handle_cell(assigns) do
-    assigns = assign_new(assigns, :title, fn -> gettext("Drag to reorder") end)
+    # `attr :title, default: nil` puts `:title => nil` in assigns, so
+    # `assign_new` would be a no-op. Resolve the default explicitly so
+    # callers can pass `title={nil}` (or omit it) and still get the
+    # gettext'd default for accessibility.
+    assigns = assign(assigns, :title, assigns.title || gettext("Drag to reorder"))
 
     ~H"""
     <td

--- a/lib/phoenix_kit_web/users/auth.ex
+++ b/lib/phoenix_kit_web/users/auth.ex
@@ -1984,11 +1984,14 @@ defmodule PhoenixKitWeb.Users.Auth do
     # Get the default language
     default_base = Routes.get_default_admin_locale()
 
-    replacement_segment =
-      if prefixless_primary?(), do: "/", else: "/#{default_base}/"
-
-    replacement_suffix =
-      if prefixless_primary?(), do: "", else: "/#{default_base}"
+    # Single read of the setting — the two replacement variants always
+    # flip together (prefixless ↔ prefixed), so evaluating the flag
+    # twice would just risk torn reads if a concurrent setting flip
+    # landed between the two calls.
+    {replacement_segment, replacement_suffix} =
+      if prefixless_primary?(),
+        do: {"/", ""},
+        else: {"/#{default_base}/", "/#{default_base}"}
 
     corrected_path =
       conn.request_path

--- a/lib/phoenix_kit_web/users/magic_link_registration.html.heex
+++ b/lib/phoenix_kit_web/users/magic_link_registration.html.heex
@@ -20,7 +20,7 @@
     <%!-- Hidden email field for session controller --%>
     <input type="hidden" name="user[email]" value={@email} />
 
-    <fieldset class="fieldset w-full min-w-0">
+    <fieldset class="fieldset min-w-0">
       <legend class="fieldset-legend sr-only">Account Information</legend>
 
       <%!-- Username Field --%>

--- a/lib/phoenix_kit_web/users/registration.html.heex
+++ b/lib/phoenix_kit_web/users/registration.html.heex
@@ -25,7 +25,7 @@
     action={Routes.path("/users/log-in?_action=registered")}
     method="post"
   >
-    <fieldset class="fieldset w-full min-w-0">
+    <fieldset class="fieldset min-w-0">
       <legend class="fieldset-legend sr-only">Account Information</legend>
 
       <div phx-feedback-for="user[email]">

--- a/priv/static/assets/phoenix_kit.js
+++ b/priv/static/assets/phoenix_kit.js
@@ -1541,6 +1541,173 @@ if (typeof window.Chart === "undefined") {
     updated() { this._apply(); }
   };
 
+  // ---------------------------------------------------------------------------
+  // BulkSelectScope — client-side bulk-select state for admin tables.
+  //
+  // The hook owns the selection set in the browser; the server only learns
+  // about it at action time (when the user clicks an action button). This
+  // makes per-checkbox toggles feel instant — no round-trip on every click.
+  //
+  // Markup contract (inside the hook root element):
+  //
+  //   data-bulk-total="N"                   on the root, total row count
+  //                                         (drives the header's
+  //                                         all-selected check)
+  //
+  //   data-bulk-role="select-all"           the header checkbox. Click
+  //                                         toggles every row to match.
+  //
+  //   data-bulk-role="row"
+  //   data-uuid="<row-uuid>"                a per-row checkbox.
+  //
+  //   data-bulk-action="<lv-event>"         on a button: clicking pushes
+  //                                         <lv-event> to the LV with
+  //                                         `{ uuids: [...] }` payload.
+  //
+  //   data-bulk-clear                       on a button: pure client-side
+  //                                         clear (uncheck all + reset).
+  //
+  //   data-bulk-count                       text content gets set to the
+  //                                         current selected count.
+  //
+  //   data-bulk-show="has-selection"        element shown only when
+  //                                         count > 0 (hidden otherwise).
+  //   data-bulk-show="no-selection"         inverse: shown only when count
+  //                                         is 0.
+  //
+  //   data-bulk-text-template="…%{count}…"  element's textContent is
+  //                                         re-rendered from the template
+  //                                         each time the count changes
+  //                                         (%{count} → current count).
+  //
+  //   data-bulk-label-empty / -selected     button label flips between
+  //                                         the two strings based on
+  //                                         count (selected supports
+  //                                         %{count} interpolation).
+  // ---------------------------------------------------------------------------
+
+  window.PhoenixKitHooks.BulkSelectScope = {
+    mounted() {
+      this.selected = new Set();
+      this._readFromDom();
+      this._wire();
+      this._sync();
+    },
+    updated() {
+      // LV may have re-rendered the row set (filter, reload, delete).
+      // Re-derive from whatever's actually in the DOM now — that's
+      // the source of truth.
+      this._readFromDom();
+      this._wire();
+      this._sync();
+    },
+    _readFromDom() {
+      this.selected.clear();
+      this.el.querySelectorAll('[data-bulk-role="row"]').forEach((r) => {
+        if (r.checked && r.dataset.uuid) this.selected.add(r.dataset.uuid);
+      });
+    },
+    _wire() {
+      const self = this;
+      const header = this.el.querySelector('[data-bulk-role="select-all"]');
+      if (header && !header._pkBulkWired) {
+        header.addEventListener("click", function() { self._onHeaderClick(header); });
+        header._pkBulkWired = true;
+      }
+      this.el.querySelectorAll('[data-bulk-role="row"]').forEach(function(r) {
+        if (r._pkBulkWired) return;
+        r.addEventListener("click", function() { self._onRowClick(r); });
+        r._pkBulkWired = true;
+      });
+      this.el.querySelectorAll("[data-bulk-action]").forEach(function(btn) {
+        if (btn._pkBulkWired) return;
+        btn.addEventListener("click", function(e) { self._onActionClick(e, btn); });
+        btn._pkBulkWired = true;
+      });
+      this.el.querySelectorAll("[data-bulk-clear]").forEach(function(btn) {
+        if (btn._pkBulkWired) return;
+        btn.addEventListener("click", function() { self._clearAll(); });
+        btn._pkBulkWired = true;
+      });
+    },
+    _onHeaderClick(header) {
+      const rows = this.el.querySelectorAll('[data-bulk-role="row"]');
+      const self = this;
+      if (header.checked) {
+        rows.forEach(function(r) {
+          r.checked = true;
+          if (r.dataset.uuid) self.selected.add(r.dataset.uuid);
+        });
+      } else {
+        rows.forEach(function(r) { r.checked = false; });
+        this.selected.clear();
+      }
+      this._sync();
+    },
+    _onRowClick(input) {
+      const uuid = input.dataset.uuid;
+      if (!uuid) return;
+      if (input.checked) this.selected.add(uuid);
+      else this.selected.delete(uuid);
+      this._sync();
+    },
+    _onActionClick(e, btn) {
+      e.preventDefault();
+      const event = btn.dataset.bulkAction;
+      if (!event) return;
+      this.pushEventTo(this.el, event, { uuids: Array.from(this.selected) });
+    },
+    _clearAll() {
+      this.el.querySelectorAll('[data-bulk-role="row"]').forEach(function(r) {
+        r.checked = false;
+      });
+      this.selected.clear();
+      this._sync();
+    },
+    _sync() {
+      const total = parseInt(this.el.dataset.bulkTotal || "0", 10);
+      const count = this.selected.size;
+
+      const header = this.el.querySelector('[data-bulk-role="select-all"]');
+      if (header) {
+        header.checked = count > 0 && count === total;
+        header.indeterminate = count > 0 && count < total;
+      }
+
+      this.el.querySelectorAll("[data-bulk-count]").forEach(function(el) {
+        el.textContent = String(count);
+      });
+
+      this.el.querySelectorAll("[data-bulk-text-template]").forEach(function(el) {
+        el.textContent = el.dataset.bulkTextTemplate.replace("%{count}", String(count));
+      });
+
+      this.el.querySelectorAll("[data-bulk-show]").forEach(function(el) {
+        const mode = el.dataset.bulkShow;
+        const visible =
+          mode === "has-selection" ? count > 0 :
+          mode === "no-selection" ? count === 0 : true;
+        el.style.display = visible ? "" : "none";
+      });
+
+      this.el.querySelectorAll("[data-bulk-label-empty][data-bulk-label-selected]").forEach(function(el) {
+        const label = count > 0
+          ? el.dataset.bulkLabelSelected.replace("%{count}", String(count))
+          : el.dataset.bulkLabelEmpty;
+        // Only swap the text node so we don't blow away icon children.
+        let updated = false;
+        for (const node of el.childNodes) {
+          if (node.nodeType === Node.TEXT_NODE && node.textContent.trim() !== "") {
+            node.textContent = label;
+            updated = true;
+            break;
+          }
+        }
+        if (!updated) el.appendChild(document.createTextNode(label));
+      });
+    }
+  };
+
   window.PhoenixKitHooks.PkDialog = {
     _onOpened() {
       // daisyUI 5 ships a `:where(:root:has(.modal[open])) { scrollbar-gutter: stable }`

--- a/priv/static/assets/phoenix_kit.js
+++ b/priv/static/assets/phoenix_kit.js
@@ -1687,7 +1687,10 @@ if (typeof window.Chart === "undefined") {
         const visible =
           mode === "has-selection" ? count > 0 :
           mode === "no-selection" ? count === 0 :
-          mode === "has-multiple" ? count > 1 : true;
+          mode === "has-multiple" ? count > 1 :
+          // count is 0 OR > 1 — used by reorder-like buttons whose
+          // single-row case is a no-op (count=1 hides the button).
+          mode === "not-single" ? count !== 1 : true;
         el.style.display = visible ? "" : "none";
       });
 

--- a/priv/static/assets/phoenix_kit.js
+++ b/priv/static/assets/phoenix_kit.js
@@ -1655,6 +1655,20 @@ if (typeof window.Chart === "undefined") {
       e.preventDefault();
       const event = btn.dataset.bulkAction;
       if (!event) return;
+
+      // If the button is paired with a kept-in-DOM dialog, open it
+      // locally BEFORE pushing the event. The server still gets the
+      // payload + flips its `@show_*_modal` assign for state sync,
+      // but the user sees the modal instantly instead of waiting
+      // for the round-trip.
+      const dialogId = btn.dataset.bulkOpensDialog;
+      if (dialogId) {
+        const dialog = document.getElementById(dialogId);
+        if (dialog && !dialog.open && typeof dialog.showModal === "function") {
+          dialog.showModal();
+        }
+      }
+
       this.pushEventTo(this.el, event, { uuids: Array.from(this.selected) });
     },
     _clearAll() {
@@ -1760,6 +1774,24 @@ if (typeof window.Chart === "undefined") {
       const ev = this.el.dataset.closeEvent;
       if (ev) this.pushEventTo(this.el, ev, {});
     },
+    _sync() {
+      // `data-show` drives visibility for keep_in_dom modals. Conditional
+      // modals (rendered only when @show=true) get the same attribute
+      // value, so this works for both paths.
+      // Absent attribute defaults to "true" so a consumer that doesn't
+      // set data-show (legacy callers) keeps the original mount-opens
+      // behavior.
+      const wantOpen = this.el.dataset.show !== "false";
+      if (wantOpen && !this.el.open && typeof this.el.showModal === "function") {
+        this.el.showModal();
+        this._opened = true;
+        this._onOpened();
+      } else if (!wantOpen && this.el.open) {
+        // close() fires 'close' which the _onClose handler converts
+        // into a refcount decrement.
+        this.el.close();
+      }
+    },
     mounted() {
       const self = this;
       // `_opened` tracks whether we've incremented the global refcount,
@@ -1770,12 +1802,6 @@ if (typeof window.Chart === "undefined") {
       // if LV didn't process the on_close event, that could be forever.
       this._opened = false;
       this._closeFromLV = false;
-
-      if (typeof this.el.showModal === "function" && !this.el.open) {
-        this.el.showModal();
-        this._opened = true;
-        this._onOpened();
-      }
 
       self._onCancel = function(e) {
         if (!self._isCloseable()) e.preventDefault();
@@ -1801,6 +1827,11 @@ if (typeof window.Chart === "undefined") {
       this.el.addEventListener("cancel", self._onCancel);
       this.el.addEventListener("close", self._onClose);
       this.el.addEventListener("click", self._onClick);
+
+      this._sync();
+    },
+    updated() {
+      this._sync();
     },
     destroyed() {
       // LV is removing the element. Tell _onClose not to echo a close

--- a/priv/static/assets/phoenix_kit.js
+++ b/priv/static/assets/phoenix_kit.js
@@ -1686,14 +1686,22 @@ if (typeof window.Chart === "undefined") {
         const mode = el.dataset.bulkShow;
         const visible =
           mode === "has-selection" ? count > 0 :
-          mode === "no-selection" ? count === 0 : true;
+          mode === "no-selection" ? count === 0 :
+          mode === "has-multiple" ? count > 1 : true;
         el.style.display = visible ? "" : "none";
       });
 
-      this.el.querySelectorAll("[data-bulk-label-empty][data-bulk-label-selected]").forEach(function(el) {
+      // Label flip: requires at least the `selected` variant. The
+      // `empty` variant is optional — when absent, count=0 leaves the
+      // server-rendered initial text in place (which is fine, since
+      // a button without label-empty is also typically gated to hide
+      // at count=0 via data-bulk-show).
+      this.el.querySelectorAll("[data-bulk-label-selected]").forEach(function(el) {
+        const empty = el.dataset.bulkLabelEmpty;
         const label = count > 0
           ? el.dataset.bulkLabelSelected.replace("%{count}", String(count))
-          : el.dataset.bulkLabelEmpty;
+          : empty;
+        if (label === undefined) return;
         // Only swap the text node so we don't blow away icon children.
         let updated = false;
         for (const node of el.childNodes) {

--- a/priv/static/assets/phoenix_kit.js
+++ b/priv/static/assets/phoenix_kit.js
@@ -1695,13 +1695,19 @@ if (typeof window.Chart === "undefined") {
       });
 
       // Label flip: requires at least the `selected` variant. The
-      // `empty` variant is optional — when absent, count=0 leaves the
-      // server-rendered initial text in place (which is fine, since
-      // a button without label-empty is also typically gated to hide
-      // at count=0 via data-bulk-show).
+      // `empty` variant is optional — when absent, count <= 1 leaves
+      // the server-rendered initial text in place (which is fine,
+      // since a button without label-empty is also typically gated
+      // to hide at low counts via data-bulk-show).
+      //
+      // Threshold is `> 1`, not `> 0`: a one-row "Reorder selected"
+      // is a no-op (permuting a single row leaves it where it was),
+      // and "Delete 1 selected" reads identically to bare "Delete".
+      // Showing the empty label at count=1 keeps the button label
+      // honest about what's actually going to happen.
       this.el.querySelectorAll("[data-bulk-label-selected]").forEach(function(el) {
         const empty = el.dataset.bulkLabelEmpty;
-        const label = count > 0
+        const label = count > 1
           ? el.dataset.bulkLabelSelected.replace("%{count}", String(count))
           : empty;
         if (label === undefined) return;

--- a/priv/static/assets/phoenix_kit.js
+++ b/priv/static/assets/phoenix_kit.js
@@ -1578,21 +1578,33 @@ if (typeof window.Chart === "undefined") {
     },
     mounted() {
       const self = this;
-      // Element only enters the DOM when LV's @show is true — open it.
+      // `_opened` tracks whether we've incremented the global refcount,
+      // so the close event handler can decrement exactly once regardless
+      // of whether the close originated from Esc, backdrop, programmatic
+      // close, or destroyed(). Without this, a user-driven close would
+      // leave the gutter override sticky until `destroyed()` ran — and
+      // if LV didn't process the on_close event, that could be forever.
+      this._opened = false;
+      this._closeFromLV = false;
+
       if (typeof this.el.showModal === "function" && !this.el.open) {
         this.el.showModal();
+        this._opened = true;
+        this._onOpened();
       }
-      this._onOpened();
-
-      // _closeFromLV: set to true in `destroyed()` so the `close` listener
-      // can distinguish LV-driven teardown (don't echo a close event back)
-      // from user-driven closes (Esc, backdrop — echo so server state syncs).
-      this._closeFromLV = false;
 
       self._onCancel = function(e) {
         if (!self._isCloseable()) e.preventDefault();
       };
+      // 'close' fires for every close path: Esc, our own el.close() in
+      // destroyed(), backdrop click (via _onClick → el.close()), and
+      // form `method="dialog"` submits. This is the ONE place that
+      // decrements the refcount.
       self._onClose = function() {
+        if (self._opened) {
+          self._onClosed();
+          self._opened = false;
+        }
         if (!self._closeFromLV) self._pushClose();
       };
       // Backdrop click: a click event whose target is the <dialog> itself
@@ -1607,10 +1619,19 @@ if (typeof window.Chart === "undefined") {
       this.el.addEventListener("click", self._onClick);
     },
     destroyed() {
-      // LV is removing the element. Don't echo a close event — LV initiated.
+      // LV is removing the element. Tell _onClose not to echo a close
+      // event back (LV already initiated this).
       this._closeFromLV = true;
+      // Try the friendly path first (fires 'close' which decrements via
+      // _onClose). But if the element is already detached from the DOM
+      // when destroyed runs, close() may not fire 'close' on every UA —
+      // so always decrement defensively. _opened gates so we never
+      // double-decrement (whoever runs first wins).
       if (this.el.open) this.el.close();
-      this._onClosed();
+      if (this._opened) {
+        this._onClosed();
+        this._opened = false;
+      }
       if (this._onCancel) this.el.removeEventListener("cancel", this._onCancel);
       if (this._onClose) this.el.removeEventListener("close", this._onClose);
       if (this._onClick) this.el.removeEventListener("click", this._onClick);

--- a/priv/static/assets/phoenix_kit.js
+++ b/priv/static/assets/phoenix_kit.js
@@ -1594,14 +1594,33 @@ if (typeof window.Chart === "undefined") {
       this._sync();
     },
     updated() {
-      // LV may have re-rendered the row set (filter, reload, delete).
-      // Re-derive from whatever's actually in the DOM now — that's
-      // the source of truth.
-      this._readFromDom();
+      // LV may have re-rendered the row set (filter, reload, delete,
+      // reorder, apply_reorder, load_more). The server always renders
+      // checkboxes unchecked — selection lives in this hook's in-
+      // memory Set, NOT in the markup. So we restore from the Set
+      // against whatever rows are in the DOM now, and prune uuids
+      // whose rows are no longer present (filtered, deleted).
+      //
+      // Always assign `checked` explicitly (true OR false) — never
+      // skip the false case. Morphdom can reuse input nodes whose
+      // `dataset.uuid` changed (row swapped under the same node), and
+      // a stale `checked=true` left over from that reuse would render
+      // a phantom selection that this.selected doesn't actually own.
+      const surviving = new Set();
+      this.el.querySelectorAll('[data-bulk-role="row"]').forEach((r) => {
+        const uuid = r.dataset.uuid;
+        const want = !!(uuid && this.selected.has(uuid));
+        r.checked = want;
+        if (want) surviving.add(uuid);
+      });
+      this.selected = surviving;
       this._wire();
       this._sync();
     },
     _readFromDom() {
+      // Initial mount: read whatever is already checked in the markup.
+      // Used only by mounted(); updated() restores from the in-memory
+      // Set instead so selection survives LV re-renders.
       this.selected.clear();
       this.el.querySelectorAll('[data-bulk-role="row"]').forEach((r) => {
         if (r.checked && r.dataset.uuid) this.selected.add(r.dataset.uuid);
@@ -1739,6 +1758,23 @@ if (typeof window.Chart === "undefined") {
     }
   };
 
+  // Returns true if the given <dialog> is in the browser's top layer
+  // (was opened via showModal()). Uses the `:modal` pseudo-class as
+  // the truth source, with a graceful fallback to the `open`
+  // attribute for older engines that lack `:modal` support.
+  function isDialogOpenInBrowser(el) {
+    if (!el || typeof el.matches !== "function") return false;
+    try {
+      return el.matches(":modal");
+    } catch (_e) {
+      // `matches()` throws SyntaxError on the `:modal` selector when
+      // the engine doesn't recognise it (pre-2022 browsers). The
+      // fallback loses fidelity to morphdom-strip cases but is the
+      // best we can do without the pseudo-class.
+      return !!el.open;
+    }
+  }
+
   window.PhoenixKitHooks.PkDialog = {
     _onOpened() {
       // daisyUI 5 ships a `:where(:root:has(.modal[open])) { scrollbar-gutter: stable }`
@@ -1782,13 +1818,58 @@ if (typeof window.Chart === "undefined") {
       // set data-show (legacy callers) keeps the original mount-opens
       // behavior.
       const wantOpen = this.el.dataset.show !== "false";
-      if (wantOpen && !this.el.open && typeof this.el.showModal === "function") {
+      // `:modal` matches whenever the dialog is in the browser's top
+      // layer (showModal was called). This is the truth source — `el.open`
+      // is just the reflected attribute, which Phoenix LV's DOM patcher
+      // strips on re-render if it wasn't in the server template (the
+      // browser added it via showModal(), the server didn't). Using
+      // `:modal` keeps state in sync even after that attribute gets
+      // stripped on a patch.
+      //
+      // `:modal` is a relatively new CSS pseudo-class (Chrome 105+,
+      // Safari 15.6+, Firefox 117+). On browsers that have `matches()`
+      // but not `:modal` it throws SyntaxError, which would break the
+      // hook entirely — fall back to the `open` attribute so older
+      // engines degrade to the pre-fix behavior rather than crash.
+      const isOpenForBrowser = isDialogOpenInBrowser(this.el);
+      if (
+        wantOpen &&
+        !isOpenForBrowser &&
+        typeof this.el.showModal === "function"
+      ) {
         this.el.showModal();
-        this._opened = true;
-        this._onOpened();
-      } else if (!wantOpen && this.el.open) {
-        // close() fires 'close' which the _onClose handler converts
-        // into a refcount decrement.
+        if (!this._opened) {
+          this._opened = true;
+          this._onOpened();
+        }
+      } else if (wantOpen && isOpenForBrowser) {
+        // Dialog is in the top layer but the `open` attribute may have
+        // been stripped by Phoenix LV's DOM patch (the server template
+        // doesn't include `open=""` — the browser added it when
+        // showModal() ran). CSS treats `dialog:not([open])` as
+        // `display: none`, so the dialog becomes invisible AND
+        // uninteractable while still blocking clicks elsewhere from
+        // the top layer. Restore the attribute so the dialog renders.
+        if (!this.el.open) {
+          this.el.setAttribute("open", "");
+        }
+        // Also track that the dialog is open (it may have been opened
+        // externally — e.g. BulkSelectScope — before this hook saw it).
+        if (!this._opened) {
+          this._opened = true;
+          this._onOpened();
+        }
+      } else if (!wantOpen && isOpenForBrowser) {
+        // LV-driven close. If morphdom stripped the `open` attr after
+        // the external showModal, restore it so close() can actually
+        // release the top layer (close() needs `open` to fire 'close'
+        // and detach from the top layer on every UA).
+        if (!this.el.open) {
+          this.el.setAttribute("open", "");
+        }
+        // Mark the close as LV-initiated so _onClose skips the echo
+        // push (LV already knows data-show=false).
+        this._closeFromLV = true;
         this.el.close();
       }
     },
@@ -1816,6 +1897,10 @@ if (typeof window.Chart === "undefined") {
           self._opened = false;
         }
         if (!self._closeFromLV) self._pushClose();
+        // Reset the LV-initiated flag now that the close event has
+        // been fully processed. The next user-initiated close (Esc,
+        // backdrop) will fall through to the echo push as intended.
+        self._closeFromLV = false;
       };
       // Backdrop click: a click event whose target is the <dialog> itself
       // (rather than a descendant) means the user clicked outside the
@@ -1842,7 +1927,16 @@ if (typeof window.Chart === "undefined") {
       // when destroyed runs, close() may not fire 'close' on every UA —
       // so always decrement defensively. _opened gates so we never
       // double-decrement (whoever runs first wins).
-      if (this.el.open) this.el.close();
+      //
+      // Use the same "is the browser holding this dialog open?"
+      // predicate as `_sync()` — `el.open` alone is unreliable when
+      // morphdom stripped the attribute earlier. Restore `open`
+      // first if needed so `close()` can release the top layer
+      // cleanly.
+      if (isDialogOpenInBrowser(this.el)) {
+        if (!this.el.open) this.el.setAttribute("open", "");
+        this.el.close();
+      }
       if (this._opened) {
         this._onClosed();
         this._opened = false;

--- a/priv/static/assets/phoenix_kit.js
+++ b/priv/static/assets/phoenix_kit.js
@@ -1526,6 +1526,21 @@ if (typeof window.Chart === "undefined") {
   // multiple <dialog> can be open simultaneously).
   window._PkDialogOpenCount = window._PkDialogOpenCount || 0;
 
+  // ---------------------------------------------------------------------------
+  // PkCheckboxIndeterminate — applies the `indeterminate` property to a
+  // checkbox based on `data-indeterminate="true"`. HTML has no attribute
+  // form of `indeterminate`, so a small hook is needed to read the dataset
+  // and assign the JS property after every LV patch.
+  // ---------------------------------------------------------------------------
+
+  window.PhoenixKitHooks.PkCheckboxIndeterminate = {
+    _apply() {
+      this.el.indeterminate = this.el.dataset.indeterminate === "true";
+    },
+    mounted() { this._apply(); },
+    updated() { this._apply(); }
+  };
+
   window.PhoenixKitHooks.PkDialog = {
     _onOpened() {
       // daisyUI 5 ships a `:where(:root:has(.modal[open])) { scrollbar-gutter: stable }`

--- a/priv/static/assets/phoenix_kit.js
+++ b/priv/static/assets/phoenix_kit.js
@@ -1510,37 +1510,95 @@ if (typeof window.Chart === "undefined") {
   //
   // Renders the modal in the browser top layer (showModal()), so it is immune to
   // ancestor stacking contexts / z-index — fixes modals being overlapped by
-  // parent-page elements.
+  // parent-page elements. The dialog also covers the FULL visual viewport
+  // (top-layer rendering bypasses the daisyUI `scrollbar-gutter: stable` trick
+  // that previously left a 15px gap on the right of `<div class="modal">`).
   //
   //   data-show        "true" / "false" — desired open state (synced each update)
-  //   data-close-event event pushed to the component on Escape / cancel
+  //   data-close-event event pushed to the component on Escape / cancel / backdrop
+  //   data-closeable   "false" → Escape + backdrop click are no-ops (modal still
+  //                    closable only via an explicit action button). Default:
+  //                    closeable.
   // ---------------------------------------------------------------------------
 
+  // Refcount of open PkDialog modals. Used to know when to restore the
+  // html's scrollbar-gutter (only when the LAST modal closes, since
+  // multiple <dialog> can be open simultaneously).
+  window._PkDialogOpenCount = window._PkDialogOpenCount || 0;
+
   window.PhoenixKitHooks.PkDialog = {
-    _sync() {
-      const wantOpen = this.el.dataset.show === "true";
-      if (wantOpen && !this.el.open && typeof this.el.showModal === "function") {
-        this.el.showModal();
-      } else if (!wantOpen && this.el.open) {
-        this.el.close();
+    _onOpened() {
+      // daisyUI 5 ships a `:where(:root:has(.modal[open])) { scrollbar-gutter: stable }`
+      // rule that prevents body layout jump when a modal opens but ALSO
+      // reduces the layout viewport by ~15px, leaving a strip on the right
+      // where the dialog/backdrop don't reach. Override per modal open so
+      // the dialog can cover the full visual viewport. Refcounted so
+      // concurrent modals don't fight each other.
+      if (window._PkDialogOpenCount === 0) {
+        const html = document.documentElement;
+        html.dataset.pkPrevScrollbarGutter = html.style.scrollbarGutter || "";
+        html.style.setProperty("scrollbar-gutter", "auto", "important");
       }
+      window._PkDialogOpenCount += 1;
+    },
+    _onClosed() {
+      window._PkDialogOpenCount = Math.max(0, window._PkDialogOpenCount - 1);
+      if (window._PkDialogOpenCount === 0) {
+        const html = document.documentElement;
+        const prev = html.dataset.pkPrevScrollbarGutter;
+        if (prev) {
+          html.style.scrollbarGutter = prev;
+        } else {
+          html.style.removeProperty("scrollbar-gutter");
+        }
+        delete html.dataset.pkPrevScrollbarGutter;
+      }
+    },
+    _isCloseable() {
+      return this.el.dataset.closeable !== "false";
+    },
+    _pushClose() {
+      const ev = this.el.dataset.closeEvent;
+      if (ev) this.pushEventTo(this.el, ev, {});
     },
     mounted() {
       const self = this;
+      // Element only enters the DOM when LV's @show is true — open it.
+      if (typeof this.el.showModal === "function" && !this.el.open) {
+        this.el.showModal();
+      }
+      this._onOpened();
+
+      // _closeFromLV: set to true in `destroyed()` so the `close` listener
+      // can distinguish LV-driven teardown (don't echo a close event back)
+      // from user-driven closes (Esc, backdrop — echo so server state syncs).
+      this._closeFromLV = false;
+
       self._onCancel = function(e) {
-        e.preventDefault();
-        const ev = self.el.dataset.closeEvent;
-        if (ev) self.pushEventTo(self.el, ev, {});
+        if (!self._isCloseable()) e.preventDefault();
+      };
+      self._onClose = function() {
+        if (!self._closeFromLV) self._pushClose();
+      };
+      // Backdrop click: a click event whose target is the <dialog> itself
+      // (rather than a descendant) means the user clicked outside the
+      // modal-box on the ::backdrop surface. Children stop propagation
+      // naturally because event.target lands on them, not on the dialog.
+      self._onClick = function(e) {
+        if (e.target === self.el && self._isCloseable()) self.el.close();
       };
       this.el.addEventListener("cancel", self._onCancel);
-      this._sync();
-    },
-    updated() {
-      this._sync();
+      this.el.addEventListener("close", self._onClose);
+      this.el.addEventListener("click", self._onClick);
     },
     destroyed() {
-      if (this._onCancel) this.el.removeEventListener("cancel", this._onCancel);
+      // LV is removing the element. Don't echo a close event — LV initiated.
+      this._closeFromLV = true;
       if (this.el.open) this.el.close();
+      this._onClosed();
+      if (this._onCancel) this.el.removeEventListener("cancel", this._onCancel);
+      if (this._onClose) this.el.removeEventListener("close", this._onClose);
+      if (this._onClick) this.el.removeEventListener("click", this._onClick);
     }
   };
 

--- a/test/integration/users/auth_locale_test.exs
+++ b/test/integration/users/auth_locale_test.exs
@@ -34,7 +34,11 @@ defmodule PhoenixKit.Integration.Users.AuthLocaleTest do
     Settings.update_json_setting("languages_config", config)
 
     on_exit(fn ->
-      Settings.update_boolean_setting("default_language_no_prefix", false)
+      # Use the typed setter (mirrors the `setup` block in the
+      # `setting ON` describe further down) so any future cache /
+      # invalidation logic Languages.set_* wires up runs in cleanup
+      # too — the raw Settings call would skip it.
+      Languages.set_default_language_no_prefix(false)
       Settings.update_setting("languages_enabled", "false")
     end)
 

--- a/test/phoenix_kit_web/components/core/bulk_select_test.exs
+++ b/test/phoenix_kit_web/components/core/bulk_select_test.exs
@@ -1,0 +1,209 @@
+defmodule PhoenixKitWeb.Components.Core.BulkSelectTest do
+  @moduledoc """
+  Render tests for the three client-side bulk-select components.
+  Selection state lives in the DOM, owned by the `BulkSelectScope`
+  hook — these tests pin the wire-format (attribute names, hook
+  identifiers, default labels) the hook expects to find.
+  """
+  use ExUnit.Case, async: true
+
+  import Phoenix.LiveViewTest, only: [rendered_to_string: 1]
+  import Phoenix.Component, only: [sigil_H: 2]
+  import PhoenixKitWeb.Components.Core.BulkSelect
+
+  describe "bulk_select_scope/1" do
+    test "renders div with PkScope hook + data-bulk-total" do
+      assigns = %{}
+
+      result =
+        rendered_to_string(~H"""
+        <.bulk_select_scope id="my-scope" total_count={17}>
+          <span>child</span>
+        </.bulk_select_scope>
+        """)
+
+      assert result =~ ~s(id="my-scope")
+      assert result =~ ~s(phx-hook="BulkSelectScope")
+      assert result =~ ~s(data-bulk-total="17")
+      assert result =~ "<span>child</span>"
+    end
+
+    test "respects custom class" do
+      assigns = %{}
+
+      result =
+        rendered_to_string(~H"""
+        <.bulk_select_scope id="s" total_count={0} class="my-custom-class">
+          x
+        </.bulk_select_scope>
+        """)
+
+      assert result =~ "my-custom-class"
+    end
+  end
+
+  describe "bulk_select_header_cell/1" do
+    test "renders th + select-all checkbox with hook data attributes" do
+      assigns = %{}
+
+      result =
+        rendered_to_string(~H"""
+        <.bulk_select_header_cell id="select-all-projects" />
+        """)
+
+      assert result =~ "<th"
+      assert result =~ ~s(id="select-all-projects")
+      assert result =~ ~s(data-bulk-role="select-all")
+      assert result =~ ~s(type="checkbox")
+      # Default aria_label.
+      assert result =~ "Toggle select all"
+    end
+
+    test "custom aria_label overrides default" do
+      assigns = %{}
+
+      result =
+        rendered_to_string(~H"""
+        <.bulk_select_header_cell id="s" aria_label="Pick all the projects" />
+        """)
+
+      assert result =~ "Pick all the projects"
+    end
+  end
+
+  describe "bulk_select_cell/1" do
+    test "renders per-row checkbox bound to the uuid" do
+      assigns = %{}
+
+      result =
+        rendered_to_string(~H"""
+        <.bulk_select_cell value="11111111-1111-7000-8000-000000000001" />
+        """)
+
+      assert result =~ ~s(data-bulk-role="row")
+      assert result =~ ~s(data-uuid="11111111-1111-7000-8000-000000000001")
+      assert result =~ ~s(type="checkbox")
+    end
+  end
+
+  describe "bulk_actions_toolbar/1" do
+    test "renders reorder button with the configured event name" do
+      assigns = %{}
+
+      result =
+        rendered_to_string(~H"""
+        <.bulk_actions_toolbar on_open_reorder="open_reorder_modal" />
+        """)
+
+      assert result =~ ~s(data-bulk-action="open_reorder_modal")
+      # Default reorder_gate is :always — the button shows the "Reorder all" label by default.
+      assert result =~ "Reorder all"
+      # Reorder button (the one with `data-bulk-action`) must not start
+      # hidden. The Clear button always carries `style="display: none;"`
+      # because it hides when selection is empty — so we can't just
+      # check the absence of that style globally.
+      reorder_chunk =
+        result
+        |> String.split(~s(data-bulk-action="open_reorder_modal"))
+        |> Enum.at(1)
+        |> String.slice(0, 200)
+
+      refute reorder_chunk =~ ~s(style="display: none;)
+    end
+
+    test ":multi gate hides the reorder button initially" do
+      assigns = %{}
+
+      result =
+        rendered_to_string(~H"""
+        <.bulk_actions_toolbar on_open_reorder="open_reorder_modal" reorder_gate={:multi} />
+        """)
+
+      # The button still renders but is hidden via inline style; the hook
+      # flips it visible when 2+ rows are selected.
+      assert result =~ ~s(data-bulk-show="has-multiple")
+      assert result =~ ~s(style="display: none;)
+    end
+
+    test "delete button only renders when on_bulk_delete is set" do
+      assigns = %{}
+
+      without =
+        rendered_to_string(~H"""
+        <.bulk_actions_toolbar on_open_reorder="r" />
+        """)
+
+      refute without =~ "Delete"
+
+      with_delete =
+        rendered_to_string(~H"""
+        <.bulk_actions_toolbar on_open_reorder="r" on_bulk_delete="bulk_delete" />
+        """)
+
+      assert with_delete =~ ~s(data-bulk-action="bulk_delete")
+      assert with_delete =~ "Delete"
+    end
+
+    test "delete button does NOT render when allow_delete is false even if on_bulk_delete given" do
+      assigns = %{}
+
+      result =
+        rendered_to_string(~H"""
+        <.bulk_actions_toolbar
+          on_open_reorder="r"
+          on_bulk_delete="bulk_delete"
+          allow_delete={false}
+        />
+        """)
+
+      refute result =~ ~s(data-bulk-action="bulk_delete")
+    end
+
+    test "noun_singular / noun_plural feed the reorder label template" do
+      assigns = %{}
+
+      result =
+        rendered_to_string(~H"""
+        <.bulk_actions_toolbar
+          on_open_reorder="r"
+          noun_singular="project"
+          noun_plural="projects"
+        />
+        """)
+
+      # The translated "%{count} selected" template ships as the data
+      # attr the hook reads at click time. Pin its presence.
+      assert result =~ ~s(data-bulk-label-selected)
+    end
+
+    test "reorder_dialog_id wires the dialog-id for instant client open" do
+      assigns = %{}
+
+      result =
+        rendered_to_string(~H"""
+        <.bulk_actions_toolbar
+          on_open_reorder="open_reorder_modal"
+          reorder_dialog_id="reorder-modal"
+        />
+        """)
+
+      assert result =~ ~s(data-bulk-opens-dialog="reorder-modal")
+    end
+
+    test "leading slot renders before action buttons" do
+      assigns = %{}
+
+      result =
+        rendered_to_string(~H"""
+        <.bulk_actions_toolbar on_open_reorder="r">
+          <:leading><span class="sort-here">SORT</span></:leading>
+        </.bulk_actions_toolbar>
+        """)
+
+      # `sort-here` should appear before `data-bulk-action`.
+      sort_idx = :binary.match(result, "sort-here") |> elem(0)
+      action_idx = :binary.match(result, "data-bulk-action") |> elem(0)
+      assert sort_idx < action_idx
+    end
+  end
+end

--- a/test/phoenix_kit_web/components/core/load_more_test.exs
+++ b/test/phoenix_kit_web/components/core/load_more_test.exs
@@ -1,0 +1,77 @@
+defmodule PhoenixKitWeb.Components.Core.LoadMoreTest do
+  @moduledoc """
+  Render tests for `<.load_more>`. Pins three branches:
+
+  - total=0 → component renders nothing (empty list / not loaded yet)
+  - 0<loaded<total → status line + Load more button
+  - loaded>=total → status line only, no button (fully loaded)
+  """
+  use ExUnit.Case, async: true
+
+  import Phoenix.LiveViewTest, only: [rendered_to_string: 1]
+  import Phoenix.Component, only: [sigil_H: 2]
+  import PhoenixKitWeb.Components.Core.Pagination, only: [load_more: 1]
+
+  describe "load_more/1" do
+    test "total=0 renders nothing" do
+      assigns = %{}
+
+      result =
+        rendered_to_string(~H"""
+        <.load_more loaded={0} total={0} />
+        """)
+
+      refute result =~ "Showing"
+      refute result =~ "Load more"
+    end
+
+    test "loaded < total → status text + Load more button" do
+      assigns = %{}
+
+      result =
+        rendered_to_string(~H"""
+        <.load_more loaded={50} total={120} noun_plural="projects" />
+        """)
+
+      assert result =~ "Showing 50 of 120 projects"
+      assert result =~ "Load more"
+      assert result =~ ~s(phx-click="load_more")
+      assert result =~ ~s(phx-disable-with="Loading…")
+    end
+
+    test "loaded >= total → status text but no button" do
+      assigns = %{}
+
+      result =
+        rendered_to_string(~H"""
+        <.load_more loaded={120} total={120} noun_plural="projects" />
+        """)
+
+      assert result =~ "Showing 120 of 120 projects"
+      refute result =~ ~s(>Load more</button>)
+    end
+
+    test "custom on_load_more rewires the click event" do
+      assigns = %{}
+
+      result =
+        rendered_to_string(~H"""
+        <.load_more loaded={10} total={50} on_load_more="my_load_event" />
+        """)
+
+      assert result =~ ~s(phx-click="my_load_event")
+    end
+
+    test "loaded == 0 with total > 0 renders the button" do
+      assigns = %{}
+
+      result =
+        rendered_to_string(~H"""
+        <.load_more loaded={0} total={5} noun_plural="items" />
+        """)
+
+      assert result =~ "Showing 0 of 5 items"
+      assert result =~ "Load more"
+    end
+  end
+end

--- a/test/phoenix_kit_web/components/core/modal_keep_in_dom_test.exs
+++ b/test/phoenix_kit_web/components/core/modal_keep_in_dom_test.exs
@@ -1,0 +1,136 @@
+defmodule PhoenixKitWeb.Components.Core.ModalKeepInDomTest do
+  @moduledoc """
+  Render tests for `<.modal>`'s `keep_in_dom` branch — the new mode
+  added to support instant client-side open via the `PkDialog` hook.
+  Default behaviour (conditional render) is preserved for backwards
+  compat.
+  """
+  use ExUnit.Case, async: true
+
+  import Phoenix.LiveViewTest, only: [rendered_to_string: 1]
+  import Phoenix.Component, only: [sigil_H: 2]
+  import PhoenixKitWeb.Components.Core.Modal, only: [modal: 1]
+
+  describe "modal/1 default (keep_in_dom=false)" do
+    test "show=false → not rendered at all" do
+      assigns = %{}
+
+      result =
+        rendered_to_string(~H"""
+        <.modal show={false} on_close="close">
+          <:title>Hidden</:title>
+          inside
+        </.modal>
+        """)
+
+      refute result =~ "<dialog"
+      refute result =~ "Hidden"
+      refute result =~ "inside"
+    end
+
+    test "show=true → renders dialog with data-show='true'" do
+      assigns = %{}
+
+      result =
+        rendered_to_string(~H"""
+        <.modal show={true} on_close="close">
+          <:title>Visible</:title>
+          inside
+        </.modal>
+        """)
+
+      assert result =~ "<dialog"
+      assert result =~ ~s(data-show="true")
+      assert result =~ "Visible"
+      assert result =~ "inside"
+    end
+  end
+
+  describe "modal/1 with keep_in_dom=true" do
+    test "show=false STILL renders the dialog with data-show='false'" do
+      assigns = %{}
+
+      result =
+        rendered_to_string(~H"""
+        <.modal show={false} on_close="close" keep_in_dom>
+          <:title>Stays put</:title>
+          inside
+        </.modal>
+        """)
+
+      assert result =~ "<dialog"
+      assert result =~ ~s(data-show="false")
+      assert result =~ ~s(phx-hook="PkDialog")
+      # Inner content still in DOM — that's the whole point.
+      assert result =~ "Stays put"
+      assert result =~ "inside"
+    end
+
+    test "show=true → data-show='true' (same as default branch)" do
+      assigns = %{}
+
+      result =
+        rendered_to_string(~H"""
+        <.modal show={true} on_close="close" keep_in_dom>
+          inside
+        </.modal>
+        """)
+
+      assert result =~ ~s(data-show="true")
+      assert result =~ ~s(phx-hook="PkDialog")
+    end
+
+    test "close-event attr wires on_close for the hook" do
+      assigns = %{}
+
+      result =
+        rendered_to_string(~H"""
+        <.modal show={false} on_close="my_close" keep_in_dom>
+          inside
+        </.modal>
+        """)
+
+      assert result =~ ~s(data-close-event="my_close")
+    end
+
+    test "id is derived from on_close when not explicitly passed" do
+      assigns = %{}
+
+      result =
+        rendered_to_string(~H"""
+        <.modal show={false} on_close="close_reorder_modal" keep_in_dom>
+          inside
+        </.modal>
+        """)
+
+      assert result =~ ~s(id="pk-modal-close_reorder_modal")
+    end
+
+    test "explicit id overrides the derived id" do
+      assigns = %{}
+
+      result =
+        rendered_to_string(~H"""
+        <.modal id="my-dialog" show={false} on_close="x" keep_in_dom>
+          inside
+        </.modal>
+        """)
+
+      assert result =~ ~s(id="my-dialog")
+      refute result =~ ~s(id="pk-modal-x")
+    end
+
+    test "closeable=false flips the data attr" do
+      assigns = %{}
+
+      result =
+        rendered_to_string(~H"""
+        <.modal show={true} on_close="x" closeable={false}>
+          inside
+        </.modal>
+        """)
+
+      assert result =~ ~s(data-closeable="false")
+    end
+  end
+end

--- a/test/phoenix_kit_web/components/core/reorder_modal_test.exs
+++ b/test/phoenix_kit_web/components/core/reorder_modal_test.exs
@@ -1,0 +1,222 @@
+defmodule PhoenixKitWeb.Components.Core.ReorderModalTest do
+  @moduledoc """
+  Render tests for `<.reorder_modal>`. The component is shell + radio
+  UI around `<.modal>` with `keep_in_dom={true}` and a strategy-radio
+  form. Tests pin:
+
+  - Scope label switches between "Reorder all N" and "Reorder N selected"
+  - Strategy radios render with the consumer-supplied values + labels
+  - The Apply button submits the strategy radio form
+  - The dialog stays in the DOM (data-show flip drives visibility)
+  - `phx-disable-with` on Apply blocks rapid resubmits
+  """
+  use ExUnit.Case, async: true
+
+  import Phoenix.LiveViewTest, only: [rendered_to_string: 1]
+  import Phoenix.Component, only: [sigil_H: 2]
+  import PhoenixKitWeb.Components.Core.ReorderModal
+
+  @strategies [
+    {"name_asc", "A → Z by name"},
+    {"name_desc", "Z → A by name"},
+    {"created_desc", "Newest first"},
+    {"created_asc", "Oldest first"},
+    {"reverse", "Reverse current order"}
+  ]
+
+  describe "reorder_modal/1" do
+    test "renders all strategy radios with their values + labels" do
+      assigns = %{strategies: @strategies}
+
+      result =
+        rendered_to_string(~H"""
+        <.reorder_modal
+          show={false}
+          on_close="close"
+          on_apply="apply"
+          selected_count={0}
+          total_count={10}
+          strategies={@strategies}
+          noun_singular="project"
+          noun_plural="projects"
+        />
+        """)
+
+      for {value, label} <- @strategies do
+        assert result =~ ~s(value="#{value}")
+        assert result =~ label
+      end
+    end
+
+    test "selected_count=0 → 'Reorder all' label" do
+      assigns = %{strategies: @strategies}
+
+      result =
+        rendered_to_string(~H"""
+        <.reorder_modal
+          show={false}
+          on_close="close"
+          on_apply="apply"
+          selected_count={0}
+          total_count={42}
+          strategies={@strategies}
+          noun_singular="project"
+          noun_plural="projects"
+        />
+        """)
+
+      assert result =~ "Reorder all 42 projects"
+    end
+
+    test "selected_count=1 → singular 'selected' label" do
+      assigns = %{strategies: @strategies}
+
+      result =
+        rendered_to_string(~H"""
+        <.reorder_modal
+          show={false}
+          on_close="close"
+          on_apply="apply"
+          selected_count={1}
+          total_count={42}
+          strategies={@strategies}
+          noun_singular="project"
+          noun_plural="projects"
+        />
+        """)
+
+      assert result =~ "1 selected project"
+    end
+
+    test "selected_count=N>1 → 'N selected projects' label" do
+      assigns = %{strategies: @strategies}
+
+      result =
+        rendered_to_string(~H"""
+        <.reorder_modal
+          show={false}
+          on_close="close"
+          on_apply="apply"
+          selected_count={3}
+          total_count={42}
+          strategies={@strategies}
+          noun_singular="project"
+          noun_plural="projects"
+        />
+        """)
+
+      assert result =~ "3 selected projects"
+    end
+
+    test "kept in DOM regardless of show=false (data-show='false')" do
+      assigns = %{strategies: @strategies}
+
+      result =
+        rendered_to_string(~H"""
+        <.reorder_modal
+          show={false}
+          on_close="close"
+          on_apply="apply"
+          selected_count={0}
+          total_count={1}
+          strategies={@strategies}
+        />
+        """)
+
+      assert result =~ "<dialog"
+      assert result =~ ~s(data-show="false")
+    end
+
+    test "show=true flips data-show to true" do
+      assigns = %{strategies: @strategies}
+
+      result =
+        rendered_to_string(~H"""
+        <.reorder_modal
+          show={true}
+          on_close="close_event"
+          on_apply="apply_event"
+          selected_count={0}
+          total_count={1}
+          strategies={@strategies}
+        />
+        """)
+
+      assert result =~ ~s(data-show="true")
+    end
+
+    test "wires on_apply as the form's phx-submit" do
+      assigns = %{strategies: @strategies}
+
+      result =
+        rendered_to_string(~H"""
+        <.reorder_modal
+          show={true}
+          on_close="close"
+          on_apply="my_apply_event"
+          selected_count={0}
+          total_count={1}
+          strategies={@strategies}
+        />
+        """)
+
+      assert result =~ ~s(phx-submit="my_apply_event")
+    end
+
+    test "Apply button has phx-disable-with to prevent double-submit" do
+      assigns = %{strategies: @strategies}
+
+      result =
+        rendered_to_string(~H"""
+        <.reorder_modal
+          show={true}
+          on_close="close"
+          on_apply="apply"
+          selected_count={0}
+          total_count={1}
+          strategies={@strategies}
+        />
+        """)
+
+      assert result =~ ~s(phx-disable-with="Applying…")
+    end
+
+    test "respects custom id (used as dialog id + form id prefix)" do
+      assigns = %{strategies: @strategies}
+
+      result =
+        rendered_to_string(~H"""
+        <.reorder_modal
+          show={false}
+          on_close="close"
+          on_apply="apply"
+          selected_count={0}
+          total_count={1}
+          strategies={@strategies}
+          id="my-reorder"
+        />
+        """)
+
+      assert result =~ ~s(id="my-reorder")
+      assert result =~ ~s(id="my-reorder-form")
+    end
+
+    test "Cancel button fires on_close" do
+      assigns = %{strategies: @strategies}
+
+      result =
+        rendered_to_string(~H"""
+        <.reorder_modal
+          show={true}
+          on_close="my_close_event"
+          on_apply="apply"
+          selected_count={0}
+          total_count={1}
+          strategies={@strategies}
+        />
+        """)
+
+      assert result =~ ~s(phx-click="my_close_event")
+    end
+  end
+end

--- a/test/phoenix_kit_web/components/core/sort_selector_test.exs
+++ b/test/phoenix_kit_web/components/core/sort_selector_test.exs
@@ -1,0 +1,195 @@
+defmodule PhoenixKitWeb.Components.Core.SortSelectorTest do
+  @moduledoc """
+  Render tests for `<.sort_selector>`. Pins:
+
+  - select element renders with the current sort_by + options
+  - direction toggle button renders with the flipped direction value
+  - direction icon switches between asc/desc heroicons
+  - manual mode hides the direction toggle
+  - atom-or-string normalization on sort_by, sort_dir, options
+  - empty/malformed options → empty render, no crash
+  """
+  use ExUnit.Case, async: true
+
+  import Phoenix.LiveViewTest, only: [rendered_to_string: 1]
+  import Phoenix.Component, only: [sigil_H: 2]
+  import PhoenixKitWeb.Components.Core.SortSelector
+
+  @options [
+    {:position, "Manual"},
+    {:name, "Name"},
+    {:inserted_at, "Date created"}
+  ]
+
+  describe "sort_selector/1" do
+    test "renders form + select with the current sort field" do
+      assigns = %{options: @options}
+
+      result =
+        rendered_to_string(~H"""
+        <.sort_selector sort_by={:name} sort_dir={:asc} options={@options} />
+        """)
+
+      assert result =~ "<form"
+      assert result =~ ~s(phx-change="sort_form")
+      assert result =~ ~s(name="sort_by")
+      # `<.select>` renders the current value's option marked selected.
+      assert result =~ "Name"
+    end
+
+    test "direction toggle button shows asc icon when sort_dir=:asc" do
+      assigns = %{options: @options}
+
+      result =
+        rendered_to_string(~H"""
+        <.sort_selector sort_by={:name} sort_dir={:asc} options={@options} />
+        """)
+
+      assert result =~ "hero-bars-arrow-up"
+      # Click sends the flipped direction.
+      assert result =~ ~s(phx-value-sort_dir="desc")
+    end
+
+    test "direction toggle button shows desc icon when sort_dir=:desc" do
+      assigns = %{options: @options}
+
+      result =
+        rendered_to_string(~H"""
+        <.sort_selector sort_by={:name} sort_dir={:desc} options={@options} />
+        """)
+
+      assert result =~ "hero-bars-arrow-down"
+      assert result =~ ~s(phx-value-sort_dir="asc")
+    end
+
+    test "manual mode hides the direction toggle button" do
+      assigns = %{options: @options}
+
+      result =
+        rendered_to_string(~H"""
+        <.sort_selector
+          sort_by={:position}
+          sort_dir={:asc}
+          options={@options}
+          manual_field={:position}
+        />
+        """)
+
+      refute result =~ ~s(phx-value-sort_dir)
+      refute result =~ "hero-bars-arrow-up"
+      refute result =~ "hero-bars-arrow-down"
+    end
+
+    test "manual_field as string still matches sort_by atom" do
+      assigns = %{options: @options}
+
+      result =
+        rendered_to_string(~H"""
+        <.sort_selector
+          sort_by={:position}
+          sort_dir={:asc}
+          options={@options}
+          manual_field="position"
+        />
+        """)
+
+      refute result =~ ~s(phx-value-sort_dir)
+    end
+
+    test "non-manual sort_by + manual_field set → toggle still visible" do
+      assigns = %{options: @options}
+
+      result =
+        rendered_to_string(~H"""
+        <.sort_selector
+          sort_by={:name}
+          sort_dir={:asc}
+          options={@options}
+          manual_field={:position}
+        />
+        """)
+
+      assert result =~ ~s(phx-value-sort_dir="desc")
+    end
+
+    test "unknown sort_dir falls back to :asc" do
+      assigns = %{options: @options}
+
+      result =
+        rendered_to_string(~H"""
+        <.sort_selector sort_by={:name} sort_dir="banana" options={@options} />
+        """)
+
+      assert result =~ "hero-bars-arrow-up"
+    end
+
+    test "atom or string sort_by both work" do
+      assigns = %{options: @options}
+
+      r_atom =
+        rendered_to_string(~H"""
+        <.sort_selector sort_by={:name} sort_dir={:asc} options={@options} />
+        """)
+
+      r_string =
+        rendered_to_string(~H"""
+        <.sort_selector sort_by="name" sort_dir={:asc} options={@options} />
+        """)
+
+      # Both render the form + sort_by select identically.
+      assert r_atom =~ ~s(name="sort_by")
+      assert r_string =~ ~s(name="sort_by")
+    end
+
+    test "empty options list → empty render, no crash" do
+      assigns = %{}
+
+      result =
+        rendered_to_string(~H"""
+        <.sort_selector sort_by={:name} sort_dir={:asc} options={[]} />
+        """)
+
+      refute result =~ "<form"
+    end
+
+    test "nil options → empty render" do
+      assigns = %{}
+
+      result =
+        rendered_to_string(~H"""
+        <.sort_selector sort_by={:name} sort_dir={:asc} options={nil} />
+        """)
+
+      refute result =~ "<form"
+    end
+
+    test "options with one bad row → other rows survive, no crash" do
+      assigns = %{options: [{:name, "Name"}, "not_a_tuple", {:created_at, "Created"}]}
+
+      result =
+        rendered_to_string(~H"""
+        <.sort_selector sort_by={:name} sort_dir={:asc} options={@options} />
+        """)
+
+      assert result =~ "Name"
+      assert result =~ "Created"
+    end
+
+    test "custom event name flows to form + button" do
+      assigns = %{options: @options}
+
+      result =
+        rendered_to_string(~H"""
+        <.sort_selector
+          sort_by={:name}
+          sort_dir={:asc}
+          options={@options}
+          event="my_sort"
+        />
+        """)
+
+      assert result =~ ~s(phx-change="my_sort")
+      assert result =~ ~s(phx-click="my_sort")
+    end
+  end
+end

--- a/test/phoenix_kit_web/components/core/sortable_test.exs
+++ b/test/phoenix_kit_web/components/core/sortable_test.exs
@@ -1,0 +1,115 @@
+defmodule PhoenixKitWeb.Components.Core.SortableTest do
+  @moduledoc """
+  Render tests for `<.sortable_tbody>` and `<.sortable_row>`. These
+  components encode the wire-format the `SortableGrid` JS hook reads.
+  The tests pin the hook identifier, data attributes, and the
+  enable/disable branch.
+  """
+  use ExUnit.Case, async: true
+
+  import Phoenix.LiveViewTest, only: [rendered_to_string: 1]
+  import Phoenix.Component, only: [sigil_H: 2]
+  import PhoenixKitWeb.Components.Core.Sortable
+
+  describe "sortable_tbody/1" do
+    test "enabled attaches SortableGrid hook + data attrs" do
+      assigns = %{}
+
+      result =
+        rendered_to_string(~H"""
+        <.sortable_tbody id="projects-body" event="reorder_projects">
+          <tr>
+            <td>row</td>
+          </tr>
+        </.sortable_tbody>
+        """)
+
+      assert result =~ ~s(id="projects-body")
+      assert result =~ ~s(phx-hook="SortableGrid")
+      assert result =~ ~s(data-sortable="true")
+      assert result =~ ~s(data-sortable-event="reorder_projects")
+      assert result =~ ~s(data-sortable-items=".sortable-item")
+      assert result =~ ~s(data-sortable-handle=".pk-drag-handle")
+      assert result =~ "<tr>"
+      assert result =~ "<td>row</td>"
+    end
+
+    test "disabled omits the hook and data-sortable but keeps the event attr" do
+      assigns = %{}
+
+      result =
+        rendered_to_string(~H"""
+        <.sortable_tbody id="projects-body" event="reorder_projects" enabled={false}>
+          <tr>
+            <td>row</td>
+          </tr>
+        </.sortable_tbody>
+        """)
+
+      refute result =~ ~s(phx-hook="SortableGrid")
+      # Implementation renders the attribute name with an empty value
+      # rather than omitting the attribute, because `if @enabled, do: ...`
+      # in HEEx evaluates to `nil` when false. Both states tell the hook
+      # "not me" identically — pin the practical outcome (no hook attached).
+      refute result =~ ~s(data-sortable="true")
+    end
+
+    test "extra attrs pass through via :rest" do
+      assigns = %{}
+
+      result =
+        rendered_to_string(~H"""
+        <.sortable_tbody id="b" event="evt" data-extra="yep">
+          <tr></tr>
+        </.sortable_tbody>
+        """)
+
+      assert result =~ ~s(data-extra="yep")
+    end
+  end
+
+  describe "sortable_row/1" do
+    test "renders tr with sortable-item class + data-id" do
+      assigns = %{}
+
+      result =
+        rendered_to_string(~H"""
+        <.sortable_row item_id="abc-uuid">
+          <td>cell</td>
+        </.sortable_row>
+        """)
+
+      assert result =~ "<tr"
+      assert result =~ "sortable-item"
+      assert result =~ ~s(data-id="abc-uuid")
+      assert result =~ "<td>cell</td>"
+    end
+
+    test "consumer class composes alongside sortable-item" do
+      assigns = %{}
+
+      result =
+        rendered_to_string(~H"""
+        <.sortable_row item_id="uuid" class="my-row-class">
+          <td>c</td>
+        </.sortable_row>
+        """)
+
+      assert result =~ "sortable-item"
+      assert result =~ "my-row-class"
+    end
+
+    test "extra attrs pass through" do
+      assigns = %{}
+
+      result =
+        rendered_to_string(~H"""
+        <.sortable_row item_id="u" data-x="y">
+          <td>c</td>
+        </.sortable_row>
+        """)
+
+      assert result =~ ~s(data-x="y")
+    end
+  end
+end

--- a/test/phoenix_kit_web/components/core/table_default_test.exs
+++ b/test/phoenix_kit_web/components/core/table_default_test.exs
@@ -255,4 +255,133 @@ defmodule PhoenixKitWeb.Components.Core.TableDefaultTest do
       assert count == 2, "phx-target should appear on both <form> and <input>, got #{count}"
     end
   end
+
+  # ── table_default_row/1 ───────────────────────────────────────────
+
+  describe "table_default_row/1" do
+    test "carries the `group` Tailwind marker for group-hover children" do
+      assigns = %{}
+
+      result =
+        rendered_to_string(~H"""
+        <.table_default_row>
+          <td>row</td>
+        </.table_default_row>
+        """)
+
+      assert result =~ "<tr"
+      # `group` is what makes `<.drag_handle_cell>`'s opacity-0 +
+      # group-hover:opacity-100 reveal-on-hover work. Removing it from
+      # the row class set would silently kill the drag-handle UX.
+      assert result =~ "group"
+    end
+
+    test "consumer class composes alongside `group`" do
+      assigns = %{}
+
+      result =
+        rendered_to_string(~H"""
+        <.table_default_row class="my-extra">
+          <td>x</td>
+        </.table_default_row>
+        """)
+
+      assert result =~ "group"
+      assert result =~ "my-extra"
+    end
+
+    test "hover=false drops the hover class" do
+      assigns = %{}
+
+      result =
+        rendered_to_string(~H"""
+        <.table_default_row hover={false}>
+          <td>x</td>
+        </.table_default_row>
+        """)
+
+      # Should still have `group`, but the daisyUI `hover` class is gone.
+      assert result =~ "group"
+      refute result =~ ~s(class="group hover)
+    end
+  end
+
+  # ── drag_handle_cell/1 + drag_handle_header_cell/1 ─────────────────
+
+  describe "drag_handle_cell/1" do
+    test "renders td with pk-drag-handle + group-hover hide-until-hover classes" do
+      assigns = %{}
+
+      result =
+        rendered_to_string(~H"""
+        <.drag_handle_cell />
+        """)
+
+      assert result =~ "<td"
+      # SortableJS hook reads this selector for the drag handle.
+      assert result =~ "pk-drag-handle"
+      assert result =~ "cursor-grab"
+      # Hide-until-hover: parent row has `group`, this cell has
+      # `opacity-0 group-hover:opacity-100`.
+      assert result =~ "opacity-0"
+      assert result =~ "group-hover:opacity-100"
+      # Default heroicon for the handle.
+      assert result =~ "hero-bars-3"
+    end
+
+    test "has a default title for accessibility" do
+      assigns = %{}
+
+      result =
+        rendered_to_string(~H"""
+        <.drag_handle_cell />
+        """)
+
+      assert result =~ "Drag to reorder"
+    end
+
+    test "custom title overrides default" do
+      assigns = %{}
+
+      result =
+        rendered_to_string(~H"""
+        <.drag_handle_cell title="Move me" />
+        """)
+
+      assert result =~ "Move me"
+    end
+
+    test "default width class matches the matching header cell" do
+      assigns = %{}
+
+      cell =
+        rendered_to_string(~H"""
+        <.drag_handle_cell />
+        """)
+
+      header =
+        rendered_to_string(~H"""
+        <.drag_handle_header_cell />
+        """)
+
+      # Both default to `w-8` so columns stay aligned without the consumer
+      # repeating the width on both sides.
+      assert cell =~ "w-8"
+      assert header =~ "w-8"
+    end
+  end
+
+  describe "drag_handle_header_cell/1" do
+    test "renders an empty <th>" do
+      assigns = %{}
+
+      result =
+        rendered_to_string(~H"""
+        <.drag_handle_header_cell />
+        """)
+
+      assert result =~ "<th"
+      assert result =~ "w-8"
+    end
+  end
 end

--- a/test/phoenix_kit_web/components/media_gallery_test.exs
+++ b/test/phoenix_kit_web/components/media_gallery_test.exs
@@ -542,7 +542,7 @@ defmodule PhoenixKitWeb.Components.MediaGalleryTest do
       refute html =~ ~s(disabled="")
     end
 
-    test "Add button is disabled when selection equals max_count" do
+    test "Add tile is omitted when selection equals max_count" do
       uuid = "01900000-0000-7000-8000-000000000001"
 
       html =
@@ -555,12 +555,13 @@ defmodule PhoenixKitWeb.Components.MediaGalleryTest do
           })
         )
 
-      # Phoenix renders boolean true attr as bare `disabled` (no ="")
-      assert html =~ "cursor-not-allowed"
-      assert html =~ " disabled"
+      # The :add_button slot is conditional on `selection_at_limit?/3`
+      # so the entire trigger button is dropped (no disabled-state
+      # rendering). See media_gallery.html.heex line 71.
+      refute html =~ "open-picker-test-gallery"
     end
 
-    test "Add button is disabled in :single mode with one item" do
+    test "Add tile is omitted in :single mode with one item" do
       uuid = "01900000-0000-7000-8000-000000000001"
 
       html =
@@ -573,8 +574,7 @@ defmodule PhoenixKitWeb.Components.MediaGalleryTest do
           })
         )
 
-      assert html =~ "cursor-not-allowed"
-      assert html =~ " disabled"
+      refute html =~ "open-picker-test-gallery"
     end
 
     test "Add button is enabled in :single mode with empty selection" do


### PR DESCRIPTION
## Summary

- Switch `<.modal>` from `<div class="modal">` to a native `<dialog>` with the new `PkDialog` JS hook. Adds a `keep_in_dom` mode for client-driven instant-open (the kept-in-DOM dialog stays in the tree, `data-show` flips visibility).
- New core list-UI toolkit: `<.bulk_select_scope>` + `<.bulk_select_header_cell>` + `<.bulk_select_cell>` + `<.bulk_actions_toolbar>` (client-side selection via `BulkSelectScope` hook), `<.sortable_tbody>` + `<.sortable_row>`, `<.drag_handle_cell>` + `<.drag_handle_header_cell>` on `<.table_default>`, `<.reorder_modal>` strategy picker, `<.load_more>` pagination footer.
- `<.sort_selector>` race-free design (select sends only `sort_by`, arrow sends only `sort_dir`; LV handler derives the missing half from assigns).

## Critical bug fixed in this PR

When `BulkSelectScope` opened the reorder dialog via `showModal()` for instant-open, Phoenix LV's DOM patcher then stripped the browser-added `open` attribute on the next re-render. The dialog stayed in the top-layer (still capturing all clicks) while CSS `dialog:not([open])` rendered it `display: none` — visually closed but blocking the rest of the page.

`PkDialog._sync()` now uses the `:modal` pseudo-class as the truth source instead of `el.open`; restores the stripped attribute before `close()` so the top-layer is actually released. `_closeFromLV` flag suppresses the redundant close echo when LV initiated the close. `:modal` is wrapped in try/catch with `el.open` fallback for engines that lack the pseudo-class.

`BulkSelectScope.updated()` now preserves the in-memory selection Set against the freshly-rendered DOM, so checked rows survive `apply_reorder` / `load_more` / sort changes. Rows whose uuids are no longer in the DOM drop out. Assigns checked=true OR false explicitly so a recycled input node can't leak stale state.

## Polish
- PR #550 / #554 / #559 follow-ups (creator_uuid adapter whitelist, prefixless_primary? single-read in redirects + LocalePath docstring, registration fieldset class).
- `<.drag_handle_cell>` default title actually renders (attr `default: nil` was shadowing `assign_new`).
- `<.modal keep_in_dom>` docstring warns about the auto-derived-id collision risk.

## Tests
- 6 new core component test files + drag_handle additions to `table_default_test.exs` (~80 render tests pinning bulk_select toolkit, sortable, reorder_modal, load_more, sort_selector, modal keep_in_dom branch, drag_handle hide-on-hover classes).
- `media_gallery_test.exs`: 2 stale max_count tests aligned to current omit-vs-disable behavior.

## Test plan
- [ ] `mix test` passes (1443 tests + 11 doctests).
- [ ] `mix precommit` passes (format + compile + credo --strict + dialyzer).
- [ ] Manual: open the bulk-action reorder modal in phoenix_kit_projects, apply a strategy, verify the page is fully clickable afterwards (the bug this PR fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)