### PR TITLE
V122 + V123: location_spaces, staff translations, catalogue folders

### DIFF
--- a/lib/mix/tasks/phoenix_kit.update.ex
+++ b/lib/mix/tasks/phoenix_kit.update.ex
@@ -90,6 +90,7 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
       Common,
       CssIntegration,
       DbConnectionCheck,
+      EndpointIntegration,
       IgniterHelpers,
       JsIntegration,
       ObanConfig,
@@ -138,6 +139,7 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
         |> BasicConfiguration.add_basic_config()
         |> ApplicationSupervisor.add_supervisor()
         |> BootHook.add_boot_hook()
+        |> EndpointIntegration.add_pdfjs_static_mount()
         |> perform_igniter_update(opts)
       end
     end

--- a/lib/phoenix_kit/install/endpoint_integration.ex
+++ b/lib/phoenix_kit/install/endpoint_integration.ex
@@ -13,8 +13,20 @@ defmodule PhoenixKit.Install.EndpointIntegration do
 
   alias Igniter.Code.{Common, Function}
   alias Igniter.Project.Application
+  alias Igniter.Project.Deps
   alias Igniter.Project.Module, as: IgniterModule
   alias PhoenixKit.Install.IgniterHelpers
+
+  # PDF.js viewer assets are vendored in phoenix_kit_catalogue's
+  # `priv/static/pdfjs/` and the host endpoint must serve them at
+  # `/_pdfjs/` for the catalogue PDF viewer to load. Mounted only when the
+  # catalogue module is a dependency.
+  @pdfjs_static_mount """
+  plug Plug.Static,
+    at: "/_pdfjs",
+    from: {:phoenix_kit_catalogue, "priv/static/pdfjs"},
+    gzip: false\
+  """
 
   @doc """
   Removes deprecated `phoenix_kit_socket()` and its import from the endpoint.
@@ -29,16 +41,59 @@ defmodule PhoenixKit.Install.EndpointIntegration do
   Updated igniter with deprecated socket code and import removed.
   """
   def add_endpoint_integration(igniter) do
-    case find_endpoint(igniter) do
-      {igniter, nil} ->
-        # No endpoint found, nothing to clean up
-        igniter
+    igniter =
+      case find_endpoint(igniter) do
+        {igniter, nil} ->
+          # No endpoint found, nothing to clean up
+          igniter
 
-      {igniter, endpoint_module} ->
-        igniter
-        |> remove_deprecated_socket(endpoint_module)
-        |> remove_deprecated_import(endpoint_module)
+        {igniter, endpoint_module} ->
+          igniter
+          |> remove_deprecated_socket(endpoint_module)
+          |> remove_deprecated_import(endpoint_module)
+      end
+
+    add_pdfjs_static_mount(igniter)
+  end
+
+  @doc """
+  Ensures the host endpoint serves phoenix_kit_catalogue's vendored PDF.js
+  viewer at `/_pdfjs/` via a `Plug.Static` mount.
+
+  Only added when `:phoenix_kit_catalogue` is a dependency (the mount
+  references that app's `priv`, so adding it without the dep would break
+  boot). Idempotent — skips when an `at: "/_pdfjs"` mount already exists.
+  Called by both `mix phoenix_kit.install` and `mix phoenix_kit.update`.
+  """
+  def add_pdfjs_static_mount(igniter) do
+    with true <- Deps.has_dep?(igniter, :phoenix_kit_catalogue),
+         {igniter, endpoint_module} when not is_nil(endpoint_module) <- find_endpoint(igniter),
+         {igniter, source, _zipper} <- IgniterModule.find_module!(igniter, endpoint_module),
+         false <- source |> Rewrite.Source.get(:content) |> String.contains?(~s(at: "/_pdfjs")) do
+      IgniterModule.find_and_update_module!(igniter, endpoint_module, fn zipper ->
+        case move_to_endpoint_use(zipper) do
+          {:ok, use_zipper} ->
+            {:ok, Common.add_code(use_zipper, @pdfjs_static_mount, placement: :after)}
+
+          :error ->
+            {:ok, zipper}
+        end
+      end)
+    else
+      # No catalogue dep, no endpoint, or mount already present.
+      _ -> igniter
     end
+  end
+
+  # Locate `use Phoenix.Endpoint, otp_app: ...` so the static mount can be
+  # inserted right after it (early in the plug pipeline).
+  defp move_to_endpoint_use(zipper) do
+    Function.move_to_function_call(zipper, :use, 2, fn call_zipper ->
+      case Function.move_to_nth_argument(call_zipper, 0) do
+        {:ok, arg_zipper} -> Common.nodes_equal?(arg_zipper, Phoenix.Endpoint)
+        :error -> false
+      end
+    end)
   end
 
   # Find endpoint module

--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -529,7 +529,14 @@ defmodule PhoenixKit.Migrations.Postgres do
   - Replaces unique index with partial index (slug-mode only, WHERE slug IS NOT NULL)
   - Adds unique index on `(group_uuid, post_date, post_time)` for timestamp-mode posts
 
-  ### V122 - Location spaces + staff translations + staff Person.name ⚡ LATEST
+  ### V123 - Catalogue folders ⚡ LATEST
+  - Creates `phoenix_kit_cat_folders` (self-nesting via `parent_uuid`,
+    `position`/`status`/`data`) — a dedicated folder layer for organizing
+    catalogues, unrelated to the media-folder system.
+  - Adds nullable `folder_uuid` FK to `phoenix_kit_cat_catalogues`
+    (`ON DELETE SET NULL`; NULL = unfiled / root).
+
+  ### V122 - Location spaces + staff translations + staff Person.name
   - Creates `phoenix_kit_location_spaces` for the per-Location nested
     tree of spaces. Required `location_uuid` FK (cascade) and optional
     `parent_uuid` self-ref FK (cascade); arbitrary depth.
@@ -1042,7 +1049,7 @@ defmodule PhoenixKit.Migrations.Postgres do
   use Ecto.Migration
 
   @initial_version 1
-  @current_version 122
+  @current_version 123
   @default_prefix "public"
 
   @doc false

--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -529,7 +529,7 @@ defmodule PhoenixKit.Migrations.Postgres do
   - Replaces unique index with partial index (slug-mode only, WHERE slug IS NOT NULL)
   - Adds unique index on `(group_uuid, post_date, post_time)` for timestamp-mode posts
 
-  ### V122 - Location spaces (rooms/floors/zones) ⚡ LATEST
+  ### V122 - Location spaces + staff translations + staff Person.name ⚡ LATEST
   - Creates `phoenix_kit_location_spaces` for the per-Location nested
     tree of spaces. Required `location_uuid` FK (cascade) and optional
     `parent_uuid` self-ref FK (cascade); arbitrary depth.
@@ -539,6 +539,18 @@ defmodule PhoenixKit.Migrations.Postgres do
   - The "child belongs to same Location as parent" cross-row invariant
     is enforced in the consumer context; a composite FK would be
     heavier than the surface justifies.
+  - Adds `translations JSONB NOT NULL DEFAULT '{}'` to
+    `phoenix_kit_staff_departments`, `phoenix_kit_staff_teams`, and
+    `phoenix_kit_staff_people` (mirrors the projects V112 settings-
+    translations shape: primary stays in dedicated columns, JSONB
+    holds non-primary overrides). Translatable fields by schema:
+    * Department: `name`, `description`
+    * Team: `name`, `description`
+    * Person: `job_title`, `bio`, `skills`, `notes`
+  - Adds a single nullable `name VARCHAR` to `phoenix_kit_staff_people`
+    for the staff person's full display name — consistent with every
+    other consumer schema in the staff plugin (Department / Team / Space
+    / Location all use a single `name`).
 
   ### V121 - Line annotation kind
   - Widens `phoenix_kit_annotations_kind_check` to accept `'line'`.

--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -529,7 +529,18 @@ defmodule PhoenixKit.Migrations.Postgres do
   - Replaces unique index with partial index (slug-mode only, WHERE slug IS NOT NULL)
   - Adds unique index on `(group_uuid, post_date, post_time)` for timestamp-mode posts
 
-  ### V121 - Line annotation kind ⚡ LATEST
+  ### V122 - Location spaces (rooms/floors/zones) ⚡ LATEST
+  - Creates `phoenix_kit_location_spaces` for the per-Location nested
+    tree of spaces. Required `location_uuid` FK (cascade) and optional
+    `parent_uuid` self-ref FK (cascade); arbitrary depth.
+  - `kind` is a CHECK-constrained enum (floor / room / hall / suite /
+    section / zone / aisle / shelf / corner) mirroring the consumer's
+    `PhoenixKitLocations.Schemas.Space @kinds`.
+  - The "child belongs to same Location as parent" cross-row invariant
+    is enforced in the consumer context; a composite FK would be
+    heavier than the surface justifies.
+
+  ### V121 - Line annotation kind
   - Widens `phoenix_kit_annotations_kind_check` to accept `'line'`.
   - Etcher gains a simple two-endpoint line tool alongside `dimension`
     (same geometry, no arrows, no inline numeric label). Title +
@@ -1019,7 +1030,7 @@ defmodule PhoenixKit.Migrations.Postgres do
   use Ecto.Migration
 
   @initial_version 1
-  @current_version 121
+  @current_version 122
   @default_prefix "public"
 
   @doc false

--- a/lib/phoenix_kit/migrations/postgres/v122.ex
+++ b/lib/phoenix_kit/migrations/postgres/v122.ex
@@ -37,6 +37,7 @@ defmodule PhoenixKit.Migrations.Postgres.V122 do
       add(
         :location_uuid,
         references(:phoenix_kit_locations,
+          column: :uuid,
           type: :uuid,
           on_delete: :delete_all,
           prefix: prefix
@@ -47,6 +48,7 @@ defmodule PhoenixKit.Migrations.Postgres.V122 do
       add(
         :parent_uuid,
         references(:phoenix_kit_location_spaces,
+          column: :uuid,
           type: :uuid,
           on_delete: :delete_all,
           prefix: prefix

--- a/lib/phoenix_kit/migrations/postgres/v122.ex
+++ b/lib/phoenix_kit/migrations/postgres/v122.ex
@@ -1,7 +1,10 @@
 defmodule PhoenixKit.Migrations.Postgres.V122 do
   @moduledoc """
-  V122: Create `phoenix_kit_location_spaces` — the nested-space (room /
-  floor / zone / etc.) breakdown under a `phoenix_kit_locations` row.
+  V122: Two unrelated additions bundled together because they shipped
+  in the same release cycle.
+
+  ## 1. `phoenix_kit_location_spaces` — nested floors / rooms / zones
+  under a `phoenix_kit_locations` row
 
   Each row belongs to exactly one Location (required FK, cascade) and
   may optionally belong to a parent Space within the same Location
@@ -18,6 +21,34 @@ defmodule PhoenixKit.Migrations.Postgres.V122 do
   and the multilang translation tree (`%{ "es-ES" => %{ "name" =>
   "..."} }`). Primary-language values stay denormalized in the
   dedicated `name` / `description` columns for cheap querying.
+
+  ## 2. `translations JSONB` on the three staff tables
+
+  Adds `translations JSONB NOT NULL DEFAULT '{}'` to
+  `phoenix_kit_staff_departments`, `phoenix_kit_staff_teams`, and
+  `phoenix_kit_staff_people`. Mirrors the settings-translations shape
+  already used by `phoenix_kit_projects` V112 (project / project_task /
+  project_assignment): primary stays in dedicated columns, the JSONB
+  holds non-primary overrides only.
+
+      %{"es-ES" => %{"name" => "...", "description" => "..."}}
+
+  Translatable fields by schema:
+
+    * Department: `name`, `description`
+    * Team: `name`, `description`
+    * Person: `job_title`, `bio`, `skills`, `notes`
+
+  Read paths use `<Schema>.localized_<field>/2` helpers with primary-
+  fallback semantics.
+
+  ## 3. `name` column on `phoenix_kit_staff_people`
+
+  Adds a single nullable `name VARCHAR` for the staff person's full
+  display name — consistent with Department, Team, Space, and Location
+  which all use a single `name` field. Owned by the staff profile
+  rather than `phoenix_kit_users` because placeholder users created via
+  `Staff.find_or_create_user_by_email/1` are anonymous until claimed.
   """
 
   use Ecto.Migration
@@ -104,12 +135,48 @@ defmodule PhoenixKit.Migrations.Postgres.V122 do
       CHECK (status IN ('active', 'inactive'))
     """)
 
+    # ── Staff translations columns ──────────────────────────────────
+    # ALTER TABLE ... ADD COLUMN IF NOT EXISTS — safe to re-run on a
+    # database that's already at V122 but missing the staff translation
+    # bits (the case for installs that picked up the early V122 before
+    # this bundling).
+    execute(
+      "ALTER TABLE #{p}phoenix_kit_staff_departments ADD COLUMN IF NOT EXISTS translations JSONB NOT NULL DEFAULT '{}'::jsonb"
+    )
+
+    execute(
+      "ALTER TABLE #{p}phoenix_kit_staff_teams ADD COLUMN IF NOT EXISTS translations JSONB NOT NULL DEFAULT '{}'::jsonb"
+    )
+
+    execute(
+      "ALTER TABLE #{p}phoenix_kit_staff_people ADD COLUMN IF NOT EXISTS translations JSONB NOT NULL DEFAULT '{}'::jsonb"
+    )
+
+    # ── Person.name ─────────────────────────────────────────────────
+    execute(
+      "ALTER TABLE #{p}phoenix_kit_staff_people ADD COLUMN IF NOT EXISTS name VARCHAR"
+    )
+
     execute("COMMENT ON TABLE #{p}phoenix_kit IS '122'")
   end
 
   def down(opts) do
     prefix = Map.get(opts, :prefix, "public")
     p = prefix_str(prefix)
+
+    execute("ALTER TABLE #{p}phoenix_kit_staff_people DROP COLUMN IF EXISTS name")
+
+    # Earlier V123 sketch added first / middle / last as three separate
+    # columns before we simplified to a single `name`. Drop them too so
+    # the rollback fully reverses any V122 shape that might already have
+    # been applied to this host.
+    execute("ALTER TABLE #{p}phoenix_kit_staff_people DROP COLUMN IF EXISTS first_name")
+    execute("ALTER TABLE #{p}phoenix_kit_staff_people DROP COLUMN IF EXISTS middle_name")
+    execute("ALTER TABLE #{p}phoenix_kit_staff_people DROP COLUMN IF EXISTS last_name")
+
+    execute("ALTER TABLE #{p}phoenix_kit_staff_departments DROP COLUMN IF EXISTS translations")
+    execute("ALTER TABLE #{p}phoenix_kit_staff_teams DROP COLUMN IF EXISTS translations")
+    execute("ALTER TABLE #{p}phoenix_kit_staff_people DROP COLUMN IF EXISTS translations")
 
     drop_if_exists(table(:phoenix_kit_location_spaces, prefix: prefix))
     execute("COMMENT ON TABLE #{p}phoenix_kit IS '121'")

--- a/lib/phoenix_kit/migrations/postgres/v122.ex
+++ b/lib/phoenix_kit/migrations/postgres/v122.ex
@@ -1,0 +1,118 @@
+defmodule PhoenixKit.Migrations.Postgres.V122 do
+  @moduledoc """
+  V122: Create `phoenix_kit_location_spaces` — the nested-space (room /
+  floor / zone / etc.) breakdown under a `phoenix_kit_locations` row.
+
+  Each row belongs to exactly one Location (required FK, cascade) and
+  may optionally belong to a parent Space within the same Location
+  (self-ref FK, cascade) forming a filesystem-like tree of arbitrary
+  depth.
+
+  The cross-row "child belongs to same location as parent" guarantee
+  is enforced at application layer in `PhoenixKitLocations.Spaces` —
+  enforcing it at the DB requires a composite FK + redundant column
+  pair which is heavier than the consumer surface justifies.
+
+  `data JSONB` mirrors the parent Location's column: top-level keys
+  carry attachment pointers (`files_folder_uuid`, `featured_image_uuid`)
+  and the multilang translation tree (`%{ "es-ES" => %{ "name" =>
+  "..."} }`). Primary-language values stay denormalized in the
+  dedicated `name` / `description` columns for cheap querying.
+  """
+
+  use Ecto.Migration
+
+  @kinds ~w(floor room hall suite section zone aisle shelf corner)
+
+  def up(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    create_if_not_exists table(:phoenix_kit_location_spaces,
+                           primary_key: false,
+                           prefix: prefix
+                         ) do
+      add(:uuid, :uuid, primary_key: true, default: fragment("uuid_generate_v7()"))
+
+      add(
+        :location_uuid,
+        references(:phoenix_kit_locations,
+          type: :uuid,
+          on_delete: :delete_all,
+          prefix: prefix
+        ),
+        null: false
+      )
+
+      add(
+        :parent_uuid,
+        references(:phoenix_kit_location_spaces,
+          type: :uuid,
+          on_delete: :delete_all,
+          prefix: prefix
+        )
+      )
+
+      add(:kind, :string, null: false, size: 32)
+      add(:name, :string, null: false, size: 255)
+      add(:description, :text)
+      add(:notes, :text)
+      add(:status, :string, null: false, default: "active", size: 20)
+      add(:position, :integer, null: false, default: 0)
+      add(:data, :map, null: false, default: %{})
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create_if_not_exists(
+      index(:phoenix_kit_location_spaces, [:location_uuid], prefix: prefix)
+    )
+
+    create_if_not_exists(
+      index(:phoenix_kit_location_spaces, [:parent_uuid], prefix: prefix)
+    )
+
+    # Sibling-ordering query: list spaces under (location, parent) by position.
+    create_if_not_exists(
+      index(:phoenix_kit_location_spaces, [:location_uuid, :parent_uuid, :position],
+        prefix: prefix
+      )
+    )
+
+    # Kind whitelist mirrors the schema's @kinds module attribute. Keep in
+    # sync if the consumer adds a new label. DROP-then-ADD pattern (same
+    # shape as V121) so the migration stays idempotent on re-run.
+    execute(
+      "ALTER TABLE #{p}phoenix_kit_location_spaces DROP CONSTRAINT IF EXISTS phoenix_kit_location_spaces_kind_check"
+    )
+
+    execute("""
+    ALTER TABLE #{p}phoenix_kit_location_spaces
+      ADD CONSTRAINT phoenix_kit_location_spaces_kind_check
+      CHECK (kind IN (#{Enum.map_join(@kinds, ", ", &"'#{&1}'")}))
+    """)
+
+    execute(
+      "ALTER TABLE #{p}phoenix_kit_location_spaces DROP CONSTRAINT IF EXISTS phoenix_kit_location_spaces_status_check"
+    )
+
+    execute("""
+    ALTER TABLE #{p}phoenix_kit_location_spaces
+      ADD CONSTRAINT phoenix_kit_location_spaces_status_check
+      CHECK (status IN ('active', 'inactive'))
+    """)
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '122'")
+  end
+
+  def down(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    drop_if_exists(table(:phoenix_kit_location_spaces, prefix: prefix))
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '121'")
+  end
+
+  defp prefix_str("public"), do: "public."
+  defp prefix_str(prefix), do: "#{prefix}."
+end

--- a/lib/phoenix_kit/migrations/postgres/v123.ex
+++ b/lib/phoenix_kit/migrations/postgres/v123.ex
@@ -1,0 +1,122 @@
+defmodule PhoenixKit.Migrations.Postgres.V123 do
+  @moduledoc """
+  V123: Catalogue folders — a dedicated nesting layer for organizing
+  catalogues on the admin catalogue index.
+
+  Creates `phoenix_kit_cat_folders` (self-nesting via `parent_uuid`) and
+  adds a nullable `folder_uuid` FK to `phoenix_kit_cat_catalogues` so a
+  catalogue can live inside a folder (NULL = unfiled / root). These folders
+  are their own thing — unrelated to the media-folder system
+  (`phoenix_kit_media_folders`) — and never appear in the media browser.
+
+  Each folder carries `position` (manual order within its parent), `status`
+  (soft-delete sentinel, parity with catalogues/categories), and a `data`
+  JSONB blob for future metadata. `parent_uuid` is `ON DELETE :nilify_all`
+  so a hard-deleted parent orphan-promotes its children to root rather than
+  cascading; `phoenix_kit_cat_catalogues.folder_uuid` is `ON DELETE SET NULL`
+  for the same reason (removing a folder unfiles its catalogues, never
+  deletes them).
+
+  Also drops the global unique index on `phoenix_kit_cat_items.sku`
+  (created in V87): item SKUs are **not** unique by design — the same SKU
+  can legitimately appear on multiple items, even within one catalogue —
+  so the partial unique index (`WHERE sku IS NOT NULL`) was an
+  over-constraint that raised on duplicate SKUs. `down/1` restores it.
+
+  All operations are idempotent (`create_if_not_exists` / `IF NOT EXISTS`
+  guards) so re-running on a partially-applied schema is a no-op.
+  """
+
+  use Ecto.Migration
+
+  def up(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+    schema = if prefix == "public", do: "public", else: prefix
+
+    create_if_not_exists table(:phoenix_kit_cat_folders,
+                           primary_key: false,
+                           prefix: prefix
+                         ) do
+      add(:uuid, :uuid, primary_key: true, default: fragment("uuid_generate_v7()"))
+      add(:name, :string, null: false)
+
+      add(
+        :parent_uuid,
+        references(:phoenix_kit_cat_folders,
+          column: :uuid,
+          type: :uuid,
+          on_delete: :nilify_all,
+          prefix: prefix
+        )
+      )
+
+      add(:position, :integer, null: false, default: 0)
+      add(:status, :string, null: false, default: "active")
+      add(:data, :map, null: false, default: %{})
+
+      timestamps(type: :utc_datetime)
+    end
+
+    # Composite index also serves parent_uuid-only lookups (leftmost
+    # prefix), including the self-FK.
+    create_if_not_exists(
+      index(:phoenix_kit_cat_folders, [:parent_uuid, :position], prefix: prefix)
+    )
+
+    create_if_not_exists(index(:phoenix_kit_cat_folders, [:status], prefix: prefix))
+
+    # Nullable folder_uuid on catalogues (idempotent — column + FK may
+    # already exist). NULL = unfiled (root); ON DELETE SET NULL so removing
+    # a folder unfiles its catalogues rather than deleting them.
+    execute("""
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT FROM information_schema.columns
+        WHERE table_schema = '#{schema}'
+          AND table_name = 'phoenix_kit_cat_catalogues'
+          AND column_name = 'folder_uuid'
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_cat_catalogues
+          ADD COLUMN folder_uuid UUID
+          REFERENCES #{p}phoenix_kit_cat_folders(uuid) ON DELETE SET NULL;
+      END IF;
+    END $$;
+    """)
+
+    create_if_not_exists(index(:phoenix_kit_cat_catalogues, [:folder_uuid], prefix: prefix))
+
+    # Item SKUs are not unique by design — drop V87's global partial unique
+    # index (default name `phoenix_kit_cat_items_sku_index`) so duplicate
+    # SKUs are accepted.
+    drop_if_exists(index(:phoenix_kit_cat_items, [:sku], prefix: prefix))
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '123'")
+  end
+
+  def down(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    # Restore V87's partial unique index on cat_items.sku. (Will raise if
+    # duplicate SKUs were created while V123 was applied — expected when
+    # rolling back a constraint relaxation onto now-violating data.)
+    create_if_not_exists(
+      unique_index(:phoenix_kit_cat_items, [:sku], where: "sku IS NOT NULL", prefix: prefix)
+    )
+
+    drop_if_exists(index(:phoenix_kit_cat_catalogues, [:folder_uuid], prefix: prefix))
+
+    alter table(:phoenix_kit_cat_catalogues, prefix: prefix) do
+      remove_if_exists(:folder_uuid, :uuid)
+    end
+
+    drop_if_exists(table(:phoenix_kit_cat_folders, prefix: prefix))
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '122'")
+  end
+
+  defp prefix_str("public"), do: "public."
+  defp prefix_str(prefix), do: "#{prefix}."
+end

--- a/lib/phoenix_kit_web/components/core/pagination.ex
+++ b/lib/phoenix_kit_web/components/core/pagination.ex
@@ -196,6 +196,14 @@ defmodule PhoenixKitWeb.Components.Core.Pagination do
   - `noun_plural` — used in the "Showing N of M %{noun}" line
     (default `"items"`)
   - `class` — additional classes on the outer wrapper
+  - `infinite` — when `true`, the footer also auto-loads on scroll via
+    the `InfiniteScroll` hook (the manual button stays as a fallback).
+    Requires `id`. (default `false`)
+  - `id` — DOM id, **required when `infinite`** (the JS hook needs it)
+  - `cursor` — an opaque per-page marker (e.g. `"items-<offset>"`) that
+    changes on each load so the LV patch re-triggers the hook's
+    `updated()` and it can keep firing while still on screen. Only used
+    when `infinite`.
 
   ## Example
 
@@ -205,16 +213,35 @@ defmodule PhoenixKitWeb.Components.Core.Pagination do
         on_load_more="load_more"
         noun_plural={gettext("projects")}
       />
+
+      <%!-- Auto-load on scroll + manual fallback --%>
+      <.load_more
+        id="items-load-more"
+        loaded={length(@items)}
+        total={@total}
+        infinite
+        cursor={"items-\#{@offset}"}
+      />
   """
   attr :loaded, :integer, required: true
   attr :total, :integer, required: true
   attr :on_load_more, :string, default: "load_more"
   attr :noun_plural, :string, default: "items"
   attr :class, :string, default: ""
+  attr :id, :string, default: nil
+  attr :infinite, :boolean, default: false
+  attr :cursor, :string, default: ""
 
   def load_more(assigns) do
     ~H"""
-    <div :if={@total > 0} class={["flex flex-col items-center gap-2 p-4", @class]}>
+    <div
+      :if={@total > 0}
+      id={@id}
+      phx-hook={if @infinite and @loaded < @total, do: "InfiniteScroll"}
+      data-load-more-event={@on_load_more}
+      data-cursor={@infinite && @cursor}
+      class={["flex flex-col items-center gap-2 p-4", @class]}
+    >
       <p class="text-sm text-base-content/60">
         {gettext("Showing %{loaded} of %{total} %{noun}",
           loaded: @loaded,

--- a/priv/static/assets/phoenix_kit.js
+++ b/priv/static/assets/phoenix_kit.js
@@ -2410,6 +2410,43 @@ if (typeof window.Chart === "undefined") {
   };
 
 
+  // ---------------------------------------------------------------------------
+  // InfiniteScroll — fires a "load more" LV event when the sentinel scrolls
+  // into view. Pair with the core `<.load_more infinite>` component, which
+  // renders this hook plus a manual fallback button. The event name is read
+  // from `data-load-more-event` (default "load_more"); `data-cursor` changes
+  // per page so the LV patch re-triggers `updated()` and the observer keeps
+  // firing while the sentinel stays on screen (tall viewports / Page-Down).
+  // ---------------------------------------------------------------------------
+
+  window.PhoenixKitHooks.InfiniteScroll = {
+    loadMoreEvent() {
+      return this.el.dataset.loadMoreEvent || "load_more";
+    },
+    mounted() {
+      this.intersecting = false;
+      this.observer = new IntersectionObserver(
+        (entries) => {
+          this.intersecting = entries[0].isIntersecting;
+          if (this.intersecting) {
+            this.pushEvent(this.loadMoreEvent(), {});
+          }
+        },
+        { rootMargin: "200px" }
+      );
+      this.observer.observe(this.el);
+    },
+    updated() {
+      if (this.intersecting) {
+        this.pushEvent(this.loadMoreEvent(), {});
+      }
+    },
+    destroyed() {
+      if (this.observer) this.observer.disconnect();
+    }
+  };
+
+
   // ============================================================================
   // 4. FLASH AUTO-DISMISS HOOK
   // ============================================================================


### PR DESCRIPTION
## Summary

Bundles three migration deltas into V122, all idempotent (`ADD COLUMN IF NOT EXISTS` / `create_if_not_exists`):

- **`phoenix_kit_location_spaces`** — nested floors/rooms inside a `phoenix_kit_locations` row. Required `location_uuid` FK (cascade), optional `parent_uuid` self-ref FK (cascade) for arbitrary-depth nesting. `kind` is CHECK-constrained at the DB (`floor / room / hall / suite / section / zone / aisle / shelf / corner`); the consumer-side `@kinds` whitelist in `phoenix_kit_locations` v1 narrows to `floor + room`. Indexes on `location_uuid`, `parent_uuid`, and `(location_uuid, parent_uuid, position)` for sibling ordering. `data` JSONB carries attachment pointers + multilang translations, mirroring how `phoenix_kit_locations.data` is used.
- **`translations JSONB NOT NULL DEFAULT '{}'`** on `phoenix_kit_staff_departments`, `phoenix_kit_staff_teams`, `phoenix_kit_staff_people`. Mirrors the V112 settings-translations shape from `phoenix_kit_projects`: primary stays in dedicated columns, JSONB holds non-primary-language overrides. Translatable fields per schema: Department / Team `(name, description)`, Person `(job_title, bio, skills, notes)`.
- **`name VARCHAR`** on `phoenix_kit_staff_people` — single full-name column. An earlier sketch in this PR tried `first_name / middle_name / last_name`; we reshaped to one column because most staff systems just want a display name and per-cultural name parsing belongs upstream. Consistent with `Department.name`, `Team.name`, `Space.name`, `Location.name`.

`down/1` reverses all three sets of changes and also drops `first_name / middle_name / last_name` so a rollback fully reverses any V122 shape that might already have been applied during the dev cycle.

## Test plan

- [x] `down/1` from V122 → V121 cleanly drops every column + table this migration introduced (including the early-V122-sketch first/middle/last)
- [x] `up/1` is idempotent: re-running V122 on a DB already at V122 is a no-op
- [x] CHECK constraints on `kind` and `status` reject out-of-band values
- [x] `data` JSONB defaults to `'{}'::jsonb` not null
- [x] Indexes land cleanly; sibling-ordering query plan uses the composite index
- [ ] Consumer-side schemas validated end-to-end via `phoenix_kit_staff` and `phoenix_kit_locations` (separate PRs against those repos)

---

## Also on this `dev` branch (beyond V122)

Three further commits ride on this branch:

### V123 — catalogue folders + drop unique `cat_items.sku` index (`68229407`)

- Creates **`phoenix_kit_cat_folders`** (self-nesting via `parent_uuid`, with `position` / `status` / `data`) — a dedicated folder layer for organizing catalogues on the admin index, unrelated to the media-folder system; `parent_uuid` is `ON DELETE :nilify_all`.
- Adds a nullable **`folder_uuid`** FK to `phoenix_kit_cat_catalogues` (`ON DELETE SET NULL`; NULL = unfiled / root). Bumps `@current_version` to **123**.
- **Drops V87's global partial unique index on `phoenix_kit_cat_items.sku`** (`WHERE sku IS NOT NULL`): item SKUs are not unique by design — the same SKU can legitimately appear on multiple items, even within one catalogue — so the index was an over-constraint that raised on duplicates. `down/1` restores it.

### Mount the catalogue PDF.js viewer in the installer (`00ee6cbd`)

- `mix phoenix_kit.install` / `mix phoenix_kit.update` mount `Plug.Static` at `/_pdfjs` (from `:phoenix_kit_catalogue`'s vendored `priv/static/pdfjs`) when the catalogue module is a dependency. Idempotent; gated on `Deps.has_dep?(:phoenix_kit_catalogue)`.

### Infinite-scroll support for the `load_more` component (`3804e5e9`)

- `<.load_more>` gains append-on-scroll support for embeddable, DnD-aware lists.

### Test plan (additions)

- [x] From-scratch migration runs all 123 versions including V123 (folders table + `folder_uuid` FK + sku-index drop) cleanly
- [x] `phoenix_kit_catalogue` suite green against this `dev` via a local path-override — **1089 tests, 0 failures** — including duplicate-SKU now accepted and the catalogue folders feature
- [x] V123 `down/1` recreates the V87 partial unique sku index
