### PR TITLE
V125: project workflow statuses table + columns + external_id

### DIFF
--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -529,7 +529,25 @@ defmodule PhoenixKit.Migrations.Postgres do
   - Replaces unique index with partial index (slug-mode only, WHERE slug IS NOT NULL)
   - Adds unique index on `(group_uuid, post_date, post_time)` for timestamp-mode posts
 
-  ### V124 - Partial unique index on media folder names ⚡ LATEST
+  ### V125 - Project workflow statuses (entities-backed, cement-at-start) ⚡ LATEST
+  - Adds `status_entity_uuid` (FK `phoenix_kit_entities(uuid) ON DELETE SET NULL`),
+    `current_status_slug`, and a generic `settings` JSONB (first key:
+    `use_status_translations`) to `phoenix_kit_projects` — the catalog list a
+    project/template draws workflow statuses from, the selected status
+    (addressed by stable slug), and per-project preferences. NULL entity =
+    the shared default list.
+  - Creates `phoenix_kit_project_statuses` (the cemented per-project copy:
+    `project_uuid` FK cascade, `label`/`slug`/`position`, `data` JSONB
+    (per-status attrs e.g. colour) + `translations` JSONB (label i18n,
+    workspace shape), provenance `source_entity_data_uuid` with no FK).
+    Populated when a project starts so running projects use a frozen,
+    independently-editable status set.
+  - Partial index on `(status_entity_uuid) WHERE NOT NULL`; unique
+    `(project_uuid, slug)` on the cemented table.
+  - Orthogonal to `derived_status/2` + `archived_at`; the legacy `status`
+    string column is untouched.
+
+  ### V124 - Partial unique index on media folder names
   - Restricts `phoenix_kit_media_folders_name_parent_idx` to
     `WHERE trashed_at IS NULL`. Previously a trashed "untitled"
     folder still reserved its slot in the index, blocking re-creation
@@ -1061,7 +1079,7 @@ defmodule PhoenixKit.Migrations.Postgres do
   use Ecto.Migration
 
   @initial_version 1
-  @current_version 124
+  @current_version 125
   @default_prefix "public"
 
   @doc false

--- a/lib/phoenix_kit/migrations/postgres/v125.ex
+++ b/lib/phoenix_kit/migrations/postgres/v125.ex
@@ -54,6 +54,19 @@ defmodule PhoenixKit.Migrations.Postgres.V125 do
   slug-addressable (matching `current_status_slug`); index on `(project_uuid)`
   for list reads.
 
+  ## 3. External identifier on `phoenix_kit_projects`
+
+  A single nullable column lets a project be tied to a record in some external
+  system, with no UI of its own (set programmatically):
+
+    * `external_id VARCHAR(255)` — an arbitrary external reference. Deliberately
+      a free-form string so it can hold a numeric id, a UUID, or a slug from
+      whatever the project is being linked to. Not unique (several projects may
+      reference the same external thing) and not a foreign key (the target lives
+      outside this database). A partial index on
+      `(external_id) WHERE external_id IS NOT NULL` backs lookup-by-external-id
+      without indexing the common NULL case.
+
   Idempotent: re-running is a no-op once the table + columns are in the
   post-V125 shape.
   """
@@ -70,7 +83,9 @@ defmodule PhoenixKit.Migrations.Postgres.V125 do
     add_status_entity_uuid_fk(p, schema)
     add_current_status_slug_column(p, schema)
     add_project_settings_column(p, schema)
+    add_external_id_column(p, schema)
     create_status_entity_index(p, schema)
+    create_external_id_index(p, schema)
 
     execute("COMMENT ON TABLE #{p}phoenix_kit IS '125'")
   end
@@ -79,6 +94,7 @@ defmodule PhoenixKit.Migrations.Postgres.V125 do
     prefix = Map.get(opts, :prefix, "public")
     p = prefix_str(prefix)
 
+    execute("DROP INDEX IF EXISTS #{p}phoenix_kit_projects_external_id_idx")
     execute("DROP INDEX IF EXISTS #{p}phoenix_kit_projects_status_entity_idx")
 
     execute("""
@@ -86,6 +102,7 @@ defmodule PhoenixKit.Migrations.Postgres.V125 do
       DROP CONSTRAINT IF EXISTS phoenix_kit_projects_status_entity_uuid_fkey
     """)
 
+    execute("ALTER TABLE #{p}phoenix_kit_projects DROP COLUMN IF EXISTS external_id")
     execute("ALTER TABLE #{p}phoenix_kit_projects DROP COLUMN IF EXISTS settings")
     execute("ALTER TABLE #{p}phoenix_kit_projects DROP COLUMN IF EXISTS current_status_slug")
     execute("ALTER TABLE #{p}phoenix_kit_projects DROP COLUMN IF EXISTS status_entity_uuid")
@@ -187,6 +204,25 @@ defmodule PhoenixKit.Migrations.Postgres.V125 do
     """)
   end
 
+  # Free-form external reference (no UI). A nullable string so it can carry a
+  # numeric id, a UUID, or a slug from whatever system the project is linked to.
+  defp add_external_id_column(p, schema) do
+    execute("""
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT FROM information_schema.columns
+        WHERE table_schema = '#{schema}'
+          AND table_name = 'phoenix_kit_projects'
+          AND column_name = 'external_id'
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_projects
+          ADD COLUMN external_id VARCHAR(255);
+      END IF;
+    END $$;
+    """)
+  end
+
   defp add_current_status_slug_column(p, schema) do
     execute("""
     DO $$
@@ -220,6 +256,27 @@ defmodule PhoenixKit.Migrations.Postgres.V125 do
         CREATE INDEX phoenix_kit_projects_status_entity_idx
           ON #{p}phoenix_kit_projects (status_entity_uuid)
           WHERE status_entity_uuid IS NOT NULL;
+      END IF;
+    END $$;
+    """)
+  end
+
+  # Partial index over projects carrying an external reference — backs
+  # lookup-by-external-id without indexing the common NULL case. Non-unique:
+  # several projects may legitimately point at the same external record.
+  defp create_external_id_index(p, schema) do
+    execute("""
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT FROM pg_indexes
+        WHERE schemaname = '#{schema}'
+          AND tablename = 'phoenix_kit_projects'
+          AND indexname = 'phoenix_kit_projects_external_id_idx'
+      ) THEN
+        CREATE INDEX phoenix_kit_projects_external_id_idx
+          ON #{p}phoenix_kit_projects (external_id)
+          WHERE external_id IS NOT NULL;
       END IF;
     END $$;
     """)

--- a/lib/phoenix_kit/migrations/postgres/v125.ex
+++ b/lib/phoenix_kit/migrations/postgres/v125.ex
@@ -1,0 +1,233 @@
+defmodule PhoenixKit.Migrations.Postgres.V125 do
+  @moduledoc """
+  V125: Project workflow statuses (entities-backed, cement-at-start).
+
+  Adds a user-defined "workflow status" capability to `phoenix_kit_projects`,
+  orthogonal to the computed `Project.derived_status/2` lifecycle and the
+  `archived_at` soft-hide. The status vocabulary is configured through the
+  optional `phoenix_kit_entities` module (the "catalog"), and snapshotted into
+  local projects-owned storage when a project starts (the "cement").
+
+  Two layers:
+
+  ## 1. Catalog reference on `phoenix_kit_projects`
+
+  Two nullable columns let a project (or template) point at the catalog list it
+  draws statuses from, and remember the currently-selected status:
+
+    * `status_entity_uuid UUID` → FK `phoenix_kit_entities(uuid) ON DELETE SET NULL`
+      — which entity (status vocabulary) this project/template uses. NULL = the
+      shared default list. `ON DELETE SET NULL` so deleting a catalog entity
+      degrades the project to the shared default, never cascades.
+    * `current_status_slug VARCHAR(255)` — the selected status, addressed by its
+      stable slug. The slug is the cross-boundary identity: pre-start it resolves
+      against the live catalog rows; post-start against the cemented local rows
+      below. Storing a slug (not a row UUID) avoids a foreign key whose target
+      table changes at the cement boundary.
+
+  A partial index on `(status_entity_uuid) WHERE status_entity_uuid IS NOT NULL`
+  backs the "Used by N projects" reverse-reference count and grouped lookups.
+
+  ## 2. Local cemented copy: `phoenix_kit_project_statuses`
+
+  When a project starts, its chosen catalog statuses are copied into this table
+  and the running project uses its own frozen, independently-editable copy —
+  later edits to the catalog entity do NOT retroactively rewrite live projects.
+  Mirrors the module's existing template→instance philosophy (an Assignment
+  copies its Task template's fields at creation, then edits independently).
+
+    * `project_uuid` → FK `phoenix_kit_projects(uuid) ON DELETE CASCADE` — the
+      cemented statuses die with the project.
+    * `label` / `slug` / `position` — the snapshotted status (primary-language
+      label + stable slug + order).
+    * `data JSONB` — per-status attributes (e.g. `{"color": "#34d399"}`).
+      JSONB so colour and any future fields ride along without a migration.
+    * `translations JSONB` — secondary-language label overrides, workspace
+      shape `%{"es-ES" => %{"label" => "…"}}` (mirrors Project/Task/Assignment).
+      Empty today; ready for status-label i18n.
+    * `source_entity_data_uuid UUID` — provenance pointer back to the catalog
+      `phoenix_kit_entity_data` row it was copied from. Intentionally NOT a
+      foreign key: `phoenix_kit_entities` is an optional module, the cemented row
+      must survive the catalog row being deleted, and the value is informational.
+
+  Unique `(project_uuid, slug)` so a project's cemented statuses are
+  slug-addressable (matching `current_status_slug`); index on `(project_uuid)`
+  for list reads.
+
+  Idempotent: re-running is a no-op once the table + columns are in the
+  post-V125 shape.
+  """
+
+  use Ecto.Migration
+
+  def up(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+    schema = schema_for(prefix)
+
+    create_project_statuses_table(p)
+    add_status_entity_uuid_column(p, schema)
+    add_status_entity_uuid_fk(p, schema)
+    add_current_status_slug_column(p, schema)
+    add_project_settings_column(p, schema)
+    create_status_entity_index(p, schema)
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '125'")
+  end
+
+  def down(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    execute("DROP INDEX IF EXISTS #{p}phoenix_kit_projects_status_entity_idx")
+
+    execute("""
+    ALTER TABLE #{p}phoenix_kit_projects
+      DROP CONSTRAINT IF EXISTS phoenix_kit_projects_status_entity_uuid_fkey
+    """)
+
+    execute("ALTER TABLE #{p}phoenix_kit_projects DROP COLUMN IF EXISTS settings")
+    execute("ALTER TABLE #{p}phoenix_kit_projects DROP COLUMN IF EXISTS current_status_slug")
+    execute("ALTER TABLE #{p}phoenix_kit_projects DROP COLUMN IF EXISTS status_entity_uuid")
+
+    execute("DROP TABLE IF EXISTS #{p}phoenix_kit_project_statuses")
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '124'")
+  end
+
+  # The cemented per-project status rows. `IF NOT EXISTS` keeps the create
+  # idempotent; `source_entity_data_uuid` is a bare UUID (no FK) on purpose —
+  # the catalog lives in the optional phoenix_kit_entities package and the
+  # snapshot must outlive its source.
+  defp create_project_statuses_table(p) do
+    execute("""
+    CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_project_statuses (
+      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      project_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_projects(uuid) ON DELETE CASCADE,
+      label VARCHAR(255) NOT NULL,
+      slug VARCHAR(255) NOT NULL,
+      position INTEGER NOT NULL DEFAULT 0,
+      data JSONB NOT NULL DEFAULT '{}'::jsonb,
+      translations JSONB NOT NULL DEFAULT '{}'::jsonb,
+      source_entity_data_uuid UUID,
+      inserted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+    """)
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS phoenix_kit_project_statuses_project_index
+    ON #{p}phoenix_kit_project_statuses (project_uuid)
+    """)
+
+    execute("""
+    CREATE UNIQUE INDEX IF NOT EXISTS phoenix_kit_project_statuses_project_slug_index
+    ON #{p}phoenix_kit_project_statuses (project_uuid, slug)
+    """)
+  end
+
+  defp add_status_entity_uuid_column(p, schema) do
+    execute("""
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT FROM information_schema.columns
+        WHERE table_schema = '#{schema}'
+          AND table_name = 'phoenix_kit_projects'
+          AND column_name = 'status_entity_uuid'
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_projects
+          ADD COLUMN status_entity_uuid UUID;
+      END IF;
+    END $$;
+    """)
+  end
+
+  # FK to the catalog entity. Postgres has no `ADD CONSTRAINT IF NOT EXISTS`,
+  # so guard on the constraint name. `ON DELETE SET NULL` degrades the project
+  # to the shared default when its catalog entity is deleted.
+  defp add_status_entity_uuid_fk(p, schema) do
+    execute("""
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT FROM information_schema.table_constraints
+        WHERE table_schema = '#{schema}'
+          AND table_name = 'phoenix_kit_projects'
+          AND constraint_name = 'phoenix_kit_projects_status_entity_uuid_fkey'
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_projects
+          ADD CONSTRAINT phoenix_kit_projects_status_entity_uuid_fkey
+          FOREIGN KEY (status_entity_uuid)
+          REFERENCES #{p}phoenix_kit_entities(uuid)
+          ON DELETE SET NULL;
+      END IF;
+    END $$;
+    """)
+  end
+
+  # Generic per-project preferences JSONB. First consumer: the
+  # `use_status_translations` flag (whether to display status titles in the
+  # viewer's locale). A JSONB rather than a typed column so future
+  # per-project toggles ride along without another migration.
+  defp add_project_settings_column(p, schema) do
+    execute("""
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT FROM information_schema.columns
+        WHERE table_schema = '#{schema}'
+          AND table_name = 'phoenix_kit_projects'
+          AND column_name = 'settings'
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_projects
+          ADD COLUMN settings JSONB NOT NULL DEFAULT '{}'::jsonb;
+      END IF;
+    END $$;
+    """)
+  end
+
+  defp add_current_status_slug_column(p, schema) do
+    execute("""
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT FROM information_schema.columns
+        WHERE table_schema = '#{schema}'
+          AND table_name = 'phoenix_kit_projects'
+          AND column_name = 'current_status_slug'
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_projects
+          ADD COLUMN current_status_slug VARCHAR(255);
+      END IF;
+    END $$;
+    """)
+  end
+
+  # Partial index over the projects/templates that reference a catalog entity —
+  # backs the reverse-reference "Used by N projects" count and grouped status
+  # resolution for list views.
+  defp create_status_entity_index(p, schema) do
+    execute("""
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT FROM pg_indexes
+        WHERE schemaname = '#{schema}'
+          AND tablename = 'phoenix_kit_projects'
+          AND indexname = 'phoenix_kit_projects_status_entity_idx'
+      ) THEN
+        CREATE INDEX phoenix_kit_projects_status_entity_idx
+          ON #{p}phoenix_kit_projects (status_entity_uuid)
+          WHERE status_entity_uuid IS NOT NULL;
+      END IF;
+    END $$;
+    """)
+  end
+
+  defp schema_for("public"), do: "public"
+  defp schema_for(prefix), do: prefix
+
+  defp prefix_str("public"), do: "public."
+  defp prefix_str(prefix), do: "#{prefix}."
+end

--- a/test/phoenix_kit/migrations/v125_test.exs
+++ b/test/phoenix_kit/migrations/v125_test.exs
@@ -1,0 +1,157 @@
+defmodule PhoenixKit.Migrations.Postgres.V125Test do
+  @moduledoc """
+  Tests V125's schema state — project workflow statuses.
+
+  V125.up/down can't be invoked outside an `Ecto.Migrator` runner (they
+  rely on `Ecto.Migration.execute/1` which checks for a runner process —
+  same constraint as V106Test/V107Test/V112Test). The schema is verified
+  at boot: `test_helper.exs` runs `ensure_current/2` (now through V125)
+  before any test, so these assertions pin the post-V125 shape and a
+  regression that drops/re-adds the wrong thing surfaces here. The
+  `down/0` round-trip is verified separately via a standalone migrate /
+  rollback script (outside the sandbox).
+
+  Pinned:
+
+  1. `phoenix_kit_project_statuses` table — the cemented per-project copy,
+     with a `project_uuid` FK that cascades, slug-unique per project.
+  2. `status_entity_uuid` (nullable UUID, FK to `phoenix_kit_entities`
+     with `ON DELETE SET NULL`) + `current_status_slug` (nullable) on
+     `phoenix_kit_projects`.
+  3. Partial index `phoenix_kit_projects_status_entity_idx` on
+     `(status_entity_uuid) WHERE status_entity_uuid IS NOT NULL`.
+  """
+
+  use PhoenixKit.DataCase, async: false
+
+  alias PhoenixKit.Test.Repo
+
+  defp column(table, column) do
+    %{rows: rows} =
+      Repo.query!(
+        """
+        SELECT data_type, is_nullable, column_default
+        FROM information_schema.columns
+        WHERE table_name = $1 AND column_name = $2
+        """,
+        [table, column]
+      )
+
+    case rows do
+      [[data_type, is_nullable, default]] ->
+        %{type: data_type, nullable: is_nullable, default: default}
+
+      [] ->
+        nil
+    end
+  end
+
+  defp index_exists?(name) do
+    %{rows: [[exists]]} =
+      Repo.query!("SELECT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = $1)", [name])
+
+    exists
+  end
+
+  # Returns the ON DELETE action ('a' no action, 'r' restrict, 'c' cascade,
+  # 'n' set null, 'd' set default) for a named FK constraint.
+  defp fk_delete_rule(constraint_name) do
+    %{rows: rows} =
+      Repo.query!(
+        "SELECT confdeltype FROM pg_constraint WHERE conname = $1",
+        [constraint_name]
+      )
+
+    case rows do
+      [[rule]] -> rule
+      [] -> nil
+    end
+  end
+
+  describe "phoenix_kit_project_statuses table" do
+    test "exists with the expected columns" do
+      assert %{type: "uuid", nullable: "NO"} = column("phoenix_kit_project_statuses", "uuid")
+
+      assert %{type: "uuid", nullable: "NO"} =
+               column("phoenix_kit_project_statuses", "project_uuid")
+
+      assert %{type: "character varying", nullable: "NO"} =
+               column("phoenix_kit_project_statuses", "label")
+
+      assert %{type: "character varying", nullable: "NO"} =
+               column("phoenix_kit_project_statuses", "slug")
+
+      assert %{type: "integer", nullable: "NO", default: "0"} =
+               column("phoenix_kit_project_statuses", "position")
+
+      assert %{type: "jsonb", nullable: "NO"} = column("phoenix_kit_project_statuses", "data")
+
+      assert %{type: "jsonb", nullable: "NO"} =
+               column("phoenix_kit_project_statuses", "translations")
+
+      assert %{type: "uuid", nullable: "YES"} =
+               column("phoenix_kit_project_statuses", "source_entity_data_uuid")
+    end
+
+    test "project_uuid FK cascades on delete" do
+      assert fk_delete_rule("phoenix_kit_project_statuses_project_uuid_fkey") == "c"
+    end
+
+    test "has a per-project index and a unique (project_uuid, slug) index" do
+      assert index_exists?("phoenix_kit_project_statuses_project_index")
+      assert index_exists?("phoenix_kit_project_statuses_project_slug_index")
+    end
+
+    test "enforces slug uniqueness within a project" do
+      %{rows: [[project_bin]]} =
+        Repo.query!(
+          "INSERT INTO phoenix_kit_projects (name) VALUES ($1) RETURNING uuid",
+          ["Status Host"]
+        )
+
+      insert = fn ->
+        Repo.query!(
+          "INSERT INTO phoenix_kit_project_statuses (project_uuid, label, slug) VALUES ($1, $2, $3)",
+          [project_bin, "Done", "done"]
+        )
+      end
+
+      assert insert.()
+      assert_raise Postgrex.Error, insert
+    end
+  end
+
+  describe "phoenix_kit_projects catalog columns" do
+    test "status_entity_uuid is a nullable uuid" do
+      assert %{type: "uuid", nullable: "YES"} =
+               column("phoenix_kit_projects", "status_entity_uuid")
+    end
+
+    test "current_status_slug is a nullable varchar" do
+      assert %{type: "character varying", nullable: "YES"} =
+               column("phoenix_kit_projects", "current_status_slug")
+    end
+
+    test "settings is a JSONB NOT NULL default '{}'" do
+      assert %{type: "jsonb", nullable: "NO", default: default} =
+               column("phoenix_kit_projects", "settings")
+
+      assert default =~ ~r/'\{\}'::jsonb/
+    end
+
+    test "status_entity_uuid FK sets null on delete" do
+      assert fk_delete_rule("phoenix_kit_projects_status_entity_uuid_fkey") == "n"
+    end
+
+    test "partial index on status_entity_uuid exists and is predicated on NOT NULL" do
+      assert index_exists?("phoenix_kit_projects_status_entity_idx")
+
+      %{rows: [[indexdef]]} =
+        Repo.query!(
+          "SELECT indexdef FROM pg_indexes WHERE indexname = 'phoenix_kit_projects_status_entity_idx'"
+        )
+
+      assert indexdef =~ "status_entity_uuid IS NOT NULL"
+    end
+  end
+end

--- a/test/phoenix_kit/migrations/v125_test.exs
+++ b/test/phoenix_kit/migrations/v125_test.exs
@@ -20,6 +20,8 @@ defmodule PhoenixKit.Migrations.Postgres.V125Test do
      `phoenix_kit_projects`.
   3. Partial index `phoenix_kit_projects_status_entity_idx` on
      `(status_entity_uuid) WHERE status_entity_uuid IS NOT NULL`.
+  4. `external_id` (nullable varchar) on `phoenix_kit_projects` plus its
+     partial index `phoenix_kit_projects_external_id_idx`.
   """
 
   use PhoenixKit.DataCase, async: false
@@ -152,6 +154,22 @@ defmodule PhoenixKit.Migrations.Postgres.V125Test do
         )
 
       assert indexdef =~ "status_entity_uuid IS NOT NULL"
+    end
+
+    test "external_id is a nullable varchar" do
+      assert %{type: "character varying", nullable: "YES"} =
+               column("phoenix_kit_projects", "external_id")
+    end
+
+    test "partial index on external_id exists and is predicated on NOT NULL" do
+      assert index_exists?("phoenix_kit_projects_external_id_idx")
+
+      %{rows: [[indexdef]]} =
+        Repo.query!(
+          "SELECT indexdef FROM pg_indexes WHERE indexname = 'phoenix_kit_projects_external_id_idx'"
+        )
+
+      assert indexdef =~ "external_id IS NOT NULL"
     end
   end
 end


### PR DESCRIPTION
## Summary

Adds migration **V125**, which backs the entity-controlled workflow-status feature in `phoenix_kit_projects`. Two parts:

### Workflow statuses
- New table **`phoenix_kit_project_statuses`** — the cemented per-project status snapshot: `uuid`, `project_uuid` (FK → `phoenix_kit_projects` `ON DELETE CASCADE`), `label`, `slug`, `position`, `data` JSONB (colour + future attrs), `translations` JSONB (per-language label i18n), `source_entity_data_uuid` (provenance, no FK), timestamps. Index on `(project_uuid)`, unique on `(project_uuid, slug)`.
- New columns on **`phoenix_kit_projects`**: `status_entity_uuid` (FK → `phoenix_kit_entities` `ON DELETE SET NULL`), `current_status_slug` (varchar), `settings` JSONB. Partial index on `(status_entity_uuid) WHERE NOT NULL`.

### External identifier
- New column `external_id VARCHAR(255)` on `phoenix_kit_projects` — a free-form external reference (id / uuid / slug) for tying a project to an external system. Not unique, not a foreign key (target lives elsewhere). Partial index on `(external_id) WHERE NOT NULL` for lookup-by-external-id. No UI — set programmatically.

All operations are idempotent (`IF NOT EXISTS` / constraint-name guards); `down/0` drops everything and resets the marker to `124`. `@current_version` bumped 124 → 125.

## Verification
- `mix test test/phoenix_kit/migrations/v125_test.exs` — **11 tests, 0 failures** on a fresh `V01→V125` migrate (pins the table columns, FK delete rules, partial indexes, and `external_id`).
- `down/0` round-trip verified outside the sandbox (marker `125 → 124 → 125`).

## Test plan
- [x] Fresh migrate pins the post-V125 schema (table, columns, FKs, indexes)
- [x] `external_id` column + partial index asserted
- [x] `status_entity_uuid` FK is `ON DELETE SET NULL`; `project_uuid` FK is `ON DELETE CASCADE`
- [x] idempotent re-run is a no-op

> Companion PR: the consumer side is `BeamLabEU/phoenix_kit_projects` (workflow-statuses feature). That module pins `phoenix_kit ~> 1.7.121` and stays red until this ships in a release (≥ 1.7.122) and the pin is bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)