### PR TITLE
Docs: core integrates on main (dev retired), CI is manual-only

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,8 @@ ast-grep --lang elixir --pattern 'def $FUNC($$$ARGS) do $$$BODY end' lib/
 
 ## Pull Requests
 
-- **CI/CD:** GitHub Actions on push to `main`, `dev`, `claude/**`, all PRs. Checks: format, credo, dialyzer, compile (warnings as errors), deps audit, tests with PostgreSQL.
+- **Branch:** core integrates on **`main`** — open PRs against `main` (`gh pr create --base main --head mdon:main`). The `dev` branch was **retired 2026-06-01**; do not target it. (Historical: core used `dev` as its integration branch until then.)
+- **CI/CD:** the `.github/workflows/ci.yml` workflow is **manual-only** (`workflow_dispatch`) — the equivalent checks run locally via `mix precommit` / `mix quality.ci`. Checks: format, credo, dialyzer, compile (warnings as errors), deps audit, tests with PostgreSQL.
 - **Commit messages:** start with `Add`, `Update`, `Fix`, `Remove`, `Merge`.
 - **Version management:** `mix.exs` `@version` + `CHANGELOG.md`. Run `mix compile`, `mix test`, `mix format`, `mix credo --strict` before committing. Get current versions:
   ```bash


### PR DESCRIPTION
## Summary

Documentation-only. Fixes two stale statements in the core `AGENTS.md`'s Pull Requests section so future contributors (human or AI) aren't misled about where to open PRs:

- **Branch:** core now integrates on **`main`**. The `dev` branch was retired 2026-06-01; PRs target `main` (`gh pr create --base main --head mdon:main`). Added an explicit Branch bullet.
- **CI/CD:** `.github/workflows/ci.yml` is `workflow_dispatch`-only (manual / runs locally), not push-triggered on `main`/`dev`/`claude/**` as the line previously claimed.

`CLAUDE.md` is a symlink to `AGENTS.md`, so this covers both.

## Verification
- Docs-only; no code touched. Verified `ci.yml` triggers solely on `workflow_dispatch`.