### PR TITLE
Add V127 (sub-project links) + V128 (project assignee) migrations

### DIFF
--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -529,7 +529,24 @@ defmodule PhoenixKit.Migrations.Postgres do
   - Replaces unique index with partial index (slug-mode only, WHERE slug IS NOT NULL)
   - Adds unique index on `(group_uuid, post_date, post_time)` for timestamp-mode posts
 
-  ### V126 - Standalone notifications ⚡ LATEST
+  ### V128 - Assignee on projects (and sub-projects) ⚡ LATEST
+  - Adds `assigned_team_uuid` / `assigned_department_uuid` / `assigned_person_uuid`
+    (FKs to the staff tables, `ON DELETE SET NULL`) to `phoenix_kit_projects`,
+    with a `num_nonnulls(...) <= 1` single-assignee CHECK + a partial index per
+    FK. Lets a whole project — or, since a sub-project is a project (V127), a
+    sub-project — be assigned to a Department/Team/Person like a task.
+
+  ### V127 - Sub-projects as tasks
+  - Adds `child_project_uuid` (FK `phoenix_kit_projects(uuid) ON DELETE RESTRICT`)
+    to `phoenix_kit_project_assignments` — a sub-project is an assignment that
+    points at a child project instead of a task template, so it lives in the
+    parent's task timeline with dependencies + drag-reorder for free.
+  - Drops `NOT NULL` on `task_uuid`; adds a `CHECK` that exactly one of
+    `task_uuid` / `child_project_uuid` is set (XOR).
+  - Partial UNIQUE index on `(child_project_uuid) WHERE NOT NULL` (a project is
+    a child of at most one parent); plain index on `(child_project_uuid)`.
+
+  ### V126 - Standalone notifications
   - Drops NOT NULL on `phoenix_kit_notifications.activity_uuid` so a
     notification can exist without an originating activity (the unique
     `(activity_uuid, recipient_uuid)` index still holds — NULLs are
@@ -1089,7 +1106,7 @@ defmodule PhoenixKit.Migrations.Postgres do
   use Ecto.Migration
 
   @initial_version 1
-  @current_version 126
+  @current_version 128
   @default_prefix "public"
 
   @doc false

--- a/lib/phoenix_kit/migrations/postgres/v127.ex
+++ b/lib/phoenix_kit/migrations/postgres/v127.ex
@@ -1,0 +1,195 @@
+defmodule PhoenixKit.Migrations.Postgres.V127 do
+  @moduledoc """
+  V127: Sub-projects as tasks (`phoenix_kit_project_assignments.child_project_uuid`).
+
+  Lets a project be embedded inside another project as one of its task rows.
+  A sub-project is an `Assignment` that points at a child `Project` instead of
+  a reusable `Task` template — so it lives in the parent's task timeline and
+  gets dependencies + drag-reorder for free (both are already assignment-level
+  and project-scoped). The child project is the single source of truth; the
+  parent's linking assignment carries denormalized rollup fields (status /
+  progress_pct / estimated_duration / completed_at) synced by the context layer
+  whenever the child changes, so every existing read site (schedule math,
+  `recompute_project_completion`, dashboards, sorting) keeps working unchanged.
+
+  Changes to `phoenix_kit_project_assignments`:
+
+    * `child_project_uuid UUID` → FK `phoenix_kit_projects(uuid) ON DELETE RESTRICT`.
+      `RESTRICT` (not `CASCADE`) so a stray child-project delete fails loudly
+      instead of silently mutating the parent's task list — recursive teardown
+      is orchestrated explicitly in `PhoenixKitProjects.Projects` inside a
+      transaction so it can log activity and tear the subtree down in order.
+    * `task_uuid` loses its `NOT NULL` — a sub-project assignment has no template.
+    * `CHECK ((task_uuid IS NOT NULL) <> (child_project_uuid IS NOT NULL))` —
+      exactly one of the two is set (XOR). Existing rows (task set, child NULL)
+      satisfy it, so the constraint validates against current data without a
+      backfill.
+    * Partial UNIQUE index on `(child_project_uuid) WHERE child_project_uuid IS
+      NOT NULL` — a project is a child of at most one parent assignment. This is
+      also what forces template cloning to *deep-clone* child subtrees rather
+      than point two parents at the same child.
+    * Plain index on `(child_project_uuid)` for "find the linking row for this
+      child" lookups (parent breadcrumb, rollup sync).
+
+  Idempotent: re-running is a no-op once the column/constraints/indexes exist.
+  """
+
+  use Ecto.Migration
+
+  def up(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+    schema = schema_for(prefix)
+
+    add_child_project_uuid_column(p, schema)
+    add_child_project_uuid_fk(p, schema)
+    drop_task_uuid_not_null(p)
+    add_task_xor_child_check(p, schema)
+    create_child_project_unique_index(p, schema)
+    create_child_project_index(p)
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '127'")
+  end
+
+  def down(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    execute("DROP INDEX IF EXISTS #{p}phoenix_kit_project_assignments_child_project_index")
+    execute("DROP INDEX IF EXISTS #{p}phoenix_kit_project_assignments_child_project_unique")
+
+    execute("""
+    ALTER TABLE #{p}phoenix_kit_project_assignments
+      DROP CONSTRAINT IF EXISTS phoenix_kit_project_assignments_task_xor_child
+    """)
+
+    execute("""
+    ALTER TABLE #{p}phoenix_kit_project_assignments
+      DROP CONSTRAINT IF EXISTS phoenix_kit_project_assignments_child_project_uuid_fkey
+    """)
+
+    # Drop the sub-project linking rows first. The XOR check guaranteed every
+    # such row had `task_uuid IS NULL` (a child link, not a task), so they are
+    # exactly the rows that would violate the NOT NULL we restore below. They
+    # have no task identity to fall back on, so rollback discards them (the
+    # child projects themselves survive as standalone projects). Must run
+    # BEFORE dropping `child_project_uuid` only conceptually — `task_uuid IS
+    # NULL` already identifies them, and the column is about to go.
+    execute("DELETE FROM #{p}phoenix_kit_project_assignments WHERE task_uuid IS NULL")
+
+    execute(
+      "ALTER TABLE #{p}phoenix_kit_project_assignments DROP COLUMN IF EXISTS child_project_uuid"
+    )
+
+    # Restore the pre-V127 NOT NULL on task_uuid. Safe now: the XOR check is
+    # gone and the only rows that could have had a NULL task_uuid (the child
+    # links) were just deleted, so every remaining row is a plain
+    # template-backed assignment with task_uuid set.
+    execute("ALTER TABLE #{p}phoenix_kit_project_assignments ALTER COLUMN task_uuid SET NOT NULL")
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '126'")
+  end
+
+  defp add_child_project_uuid_column(p, schema) do
+    execute("""
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT FROM information_schema.columns
+        WHERE table_schema = '#{schema}'
+          AND table_name = 'phoenix_kit_project_assignments'
+          AND column_name = 'child_project_uuid'
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_project_assignments
+          ADD COLUMN child_project_uuid UUID;
+      END IF;
+    END $$;
+    """)
+  end
+
+  # FK to the embedded child project. `ON DELETE RESTRICT` keeps the parent's
+  # task list honest: you can't delete a project that is still embedded as a
+  # sub-project — the context tears the subtree down explicitly instead.
+  # Postgres has no `ADD CONSTRAINT IF NOT EXISTS`, so guard on the name.
+  defp add_child_project_uuid_fk(p, schema) do
+    execute("""
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT FROM information_schema.table_constraints
+        WHERE table_schema = '#{schema}'
+          AND table_name = 'phoenix_kit_project_assignments'
+          AND constraint_name = 'phoenix_kit_project_assignments_child_project_uuid_fkey'
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_project_assignments
+          ADD CONSTRAINT phoenix_kit_project_assignments_child_project_uuid_fkey
+          FOREIGN KEY (child_project_uuid)
+          REFERENCES #{p}phoenix_kit_projects(uuid)
+          ON DELETE RESTRICT;
+      END IF;
+    END $$;
+    """)
+  end
+
+  # A sub-project assignment has no task template, so task_uuid must be
+  # nullable. `DROP NOT NULL` is itself idempotent (a no-op when already
+  # nullable), so no existence guard is needed.
+  defp drop_task_uuid_not_null(p) do
+    execute(
+      "ALTER TABLE #{p}phoenix_kit_project_assignments ALTER COLUMN task_uuid DROP NOT NULL"
+    )
+  end
+
+  # Exactly one of task_uuid / child_project_uuid is set. `<>` is boolean XOR
+  # in Postgres. Existing rows (task set, child NULL) already satisfy it.
+  defp add_task_xor_child_check(p, schema) do
+    execute("""
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT FROM information_schema.table_constraints
+        WHERE table_schema = '#{schema}'
+          AND table_name = 'phoenix_kit_project_assignments'
+          AND constraint_name = 'phoenix_kit_project_assignments_task_xor_child'
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_project_assignments
+          ADD CONSTRAINT phoenix_kit_project_assignments_task_xor_child
+          CHECK ((task_uuid IS NOT NULL) <> (child_project_uuid IS NOT NULL));
+      END IF;
+    END $$;
+    """)
+  end
+
+  # A project can be embedded as a sub-project in at most one parent. Partial
+  # so the common task-backed rows (child NULL) don't collide.
+  defp create_child_project_unique_index(p, schema) do
+    execute("""
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT FROM pg_indexes
+        WHERE schemaname = '#{schema}'
+          AND tablename = 'phoenix_kit_project_assignments'
+          AND indexname = 'phoenix_kit_project_assignments_child_project_unique'
+      ) THEN
+        CREATE UNIQUE INDEX phoenix_kit_project_assignments_child_project_unique
+          ON #{p}phoenix_kit_project_assignments (child_project_uuid)
+          WHERE child_project_uuid IS NOT NULL;
+      END IF;
+    END $$;
+    """)
+  end
+
+  defp create_child_project_index(p) do
+    execute("""
+    CREATE INDEX IF NOT EXISTS phoenix_kit_project_assignments_child_project_index
+    ON #{p}phoenix_kit_project_assignments (child_project_uuid)
+    """)
+  end
+
+  defp schema_for("public"), do: "public"
+  defp schema_for(prefix), do: prefix
+
+  defp prefix_str("public"), do: "public."
+  defp prefix_str(prefix), do: "#{prefix}."
+end

--- a/lib/phoenix_kit/migrations/postgres/v128.ex
+++ b/lib/phoenix_kit/migrations/postgres/v128.ex
@@ -1,0 +1,138 @@
+defmodule PhoenixKit.Migrations.Postgres.V128 do
+  @moduledoc """
+  V128: Assignee on projects (and sub-projects).
+
+  Lets a whole project be assigned to a Department / Team / Person, exactly like
+  a task (`phoenix_kit_project_assignments`) already can. Because a sub-project
+  *is* a project (V127), this single set of columns covers both top-level
+  projects and sub-projects — a sub-project's assignee lives on its own project
+  row.
+
+  Adds to `phoenix_kit_projects`:
+
+    * `assigned_team_uuid` → FK `phoenix_kit_staff_teams(uuid) ON DELETE SET NULL`
+    * `assigned_department_uuid` → FK `phoenix_kit_staff_departments(uuid) ON DELETE SET NULL`
+    * `assigned_person_uuid` → FK `phoenix_kit_staff_people(uuid) ON DELETE SET NULL`
+    * `CHECK num_nonnulls(team, department, person) <= 1` — at most one assignee
+      (the same single-assignee rule the assignments table uses).
+    * a partial index per FK for "what's assigned to X" lookups.
+
+  `ON DELETE SET NULL` so removing a team/department/person un-assigns the
+  project rather than deleting it. Idempotent DO-blocks throughout.
+  """
+
+  use Ecto.Migration
+
+  def up(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+    schema = schema_for(prefix)
+
+    add_assignee_column(p, schema, "assigned_team_uuid", "phoenix_kit_staff_teams")
+    add_assignee_column(p, schema, "assigned_department_uuid", "phoenix_kit_staff_departments")
+    add_assignee_column(p, schema, "assigned_person_uuid", "phoenix_kit_staff_people")
+    add_single_assignee_check(p, schema)
+    create_assignee_index(p, schema, "assigned_team_uuid", "team")
+    create_assignee_index(p, schema, "assigned_department_uuid", "department")
+    create_assignee_index(p, schema, "assigned_person_uuid", "person")
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '128'")
+  end
+
+  def down(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    execute("DROP INDEX IF EXISTS #{p}phoenix_kit_projects_assigned_person_idx")
+    execute("DROP INDEX IF EXISTS #{p}phoenix_kit_projects_assigned_department_idx")
+    execute("DROP INDEX IF EXISTS #{p}phoenix_kit_projects_assigned_team_idx")
+
+    execute("""
+    ALTER TABLE #{p}phoenix_kit_projects
+      DROP CONSTRAINT IF EXISTS phoenix_kit_projects_single_assignee
+    """)
+
+    execute("ALTER TABLE #{p}phoenix_kit_projects DROP COLUMN IF EXISTS assigned_person_uuid")
+    execute("ALTER TABLE #{p}phoenix_kit_projects DROP COLUMN IF EXISTS assigned_department_uuid")
+    execute("ALTER TABLE #{p}phoenix_kit_projects DROP COLUMN IF EXISTS assigned_team_uuid")
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '127'")
+  end
+
+  defp add_assignee_column(p, schema, column, target_table) do
+    constraint = "phoenix_kit_projects_#{column}_fkey"
+
+    execute("""
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT FROM information_schema.columns
+        WHERE table_schema = '#{schema}'
+          AND table_name = 'phoenix_kit_projects'
+          AND column_name = '#{column}'
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_projects ADD COLUMN #{column} UUID;
+      END IF;
+
+      IF NOT EXISTS (
+        SELECT FROM information_schema.table_constraints
+        WHERE table_schema = '#{schema}'
+          AND table_name = 'phoenix_kit_projects'
+          AND constraint_name = '#{constraint}'
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_projects
+          ADD CONSTRAINT #{constraint}
+          FOREIGN KEY (#{column})
+          REFERENCES #{p}#{target_table}(uuid)
+          ON DELETE SET NULL;
+      END IF;
+    END $$;
+    """)
+  end
+
+  # At most one of team/department/person set. Mirrors the assignments table's
+  # `phoenix_kit_project_assignments_single_assignee` check.
+  defp add_single_assignee_check(p, schema) do
+    execute("""
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT FROM information_schema.table_constraints
+        WHERE table_schema = '#{schema}'
+          AND table_name = 'phoenix_kit_projects'
+          AND constraint_name = 'phoenix_kit_projects_single_assignee'
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_projects
+          ADD CONSTRAINT phoenix_kit_projects_single_assignee
+          CHECK (num_nonnulls(assigned_team_uuid, assigned_department_uuid, assigned_person_uuid) <= 1);
+      END IF;
+    END $$;
+    """)
+  end
+
+  defp create_assignee_index(p, schema, column, short) do
+    index = "phoenix_kit_projects_assigned_#{short}_idx"
+
+    execute("""
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT FROM pg_indexes
+        WHERE schemaname = '#{schema}'
+          AND tablename = 'phoenix_kit_projects'
+          AND indexname = '#{index}'
+      ) THEN
+        CREATE INDEX #{index}
+          ON #{p}phoenix_kit_projects (#{column})
+          WHERE #{column} IS NOT NULL;
+      END IF;
+    END $$;
+    """)
+  end
+
+  defp schema_for("public"), do: "public"
+  defp schema_for(prefix), do: prefix
+
+  defp prefix_str("public"), do: "public."
+  defp prefix_str(prefix), do: "#{prefix}."
+end


### PR DESCRIPTION
_Renumbered V126/V127 → V127/V128 after rebasing onto main, which took V126 for standalone notifications (#579)._

Core schema support for the `phoenix_kit_projects` nested-sub-projects + project-assignee feature. Two versioned migrations; bumps `@current_version` 126 → 128.

## V127 — Sub-projects as tasks
Adds `child_project_uuid` to `phoenix_kit_project_assignments` so an assignment can embed a child project instead of a task template:
- FK → `phoenix_kit_projects(uuid)` **ON DELETE RESTRICT** (recursive teardown is orchestrated explicitly in the context, not via cascade).
- Drops `task_uuid` `NOT NULL`; adds a `CHECK ((task_uuid IS NOT NULL) <> (child_project_uuid IS NOT NULL))` XOR.
- Partial UNIQUE index on `child_project_uuid` (a project is a child of at most one parent) + a plain lookup index.
- `down/1` deletes the child-link rows (which have `task_uuid IS NULL`) **before** restoring `task_uuid NOT NULL`, so rollback can't fail on those rows.

## V128 — Assignee on projects (and sub-projects)
Adds `assigned_team_uuid` / `assigned_department_uuid` / `assigned_person_uuid` to `phoenix_kit_projects` (ON DELETE SET NULL), a single-assignee `CHECK (num_nonnulls(...) <= 1)`, and partial indexes. Since a sub-project is a project, this one column set also covers assigning a sub-project.

Both migrations are idempotent (existence-guarded), prefix-aware, and set the `COMMENT ON TABLE phoenix_kit` version marker correctly in both directions (126↔125, 127↔126).

Consumed by the `phoenix_kit_projects` sub-projects PR (which pins the core release that ships these).
