### PR TITLE
Generalize AI translation: shared pipeline, glue, hint + quality

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -83,6 +83,9 @@
   # PhoenixKit.Modules.AI.available?/0. @compile no_warn_undefined silences the
   # compiler; Dialyzer needs this ignore for the same call.
   {"lib/modules/ai/translation.ex", :unknown_function},
+  # PhoenixKitAI.{enabled?,list_endpoints,list_prompts,get_prompt_by_slug,create_prompt}
+  # — same optional-plugin story for the orchestration context.
+  {"lib/modules/ai/translations.ex", :unknown_function},
 
   # Integrations: Dialyzer infers boolean branches in cond/case are unreachable
   # when provider auth_type covers all spec'd atoms. False positive — defensive code.

--- a/dev_docs/plans/2026-06-02-ai-translation-generalization.md
+++ b/dev_docs/plans/2026-06-02-ai-translation-generalization.md
@@ -1,0 +1,156 @@
+# AI Translation Generalization
+
+**Status:** in progress (Phase 1 additive core + catalogue). Authored 2026-06-02.
+
+## Problem
+
+`PhoenixKit.Modules.AI.Translation` already centralizes the *engine*
+(`translate_fields/6` + structured-response parsing). But every consumer
+re-implements the same orchestration on top of it:
+
+- A `Translations` context (availability checks, list endpoints/prompts,
+  settings-key resolution, default-prompt generation, `enqueue/1`,
+  `enqueue_all_missing/2`, param validation).
+- An Oban worker (load resource → build field map → `translate_fields` →
+  persist to a `translations` JSONB → broadcast → activity log → retry
+  classification → uniqueness).
+- Form glue (in-flight state, dispatch, PubSub handling) + UI.
+
+`phoenix_kit_projects` and `phoenix_kit_publishing` each carry ~1000 lines
+of this, with slight behavioral drift. Adding `phoenix_kit_catalogue`
+would be a third copy. This plan hoists the orchestration into core so a
+consumer needs only a small **adapter** + a UI call.
+
+## What already lives in core (do not duplicate)
+
+- `PhoenixKit.Modules.AI.Translation.translate_fields/6` — the AI call +
+  `---FIELD---` parse. Returns `{:ok, %{field => text}}` / `{:error, _}`.
+- `PhoenixKit.Modules.AI.available?/0` — plugin loaded?
+- `PhoenixKitWeb.Components.Core.LanguageSwitcher` `ai_translate` attr —
+  the per-language sparkle + "translate all missing" UI primitive.
+  (`multilang_tabs` does NOT forward it yet — Phase 2.)
+
+## Design — additive core (Phase 1)
+
+### 1. `PhoenixKit.Modules.AI.Translatable` (behaviour)
+
+The only per-module code. A consumer implements one adapter module:
+
+```elixir
+@callback fetch(resource_type :: String.t(), uuid :: String.t()) ::
+            {:ok, struct()} | {:error, term()}
+@callback source_fields(resource :: struct(), source_lang :: String.t()) ::
+            %{optional(String.t()) => String.t()}
+@callback put_translation(resource :: struct(), target_lang :: String.t(),
+            fields :: %{optional(String.t()) => String.t()}, opts :: keyword()) ::
+            {:ok, struct()} | {:error, term()}
+@callback pubsub_topics(resource :: struct()) :: [binary()]   # optional
+@optional_callbacks pubsub_topics: 1
+```
+
+### 2. Discovery (`PhoenixKit.ModuleRegistry`)
+
+A module declares an optional `ai_translatables/0` callback returning
+`[{resource_type :: String.t(), adapter_module}]` (same discovery shape as
+`notification_types/0` / `admin_tabs/0`). `ModuleRegistry.all_ai_translatables/0`
+scans `all_modules()` and folds into `%{resource_type => adapter}`.
+`find_ai_translatable/1` resolves one. **`resource_type` strings must be
+globally unique** (namespace them: `"catalogue"`, `"catalogue_category"`,
+`"catalogue_item"`, `"project"`, `"post"`, …).
+
+### 3. `PhoenixKit.Modules.AI.TranslateWorker` (generic Oban worker)
+
+`queue: :default`, `max_attempts: 3`, unique per
+`(resource_type, resource_uuid, target_lang)` with `period: :infinity`
+over all incomplete states. `perform/1`:
+
+1. Resolve adapter from `resource_type` (discard if unknown).
+2. `adapter.fetch/2` → resource (discard if not found).
+3. `adapter.source_fields/2` → field map (empty ⇒ broadcast completed-empty, `:ok`).
+4. `Translation.translate_fields/6`.
+5. `adapter.put_translation/4` (adapter owns atomic/merge write).
+6. Broadcast `{:ai_translation, event, payload}` on the core topic +
+   `adapter.pubsub_topics/1`; one `ai.translation_added` activity entry.
+7. Retry only transient AI errors (timeout/rate-limit/5xx); discard
+   deterministic ones (parse, missing plugin/endpoint/prompt, persist).
+
+Broadcast events: `:translation_started | :translation_completed | :translation_failed`.
+Completed payload carries `fields` (the translated map) so a host LV can
+patch its live changeset without a DB re-read.
+
+### 4. `PhoenixKit.Modules.AI.Translation` orchestration additions
+
+- `available?/0` — `AI.available?` AND ≥1 enabled endpoint.
+- `list_endpoints/0`, `list_prompts/0` — `[{uuid, name}]`, guarded.
+- `default_endpoint_uuid/0` — setting `ai_translation_endpoint_uuid`, else
+  first enabled endpoint.
+- `default_prompt_uuid/0` — setting `ai_translation_prompt_uuid`, else the
+  shared `ai-translate-content` prompt by slug.
+- `ensure_default_prompt/0` — idempotently create the shared prompt.
+- `enqueue/1`, `enqueue_all_missing/2` — validate + insert `TranslateWorker`.
+- `topic/0`, `topic/2`, `subscribe/2`, `missing_languages/3` — PubSub +
+  helper for a host to compute missing langs.
+
+The bespoke per-resource Settings keys (`projects_translation_*`,
+`publishing_*`) collapse to one shared pair; a consumer may still override
+per-call by passing explicit `endpoint_uuid`/`prompt_uuid`.
+
+## Design — core UI (Phase 2)
+
+- `multilang_tabs` forwards an `ai_translate` map to its internal
+  `language_switcher`.
+- A `use PhoenixKitWeb.AITranslate.Embed` macro injects the
+  `handle_event("ai_translate", …)` + `handle_info({:ai_translation, …})`
+  glue via `attach_hook` (same shape as `MediaBrowser.Embed`), so a form
+  is `use` + `<.multilang_tabs ai_translate={...}>`.
+
+## Consumers
+
+- **catalogue (Phase 1, this pass):** optional `:phoenix_kit_ai` dep +
+  `PhoenixKitCatalogue.AITranslatable` adapter (resource types
+  `catalogue` / `catalogue_category` / `catalogue_item`, fields
+  `name` + `description`, stored in `data["translations"][lang]`) +
+  `ai_translatables/0` registration + a minimal "Translate missing with
+  AI" affordance on the three form LVs. Greenfield — browser-verifiable.
+- **projects / publishing (Phase 3, deferred):** refactor onto the core
+  API, deleting their bespoke `Translations` context + worker. Gated on
+  their full test suites staying green. **Requires a core release + Hex
+  pin bump (boss-only), so it lands after core ships.**
+
+## Hardening follow-ups (6-AI quorum, 2026-06-02)
+
+A full quorum (Codex, Gemini, Kimi, Vibe, ZAI, M2) **unanimously validated
+the one-Oban-job-per-target-language fan-out** as the right default (all
+rejected a single 40-language call as fragile/all-or-nothing, and the
+sequential single job for UX/timeout reasons). Applied + outstanding:
+
+- **DONE — snooze on rate-limit.** `{:ai_error, :rate_limited}` →
+  `{:snooze, 30}` in `TranslateWorker` instead of consuming a retry, so a
+  burst drains rather than exhausting `max_attempts`. Works on any host.
+- **TODO (quorum's #1, unanimous) — dedicated capped Oban queue.** The
+  worker currently runs on `:default` (no per-resource cap → a ~40-call
+  burst can trip provider 429s). Move it to a dedicated `ai_translation`
+  queue with a small `limit` (panel range 3–8), wired into the host via
+  `mix phoenix_kit.install/.update` (mirror `Install.ObanConfig` for the
+  `catalogue_pdf` queue) + a queue-availability guard like the catalogue
+  PDF worker, so jobs fail-visible instead of silently sitting when the
+  queue is absent. Deferred deliberately: half-wiring it (worker off
+  `:default` without the host config) would stop jobs running, and it
+  belongs with the install-task/release work.
+- **OPTIONAL (later, if cost dominates) — small language batches** (2–5
+  langs per AI call): cuts repeated input tokens, but Kimi dissents
+  (breaks granular retry, no call-count saving). Not the default.
+- **OPTIONAL — staggered enqueue** (`schedule_in` offsets) as a softer
+  burst cap where a dedicated queue isn't available.
+
+Dedup mechanism: app-level query (4 always-present states) is intentional
+over Oban `unique:` — `unique:` with an explicit 4-state list avoids the
+runtime `22P02` but emits a compile warning that fails core's
+`--warnings-as-errors`; same trade-off the catalogue PDF worker made.
+
+## Release / sequencing
+
+Core changes are boss-only to release. In `phoenix_kit_parent` (local
+path deps) the whole tree compiles + runs, so Phase 1 is end-to-end
+verifiable now. Hex pin bumps for catalogue/projects/publishing are a
+follow-up the boss handles on the next core release.

--- a/dev_docs/plans/2026-06-02-ai-translation-generalization.md
+++ b/dev_docs/plans/2026-06-02-ai-translation-generalization.md
@@ -95,14 +95,36 @@ The bespoke per-resource Settings keys (`projects_translation_*`,
 `publishing_*`) collapse to one shared pair; a consumer may still override
 per-call by passing explicit `endpoint_uuid`/`prompt_uuid`.
 
-## Design — core UI (Phase 2)
+## Core UI (Phase 2) — DONE
 
-- `multilang_tabs` forwards an `ai_translate` map to its internal
-  `language_switcher`.
-- A `use PhoenixKitWeb.AITranslate.Embed` macro injects the
-  `handle_event("ai_translate", …)` + `handle_info({:ai_translation, …})`
-  glue via `attach_hook` (same shape as `MediaBrowser.Embed`), so a form
-  is `use` + `<.multilang_tabs ai_translate={...}>`.
+Built as a standalone shared component rather than a `multilang_tabs`
+passthrough + `use` macro (simpler, and composes with any form layout):
+
+- **`PhoenixKitWeb.Components.AITranslate`** — render-only
+  `<.ai_translate_button>` + `<.ai_translate_modal>` + `<.ai_translate_progress>`,
+  driven by a single `ai_translate` config map (string/atom keys). The modal
+  carries endpoint + prompt selectors, a Generate-Default-Prompt button, a
+  scope picker (missing-only / all-overwrite / current-tab), in-flight
+  status, and one scope-driven Translate action (`phx-value-lang` =
+  `"*"` / `"**"` / concrete code). Hoisted from `phoenix_kit_projects`'
+  bespoke `AITranslateBar`, made generic (core Gettext + Core.Icon).
+- The **host owns the state + event handlers** (mount state, modal
+  open/close, endpoint/prompt/scope selection, generate-prompt,
+  scope dispatch, the `{:ai_translation, _, _}` lifecycle + live changeset
+  patch). Catalogue's `Web.Helpers` is the reference glue; a future
+  `use`-macro could fold this into core, but the per-consumer completion
+  merge (how to write translated fields into the form) stays consumer-specific.
+
+### Known limitation (codex review)
+
+A force-stored translation that equals the primary (so the field shows
+instead of looking failed) is **re-dropped if the user then manually saves
+the form** — the shared multilang save path (`merge_translatable_params` →
+`Multilang.put_language_data`) strips equal-to-primary overrides. The
+translate-time UX (field populated + DB-persisted) is correct; only a
+subsequent manual save reverts an identical value to "inherited". Fixing
+that fully means an opt-out on the multilang save path (out of scope —
+affects every multilang form).
 
 ## Consumers
 

--- a/dev_docs/pull_requests/2026/572-v125-project-statuses/FOLLOW_UP.md
+++ b/dev_docs/pull_requests/2026/572-v125-project-statuses/FOLLOW_UP.md
@@ -1,0 +1,17 @@
+# Follow-up: PR #572 — V125 project statuses
+
+Triaged 2026-06-03 (quality-sweep Phase 1). Source review: `CLAUDE_REVIEW.md`.
+
+## Skipped (with rationale)
+
+Both findings are `NITPICK`s confirmed still-present but intentional:
+
+- **`v125_test.exs` uses `async: false`** (`test/phoenix_kit/migrations/v125_test.exs:27`)
+  — matches the sibling V-migration test precedent (all `vNNN_test.exs` run
+  non-async against the shared migration DB). Left for consistency.
+- **`schema_for/1` is a one-line identity passthrough** — kept for symmetry
+  with the neighbouring `prefix_str/1` helper; harmless.
+
+## Open
+
+None.

--- a/dev_docs/pull_requests/2026/573-catalogue-pdf-oban-queue/FOLLOW_UP.md
+++ b/dev_docs/pull_requests/2026/573-catalogue-pdf-oban-queue/FOLLOW_UP.md
@@ -1,0 +1,20 @@
+# Follow-up: PR #573 — Catalogue PDF Oban queue
+
+Triaged 2026-06-03 (quality-sweep Phase 1). Source review: `CLAUDE_REVIEW.md`.
+
+## Punted (separate refactor)
+
+- **`IMPROVEMENT - MEDIUM`: five near-duplicate `ensure_*_queue/2` functions**
+  (`lib/phoenix_kit/install/oban_config.ex` — `ensure_posts_queue` :196,
+  `ensure_sitemap_queue` :242, `ensure_shop_imports_queue` :287,
+  `ensure_newsletters_delivery_queue` :332, `ensure_catalogue_pdf_queue` :380).
+  They differ only in queue name + concurrency and could collapse into a single
+  data-driven `ensure_queue(content, app_name, name, concurrency)`. Confirmed
+  still live. The PR **explicitly deferred** this as out-of-scope (correct
+  call — it spans installer codegen for every content module). Surfaced to Max
+  2026-06-03; decision: **punt to a dedicated installer-dedup refactor**, not
+  this sweep.
+
+## Open
+
+None (the punted refactor is tracked here as the trigger note).

--- a/lib/modules/ai/translatable.ex
+++ b/lib/modules/ai/translatable.ex
@@ -1,0 +1,89 @@
+defmodule PhoenixKit.Modules.AI.Translatable do
+  @moduledoc """
+  Behaviour a feature module implements to make a resource AI-translatable
+  through core's generic translation pipeline
+  (`PhoenixKit.Modules.AI.TranslateWorker` +
+  `PhoenixKit.Modules.AI.Translations`).
+
+  An adapter is the *only* per-module code needed — the load, the field
+  extraction, and the persist. Everything else (enqueue, the Oban worker,
+  the AI call, parsing, broadcasts, the audit log, retry policy) lives in
+  core and is shared across every consumer.
+
+  ## Registration
+
+  The feature module exposes its adapters via the optional
+  `ai_translatables/0` callback on `PhoenixKit.Module`, returning
+  `[{resource_type, adapter_module}]`:
+
+      @impl PhoenixKit.Module
+      def ai_translatables do
+        [
+          {"catalogue", PhoenixKitCatalogue.AITranslatable},
+          {"catalogue_category", PhoenixKitCatalogue.AITranslatable},
+          {"catalogue_item", PhoenixKitCatalogue.AITranslatable}
+        ]
+      end
+
+  `resource_type` strings MUST be globally unique across all modules —
+  namespace them (`"catalogue_item"`, not `"item"`). The same adapter
+  module may serve several resource types; it dispatches on the
+  `resource_type` argument passed to each callback.
+
+  ## Storage contract
+
+  `put_translation/4` owns the write and MUST be **atomic + merge-safe**.
+  `enqueue_all_missing/2` dispatches one concurrent job per target language,
+  so several jobs write the *same row's* translation store at once. The
+  `resource` struct handed in was loaded BEFORE the (multi-second) AI call,
+  so it is stale by persist time — merging the new language into that
+  in-memory struct and doing a plain update will silently drop sibling
+  languages other jobs committed in the meantime.
+
+  Persist against the **current** row, one of:
+
+  - a single atomic SQL write to the per-language path, e.g.
+    `jsonb_set(coalesce(data, '{}'), {translations, <lang>}, <fields>, true)`
+    via `update_all` (different languages touch different paths → no
+    conflict); or
+  - a `Repo.transaction` that re-reads the row `lock: "FOR UPDATE"`, merges,
+    and writes.
+
+  Either keeps the multilang form's edit round-trip working unchanged.
+  """
+
+  @type resource_type :: String.t()
+  @type lang :: String.t()
+  @type fields :: %{optional(String.t()) => String.t()}
+
+  @doc "Load a resource by its (type, uuid). `{:error, :resource_not_found}` when absent."
+  @callback fetch(resource_type(), uuid :: String.t()) :: {:ok, struct()} | {:error, term()}
+
+  @doc """
+  The `%{field_name => text}` to translate, read in `source_lang`.
+
+  Return only non-empty fields — empty ones waste tokens and confuse the
+  model. Field names become the prompt variables + `---FIELD---` markers.
+  """
+  @callback source_fields(resource :: struct(), source_lang :: lang()) :: fields()
+
+  @doc """
+  Persist `fields` into `resource` for `target_lang`. Must merge (not
+  clobber other languages). `opts` carries `:actor_uuid`.
+  """
+  @callback put_translation(
+              resource :: struct(),
+              target_lang :: lang(),
+              fields :: fields(),
+              opts :: keyword()
+            ) :: {:ok, struct()} | {:error, term()}
+
+  @doc """
+  Optional extra PubSub topics (besides the core translation topic) to
+  fan status events out on — e.g. the module's own resource topic so an
+  already-subscribed LV gets translation lifecycle events too.
+  """
+  @callback pubsub_topics(resource :: struct()) :: [binary()]
+
+  @optional_callbacks pubsub_topics: 1
+end

--- a/lib/modules/ai/translate_worker.ex
+++ b/lib/modules/ai/translate_worker.ex
@@ -280,6 +280,10 @@ defmodule PhoenixKit.Modules.AI.TranslateWorker do
   @doc false
   @spec retryable?(term()) :: boolean()
   def retryable?({:ai_error, :request_timeout}), do: true
+  # PhoenixKit.AI's HTTP client surfaces a request timeout as `:timeout`
+  # ({:error, :timeout} → {:ai_error, :timeout} here). A timeout is transient
+  # — retry rather than discard, so a one-off slow/hung provider call re-runs.
+  def retryable?({:ai_error, :timeout}), do: true
   def retryable?({:ai_error, :rate_limited}), do: true
   def retryable?({:ai_error, {:connection_error, _}}), do: true
   def retryable?({:ai_error, {:exit, _}}), do: true

--- a/lib/modules/ai/translate_worker.ex
+++ b/lib/modules/ai/translate_worker.ex
@@ -1,0 +1,301 @@
+defmodule PhoenixKit.Modules.AI.TranslateWorker do
+  @moduledoc """
+  Generic Oban worker that translates one resource's fields into a single
+  target language, shared by every consumer module.
+
+  Resolves a `PhoenixKit.Modules.AI.Translatable` adapter from the
+  job's `resource_type` (registered via `ai_translatables/0` and
+  discovered through `PhoenixKit.ModuleRegistry`), then runs:
+
+      adapter.fetch/2 → adapter.source_fields/2 →
+      Translation.translate_fields/6 → adapter.put_translation/4
+
+  broadcasting `{:ai_translation, event, payload}` at each lifecycle step
+  (see `PhoenixKit.Modules.AI.Translations`) and writing one
+  `ai.translation_added` activity entry on success.
+
+  ## Job args
+
+      %{
+        "resource_type" => "catalogue_item",
+        "resource_uuid" => uuid,
+        "endpoint_uuid" => uuid,
+        "prompt_uuid"   => uuid,
+        "source_lang"   => "en",
+        "target_lang"   => "es",
+        "actor_uuid"    => uuid_or_nil
+      }
+
+  ## De-duplication
+
+  De-dup is **app-level** in `PhoenixKit.Modules.AI.Translations.enqueue/1`
+  (one in-flight job per `(resource_type, resource_uuid, target_lang)`), NOT
+  Oban's built-in `unique:`. Oban's uniqueness query references the
+  `:suspended` job state, which is absent from the `oban_job_state` enum on
+  hosts that upgraded the Oban *lib* ahead of its *migration* — there the
+  query raises `22P02` and kills every enqueue. The app guard queries only
+  the four always-present states (`available`/`scheduled`/`executing`/
+  `retryable`) and fails open. Same trade-off as the catalogue PDF worker.
+  """
+
+  use Oban.Worker, queue: :default, max_attempts: 3
+
+  require Logger
+
+  alias PhoenixKit.ModuleRegistry
+  alias PhoenixKit.Modules.AI.{Translation, Translations}
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: args} = job) do
+    with {:ok, type} <- fetch_arg(args, "resource_type"),
+         {:ok, uuid} <- fetch_arg(args, "resource_uuid"),
+         {:ok, endpoint} <- fetch_arg(args, "endpoint_uuid"),
+         {:ok, prompt} <- fetch_arg(args, "prompt_uuid"),
+         {:ok, source} <- fetch_arg(args, "source_lang"),
+         {:ok, target} <- fetch_arg(args, "target_lang"),
+         {:ok, adapter} <- resolve_adapter(type),
+         {:ok, resource} <- load_resource(adapter, type, uuid) do
+      do_translate(%{
+        type: type,
+        uuid: uuid,
+        endpoint: endpoint,
+        prompt: prompt,
+        source: source,
+        target: target,
+        actor: Map.get(args, "actor_uuid"),
+        adapter: adapter,
+        resource: resource,
+        attempt: job.attempt,
+        max_attempts: job.max_attempts
+      })
+    else
+      {:error, reason} ->
+        # Deterministic setup failure (bad args, unknown adapter, missing
+        # row) — not worth retrying. Surface a normalised failure on the
+        # global topic (we may lack a per-resource topic), then discard.
+        Translations.broadcast(:translation_failed, %{
+          resource_type: Map.get(args, "resource_type"),
+          resource_uuid: Map.get(args, "resource_uuid"),
+          source_lang: Map.get(args, "source_lang"),
+          target_lang: Map.get(args, "target_lang"),
+          reason: reason
+        })
+
+        {:discard, reason}
+    end
+  end
+
+  defp do_translate(ctx) do
+    broadcast(ctx, :translation_started, %{})
+
+    case safe_source_fields(ctx) do
+      {:error, reason} ->
+        # Adapter misbehaved (crashed or returned a non-`%{String=>String}`
+        # map). Deterministic — discard with a clean failure broadcast.
+        fail(ctx, {:adapter_error, reason}, retry?: false)
+
+      fields when map_size(fields) == 0 ->
+        # Nothing to translate — treat as success so the host clears its
+        # spinner; the resource just has no source content for these fields.
+        broadcast(ctx, :translation_completed, %{fields: %{}, empty: true})
+        :ok
+
+      fields ->
+        case Translation.translate_fields(
+               ctx.endpoint,
+               ctx.prompt,
+               ctx.source,
+               ctx.target,
+               fields,
+               actor_uuid: ctx.actor,
+               resource_type: ctx.type,
+               resource_uuid: ctx.uuid,
+               source: "PhoenixKit.Modules.AI.TranslateWorker"
+             ) do
+          {:ok, translated} ->
+            persist(ctx, translated)
+
+          # Rate-limited: snooze instead of consuming a retry attempt, so a
+          # burst of concurrent jobs (enqueue_all_missing) backs off and
+          # drains rather than exhausting max_attempts. The language stays
+          # in-flight on the UI (no terminal broadcast) until it lands.
+          {:error, {:ai_error, :rate_limited}} ->
+            {:snooze, 30}
+
+          {:error, reason} ->
+            fail(ctx, reason, retry?: retryable?(reason))
+        end
+    end
+  end
+
+  defp persist(ctx, translated) do
+    case safe_put_translation(ctx, translated) do
+      {:ok, _updated} ->
+        log_added(ctx, translated)
+        broadcast(ctx, :translation_completed, %{fields: translated})
+        :ok
+
+      {:error, reason} ->
+        Logger.warning(
+          "[AI.TranslateWorker] persist failed for #{ctx.type} #{ctx.uuid}: #{inspect(reason)}"
+        )
+
+        # Persist failures are deterministic (changeset/constraint) — discard.
+        fail(ctx, {:persist_error, reason}, retry?: false)
+    end
+  end
+
+  # Broadcast a terminal failure only when the job won't be retried (either
+  # deterministic, or the final attempt). During a pending retry we stay
+  # silent so a host UI keeps its spinner rather than flashing a failure the
+  # next attempt may clear.
+  defp fail(ctx, reason, retry?: retry?) do
+    Logger.warning(
+      "[AI.TranslateWorker] translation failed for #{ctx.type} #{ctx.uuid} → #{ctx.target} " <>
+        "(attempt #{ctx.attempt}/#{ctx.max_attempts}): #{inspect(reason)}"
+    )
+
+    final? = ctx.attempt >= ctx.max_attempts
+
+    cond do
+      retry? and not final? ->
+        {:error, reason}
+
+      retry? ->
+        # Out of attempts — now it's terminal, so surface it.
+        broadcast(ctx, :translation_failed, %{reason: reason})
+        {:error, reason}
+
+      true ->
+        broadcast(ctx, :translation_failed, %{reason: reason})
+        {:discard, reason}
+    end
+  end
+
+  # Adapter callbacks are external module code — normalize crashes and bad
+  # return shapes into `{:error, _}` instead of letting them blow up the
+  # worker after `:translation_started` (which would retry with no clean
+  # failure signal).
+  defp safe_source_fields(ctx) do
+    case ctx.adapter.source_fields(ctx.resource, ctx.source) do
+      map when is_map(map) ->
+        if Enum.all?(map, fn {k, v} -> is_binary(k) and is_binary(v) end) do
+          map
+        else
+          {:error, :non_string_fields}
+        end
+
+      other ->
+        {:error, {:bad_source_fields, other}}
+    end
+  rescue
+    e -> {:error, {:exception, Exception.message(e)}}
+  end
+
+  defp safe_put_translation(ctx, translated) do
+    case ctx.adapter.put_translation(ctx.resource, ctx.target, translated, actor_uuid: ctx.actor) do
+      {:ok, updated} -> {:ok, updated}
+      {:error, reason} -> {:error, reason}
+      other -> {:error, {:bad_put_translation, other}}
+    end
+  rescue
+    e -> {:error, {:exception, Exception.message(e)}}
+  end
+
+  # ── Adapter resolution + loading ─────────────────────────────────
+
+  defp resolve_adapter(type) do
+    case ModuleRegistry.find_ai_translatable(type) do
+      nil -> {:error, {:no_adapter, type}}
+      adapter -> {:ok, adapter}
+    end
+  end
+
+  defp load_resource(adapter, type, uuid) do
+    case adapter.fetch(type, uuid) do
+      {:ok, resource} -> {:ok, resource}
+      {:error, reason} -> {:error, reason}
+      other -> {:error, {:bad_adapter_fetch, other}}
+    end
+  end
+
+  # ── Broadcast + activity ─────────────────────────────────────────
+
+  defp broadcast(ctx, event, extra) do
+    payload =
+      Map.merge(
+        %{
+          resource_type: ctx.type,
+          resource_uuid: ctx.uuid,
+          source_lang: ctx.source,
+          target_lang: ctx.target
+        },
+        extra
+      )
+
+    Translations.broadcast(event, payload, adapter_topics(ctx))
+  end
+
+  defp adapter_topics(%{adapter: adapter, resource: resource}) do
+    if function_exported?(adapter, :pubsub_topics, 1) do
+      case adapter.pubsub_topics(resource) do
+        topics when is_list(topics) -> topics
+        _ -> []
+      end
+    else
+      []
+    end
+  rescue
+    # A broadcast helper must never crash the worker — drop extra topics.
+    _ -> []
+  end
+
+  defp log_added(ctx, translated) do
+    if Code.ensure_loaded?(PhoenixKit.Activity) and
+         function_exported?(PhoenixKit.Activity, :log, 1) do
+      PhoenixKit.Activity.log(%{
+        action: "ai.translation_added",
+        module: "ai",
+        mode: "auto",
+        actor_uuid: ctx.actor,
+        resource_type: ctx.type,
+        resource_uuid: ctx.uuid,
+        metadata: %{
+          "source_lang" => ctx.source,
+          "target_lang" => ctx.target,
+          "fields" => Map.keys(translated)
+        }
+      })
+    end
+  rescue
+    # The audit entry is best-effort — a logging failure must not fail an
+    # otherwise-successful translation (the row is already persisted).
+    error ->
+      Logger.warning("[AI.TranslateWorker] activity log failed: #{Exception.message(error)}")
+      :ok
+  end
+
+  # ── Retry classification ─────────────────────────────────────────
+
+  @doc false
+  @spec retryable?(term()) :: boolean()
+  def retryable?({:ai_error, :request_timeout}), do: true
+  def retryable?({:ai_error, :rate_limited}), do: true
+  def retryable?({:ai_error, {:connection_error, _}}), do: true
+  def retryable?({:ai_error, {:exit, _}}), do: true
+
+  def retryable?({:ai_error, {:api_error, status}})
+      when status in [500, 502, 503, 504, 522, 524, 529],
+      do: true
+
+  def retryable?(_), do: false
+
+  # ── Args ─────────────────────────────────────────────────────────
+
+  defp fetch_arg(args, key) do
+    case Map.get(args, key) do
+      v when is_binary(v) and v != "" -> {:ok, v}
+      _ -> {:error, {:missing_arg, key}}
+    end
+  end
+end

--- a/lib/modules/ai/translations.ex
+++ b/lib/modules/ai/translations.ex
@@ -149,6 +149,12 @@ defmodule PhoenixKit.Modules.AI.Translations do
     )
   end
 
+  @doc "Is the shared default translation prompt already provisioned?"
+  @spec default_prompt_exists?() :: boolean()
+  def default_prompt_exists? do
+    safe_ai(fn -> PhoenixKitAI.get_prompt_by_slug(@prompt_slug) != nil end, false)
+  end
+
   @doc """
   Idempotently provision the shared translation prompt. Returns
   `{:ok, prompt}` (existing or freshly created) or `{:error, reason}`.

--- a/lib/modules/ai/translations.ex
+++ b/lib/modules/ai/translations.ex
@@ -1,0 +1,468 @@
+defmodule PhoenixKit.Modules.AI.Translations do
+  @moduledoc """
+  Core orchestration for AI-driven translation — the shared layer every
+  feature module enqueues against instead of re-implementing its own
+  context + worker.
+
+  Pairs with:
+
+  - `PhoenixKit.Modules.AI.Translation` — the engine (the AI call + parse).
+  - `PhoenixKit.Modules.AI.Translatable` — the per-module adapter behaviour.
+  - `PhoenixKit.Modules.AI.TranslateWorker` — the generic Oban worker this
+    module enqueues.
+
+  ## What a consumer does
+
+  1. Implement a `Translatable` adapter and register it via
+     `ai_translatables/0` on its `PhoenixKit.Module`.
+  2. From a form LV: `subscribe/1`, then on a button click call
+     `enqueue/1` (or `enqueue_all_missing/2`), and react to the
+     `{:ai_translation, event, payload}` messages.
+
+  Everything else — the AI call, parsing, persistence (via the adapter),
+  retry policy, broadcasts, and the unified audit log — is shared.
+
+  ## Status messages
+
+  The worker broadcasts `{:ai_translation, event, payload}` where `event`
+  is `:translation_started | :translation_completed | :translation_failed`.
+  `payload` always has `:resource_type`, `:resource_uuid`, `:source_lang`,
+  `:target_lang`. `:translation_completed` adds `:fields` (the translated
+  `%{field => text}` map, possibly empty); `:translation_failed` adds
+  `:reason`.
+  """
+
+  import Ecto.Query
+
+  alias PhoenixKit.Modules.AI
+  alias PhoenixKit.Modules.AI.TranslateWorker
+  alias PhoenixKit.PubSub.Manager, as: PubSubManager
+  alias PhoenixKit.Settings
+
+  # Job states that mean "already covered" for de-dup. Deliberately excludes
+  # `:suspended` — it's missing from the `oban_job_state` enum on some hosts
+  # and referencing it in a query raises `22P02` (see TranslateWorker docs).
+  @incomplete_states ~w(available scheduled executing retryable)
+
+  @endpoint_setting_key "ai_translation_endpoint_uuid"
+  @prompt_setting_key "ai_translation_prompt_uuid"
+  # `PhoenixKitAI` derives a prompt's slug from its name (`Slug.slugify/1`,
+  # overriding any passed `:slug`), so the slug here MUST equal
+  # `slugify(@prompt_name)` or the idempotency lookup never matches and every
+  # `ensure_default_prompt/0` re-attempts the create.
+  @prompt_name "PhoenixKit Translate Content"
+  @prompt_slug "phoenixkit-translate-content"
+  @topic "phoenix_kit:ai_translation"
+
+  # `PhoenixKitAI` is an optional plugin — guard MFAs so core compiles +
+  # runs on hosts without it.
+  @compile {:no_warn_undefined,
+            [
+              {PhoenixKitAI, :enabled?, 0},
+              {PhoenixKitAI, :list_endpoints, 1},
+              {PhoenixKitAI, :list_prompts, 1},
+              {PhoenixKitAI, :get_prompt_by_slug, 1},
+              {PhoenixKitAI, :create_prompt, 1},
+              {PhoenixKitAI, :create_prompt, 2}
+            ]}
+
+  # ── Availability + configuration ─────────────────────────────────
+
+  @doc """
+  Is AI translation usable right now? `PhoenixKitAI` loaded + enabled +
+  at least one enabled endpoint configured. Hosts gate the UI on this.
+  """
+  @spec available?() :: boolean()
+  def available? do
+    AI.available?() and
+      safe_ai(fn -> PhoenixKitAI.enabled?() end, false) and
+      list_endpoints() != []
+  end
+
+  @doc "Configured AI endpoints as `[{uuid, name}]`. Empty when unavailable."
+  @spec list_endpoints() :: [{String.t(), String.t()}]
+  def list_endpoints do
+    safe_ai(
+      fn ->
+        if PhoenixKitAI.enabled?() do
+          {endpoints, _} = PhoenixKitAI.list_endpoints(enabled: true)
+          Enum.map(endpoints, &{&1.uuid, &1.name})
+        else
+          []
+        end
+      end,
+      []
+    )
+  end
+
+  @doc "Configured AI prompts as `[{uuid, name}]`. Empty when unavailable."
+  @spec list_prompts() :: [{String.t(), String.t()}]
+  def list_prompts do
+    safe_ai(
+      fn ->
+        if PhoenixKitAI.enabled?() do
+          case PhoenixKitAI.list_prompts(enabled: true) do
+            {prompts, _} -> Enum.map(prompts, &{&1.uuid, &1.name})
+            prompts when is_list(prompts) -> Enum.map(prompts, &{&1.uuid, &1.name})
+          end
+        else
+          []
+        end
+      end,
+      []
+    )
+  end
+
+  @doc "Default endpoint UUID: the `#{@endpoint_setting_key}` setting, else the first enabled endpoint, else nil."
+  @spec default_endpoint_uuid() :: String.t() | nil
+  def default_endpoint_uuid do
+    case blank_to_nil(Settings.get_setting(@endpoint_setting_key)) do
+      nil ->
+        case list_endpoints() do
+          [{uuid, _name} | _] -> uuid
+          [] -> nil
+        end
+
+      uuid ->
+        uuid
+    end
+  end
+
+  @doc "Default prompt UUID: the `#{@prompt_setting_key}` setting, else the shared `#{@prompt_slug}` prompt, else nil."
+  @spec default_prompt_uuid() :: String.t() | nil
+  def default_prompt_uuid do
+    case blank_to_nil(Settings.get_setting(@prompt_setting_key)) do
+      nil -> shared_prompt_uuid()
+      uuid -> uuid
+    end
+  end
+
+  defp shared_prompt_uuid do
+    safe_ai(
+      fn ->
+        case PhoenixKitAI.get_prompt_by_slug(@prompt_slug) do
+          nil -> nil
+          prompt -> prompt.uuid
+        end
+      end,
+      nil
+    )
+  end
+
+  @doc """
+  Idempotently provision the shared translation prompt. Returns
+  `{:ok, prompt}` (existing or freshly created) or `{:error, reason}`.
+  `{:error, :ai_not_installed}` when the plugin is unavailable.
+  """
+  @spec ensure_default_prompt() :: {:ok, struct()} | {:error, term()}
+  def ensure_default_prompt do
+    if AI.available?() do
+      safe_ai(fn -> do_ensure_prompt() end, {:error, :ai_not_installed})
+    else
+      {:error, :ai_not_installed}
+    end
+  end
+
+  defp do_ensure_prompt do
+    case PhoenixKitAI.get_prompt_by_slug(@prompt_slug) do
+      nil ->
+        case PhoenixKitAI.create_prompt(default_prompt_attrs()) do
+          {:ok, prompt} ->
+            {:ok, prompt}
+
+          # Lost a create race (or the slug/name was taken concurrently) —
+          # re-read by slug. Since @prompt_slug == slugify(@prompt_name), the
+          # row the racing caller inserted is now findable.
+          {:error, %Ecto.Changeset{}} ->
+            case PhoenixKitAI.get_prompt_by_slug(@prompt_slug) do
+              nil -> {:error, :prompt_unavailable}
+              prompt -> {:ok, prompt}
+            end
+        end
+
+      prompt ->
+        {:ok, prompt}
+    end
+  end
+
+  # The SOURCE block enumerates the common translatable field names across
+  # PhoenixKit modules (name/title/description/summary/body/content). The
+  # engine binds only the fields an adapter actually provides; any unbound
+  # `{{placeholder}}` stays literal in the rendered prompt and the RULES tell
+  # the model to skip it, and only requested fields are parsed back. An
+  # adapter whose `source_fields/2` returns a field name NOT listed here must
+  # supply its own prompt (pass `prompt_uuid`) — its value would otherwise
+  # never reach the model and the parse would report a missing field.
+  defp default_prompt_attrs do
+    %{
+      slug: @prompt_slug,
+      name: @prompt_name,
+      description: "Shared PhoenixKit prompt for translating resource fields between languages.",
+      content: """
+      You are translating fields of a content resource from {{SourceLanguage}} to {{TargetLanguage}}.
+
+      RULES:
+      - Preserve formatting exactly (line breaks, spacing, Markdown if present).
+      - Do NOT translate text inside code blocks, inline code, or URLs.
+      - Translate naturally and idiomatically — match the tone of the source.
+      - Keep any HTML tags and special syntax unchanged.
+      - Output ONLY the structured markers below — no commentary, no preface, no closing remarks.
+
+      OUTPUT FORMAT — for each non-empty field in the SOURCE section below,
+      emit ONE marker named after the field (uppercased), followed by the
+      translation:
+
+          ---<FIELD_NAME_UPPERCASE>---
+          [translated value]
+
+      Example:
+
+          ---NAME---
+          <translated name>
+
+          ---DESCRIPTION---
+          <translated description>
+
+      Skip any field that is missing, blank, or still a literal placeholder
+      (e.g. a value that looks like `{{title}}` means the caller did not bind
+      it) — do NOT emit a marker for it, and do NOT translate the placeholder
+      text itself.
+
+      === SOURCE ===
+
+      Name: {{name}}
+
+      Title: {{title}}
+
+      Summary: {{summary}}
+
+      Description: {{description}}
+
+      Body: {{body}}
+
+      Content: {{content}}
+      """
+    }
+  end
+
+  # ── PubSub ───────────────────────────────────────────────────────
+
+  @doc "The global AI-translation status topic."
+  @spec topic() :: String.t()
+  def topic, do: @topic
+
+  @doc "Per-resource AI-translation status topic."
+  @spec topic(String.t(), String.t()) :: String.t()
+  def topic(resource_type, resource_uuid)
+      when is_binary(resource_type) and is_binary(resource_uuid),
+      do: "#{@topic}:#{resource_type}:#{resource_uuid}"
+
+  @doc "Subscribe to the global translation topic."
+  @spec subscribe() :: :ok | {:error, term()}
+  def subscribe, do: PubSubManager.subscribe(@topic)
+
+  @doc "Subscribe to a single resource's translation topic."
+  @spec subscribe(String.t(), String.t()) :: :ok | {:error, term()}
+  def subscribe(resource_type, resource_uuid),
+    do: PubSubManager.subscribe(topic(resource_type, resource_uuid))
+
+  @doc false
+  # Called by `TranslateWorker` to fan an event out on the global topic,
+  # the per-resource topic, and any adapter-supplied topics.
+  def broadcast(event, payload, extra_topics \\ []) do
+    msg = {:ai_translation, event, payload}
+    PubSubManager.broadcast(@topic, msg)
+
+    with %{resource_type: t, resource_uuid: u} when is_binary(t) and is_binary(u) <- payload do
+      PubSubManager.broadcast(topic(t, u), msg)
+    end
+
+    Enum.each(extra_topics, &PubSubManager.broadcast(&1, msg))
+    :ok
+  end
+
+  # ── Missing-language helper ──────────────────────────────────────
+
+  @doc """
+  Given the enabled base language codes, the primary code, and the langs
+  that already have a translation, return the still-missing base codes
+  (primary excluded — it's the source, never a target).
+  """
+  @spec missing_languages([String.t()], String.t(), [String.t()]) :: [String.t()]
+  def missing_languages(enabled_codes, primary_code, existing_langs)
+      when is_list(enabled_codes) and is_list(existing_langs) do
+    existing = MapSet.new(existing_langs)
+
+    Enum.filter(enabled_codes, fn code ->
+      code != primary_code and not MapSet.member?(existing, code)
+    end)
+  end
+
+  # ── Enqueue ──────────────────────────────────────────────────────
+
+  @type enqueue_params :: %{
+          required(:resource_type) => String.t(),
+          required(:resource_uuid) => String.t(),
+          required(:endpoint_uuid) => String.t(),
+          required(:prompt_uuid) => String.t(),
+          required(:source_lang) => String.t(),
+          required(:target_lang) => String.t(),
+          optional(:actor_uuid) => String.t() | nil
+        }
+
+  @doc """
+  Enqueue one translation job for a single `(resource, target_lang)`.
+
+  Returns `{:ok, %{conflict?: boolean}}` (`conflict?: true` when an
+  identical job is already in flight) or `{:error, reason}` on a malformed
+  input map.
+  """
+  @spec enqueue(map()) :: {:ok, %{conflict?: boolean()}} | {:error, term()}
+  def enqueue(%{} = params) do
+    with :ok <- validate(params, full_required()) do
+      if job_in_flight?(params) do
+        {:ok, %{conflict?: true}}
+      else
+        case params |> to_args() |> TranslateWorker.new() |> Oban.insert() do
+          {:ok, _job} -> {:ok, %{conflict?: false}}
+          {:error, reason} -> {:error, reason}
+        end
+      end
+    end
+  end
+
+  def enqueue(_other), do: {:error, {:invalid, :not_a_map}}
+
+  # App-level uniqueness: is there already a non-terminal TranslateWorker job
+  # for this (resource_type, resource_uuid, target_lang)? Fails open (returns
+  # false → proceed with insert) on any query error.
+  defp job_in_flight?(params) do
+    repo = PhoenixKit.RepoHelper.repo()
+    type = value_for(params, :resource_type)
+    uuid = value_for(params, :resource_uuid)
+    target = value_for(params, :target_lang)
+
+    query =
+      from(j in "oban_jobs",
+        where: j.worker == "PhoenixKit.Modules.AI.TranslateWorker",
+        where: j.state in ^@incomplete_states,
+        where: fragment("?->>'resource_type' = ?", j.args, ^type),
+        where: fragment("?->>'resource_uuid' = ?", j.args, ^uuid),
+        where: fragment("?->>'target_lang' = ?", j.args, ^target)
+      )
+
+    repo.exists?(query)
+  rescue
+    _ -> false
+  end
+
+  @doc """
+  Enqueue one job per missing target language. `base_params` is
+  `enqueue_params` minus `:target_lang`. Returns
+  `{:ok, %{enqueued, conflicts, errors, in_flight}}` — `in_flight` is the
+  langs a host should mark spinning (newly enqueued + conflicts; never the
+  errored ones, since no broadcast will arrive to clear them).
+  """
+  @spec enqueue_all_missing(map(), [String.t()]) ::
+          {:ok,
+           %{
+             enqueued: non_neg_integer(),
+             conflicts: non_neg_integer(),
+             errors: [{String.t(), term()}],
+             in_flight: [String.t()]
+           }}
+          | {:error, term()}
+  def enqueue_all_missing(%{} = base_params, missing_langs) when is_list(missing_langs) do
+    case validate(Map.drop(base_params, [:target_lang]), partial_required()) do
+      :ok ->
+        results =
+          Enum.map(missing_langs, fn lang ->
+            {lang, base_params |> Map.put(:target_lang, lang) |> enqueue()}
+          end)
+
+        enqueued = for {lang, {:ok, %{conflict?: false}}} <- results, do: lang
+        conflicts = for {lang, {:ok, %{conflict?: true}}} <- results, do: lang
+        errors = for {lang, {:error, reason}} <- results, do: {lang, reason}
+
+        {:ok,
+         %{
+           enqueued: length(enqueued),
+           conflicts: length(conflicts),
+           errors: errors,
+           in_flight: enqueued ++ conflicts
+         }}
+
+      {:error, _} = err ->
+        err
+    end
+  end
+
+  def enqueue_all_missing(_base, _langs), do: {:error, {:invalid, :bad_arguments}}
+
+  defp full_required,
+    do: [:resource_type, :resource_uuid, :endpoint_uuid, :prompt_uuid, :source_lang, :target_lang]
+
+  defp partial_required,
+    do: [:resource_type, :resource_uuid, :endpoint_uuid, :prompt_uuid, :source_lang]
+
+  defp validate(params, required) do
+    missing = for key <- required, blank?(value_for(params, key)), do: key
+
+    bad_uuids =
+      for key <- [:resource_uuid, :endpoint_uuid, :prompt_uuid],
+          value = value_for(params, key),
+          is_binary(value),
+          not blank?(value),
+          Ecto.UUID.cast(value) == :error,
+          do: key
+
+    cond do
+      missing != [] -> {:error, {:invalid, missing}}
+      bad_uuids != [] -> {:error, {:invalid_uuids, bad_uuids}}
+      true -> :ok
+    end
+  end
+
+  defp value_for(params, key) when is_atom(key) do
+    case Map.fetch(params, key) do
+      {:ok, value} -> value
+      :error -> Map.get(params, Atom.to_string(key))
+    end
+  end
+
+  defp blank?(nil), do: true
+  defp blank?(""), do: true
+  defp blank?(value) when is_binary(value), do: String.trim(value) == ""
+  defp blank?(_), do: false
+
+  defp blank_to_nil(value) when is_binary(value),
+    do: if(String.trim(value) == "", do: nil, else: value)
+
+  defp blank_to_nil(_), do: nil
+
+  defp to_args(params) do
+    %{
+      "resource_type" => value_for(params, :resource_type),
+      "resource_uuid" => value_for(params, :resource_uuid),
+      "endpoint_uuid" => value_for(params, :endpoint_uuid),
+      "prompt_uuid" => value_for(params, :prompt_uuid),
+      "source_lang" => value_for(params, :source_lang),
+      "target_lang" => value_for(params, :target_lang),
+      "actor_uuid" => value_for(params, :actor_uuid)
+    }
+  end
+
+  # Plugin-boundary fuse: an absent/broken optional plugin must not crash
+  # the caller. Narrow rescue for the shapes a missing/incompatible plugin
+  # raises; broad catch for the arbitrary GenServer tree underneath.
+  defp safe_ai(fun, default) do
+    fun.()
+  rescue
+    UndefinedFunctionError -> default
+    FunctionClauseError -> default
+    ArgumentError -> default
+  catch
+    :exit, _ -> default
+    :throw, _ -> default
+  end
+end

--- a/lib/modules/ai/translations.ex
+++ b/lib/modules/ai/translations.ex
@@ -273,17 +273,25 @@ defmodule PhoenixKit.Modules.AI.Translations do
     do: PubSubManager.subscribe(topic(resource_type, resource_uuid))
 
   @doc false
-  # Called by `TranslateWorker` to fan an event out on the global topic,
-  # the per-resource topic, and any adapter-supplied topics.
+  # Called by `TranslateWorker` to fan an event out. The FULL payload (incl.
+  # the translated `fields`) goes ONLY to the per-resource topic — that's the
+  # one the form LV subscribes to and patches its changeset from. The global
+  # topic + any adapter-supplied topics get a content-free SUMMARY (everything
+  # but `:fields`), so translated resource text is never fanned out to broad
+  # topics a monitor/dashboard might subscribe to (payload-minimal rule).
   def broadcast(event, payload, extra_topics \\ []) do
-    msg = {:ai_translation, event, payload}
-    PubSubManager.broadcast(@topic, msg)
+    summary = {:ai_translation, event, Map.drop(payload, [:fields])}
 
-    with %{resource_type: t, resource_uuid: u} when is_binary(t) and is_binary(u) <- payload do
-      PubSubManager.broadcast(topic(t, u), msg)
+    case payload do
+      %{resource_type: t, resource_uuid: u} when is_binary(t) and is_binary(u) ->
+        PubSubManager.broadcast(topic(t, u), {:ai_translation, event, payload})
+
+      _ ->
+        :ok
     end
 
-    Enum.each(extra_topics, &PubSubManager.broadcast(&1, msg))
+    PubSubManager.broadcast(@topic, summary)
+    Enum.each(extra_topics, &PubSubManager.broadcast(&1, summary))
     :ok
   end
 

--- a/lib/phoenix_kit/module.ex
+++ b/lib/phoenix_kit/module.ex
@@ -151,6 +151,17 @@ defmodule PhoenixKit.Module do
   @callback notification_types() :: [map()]
 
   @doc """
+  Optional. Declare AI-translatable resources contributed by this module.
+
+  Returns `[{resource_type, adapter_module}]` where `adapter_module`
+  implements `PhoenixKit.Modules.AI.Translatable`. Discovered by
+  `PhoenixKit.ModuleRegistry.all_ai_translatables/0` and dispatched by
+  `PhoenixKit.Modules.AI.TranslateWorker`. `resource_type` strings must be
+  globally unique (namespace them, e.g. `"catalogue_item"`).
+  """
+  @callback ai_translatables() :: [{String.t(), module()}]
+
+  @doc """
   Returns Tailwind CSS source roots for scanning.
 
   Each entry is either:
@@ -227,6 +238,7 @@ defmodule PhoenixKit.Module do
     required_integrations: 0,
     integration_providers: 0,
     notification_types: 0,
+    ai_translatables: 0,
     css_sources: 0,
     migrate_legacy: 0
   ]
@@ -281,6 +293,9 @@ defmodule PhoenixKit.Module do
       def notification_types, do: []
 
       @impl PhoenixKit.Module
+      def ai_translatables, do: []
+
+      @impl PhoenixKit.Module
       def css_sources, do: []
 
       @impl PhoenixKit.Module
@@ -299,6 +314,7 @@ defmodule PhoenixKit.Module do
                      required_integrations: 0,
                      integration_providers: 0,
                      notification_types: 0,
+                     ai_translatables: 0,
                      css_sources: 0,
                      migrate_legacy: 0
     end

--- a/lib/phoenix_kit/module_registry.ex
+++ b/lib/phoenix_kit/module_registry.ex
@@ -197,6 +197,46 @@ defmodule PhoenixKit.ModuleRegistry do
     end)
   end
 
+  @doc """
+  Collect AI-translatable adapters from all registered modules.
+
+  Scans each module's optional `ai_translatables/0` callback (returning
+  `[{resource_type, adapter_module}]`) and folds into a
+  `%{resource_type => adapter_module}` map. `resource_type` strings are
+  expected to be globally unique; on a collision the first registered
+  module wins (`Map.put_new/3`). Drives
+  `PhoenixKit.Modules.AI.TranslateWorker`'s adapter dispatch.
+  """
+  @spec all_ai_translatables() :: %{String.t() => module()}
+  def all_ai_translatables do
+    all_modules()
+    |> Enum.flat_map(&safe_call(&1, :ai_translatables, []))
+    |> Enum.reduce(%{}, fn
+      {type, adapter}, acc when is_binary(type) and is_atom(adapter) ->
+        case acc do
+          %{^type => existing} when existing != adapter ->
+            Logger.warning(
+              "[ModuleRegistry] duplicate ai_translatable resource_type #{inspect(type)}: " <>
+                "keeping #{inspect(existing)}, ignoring #{inspect(adapter)}"
+            )
+
+            acc
+
+          _ ->
+            Map.put(acc, type, adapter)
+        end
+
+      _other, acc ->
+        acc
+    end)
+  end
+
+  @doc "Resolve the AI-translatable adapter for a `resource_type`, or `nil`."
+  @spec find_ai_translatable(String.t()) :: module() | nil
+  def find_ai_translatable(resource_type) when is_binary(resource_type) do
+    Map.get(all_ai_translatables(), resource_type)
+  end
+
   @doc "Find a registered module by its key string."
   @spec get_by_key(String.t()) :: module() | nil
   def get_by_key(key) when is_binary(key) do

--- a/lib/phoenix_kit_web/components/ai_translate.ex
+++ b/lib/phoenix_kit_web/components/ai_translate.ex
@@ -264,7 +264,46 @@ defmodule PhoenixKitWeb.Components.AITranslate do
     """
   end
 
+  attr(:ai_translate, :map, default: nil, doc: "Same config map; reads `:slow` + `:in_flight`.")
+
+  @doc """
+  Reassurance line shown when a translation is taking a while (`slow: true`
+  in the config while jobs are still in flight). A leading attention icon
+  flags the line, then the visible message, then a trailing info icon whose
+  tooltip carries the fuller "you can leave, nothing is lost" detail.
+  Renders nothing otherwise.
+  """
+  def ai_translate_hint(assigns) do
+    ~H"""
+    <%= if hint_visible?(@ai_translate) do %>
+      <div class="flex items-start gap-1.5 text-xs text-base-content/70 mt-1">
+        <Icon.icon name="hero-exclamation-triangle" class="w-4 h-4 text-warning shrink-0 mt-px" />
+        <span>
+          {gettext(
+            "This is taking longer than usual. Translations keep running in the background — you can safely leave this page."
+          )}<span
+            class="tooltip tooltip-top cursor-help align-middle ml-1 [--tooltip-max-width:20rem]"
+            data-tip={
+              gettext(
+                "Each language is saved automatically the moment it finishes, so it's fine to navigate away or keep editing other fields — nothing will be lost."
+              )
+            }
+          ><Icon.icon
+              name="hero-information-circle"
+              class="inline-block w-4 h-4 text-base-content/50"
+            /></span>
+        </span>
+      </div>
+    <% end %>
+    """
+  end
+
   # ─── Visibility / state helpers ────────────────────────────────
+
+  defp hint_visible?(cfg) when is_map(cfg),
+    do: enabled?(cfg) and get(cfg, :slow) == true and has_in_flight?(cfg)
+
+  defp hint_visible?(_), do: false
 
   defp button_visible?(cfg) when is_map(cfg), do: enabled?(cfg) and toggle_event_name(cfg) != nil
   defp button_visible?(_), do: false

--- a/lib/phoenix_kit_web/components/ai_translate.ex
+++ b/lib/phoenix_kit_web/components/ai_translate.ex
@@ -1,0 +1,465 @@
+defmodule PhoenixKitWeb.Components.AITranslate do
+  @moduledoc """
+  Shared AI-translation UI for multilang form LiveViews — the
+  publishing/projects-style trigger button + modal, on top of core's
+  `PhoenixKit.Modules.AI.Translations` pipeline.
+
+  Render-only function components driven by a single `ai_translate` config
+  map the host LV builds each render; the host owns the state + event
+  handlers (see `PhoenixKit.Modules.AI.Translations` for the backend and
+  any consumer's form LV for the wiring shape). Three surfaces:
+
+    * `<.ai_translate_button>` — compact "AI Translate" trigger above the
+      multilang tabs; toggles the modal. Spinner while a job is in flight.
+    * `<.ai_translate_modal>` — daisyUI dialog: endpoint + prompt
+      selectors, a "Generate Default Prompt" button when none exists, a
+      scope picker (missing-only / all-overwrite / current tab), in-flight
+      status, and one scope-driven "Translate" action.
+    * `<.ai_translate_progress>` — slim inline progress bar for the session.
+
+  ## Host contract
+
+  Pass `ai_translate: %{...}` (string OR atom keys accepted):
+
+      %{
+        enabled: true,                  # gates render
+        event: "translate_lang",        # dispatch (phx-value-lang)
+        toggle_event: "toggle_ai",      # open/close modal
+        select_endpoint_event: "...",   # endpoint dropdown change
+        select_prompt_event: "...",     # prompt dropdown change
+        select_scope_event: "...",      # scope radio change
+        generate_prompt_event: "...",   # generate-default-prompt
+        missing: ["es", "de"],          # langs lacking a translation
+        all_langs: ["es", "de", "fr"],  # every non-primary enabled lang
+        in_flight: ["es"],              # jobs running now
+        modal_open: false,
+        endpoints: [{uuid, name}, ...],
+        prompts: [{uuid, name}, ...],
+        selected_endpoint_uuid: "...",
+        selected_prompt_uuid: "...",
+        scope: :missing,                # :missing | :all | :current
+        default_prompt_exists: true,
+        current_lang: "es",
+        primary_lang: "en",
+        primary_lang_name: "English",
+        # progress bar (optional):
+        translation_status: :in_progress, # nil | :in_progress | :completed
+        translation_progress: 1,
+        translation_total: 3
+      }
+
+  ## Action contract
+
+  The modal's single "Translate" button sends `event` with a `lang` value
+  driven by `scope`:
+
+    - `:missing` → `phx-value-lang="*"` (bulk, missing only)
+    - `:all`     → `phx-value-lang="**"` (bulk, overwrite all non-primary)
+    - `:current` → `phx-value-lang=<current_lang>` (single)
+
+  Host's `handle_event(event, %{"lang" => lang}, socket)` branches on `"*"`,
+  `"**"`, or a concrete code.
+
+  ## Placement
+
+  The modal contains its own `<form phx-change>` selectors — HTML forbids
+  nested forms, so render `<.ai_translate_modal>` **outside** (after) the
+  host's outer `</.form>`. The button can live inside the form. Both take
+  the same config map; build it once and pass to both.
+  """
+
+  use Phoenix.Component
+  use Gettext, backend: PhoenixKitWeb.Gettext
+
+  alias PhoenixKitWeb.Components.Core.Icon
+
+  attr(:ai_translate, :map, default: nil, doc: "Config map — see moduledoc.")
+
+  @doc "Compact trigger button. Hidden when disabled / no toggle event."
+  def ai_translate_button(assigns) do
+    ~H"""
+    <%= if button_visible?(@ai_translate) do %>
+      <button
+        type="button"
+        class="btn btn-ghost btn-xs gap-2"
+        phx-click={toggle_event_name(@ai_translate)}
+        aria-haspopup="dialog"
+        aria-expanded={if modal_open?(@ai_translate), do: "true", else: "false"}
+      >
+        <Icon.icon name="hero-language" class="w-4 h-4 text-primary" />
+        <span>{gettext("AI Translate")}</span>
+        <%= if has_in_flight?(@ai_translate) do %>
+          <span class="loading loading-spinner loading-xs"></span>
+        <% end %>
+      </button>
+    <% end %>
+    """
+  end
+
+  attr(:ai_translate, :map, default: nil, doc: "Config map — see moduledoc.")
+
+  @doc "Modal dialog: endpoint/prompt selectors + scope picker + action."
+  def ai_translate_modal(assigns) do
+    ~H"""
+    <%= if modal_renderable?(@ai_translate) do %>
+      <dialog id="ai-translation-modal" class={["modal", modal_open?(@ai_translate) && "modal-open"]}>
+        <div class="modal-box max-w-lg">
+          <div class="flex items-center justify-between mb-4">
+            <h3 class="font-bold text-lg flex items-center gap-2">
+              <Icon.icon name="hero-language" class="w-5 h-5 text-primary" />
+              {gettext("AI Translation")}
+            </h3>
+            <button
+              type="button"
+              class="btn btn-sm btn-circle btn-ghost"
+              phx-click={toggle_event_name(@ai_translate)}
+              aria-label={gettext("Close")}
+            >
+              <Icon.icon name="hero-x-mark" class="w-4 h-4" />
+            </button>
+          </div>
+
+          <div class="space-y-4">
+            <p class="text-sm text-base-content/70">
+              {gettext(
+                "Source: %{lang}. Each translation runs as a background job — you can keep editing while it finishes.",
+                lang: source_lang_label(@ai_translate)
+              )}
+            </p>
+
+            <div class="space-y-1">
+              <form phx-change={get(@ai_translate, :select_endpoint_event)}>
+                <label class="select select-sm w-full">
+                  <select name="endpoint_uuid">
+                    <option value="">{gettext("Select an endpoint...")}</option>
+                    <%= for {id, name} <- ai_endpoints(@ai_translate) do %>
+                      <option value={id} selected={get(@ai_translate, :selected_endpoint_uuid) == id}>
+                        {name}
+                      </option>
+                    <% end %>
+                  </select>
+                </label>
+              </form>
+            </div>
+
+            <div class="space-y-1">
+              <form phx-change={get(@ai_translate, :select_prompt_event)}>
+                <label class="select select-sm w-full">
+                  <select name="prompt_uuid">
+                    <option value="">{gettext("Select a prompt...")}</option>
+                    <%= for {id, name} <- ai_prompts(@ai_translate) do %>
+                      <option value={id} selected={get(@ai_translate, :selected_prompt_uuid) == id}>
+                        {name}
+                      </option>
+                    <% end %>
+                  </select>
+                </label>
+              </form>
+              <%= unless get(@ai_translate, :default_prompt_exists) == true do %>
+                <button
+                  type="button"
+                  class="btn btn-outline btn-xs gap-1"
+                  phx-click={get(@ai_translate, :generate_prompt_event)}
+                >
+                  <Icon.icon name="hero-sparkles" class="w-3 h-3" />
+                  {gettext("Generate Default Prompt")}
+                </button>
+              <% end %>
+            </div>
+
+            <%= if has_in_flight?(@ai_translate) do %>
+              <div class="alert alert-info py-2 text-xs gap-2">
+                <span class="loading loading-spinner loading-xs"></span>
+                <span>
+                  {gettext("Translating to %{langs}…",
+                    langs:
+                      @ai_translate |> normalized_in_flight() |> Enum.map_join(", ", &String.upcase/1)
+                  )}
+                </span>
+              </div>
+            <% end %>
+
+            <fieldset class="space-y-2">
+              <legend class="text-sm font-medium">{gettext("Translate")}</legend>
+              <%= for {value, label, disabled} <- scope_options(@ai_translate) do %>
+                <label class={[
+                  "flex items-start gap-2 cursor-pointer p-2 rounded hover:bg-base-200",
+                  disabled && "opacity-50 cursor-not-allowed pointer-events-none"
+                ]}>
+                  <input
+                    type="radio"
+                    name="scope"
+                    value={value}
+                    class="radio radio-sm radio-primary mt-0.5"
+                    checked={Atom.to_string(current_scope(@ai_translate)) == value}
+                    disabled={disabled}
+                    phx-click={if disabled, do: nil, else: get(@ai_translate, :select_scope_event)}
+                    phx-value-scope={value}
+                  />
+                  <span class="text-sm leading-tight">{label}</span>
+                </label>
+              <% end %>
+            </fieldset>
+
+            <%= if current_scope(@ai_translate) == :all do %>
+              <div class="alert alert-warning py-2 text-xs gap-2">
+                <Icon.icon name="hero-exclamation-triangle" class="w-4 h-4 shrink-0" />
+                <span>
+                  {gettext(
+                    "Existing translations in every non-primary language will be overwritten on completion."
+                  )}
+                </span>
+              </div>
+            <% end %>
+
+            <div class="flex flex-wrap gap-3">
+              <button
+                type="button"
+                class={[
+                  "btn btn-primary btn-sm gap-1",
+                  action_disabled?(@ai_translate) && "btn-disabled"
+                ]}
+                phx-click={event_name(@ai_translate)}
+                phx-value-lang={scope_target(@ai_translate)}
+                phx-disable-with={gettext("Starting…")}
+                disabled={action_disabled?(@ai_translate)}
+              >
+                <Icon.icon name="hero-sparkles" class="w-4 h-4" />
+                {action_label(@ai_translate)}
+              </button>
+            </div>
+          </div>
+        </div>
+        <div class="modal-backdrop" phx-click={toggle_event_name(@ai_translate)}></div>
+      </dialog>
+    <% end %>
+    """
+  end
+
+  attr(:ai_translate, :map,
+    required: true,
+    doc: "Same config map; reads translation_status/progress/total."
+  )
+
+  attr(:wrapper_class, :string, default: "flex-1 min-w-0")
+  attr(:class, :string, default: "progress h-2 w-full block")
+
+  @doc "Slim inline session progress bar. Renders once a dispatch has started."
+  def ai_translate_progress(assigns) do
+    ~H"""
+    <%= if progress_visible?(@ai_translate) do %>
+      <div class={@wrapper_class}>
+        <progress
+          class={[
+            @class,
+            translation_status(@ai_translate) == :completed && "progress-success",
+            translation_status(@ai_translate) != :completed && "progress-primary"
+          ]}
+          value={translation_progress(@ai_translate)}
+          max={max(translation_total(@ai_translate), 1)}
+        >
+        </progress>
+      </div>
+    <% end %>
+    """
+  end
+
+  # ─── Visibility / state helpers ────────────────────────────────
+
+  defp button_visible?(cfg) when is_map(cfg), do: enabled?(cfg) and toggle_event_name(cfg) != nil
+  defp button_visible?(_), do: false
+
+  defp modal_renderable?(cfg) when is_map(cfg),
+    do: enabled?(cfg) and toggle_event_name(cfg) != nil
+
+  defp modal_renderable?(_), do: false
+
+  defp modal_open?(cfg), do: get(cfg, :modal_open) == true
+  defp enabled?(cfg), do: get(cfg, :enabled) == true
+
+  defp actionable_missing(cfg) do
+    in_flight = normalized_in_flight(cfg)
+    Enum.reject(normalized_missing(cfg), &(&1 in in_flight))
+  end
+
+  defp has_in_flight?(cfg), do: normalized_in_flight(cfg) != []
+
+  defp translation_status(cfg) when is_map(cfg), do: get(cfg, :translation_status)
+  defp translation_status(_), do: nil
+  defp translation_progress(cfg) when is_map(cfg), do: get(cfg, :translation_progress) || 0
+  defp translation_progress(_), do: 0
+  defp translation_total(cfg) when is_map(cfg), do: get(cfg, :translation_total) || 0
+  defp translation_total(_), do: 0
+
+  defp progress_visible?(cfg) when is_map(cfg) do
+    enabled?(cfg) and translation_status(cfg) in [:in_progress, :completed] and
+      translation_total(cfg) > 0
+  end
+
+  defp progress_visible?(_), do: false
+
+  defp normalized_missing(cfg),
+    do: cfg |> get(:missing) |> List.wrap() |> Enum.map(&to_lang/1) |> Enum.reject(&is_nil/1)
+
+  defp normalized_in_flight(cfg),
+    do: cfg |> get(:in_flight) |> List.wrap() |> Enum.map(&to_lang/1) |> Enum.reject(&is_nil/1)
+
+  defp to_lang(value) when is_binary(value),
+    do: if(String.trim(value) == "", do: nil, else: value)
+
+  defp to_lang(value) when is_atom(value) and not is_nil(value), do: Atom.to_string(value)
+  defp to_lang(_), do: nil
+
+  defp ai_endpoints(cfg), do: cfg |> get(:endpoints) |> List.wrap()
+  defp ai_prompts(cfg), do: cfg |> get(:prompts) |> List.wrap()
+
+  # ─── Scope picker ──────────────────────────────────────────────
+
+  defp scope_options(cfg) do
+    missing_count = length(actionable_missing(cfg))
+    all_count = length(all_target_langs(cfg))
+    current = get(cfg, :current_lang)
+
+    [
+      {"missing",
+       gettext("Missing only (%{count} %{plural})",
+         count: missing_count,
+         plural: ngettext_plural(missing_count, "language", "languages")
+       ), missing_count == 0},
+      {"all",
+       gettext("All non-primary languages (%{count}, overwrites existing)", count: all_count),
+       all_count == 0},
+      {"current",
+       gettext("Current tab only (%{lang})",
+         lang: if(is_binary(current), do: String.upcase(current), else: "—")
+       ), not current_scope_available?(cfg)}
+    ]
+  end
+
+  defp source_lang_label(cfg) do
+    name = get(cfg, :primary_lang_name)
+    code = get(cfg, :primary_lang)
+
+    cond do
+      is_binary(name) and String.trim(name) != "" -> name
+      is_binary(code) and String.trim(code) != "" -> String.upcase(code)
+      true -> gettext("the primary language")
+    end
+  end
+
+  defp current_scope_available?(cfg) do
+    current = get(cfg, :current_lang)
+    primary = get(cfg, :primary_lang)
+    is_binary(current) and current != "" and current != primary
+  end
+
+  defp all_target_langs(cfg) do
+    primary = get(cfg, :primary_lang)
+
+    cfg
+    |> get(:all_langs)
+    |> List.wrap()
+    |> Enum.map(&to_lang/1)
+    |> Enum.reject(&(is_nil(&1) or &1 == primary))
+  end
+
+  # The scope to actually act on: the configured one when it's enabled,
+  # otherwise the first enabled option. Without this, the default `:missing`
+  # strands the modal on a disabled radio + a disabled "Translate 0 missing"
+  # button once everything's translated, even though "All non-primary" is
+  # available. Drives the checked radio, the action label/target, and the
+  # enabled state so the modal always offers a usable default.
+  defp current_scope(cfg) do
+    configured = configured_scope(cfg)
+    opts = scope_options(cfg)
+
+    if scope_disabled?(opts, configured) do
+      first_enabled_scope(opts) || configured
+    else
+      configured
+    end
+  end
+
+  defp configured_scope(cfg) do
+    case get(cfg, :scope) do
+      s when s in [:missing, "missing"] -> :missing
+      s when s in [:all, "all"] -> :all
+      s when s in [:current, "current"] -> :current
+      _ -> :missing
+    end
+  end
+
+  defp scope_disabled?(opts, scope) do
+    Enum.any?(opts, fn {value, _label, disabled} ->
+      value == Atom.to_string(scope) and disabled
+    end)
+  end
+
+  defp first_enabled_scope(opts) do
+    case Enum.find(opts, fn {_value, _label, disabled} -> not disabled end) do
+      {value, _label, _disabled} -> String.to_existing_atom(value)
+      nil -> nil
+    end
+  end
+
+  defp scope_target(cfg) do
+    case current_scope(cfg) do
+      :missing -> "*"
+      :all -> "**"
+      :current -> get(cfg, :current_lang) || ""
+    end
+  end
+
+  defp action_label(cfg) do
+    case current_scope(cfg) do
+      :missing ->
+        gettext("Translate %{n} missing", n: length(actionable_missing(cfg)))
+
+      :all ->
+        gettext("Translate all %{n} languages", n: length(all_target_langs(cfg)))
+
+      :current ->
+        gettext("Translate to %{lang}", lang: String.upcase(get(cfg, :current_lang) || ""))
+    end
+  end
+
+  defp action_disabled?(cfg) do
+    blank?(get(cfg, :selected_endpoint_uuid)) or blank?(get(cfg, :selected_prompt_uuid)) or
+      has_in_flight?(cfg) or scope_empty?(cfg)
+  end
+
+  defp scope_empty?(cfg) do
+    case current_scope(cfg) do
+      :missing -> actionable_missing(cfg) == []
+      :all -> all_target_langs(cfg) == []
+      :current -> not current_scope_available?(cfg)
+    end
+  end
+
+  defp ngettext_plural(1, sing, _plur), do: sing
+  defp ngettext_plural(_, _sing, plur), do: plur
+
+  defp blank?(nil), do: true
+  defp blank?(""), do: true
+  defp blank?(v) when is_binary(v), do: String.trim(v) == ""
+  defp blank?(_), do: false
+
+  defp event_name(cfg), do: trimmed_event(cfg, :event)
+  defp toggle_event_name(cfg), do: trimmed_event(cfg, :toggle_event)
+
+  defp trimmed_event(cfg, key) do
+    case get(cfg, key) do
+      ev when is_binary(ev) -> if String.trim(ev) == "", do: nil, else: ev
+      _ -> nil
+    end
+  end
+
+  defp get(cfg, key) when is_map(cfg) and is_atom(key) do
+    case Map.fetch(cfg, key) do
+      {:ok, v} -> v
+      :error -> Map.get(cfg, Atom.to_string(key))
+    end
+  end
+
+  defp get(_, _), do: nil
+end

--- a/lib/phoenix_kit_web/components/ai_translate/form_binding.ex
+++ b/lib/phoenix_kit_web/components/ai_translate/form_binding.ex
@@ -1,0 +1,40 @@
+defmodule PhoenixKitWeb.Components.AITranslate.FormBinding do
+  @moduledoc """
+  The small storage-specific contract a form LiveView supplies to the
+  shared AI-translate glue (`PhoenixKitWeb.Components.AITranslate.FormGlue`).
+
+  Everything about the modal/progress/stall state machine, the dispatch, and
+  the PubSub event handling is generic and lives in the glue. The only things
+  that differ per consumer are *where/how translations are stored in the live
+  changeset* and *who the actor is* — those three callbacks.
+
+  Implementations are tiny modules (see `PhoenixKitCatalogue.AITranslateBinding`
+  / `PhoenixKitProjects.AITranslateBinding`). The module is passed once to
+  `FormGlue.assign_ai_translation/4` and stashed in assigns.
+  """
+
+  @doc """
+  The enabled non-primary language codes that ALREADY have at least one
+  non-blank translatable field, read from the live form's assigns (so it
+  reflects unsaved + just-translated state). The glue subtracts these from the
+  enabled set to get the "missing" list.
+  """
+  @callback existing_translation_langs(resource_type :: String.t(), assigns :: map()) ::
+              [String.t()]
+
+  @doc """
+  Merge a completed translation's `fields` (plain engine field names →
+  translated values) into `changeset` for `lang`, returning the updated
+  changeset. PURE changeset→changeset — the glue re-assigns it via the LV's
+  own assign helper, so this must not touch the socket.
+  """
+  @callback apply_translation(
+              resource_type :: String.t(),
+              changeset :: Ecto.Changeset.t(),
+              lang :: String.t(),
+              fields :: map()
+            ) :: Ecto.Changeset.t()
+
+  @doc "The acting user's UUID (or nil) for the translation audit trail."
+  @callback actor_uuid(socket :: Phoenix.LiveView.Socket.t()) :: Ecto.UUID.t() | nil
+end

--- a/lib/phoenix_kit_web/components/ai_translate/form_glue.ex
+++ b/lib/phoenix_kit_web/components/ai_translate/form_glue.ex
@@ -1,0 +1,551 @@
+defmodule PhoenixKitWeb.Components.AITranslate.FormGlue do
+  @moduledoc """
+  Shared LiveView glue for the AI-translate modal — the stateful counterpart
+  to the render-only `PhoenixKitWeb.Components.AITranslate` components.
+
+  Owns the whole modal/progress/stall state machine so consumers (catalogue,
+  projects, …) don't each re-implement it:
+
+    * mount state + per-resource PubSub subscription (`assign_ai_translation/4`)
+    * modal open/close, endpoint/prompt/scope selection, generate-default-prompt
+    * scope-driven dispatch (missing `"*"` / overwrite `"**"` / single tab)
+      via core `PhoenixKit.Modules.AI.Translations`
+    * live progress + a STALL hint ("taking a while…") driven by a per-arm
+      timer that fires only when no language completes for `ai_stall_ms/0`
+    * folding `{:ai_translation, _, _}` PubSub events back into the form
+
+  The only storage-specific behaviour — which langs already have a translation,
+  how to merge a completed translation into the live changeset, and who the
+  actor is — is supplied by a `PhoenixKitWeb.Components.AITranslate.FormBinding`
+  module, passed once at mount.
+
+  ## Host wiring (thin)
+
+      use Gettext, ...
+      alias PhoenixKitWeb.Components.AITranslate.FormGlue
+
+      # mount/3 (on :edit pass the resource, on :new pass nil)
+      |> FormGlue.assign_ai_translation("project", project_or_nil, MyApp.AITranslateBinding)
+
+      # one config call feeds button + modal + progress + hint
+      <.ai_translate_button ai_translate={FormGlue.ai_translate_config(assigns)} />
+
+      # six thin handle_event clauses delegate to:
+      #   toggle_ai_modal/1, select_ai_endpoint/2, select_ai_prompt/2,
+      #   select_ai_scope/2, generate_ai_prompt/1, dispatch_ai_translate/2
+
+      # one handle_info:
+      def handle_info({:ai_translation, event, payload}, socket),
+        do: {:noreply, FormGlue.handle_ai_translation_event(socket, event, payload, &assign_form/2)}
+
+  `assign_form/2` (the 4th arg to `handle_ai_translation_event/4`) is the LV's
+  own `(socket, changeset) -> socket` helper — the glue uses it to re-assign
+  the patched changeset so the LV's exact form-sync behaviour is preserved.
+  """
+
+  use Gettext, backend: PhoenixKitWeb.Gettext
+
+  alias PhoenixKit.Modules.AI.Translations
+  alias PhoenixKit.Utils.Multilang
+
+  # How long the progress bar may STALL — no language completing — before the
+  # "taking a while, runs in the background" hint shows. About the bar hanging,
+  # not any single language's duration. Each completion resets the clock.
+  # Overridable via `config :phoenix_kit, :ai_translation_stall_ms`.
+  @default_ai_stall_ms 5_000
+
+  defp ai_stall_ms do
+    Application.get_env(:phoenix_kit, :ai_translation_stall_ms, @default_ai_stall_ms)
+  end
+
+  @doc """
+  Assign the AI-translate mount state and (on the connected mount of an
+  existing resource) subscribe to its core translation topic.
+
+  Pass the resource struct on `:edit`; pass `nil` on `:new`. `resource_type`
+  is the key registered via `ai_translatables/0`; `binding` is the consumer's
+  `FormBinding` module.
+  """
+  @spec assign_ai_translation(
+          Phoenix.LiveView.Socket.t(),
+          String.t(),
+          struct() | nil,
+          module()
+        ) :: Phoenix.LiveView.Socket.t()
+  def assign_ai_translation(socket, resource_type, %{uuid: uuid} = _resource, binding)
+      when is_binary(resource_type) and is_binary(uuid) and is_atom(binding) do
+    available? = Translations.available?()
+
+    if available? and Phoenix.LiveView.connected?(socket) do
+      Translations.subscribe(resource_type, uuid)
+    end
+
+    socket
+    |> Phoenix.Component.assign(
+      ai_form_binding: binding,
+      ai_resource_type: resource_type,
+      ai_resource_uuid: uuid,
+      ai_translation_available?: available?,
+      ai_in_flight: [],
+      ai_scope: :missing,
+      ai_modal_open: false,
+      ai_status: nil,
+      ai_progress: 0,
+      ai_total: 0,
+      ai_slow: false,
+      ai_slow_timer_ref: nil,
+      ai_slow_token: nil
+    )
+    |> assign_endpoint_prompt_state(available?)
+  end
+
+  def assign_ai_translation(socket, _resource_type, _resource, binding) do
+    Phoenix.Component.assign(socket,
+      ai_form_binding: binding,
+      ai_resource_type: nil,
+      ai_resource_uuid: nil,
+      ai_translation_available?: false,
+      ai_in_flight: [],
+      ai_scope: :missing,
+      ai_modal_open: false,
+      ai_status: nil,
+      ai_progress: 0,
+      ai_total: 0,
+      ai_slow: false,
+      ai_slow_timer_ref: nil,
+      ai_slow_token: nil,
+      ai_endpoints: [],
+      ai_prompts: [],
+      ai_selected_endpoint: nil,
+      ai_selected_prompt: nil,
+      ai_default_prompt_exists: false
+    )
+  end
+
+  # The endpoint/prompt lookups hit Settings + the AI plugin, so only run them
+  # on the connected mount (the dead HTTP render doesn't need them, and mount/3
+  # fires twice).
+  defp assign_endpoint_prompt_state(socket, true) do
+    if Phoenix.LiveView.connected?(socket) do
+      Phoenix.Component.assign(socket,
+        ai_endpoints: Translations.list_endpoints(),
+        ai_prompts: Translations.list_prompts(),
+        ai_selected_endpoint: Translations.default_endpoint_uuid(),
+        ai_selected_prompt: Translations.default_prompt_uuid(),
+        ai_default_prompt_exists: Translations.default_prompt_exists?()
+      )
+    else
+      empty_endpoint_prompt_state(socket)
+    end
+  end
+
+  defp assign_endpoint_prompt_state(socket, _false), do: empty_endpoint_prompt_state(socket)
+
+  defp empty_endpoint_prompt_state(socket) do
+    Phoenix.Component.assign(socket,
+      ai_endpoints: [],
+      ai_prompts: [],
+      ai_selected_endpoint: nil,
+      ai_selected_prompt: nil,
+      ai_default_prompt_exists: false
+    )
+  end
+
+  @doc "Modal open/close toggle."
+  def toggle_ai_modal(socket),
+    do: Phoenix.Component.assign(socket, :ai_modal_open, not socket.assigns.ai_modal_open)
+
+  @doc "Endpoint dropdown change."
+  def select_ai_endpoint(socket, uuid),
+    do: Phoenix.Component.assign(socket, :ai_selected_endpoint, blank_to_nil(uuid))
+
+  @doc "Prompt dropdown change."
+  def select_ai_prompt(socket, uuid),
+    do: Phoenix.Component.assign(socket, :ai_selected_prompt, blank_to_nil(uuid))
+
+  @doc "Scope radio change (`missing` | `all` | `current`)."
+  def select_ai_scope(socket, scope) when scope in ~w(missing all current),
+    do: Phoenix.Component.assign(socket, :ai_scope, String.to_existing_atom(scope))
+
+  def select_ai_scope(socket, _scope), do: socket
+
+  @doc "Provision the shared default translation prompt and select it."
+  def generate_ai_prompt(socket) do
+    case Translations.ensure_default_prompt() do
+      {:ok, %{uuid: uuid}} ->
+        socket
+        |> Phoenix.Component.assign(:ai_prompts, Translations.list_prompts())
+        |> Phoenix.Component.assign(:ai_default_prompt_exists, true)
+        |> Phoenix.Component.assign(:ai_selected_prompt, uuid)
+        |> Phoenix.LiveView.put_flash(:info, gettext("Default translation prompt generated."))
+
+      {:error, _reason} ->
+        flash_error(socket, gettext("Could not generate the default translation prompt."))
+    end
+  end
+
+  @doc """
+  Build the `ai_translate` config map for the `AITranslate` components from the
+  form's assigns, or `nil` when AI translation isn't available. The `missing`
+  list comes from the binding (live changeset), so it reflects unsaved +
+  just-translated state.
+  """
+  @spec ai_translate_config(map()) :: map() | nil
+  def ai_translate_config(assigns) do
+    if assigns[:ai_translation_available?] do
+      %{
+        enabled: true,
+        event: "ai_translate_lang",
+        toggle_event: "ai_toggle_modal",
+        select_endpoint_event: "ai_select_endpoint",
+        select_prompt_event: "ai_select_prompt",
+        select_scope_event: "ai_select_scope",
+        generate_prompt_event: "ai_generate_prompt",
+        missing: missing_langs(assigns),
+        all_langs: all_target_langs(),
+        in_flight: assigns.ai_in_flight,
+        modal_open: assigns.ai_modal_open,
+        endpoints: assigns.ai_endpoints,
+        prompts: assigns.ai_prompts,
+        selected_endpoint_uuid: assigns.ai_selected_endpoint,
+        selected_prompt_uuid: assigns.ai_selected_prompt,
+        scope: assigns.ai_scope,
+        default_prompt_exists: assigns.ai_default_prompt_exists,
+        current_lang: assigns[:current_lang],
+        primary_lang: Multilang.primary_language(),
+        primary_lang_name: lang_name(assigns[:language_tabs], Multilang.primary_language()),
+        translation_status: assigns.ai_status,
+        translation_progress: assigns.ai_progress,
+        translation_total: assigns.ai_total,
+        slow: assigns.ai_slow
+      }
+    end
+  end
+
+  defp lang_name(tabs, code) do
+    case Enum.find(tabs || [], &(&1.code == code)) do
+      %{name: name} when is_binary(name) -> name
+      _ -> nil
+    end
+  end
+
+  @doc """
+  Dispatch a translation from the modal's "Translate" action. `lang` is the
+  scope sentinel: `"*"` (missing only), `"**"` (all non-primary, overwrite),
+  or a concrete language code (current tab). Closes the modal, grows
+  `:ai_in_flight`, advances the progress session, and flashes the outcome.
+  """
+  @spec dispatch_ai_translate(Phoenix.LiveView.Socket.t(), String.t()) ::
+          Phoenix.LiveView.Socket.t()
+  def dispatch_ai_translate(socket, lang) do
+    socket = Phoenix.Component.assign(socket, :ai_modal_open, false)
+    endpoint = socket.assigns.ai_selected_endpoint || Translations.default_endpoint_uuid()
+    prompt = socket.assigns.ai_selected_prompt || Translations.default_prompt_uuid()
+
+    cond do
+      blank_to_nil(endpoint) == nil ->
+        flash_error(socket, gettext("Select an AI endpoint first."))
+
+      blank_to_nil(prompt) == nil ->
+        flash_error(socket, gettext("Select a translation prompt first."))
+
+      true ->
+        do_dispatch_ai(socket, lang, endpoint, prompt)
+    end
+  end
+
+  # Bulk scopes: "*" (missing) / "**" (all non-primary).
+  defp do_dispatch_ai(socket, scope, endpoint, prompt) when scope in ["*", "**"] do
+    targets =
+      case scope do
+        "*" -> missing_langs(socket.assigns)
+        "**" -> all_target_langs()
+      end
+      |> Enum.reject(&(&1 in socket.assigns.ai_in_flight))
+
+    base = %{
+      resource_type: socket.assigns.ai_resource_type,
+      resource_uuid: socket.assigns.ai_resource_uuid,
+      endpoint_uuid: endpoint,
+      prompt_uuid: prompt,
+      source_lang: Multilang.primary_language(),
+      actor_uuid: actor_uuid(socket)
+    }
+
+    case Translations.enqueue_all_missing(base, targets) do
+      {:ok, %{in_flight: [_ | _] = in_flight, errors: errors}} ->
+        socket
+        |> add_in_flight(in_flight)
+        |> bump_started(length(in_flight))
+        |> dispatch_flash(in_flight, errors)
+
+      {:ok, %{errors: [_ | _] = errors}} ->
+        dispatch_flash(socket, [], errors)
+
+      {:ok, _} ->
+        Phoenix.LiveView.put_flash(socket, :info, gettext("Nothing to translate."))
+
+      {:error, _reason} ->
+        flash_error(socket, gettext("Could not start translation."))
+    end
+  end
+
+  # A stale/crafted empty target — no-op.
+  defp do_dispatch_ai(socket, lang, _endpoint, _prompt)
+       when is_binary(lang) and lang == "",
+       do: socket
+
+  # Single language (current tab). Refuse to translate INTO the source.
+  defp do_dispatch_ai(socket, lang, endpoint, prompt) do
+    if lang == Multilang.primary_language() do
+      flash_error(socket, gettext("Can't translate the source language."))
+    else
+      do_dispatch_single(socket, lang, endpoint, prompt)
+    end
+  end
+
+  defp do_dispatch_single(socket, lang, endpoint, prompt) do
+    params = %{
+      resource_type: socket.assigns.ai_resource_type,
+      resource_uuid: socket.assigns.ai_resource_uuid,
+      endpoint_uuid: endpoint,
+      prompt_uuid: prompt,
+      source_lang: Multilang.primary_language(),
+      target_lang: lang,
+      actor_uuid: actor_uuid(socket)
+    }
+
+    case Translations.enqueue(params) do
+      {:ok, %{conflict?: false}} ->
+        socket
+        |> add_in_flight([lang])
+        |> bump_started(1)
+        |> Phoenix.LiveView.put_flash(
+          :info,
+          gettext("Translating to %{lang}…", lang: String.upcase(lang))
+        )
+
+      {:ok, %{conflict?: true}} ->
+        Phoenix.LiveView.put_flash(socket, :info, gettext("Translation already in progress."))
+
+      {:error, _reason} ->
+        flash_error(socket, gettext("Could not start translation."))
+    end
+  end
+
+  defp add_in_flight(socket, langs),
+    do:
+      Phoenix.Component.assign(
+        socket,
+        :ai_in_flight,
+        Enum.uniq(socket.assigns.ai_in_flight ++ langs)
+      )
+
+  # Progress session: reset on a fresh start, add to a running total.
+  defp bump_started(socket, count) when count > 0 do
+    socket = arm_stall_timer(socket)
+
+    case socket.assigns.ai_status do
+      s when s in [nil, :completed] ->
+        Phoenix.Component.assign(socket,
+          ai_status: :in_progress,
+          ai_progress: 0,
+          ai_total: count,
+          ai_slow: false
+        )
+
+      :in_progress ->
+        Phoenix.Component.assign(socket, :ai_total, socket.assigns.ai_total + count)
+    end
+  end
+
+  defp bump_started(socket, _zero), do: socket
+
+  # (Re)start the stall clock: cancel any pending timer, schedule a fresh one,
+  # clear the hint. Called at dispatch AND after each completion so the timer
+  # only fires when progress has STALLED for `ai_stall_ms/0`.
+  defp arm_stall_timer(socket) do
+    socket = cancel_stall_timer(socket)
+
+    # A per-arm token guards against a stale `:slow_tick` already delivered to
+    # the mailbox before `cancel_stall_timer/1` ran (cancel can't un-send it).
+    token = make_ref()
+
+    ref =
+      if Phoenix.LiveView.connected?(socket) do
+        Process.send_after(self(), {:ai_translation, :slow_tick, %{token: token}}, ai_stall_ms())
+      end
+
+    Phoenix.Component.assign(socket,
+      ai_slow_timer_ref: ref,
+      ai_slow_token: token,
+      ai_slow: false
+    )
+  end
+
+  defp cancel_stall_timer(socket) do
+    case socket.assigns[:ai_slow_timer_ref] do
+      ref when is_reference(ref) -> Process.cancel_timer(ref)
+      _ -> :ok
+    end
+
+    Phoenix.Component.assign(socket, ai_slow_timer_ref: nil, ai_slow_token: nil)
+  end
+
+  defp missing_langs(assigns) do
+    binding = assigns.ai_form_binding
+
+    Translations.missing_languages(
+      Multilang.enabled_languages(),
+      Multilang.primary_language(),
+      binding.existing_translation_langs(assigns.ai_resource_type, assigns)
+    )
+  end
+
+  defp all_target_langs do
+    primary = Multilang.primary_language()
+    Enum.reject(Multilang.enabled_languages(), &(&1 == primary))
+  end
+
+  defp blank_to_nil(nil), do: nil
+  defp blank_to_nil(v) when is_binary(v), do: if(String.trim(v) == "", do: nil, else: v)
+  defp blank_to_nil(v), do: v
+
+  defp actor_uuid(socket), do: socket.assigns.ai_form_binding.actor_uuid(socket)
+
+  defp dispatch_flash(socket, in_flight, errors) do
+    cond do
+      in_flight == [] and errors != [] ->
+        flash_error(socket, gettext("Translation could not be started."))
+
+      errors != [] ->
+        Phoenix.LiveView.put_flash(
+          socket,
+          :info,
+          ngettext(
+            "Translating %{count} language; some could not start.",
+            "Translating %{count} languages; some could not start.",
+            length(in_flight)
+          )
+        )
+
+      true ->
+        Phoenix.LiveView.put_flash(
+          socket,
+          :info,
+          ngettext(
+            "Translating %{count} language…",
+            "Translating %{count} languages…",
+            length(in_flight)
+          )
+        )
+    end
+  end
+
+  @doc """
+  Fold a `{:ai_translation, event, payload}` message into the form socket.
+
+  `assign_cs` is the LV's own `(socket, changeset) -> socket` helper — on
+  `:translation_completed` the binding merges the translated fields into the
+  live changeset and `assign_cs` re-assigns it (so the result shows without a
+  DB reload and unsaved edits survive). Returns the updated socket.
+  """
+  @spec handle_ai_translation_event(
+          Phoenix.LiveView.Socket.t(),
+          atom(),
+          map(),
+          (Phoenix.LiveView.Socket.t(), Ecto.Changeset.t() -> Phoenix.LiveView.Socket.t())
+        ) :: Phoenix.LiveView.Socket.t()
+  def handle_ai_translation_event(socket, :translation_started, %{target_lang: lang}, _assign_cs)
+      when is_binary(lang) do
+    if lang in socket.assigns.ai_in_flight do
+      # Our own dispatch already added it + sized the progress session.
+      socket
+    else
+      # A job started elsewhere (another session/tab on this resource). Track
+      # it AND grow the session so a later completion can't push past total.
+      socket
+      |> add_in_flight([lang])
+      |> bump_started(1)
+    end
+  end
+
+  def handle_ai_translation_event(socket, :translation_completed, payload, assign_cs) do
+    lang = payload[:target_lang]
+    fields = payload[:fields] || %{}
+
+    # No per-language flash — with many languages that's dozens of toasts. The
+    # progress bar + the field filling in carry the signal.
+    socket
+    |> maybe_apply_translation(lang, fields, assign_cs)
+    |> mark_lang_done(lang)
+  end
+
+  def handle_ai_translation_event(socket, :translation_failed, payload, _assign_cs) do
+    lang = payload[:target_lang]
+
+    socket
+    |> mark_lang_done(lang)
+    |> Phoenix.LiveView.put_flash(:error, ai_failed_flash(lang))
+  end
+
+  # Stall timer landed: no language completed for `ai_stall_ms/0` — show the
+  # "taking a while" reassurance, but only if something's still running and the
+  # tick isn't a stale one from a superseded clock.
+  def handle_ai_translation_event(socket, :slow_tick, payload, _assign_cs) do
+    cond do
+      socket.assigns.ai_in_flight == [] -> socket
+      payload[:token] != socket.assigns[:ai_slow_token] -> socket
+      true -> Phoenix.Component.assign(socket, :ai_slow, true)
+    end
+  end
+
+  def handle_ai_translation_event(socket, _event, _payload, _assign_cs), do: socket
+
+  defp maybe_apply_translation(socket, lang, fields, assign_cs)
+       when is_binary(lang) and map_size(fields) > 0 do
+    binding = socket.assigns.ai_form_binding
+    cs = socket.assigns.form.source
+    new_cs = binding.apply_translation(socket.assigns.ai_resource_type, cs, lang, fields)
+    assign_cs.(socket, new_cs)
+  end
+
+  defp maybe_apply_translation(socket, _lang, _fields, _assign_cs), do: socket
+
+  # Terminal lifecycle for a language: drop from in-flight, advance progress,
+  # flip to :completed when nothing's left. No-op for a stale/duplicate event.
+  defp mark_lang_done(socket, lang) when is_binary(lang) do
+    in_flight = socket.assigns.ai_in_flight
+
+    if lang in in_flight do
+      new_in_flight = in_flight -- [lang]
+      # Clamp to total — defends the bar against any started/completed skew.
+      progress = min((socket.assigns.ai_progress || 0) + 1, socket.assigns.ai_total)
+      status = if new_in_flight == [], do: :completed, else: :in_progress
+
+      socket =
+        Phoenix.Component.assign(socket,
+          ai_in_flight: new_in_flight,
+          ai_progress: progress,
+          ai_status: status
+        )
+
+      # Progress advanced: restart the stall clock (hide the hint) if more
+      # remain, or cancel it entirely once the batch is done.
+      if new_in_flight == [],
+        do: socket |> cancel_stall_timer() |> Phoenix.Component.assign(:ai_slow, false),
+        else: arm_stall_timer(socket)
+    else
+      socket
+    end
+  end
+
+  defp mark_lang_done(socket, _lang), do: socket
+
+  defp ai_failed_flash(lang) when is_binary(lang),
+    do: gettext("Translation failed for %{lang}.", lang: String.upcase(lang))
+
+  defp ai_failed_flash(_), do: gettext("Translation failed.")
+
+  defp flash_error(socket, msg), do: Phoenix.LiveView.put_flash(socket, :error, msg)
+end

--- a/test/phoenix_kit/modules/ai/translate_worker_test.exs
+++ b/test/phoenix_kit/modules/ai/translate_worker_test.exs
@@ -1,0 +1,75 @@
+defmodule PhoenixKit.Modules.AI.TranslateWorkerTest do
+  @moduledoc """
+  Unit coverage for `PhoenixKit.Modules.AI.TranslateWorker` that doesn't need
+  a live `PhoenixKitAI` plugin:
+
+    * `retryable?/1` — transient AI errors retry, deterministic ones don't.
+    * `perform/1` setup-failure paths (bad args / unknown adapter) discard
+      cleanly and broadcast a normalised `:translation_failed` — all BEFORE
+      any AI call.
+
+  The success path (the real `ask_with_prompt/4` round-trip + persist) needs a
+  seeded endpoint + prompt + a registered adapter, so it's covered by each
+  consumer's browser/integration verification.
+  """
+
+  # async: false — perform's failure path broadcasts on the shared global topic.
+  use ExUnit.Case, async: false
+
+  alias PhoenixKit.Modules.AI.{TranslateWorker, Translations}
+
+  describe "retryable?/1" do
+    test "transient AI errors retry" do
+      assert TranslateWorker.retryable?({:ai_error, :request_timeout})
+      assert TranslateWorker.retryable?({:ai_error, :timeout})
+      assert TranslateWorker.retryable?({:ai_error, :rate_limited})
+      assert TranslateWorker.retryable?({:ai_error, {:connection_error, :closed}})
+      assert TranslateWorker.retryable?({:ai_error, {:exit, :timeout}})
+    end
+
+    test "5xx-class API errors retry; 4xx and others don't" do
+      assert TranslateWorker.retryable?({:ai_error, {:api_error, 500}})
+      assert TranslateWorker.retryable?({:ai_error, {:api_error, 503}})
+      refute TranslateWorker.retryable?({:ai_error, {:api_error, 400}})
+      refute TranslateWorker.retryable?({:ai_error, {:api_error, 429}})
+    end
+
+    test "deterministic errors don't retry" do
+      refute TranslateWorker.retryable?({:parse_error, :no_markers})
+      refute TranslateWorker.retryable?(:ai_not_installed)
+      refute TranslateWorker.retryable?({:no_adapter, "x"})
+      refute TranslateWorker.retryable?(:anything_else)
+    end
+  end
+
+  describe "perform/1 setup failures (no AI call)" do
+    test "missing required arg → discard with {:missing_arg, _}" do
+      job = %Oban.Job{args: %{"resource_uuid" => "u"}, attempt: 1, max_attempts: 3}
+      assert {:discard, {:missing_arg, "resource_type"}} = TranslateWorker.perform(job)
+    end
+
+    test "unknown resource type → discard {:no_adapter, _} + failure broadcast" do
+      :ok = Translations.subscribe()
+
+      job = %Oban.Job{
+        args: %{
+          "resource_type" => "totally_unregistered",
+          "resource_uuid" => "00000000-0000-0000-0000-0000000000b1",
+          "endpoint_uuid" => "e",
+          "prompt_uuid" => "p",
+          "source_lang" => "en",
+          "target_lang" => "es"
+        },
+        attempt: 1,
+        max_attempts: 3
+      }
+
+      assert {:discard, {:no_adapter, "totally_unregistered"}} = TranslateWorker.perform(job)
+
+      assert_receive {:ai_translation, :translation_failed, payload}
+      assert payload.resource_type == "totally_unregistered"
+      assert payload.target_lang == "es"
+      assert payload.reason == {:no_adapter, "totally_unregistered"}
+    end
+  end
+end

--- a/test/phoenix_kit/modules/ai/translations_test.exs
+++ b/test/phoenix_kit/modules/ai/translations_test.exs
@@ -1,0 +1,107 @@
+defmodule PhoenixKit.Modules.AI.TranslationsTest do
+  @moduledoc """
+  Unit coverage for `PhoenixKit.Modules.AI.Translations` orchestration that
+  doesn't need a live `PhoenixKitAI` plugin or a configured endpoint/prompt:
+
+    * `missing_languages/3` — pure set difference (primary excluded).
+    * availability/list helpers degrade to safe defaults when the plugin
+      isn't loaded (core CI doesn't load `PhoenixKitAI`).
+    * `broadcast/3` payload scoping — the FULL payload (with `:fields`) goes
+      ONLY to the per-resource topic; the global + adapter topics get a
+      content-free summary. Pins the payload-minimal fix.
+
+  The end-to-end `enqueue`/`TranslateWorker` round-trip needs a seeded
+  endpoint + prompt and lives in each consumer's worker test.
+  """
+
+  # async: false — the global `phoenix_kit:ai_translation` topic is shared, so
+  # serial runs keep one test's broadcast out of another's mailbox.
+  use ExUnit.Case, async: false
+
+  alias PhoenixKit.Modules.AI.Translations
+
+  describe "missing_languages/3" do
+    test "returns enabled non-primary codes that have no translation yet" do
+      assert Translations.missing_languages(["en", "es", "fr", "de"], "en", ["es"]) ==
+               ["fr", "de"]
+    end
+
+    test "excludes the primary language even if it's not in existing" do
+      refute "en" in Translations.missing_languages(["en", "es"], "en", [])
+    end
+
+    test "everything translated → empty" do
+      assert Translations.missing_languages(["en", "es", "fr"], "en", ["es", "fr"]) == []
+    end
+
+    test "preserves the enabled-codes order" do
+      assert Translations.missing_languages(["de", "fr", "es"], "en", []) == ["de", "fr", "es"]
+    end
+  end
+
+  describe "availability when the AI plugin is absent (core CI)" do
+    test "available?/0 is false" do
+      refute Translations.available?()
+    end
+
+    test "list_endpoints/0 and list_prompts/0 degrade to []" do
+      assert Translations.list_endpoints() == []
+      assert Translations.list_prompts() == []
+    end
+  end
+
+  describe "broadcast/3 payload scoping" do
+    test "the per-resource topic receives the FULL payload (with :fields)" do
+      uuid = "00000000-0000-0000-0000-0000000000a1"
+      :ok = Translations.subscribe("catalogue_item", uuid)
+
+      Translations.broadcast(:translation_completed, %{
+        resource_type: "catalogue_item",
+        resource_uuid: uuid,
+        target_lang: "es",
+        fields: %{"name" => "Hola"}
+      })
+
+      assert_receive {:ai_translation, :translation_completed, payload}
+      assert payload.fields == %{"name" => "Hola"}
+      assert payload.target_lang == "es"
+    end
+
+    test "the global topic receives a SUMMARY without :fields" do
+      uuid = "00000000-0000-0000-0000-0000000000a2"
+      :ok = Translations.subscribe()
+
+      Translations.broadcast(:translation_completed, %{
+        resource_type: "catalogue_item",
+        resource_uuid: uuid,
+        target_lang: "es",
+        fields: %{"name" => "Hola"}
+      })
+
+      assert_receive {:ai_translation, :translation_completed, payload}
+      refute Map.has_key?(payload, :fields)
+      # The non-content fields still ride along for monitors.
+      assert payload.resource_type == "catalogue_item"
+      assert payload.target_lang == "es"
+    end
+
+    test "extra (adapter) topics also get the content-free summary" do
+      extra = "phoenix_kit:test_adapter_topic"
+      :ok = PhoenixKit.PubSub.Manager.subscribe(extra)
+
+      Translations.broadcast(
+        :translation_completed,
+        %{
+          resource_type: "catalogue_item",
+          resource_uuid: "00000000-0000-0000-0000-0000000000a3",
+          target_lang: "es",
+          fields: %{"name" => "Hola"}
+        },
+        [extra]
+      )
+
+      assert_receive {:ai_translation, :translation_completed, payload}
+      refute Map.has_key?(payload, :fields)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Generalizes AI-driven translation into core so feature modules plug in via a small adapter instead of re-implementing the whole stack (projects + publishing each carried ~1000 lines of it). Adds the generic per-language Oban worker, the orchestration context, the shared modal + LiveView glue with a "taking a while" stall hint, retry-on-timeout, and a Phase 1/2 quality pass.

### Generic pipeline
- `Modules.AI.Translatable` behaviour (`fetch/2`, `source_fields/2`, `put_translation/4`, optional `pubsub_topics/1`) + `ai_translatables/0` module callback + `ModuleRegistry` discovery.
- `Modules.AI.Translations` orchestration — availability, endpoint/prompt defaults, idempotent shared prompt, `enqueue/1` + `enqueue_all_missing/2`, PubSub, `missing_languages/3`.
- `Modules.AI.TranslateWorker` — generic one-job-per-language Oban worker: retry classification (transient incl. `:timeout` retries, 5xx retries, deterministic discards), `{:snooze, 30}` on rate-limit, `ai.translation_added` audit.

### Shared UI
- `PhoenixKitWeb.Components.AITranslate` — button / modal / progress / hint (the "taking a while, runs in the background" reassurance on a stalled bar).
- `PhoenixKitWeb.Components.AITranslate.{FormGlue,FormBinding}` — the shared LiveView state machine (modal events, scope dispatch, live progress, the stall timer with a per-arm token guard) behind a 3-callback binding, so consumers wire an adapter + a tiny binding and delegate.

### Hardening
- `broadcast/3` keeps translated **content** off the global topic: the full payload (with `:fields`) goes only to the per-resource topic the form consumes; the global + adapter topics get a content-free summary.

### Tests & docs
- `translations_test` + `translate_worker_test` (14 tests): `missing_languages/3`, plugin-absent defaults, broadcast payload-scoping, `retryable?/1`, and `perform/1` setup-failure paths.
- Phase 1 triage `FOLLOW_UP.md` for PRs #572, #573.

## Verification
- `mix format --check-formatted` / `mix credo --strict` / `mix dialyzer` clean; 14 new tests green.
- Browser-verified end to end via the integration app: catalogue, projects, and staff all translate, fill the form live, and persist.

## Note
This is the foundational PR — the catalogue / projects / publishing PRs consume this generalization and need a release containing it before they build standalone.