### PR TITLE
Add V129: fix missing subscription_type_uuid column on subscriptions

### DIFF
--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -529,7 +529,15 @@ defmodule PhoenixKit.Migrations.Postgres do
   - Replaces unique index with partial index (slug-mode only, WHERE slug IS NOT NULL)
   - Adds unique index on `(group_uuid, post_date, post_time)` for timestamp-mode posts
 
-  ### V128 - Assignee on projects (and sub-projects) ⚡ LATEST
+  ### V129 - Add missing subscription_type_uuid column ⚡ LATEST
+  - Adds `subscription_type_uuid` (UUID, FK to `phoenix_kit_subscription_types(uuid)`
+    `ON DELETE SET NULL`) + a partial index to `phoenix_kit_subscriptions`. The
+    column the billing `Subscription` schema uses was only ever *renamed* in V65
+    (`plan_uuid` → `subscription_type_uuid`), never added, and `plan_uuid` never
+    existed — so on a fresh build the column was absent and subscription
+    inserts/queries raised `undefined_column`. Idempotent.
+
+  ### V128 - Assignee on projects (and sub-projects)
   - Adds `assigned_team_uuid` / `assigned_department_uuid` / `assigned_person_uuid`
     (FKs to the staff tables, `ON DELETE SET NULL`) to `phoenix_kit_projects`,
     with a `num_nonnulls(...) <= 1` single-assignee CHECK + a partial index per
@@ -1107,7 +1115,7 @@ defmodule PhoenixKit.Migrations.Postgres do
   use Ecto.Migration
 
   @initial_version 1
-  @current_version 128
+  @current_version 129
   @default_prefix "public"
 
   @doc false

--- a/lib/phoenix_kit/migrations/postgres/v129.ex
+++ b/lib/phoenix_kit/migrations/postgres/v129.ex
@@ -1,0 +1,102 @@
+defmodule PhoenixKit.Migrations.Postgres.V129 do
+  @moduledoc """
+  V129: Add the missing `subscription_type_uuid` column to subscriptions.
+
+  `phoenix_kit_subscriptions` was created in V33 with an integer `plan_id`
+  (renamed to `subscription_type_id` in V65). The UUID foreign key the
+  `PhoenixKitBilling.Schemas.Subscription` schema actually uses —
+  `subscription_type_uuid` — was only ever *renamed* (V65:
+  `plan_uuid` → `subscription_type_uuid`), never **added**, and `plan_uuid`
+  never existed. So on a fresh `ensure_current/2` build the column is absent
+  and every subscription insert / Subscriptions LiveView query raises
+  `undefined_column`.
+
+  This migration adds it idempotently:
+
+    * `subscription_type_uuid` UUID → FK
+      `phoenix_kit_subscription_types(uuid) ON DELETE SET NULL`
+    * a partial index for "subscriptions of type X" lookups.
+
+  Nullable + `ON DELETE SET NULL` so deleting a subscription type un-links
+  its subscriptions rather than cascading. Databases that already acquired
+  the column (via a historic `plan_uuid` rename) are untouched — every step
+  is guarded.
+  """
+
+  use Ecto.Migration
+
+  def up(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+    schema = schema_for(prefix)
+
+    execute("""
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT FROM information_schema.columns
+        WHERE table_schema = '#{schema}'
+          AND table_name = 'phoenix_kit_subscriptions'
+          AND column_name = 'subscription_type_uuid'
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_subscriptions ADD COLUMN subscription_type_uuid UUID;
+      END IF;
+
+      IF NOT EXISTS (
+        SELECT FROM information_schema.table_constraints
+        WHERE table_schema = '#{schema}'
+          AND table_name = 'phoenix_kit_subscriptions'
+          AND constraint_name = 'phoenix_kit_subscriptions_subscription_type_uuid_fkey'
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_subscriptions
+          ADD CONSTRAINT phoenix_kit_subscriptions_subscription_type_uuid_fkey
+          FOREIGN KEY (subscription_type_uuid)
+          REFERENCES #{p}phoenix_kit_subscription_types(uuid)
+          ON DELETE SET NULL;
+      END IF;
+    END $$;
+    """)
+
+    execute("""
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT FROM pg_indexes
+        WHERE schemaname = '#{schema}'
+          AND tablename = 'phoenix_kit_subscriptions'
+          AND indexname = 'phoenix_kit_subscriptions_subscription_type_uuid_idx'
+      ) THEN
+        CREATE INDEX phoenix_kit_subscriptions_subscription_type_uuid_idx
+          ON #{p}phoenix_kit_subscriptions (subscription_type_uuid)
+          WHERE subscription_type_uuid IS NOT NULL;
+      END IF;
+    END $$;
+    """)
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '129'")
+  end
+
+  def down(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    execute("DROP INDEX IF EXISTS #{p}phoenix_kit_subscriptions_subscription_type_uuid_idx")
+
+    execute("""
+    ALTER TABLE #{p}phoenix_kit_subscriptions
+      DROP CONSTRAINT IF EXISTS phoenix_kit_subscriptions_subscription_type_uuid_fkey
+    """)
+
+    execute(
+      "ALTER TABLE #{p}phoenix_kit_subscriptions DROP COLUMN IF EXISTS subscription_type_uuid"
+    )
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '128'")
+  end
+
+  defp schema_for("public"), do: "public"
+  defp schema_for(prefix), do: prefix
+
+  defp prefix_str("public"), do: "public."
+  defp prefix_str(prefix), do: "#{prefix}."
+end


### PR DESCRIPTION
## Summary

Fixes a fresh-install defect in `phoenix_kit_subscriptions`: the `subscription_type_uuid` UUID foreign key that `PhoenixKitBilling.Schemas.Subscription` uses was **never added** by any migration.

- V33 created the table with an integer `plan_id` (later renamed to `subscription_type_id` in V65).
- V65 *conditionally* renamed `plan_uuid → subscription_type_uuid` — but `plan_uuid` never existed, so the rename was a no-op on every fresh build.

Result: on a fresh `ensure_current/2`, the column is absent, and every subscription insert (and the billing **Subscriptions** LiveView) raises `Postgrex.Error … undefined_column "subscription_type_uuid"`. Existing long-lived databases that somehow acquired the column are unaffected. (Surfaced by the `phoenix_kit_billing` quality sweep, which had to `@tag :skip` three subscription tests pending this fix.)

## Change

New **V129** migration, idempotent throughout (guarded DO-blocks):
- adds `subscription_type_uuid UUID` to `phoenix_kit_subscriptions`
- FK → `phoenix_kit_subscription_types(uuid)` `ON DELETE SET NULL`
- partial index `… WHERE subscription_type_uuid IS NOT NULL`
- bumps `@current_version` to 129; `down/1` drops the index/FK/column and resets the marker to 128.

## Verification

Fresh migrate (`test.reset` + `ensure_current`) on an empty DB:
- `subscription_type_uuid : uuid` present ✓
- FK `phoenix_kit_subscriptions_subscription_type_uuid_fkey` ✓
- index `phoenix_kit_subscriptions_subscription_type_uuid_idx` ✓
- `COMMENT ON TABLE phoenix_kit` = `129` ✓
- `mix format` clean, `mix credo --strict` clean.

No `@version` / CHANGELOG bump (left for the release cut).

## Follow-up
Once this ships in a release, the three `@tag :skip` subscription tests in `phoenix_kit_billing` can be un-skipped.