### PR TITLE
Add host-wiring Embed macros, comment leaf-event forwarding, and V131 staff metadata migration

### DIFF
--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -529,7 +529,14 @@ defmodule PhoenixKit.Migrations.Postgres do
   - Replaces unique index with partial index (slug-mode only, WHERE slug IS NOT NULL)
   - Adds unique index on `(group_uuid, post_date, post_time)` for timestamp-mode posts
 
-  ### V130 - Marker annotation kind ⚡ LATEST
+  ### V131 - `metadata JSONB` on staff people ⚡ LATEST
+  - Adds a general-purpose `metadata JSONB NOT NULL DEFAULT '{}'` column to
+    `phoenix_kit_staff_people` (mirrors `phoenix_kit_entities.entity_data`).
+    First consumer is staff soft-delete: stashes the prior lifecycle status
+    under `metadata["trashed_from_status"]` so restore can return the person to
+    active/inactive. Idempotent `ADD COLUMN IF NOT EXISTS`.
+
+  ### V130 - Marker annotation kind
   - Widens `phoenix_kit_annotations_kind_check` to allow `'marker'` (the Etcher
     highlighter tool). Markers persist via `annotations-changed` but skip the
     composer (no title/comment) — without this the insert is rejected and the
@@ -1121,7 +1128,7 @@ defmodule PhoenixKit.Migrations.Postgres do
   use Ecto.Migration
 
   @initial_version 1
-  @current_version 130
+  @current_version 131
   @default_prefix "public"
 
   @doc false

--- a/lib/phoenix_kit/migrations/postgres/v131.ex
+++ b/lib/phoenix_kit/migrations/postgres/v131.ex
@@ -1,0 +1,44 @@
+defmodule PhoenixKit.Migrations.Postgres.V131 do
+  @moduledoc """
+  V131: `metadata JSONB` on `phoenix_kit_staff_people`.
+
+  Adds a general-purpose `metadata JSONB NOT NULL DEFAULT '{}'` column to
+  the staff people table, mirroring the shape `phoenix_kit_entities`
+  `entity_data` already uses. The immediate consumer is soft-delete:
+  `PhoenixKitStaff.Staff.trash_person/2` stashes the row's prior
+  lifecycle status under `metadata["trashed_from_status"]` so
+  `restore_person/2` can return the person to active/inactive instead of
+  unconditionally landing on "active".
+
+  The column is deliberately generic (not a `trashed_from_status`-specific
+  field) so future per-person metadata can reuse it without another
+  migration — same rationale as the entity_data metadata column.
+
+  Idempotent: `ADD COLUMN IF NOT EXISTS`, safe to re-run.
+  """
+
+  use Ecto.Migration
+
+  def up(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    execute(
+      "ALTER TABLE #{p}phoenix_kit_staff_people ADD COLUMN IF NOT EXISTS metadata JSONB NOT NULL DEFAULT '{}'::jsonb"
+    )
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '131'")
+  end
+
+  def down(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    execute("ALTER TABLE #{p}phoenix_kit_staff_people DROP COLUMN IF EXISTS metadata")
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '130'")
+  end
+
+  defp prefix_str("public"), do: "public."
+  defp prefix_str(prefix), do: "#{prefix}."
+end

--- a/lib/phoenix_kit_web/components/ai_translate/embed.ex
+++ b/lib/phoenix_kit_web/components/ai_translate/embed.ex
@@ -1,0 +1,117 @@
+defmodule PhoenixKitWeb.Components.AITranslate.Embed do
+  @moduledoc """
+  Host-side wiring for the AI-translate modal — `use` this in a form
+  LiveView and it injects the boilerplate that every consumer of
+  `PhoenixKitWeb.Components.AITranslate.FormGlue` was hand-duplicating:
+
+    * the six `handle_event` clauses that delegate the modal's button
+      clicks (`ai_toggle_modal`, `ai_select_endpoint`, `ai_select_prompt`,
+      `ai_select_scope`, `ai_generate_prompt`, `ai_translate_lang`) to the
+      matching `FormGlue` helpers, and
+    * the `handle_info({:ai_translation, event, payload}, socket)` clause
+      that folds PubSub progress/result events back into the form.
+
+  Forgetting any of these is a silent failure: the modal renders, but
+  translations never run, progress never updates, or the form never
+  re-syncs with the result. The macro makes that impossible to forget.
+
+  ## Usage
+
+      use MyAppWeb, :live_view
+      use PhoenixKitWeb.Components.AITranslate.Embed
+
+      # still call this yourself in mount/apply_action — the resource is
+      # dynamic (the loaded record on :edit, nil on :new):
+      |> FormGlue.assign_ai_translation("project", project_or_nil, MyBinding)
+
+      # render the button/progress/hint/modal from FormGlue.ai_translate_config(assigns)
+
+  ## How it composes
+
+  The handlers are attached as `:handle_event` / `:handle_info` lifecycle
+  hooks via `on_mount`, so they **compose** with the form's own
+  `handle_event`/`handle_info` clauses — no clause-grouping warning, no
+  clobbering. Non-AI events/messages pass straight through
+  (`{:cont, socket}`); the AI ones are handled and halted. Mirrors the
+  lifecycle-hook approach in `PhoenixKitWeb.Components.MediaBrowser.Embed`
+  and `PhoenixKitComments.Embed`.
+
+  ## Form re-sync
+
+  After a translation merges into the live changeset, the form must be
+  re-assigned. The default sets both `:changeset` and `:form`
+  (`assign(socket, changeset: cs, form: to_form(cs))`) — the superset
+  that fits every current consumer. A host whose sync differs can define
+  `ai_translate_assign_form/2` (`(socket, changeset) -> socket`); the hook
+  uses it when present.
+  """
+
+  alias PhoenixKitWeb.Components.AITranslate.FormGlue
+
+  defmacro __using__(_opts) do
+    quote do
+      on_mount(PhoenixKitWeb.Components.AITranslate.Embed)
+    end
+  end
+
+  @doc false
+  def on_mount(:default, _params, _session, socket) do
+    socket =
+      socket
+      |> Phoenix.LiveView.attach_hook(
+        :phoenix_kit_ai_translate_events,
+        :handle_event,
+        &__handle_event__/3
+      )
+      |> Phoenix.LiveView.attach_hook(
+        :phoenix_kit_ai_translate_info,
+        :handle_info,
+        &__handle_info__/2
+      )
+
+    {:cont, socket}
+  end
+
+  @doc false
+  def __handle_event__("ai_translate_lang", %{"lang" => lang}, socket),
+    do: {:halt, FormGlue.dispatch_ai_translate(socket, lang)}
+
+  def __handle_event__("ai_toggle_modal", _params, socket),
+    do: {:halt, FormGlue.toggle_ai_modal(socket)}
+
+  def __handle_event__("ai_select_endpoint", %{"endpoint_uuid" => uuid}, socket),
+    do: {:halt, FormGlue.select_ai_endpoint(socket, uuid)}
+
+  def __handle_event__("ai_select_prompt", %{"prompt_uuid" => uuid}, socket),
+    do: {:halt, FormGlue.select_ai_prompt(socket, uuid)}
+
+  def __handle_event__("ai_select_scope", %{"scope" => scope}, socket),
+    do: {:halt, FormGlue.select_ai_scope(socket, scope)}
+
+  def __handle_event__("ai_generate_prompt", _params, socket),
+    do: {:halt, FormGlue.generate_ai_prompt(socket)}
+
+  def __handle_event__(_event, _params, socket), do: {:cont, socket}
+
+  @doc false
+  def __handle_info__({:ai_translation, event, payload}, socket) do
+    {:halt, FormGlue.handle_ai_translation_event(socket, event, payload, &resync_form/2)}
+  end
+
+  def __handle_info__(_msg, socket), do: {:cont, socket}
+
+  # Re-assign the form after a translation patches the changeset. Honors a
+  # host-defined `ai_translate_assign_form/2` override; otherwise sets both
+  # `:changeset` and `:form`.
+  defp resync_form(socket, changeset) do
+    view = socket.view
+
+    if is_atom(view) and function_exported?(view, :ai_translate_assign_form, 2) do
+      view.ai_translate_assign_form(socket, changeset)
+    else
+      socket
+      |> Phoenix.Component.assign(:changeset, changeset)
+      |> Phoenix.Component.assign(:form, Phoenix.Component.to_form(changeset))
+    end
+  end
+end

--- a/lib/phoenix_kit_web/components/core/markdown_editor.ex
+++ b/lib/phoenix_kit_web/components/core/markdown_editor.ex
@@ -38,13 +38,23 @@ defmodule PhoenixKitWeb.Components.Core.MarkdownEditor do
   When text is selected, formatting wraps the selection. When no text is
   selected, a placeholder is inserted and auto-selected for easy replacement.
 
-  ## Events Sent to Parent
+  ## Events Sent to Parent — required host wiring (silent failure otherwise)
 
-  The component sends messages to the parent LiveView via `send/2`:
+  This is a `LiveComponent`, so it has no `handle_info` of its own: it
+  reports edits by sending **process messages to the host LiveView** via
+  `send/2`. The host MUST handle these, or the edits are silently lost
+  (the editor looks live but the parent never sees the typed content —
+  no crash, no warning):
 
-  - `{:editor_content_changed, %{content: content, editor_id: id}}` - Content updated
-  - `{:editor_insert_component, %{type: :image | :video, editor_id: id}}` - Toolbar button clicked
-  - `{:editor_save_requested, %{editor_id: id}}` - Save button clicked
+  - `{:editor_content_changed, %{content: content, editor_id: id}}` —
+    **required.** Content updated; the host folds `content` into its own
+    changeset/assign. Forget this and the form never sees what's typed.
+  - `{:editor_insert_component, %{type: :image | :video, editor_id: id}}` —
+    toolbar insert button clicked (handle if you support media inserts).
+  - `{:editor_save_requested, %{editor_id: id}}` — save button clicked.
+
+  Each host folds the content into its own form differently, so there is
+  intentionally no `use ...Embed` macro — the handling is yours to write.
 
   ## Commands from Parent
 

--- a/lib/phoenix_kit_web/components/media_gallery.ex
+++ b/lib/phoenix_kit_web/components/media_gallery.ex
@@ -45,13 +45,20 @@ defmodule PhoenixKitWeb.Components.MediaGallery do
     always 1 (implied by `mode`). When the limit is reached, the "Add" tile is
     hidden entirely (not just disabled) and `apply_selection` refuses to exceed it.
 
-  ## Change notifications
+  ## Change notifications — required host wiring (silent failure otherwise)
 
-  After any change (pick / remove / reorder), the component sends:
+  This is a `LiveComponent`, so it has no `handle_info` of its own: after
+  any change (pick / remove / reorder) it sends a **process message to the
+  host LiveView** via `send/2`:
 
       {PhoenixKitWeb.Components.MediaGallery, id, {:changed, ordered_uuids}}
 
-  to the parent LiveView via `send/2`.
+  The host MUST handle this (see the Usage example above) and persist
+  `ordered_uuids` — it is a *controlled* component: it renders whatever the
+  host passes back as `:selected`. Forget the handler and the user's
+  picks/reorders are silently dropped (no crash, no warning). Each host
+  stores the selection differently (its own field/assoc), so there is
+  intentionally no `use ...Embed` macro — the handling is yours to write.
 
   ## Reorder event contract
 

--- a/lib/phoenix_kit_web/live/components/media_selector_modal.ex
+++ b/lib/phoenix_kit_web/live/components/media_selector_modal.ex
@@ -34,6 +34,28 @@ defmodule PhoenixKitWeb.Live.Components.MediaSelectorModal do
         {:noreply, socket |> assign(:gallery_uuids, file_uuids)}
       end
 
+  ## Required host wiring (do not skip — silent failure otherwise)
+
+  This is a `LiveComponent`, so it has no `handle_info` of its own; it
+  reports the user's choice by sending a **process message to the host
+  LiveView**. The host MUST handle it, or the selection is silently
+  dropped (the modal closes, nothing happens — no crash, no warning):
+
+    * `handle_info({:media_selected, file_uuids}, socket)` — **required.**
+      Fired when the user confirms; `file_uuids` is the chosen list.
+    * `handle_info({:media_selector_closed}, socket)` — recommended (fired
+      on cancel/close) so the host can reset its own open-state assign.
+
+  Each host does something different with the files (avatar, gallery,
+  product images…), so there is intentionally no `use ...Embed` macro to
+  inject this — the handling is yours to write.
+
+  Alternative — `:notify`: pass `notify: {SomeComponent, id}` and the
+  result is delivered to that **component** via `send_update` instead
+  (`update(%{media_selected: uuids}, socket)` /
+  `update(%{media_selector_closed: true}, socket)`), for when the
+  consumer is itself a LiveComponent.
+
   ## Attrs
 
     * `show` — boolean, controls modal visibility

--- a/lib/phoenix_kit_web/live/users/media_detail.ex
+++ b/lib/phoenix_kit_web/live/users/media_detail.ex
@@ -176,6 +176,27 @@ defmodule PhoenixKitWeb.Live.Users.MediaDetail do
     end
   end
 
+  # The embedded CommentsComponent's Leaf editor reports its content via a
+  # {:leaf_changed, ...} process message to this host LV; without forwarding
+  # it to the component, "Post Comment" silently no-ops. phoenix_kit_comments
+  # is optional from core, so resolve it at runtime (safe no-op if absent).
+  # NOTE: defining handle_info means unmatched messages no longer hit
+  # LiveView's default — hence the catch-all below.
+  def handle_info({:leaf_changed, _} = msg, socket) do
+    case Code.ensure_loaded(PhoenixKitComments.Web.CommentsComponent) do
+      {:module, mod} ->
+        case mod.forward_leaf_event(msg, socket) do
+          {:noreply, socket} -> {:noreply, socket}
+          _ -> {:noreply, socket}
+        end
+
+      _ ->
+        {:noreply, socket}
+    end
+  end
+
+  def handle_info(_msg, socket), do: {:noreply, socket}
+
   defp load_file_data(socket, file_uuid) do
     repo = PhoenixKit.Config.get_repo()
 


### PR DESCRIPTION
## Summary

Foundation/host-wiring improvements extracted while hardening the comment + AI-translation embedding patterns, plus the migration backing staff soft-delete.

### Commits
- **Fix media detail comments: forward Leaf editor events to the component** — the Leaf rich-text composer reports its content via a `{:leaf_changed}` process message to the host LiveView; media_detail wasn't forwarding it, so "Post Comment" silently posted empty content. Adds the runtime forward to `CommentsComponent.forward_leaf_event/2` (+ catch-all).
- **Add AITranslate.Embed macro for host wiring** — `PhoenixKitWeb.Components.AITranslate.Embed`: an `on_mount` that injects the 6 identical `ai_*` `handle_event` clauses + the `{:ai_translation}` `handle_info` via `attach_hook`, removing the duplicated boilerplate every translate-form consumer was hand-copying. Default form re-sync matches the consumers' `assign_form`; optional `ai_translate_assign_form/2` override.
- **Document required host wiring on callback-message components** — loud "required host wiring / silent failure otherwise" moduledoc contracts on `MediaSelectorModal`, `MarkdownEditor`, and `MediaGallery` (these stay docs-only by design — per-consumer logic, not uniform boilerplate, so no macro).
- **Add V131 migration: metadata JSONB on staff people** — general-purpose `metadata JSONB NOT NULL DEFAULT '{}'` on `phoenix_kit_staff_people` (mirrors `entity_data`); first consumer is staff soft-delete (stashes prior lifecycle status under `metadata["trashed_from_status"]`). Idempotent `ADD COLUMN IF NOT EXISTS`; `@current_version` → 131.

All compile clean against the integrated tree; no version/CHANGELOG bump (release-cut handled separately).