### PR TITLE
V135: structured staff skills + per-skill dynamic proficiency levels

### DIFF
--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -532,7 +532,10 @@ defmodule PhoenixKit.Migrations.Postgres do
   ### V135 - Structured staff skills ⚡ LATEST
   - Replaces the free-text `phoenix_kit_staff_people.skills` column with a
     first-class translatable `phoenix_kit_staff_skills` entity + a
-    `phoenix_kit_staff_person_skills` join (nullable `proficiency_level`).
+    `phoenix_kit_staff_person_skills` join. Each skill carries its own
+    per-skill, translatable proficiency levels (`levels` JSONB array of
+    `{id, name, translations}`) and an `allow_multiple_levels` boolean; the
+    join's `proficiency_levels` JSONB array holds the selected level ids.
     Migrates the comma-separated free-text into structured rows (case-insensitive
     dedup, guarded for retry-safety) and drops the column. Lossy by design:
     per-locale `translations["skills"]` overrides don't map to structured skills

--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -539,7 +539,9 @@ defmodule PhoenixKit.Migrations.Postgres do
     Migrates the comma-separated free-text into structured rows (case-insensitive
     dedup, guarded for retry-safety) and drops the column. Lossy by design:
     per-locale `translations["skills"]` overrides don't map to structured skills
-    and are stripped.
+    and are stripped. Also adds a partial index on
+    `phoenix_kit_staff_people(date_of_birth)` (active + non-null DOB only) for
+    `Staff.upcoming_birthdays/1`.
 
   ### V134 - Folder header customization
   - Adds the folder hero-header columns to `phoenix_kit_media_folders`:

--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -529,7 +529,16 @@ defmodule PhoenixKit.Migrations.Postgres do
   - Replaces unique index with partial index (slug-mode only, WHERE slug IS NOT NULL)
   - Adds unique index on `(group_uuid, post_date, post_time)` for timestamp-mode posts
 
-  ### V134 - Folder header customization ⚡ LATEST
+  ### V135 - Structured staff skills ⚡ LATEST
+  - Replaces the free-text `phoenix_kit_staff_people.skills` column with a
+    first-class translatable `phoenix_kit_staff_skills` entity + a
+    `phoenix_kit_staff_person_skills` join (nullable `proficiency_level`).
+    Migrates the comma-separated free-text into structured rows (case-insensitive
+    dedup, guarded for retry-safety) and drops the column. Lossy by design:
+    per-locale `translations["skills"]` overrides don't map to structured skills
+    and are stripped.
+
+  ### V134 - Folder header customization
   - Adds the folder hero-header columns to `phoenix_kit_media_folders`:
     `cover_file_uuid` (background image), `logo_file_uuid` (icon),
     `header_size` (small/medium/large), and the `header_show_*` visibility
@@ -1147,7 +1156,7 @@ defmodule PhoenixKit.Migrations.Postgres do
   use Ecto.Migration
 
   @initial_version 1
-  @current_version 134
+  @current_version 135
   @default_prefix "public"
 
   @doc false

--- a/lib/phoenix_kit/migrations/postgres/v135.ex
+++ b/lib/phoenix_kit/migrations/postgres/v135.ex
@@ -1,0 +1,146 @@
+defmodule PhoenixKit.Migrations.Postgres.V135 do
+  @moduledoc """
+  V135: Structured staff skills.
+
+  Replaces the free-text `phoenix_kit_staff_people.skills` column with a
+  first-class, translatable `Skill` entity assigned to people many-to-many,
+  each assignment carrying an optional proficiency level. Creates:
+
+  - `phoenix_kit_staff_skills` — translatable skill (name + description +
+    `translations` JSONB), globally unique by `lower(name)`
+  - `phoenix_kit_staff_person_skills` — person ↔ skill join with a nullable
+    `proficiency_level` (`beginner` / `intermediate` / `advanced` / `expert`,
+    or NULL = "not set")
+
+  ## Data migration
+
+  The free-text `skills` column (comma-separated) is split, trimmed,
+  case-insensitively de-duplicated into `Skill` rows, and each person is
+  linked to the skills parsed from their string (proficiency `NULL`). Then
+  the column is dropped. The parse/insert runs inside a column-existence
+  guard so a partial re-run (column already dropped) is a safe no-op.
+
+  **Lossy by design (documented):** the column holds only the primary-language
+  skill string. Per-locale skill overrides — `translations[locale]["skills"]`
+  on the people table, a *separate* JSONB column — do **not** map cleanly to
+  structured skills and are **dropped** (the orphaned `"skills"` keys are
+  stripped from each person's `translations`). Structured skills carry their
+  own translations going forward.
+  """
+
+  use Ecto.Migration
+
+  def up(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    # 1. Skills entity (translatable, flat — no parent).
+    execute("""
+    CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_staff_skills (
+      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      name VARCHAR(255) NOT NULL,
+      description TEXT,
+      translations JSONB NOT NULL DEFAULT '{}'::jsonb,
+      inserted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+    """)
+
+    execute("""
+    CREATE UNIQUE INDEX IF NOT EXISTS phoenix_kit_staff_skills_lower_name_index
+    ON #{p}phoenix_kit_staff_skills (lower(name))
+    """)
+
+    # 2. person ↔ skill join + nullable proficiency level.
+    execute("""
+    CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_staff_person_skills (
+      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      staff_person_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_staff_people(uuid) ON DELETE CASCADE,
+      skill_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_staff_skills(uuid) ON DELETE CASCADE,
+      proficiency_level VARCHAR(50),
+      inserted_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+    """)
+
+    execute("""
+    CREATE UNIQUE INDEX IF NOT EXISTS phoenix_kit_staff_person_skills_person_skill_index
+    ON #{p}phoenix_kit_staff_person_skills (staff_person_uuid, skill_uuid)
+    """)
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS phoenix_kit_staff_person_skills_skill_index
+    ON #{p}phoenix_kit_staff_person_skills (skill_uuid)
+    """)
+
+    # 3. Migrate the free-text column → structured rows. Guarded on the
+    #    column still existing so a retry after the DROP below is a no-op
+    #    (PL/pgSQL plans the inner statements lazily, so they're never parsed
+    #    when the column is gone). Prefix threaded through the dynamic SQL.
+    execute("""
+    DO $$
+    BEGIN
+      IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = '#{prefix}'
+          AND table_name = 'phoenix_kit_staff_people'
+          AND column_name = 'skills'
+      ) THEN
+        -- distinct skills, deterministic canonical casing
+        INSERT INTO #{p}phoenix_kit_staff_skills (name)
+        SELECT DISTINCT ON (lower(trim(tok))) trim(tok)
+        FROM #{p}phoenix_kit_staff_people pers
+        CROSS JOIN LATERAL regexp_split_to_table(pers.skills, ',') AS tok
+        WHERE pers.skills IS NOT NULL AND trim(tok) <> ''
+        ORDER BY lower(trim(tok)), trim(tok)
+        ON CONFLICT (lower(name)) DO NOTHING;
+
+        -- link each person to the skills parsed from their string
+        INSERT INTO #{p}phoenix_kit_staff_person_skills (staff_person_uuid, skill_uuid)
+        SELECT DISTINCT pers.uuid, sk.uuid
+        FROM #{p}phoenix_kit_staff_people pers
+        CROSS JOIN LATERAL regexp_split_to_table(pers.skills, ',') AS tok
+        JOIN #{p}phoenix_kit_staff_skills sk ON lower(sk.name) = lower(trim(tok))
+        WHERE pers.skills IS NOT NULL AND trim(tok) <> ''
+        ON CONFLICT (staff_person_uuid, skill_uuid) DO NOTHING;
+
+        -- strip the now-orphaned per-locale "skills" overrides from the
+        -- separate translations JSONB (idempotent: removing an absent key
+        -- is a no-op; other translated fields are preserved)
+        UPDATE #{p}phoenix_kit_staff_people pers
+        SET translations = (
+          SELECT COALESCE(jsonb_object_agg(lang, submap - 'skills'), '{}'::jsonb)
+          FROM jsonb_each(pers.translations) AS t(lang, submap)
+        )
+        WHERE pers.translations <> '{}'::jsonb;
+      END IF;
+    END $$;
+    """)
+
+    # 4. Drop the free-text column (independently idempotent).
+    execute("ALTER TABLE #{p}phoenix_kit_staff_people DROP COLUMN IF EXISTS skills")
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '135'")
+  end
+
+  @doc """
+  Drops the two skills tables and re-adds the free-text `skills` column.
+
+  **Lossy rollback:** the re-added `skills` column is empty — structured
+  skill rows and assignments are destroyed and the original free-text values
+  are not restored.
+  """
+  def down(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    execute("ALTER TABLE #{p}phoenix_kit_staff_people ADD COLUMN IF NOT EXISTS skills TEXT")
+
+    execute("DROP TABLE IF EXISTS #{p}phoenix_kit_staff_person_skills")
+    execute("DROP TABLE IF EXISTS #{p}phoenix_kit_staff_skills")
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '134'")
+  end
+
+  defp prefix_str("public"), do: "public."
+  defp prefix_str(prefix), do: "#{prefix}."
+end

--- a/lib/phoenix_kit/migrations/postgres/v135.ex
+++ b/lib/phoenix_kit/migrations/postgres/v135.ex
@@ -16,6 +16,10 @@ defmodule PhoenixKit.Migrations.Postgres.V135 do
     `proficiency_levels` JSONB array holds the selected level `id`s into the
     parent skill's `levels` (`[]` = no level / "not set")
 
+  Also adds a partial index on `phoenix_kit_staff_people(date_of_birth)`
+  (active + non-null DOB only) so `Staff.upcoming_birthdays/1` scans a small
+  index rather than the full people table.
+
   ## Data migration
 
   The free-text `skills` column (comma-separated) is split, trimmed,
@@ -125,6 +129,16 @@ defmodule PhoenixKit.Migrations.Postgres.V135 do
     # 4. Drop the free-text column (independently idempotent).
     execute("ALTER TABLE #{p}phoenix_kit_staff_people DROP COLUMN IF EXISTS skills")
 
+    # 5. Partial index for `Staff.upcoming_birthdays/1`, which filters
+    #    `status = 'active' AND date_of_birth IS NOT NULL` before its
+    #    next-anniversary window fragment — so Postgres scans a small index
+    #    instead of the full people table as the roster grows.
+    execute("""
+    CREATE INDEX IF NOT EXISTS phoenix_kit_staff_people_active_dob_index
+    ON #{p}phoenix_kit_staff_people (date_of_birth)
+    WHERE status = 'active' AND date_of_birth IS NOT NULL
+    """)
+
     execute("COMMENT ON TABLE #{p}phoenix_kit IS '135'")
   end
 
@@ -138,6 +152,8 @@ defmodule PhoenixKit.Migrations.Postgres.V135 do
   def down(opts) do
     prefix = Map.get(opts, :prefix, "public")
     p = prefix_str(prefix)
+
+    execute("DROP INDEX IF EXISTS #{p}phoenix_kit_staff_people_active_dob_index")
 
     execute("ALTER TABLE #{p}phoenix_kit_staff_people ADD COLUMN IF NOT EXISTS skills TEXT")
 

--- a/lib/phoenix_kit/migrations/postgres/v135.ex
+++ b/lib/phoenix_kit/migrations/postgres/v135.ex
@@ -4,13 +4,17 @@ defmodule PhoenixKit.Migrations.Postgres.V135 do
 
   Replaces the free-text `phoenix_kit_staff_people.skills` column with a
   first-class, translatable `Skill` entity assigned to people many-to-many,
-  each assignment carrying an optional proficiency level. Creates:
+  each assignment carrying zero or more of the skill's own proficiency levels.
+  Creates:
 
   - `phoenix_kit_staff_skills` — translatable skill (name + description +
-    `translations` JSONB), globally unique by `lower(name)`
-  - `phoenix_kit_staff_person_skills` — person ↔ skill join with a nullable
-    `proficiency_level` (`beginner` / `intermediate` / `advanced` / `expert`,
-    or NULL = "not set")
+    `translations` JSONB), globally unique by `lower(name)`. Carries its own
+    **per-skill, translatable proficiency levels** in a `levels` JSONB array
+    (each `{"id", "name", "translations"}`) plus an `allow_multiple_levels`
+    boolean that decides whether an assignment may hold one level or several.
+  - `phoenix_kit_staff_person_skills` — person ↔ skill join whose
+    `proficiency_levels` JSONB array holds the selected level `id`s into the
+    parent skill's `levels` (`[]` = no level / "not set")
 
   ## Data migration
 
@@ -41,6 +45,8 @@ defmodule PhoenixKit.Migrations.Postgres.V135 do
       name VARCHAR(255) NOT NULL,
       description TEXT,
       translations JSONB NOT NULL DEFAULT '{}'::jsonb,
+      levels JSONB NOT NULL DEFAULT '[]'::jsonb,
+      allow_multiple_levels BOOLEAN NOT NULL DEFAULT false,
       inserted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
       updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
     )
@@ -57,7 +63,7 @@ defmodule PhoenixKit.Migrations.Postgres.V135 do
       uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
       staff_person_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_staff_people(uuid) ON DELETE CASCADE,
       skill_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_staff_skills(uuid) ON DELETE CASCADE,
-      proficiency_level VARCHAR(50),
+      proficiency_levels JSONB NOT NULL DEFAULT '[]'::jsonb,
       inserted_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
     )
     """)


### PR DESCRIPTION
## Summary

Adds the **V135** versioned migration that backs `phoenix_kit_staff`'s
structured-skills feature, replacing the old free-text
`phoenix_kit_staff_people.skills` column:

- **`phoenix_kit_staff_skills`** — first-class translatable skill (name +
  description + `translations` JSONB, globally unique `lower(name)`). Carries
  its own **per-skill, translatable proficiency levels** in a `levels` JSONB
  array (`{id, name, translations}` with stable ids) plus an
  `allow_multiple_levels` boolean.
- **`phoenix_kit_staff_person_skills`** — person ↔ skill join whose
  `proficiency_levels` JSONB array holds the selected level ids into the
  parent skill's `levels` (`[]` = no level).
- **Data migration** — the comma-separated free-text `skills` is split,
  case-insensitively de-duplicated into `Skill` rows, linked to people, and
  the column is dropped. Guarded for retry-safety. **Lossy by design:**
  per-locale `translations["skills"]` overrides don't map to structured
  skills and are stripped (documented in the migration moduledoc).
- **Partial index** on `phoenix_kit_staff_people(date_of_birth)` (active +
  non-null DOB only) for `Staff.upcoming_birthdays/1`.

`@current_version` → **135**. The migration is additive/guarded
(`CREATE TABLE/INDEX IF NOT EXISTS`, `DROP COLUMN IF EXISTS`); `down/1` drops
the tables + index and re-adds the (empty) free-text column.

## Verification

- Exercised end-to-end by the `phoenix_kit_staff` consumer (its full suite —
  434 tests, 0 failures — builds the schema via
  `PhoenixKit.Migration.ensure_current/2`, i.e. it runs V135).
- Migrated up + rolled back + replayed on a local dev DB; partial index and
  columns confirmed present; manual browser testing of the staff skills UI.
- This is a self-contained additive migration (no core runtime logic depends
  on it); core CI will run on this PR.

## Consumer

`phoenix_kit_staff` depends on this migration — its PR is CI-red against
published core until this lands and a release is cut.