### PR TITLE
MediaBrowser: mobile layout, sidebar branch highlight, and folder UX fixes

### DIFF
--- a/lib/modules/storage/storage.ex
+++ b/lib/modules/storage/storage.ex
@@ -936,6 +936,42 @@ defmodule PhoenixKit.Modules.Storage do
     |> repo().all()
   end
 
+  @doc """
+  Lists non-trashed folders whose name matches `search` (case-insensitive
+  `ilike`), within the same scope the media-browser file search uses:
+
+    * a specific `folder_uuid` → its direct child folders
+    * scope root (scope set, no `folder_uuid`) → folders anywhere under the scope
+    * real root (no scope, no `folder_uuid`) → all folders
+
+  Returns `[]` for a blank search.
+  """
+  def search_folders(search, folder_uuid \\ nil, scope_folder_id \\ nil)
+
+  def search_folders(search, _folder_uuid, _scope) when search in [nil, ""], do: []
+
+  def search_folders(search, folder_uuid, scope_folder_id) do
+    base =
+      cond do
+        folder_uuid not in [nil, ""] ->
+          from(f in Folder, where: f.parent_uuid == ^folder_uuid)
+
+        scope_folder_id ->
+          # The scope folder itself isn't a listable result — only its descendants.
+          subtree = folder_subtree_uuids(scope_folder_id)
+          from(f in Folder, where: f.uuid in ^subtree and f.uuid != ^scope_folder_id)
+
+        true ->
+          from(f in Folder)
+      end
+
+    base
+    |> where([f], is_nil(f.trashed_at))
+    |> where([f], ilike(f.name, ^"%#{search}%"))
+    |> order_by([f], asc: f.name)
+    |> repo().all()
+  end
+
   @doc "Gets a single folder by UUID."
   def get_folder(nil), do: nil
   def get_folder(uuid), do: repo().get(Folder, uuid)

--- a/lib/phoenix_kit_web/components/folder_explorer.ex
+++ b/lib/phoenix_kit_web/components/folder_explorer.ex
@@ -601,7 +601,7 @@ defmodule PhoenixKitWeb.Components.FolderExplorer do
     "relative pl-3.5 " <>
       "before:content-[''] before:absolute before:left-0 before:top-0 before:h-full before:w-0.5 before:bg-[var(--pk-tree-line)] " <>
       "after:content-[''] after:absolute after:left-0 after:top-0 after:h-[0.8125rem] after:w-4 after:bg-transparent " <>
-      "after:border-l-2 after:border-b-2 after:border-[var(--pk-tree-line-active)] after:rounded-bl-lg " <>
+      "after:border-l-2 after:border-b-2 after:border-[var(--pk-tree-line-active)] " <>
       "last:before:h-[0.875rem] last:before:w-4 last:before:bg-transparent " <>
       "last:before:border-l-2 last:before:border-b-2 last:before:border-[var(--pk-tree-line-active)] last:before:rounded-bl-lg " <>
       "last:after:hidden"
@@ -611,7 +611,7 @@ defmodule PhoenixKitWeb.Components.FolderExplorer do
     "relative pl-3.5 " <>
       "before:content-[''] before:absolute before:left-0 before:top-0 before:h-full before:w-0.5 before:bg-[var(--pk-tree-line)] " <>
       "after:content-[''] after:absolute after:left-0 after:top-0 after:h-[0.8125rem] after:w-9 after:bg-transparent " <>
-      "after:border-l-2 after:border-b-2 after:border-[var(--pk-tree-line-active)] after:rounded-bl-lg " <>
+      "after:border-l-2 after:border-b-2 after:border-[var(--pk-tree-line-active)] " <>
       "last:before:h-[0.875rem] last:before:w-9 last:before:bg-transparent " <>
       "last:before:border-l-2 last:before:border-b-2 last:before:border-[var(--pk-tree-line-active)] last:before:rounded-bl-lg " <>
       "last:after:hidden"

--- a/lib/phoenix_kit_web/components/folder_explorer.ex
+++ b/lib/phoenix_kit_web/components/folder_explorer.ex
@@ -84,6 +84,16 @@ defmodule PhoenixKitWeb.Components.FolderExplorer do
   attr :show_trash, :boolean, default: true
 
   def folder_explorer(assigns) do
+    # UUIDs on the path from a root folder down to (and including) the
+    # current folder. Each node's guide-line connector is darkened when its
+    # uuid is in this set, so the user can trace the branch they're inside.
+    assigns =
+      assign(
+        assigns,
+        :active_path,
+        active_path_uuids(assigns.folder_tree, assigns.current_folder)
+      )
+
     ~H"""
     <div
       id={@id}
@@ -178,6 +188,7 @@ defmodule PhoenixKitWeb.Components.FolderExplorer do
               <.folder_tree_node
                 node={node}
                 current_folder={@current_folder}
+                active_path={@active_path}
                 expanded_folders={@expanded_folders}
                 renaming_folder={@renaming_folder}
                 renaming_source={@renaming_source}
@@ -222,6 +233,17 @@ defmodule PhoenixKitWeb.Components.FolderExplorer do
 
   attr :node, :map, required: true
   attr :current_folder, :any, required: true
+
+  attr :active_path, :any,
+    default: MapSet.new(),
+    doc: "UUIDs from a root folder to the current folder; darkens their connector lines."
+
+  attr :connector_mode, :atom,
+    default: :normal,
+    values: [:normal, :active_trunk, :active_turn],
+    doc:
+      "How this node's guide line is drawn: normal, a darkened pass-through trunk, or the darkened turn into the active branch."
+
   attr :expanded_folders, :any, required: true
   attr :renaming_folder, :any, default: nil
   attr :renaming_text, :string, default: ""
@@ -278,11 +300,30 @@ defmodule PhoenixKitWeb.Components.FolderExplorer do
           assigns.renaming_source == "sidebar"
       )
 
+    # This node's own connector style comes from its parent (`@connector_mode`).
+    # For ITS children we find which one (if any) continues the active branch:
+    # children above it get a darkened vertical trunk (`:active_trunk`), the
+    # branch child itself gets the darkened turn (`:active_turn`), the rest stay
+    # normal. Suppressed in trash view (the tree highlight is off there).
+    assigns =
+      assign(
+        assigns,
+        :on_path_child_index,
+        if(assigns.filter_trash,
+          do: nil,
+          else:
+            Enum.find_index(
+              assigns.node.children,
+              &MapSet.member?(assigns.active_path, &1.folder.uuid)
+            )
+        )
+      )
+
     assigns =
       assign(
         assigns,
         :tree_connector_class,
-        tree_connector_class(assigns.depth, assigns.has_children)
+        tree_connector_class(assigns.depth, assigns.has_children, assigns.connector_mode)
       )
 
     ~H"""
@@ -419,12 +460,14 @@ defmodule PhoenixKitWeb.Components.FolderExplorer do
         --%>
         <ul
           class="ml-3 overflow-hidden"
-          style={"--pk-tree-line: #{tree_line_color(@node.folder.color)}"}
+          style={"--pk-tree-line: #{tree_line_color(@node.folder.color)}; --pk-tree-line-active: #{tree_line_color_active(@node.folder.color)}"}
         >
-          <%= for child <- @node.children do %>
+          <%= for {child, idx} <- Enum.with_index(@node.children) do %>
             <.folder_tree_node
               node={child}
               current_folder={@current_folder}
+              active_path={@active_path}
+              connector_mode={child_connector_mode(@on_path_child_index, idx)}
               expanded_folders={@expanded_folders}
               renaming_folder={@renaming_folder}
               renaming_source={@renaming_source}
@@ -476,10 +519,49 @@ defmodule PhoenixKitWeb.Components.FolderExplorer do
     end
   end
 
+  # Darker (less transparent) variant of the same line color, used for the
+  # connectors on the active root→current branch — same hue, just bolder. A
+  # colored folder bumps alpha `80` (~50%) → `E6` (~90%); the neutral falls
+  # back to currentColor at 85% (still theme-adaptive, not solid black).
   @doc false
-  def tree_connector_class(0, _has_children), do: false
+  def tree_line_color_active(color) do
+    case folder_color_hex(color) do
+      nil -> "color-mix(in oklab, currentColor 85%, transparent)"
+      hex -> hex <> "E6"
+    end
+  end
 
-  def tree_connector_class(_depth, true = _has_children) do
+  # Which connector mode a child renders, given the index of the branch child
+  # in the same group (or nil when none): everything above the branch child is
+  # a darkened pass-through trunk, the branch child is the darkened turn, the
+  # rest are normal.
+  defp child_connector_mode(nil, _idx), do: :normal
+  defp child_connector_mode(branch_idx, idx) when idx < branch_idx, do: :active_trunk
+  defp child_connector_mode(branch_idx, idx) when idx == branch_idx, do: :active_turn
+  defp child_connector_mode(_branch_idx, _idx), do: :normal
+
+  # Connector classes are returned as whole literal Tailwind strings (never
+  # interpolate the utility tokens — the JIT scans source for complete class
+  # names, so each variant is spelled out in full).
+  #
+  # Three modes:
+  #   * :normal       — light vertical trunk + light elbow into the row.
+  #   * :active_trunk — the active branch descends PAST this side row, so its
+  #                     vertical trunk is darkened while the elbow into the row
+  #                     stays light (the path doesn't enter here).
+  #   * :active_turn  — the active branch turns INTO this row. The trunk stays
+  #                     light so it can continue down to later siblings, and a
+  #                     darkened L-elbow (`after`) draws the turn over its top.
+  #                     A last child has no trunk below, so its `before` becomes
+  #                     the darkened elbow instead.
+  #
+  # `w-4` vs `w-9`: a row with a disclosure chevron stops the elbow at the
+  # chevron (`w-4`); a childless row runs it across the empty chevron column to
+  # the folder icon (`w-9`).
+  @doc false
+  def tree_connector_class(0, _has_children, _mode), do: false
+
+  def tree_connector_class(_depth, true = _has_children, :normal) do
     "relative pl-3.5 " <>
       "before:content-[''] before:absolute before:left-0 before:top-0 before:h-full before:w-0.5 before:bg-[var(--pk-tree-line)] " <>
       "after:content-[''] after:absolute after:left-0 after:top-[0.8125rem] after:h-0.5 after:w-4 after:bg-[var(--pk-tree-line)] " <>
@@ -488,13 +570,81 @@ defmodule PhoenixKitWeb.Components.FolderExplorer do
       "last:after:hidden"
   end
 
-  def tree_connector_class(_depth, false = _has_children) do
+  def tree_connector_class(_depth, false = _has_children, :normal) do
     "relative pl-3.5 " <>
       "before:content-[''] before:absolute before:left-0 before:top-0 before:h-full before:w-0.5 before:bg-[var(--pk-tree-line)] " <>
       "after:content-[''] after:absolute after:left-0 after:top-[0.8125rem] after:h-0.5 after:w-9 after:bg-[var(--pk-tree-line)] " <>
       "last:before:h-[0.875rem] last:before:w-9 last:before:bg-transparent " <>
       "last:before:border-l-2 last:before:border-b-2 last:before:border-[var(--pk-tree-line)] last:before:rounded-bl-lg " <>
       "last:after:hidden"
+  end
+
+  def tree_connector_class(_depth, true = _has_children, :active_trunk) do
+    "relative pl-3.5 " <>
+      "before:content-[''] before:absolute before:left-0 before:top-0 before:h-full before:w-0.5 before:bg-[var(--pk-tree-line-active)] " <>
+      "after:content-[''] after:absolute after:left-0 after:top-[0.8125rem] after:h-0.5 after:w-4 after:bg-[var(--pk-tree-line)] " <>
+      "last:before:h-[0.875rem] last:before:w-4 last:before:bg-transparent " <>
+      "last:before:border-l-2 last:before:border-b-2 last:before:border-[var(--pk-tree-line-active)] last:before:rounded-bl-lg " <>
+      "last:after:hidden"
+  end
+
+  def tree_connector_class(_depth, false = _has_children, :active_trunk) do
+    "relative pl-3.5 " <>
+      "before:content-[''] before:absolute before:left-0 before:top-0 before:h-full before:w-0.5 before:bg-[var(--pk-tree-line-active)] " <>
+      "after:content-[''] after:absolute after:left-0 after:top-[0.8125rem] after:h-0.5 after:w-9 after:bg-[var(--pk-tree-line)] " <>
+      "last:before:h-[0.875rem] last:before:w-9 last:before:bg-transparent " <>
+      "last:before:border-l-2 last:before:border-b-2 last:before:border-[var(--pk-tree-line-active)] last:before:rounded-bl-lg " <>
+      "last:after:hidden"
+  end
+
+  def tree_connector_class(_depth, true = _has_children, :active_turn) do
+    "relative pl-3.5 " <>
+      "before:content-[''] before:absolute before:left-0 before:top-0 before:h-full before:w-0.5 before:bg-[var(--pk-tree-line)] " <>
+      "after:content-[''] after:absolute after:left-0 after:top-0 after:h-[0.8125rem] after:w-4 after:bg-transparent " <>
+      "after:border-l-2 after:border-b-2 after:border-[var(--pk-tree-line-active)] after:rounded-bl-lg " <>
+      "last:before:h-[0.875rem] last:before:w-4 last:before:bg-transparent " <>
+      "last:before:border-l-2 last:before:border-b-2 last:before:border-[var(--pk-tree-line-active)] last:before:rounded-bl-lg " <>
+      "last:after:hidden"
+  end
+
+  def tree_connector_class(_depth, false = _has_children, :active_turn) do
+    "relative pl-3.5 " <>
+      "before:content-[''] before:absolute before:left-0 before:top-0 before:h-full before:w-0.5 before:bg-[var(--pk-tree-line)] " <>
+      "after:content-[''] after:absolute after:left-0 after:top-0 after:h-[0.8125rem] after:w-9 after:bg-transparent " <>
+      "after:border-l-2 after:border-b-2 after:border-[var(--pk-tree-line-active)] after:rounded-bl-lg " <>
+      "last:before:h-[0.875rem] last:before:w-9 last:before:bg-transparent " <>
+      "last:before:border-l-2 last:before:border-b-2 last:before:border-[var(--pk-tree-line-active)] last:before:rounded-bl-lg " <>
+      "last:after:hidden"
+  end
+
+  # ──────────────────────────────────────────────────────────────
+  # Active-branch path (root → current folder)
+  # ──────────────────────────────────────────────────────────────
+
+  # Set of folder UUIDs on the path from a root node down to (and including)
+  # the current folder. Empty when there is no current folder or it isn't in
+  # the tree. Walks the already-nested tree, so it's O(n) over visible nodes.
+  @doc false
+  def active_path_uuids(_tree, nil), do: MapSet.new()
+
+  def active_path_uuids(tree, current_folder) do
+    case find_node_path(tree, current_folder.uuid) do
+      nil -> MapSet.new()
+      path -> MapSet.new(path)
+    end
+  end
+
+  defp find_node_path(nodes, target_uuid) do
+    Enum.find_value(nodes, fn node ->
+      if node.folder.uuid == target_uuid do
+        [target_uuid]
+      else
+        case find_node_path(node.children, target_uuid) do
+          nil -> nil
+          sub -> [node.folder.uuid | sub]
+        end
+      end
+    end)
   end
 
   # ──────────────────────────────────────────────────────────────

--- a/lib/phoenix_kit_web/components/folder_explorer.ex
+++ b/lib/phoenix_kit_web/components/folder_explorer.ex
@@ -15,7 +15,7 @@ defmodule PhoenixKitWeb.Components.FolderExplorer do
   implement the relevant `handle_event/3` clauses:
 
       navigate_folder, navigate_root, navigate_view_all,
-      toggle_folder_expand, toggle_sidebar, create_untitled_folder,
+      toggle_folder_expand, toggle_sidebar, open_new_folder_modal,
       start_rename_folder, rename_folder_input, rename_folder,
       cancel_rename_folder, toggle_trash_filter
 
@@ -129,7 +129,7 @@ defmodule PhoenixKitWeb.Components.FolderExplorer do
             <div class="flex gap-0.5">
               <button
                 :if={@show_create}
-                phx-click="create_untitled_folder"
+                phx-click="open_new_folder_modal"
                 phx-target={@myself}
                 class="btn btn-ghost btn-xs"
                 title={gettext("New folder")}

--- a/lib/phoenix_kit_web/components/media_browser.ex
+++ b/lib/phoenix_kit_web/components/media_browser.ex
@@ -1045,7 +1045,7 @@ defmodule PhoenixKitWeb.Components.MediaBrowser do
 
     if folder && name != "" do
       case Storage.update_folder(folder, %{name: String.trim(name)}, scope) do
-        {:ok, _} ->
+        {:ok, updated} ->
           parent_uuid = current_folder_uuid(socket)
 
           {:noreply,
@@ -1054,7 +1054,8 @@ defmodule PhoenixKitWeb.Components.MediaBrowser do
            |> assign(:renaming_source, nil)
            |> assign(:renaming_text, "")
            |> assign(:folders, Storage.list_folders(parent_uuid, scope))
-           |> assign(:folder_tree, Storage.list_folder_tree(scope))}
+           |> assign(:folder_tree, Storage.list_folder_tree(scope))
+           |> refresh_header_folder(folder_uuid, updated)}
 
         {:error, :out_of_scope} ->
           {:noreply,
@@ -1988,6 +1989,34 @@ defmodule PhoenixKitWeb.Components.MediaBrowser do
     socket
     |> assign(:folders, folders)
     |> assign(:folder_tree, Storage.list_folder_tree(scope))
+  end
+
+  # Keep the hero header (and the open Edit-header panel) in sync when the
+  # renamed folder is the one shown there. The title/description block reads
+  # `@current_folder`/`@scope_folder`, not the sidebar tree — without this it
+  # would keep displaying the pre-rename name after a sidebar rename.
+  defp refresh_header_folder(socket, folder_uuid, updated) do
+    same? = fn folder ->
+      folder && to_string(folder.uuid) == to_string(folder_uuid)
+    end
+
+    socket =
+      if same?.(socket.assigns[:current_folder]),
+        do: assign(socket, :current_folder, updated),
+        else: socket
+
+    socket =
+      if same?.(socket.assigns[:scope_folder]),
+        do:
+          socket
+          |> assign(:scope_folder, updated)
+          |> assign(:scope_folder_name, updated.name),
+        else: socket
+
+    if socket.assigns[:editing_folder_header] &&
+         to_string(socket.assigns.editing_folder_header) == to_string(folder_uuid),
+       do: assign(socket, :folder_header_name, updated.name),
+       else: socket
   end
 
   # Combined trash count for the sidebar badge — files + folders.

--- a/lib/phoenix_kit_web/components/media_browser.ex
+++ b/lib/phoenix_kit_web/components/media_browser.ex
@@ -329,12 +329,17 @@ defmodule PhoenixKitWeb.Components.MediaBrowser do
       )
     )
     |> assign(:breadcrumbs, breadcrumbs)
-    # The "all" view, the orphaned view, and any active search are flat file
-    # listings — they show no folder cards, only the matching files. (The
-    # sidebar folder tree is unaffected; only the grid's folder cards here.)
+    # The "all" view and the orphaned view are flat file listings — no folder
+    # cards. A name search keeps the file results but ALSO surfaces folders
+    # whose name matches (same scope as the file search). (The sidebar folder
+    # tree is unaffected; only the grid's folder cards here.)
     |> assign(
       :folders,
-      if(file_view == "all" or filter_orphaned or q != "", do: [], else: folders)
+      cond do
+        file_view == "all" or filter_orphaned -> []
+        q != "" -> Storage.search_folders(q, actual_uuid, scope)
+        true -> folders
+      end
     )
     |> assign(:search_query, q)
     |> assign(:current_page, page)
@@ -897,7 +902,7 @@ defmodule PhoenixKitWeb.Components.MediaBrowser do
       folders =
         cond do
           file_view == "all" -> []
-          query != "" -> []
+          query != "" -> Storage.search_folders(query, folder_uuid, scope)
           true -> Storage.list_folders(folder_uuid, scope)
         end
 

--- a/lib/phoenix_kit_web/components/media_browser.ex
+++ b/lib/phoenix_kit_web/components/media_browser.ex
@@ -460,6 +460,11 @@ defmodule PhoenixKitWeb.Components.MediaBrowser do
     |> assign(:selected_files, MapSet.new())
     |> assign(:selected_folders, MapSet.new())
     |> assign(:show_move_modal, false)
+    # New-folder modal: the typed name plus the default placeholder
+    # ("untitled" / "untitled N") shown when left blank.
+    |> assign(:show_new_folder_modal, false)
+    |> assign(:new_folder_name, "")
+    |> assign(:new_folder_placeholder, "")
     # Expand state for the Move modal's directory tree (separate from the
     # sidebar's :expanded_folders so drilling one doesn't move the other).
     # Starts collapsed → top-level folders only, drill in via the chevrons.
@@ -625,34 +630,61 @@ defmodule PhoenixKitWeb.Components.MediaBrowser do
   # in any toolbar and a folder appears named "untitled" (or
   # "untitled 1", "untitled 2", ... if that's taken). The new folder
   # immediately opens inline rename in the sidebar.
-  def handle_event("create_untitled_folder", _params, socket) do
-    cond do
-      socket.assigns[:filter_trash] ->
-        {:noreply, put_flash(socket, :error, gettext("Cannot create folders in trash"))}
+  # Open the New-folder modal, seeding the placeholder with the next default
+  # name. Creation itself is deferred to "submit_new_folder" so Cancel adds
+  # nothing.
+  def handle_event("open_new_folder_modal", _params, socket) do
+    case folder_creation_block(socket) do
+      nil ->
+        parent_uuid = current_folder_uuid(socket)
+        scope = scope_folder_id(socket)
 
-      socket.assigns[:file_view] == "all" ->
         {:noreply,
-         put_flash(socket, :error, gettext("Cannot create folders in the all-files view"))}
+         socket
+         |> assign(:show_new_folder_modal, true)
+         |> assign(:new_folder_name, "")
+         |> assign(:new_folder_placeholder, next_untitled_name(parent_uuid, scope))}
 
-      true ->
+      msg ->
+        {:noreply, put_flash(socket, :error, msg)}
+    end
+  end
+
+  def handle_event("new_folder_input", %{"name" => name}, socket) do
+    {:noreply, assign(socket, :new_folder_name, name)}
+  end
+
+  def handle_event("close_new_folder_modal", _params, socket) do
+    {:noreply, assign(socket, :show_new_folder_modal, false)}
+  end
+
+  def handle_event("submit_new_folder", %{"name" => name}, socket) do
+    case folder_creation_block(socket) do
+      nil ->
         parent_uuid = current_folder_uuid(socket)
         scope = scope_folder_id(socket)
         user = socket.assigns[:phoenix_kit_current_user]
-        name = next_untitled_name(parent_uuid, scope)
+
+        # Blank → fall back to the placeholder default ("untitled"/"untitled N").
+        name =
+          case String.trim(name) do
+            "" -> next_untitled_name(parent_uuid, scope)
+            trimmed -> trimmed
+          end
+
+        socket = assign(socket, :show_new_folder_modal, false)
 
         case Storage.create_folder(
                %{name: name, parent_uuid: parent_uuid, user_uuid: user && user.uuid},
                scope
              ) do
-          {:ok, folder} ->
+          {:ok, _folder} ->
             {:noreply,
              socket
+             |> assign(:new_folder_name, "")
              |> reload_folder_lists()
              |> expand_sidebar_folder(parent_uuid)
              |> assign(:sidebar_collapsed, false)
-             |> assign(:renaming_folder, folder.uuid)
-             |> assign(:renaming_source, "sidebar")
-             |> assign(:renaming_text, name)
              |> put_flash(:info, gettext("Folder \"%{name}\" created", name: name))}
 
           {:error, :out_of_scope} ->
@@ -662,6 +694,12 @@ defmodule PhoenixKitWeb.Components.MediaBrowser do
           {:error, _changeset} ->
             {:noreply, put_flash(socket, :error, gettext("Failed to create folder"))}
         end
+
+      msg ->
+        {:noreply,
+         socket
+         |> assign(:show_new_folder_modal, false)
+         |> put_flash(:error, msg)}
     end
   end
 
@@ -2645,6 +2683,21 @@ defmodule PhoenixKitWeb.Components.MediaBrowser do
   # trashed siblings invisible to the unique constraint, so
   # `list_folders/2`'s active-only view matches what the DB will
   # accept.
+  # Returns a flash message when folder creation isn't allowed in the current
+  # view (trash / all-files), or nil when it's fine.
+  defp folder_creation_block(socket) do
+    cond do
+      socket.assigns[:filter_trash] ->
+        gettext("Cannot create folders in trash")
+
+      socket.assigns[:file_view] == "all" ->
+        gettext("Cannot create folders in the all-files view")
+
+      true ->
+        nil
+    end
+  end
+
   defp next_untitled_name(parent_uuid, scope) do
     base = gettext("untitled")
 

--- a/lib/phoenix_kit_web/components/media_browser.html.heex
+++ b/lib/phoenix_kit_web/components/media_browser.html.heex
@@ -96,7 +96,7 @@
     <%!-- Main Layout: Sidebar + Content in a unified card --%>
     <div class={["card bg-base-100 shadow-xl", @fill_height && "flex-1 min-h-0"]}>
       <div class={[
-        "card-body p-4 flex flex-row gap-0 overflow-hidden",
+        "card-body p-2 sm:p-4 flex flex-row gap-0 overflow-hidden",
         if(@fill_height, do: "flex-1 min-h-0", else: "h-[72vh] max-h-[48rem] min-h-[24rem]")
       ]}>
         <%!-- Folder Sidebar --%>
@@ -118,7 +118,7 @@
         />
 
         <%!-- Main content area --%>
-        <div class="flex-1 min-w-0 min-h-0 pl-4 flex flex-col">
+        <div class="flex-1 min-w-0 min-h-0 lg:pl-4 flex flex-col">
           <%!-- Hidden upload input for folder drag-drop (always in DOM when in a folder) --%>
           <%= if @has_buckets && !@show_upload && assigns[:parent_uploads] do %>
             <form
@@ -251,9 +251,9 @@
               <% header_min_h =
                 header_folder &&
                   case header_folder.header_size do
-                    "small" -> "min-h-[140px]"
-                    "large" -> "min-h-[320px]"
-                    _ -> "min-h-[200px]"
+                    "small" -> "min-h-[100px] sm:min-h-[140px]"
+                    "large" -> "min-h-[160px] sm:min-h-[320px]"
+                    _ -> "min-h-[130px] sm:min-h-[200px]"
                   end %>
               <% show_background = !header_folder || header_folder.header_show_background %>
               <% show_logo =
@@ -270,7 +270,7 @@
                    dropdowns open *over* the sticky table header instead of
                    being painted behind it. --%>
               <div class={[
-                "relative z-30 rounded-xl mb-4 flex flex-col justify-end",
+                "relative z-30 rounded-xl mb-3 sm:mb-4 flex flex-col justify-end",
                 header_min_h
               ]}>
                 <%!-- Background: cover image (when shown), folder-color gradient,
@@ -586,7 +586,7 @@
                        a blank line ("crazy top padding"). --%>
                 <%!-- Content (title / description / meta / toolbar) over the
                      faded bottom area. The toolbar is folded in below. --%>
-                <div class="relative z-10 p-4 flex flex-col gap-1">
+                <div class="relative z-10 p-3 sm:p-4 flex flex-col gap-1">
                   <% small_header = header_folder && header_folder.header_size == "small" %>
                   <%!-- Logo + text. On a SMALL header the logo sits to the LEFT
                        of the title/description (so it can be larger despite the
@@ -606,16 +606,16 @@
                         class={[
                           "object-contain shrink-0 drop-shadow-lg",
                           case header_folder.header_size do
-                            "small" -> "w-16 h-16"
-                            "large" -> "w-20 h-20"
-                            _ -> "w-14 h-14"
+                            "small" -> "w-12 h-12 sm:w-16 sm:h-16"
+                            "large" -> "w-14 h-14 sm:w-20 sm:h-20"
+                            _ -> "w-10 h-10 sm:w-14 sm:h-14"
                           end
                         ]}
                       />
                     <% end %>
                     <div class="flex flex-col gap-0.5 min-w-0">
                       <%= if show_title do %>
-                        <h2 class="text-2xl font-bold text-base-content break-words leading-tight">
+                        <h2 class="text-lg sm:text-2xl font-bold text-base-content break-words leading-tight">
                           <%= cond do %>
                             <% @filter_trash -> %>
                               {gettext("Trash")}
@@ -638,7 +638,7 @@
                              leading newline would render as a blank line). --%>
                         <%= if show_description do %>
                           <%= if header_folder.description not in [nil, ""] do %>
-                            <p class="text-sm text-base-content/80 max-w-2xl">
+                            <p class="text-xs sm:text-sm text-base-content/80 max-w-2xl line-clamp-2 sm:line-clamp-none">
                               {header_folder.description}
                             </p>
                           <% else %>
@@ -704,55 +704,51 @@
                     <% selected_count =
                       MapSet.size(@selected_files) + MapSet.size(@selected_folders) %>
                     <div class="flex flex-wrap items-center gap-2 mt-1">
-                      <button
-                        phx-click="toggle_select_mode"
-                        phx-target={@myself}
-                        class="btn btn-sm btn-neutral gap-1.5"
-                        title={gettext("Exit selection")}
-                      >
-                        <.icon name="hero-x-mark" class="w-4 h-4" /> {gettext("Done")}
-                      </button>
+                      <%!-- Count on the left; every control sits in the
+                           right-aligned cluster (Select all / Clear, the bulk
+                           actions, then Done) to match the actions-on-the-right
+                           convention used across the toolbars. --%>
                       <span class="text-sm font-semibold">
                         {ngettext("%{count} selected", "%{count} selected", selected_count)}
                       </span>
-                      <button
-                        phx-click="select_all"
-                        phx-target={@myself}
-                        class="btn btn-xs btn-ghost"
-                      >
-                        {gettext("Select all")}
-                      </button>
-                      <%= if selected_count > 0 do %>
+                      <div class="flex flex-wrap items-center justify-end gap-2 ml-auto">
                         <button
-                          phx-click="deselect_all"
+                          phx-click="select_all"
                           phx-target={@myself}
                           class="btn btn-xs btn-ghost"
                         >
-                          {gettext("Clear")}
+                          {gettext("Select all")}
                         </button>
-                      <% end %>
+                        <%= if selected_count > 0 do %>
+                          <button
+                            phx-click="deselect_all"
+                            phx-target={@myself}
+                            class="btn btn-xs btn-ghost"
+                          >
+                            {gettext("Clear")}
+                          </button>
+                        <% end %>
 
-                      <%!-- Bulk actions, right-aligned, only with a selection --%>
-                      <%= if selected_count > 0 do %>
-                        <div class="flex items-center gap-2 ml-auto">
+                        <%!-- Bulk actions, only with a selection --%>
+                        <%= if selected_count > 0 do %>
                           <button
                             phx-click="show_move_modal"
                             phx-target={@myself}
                             class="btn btn-sm btn-primary gap-1"
+                            title={gettext("Move")}
                           >
-                            <.icon name="hero-folder-arrow-down" class="w-4 h-4" /> {gettext(
-                              "Move"
-                            )}
+                            <.icon name="hero-folder-arrow-down" class="w-4 h-4" />
+                            <span class="hidden sm:inline">{gettext("Move")}</span>
                           </button>
                           <%= if MapSet.size(@selected_files) > 0 do %>
                             <button
                               phx-click="download_selected"
                               phx-target={@myself}
                               class="btn btn-sm btn-ghost gap-1"
+                              title={gettext("Download")}
                             >
-                              <.icon name="hero-arrow-down-tray" class="w-4 h-4" /> {gettext(
-                                "Download"
-                              )}
+                              <.icon name="hero-arrow-down-tray" class="w-4 h-4" />
+                              <span class="hidden sm:inline">{gettext("Download")}</span>
                             </button>
                           <% end %>
                           <button
@@ -766,14 +762,30 @@
                               )
                             }
                             class="btn btn-sm btn-error gap-1"
+                            title={
+                              if @filter_trash,
+                                do: gettext("Delete permanently"),
+                                else: gettext("Delete")
+                            }
                           >
                             <.icon name="hero-trash" class="w-4 h-4" />
-                            {if @filter_trash,
-                              do: gettext("Delete permanently"),
-                              else: gettext("Delete")}
+                            <span class="hidden sm:inline">
+                              {if @filter_trash,
+                                do: gettext("Delete permanently"),
+                                else: gettext("Delete")}
+                            </span>
                           </button>
-                        </div>
-                      <% end %>
+                        <% end %>
+
+                        <button
+                          phx-click="toggle_select_mode"
+                          phx-target={@myself}
+                          class="btn btn-sm btn-neutral gap-1.5"
+                          title={gettext("Exit selection")}
+                        >
+                          <.icon name="hero-x-mark" class="w-4 h-4" /> {gettext("Done")}
+                        </button>
+                      </div>
                     </div>
                   <% else %>
                     <% display_options = [
@@ -807,101 +819,134 @@
                       |> then(&(&1 && elem(&1, 1))) %>
                     <div class="flex flex-wrap items-center gap-2 mt-1">
                       <%= if not @filter_trash and not @filter_orphaned do %>
-                        <%!-- Display (grid/list) --%>
-                        <div class="dropdown">
-                          <div tabindex="0" role="button" class="btn btn-sm gap-2">
-                            <.icon
-                              name={
-                                if @view_mode == "list",
-                                  do: "hero-bars-3-bottom-left",
-                                  else: "hero-squares-2x2"
-                              }
-                              class="w-4 h-4"
-                            />
-                            {if @view_mode == "list", do: gettext("List"), else: gettext("Grid")}
-                            <.icon name="hero-chevron-down" class="w-3.5 h-3.5 opacity-60" />
+                        <%!-- Display / Sort / Filter group. On mobile this hides
+                             while the search field is open so search fills the
+                             toolbar row as a single clean bar. --%>
+                        <div class={[
+                          "flex flex-wrap items-center gap-2",
+                          (@show_search or @search_query != "") && "hidden sm:flex"
+                        ]}>
+                          <%!-- Display (grid/list) --%>
+                          <div class="dropdown">
+                            <div tabindex="0" role="button" class="btn btn-sm gap-2">
+                              <.icon
+                                name={
+                                  if @view_mode == "list",
+                                    do: "hero-bars-3-bottom-left",
+                                    else: "hero-squares-2x2"
+                                }
+                                class="w-4 h-4"
+                              />
+                              <span class="hidden sm:inline">
+                                {if @view_mode == "list",
+                                  do: gettext("List"),
+                                  else: gettext("Grid")}
+                              </span>
+                              <.icon
+                                name="hero-chevron-down"
+                                class="hidden sm:inline-block w-3.5 h-3.5 opacity-60"
+                              />
+                            </div>
+                            <ul
+                              tabindex="0"
+                              onclick="document.activeElement.blur()"
+                              class="dropdown-content menu bg-base-100 rounded-box z-20 w-44 p-2 shadow border border-base-200"
+                            >
+                              <%= for {val, label, icon} <- display_options do %>
+                                <li>
+                                  <button
+                                    phx-click="set_view_mode"
+                                    phx-value-mode={val}
+                                    phx-target={@myself}
+                                    class={@view_mode == val && "active"}
+                                  >
+                                    <.icon name={icon} class="w-4 h-4" /> {label}
+                                  </button>
+                                </li>
+                              <% end %>
+                            </ul>
                           </div>
-                          <ul
-                            tabindex="0"
-                            onclick="document.activeElement.blur()"
-                            class="dropdown-content menu bg-base-100 rounded-box z-20 w-44 p-2 shadow border border-base-200"
-                          >
-                            <%= for {val, label, icon} <- display_options do %>
-                              <li>
-                                <button
-                                  phx-click="set_view_mode"
-                                  phx-value-mode={val}
-                                  phx-target={@myself}
-                                  class={@view_mode == val && "active"}
-                                >
-                                  <.icon name={icon} class="w-4 h-4" /> {label}
-                                </button>
-                              </li>
-                            <% end %>
-                          </ul>
-                        </div>
 
-                        <%!-- Sort --%>
-                        <div class="dropdown">
-                          <div tabindex="0" role="button" class="btn btn-sm gap-2">
-                            <.icon name="hero-arrows-up-down" class="w-4 h-4" />
-                            {sort_label || gettext("Sort")}
-                            <.icon name="hero-chevron-down" class="w-3.5 h-3.5 opacity-60" />
+                          <%!-- Sort --%>
+                          <div class="dropdown">
+                            <div tabindex="0" role="button" class="btn btn-sm gap-2">
+                              <.icon name="hero-arrows-up-down" class="w-4 h-4" />
+                              <span class="hidden sm:inline">{sort_label || gettext("Sort")}</span>
+                              <.icon
+                                name="hero-chevron-down"
+                                class="hidden sm:inline-block w-3.5 h-3.5 opacity-60"
+                              />
+                            </div>
+                            <ul
+                              tabindex="0"
+                              onclick="document.activeElement.blur()"
+                              class="dropdown-content menu bg-base-100 rounded-box z-20 w-44 p-2 shadow border border-base-200"
+                            >
+                              <%= for {val, label} <- sort_options do %>
+                                <li>
+                                  <button
+                                    phx-click="set_sort"
+                                    phx-value-sort={val}
+                                    phx-target={@myself}
+                                    class={@sort_by == val && "active"}
+                                  >
+                                    {label}
+                                  </button>
+                                </li>
+                              <% end %>
+                            </ul>
                           </div>
-                          <ul
-                            tabindex="0"
-                            onclick="document.activeElement.blur()"
-                            class="dropdown-content menu bg-base-100 rounded-box z-20 w-44 p-2 shadow border border-base-200"
-                          >
-                            <%= for {val, label} <- sort_options do %>
-                              <li>
-                                <button
-                                  phx-click="set_sort"
-                                  phx-value-sort={val}
-                                  phx-target={@myself}
-                                  class={@sort_by == val && "active"}
-                                >
-                                  {label}
-                                </button>
-                              </li>
-                            <% end %>
-                          </ul>
-                        </div>
 
-                        <%!-- Filter (file type) --%>
-                        <div class="dropdown">
-                          <div tabindex="0" role="button" class="btn btn-sm gap-2">
-                            <.icon name="hero-funnel" class="w-4 h-4" />
-                            {if @file_type_filter == "all",
-                              do: gettext("Filter"),
-                              else: filter_label}
-                            <.icon name="hero-chevron-down" class="w-3.5 h-3.5 opacity-60" />
+                          <%!-- Filter (file type) --%>
+                          <div class="dropdown">
+                            <div tabindex="0" role="button" class="btn btn-sm gap-2">
+                              <.icon name="hero-funnel" class="w-4 h-4" />
+                              <span class={[
+                                "sm:inline",
+                                @file_type_filter == "all" && "hidden"
+                              ]}>
+                                {if @file_type_filter == "all",
+                                  do: gettext("Filter"),
+                                  else: filter_label}
+                              </span>
+                              <.icon
+                                name="hero-chevron-down"
+                                class="hidden sm:inline-block w-3.5 h-3.5 opacity-60"
+                              />
+                            </div>
+                            <ul
+                              tabindex="0"
+                              onclick="document.activeElement.blur()"
+                              class="dropdown-content menu bg-base-100 rounded-box z-20 w-44 p-2 shadow border border-base-200"
+                            >
+                              <%= for {val, label} <- filter_options do %>
+                                <li>
+                                  <button
+                                    phx-click="set_file_filter"
+                                    phx-value-type={val}
+                                    phx-target={@myself}
+                                    class={@file_type_filter == val && "active"}
+                                  >
+                                    {label}
+                                  </button>
+                                </li>
+                              <% end %>
+                            </ul>
                           </div>
-                          <ul
-                            tabindex="0"
-                            onclick="document.activeElement.blur()"
-                            class="dropdown-content menu bg-base-100 rounded-box z-20 w-44 p-2 shadow border border-base-200"
-                          >
-                            <%= for {val, label} <- filter_options do %>
-                              <li>
-                                <button
-                                  phx-click="set_file_filter"
-                                  phx-value-type={val}
-                                  phx-target={@myself}
-                                  class={@file_type_filter == val && "active"}
-                                >
-                                  {label}
-                                </button>
-                              </li>
-                            <% end %>
-                          </ul>
                         </div>
                       <% end %>
 
                       <%!-- Actions, pushed to the right. Contextual destructive
                            actions + Search + the primary Add Media; secondary
-                           actions (Select, New folder) live in the ⋯ overflow. --%>
-                      <div class="flex items-center gap-2 ml-auto">
+                           actions (Select, New folder) live in the ⋯ overflow.
+                           On mobile, opening search hides every sibling button
+                           (and the filter group above) and the cluster goes
+                           `w-full`, so the search field becomes a single clean
+                           full-width bar instead of squeezing the icon toolbar. --%>
+                      <div class={[
+                        "flex flex-wrap items-center justify-end gap-2 ml-auto",
+                        (@show_search or @search_query != "") && "w-full sm:w-auto"
+                      ]}>
                         <%!-- Empty Trash (trash view) --%>
                         <%= if @filter_trash and @total_count > 0 do %>
                           <button
@@ -914,7 +959,10 @@
                                 @total_count
                               )
                             }
-                            class="btn btn-sm btn-error gap-1"
+                            class={[
+                              "btn btn-sm btn-error gap-1",
+                              (@show_search or @search_query != "") && "hidden sm:inline-flex"
+                            ]}
                           >
                             <.icon name="hero-trash" class="w-4 h-4" /> {gettext("Empty Trash")}
                           </button>
@@ -932,7 +980,10 @@
                                 @total_count
                               )
                             }
-                            class="btn btn-sm btn-error gap-2"
+                            class={[
+                              "btn btn-sm btn-error gap-2",
+                              (@show_search or @search_query != "") && "hidden sm:inline-flex"
+                            ]}
                           >
                             <.icon name="hero-trash" class="w-4 h-4" /> {gettext(
                               "Delete all orphaned"
@@ -948,9 +999,9 @@
                             phx-change="search"
                             phx-submit="search"
                             phx-target={@myself}
-                            class="contents"
+                            class="w-full sm:w-auto min-w-0"
                           >
-                            <label class="input input-bordered input-sm flex items-center gap-1.5 w-44 max-w-[60vw] pr-1">
+                            <label class="input input-bordered input-sm flex items-center gap-1.5 w-full sm:w-44 max-w-none sm:max-w-[60vw] pr-1">
                               <.icon
                                 name="hero-magnifying-glass"
                                 class="w-4 h-4 text-base-content/40 shrink-0"
@@ -997,20 +1048,26 @@
                             phx-click="toggle_upload"
                             phx-target={@myself}
                             class={[
-                              "btn btn-sm gap-2 min-w-[8.5rem]",
-                              if(@show_upload, do: "btn-error", else: "btn-primary")
+                              "btn btn-sm gap-2 sm:min-w-[8.5rem]",
+                              if(@show_upload, do: "btn-error", else: "btn-primary"),
+                              (@show_search or @search_query != "") && "hidden sm:inline-flex"
                             ]}
                           >
                             <%= if @show_upload do %>
-                              <.icon name="hero-x-mark" class="w-4 h-4" /> {gettext("Cancel")}
+                              <.icon name="hero-x-mark" class="w-4 h-4" />
+                              <span class="hidden sm:inline">{gettext("Cancel")}</span>
                             <% else %>
-                              <.icon name="hero-plus" class="w-4 h-4" /> {gettext("Add Media")}
+                              <.icon name="hero-plus" class="w-4 h-4" />
+                              <span class="hidden sm:inline">{gettext("Add Media")}</span>
                             <% end %>
                           </button>
                         <% end %>
 
                         <%!-- Overflow: secondary actions --%>
-                        <div class="dropdown dropdown-end">
+                        <div class={[
+                          "dropdown dropdown-end",
+                          (@show_search or @search_query != "") && "hidden sm:block"
+                        ]}>
                           <div
                             tabindex="0"
                             role="button"
@@ -1478,11 +1535,11 @@
                             <% end %>
                             <th class="w-12"></th>
                             <th>{gettext("Name")}</th>
-                            <th>{gettext("Path")}</th>
-                            <th>{gettext("Description")}</th>
-                            <th>{gettext("Type")}</th>
-                            <th>{gettext("Size")}</th>
-                            <th>{gettext("Date")}</th>
+                            <th class="hidden lg:table-cell">{gettext("Path")}</th>
+                            <th class="hidden lg:table-cell">{gettext("Description")}</th>
+                            <th class="hidden sm:table-cell">{gettext("Type")}</th>
+                            <th class="hidden sm:table-cell">{gettext("Size")}</th>
+                            <th class="hidden md:table-cell">{gettext("Date")}</th>
                             <th class="w-10"></th>
                           </tr>
                         </thead>
@@ -1657,8 +1714,16 @@
                                         {folder.name}
                                       <% end %>
                                     </span>
+                                    <%!-- Mobile-only meta line: the hidden Type/Date
+                                         columns folded under the name so the row
+                                         stays readable without horizontal scroll. --%>
+                                    <div class="md:hidden flex items-center gap-1.5 text-xs text-base-content/50 mt-0.5">
+                                      <span>{gettext("Folder")}</span>
+                                      <span>·</span>
+                                      <span>{Calendar.strftime(folder.inserted_at, "%b %d, %Y")}</span>
+                                    </div>
                                   </td>
-                                  <td>
+                                  <td class="hidden lg:table-cell">
                                     <%= if folders_path do %>
                                       <span class="text-xs text-base-content/50">
                                         {folders_path}
@@ -1667,7 +1732,7 @@
                                       <span class="text-xs text-base-content/30">/</span>
                                     <% end %>
                                   </td>
-                                  <td>
+                                  <td class="hidden lg:table-cell">
                                     <%= if folder.description not in [nil, ""] do %>
                                       <span
                                         class="text-xs text-base-content/60 line-clamp-2"
@@ -1679,13 +1744,13 @@
                                       <span class="text-xs text-base-content/30">—</span>
                                     <% end %>
                                   </td>
-                                  <td>
+                                  <td class="hidden sm:table-cell">
                                     <span class="badge badge-ghost badge-sm h-auto">
                                       {gettext("Folder")}
                                     </span>
                                   </td>
-                                  <td></td>
-                                  <td class="text-sm text-base-content/70">
+                                  <td class="hidden sm:table-cell"></td>
+                                  <td class="hidden md:table-cell text-sm text-base-content/70">
                                     {Calendar.strftime(folder.inserted_at, "%b %d, %Y")}
                                   </td>
                                   <td>
@@ -1810,9 +1875,19 @@
                                 </div>
                               </td>
                               <td>
-                                <span class="font-medium text-sm">{file.filename}</span>
+                                <span class="font-medium text-sm break-all">{file.filename}</span>
+                                <%!-- Mobile-only meta line: the hidden Type/Size/Date
+                                     columns folded under the filename so the row
+                                     stays readable without horizontal scroll. --%>
+                                <div class="md:hidden flex flex-wrap items-center gap-1.5 text-xs text-base-content/50 mt-0.5">
+                                  <span>{String.upcase(file.file_type)}</span>
+                                  <span>·</span>
+                                  <span>{format_file_size(file.size)}</span>
+                                  <span>·</span>
+                                  <span>{Calendar.strftime(file.inserted_at, "%b %d, %Y")}</span>
+                                </div>
                               </td>
-                              <td>
+                              <td class="hidden lg:table-cell">
                                 <%= if file.folder_path do %>
                                   <span class="text-xs text-base-content/50">
                                     {file.folder_path}
@@ -1821,18 +1896,18 @@
                                   <span class="text-xs text-base-content/30">/</span>
                                 <% end %>
                               </td>
-                              <td>
+                              <td class="hidden lg:table-cell">
                                 <span class="text-xs text-base-content/30">—</span>
                               </td>
-                              <td>
+                              <td class="hidden sm:table-cell">
                                 <span class="badge badge-ghost badge-sm h-auto">
                                   {String.upcase(file.file_type)}
                                 </span>
                               </td>
-                              <td class="text-sm text-base-content/70">
+                              <td class="hidden sm:table-cell text-sm text-base-content/70">
                                 {format_file_size(file.size)}
                               </td>
-                              <td class="text-sm text-base-content/70">
+                              <td class="hidden md:table-cell text-sm text-base-content/70">
                                 {Calendar.strftime(file.inserted_at, "%b %d, %Y")}
                               </td>
                               <td>

--- a/lib/phoenix_kit_web/components/media_browser.html.heex
+++ b/lib/phoenix_kit_web/components/media_browser.html.heex
@@ -624,7 +624,14 @@
                             <% @file_view == "all" -> %>
                               {gettext("All Files")}
                             <% @current_folder -> %>
-                              {@current_folder.name}
+                              <%!-- Live-preview the sidebar rename so the header
+                                   title tracks what's being typed, then settles
+                                   on the saved name. --%>
+                              <%= if @renaming_folder == @current_folder.uuid && @renaming_text != "" do %>
+                                {@renaming_text}
+                              <% else %>
+                                {@current_folder.name}
+                              <% end %>
                             <% true -> %>
                               {if @scope_folder_id,
                                 do: @scope_folder_name,

--- a/lib/phoenix_kit_web/components/media_browser.html.heex
+++ b/lib/phoenix_kit_web/components/media_browser.html.heex
@@ -1100,7 +1100,7 @@
                               </button>
                             </li>
                             <li>
-                              <button phx-click="create_untitled_folder" phx-target={@myself}>
+                              <button phx-click="open_new_folder_modal" phx-target={@myself}>
                                 <.icon name="hero-folder-plus" class="w-4 h-4" /> {gettext(
                                   "New folder"
                                 )}
@@ -2079,6 +2079,54 @@
           </div>
         </div>
         <div class="modal-backdrop" phx-click="close_move_modal" phx-target={@myself}></div>
+      </div>
+    <% end %>
+
+    <%!-- New Folder Modal — name the folder before it's created; Cancel
+         (button / backdrop / Esc) adds nothing. The placeholder is the next
+         default name, used as-is when the field is left blank. --%>
+    <%= if @show_new_folder_modal do %>
+      <div class="modal modal-open">
+        <div class="modal-box max-w-sm">
+          <h3 class="font-bold text-lg flex items-center gap-2">
+            <.icon name="hero-folder-plus" class="w-5 h-5 text-primary" />
+            {gettext("New folder")}
+          </h3>
+          <p class="text-sm text-base-content/60 mt-1 mb-4">
+            {gettext("Name your folder, or leave it blank to use the default.")}
+          </p>
+          <form phx-submit="submit_new_folder" phx-change="new_folder_input" phx-target={@myself}>
+            <input
+              id="new-folder-name-input"
+              type="text"
+              name="name"
+              value={@new_folder_name}
+              placeholder={@new_folder_placeholder}
+              maxlength="255"
+              autocomplete="off"
+              class="input input-bordered w-full"
+              phx-mounted={JS.focus()}
+              phx-keydown="close_new_folder_modal"
+              phx-key="Escape"
+              phx-target={@myself}
+            />
+            <div class="modal-action">
+              <button
+                type="button"
+                phx-click="close_new_folder_modal"
+                phx-target={@myself}
+                class="btn btn-ghost"
+              >
+                {gettext("Cancel")}
+              </button>
+              <button type="submit" class="btn btn-primary gap-2">
+                <.icon name="hero-folder-plus" class="w-4 h-4" />
+                {gettext("Create folder")}
+              </button>
+            </div>
+          </form>
+        </div>
+        <div class="modal-backdrop" phx-click="close_new_folder_modal" phx-target={@myself}></div>
       </div>
     <% end %>
   <% end %>


### PR DESCRIPTION
A batch of MediaBrowser improvements — mobile responsiveness, a folder-tree active-branch decoration, and several folder UX fixes. All changes are scoped to the media browser component and its storage context.

## Changes

**Mobile layout** (`2175d26c`)
- Shorter hero header on phones (smaller min-heights/title/logo, clamped description, tighter padding) so the file list gets room.
- List view hides Path/Description/Type/Size/Date columns on small screens and folds Type · Size · Date into a meta line under the name — removes horizontal scroll.
- Toolbar: Display/Sort/Filter become icon-only on mobile; opening search hides the other controls so it fills the row as one clean bar.
- Select mode: count on the left, all controls right-aligned (Select all / Clear / bulk actions / Done); bulk actions icon-only on mobile.

**Sidebar active-branch highlight** (`af27d996`, `77932be4`)
- Darken the guide-line segments from the root folder down to the folder you're in, so the active branch is traceable by eye. Same hue as the existing lines, just less transparent (a parallel `--pk-tree-line-active` variable). Mid-branch turns stay sharp 90°, the last child stays rounded — both bolded. Suppressed in trash view.

**Folder UX fixes**
- Rename now updates the hero header title (it read `@current_folder`, which wasn't refreshed on rename), plus a live preview while typing. (`718fc28a`)
- New folder opens a name-it modal (placeholder = next default name; Cancel adds nothing) instead of creating an untitled folder + inline rename. (`3314bccf`)
- Search now returns matching folders alongside matching files, scoped like the file search (new `Storage.search_folders/3`). (`266f74a5`)

## Checks
`mix quality` passes — format, credo --strict (no issues), dialyzer (passed). Compiles with warnings-as-errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)