### PR TITLE
File-comment resolution, annotation deep-link, and admin navbar fixes

### DIFF
--- a/lib/phoenix_kit/annotations/annotations.ex
+++ b/lib/phoenix_kit/annotations/annotations.ex
@@ -49,6 +49,32 @@ defmodule PhoenixKit.Annotations do
 
   def has_annotations?(_), do: false
 
+  @doc """
+  Resolves `"file"` comment resources for the comments moderation admin.
+
+  Comments on files — including annotation discussions, which are anchored to
+  the file with `metadata.annotation_uuid` — carry `resource_type: "file"` and
+  `resource_uuid: file_uuid`. This maps those file uuids to the file's display
+  name and admin media path so the moderation list links to the file instead
+  of showing a bare uuid.
+
+  Registered as the `"file"` handler by `phoenix_kit_comments`'
+  `resolve_comment_resources/1` dispatch (gated on this module being loaded).
+  """
+  @spec resolve_comment_resources([uuid()]) :: %{uuid() => map()}
+  def resolve_comment_resources(resource_uuids) when is_list(resource_uuids) do
+    from(f in StorageFile,
+      where: f.uuid in ^resource_uuids,
+      select: {f.uuid, f.original_file_name, f.file_name}
+    )
+    |> RepoHelper.all()
+    |> Map.new(fn {uuid, original_name, file_name} ->
+      {uuid, %{title: original_name || file_name || "File", path: "/admin/media/#{uuid}"}}
+    end)
+  rescue
+    _ -> %{}
+  end
+
   @doc "List annotations for a file, ordered by `position` then insertion time."
   @spec list_for_file(uuid()) :: [Annotation.t()]
   def list_for_file(file_uuid) do

--- a/lib/phoenix_kit/annotations/annotations.ex
+++ b/lib/phoenix_kit/annotations/annotations.ex
@@ -21,6 +21,7 @@ defmodule PhoenixKit.Annotations do
   alias PhoenixKit.Annotations.Annotation
   alias PhoenixKit.Modules.Storage
   alias PhoenixKit.Modules.Storage.File, as: StorageFile
+  alias PhoenixKit.Modules.Storage.URLSigner
   alias PhoenixKit.RepoHelper
 
   @type attrs :: map()
@@ -65,11 +66,20 @@ defmodule PhoenixKit.Annotations do
   def resolve_comment_resources(resource_uuids) when is_list(resource_uuids) do
     from(f in StorageFile,
       where: f.uuid in ^resource_uuids,
-      select: {f.uuid, f.original_file_name, f.file_name}
+      select: {f.uuid, f.original_file_name, f.file_name, f.file_type}
     )
     |> RepoHelper.all()
-    |> Map.new(fn {uuid, original_name, file_name} ->
-      {uuid, %{title: original_name || file_name || "File", path: "/admin/media/#{uuid}"}}
+    |> Map.new(fn {uuid, original_name, file_name, file_type} ->
+      info = %{title: original_name || file_name || "File", path: "/admin/media/#{uuid}"}
+
+      # A small signed thumbnail for image files, so the comments admin can show
+      # a preview chip. Falls back to no thumb for non-images (or missing variants).
+      info =
+        if file_type == "image",
+          do: Map.put(info, :thumb_url, URLSigner.signed_url(to_string(uuid), "thumbnail")),
+          else: info
+
+      {uuid, info}
     end)
   rescue
     _ -> %{}

--- a/lib/phoenix_kit_web/components/folder_explorer.ex
+++ b/lib/phoenix_kit_web/components/folder_explorer.ex
@@ -119,13 +119,9 @@ defmodule PhoenixKitWeb.Components.FolderExplorer do
           style="width: 240px; max-width: 240px;"
         >
           <div class="flex items-center justify-between mb-3">
-            <%= if is_nil(@scope_folder_id) do %>
-              <h3 class="font-semibold text-sm text-base-content/70 uppercase tracking-wider">
-                {gettext("Folders")}
-              </h3>
-            <% else %>
-              <div></div>
-            <% end %>
+            <h3 class="font-semibold text-sm text-base-content/70 uppercase tracking-wider">
+              {gettext("Folders")}
+            </h3>
             <div class="flex gap-0.5">
               <button
                 :if={@show_create}

--- a/lib/phoenix_kit_web/components/layout_wrapper.ex
+++ b/lib/phoenix_kit_web/components/layout_wrapper.ex
@@ -331,13 +331,22 @@ defmodule PhoenixKitWeb.Components.LayoutWrapper do
                     >
                       {@project_title}
                     </.link>
-                    <span class="font-bold text-base-content shrink-0">{gettext("Admin Panel")}</span>
+                    <%!-- On mobile, when a page has a title, hide the "Admin
+                         Panel /" prefix and show just the page title — the full
+                         breadcrumb is too wide and overlaps the right-side theme
+                         / notifications controls. --%>
+                    <span class={[
+                      "font-bold text-base-content shrink-0",
+                      @page_title && "hidden sm:inline"
+                    ]}>
+                      {gettext("Admin Panel")}
+                    </span>
                     <%!-- Current page breadcrumb: " / Page Title · subtitle".
                          Pushed in via page_title / page_subtitle so pages can
                          drop their own in-content header and reclaim the space. --%>
                     <span :if={@page_title} class="flex items-center gap-1.5 min-w-0">
-                      <span class="text-base-content/30 shrink-0">/</span>
-                      <span class="font-semibold text-base-content shrink-0">{@page_title}</span>
+                      <span class="text-base-content/30 shrink-0 hidden sm:inline">/</span>
+                      <span class="font-semibold text-base-content truncate min-w-0">{@page_title}</span>
                       <span
                         :if={@page_subtitle}
                         class="text-sm text-base-content/50 truncate hidden md:inline"

--- a/lib/phoenix_kit_web/components/layouts/admin.html.heex
+++ b/lib/phoenix_kit_web/components/layouts/admin.html.heex
@@ -13,6 +13,8 @@
   phoenix_kit_current_scope={assigns[:phoenix_kit_current_scope]}
   current_path={assigns[:url_path] || assigns[:current_path] || "/admin"}
   current_locale={assigns[:current_locale]}
+  page_title={assigns[:page_title]}
+  page_subtitle={assigns[:page_subtitle]}
   from_layout={true}
 >
   {@inner_content}

--- a/lib/phoenix_kit_web/components/media_browser.html.heex
+++ b/lib/phoenix_kit_web/components/media_browser.html.heex
@@ -132,7 +132,7 @@
 
           <div class="min-h-0 flex-1 flex flex-col">
             <div
-              class="p-2 min-h-0 flex-1 flex flex-col"
+              class="px-2 pb-2 min-h-0 flex-1 flex flex-col"
               id={if @has_buckets, do: "folder-drop-upload"}
               phx-hook={if @has_buckets, do: "FolderDropUpload"}
               phx-target={if @has_buckets, do: @myself}
@@ -178,7 +178,11 @@
                 folder it becomes a clickable button followed by the ancestor
                 path and the current folder.
               --%>
-              <nav class="breadcrumbs text-sm mb-2">
+              <%!-- `!py-0` strips daisyUI's default breadcrumb padding and the
+                   removed top padding above lets this row sit flush with the
+                   sidebar's "Folders" header; `mb-3` matches that header's
+                   bottom gap so the rows below line up too. --%>
+              <nav class="breadcrumbs text-sm mb-3 !py-0 min-h-[1.5rem] flex items-center">
                 <ul>
                   <%= if @current_folder do %>
                     <li>

--- a/lib/phoenix_kit_web/components/media_browser.html.heex
+++ b/lib/phoenix_kit_web/components/media_browser.html.heex
@@ -94,7 +94,11 @@
     <% end %>
 
     <%!-- Main Layout: Sidebar + Content in a unified card --%>
-    <div class={["card bg-base-100 shadow-xl", @fill_height && "flex-1 min-h-0"]}>
+    <%!-- `isolate` confines the hero header's `z-30` (and the toolbar
+         dropdowns' `z-20`) to this card's own stacking context, so they no
+         longer paint over the mobile drawer/navbar. Modals live outside this
+         card and are unaffected. --%>
+    <div class={["card bg-base-100 shadow-xl isolate", @fill_height && "flex-1 min-h-0"]}>
       <div class={[
         "card-body p-2 sm:p-4 flex flex-row gap-0 overflow-hidden",
         if(@fill_height, do: "flex-1 min-h-0", else: "h-[72vh] max-h-[48rem] min-h-[24rem]")

--- a/lib/phoenix_kit_web/live/users/media.html.heex
+++ b/lib/phoenix_kit_web/live/users/media.html.heex
@@ -8,7 +8,7 @@
   project_title={@project_title}
   current_locale={@current_locale}
 >
-  <div class="flex flex-col w-full px-4 py-6 h-[calc(100dvh-4rem)]">
+  <div class="flex flex-col w-full h-[calc(100dvh-4rem)]">
     <.live_component
       module={PhoenixKitWeb.Components.MediaBrowser}
       id="media-browser"

--- a/lib/phoenix_kit_web/live/users/media_detail.ex
+++ b/lib/phoenix_kit_web/live/users/media_detail.ex
@@ -47,9 +47,24 @@ defmodule PhoenixKitWeb.Live.Users.MediaDetail do
       |> assign(:show_delete_modal, false)
       |> load_file_data(file_uuid)
       |> assign(:viewer_annotations, MediaCanvasViewer.load_annotations_for(file_uuid))
+      |> maybe_select_annotation(file_uuid, params["annotation"])
 
     {:ok, socket}
   end
+
+  # Deep-link from a comment's "file" resource (e.g. the comments moderation
+  # admin) can carry `?annotation=<uuid>` to focus the Etcher shape the comment
+  # is anchored to. Push the select-shape event; the JS bridge retries until the
+  # canvas layer is ready (the event is a no-op on the static mount).
+  defp maybe_select_annotation(socket, file_uuid, annotation_uuid)
+       when is_binary(annotation_uuid) and annotation_uuid != "" do
+    Phoenix.LiveView.push_event(socket, "etcher:select-shape", %{
+      fresco_id: "media-zoom-" <> file_uuid,
+      uuid: annotation_uuid
+    })
+  end
+
+  defp maybe_select_annotation(socket, _file_uuid, _annotation_uuid), do: socket
 
   def handle_event("confirm_delete", _params, socket) do
     {:noreply, assign(socket, :show_delete_modal, true)}

--- a/priv/static/assets/phoenix_kit.js
+++ b/priv/static/assets/phoenix_kit.js
@@ -3994,6 +3994,28 @@ if (typeof window.Chart === "undefined") {
     layer.deleteShape(detail.uuid);
   });
 
+  // Deep-link shape selection. A comment's "file" resource link (e.g. from the
+  // comments moderation admin) can carry `?annotation=<uuid>`; MediaDetail
+  // pushes `etcher:select-shape` so the shape is pinned (selected) as if the
+  // user clicked it. The Etcher layer mounts asynchronously after the canvas
+  // hook initializes, so retry until the layer + shape exist (give up after
+  // ~6s). selectShape no-ops on readonly shapes.
+  window.addEventListener("phx:etcher:select-shape", function(e) {
+    var detail = e && e.detail;
+    if (!detail || !detail.fresco_id || !detail.uuid) return;
+    var attempts = 0;
+    (function trySelect() {
+      var layer = window.Etcher && window.Etcher.layerFor &&
+                  window.Etcher.layerFor(detail.fresco_id);
+      if (layer && typeof layer.selectShape === "function" &&
+          typeof layer.getShape === "function" && layer.getShape(detail.uuid)) {
+        layer.selectShape(detail.uuid);
+        return;
+      }
+      if (attempts++ < 60) setTimeout(trySelect, 100);
+    })();
+  });
+
   window.Etcher.tooltipSlots = {
     // Header → annotation title (user-chosen label) if present;
     // otherwise the comment author; otherwise the shape kind.


### PR DESCRIPTION
Core support for the `phoenix_kit_comments` admin work, plus two admin navbar fixes. Four commits on top of the merged #595.

## Comment ↔ media/annotation
- **`PhoenixKit.Annotations.resolve_comment_resources/1`** — resolves `"file"` comment resources to the file's name + media path (and a signed `"thumbnail"` URL for images), so the comments moderation admin can show a linked thumbnail chip instead of a bare uuid.
- **Annotation deep-link** — `MediaDetail` reads `?annotation=<uuid>` and pushes an `etcher:select-shape` event; a new `phoenix_kit.js` bridge retries `layer.selectShape(uuid)` until the Etcher canvas is ready, so a comment's chip lands on the file with that shape selected. (`selectShape` no-ops on readonly shapes.)

## Admin navbar
- **Forward `page_title`/`page_subtitle`** from the plugin admin layout (`admin.html.heex`) to `app_layout`, so plugin pages can drop their in-content header and show the title/subtitle in the navbar breadcrumb (matching the core media page).
- **Mobile breadcrumb collapse** — when a page has a title, hide the `… Admin Panel /` prefix below `sm` (and let the title truncate) so it no longer overlaps the theme/notifications controls.

## Checks
Compiles clean; credo clean on changed files. The JS change ships in the vendored `phoenix_kit.js` (parent apps refresh via `mix phoenix_kit.update`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)