### PR TITLE
Admin UI consistency pass + centralize the MDEx dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 1.7.158 - 2026-06-17
+
+Centralize the MDEx (markdown) dependency in core.
+
+### Changed
+- **`mdex` is now a direct dependency of `phoenix_kit`** (`~> 0.13`), so every
+  module shares one resolved version through the core dependency tree instead of
+  each declaring its own and risking version mismatches — the same arrangement
+  already used for `leaf`. Modules that render markdown (e.g.
+  `phoenix_kit_comments`) call `MDEx` directly and should rely on it being
+  provided transitively via `phoenix_kit` rather than declaring their own
+  `mdex` dep.
+
 ## 1.7.157 - 2026-06-17
 
 Core support for the `phoenix_kit_comments` admin work — file-comment resolution

--- a/lib/phoenix_kit_web/components/core/admin_page_header.ex
+++ b/lib/phoenix_kit_web/components/core/admin_page_header.ex
@@ -62,10 +62,10 @@ defmodule PhoenixKitWeb.Components.Core.AdminPageHeader do
     ~H"""
     <header class="mb-3 sm:mb-6">
       <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-        <div class="flex items-center gap-3">
-          <div>
+        <div class="flex items-center gap-3 min-w-0">
+          <div class="min-w-0">
             <%= if @title do %>
-              <h1 class="text-xl sm:text-2xl lg:text-3xl font-bold text-base-content">
+              <h1 class="text-xl sm:text-2xl lg:text-3xl font-bold text-base-content break-words">
                 {@title}
               </h1>
               <p :if={@subtitle} class="text-sm sm:text-base text-base-content/60 mt-0.5">

--- a/lib/phoenix_kit_web/components/layout_wrapper.ex
+++ b/lib/phoenix_kit_web/components/layout_wrapper.ex
@@ -309,7 +309,7 @@ defmodule PhoenixKitWeb.Components.LayoutWrapper do
             <header class="bg-base-100 shadow-sm border-b border-base-300 fixed top-0 left-0 right-0 z-50">
               <div class="flex items-center justify-between h-16 px-4">
                 <%!-- Left: Burger Menu, Logo and Title --%>
-                <div class="flex items-center gap-3">
+                <div class="flex items-center gap-3 min-w-0">
                   <%!-- Burger Menu Button (Far left) --%>
                   <label
                     for="admin-mobile-menu"

--- a/lib/phoenix_kit_web/live/activity/index.html.heex
+++ b/lib/phoenix_kit_web/live/activity/index.html.heex
@@ -3,17 +3,12 @@
   flash={@flash}
   phoenix_kit_current_scope={assigns[:phoenix_kit_current_scope]}
   page_title={gettext("Activity")}
+  page_subtitle={gettext("Business-level activity across the platform")}
   current_path={@url_path}
   project_title={@project_title}
   current_locale={assigns[:current_locale]}
 >
   <div class="container flex flex-col mx-auto px-4 py-6">
-    <.admin_page_header
-      back={Routes.path("/admin")}
-      title={gettext("Activity")}
-      subtitle={gettext("Business-level activity across the platform")}
-    />
-
     <%!-- Activity List --%>
     <.table_default
       id="activity-table"

--- a/lib/phoenix_kit_web/live/activity/show.html.heex
+++ b/lib/phoenix_kit_web/live/activity/show.html.heex
@@ -3,17 +3,12 @@
   flash={@flash}
   phoenix_kit_current_scope={assigns[:phoenix_kit_current_scope]}
   page_title={gettext("Activity Detail")}
+  page_subtitle={@entry.action}
   current_path={@url_path}
   project_title={@project_title}
   current_locale={assigns[:current_locale]}
 >
   <div class="container flex flex-col mx-auto px-4 py-6">
-    <.admin_page_header
-      back={Routes.path("/admin/activity")}
-      title={gettext("Activity Detail")}
-      subtitle={@entry.action}
-    />
-
     <div class="max-w-4xl mx-auto w-full space-y-6">
       <%!-- Action & Status --%>
       <div class="card bg-base-100 shadow-sm">

--- a/lib/phoenix_kit_web/live/dashboard.html.heex
+++ b/lib/phoenix_kit_web/live/dashboard.html.heex
@@ -2,21 +2,17 @@
   socket={@socket}
   flash={@flash}
   phoenix_kit_current_scope={assigns[:phoenix_kit_current_scope]}
-  page_title="{@project_title} Dashboard"
+  page_title={gettext("Dashboard")}
+  page_subtitle={
+    gettext("Welcome to the %{project_title} administration panel",
+      project_title: @project_title
+    )
+  }
   current_path={@url_path}
   project_title={@project_title}
   current_locale={@current_locale}
 >
   <div class="container flex-col mx-auto px-4 py-8">
-    <.admin_page_header
-      title={"#{@project_title} #{gettext("Dashboard")}"}
-      subtitle={
-        gettext("Welcome to the %{project_title} administration panel",
-          project_title: @project_title
-        )
-      }
-    />
-
     <%!-- Admin Menu Actions --%>
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6 gap-6 mb-8">
       <.link

--- a/lib/phoenix_kit_web/live/modules.html.heex
+++ b/lib/phoenix_kit_web/live/modules.html.heex
@@ -2,18 +2,13 @@
   socket={@socket}
   flash={@flash}
   phoenix_kit_current_scope={assigns[:phoenix_kit_current_scope]}
-  page_title={"#{@project_title} #{gettext("Modules")}"}
+  page_title={gettext("Modules")}
+  page_subtitle={gettext("Manage modules")}
   current_path={@url_path}
   project_title={@project_title}
   current_locale={@current_locale}
 >
   <div class="container flex flex-col mx-auto px-4 py-6">
-    <.admin_page_header
-      back={PhoenixKit.Utils.Routes.path("/admin")}
-      title={gettext("Modules")}
-      subtitle={gettext("Manage modules")}
-    />
-
     <%!-- Dependency warnings --%>
     <div :if={@dep_warnings != []} class="mb-4 space-y-2">
       <div

--- a/lib/phoenix_kit_web/live/modules/jobs/index.html.heex
+++ b/lib/phoenix_kit_web/live/modules/jobs/index.html.heex
@@ -3,17 +3,12 @@
   flash={@flash}
   phoenix_kit_current_scope={assigns[:phoenix_kit_current_scope]}
   page_title="Jobs"
+  page_subtitle="View background job status and history"
   current_path={@url_path}
   project_title={@project_title}
   current_locale={assigns[:current_locale]}
 >
   <div class="p-6">
-    <.admin_page_header
-      back={Routes.path("/admin/modules")}
-      title="Jobs"
-      subtitle="View background job status and history"
-    />
-
     <%!-- Stats Cards --%>
     <div class="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-7 gap-3 mb-6">
       <div class="stat bg-base-100 rounded-lg shadow p-3">

--- a/lib/phoenix_kit_web/live/modules/languages.html.heex
+++ b/lib/phoenix_kit_web/live/modules/languages.html.heex
@@ -2,7 +2,8 @@
   socket={@socket}
   flash={@flash}
   phoenix_kit_current_scope={assigns[:phoenix_kit_current_scope]}
-  page_title="{@project_title} Languages"
+  page_title="Languages"
+  page_subtitle="Manage available languages for your application"
   current_path={@current_path}
   project_title={@project_title}
   current_locale={@current_locale}
@@ -12,12 +13,6 @@
     class="container flex flex-col mx-auto px-4 py-6"
     phx-hook="PreserveScroll"
   >
-    <.admin_page_header
-      back={PhoenixKit.Utils.Routes.path("/admin/modules")}
-      title="Languages"
-      subtitle="Manage available languages for your application"
-    />
-
     <%!-- Summary Section --%>
     <div class="card bg-base-100 shadow-xl mb-6">
       <div class="card-body">

--- a/lib/phoenix_kit_web/live/modules/notifications/index.html.heex
+++ b/lib/phoenix_kit_web/live/modules/notifications/index.html.heex
@@ -2,23 +2,18 @@
   socket={@socket}
   flash={@flash}
   phoenix_kit_current_scope={assigns[:phoenix_kit_current_scope]}
-  page_title="Notifications"
+  page_title={gettext("Notifications")}
+  page_subtitle={gettext("Per-user in-app notifications driven by the activity log")}
   current_path={@url_path}
   project_title={@project_title}
   current_locale={assigns[:current_locale]}
 >
   <div class="p-6">
-    <.admin_page_header
-      back={Routes.path("/admin/modules")}
-      title={gettext("Notifications")}
-      subtitle={gettext("Per-user in-app notifications driven by the activity log")}
-    >
-      <:actions>
-        <button type="button" phx-click="refresh" class="btn btn-sm btn-ghost gap-2">
-          <.icon name="hero-arrow-path" class="w-4 h-4" /> {gettext("Refresh")}
-        </button>
-      </:actions>
-    </.admin_page_header>
+    <div class="flex justify-end mb-4">
+      <button type="button" phx-click="refresh" class="btn btn-sm btn-ghost gap-2">
+        <.icon name="hero-arrow-path" class="w-4 h-4" /> {gettext("Refresh")}
+      </button>
+    </div>
 
     <%!-- Aggregate counts --%>
     <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">

--- a/lib/phoenix_kit_web/live/settings.html.heex
+++ b/lib/phoenix_kit_web/live/settings.html.heex
@@ -2,18 +2,13 @@
   socket={@socket}
   flash={@flash}
   phoenix_kit_current_scope={assigns[:phoenix_kit_current_scope]}
-  page_title="{@project_title} Settings"
+  page_title={gettext("Settings")}
+  page_subtitle={gettext("Configure system preferences and options")}
   current_path={@url_path}
   project_title={@project_title}
   current_locale={@current_locale}
 >
   <div class="container flex flex-col mx-auto px-4 py-6">
-    <.admin_page_header
-      back={PhoenixKit.Utils.Routes.path("/admin")}
-      title={gettext("Settings")}
-      subtitle={gettext("Configure system preferences and options")}
-    />
-
     <%!-- Settings Form --%>
     <div class="card bg-base-100 shadow-xl">
       <div class="card-body">

--- a/lib/phoenix_kit_web/live/settings/authorization.html.heex
+++ b/lib/phoenix_kit_web/live/settings/authorization.html.heex
@@ -2,18 +2,13 @@
   socket={@socket}
   flash={@flash}
   phoenix_kit_current_scope={assigns[:phoenix_kit_current_scope]}
-  page_title="{@project_title} Authorization Settings"
+  page_title={gettext("Authorization Settings")}
+  page_subtitle={gettext("Manage login page branding and authentication methods")}
   current_path={@url_path}
   project_title={@project_title}
   current_locale={@current_locale}
 >
   <div class="container flex flex-col mx-auto px-4 py-6">
-    <.admin_page_header
-      back={PhoenixKit.Utils.Routes.path("/admin/settings")}
-      title={gettext("Authorization Settings")}
-      subtitle={gettext("Manage login page branding and authentication methods")}
-    />
-
     <%!-- Settings Form --%>
     <div class="card bg-base-100 shadow-xl">
       <div class="card-body">

--- a/lib/phoenix_kit_web/live/settings/integrations.html.heex
+++ b/lib/phoenix_kit_web/live/settings/integrations.html.heex
@@ -2,18 +2,13 @@
   socket={@socket}
   flash={@flash}
   phoenix_kit_current_scope={assigns[:phoenix_kit_current_scope]}
-  page_title={"#{@project_title} - Integrations"}
+  page_title={gettext("Integrations")}
+  page_subtitle={gettext("Connect external services for use across modules")}
   current_path={@current_path}
   project_title={@project_title}
   current_locale={@current_locale}
 >
   <div class="container mx-auto px-4 py-6">
-    <.admin_page_header
-      back={PhoenixKit.Utils.Routes.path("/admin/settings")}
-      title={gettext("Integrations")}
-      subtitle={gettext("Connect external services for use across modules")}
-    />
-
     <%!-- Flash messages --%>
     <%!-- Connections table --%>
     <div :if={@connections != []}>

--- a/lib/phoenix_kit_web/live/settings/organization.html.heex
+++ b/lib/phoenix_kit_web/live/settings/organization.html.heex
@@ -2,18 +2,13 @@
   socket={@socket}
   flash={@flash}
   phoenix_kit_current_scope={assigns[:phoenix_kit_current_scope]}
-  page_title="{@project_title} - Organization"
+  page_title={gettext("Organization Settings")}
+  page_subtitle={gettext("Company information shared across Legal and Billing modules")}
   current_path={@current_path}
   project_title={@project_title}
   current_locale={@current_locale}
 >
   <div class="container mx-auto px-4 py-6">
-    <.admin_page_header
-      back={PhoenixKit.Utils.Routes.path("/admin/settings")}
-      title={gettext("Organization Settings")}
-      subtitle={gettext("Company information shared across Legal and Billing modules")}
-    />
-
     <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
       <%!-- Company Information --%>
       <div class="card bg-base-100 shadow-xl">

--- a/lib/phoenix_kit_web/live/settings/seo.html.heex
+++ b/lib/phoenix_kit_web/live/settings/seo.html.heex
@@ -2,22 +2,17 @@
   socket={@socket}
   flash={@flash}
   phoenix_kit_current_scope={assigns[:phoenix_kit_current_scope]}
-  page_title="{@project_title} - SEO Settings"
+  page_title={gettext("SEO Settings")}
+  page_subtitle={
+    gettext(
+      "Configure environment-wide search optimization defaults and metadata directives from a single place."
+    )
+  }
   current_path={@current_path}
   project_title={@project_title}
   current_locale={@current_locale}
 >
   <div class="container mx-auto px-4 py-6 space-y-6">
-    <.admin_page_header
-      back={PhoenixKit.Utils.Routes.path("/admin/settings")}
-      title={gettext("SEO Settings")}
-      subtitle={
-        gettext(
-          "Configure environment-wide search optimization defaults and metadata directives from a single place."
-        )
-      }
-    />
-
     <div class="card bg-base-100 shadow-xl border border-base-200">
       <div class="card-body space-y-4">
         <div class="flex items-start justify-between gap-4">

--- a/lib/phoenix_kit_web/live/settings/users.html.heex
+++ b/lib/phoenix_kit_web/live/settings/users.html.heex
@@ -2,18 +2,13 @@
   socket={@socket}
   flash={@flash}
   phoenix_kit_current_scope={assigns[:phoenix_kit_current_scope]}
-  page_title={@project_title <> " " <> gettext("User Settings")}
+  page_title={gettext("User Settings")}
+  page_subtitle={gettext("Manage user registration, defaults, and custom fields")}
   current_path={@url_path}
   project_title={@project_title}
   current_locale={@current_locale}
 >
   <div class="container flex flex-col mx-auto px-4 py-6">
-    <.admin_page_header
-      back={PhoenixKit.Utils.Routes.path("/admin/settings")}
-      title={gettext("User Settings")}
-      subtitle={gettext("Manage user registration, defaults, and custom fields")}
-    />
-
     <%!-- Settings Form --%>
     <div class="space-y-6">
       <%!-- User Configuration Settings Card --%>

--- a/lib/phoenix_kit_web/live/users/live_sessions.html.heex
+++ b/lib/phoenix_kit_web/live/users/live_sessions.html.heex
@@ -2,21 +2,19 @@
   socket={@socket}
   flash={@flash}
   phoenix_kit_current_scope={assigns[:phoenix_kit_current_scope]}
-  page_title={gettext("Live Sessions") <> " - " <> @project_title <> " " <> gettext("Admin")}
+  page_title={gettext("Live Sessions")}
+  page_subtitle={gettext("Real-time monitoring of all active sessions with live updates.")}
   current_path={@url_path}
   project_title={@project_title}
 >
   <div class="container mx-auto px-4 py-8">
-    <.admin_page_header back={PhoenixKit.Utils.Routes.path("/admin/users")}>
-      <h1 class="text-xl sm:text-2xl lg:text-3xl font-bold text-base-content">
-        {gettext("Live Sessions")}
-      </h1>
-      <p class="text-sm text-base-content/60 mt-0.5">
-        {gettext("Real-time monitoring of all active sessions with live updates.")} {gettext(
-          "Last updated:"
-        )} {Calendar.strftime(@last_updated, "%H:%M:%S")}
+    <%!-- Slim action bar: title/subtitle now live in the navbar; keep the
+         live-updated timestamp and the live-monitoring controls. --%>
+    <div class="flex flex-wrap items-center justify-between gap-2 mb-4 sm:mb-6">
+      <p class="text-sm text-base-content/60">
+        {gettext("Last updated:")} {Calendar.strftime(@last_updated, "%H:%M:%S")}
       </p>
-      <:actions>
+      <div class="flex flex-wrap items-center gap-2">
         <%!-- Live Indicator --%>
         <div class="flex items-center gap-2 px-3 py-1 bg-success/10 text-success rounded-full">
           <div class="w-2 h-2 bg-success rounded-full animate-pulse"></div>
@@ -37,14 +35,11 @@
           <% end %>
         </button>
         <%!-- Manual refresh --%>
-        <button
-          phx-click="refresh_now"
-          class="btn btn-sm btn-outline"
-        >
+        <button phx-click="refresh_now" class="btn btn-sm btn-outline">
           <.icon name="hero-arrow-path" class="w-5 h-5" /> {gettext("Refresh")}
         </button>
-      </:actions>
-    </.admin_page_header>
+      </div>
+    </div>
 
     <%!-- Statistics Cards --%>
     <div class="grid grid-cols-1 md:grid-cols-4 gap-6 mb-8">

--- a/lib/phoenix_kit_web/live/users/permissions_matrix.html.heex
+++ b/lib/phoenix_kit_web/live/users/permissions_matrix.html.heex
@@ -3,17 +3,12 @@
   flash={@flash}
   phoenix_kit_current_scope={assigns[:phoenix_kit_current_scope]}
   page_title={gettext("Permissions")}
+  page_subtitle={gettext("Overview of role permissions across all modules")}
   current_path={@url_path}
   project_title={@project_title}
   current_locale={@current_locale}
 >
   <div class="container flex-col mx-auto px-4 py-6">
-    <.admin_page_header
-      back={PhoenixKit.Utils.Routes.path("/admin/users/roles")}
-      title={gettext("Permissions")}
-      subtitle={gettext("Overview of role permissions across all modules")}
-    />
-
     <%!-- Matrix Table --%>
     <div class="bg-base-100">
       <div class="rounded-lg shadow-md overflow-x-auto overflow-y-clip">

--- a/lib/phoenix_kit_web/live/users/roles.html.heex
+++ b/lib/phoenix_kit_web/live/users/roles.html.heex
@@ -3,17 +3,12 @@
   flash={@flash}
   phoenix_kit_current_scope={assigns[:phoenix_kit_current_scope]}
   page_title={gettext("Role Management")}
+  page_subtitle={gettext("Create and manage user roles")}
   current_path={@url_path}
   project_title={@project_title}
   current_locale={@current_locale}
 >
   <div class="container flex-col mx-auto px-4 py-6">
-    <.admin_page_header
-      back={PhoenixKit.Utils.Routes.path("/admin/users")}
-      title={gettext("Role Management")}
-      subtitle={gettext("Create and manage user roles")}
-    />
-
     <%!-- Create Role Modal --%>
     <.modal show={@show_create_form} on_close="hide_form" max_width="2xl">
       <:title>{gettext("Create New Role")}</:title>

--- a/lib/phoenix_kit_web/live/users/sessions.html.heex
+++ b/lib/phoenix_kit_web/live/users/sessions.html.heex
@@ -3,17 +3,12 @@
   flash={@flash}
   phoenix_kit_current_scope={assigns[:phoenix_kit_current_scope]}
   page_title={gettext("Session Management")}
+  page_subtitle={gettext("Monitor and manage active user sessions")}
   current_path={@url_path}
   project_title={@project_title}
   current_locale={@current_locale}
 >
   <div class="container flex-col mx-auto px-4 py-6">
-    <.admin_page_header
-      back={PhoenixKit.Utils.Routes.path("/admin/users")}
-      title={gettext("Session Management")}
-      subtitle={gettext("Monitor and manage active user sessions")}
-    />
-
     <%!-- Session Statistics --%>
     <div class="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6">
       <PhoenixKitWeb.Components.Core.StatCard.stat_card

--- a/lib/phoenix_kit_web/live/users/user_details.html.heex
+++ b/lib/phoenix_kit_web/live/users/user_details.html.heex
@@ -9,8 +9,10 @@
 >
   <div class="container flex-col mx-auto px-4 py-6">
     <.admin_page_header back={PhoenixKit.Utils.Routes.path("/admin/users")}>
-      <h1 class="text-xl sm:text-2xl lg:text-3xl font-bold text-base-content">{@page_title}</h1>
-      <p class="text-sm text-base-content/60 mt-0.5">{@user.email}</p>
+      <h1 class="text-xl sm:text-2xl lg:text-3xl font-bold text-base-content break-words min-w-0">
+        {@page_title}
+      </h1>
+      <p class="text-sm text-base-content/60 mt-0.5 break-words">{@user.email}</p>
       <:actions>
         <.link
           navigate={PhoenixKit.Utils.Routes.path("/admin/users/edit/#{@user.uuid}")}
@@ -97,12 +99,15 @@
                   <.user_avatar user={@user} size="lg" class="!w-24 !h-24 !text-3xl" />
                 </div>
 
-                <%!-- Name --%>
-                <h2 class="card-title">{user_display_name(@user)}</h2>
+                <%!-- Name (block, not card-title's flex, so a long unbreakable
+                     name wraps within the card instead of overflowing both sides). --%>
+                <h2 class="text-xl font-semibold break-words w-full">
+                  {user_display_name(@user)}
+                </h2>
 
                 <%!-- Username --%>
                 <%= if @user.username do %>
-                  <p class="text-base-content/70">@{@user.username}</p>
+                  <p class="text-base-content/70 break-words w-full">@{@user.username}</p>
                 <% end %>
 
                 <%!-- Status Badges --%>

--- a/lib/phoenix_kit_web/live/users/users.ex
+++ b/lib/phoenix_kit_web/live/users/users.ex
@@ -16,6 +16,10 @@ defmodule PhoenixKitWeb.Live.Users.Users do
   @per_page 10
   @max_cell_length 20
 
+  # Per-admin grid/list preference for the users table, persisted in the
+  # current user's custom_fields (mirrors the media browser's view toggle).
+  @view_mode_key "users_view_mode"
+
   def mount(_params, _session, socket) do
     # Subscribe to user events for live updates
     if connected?(socket) do
@@ -53,6 +57,7 @@ defmodule PhoenixKitWeb.Live.Users.Users do
       |> assign(:per_page, @per_page)
       |> assign(:search_query, "")
       |> assign(:show_search, false)
+      |> assign(:view_mode, load_user_view_mode(socket.assigns[:phoenix_kit_current_user]))
       |> assign(:filter_role, "all")
       |> assign(
         :org_accounts_enabled,
@@ -118,6 +123,17 @@ defmodule PhoenixKitWeb.Live.Users.Users do
   # Collapse the search row on blur, but only while it is empty.
   def handle_event("close_search_if_empty", _params, socket) do
     {:noreply, assign(socket, :show_search, socket.assigns.search_query != "")}
+  end
+
+  # Switch between the table and card views, persisting the choice on the
+  # current user so it survives reloads (mirrors the media browser).
+  def handle_event("set_view_mode", %{"mode" => mode}, socket) when mode in ["card", "table"] do
+    user = persist_user_view_mode(socket.assigns[:phoenix_kit_current_user], mode)
+
+    {:noreply,
+     socket
+     |> assign(:phoenix_kit_current_user, user)
+     |> assign(:view_mode, mode)}
   end
 
   def handle_event("filter_by_role", %{"role" => role}, socket) do
@@ -762,6 +778,32 @@ defmodule PhoenixKitWeb.Live.Users.Users do
     |> assign(:confirmed_users, stats.confirmed_users)
     |> assign(:pending_users, stats.pending_users)
   end
+
+  # Read the per-user table/card preference from custom_fields, defaulting to
+  # "table". Tolerant of a missing/garbage value.
+  defp load_user_view_mode(%{} = user) do
+    case Auth.get_user_field(user, @view_mode_key) do
+      mode when mode in ["card", "table"] -> mode
+      _ -> "table"
+    end
+  end
+
+  defp load_user_view_mode(_), do: "table"
+
+  # Persist the preference into a freshly-read custom_fields copy so a
+  # concurrent change elsewhere isn't clobbered. Returns the updated user (or
+  # the original on no-user / error) for the caller to re-assign.
+  defp persist_user_view_mode(%{uuid: uuid} = user, mode) when is_binary(uuid) do
+    fresh = Auth.get_user(uuid) || user
+    merged = Map.put(fresh.custom_fields || %{}, @view_mode_key, mode)
+
+    case Auth.update_user_custom_fields(fresh, merged) do
+      {:ok, updated} -> updated
+      {:error, _} -> user
+    end
+  end
+
+  defp persist_user_view_mode(user, _mode), do: user
 
   defp get_user_roles(user) do
     # Use preloaded roles if available

--- a/lib/phoenix_kit_web/live/users/users.ex
+++ b/lib/phoenix_kit_web/live/users/users.ex
@@ -965,6 +965,14 @@ defmodule PhoenixKitWeb.Live.Users.Users do
     column_id == "actions" || TableColumns.get_column_metadata(column_id) != nil
   end
 
+  # Per-column responsive class for the table view. On mobile (table-fixed)
+  # only the email + actions columns are shown — the rest collapse — so the
+  # list reads as a compact row (avatar/email/name + a `…` menu) like the
+  # media browser. The actions column is pinned narrow so email fills the rest.
+  def mobile_col_class("actions"), do: "w-12 md:w-auto"
+  def mobile_col_class("email"), do: ""
+  def mobile_col_class(_), do: "hidden md:table-cell"
+
   # Get valid columns only (filters out deleted custom fields)
   def get_valid_columns(columns) do
     Enum.filter(columns, &should_render_column?/1)

--- a/lib/phoenix_kit_web/live/users/users.ex
+++ b/lib/phoenix_kit_web/live/users/users.ex
@@ -52,6 +52,7 @@ defmodule PhoenixKitWeb.Live.Users.Users do
       |> assign(:page, 1)
       |> assign(:per_page, @per_page)
       |> assign(:search_query, "")
+      |> assign(:show_search, false)
       |> assign(:filter_role, "all")
       |> assign(
         :org_accounts_enabled,
@@ -95,6 +96,28 @@ defmodule PhoenixKitWeb.Live.Users.Users do
       |> load_users()
 
     {:noreply, socket}
+  end
+
+  # Toggle the collapsed search row open/closed (mirrors the media browser).
+  def handle_event("toggle_search", _params, socket) do
+    {:noreply, assign(socket, :show_search, !socket.assigns.show_search)}
+  end
+
+  # Clear the query and close the search row (the ✕ button).
+  def handle_event("clear_search", _params, socket) do
+    socket =
+      socket
+      |> assign(:search_query, "")
+      |> assign(:show_search, false)
+      |> assign(:page, 1)
+      |> load_users()
+
+    {:noreply, socket}
+  end
+
+  # Collapse the search row on blur, but only while it is empty.
+  def handle_event("close_search_if_empty", _params, socket) do
+    {:noreply, assign(socket, :show_search, socket.assigns.search_query != "")}
   end
 
   def handle_event("filter_by_role", %{"role" => role}, socket) do

--- a/lib/phoenix_kit_web/live/users/users.html.heex
+++ b/lib/phoenix_kit_web/live/users/users.html.heex
@@ -137,45 +137,84 @@
           </form>
         </:sort_bar>
         <:toolbar_actions>
-          <%!-- Role Filter --%>
-          <form phx-change="filter_by_role" class="contents">
-            <select
-              name="role"
-              class="select select-sm w-32 min-w-0"
-              title={gettext("Filter by role")}
+          <%!-- Role Filter (media-style dropdown) --%>
+          <% role_options = [
+            {"all", gettext("All Users")},
+            {"Owner", gettext("Owners Only")},
+            {"Admin", gettext("Admins Only")},
+            {"User", gettext("Regular Users")}
+          ] %>
+          <% role_label =
+            role_options
+            |> Enum.find(fn {v, _} -> v == @filter_role end)
+            |> then(&(&1 && elem(&1, 1))) %>
+          <div class="dropdown">
+            <div tabindex="0" role="button" class="btn btn-sm gap-2">
+              <.icon name="hero-user-group" class="w-4 h-4" />
+              <span class="hidden sm:inline">{role_label || gettext("Role")}</span>
+              <.icon
+                name="hero-chevron-down"
+                class="hidden sm:inline-block w-3.5 h-3.5 opacity-60"
+              />
+            </div>
+            <ul
+              tabindex="0"
+              onclick="document.activeElement.blur()"
+              class="dropdown-content menu bg-base-100 rounded-box z-20 w-44 p-2 shadow border border-base-200"
             >
-              <option value="all" selected={@filter_role == "all"}>{gettext("All Users")}</option>
-              <option value="Owner" selected={@filter_role == "Owner"}>
-                {gettext("Owners Only")}
-              </option>
-              <option value="Admin" selected={@filter_role == "Admin"}>
-                {gettext("Admins Only")}
-              </option>
-              <option value="User" selected={@filter_role == "User"}>
-                {gettext("Regular Users")}
-              </option>
-            </select>
-          </form>
-          <%!-- Account Type Filter --%>
+              <%= for {val, label} <- role_options do %>
+                <li>
+                  <button
+                    phx-click="filter_by_role"
+                    phx-value-role={val}
+                    class={@filter_role == val && "active"}
+                  >
+                    {label}
+                  </button>
+                </li>
+              <% end %>
+            </ul>
+          </div>
+          <%!-- Account Type Filter (media-style dropdown) --%>
           <%= if @org_accounts_enabled do %>
-            <form phx-change="filter_by_account_type" class="contents">
-              <select
-                class="select select-sm w-36 min-w-0"
-                name="account_type"
-                value={@filter_account_type}
-                title={gettext("Filter by account type")}
+            <% account_type_options = [
+              {"all", gettext("All Types")},
+              {"person", gettext("Person")},
+              {"organization", gettext("Organization")}
+            ] %>
+            <% account_type_label =
+              account_type_options
+              |> Enum.find(fn {v, _} -> v == @filter_account_type end)
+              |> then(&(&1 && elem(&1, 1))) %>
+            <div class="dropdown">
+              <div tabindex="0" role="button" class="btn btn-sm gap-2">
+                <.icon name="hero-identification" class="w-4 h-4" />
+                <span class="hidden sm:inline">
+                  {account_type_label || gettext("Account type")}
+                </span>
+                <.icon
+                  name="hero-chevron-down"
+                  class="hidden sm:inline-block w-3.5 h-3.5 opacity-60"
+                />
+              </div>
+              <ul
+                tabindex="0"
+                onclick="document.activeElement.blur()"
+                class="dropdown-content menu bg-base-100 rounded-box z-20 w-44 p-2 shadow border border-base-200"
               >
-                <option value="all" selected={@filter_account_type == "all"}>
-                  {gettext("All Types")}
-                </option>
-                <option value="person" selected={@filter_account_type == "person"}>
-                  {gettext("Person")}
-                </option>
-                <option value="organization" selected={@filter_account_type == "organization"}>
-                  {gettext("Organization")}
-                </option>
-              </select>
-            </form>
+                <%= for {val, label} <- account_type_options do %>
+                  <li>
+                    <button
+                      phx-click="filter_by_account_type"
+                      phx-value-account_type={val}
+                      class={@filter_account_type == val && "active"}
+                    >
+                      {label}
+                    </button>
+                  </li>
+                <% end %>
+              </ul>
+            </div>
           <% end %>
           <button
             class="btn btn-sm btn-info"

--- a/lib/phoenix_kit_web/live/users/users.html.heex
+++ b/lib/phoenix_kit_web/live/users/users.html.heex
@@ -154,9 +154,17 @@
               |> Enum.find(fn {v, _} -> v == @filter_role end)
               |> then(&(&1 && elem(&1, 1))) %>
             <div class="dropdown">
-              <div tabindex="0" role="button" class="btn btn-sm gap-2">
+              <div
+                tabindex="0"
+                role="button"
+                class={["btn btn-sm gap-2", @filter_role != "all" && "btn-active"]}
+              >
                 <.icon name="hero-user-group" class="w-4 h-4" />
-                <span class="hidden sm:inline">{role_label || gettext("Role")}</span>
+                <%!-- Show the active role on mobile too (only "All Users" collapses
+                     to the bare icon) so the current filter is always legible. --%>
+                <span class={["sm:inline", @filter_role == "all" && "hidden"]}>
+                  {role_label || gettext("Role")}
+                </span>
                 <.icon
                   name="hero-chevron-down"
                   class="hidden sm:inline-block w-3.5 h-3.5 opacity-60"
@@ -192,9 +200,13 @@
                 |> Enum.find(fn {v, _} -> v == @filter_account_type end)
                 |> then(&(&1 && elem(&1, 1))) %>
               <div class="dropdown">
-                <div tabindex="0" role="button" class="btn btn-sm gap-2">
+                <div
+                  tabindex="0"
+                  role="button"
+                  class={["btn btn-sm gap-2", @filter_account_type != "all" && "btn-active"]}
+                >
                   <.icon name="hero-identification" class="w-4 h-4" />
-                  <span class="hidden sm:inline">
+                  <span class={["sm:inline", @filter_account_type == "all" && "hidden"]}>
                     {account_type_label || gettext("Account type")}
                   </span>
                   <.icon

--- a/lib/phoenix_kit_web/live/users/users.html.heex
+++ b/lib/phoenix_kit_web/live/users/users.html.heex
@@ -95,25 +95,55 @@
         }
       >
         <:toolbar_title>
-          <form phx-change="search" class="contents">
-            <label class="input input-sm w-full md:w-80 lg:w-96 min-w-0">
-              <.icon name="hero-magnifying-glass" class="h-4 w-4 opacity-50" />
+          <%!-- Collapsed search: a magnifier that opens the full-width search
+               row below the toolbar (see :sort_bar), mirroring the media browser. --%>
+          <button
+            type="button"
+            phx-click="toggle_search"
+            class={[
+              "btn btn-sm btn-circle btn-ghost",
+              (@show_search or @search_query != "") && "btn-active"
+            ]}
+            title={gettext("Search")}
+          >
+            <.icon name="hero-magnifying-glass" class="h-4 w-4" />
+          </button>
+        </:toolbar_title>
+        <:sort_bar :if={@show_search or @search_query != ""}>
+          <form phx-change="search" phx-submit="search">
+            <label class="input input-sm input-bordered flex items-center gap-2 w-full">
+              <.icon name="hero-magnifying-glass" class="h-4 w-4 opacity-50 shrink-0" />
               <input
-                type="search"
+                id="users-search-input"
+                type="text"
                 name="search"
                 value={@search_query}
                 placeholder={gettext("Search by email, username, or name...")}
-                class="grow"
+                class="grow min-w-0"
                 phx-debounce="300"
+                autocomplete="off"
+                phx-mounted={Phoenix.LiveView.JS.focus()}
+                phx-blur="close_search_if_empty"
               />
+              <button
+                type="button"
+                phx-click="clear_search"
+                class="btn btn-ghost btn-xs btn-circle shrink-0"
+                title={gettext("Close search")}
+              >
+                <.icon name="hero-x-mark" class="h-3.5 w-3.5" />
+              </button>
             </label>
           </form>
-        </:toolbar_title>
+        </:sort_bar>
         <:toolbar_actions>
           <%!-- Role Filter --%>
-          <span class="text-sm text-base-content/70 whitespace-nowrap">{gettext("Role:")}</span>
           <form phx-change="filter_by_role" class="contents">
-            <select name="role" class="select select-sm w-36 min-w-0">
+            <select
+              name="role"
+              class="select select-sm w-32 min-w-0"
+              title={gettext("Filter by role")}
+            >
               <option value="all" selected={@filter_role == "all"}>{gettext("All Users")}</option>
               <option value="Owner" selected={@filter_role == "Owner"}>
                 {gettext("Owners Only")}
@@ -128,14 +158,12 @@
           </form>
           <%!-- Account Type Filter --%>
           <%= if @org_accounts_enabled do %>
-            <span class="text-sm text-base-content/70 whitespace-nowrap">
-              {gettext("Account type:")}
-            </span>
             <form phx-change="filter_by_account_type" class="contents">
               <select
-                class="select select-sm w-40 min-w-0"
+                class="select select-sm w-36 min-w-0"
                 name="account_type"
                 value={@filter_account_type}
+                title={gettext("Filter by account type")}
               >
                 <option value="all" selected={@filter_account_type == "all"}>
                   {gettext("All Types")}
@@ -159,10 +187,10 @@
           <.link
             navigate={PhoenixKit.Utils.Routes.path("/admin/users/new")}
             class="btn btn-sm btn-primary"
+            title={gettext("Add New User")}
           >
-            <PhoenixKitWeb.Components.Core.Icons.icon_user_add class="h-4 w-4" /> {gettext(
-              "Add New User"
-            )}
+            <PhoenixKitWeb.Components.Core.Icons.icon_user_add class="h-4 w-4" />
+            <span class="hidden lg:inline">{gettext("Add New User")}</span>
           </.link>
         </:toolbar_actions>
         <:card_header :let={user}>

--- a/lib/phoenix_kit_web/live/users/users.html.heex
+++ b/lib/phoenix_kit_web/live/users/users.html.heex
@@ -760,15 +760,19 @@
     <%!-- Column Selection Modal --%>
     <%= if @show_column_modal do %>
       <div class="modal modal-open" id="column-modal">
-        <div class="modal-box max-w-5xl max-h-[90vh] overflow-hidden">
-          <h3 class="font-bold text-xl mb-4">{gettext("Customize Table Columns")}</h3>
-          <p class="text-base-content/70 mb-6">
+        <div class="modal-box max-w-5xl w-11/12 max-h-[90vh] flex flex-col">
+          <h3 class="font-bold text-xl mb-4 shrink-0">{gettext("Customize Table Columns")}</h3>
+          <p class="text-base-content/70 mb-6 shrink-0">
             {gettext(
               "Drag to reorder selected columns above, or add new columns from the options below. Actions column is always included."
             )}
           </p>
 
-          <form phx-submit="update_table_columns" id="column-form">
+          <form
+            phx-submit="update_table_columns"
+            id="column-form"
+            class="flex flex-col flex-1 min-h-0"
+          >
             <%!-- Hidden input to store the column order for form submission --%>
             <input
               type="hidden"
@@ -777,7 +781,7 @@
               value={Enum.join(@temp_selected_columns || @selected_columns, ",")}
             />
 
-            <div class="flex flex-col lg:flex-row gap-6 mb-6">
+            <div class="flex flex-col lg:flex-row gap-6 mb-6 flex-1 min-h-0 overflow-y-auto lg:overflow-visible">
               <%!-- Selected Columns Section (Left/Top) --%>
               <div class="flex-1">
                 <div class="flex items-center justify-between mb-3">
@@ -797,7 +801,7 @@
                   on_reorder="reorder_selected_columns"
                   layout={:list}
                   gap="space-y-2"
-                  class="min-h-[200px] max-h-[400px] overflow-y-auto border-2 border-dashed border-base-300 rounded-lg p-3 bg-base-50"
+                  class="min-h-[120px] lg:min-h-[200px] lg:max-h-[400px] lg:overflow-y-auto border-2 border-dashed border-base-300 rounded-lg p-3 bg-base-50"
                   item_class="flex items-center p-3 rounded-lg bg-primary/10 border border-primary/30 hover:bg-primary/20 transition-colors"
                 >
                   <:item :let={column_id}>
@@ -842,7 +846,7 @@
                     {gettext("Click to add")}
                   </span>
                 </div>
-                <div class="max-h-[400px] overflow-y-auto border border-base-200 rounded-lg bg-base-100">
+                <div class="lg:max-h-[400px] lg:overflow-y-auto border border-base-200 rounded-lg bg-base-100">
                   <%!-- Standard Fields Section --%>
                   <%= if map_size(@available_columns.standard) > 0 do %>
                     <div class="p-3">
@@ -948,7 +952,7 @@
               </div>
             </div>
 
-            <div class="modal-action">
+            <div class="modal-action shrink-0 flex-wrap pt-4 border-t border-base-200">
               <button type="submit" class="btn btn-primary">
                 {gettext("Apply Changes")}
               </button>

--- a/lib/phoenix_kit_web/live/users/users.html.heex
+++ b/lib/phoenix_kit_web/live/users/users.html.heex
@@ -233,20 +233,21 @@
           </.link>
         </:toolbar_actions>
         <:card_header :let={user}>
-          <div class="flex items-center gap-3">
+          <div class="flex items-center gap-3 min-w-0">
             <.user_avatar user={user} size="sm" />
             <div class="flex flex-col gap-0.5 min-w-0">
-              <div class="flex flex-wrap items-center gap-2">
-                <span class="font-medium text-sm truncate">{user.email}</span>
+              <div class="flex items-center gap-2 min-w-0">
+                <span class="font-medium text-sm truncate min-w-0">{user.email}</span>
                 <%= if user.uuid == @phoenix_kit_current_user.uuid do %>
-                  <span class="badge badge-info badge-xs h-auto">{gettext("you")}</span>
-                <% end %>
-                <%= if User.full_name(user) && User.full_name(user) != "" do %>
-                  <span class="text-sm text-base-content/60">{User.full_name(user)}</span>
+                  <span class="badge badge-info badge-xs h-auto shrink-0">{gettext("you")}</span>
                 <% end %>
               </div>
+              <% full_name = User.full_name(user) %>
+              <%= if full_name && full_name != "" do %>
+                <span class="text-sm text-base-content/60 truncate">{full_name}</span>
+              <% end %>
               <%= if user.username do %>
-                <div class="text-xs text-base-content/50">@{user.username}</div>
+                <div class="text-xs text-base-content/50 truncate">@{user.username}</div>
               <% end %>
             </div>
           </div>

--- a/lib/phoenix_kit_web/live/users/users.html.heex
+++ b/lib/phoenix_kit_web/live/users/users.html.heex
@@ -8,7 +8,7 @@
   project_title={@project_title}
   current_locale={@current_locale}
 >
-  <div class="container flex-col mx-auto px-4 py-6">
+  <div class="flex flex-col w-full p-4">
     <%!-- Role Management Modal --%>
     <%= if @show_role_modal && @managing_user do %>
       <div class="modal modal-open">

--- a/lib/phoenix_kit_web/live/users/users.html.heex
+++ b/lib/phoenix_kit_web/live/users/users.html.heex
@@ -79,7 +79,7 @@
       <.table_default
         id="users-table"
         variant="zebra"
-        class="w-full"
+        class="w-full table-fixed md:table-auto"
         toggleable={true}
         show_toggle={false}
         view_mode={@view_mode}
@@ -304,7 +304,9 @@
           <.table_default_row>
             <%= for column_id <- @selected_columns do %>
               <%= if should_render_column?(column_id) do %>
-                <.table_default_header_cell>
+                <%!-- On mobile only the email + actions columns show; the rest
+                     collapse (hidden md:table-cell), mirroring the media list. --%>
+                <.table_default_header_cell class={mobile_col_class(column_id)}>
                   {render_column_header(column_id)}
                 </.table_default_header_cell>
               <% end %>
@@ -346,7 +348,7 @@
               <.table_default_row>
                 <%= for column_id <- @selected_columns do %>
                   <%= if should_render_column?(column_id) do %>
-                    <.table_default_cell>
+                    <.table_default_cell class={mobile_col_class(column_id)}>
                       <%= cond do %>
                         <% column_id == "email" -> %>
                           <.link
@@ -381,6 +383,17 @@
                                   title={"@#{user.username}"}
                                 >
                                   @{user.username}
+                                </div>
+                              <% end %>
+                              <%!-- Name shown inline on mobile only, since the
+                                   full_name column is hidden there. --%>
+                              <% mobile_full_name = User.full_name(user) %>
+                              <%= if mobile_full_name && mobile_full_name != "" do %>
+                                <div
+                                  class="md:hidden text-sm text-base-content/60 truncate"
+                                  title={mobile_full_name}
+                                >
+                                  {mobile_full_name}
                                 </div>
                               <% end %>
                             </div>

--- a/lib/phoenix_kit_web/live/users/users.html.heex
+++ b/lib/phoenix_kit_web/live/users/users.html.heex
@@ -81,6 +81,9 @@
         variant="zebra"
         class="w-full"
         toggleable={true}
+        show_toggle={false}
+        view_mode={@view_mode}
+        view_event="set_view_mode"
         items={@users}
         card_title={fn user -> user.email end}
         card_fields={
@@ -95,19 +98,130 @@
         }
       >
         <:toolbar_title>
-          <%!-- Collapsed search: a magnifier that opens the full-width search
-               row below the toolbar (see :sort_bar), mirroring the media browser. --%>
-          <button
-            type="button"
-            phx-click="toggle_search"
-            class={[
-              "btn btn-sm btn-circle btn-ghost",
-              (@show_search or @search_query != "") && "btn-active"
-            ]}
-            title={gettext("Search")}
-          >
-            <.icon name="hero-magnifying-glass" class="h-4 w-4" />
-          </button>
+          <%!-- View + filter controls live on the left (matches the media browser).
+               The slot is a plain block, so wrap them in a flex row for gap. --%>
+          <div class="flex flex-wrap items-center gap-2">
+            <%!-- Display (grid/list) — media-style dropdown --%>
+            <% display_options = [
+              {"card", gettext("Grid"), "hero-squares-2x2"},
+              {"table", gettext("List"), "hero-bars-3-bottom-left"}
+            ] %>
+            <div class="dropdown">
+              <div tabindex="0" role="button" class="btn btn-sm gap-2">
+                <.icon
+                  name={
+                    if @view_mode == "table",
+                      do: "hero-bars-3-bottom-left",
+                      else: "hero-squares-2x2"
+                  }
+                  class="w-4 h-4"
+                />
+                <span class="hidden sm:inline">
+                  {if @view_mode == "table", do: gettext("List"), else: gettext("Grid")}
+                </span>
+                <.icon
+                  name="hero-chevron-down"
+                  class="hidden sm:inline-block w-3.5 h-3.5 opacity-60"
+                />
+              </div>
+              <ul
+                tabindex="0"
+                onclick="document.activeElement.blur()"
+                class="dropdown-content menu bg-base-100 rounded-box z-20 w-44 p-2 shadow border border-base-200"
+              >
+                <%= for {val, label, icon} <- display_options do %>
+                  <li>
+                    <button
+                      phx-click="set_view_mode"
+                      phx-value-mode={val}
+                      class={@view_mode == val && "active"}
+                    >
+                      <.icon name={icon} class="w-4 h-4" /> {label}
+                    </button>
+                  </li>
+                <% end %>
+              </ul>
+            </div>
+            <%!-- Role Filter (media-style dropdown) --%>
+            <% role_options = [
+              {"all", gettext("All Users")},
+              {"Owner", gettext("Owners Only")},
+              {"Admin", gettext("Admins Only")},
+              {"User", gettext("Regular Users")}
+            ] %>
+            <% role_label =
+              role_options
+              |> Enum.find(fn {v, _} -> v == @filter_role end)
+              |> then(&(&1 && elem(&1, 1))) %>
+            <div class="dropdown">
+              <div tabindex="0" role="button" class="btn btn-sm gap-2">
+                <.icon name="hero-user-group" class="w-4 h-4" />
+                <span class="hidden sm:inline">{role_label || gettext("Role")}</span>
+                <.icon
+                  name="hero-chevron-down"
+                  class="hidden sm:inline-block w-3.5 h-3.5 opacity-60"
+                />
+              </div>
+              <ul
+                tabindex="0"
+                onclick="document.activeElement.blur()"
+                class="dropdown-content menu bg-base-100 rounded-box z-20 w-44 p-2 shadow border border-base-200"
+              >
+                <%= for {val, label} <- role_options do %>
+                  <li>
+                    <button
+                      phx-click="filter_by_role"
+                      phx-value-role={val}
+                      class={@filter_role == val && "active"}
+                    >
+                      {label}
+                    </button>
+                  </li>
+                <% end %>
+              </ul>
+            </div>
+            <%!-- Account Type Filter (media-style dropdown) --%>
+            <%= if @org_accounts_enabled do %>
+              <% account_type_options = [
+                {"all", gettext("All Types")},
+                {"person", gettext("Person")},
+                {"organization", gettext("Organization")}
+              ] %>
+              <% account_type_label =
+                account_type_options
+                |> Enum.find(fn {v, _} -> v == @filter_account_type end)
+                |> then(&(&1 && elem(&1, 1))) %>
+              <div class="dropdown">
+                <div tabindex="0" role="button" class="btn btn-sm gap-2">
+                  <.icon name="hero-identification" class="w-4 h-4" />
+                  <span class="hidden sm:inline">
+                    {account_type_label || gettext("Account type")}
+                  </span>
+                  <.icon
+                    name="hero-chevron-down"
+                    class="hidden sm:inline-block w-3.5 h-3.5 opacity-60"
+                  />
+                </div>
+                <ul
+                  tabindex="0"
+                  onclick="document.activeElement.blur()"
+                  class="dropdown-content menu bg-base-100 rounded-box z-20 w-44 p-2 shadow border border-base-200"
+                >
+                  <%= for {val, label} <- account_type_options do %>
+                    <li>
+                      <button
+                        phx-click="filter_by_account_type"
+                        phx-value-account_type={val}
+                        class={@filter_account_type == val && "active"}
+                      >
+                        {label}
+                      </button>
+                    </li>
+                  <% end %>
+                </ul>
+              </div>
+            <% end %>
+          </div>
         </:toolbar_title>
         <:sort_bar :if={@show_search or @search_query != ""}>
           <form phx-change="search" phx-submit="search">
@@ -137,85 +251,19 @@
           </form>
         </:sort_bar>
         <:toolbar_actions>
-          <%!-- Role Filter (media-style dropdown) --%>
-          <% role_options = [
-            {"all", gettext("All Users")},
-            {"Owner", gettext("Owners Only")},
-            {"Admin", gettext("Admins Only")},
-            {"User", gettext("Regular Users")}
-          ] %>
-          <% role_label =
-            role_options
-            |> Enum.find(fn {v, _} -> v == @filter_role end)
-            |> then(&(&1 && elem(&1, 1))) %>
-          <div class="dropdown">
-            <div tabindex="0" role="button" class="btn btn-sm gap-2">
-              <.icon name="hero-user-group" class="w-4 h-4" />
-              <span class="hidden sm:inline">{role_label || gettext("Role")}</span>
-              <.icon
-                name="hero-chevron-down"
-                class="hidden sm:inline-block w-3.5 h-3.5 opacity-60"
-              />
-            </div>
-            <ul
-              tabindex="0"
-              onclick="document.activeElement.blur()"
-              class="dropdown-content menu bg-base-100 rounded-box z-20 w-44 p-2 shadow border border-base-200"
-            >
-              <%= for {val, label} <- role_options do %>
-                <li>
-                  <button
-                    phx-click="filter_by_role"
-                    phx-value-role={val}
-                    class={@filter_role == val && "active"}
-                  >
-                    {label}
-                  </button>
-                </li>
-              <% end %>
-            </ul>
-          </div>
-          <%!-- Account Type Filter (media-style dropdown) --%>
-          <%= if @org_accounts_enabled do %>
-            <% account_type_options = [
-              {"all", gettext("All Types")},
-              {"person", gettext("Person")},
-              {"organization", gettext("Organization")}
-            ] %>
-            <% account_type_label =
-              account_type_options
-              |> Enum.find(fn {v, _} -> v == @filter_account_type end)
-              |> then(&(&1 && elem(&1, 1))) %>
-            <div class="dropdown">
-              <div tabindex="0" role="button" class="btn btn-sm gap-2">
-                <.icon name="hero-identification" class="w-4 h-4" />
-                <span class="hidden sm:inline">
-                  {account_type_label || gettext("Account type")}
-                </span>
-                <.icon
-                  name="hero-chevron-down"
-                  class="hidden sm:inline-block w-3.5 h-3.5 opacity-60"
-                />
-              </div>
-              <ul
-                tabindex="0"
-                onclick="document.activeElement.blur()"
-                class="dropdown-content menu bg-base-100 rounded-box z-20 w-44 p-2 shadow border border-base-200"
-              >
-                <%= for {val, label} <- account_type_options do %>
-                  <li>
-                    <button
-                      phx-click="filter_by_account_type"
-                      phx-value-account_type={val}
-                      class={@filter_account_type == val && "active"}
-                    >
-                      {label}
-                    </button>
-                  </li>
-                <% end %>
-              </ul>
-            </div>
-          <% end %>
+          <%!-- Search (collapsed magnifier opens the row below) + actions on the
+               right, mirroring the media browser. --%>
+          <button
+            type="button"
+            phx-click="toggle_search"
+            class={[
+              "btn btn-sm btn-circle btn-ghost",
+              (@show_search or @search_query != "") && "btn-active"
+            ]}
+            title={gettext("Search")}
+          >
+            <.icon name="hero-magnifying-glass" class="h-4 w-4" />
+          </button>
           <button
             class="btn btn-sm btn-info"
             phx-click="show_column_modal"

--- a/lib/phoenix_kit_web/live/users/users.html.heex
+++ b/lib/phoenix_kit_web/live/users/users.html.heex
@@ -308,36 +308,48 @@
                             class="flex items-center gap-3 hover:opacity-80 transition-opacity"
                           >
                             <.user_avatar user={user} size="sm" />
-                            <div class="flex flex-col gap-1">
-                              <div class="flex flex-wrap items-center gap-2">
-                                <span class="font-medium link link-hover">{user.email}</span>
+                            <div class="flex flex-col gap-1 min-w-0 max-w-[18rem]">
+                              <div class="flex items-center gap-2 min-w-0">
+                                <span
+                                  class="font-medium link link-hover truncate min-w-0"
+                                  title={user.email}
+                                >
+                                  {user.email}
+                                </span>
                                 <%= if user.uuid == @phoenix_kit_current_user.uuid do %>
-                                  <span class="badge badge-info badge-xs h-auto">
+                                  <span class="badge badge-info badge-xs h-auto shrink-0">
                                     {gettext("you")}
                                   </span>
                                 <% end %>
                                 <%= if @org_accounts_enabled && user.account_type == "organization" do %>
-                                  <span class="badge badge-primary badge-xs h-auto">
+                                  <span class="badge badge-primary badge-xs h-auto shrink-0">
                                     {gettext("Org")}
                                   </span>
                                 <% end %>
                               </div>
                               <%= if user.username do %>
-                                <div class="text-sm text-base-content/60">
+                                <div
+                                  class="text-sm text-base-content/60 truncate"
+                                  title={"@#{user.username}"}
+                                >
                                   @{user.username}
                                 </div>
                               <% end %>
                             </div>
                           </.link>
                         <% column_id == "full_name" -> %>
-                          <div class="flex flex-col gap-1">
+                          <div class="flex flex-col gap-1 min-w-0 max-w-[18rem]">
                             <%= if user.first_name || user.last_name || user.organization_name do %>
-                              <div>{PhoenixKit.Users.Auth.User.full_name(user)}</div>
+                              <% full_name = PhoenixKit.Users.Auth.User.full_name(user) %>
+                              <div class="truncate" title={full_name}>{full_name}</div>
                             <% else %>
                               <div class="text-base-content/50">-</div>
                             <% end %>
                             <%= if @org_accounts_enabled && user.organization do %>
-                              <div class="text-xs text-base-content/60">
+                              <div
+                                class="text-xs text-base-content/60 truncate"
+                                title={user.organization.organization_name}
+                              >
                                 {user.organization.organization_name}
                               </div>
                             <% end %>

--- a/lib/phoenix_kit_web/live/users/users.html.heex
+++ b/lib/phoenix_kit_web/live/users/users.html.heex
@@ -3,17 +3,12 @@
   flash={@flash}
   phoenix_kit_current_scope={assigns[:phoenix_kit_current_scope]}
   page_title={gettext("User Management")}
+  page_subtitle={gettext("Manage user accounts and roles")}
   current_path={@url_path}
   project_title={@project_title}
   current_locale={@current_locale}
 >
   <div class="container flex-col mx-auto px-4 py-6">
-    <.admin_page_header
-      back={PhoenixKit.Utils.Routes.path("/admin")}
-      title={gettext("User Management")}
-      subtitle={gettext("Manage user accounts and roles")}
-    />
-
     <%!-- Role Management Modal --%>
     <%= if @show_role_modal && @managing_user do %>
       <div class="modal modal-open">

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule PhoenixKit.MixProject do
   use Mix.Project
 
-  @version "1.7.157"
+  @version "1.7.158"
   @description "A foundation for building Elixir Phoenix apps — SaaS, social networks, ERP systems, marketplaces, and more"
   @source_url "https://github.com/BeamLabEU/phoenix_kit"
 
@@ -119,6 +119,12 @@ defmodule PhoenixKit.MixProject do
 
       # Content editor
       {:leaf, "~> 0.3"},
+
+      # Markdown → HTML (comrak). Declared here in core so every module shares
+      # one resolved version instead of each pulling its own and risking
+      # mismatches. Modules (e.g. phoenix_kit_comments) call MDEx directly and
+      # rely on it being provided transitively through phoenix_kit.
+      {:mdex, "~> 0.13"},
 
       # Pan-zoom image viewer + annotation overlay. Fresco 0.5 dropped
       # OpenSeadragon and replaced the wrapped-OSD viewer with a


### PR DESCRIPTION
## Summary

A consistency pass over the admin UI (mostly the manage-users page and the navbar header pattern), plus moving the MDEx markdown dependency into core so modules stop declaring their own.

### Admin navbar header pattern
- Move page title/subtitle into the top navbar across the dashboard, manage-users, and ~16 settings/activity/users/modules pages; drop the redundant in-page `admin_page_header` (its `back=` attr was already a deprecated no-op).
- Fix the literal `page_title="{@project_title} …"` interpolation bug that rendered `{@project_title}` verbatim in the navbar on the dashboard and several settings pages.
- Add `min-w-0` to the navbar's left section and `break-words` to `admin_page_header` so long titles truncate/wrap instead of overflowing on mobile.

### Manage-users page
- Tighten padding; collapsible media-style search row; Role/Account filters restyled as daisyUI dropdowns (with active-state label + highlight).
- Mobile-friendly Customize Columns modal (scrollable body, pinned action footer).
- Truncate long names/emails in grid and table views.
- Persisted grid/list view toggle (media-style Display dropdown) that works on every breakpoint; toolbar regrouped to match the media browser (filters left, search + actions right).
- Mobile-friendly list view (collapses to a compact avatar/email/name row + `…` menu, like the media list).

### User detail page
- Stop long first/last names overflowing the navbar, page header, and profile card on mobile.

### Dependencies
- **`mdex` is now a direct dependency of core** (`~> 0.13`), so every module shares one resolved version through the dependency tree instead of each declaring its own (same arrangement as `leaf`). Bump to 1.7.158.

Verified with `mix compile --warnings-as-errors` and `mix credo --strict` (0 issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)