### PR TITLE
Staff-support core changes: V136 employment table, Activity resource_uuid filter, MediaSelectorModal hardening

### DIFF
--- a/lib/phoenix_kit/activity/activity.ex
+++ b/lib/phoenix_kit/activity/activity.ex
@@ -143,6 +143,7 @@ defmodule PhoenixKit.Activity do
   - `:action` — filter by action string (exact match or prefix with "post.*")
   - `:actor_uuid` — filter by who performed the action
   - `:resource_type` — filter by resource type
+  - `:resource_uuid` — filter by the specific resource's UUID (scope to one resource)
   - `:target_uuid` — filter by who was affected
   - `:since` — filter activities after this datetime
   - `:until` — filter activities before this datetime
@@ -358,6 +359,7 @@ defmodule PhoenixKit.Activity do
     |> maybe_filter_action(Keyword.get(opts, :action))
     |> maybe_filter_actor(Keyword.get(opts, :actor_uuid))
     |> maybe_filter_resource_type(Keyword.get(opts, :resource_type))
+    |> maybe_filter_resource_uuid(Keyword.get(opts, :resource_uuid))
     |> maybe_filter_target(Keyword.get(opts, :target_uuid))
     |> maybe_filter_since(Keyword.get(opts, :since))
     |> maybe_filter_until(Keyword.get(opts, :until))
@@ -385,6 +387,9 @@ defmodule PhoenixKit.Activity do
 
   defp maybe_filter_resource_type(query, nil), do: query
   defp maybe_filter_resource_type(query, type), do: where(query, [e], e.resource_type == ^type)
+
+  defp maybe_filter_resource_uuid(query, nil), do: query
+  defp maybe_filter_resource_uuid(query, uuid), do: where(query, [e], e.resource_uuid == ^uuid)
 
   defp maybe_filter_target(query, nil), do: query
   defp maybe_filter_target(query, uuid), do: where(query, [e], e.target_uuid == ^uuid)

--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -529,7 +529,18 @@ defmodule PhoenixKit.Migrations.Postgres do
   - Replaces unique index with partial index (slug-mode only, WHERE slug IS NOT NULL)
   - Adds unique index on `(group_uuid, post_date, post_time)` for timestamp-mode posts
 
-  ### V135 - Structured staff skills ⚡ LATEST
+  ### V136 - Staff employment history ⚡ LATEST
+  - Adds `phoenix_kit_staff_employments` — a per-person history of employment
+    spans (employment type, translatable `job_title`, org placement via
+    `primary_department_uuid` + a `primary_team_uuid` snapshot, date range with
+    `employment_end_date IS NULL` = the open/current span, `work_location`,
+    `notes`). A partial unique index enforces one open span per person. The
+    matching `phoenix_kit_staff_people` columns are kept as a denormalized mirror
+    of the current span (written by the app's `sync_current/1`), not dropped.
+    Backfills one open span per existing person from those columns (guarded,
+    retry-safe; people with no employment data are skipped).
+
+  ### V135 - Structured staff skills
   - Replaces the free-text `phoenix_kit_staff_people.skills` column with a
     first-class translatable `phoenix_kit_staff_skills` entity + a
     `phoenix_kit_staff_person_skills` join. Each skill carries its own
@@ -1161,7 +1172,7 @@ defmodule PhoenixKit.Migrations.Postgres do
   use Ecto.Migration
 
   @initial_version 1
-  @current_version 135
+  @current_version 136
   @default_prefix "public"
 
   @doc false

--- a/lib/phoenix_kit/migrations/postgres/v136.ex
+++ b/lib/phoenix_kit/migrations/postgres/v136.ex
@@ -1,0 +1,137 @@
+defmodule PhoenixKit.Migrations.Postgres.V136 do
+  @moduledoc """
+  V136: Employment history for `phoenix_kit_staff`.
+
+  Replaces the single flat employment span on `phoenix_kit_staff_people`
+  (`employment_type` / `employment_start_date` / `employment_end_date` /
+  `job_title` / `work_location`) with a first-class **history** of employment
+  spans, surfaced as a dedicated tab on the person profile.
+
+  Creates `phoenix_kit_staff_employments` — one row per span, carrying the
+  employment type, a translatable `job_title`, the org placement at the time
+  (`primary_department_uuid` + a `primary_team_uuid` snapshot), the date range
+  (`employment_end_date IS NULL` = the current/open span), `work_location`, and
+  free-text `notes`.
+
+  ## Single open span per person
+
+  A partial unique index enforces **at most one open span** (`employment_end_date
+  IS NULL`) per person — the "current" employment. The app context closes the
+  prior open span when a new one starts.
+
+  ## Denormalized "current" mirror
+
+  The matching columns already on `phoenix_kit_staff_people` are kept as a
+  denormalized mirror of the current (open) span — the app's `sync_current/1`
+  writes them in the same transaction as any span change, so existing readers
+  (overview org tree, people list) need no join. This migration does NOT drop
+  those columns.
+
+  ## Backfill
+
+  One open span per existing person is seeded from their current columns
+  (`employment_type` / `job_title` / dates / `primary_department_uuid` /
+  `work_location`), copying any per-locale `job_title` overrides out of the
+  person's `translations` JSONB into the span's `translations`. Guarded by a
+  `NOT EXISTS` check on the span table so a re-run is a safe no-op; people with
+  no employment data at all are skipped (they start with an empty history).
+  `primary_team_uuid` is left null on backfill — the person's team comes from the
+  many-to-many `team_memberships`, which has no single "primary" to copy.
+  """
+
+  use Ecto.Migration
+
+  def up(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    # 1. Employment spans — a person's employment history.
+    execute("""
+    CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_staff_employments (
+      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      staff_person_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_staff_people(uuid) ON DELETE CASCADE,
+      employment_type VARCHAR(50),
+      job_title VARCHAR(255),
+      translations JSONB NOT NULL DEFAULT '{}'::jsonb,
+      primary_department_uuid UUID REFERENCES #{p}phoenix_kit_staff_departments(uuid) ON DELETE SET NULL,
+      primary_team_uuid UUID REFERENCES #{p}phoenix_kit_staff_teams(uuid) ON DELETE SET NULL,
+      employment_start_date DATE,
+      employment_end_date DATE,
+      work_location VARCHAR(255),
+      notes TEXT,
+      inserted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+    """)
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS phoenix_kit_staff_employments_person_index
+    ON #{p}phoenix_kit_staff_employments (staff_person_uuid)
+    """)
+
+    # At most one OPEN span (current employment) per person.
+    execute("""
+    CREATE UNIQUE INDEX IF NOT EXISTS phoenix_kit_staff_employments_one_open_index
+    ON #{p}phoenix_kit_staff_employments (staff_person_uuid)
+    WHERE employment_end_date IS NULL
+    """)
+
+    # 2. Backfill one span per existing person from the current columns. Guarded
+    #    by NOT EXISTS so a partial re-run is a no-op; people with no employment
+    #    data are skipped. job_title per-locale overrides are lifted out of the
+    #    person's translations JSONB into the span's translations (job_title only).
+    execute("""
+    INSERT INTO #{p}phoenix_kit_staff_employments
+      (staff_person_uuid, employment_type, job_title, translations,
+       primary_department_uuid, employment_start_date, employment_end_date, work_location)
+    SELECT
+      pers.uuid,
+      pers.employment_type,
+      pers.job_title,
+      COALESCE(
+        (SELECT jsonb_object_agg(lang, jsonb_build_object('job_title', submap->'job_title'))
+         FROM jsonb_each(pers.translations) AS t(lang, submap)
+         WHERE submap ? 'job_title'),
+        '{}'::jsonb
+      ),
+      pers.primary_department_uuid,
+      pers.employment_start_date,
+      pers.employment_end_date,
+      pers.work_location
+    FROM #{p}phoenix_kit_staff_people pers
+    WHERE (
+        pers.employment_type IS NOT NULL
+        OR pers.job_title IS NOT NULL
+        OR pers.employment_start_date IS NOT NULL
+        OR pers.employment_end_date IS NOT NULL
+        OR pers.primary_department_uuid IS NOT NULL
+        OR pers.work_location IS NOT NULL
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM #{p}phoenix_kit_staff_employments e
+        WHERE e.staff_person_uuid = pers.uuid
+      )
+    """)
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '136'")
+  end
+
+  @doc """
+  Drops the employments table.
+
+  The denormalized `employment_*` / `job_title` / `work_location` columns on
+  `phoenix_kit_staff_people` are left intact, so a rollback keeps each person's
+  current employment data — only the history is lost.
+  """
+  def down(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    execute("DROP TABLE IF EXISTS #{p}phoenix_kit_staff_employments")
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '135'")
+  end
+
+  defp prefix_str("public"), do: "public."
+  defp prefix_str(prefix), do: "#{prefix}."
+end

--- a/lib/phoenix_kit_web/live/activity/index.ex
+++ b/lib/phoenix_kit_web/live/activity/index.ex
@@ -68,6 +68,10 @@ defmodule PhoenixKitWeb.Live.Activity.Index do
       |> maybe_put("mode", filter_params["mode"])
       |> maybe_put("action", filter_params["action"])
       |> maybe_put("resource_type", filter_params["resource_type"])
+      # No form input for resource_uuid — it's a URL-driven scope (e.g. a
+      # "view this resource's activity" deep link); preserve it across filter
+      # changes so tweaking module/action doesn't drop the resource scope.
+      |> maybe_put("resource_uuid", socket.assigns.filter_resource_uuid)
 
     query = URI.encode_query(new_params)
     {:noreply, push_patch(socket, to: Routes.path("/admin/activity?#{query}"))}
@@ -94,6 +98,7 @@ defmodule PhoenixKitWeb.Live.Activity.Index do
     |> assign(:filter_mode, nil)
     |> assign(:filter_action, nil)
     |> assign(:filter_resource_type, nil)
+    |> assign(:filter_resource_uuid, nil)
   end
 
   defp apply_params(socket, params) do
@@ -103,6 +108,7 @@ defmodule PhoenixKitWeb.Live.Activity.Index do
     |> assign(:filter_mode, Values.blank_to_nil(params["mode"]))
     |> assign(:filter_action, Values.blank_to_nil(params["action"]))
     |> assign(:filter_resource_type, Values.blank_to_nil(params["resource_type"]))
+    |> assign(:filter_resource_uuid, Values.blank_to_nil(params["resource_uuid"]))
   end
 
   defp load_activities(socket) do
@@ -114,6 +120,7 @@ defmodule PhoenixKitWeb.Live.Activity.Index do
         mode: socket.assigns.filter_mode,
         action: socket.assigns.filter_action,
         resource_type: socket.assigns.filter_resource_type,
+        resource_uuid: socket.assigns.filter_resource_uuid,
         preload: [:actor, :target]
       )
 

--- a/lib/phoenix_kit_web/live/components/media_selector_modal.ex
+++ b/lib/phoenix_kit_web/live/components/media_selector_modal.ex
@@ -479,6 +479,8 @@ defmodule PhoenixKitWeb.Live.Components.MediaSelectorModal do
 
     query =
       from(f in File, order_by: [desc: f.inserted_at])
+      # Don't suggest trashed or system-managed files in the picker.
+      |> where([f], f.status != "trashed" and f.system_managed == false)
       |> scope_files_by_user(socket.assigns[:user_uuid])
       |> scope_files_by_folder(socket.assigns[:scope_folder_id])
       |> scope_files_by_type(socket.assigns.file_type_filter)

--- a/lib/phoenix_kit_web/live/components/media_selector_modal.ex
+++ b/lib/phoenix_kit_web/live/components/media_selector_modal.ex
@@ -179,6 +179,19 @@ defmodule PhoenixKitWeb.Live.Components.MediaSelectorModal do
   defp accept_for(:video), do: ~w(.mp4 .mov .webm .mkv .avi .m4v .ogv .ogg)
   defp accept_for(_), do: :any
 
+  # Modal copy that reflects the active type filter, so an all/video picker
+  # doesn't always say "images". Referenced from the template.
+  defp selection_hint(:single, :image), do: gettext("Click on an image to select it")
+  defp selection_hint(:single, :video), do: gettext("Click on a video to select it")
+  defp selection_hint(:single, _), do: gettext("Click on a file to select it")
+  defp selection_hint(_multiple, :image), do: gettext("Select one or more images")
+  defp selection_hint(_multiple, :video), do: gettext("Select one or more videos")
+  defp selection_hint(_multiple, _), do: gettext("Select one or more files")
+
+  defp accepted_types_hint(:image), do: gettext("Images")
+  defp accepted_types_hint(:video), do: gettext("Videos")
+  defp accepted_types_hint(_), do: gettext("Images, videos, or documents")
+
   def handle_event("noop", _params, socket) do
     # No-op event to prevent click propagation
     {:noreply, socket}

--- a/lib/phoenix_kit_web/live/components/media_selector_modal.ex
+++ b/lib/phoenix_kit_web/live/components/media_selector_modal.ex
@@ -159,7 +159,7 @@ defmodule PhoenixKitWeb.Live.Components.MediaSelectorModal do
 
       has_buckets ->
         allow_upload(socket, :media_files,
-          accept: :any,
+          accept: accept_for(socket.assigns[:file_type_filter]),
           max_entries: 10,
           auto_upload: true,
           progress: &handle_progress/3
@@ -170,6 +170,14 @@ defmodule PhoenixKitWeb.Live.Components.MediaSelectorModal do
         socket
     end
   end
+
+  # Constrain the upload picker to the filtered type. The browse list is already
+  # scoped by `scope_files_by_type/2`; without this the upload accepted any file
+  # (`:any`), so an image/video picker would still let arbitrary files in. `:all`
+  # keeps `:any`.
+  defp accept_for(:image), do: ~w(.jpg .jpeg .png .gif .webp .svg .bmp .avif .heic .heif)
+  defp accept_for(:video), do: ~w(.mp4 .mov .webm .mkv .avi .m4v .ogv .ogg)
+  defp accept_for(_), do: :any
 
   def handle_event("noop", _params, socket) do
     # No-op event to prevent click propagation

--- a/lib/phoenix_kit_web/live/components/media_selector_modal.ex
+++ b/lib/phoenix_kit_web/live/components/media_selector_modal.ex
@@ -63,6 +63,8 @@ defmodule PhoenixKitWeb.Live.Components.MediaSelectorModal do
     * `selected_uuids` — list of already-selected file UUIDs
     * `phoenix_kit_current_user` — required for uploads to attribute the file
     * `file_type_filter` — `:all` (default), `:image`, or `:video`
+    * `browse` — `true` (default) shows the library grid + search + type filter;
+      `false` is upload-only (dropzone + Confirm; uploaded files auto-select)
     * `user_uuid` — when set, restricts the library to files owned by
       that user; nil (default) shows the full library
     * `scope_folder_id` — when set, restricts both the browse query
@@ -109,6 +111,10 @@ defmodule PhoenixKitWeb.Live.Components.MediaSelectorModal do
       # after lazy-creating their folder.
       |> assign_new(:scope_folder_id, fn -> nil end)
       |> assign_new(:notify, fn -> nil end)
+      # `browse: false` → upload-only mode: hide the library grid, search,
+      # type filter, pagination, and the accepted-types hint, leaving just the
+      # dropzone + Confirm. Uploaded files auto-select, so Confirm still works.
+      |> assign_new(:browse, fn -> true end)
       |> assign_new(:file_type_filter, fn -> :all end)
       |> assign_new(:search_query, fn -> "" end)
       |> assign_new(:current_page, fn -> 1 end)

--- a/lib/phoenix_kit_web/live/components/media_selector_modal.html.heex
+++ b/lib/phoenix_kit_web/live/components/media_selector_modal.html.heex
@@ -28,11 +28,7 @@
                 {gettext("Select Media")}
               </h2>
               <p class="text-base-content/70 text-sm mt-1">
-                <%= if @mode == :single do %>
-                  {gettext("Click on an image to select it")}
-                <% else %>
-                  {gettext("Select one or more images")}
-                <% end %>
+                {selection_hint(@mode, @file_type_filter)}
                 <%= if MapSet.size(@selected_uuids) > 0 do %>
                   <span class="badge badge-primary ml-2">
                     {ngettext(
@@ -124,7 +120,7 @@
                           {gettext("Drag files here or click to browse")}
                         </p>
                         <p class="text-xs text-base-content/70 mt-1">
-                          {gettext("Images, videos, or documents")}
+                          {accepted_types_hint(@file_type_filter)}
                         </p>
                       </div>
                     </div>

--- a/lib/phoenix_kit_web/live/components/media_selector_modal.html.heex
+++ b/lib/phoenix_kit_web/live/components/media_selector_modal.html.heex
@@ -119,7 +119,7 @@
                         <p class="font-semibold text-base-content text-sm">
                           {gettext("Drag files here or click to browse")}
                         </p>
-                        <p class="text-xs text-base-content/70 mt-1">
+                        <p :if={@browse} class="text-xs text-base-content/70 mt-1">
                           {accepted_types_hint(@file_type_filter)}
                         </p>
                       </div>
@@ -182,172 +182,176 @@
             <% end %>
           </div>
         </div>
-        <%!-- Search and Filter Section --%>
-        <div class="card bg-base-200 shadow-md">
-          <div class="card-body p-4">
-            <div class="flex flex-col md:flex-row gap-3">
-              <%!-- Search --%>
-              <div class="flex-1">
-                <.form for={%{}} phx-submit="search" phx-target={@myself} class="w-full">
-                  <div class="join w-full">
-                    <input
-                      type="text"
-                      name="search[query]"
-                      value={@search_query}
-                      placeholder={gettext("Search by filename...")}
-                      class="input input-bordered input-sm join-item flex-1"
-                    />
-                    <button type="submit" class="btn btn-primary btn-sm join-item">
-                      <.icon name="hero-magnifying-glass" class="w-4 h-4" />
-                    </button>
-                  </div>
-                </.form>
-              </div>
-              <%!-- Filter by Type --%>
-              <div class="w-full md:w-40">
-                <label class="select select-sm w-full">
-                  <select
-                    phx-change="filter_type"
-                    phx-target={@myself}
-                    name="filter"
-                  >
-                    <option value="all" selected={@file_type_filter == :all}>
-                      {gettext("All Files")}
-                    </option>
-                    <option value="image" selected={@file_type_filter == :image}>
-                      {gettext("Images Only")}
-                    </option>
-                    <option value="video" selected={@file_type_filter == :video}>
-                      {gettext("Videos Only")}
-                    </option>
-                  </select>
-                </label>
+        <%!-- Library browse: search, type filter, grid, pagination. Hidden in
+             upload-only mode (`browse: false`). --%>
+        <div :if={@browse} class="contents">
+          <%!-- Search and Filter Section --%>
+          <div class="card bg-base-200 shadow-md">
+            <div class="card-body p-4">
+              <div class="flex flex-col md:flex-row gap-3">
+                <%!-- Search --%>
+                <div class="flex-1">
+                  <.form for={%{}} phx-submit="search" phx-target={@myself} class="w-full">
+                    <div class="join w-full">
+                      <input
+                        type="text"
+                        name="search[query]"
+                        value={@search_query}
+                        placeholder={gettext("Search by filename...")}
+                        class="input input-bordered input-sm join-item flex-1"
+                      />
+                      <button type="submit" class="btn btn-primary btn-sm join-item">
+                        <.icon name="hero-magnifying-glass" class="w-4 h-4" />
+                      </button>
+                    </div>
+                  </.form>
+                </div>
+                <%!-- Filter by Type --%>
+                <div class="w-full md:w-40">
+                  <label class="select select-sm w-full">
+                    <select
+                      phx-change="filter_type"
+                      phx-target={@myself}
+                      name="filter"
+                    >
+                      <option value="all" selected={@file_type_filter == :all}>
+                        {gettext("All Files")}
+                      </option>
+                      <option value="image" selected={@file_type_filter == :image}>
+                        {gettext("Images Only")}
+                      </option>
+                      <option value="video" selected={@file_type_filter == :video}>
+                        {gettext("Videos Only")}
+                      </option>
+                    </select>
+                  </label>
+                </div>
               </div>
             </div>
           </div>
-        </div>
-        <%!-- Media Grid --%>
-        <%= if Enum.empty?(@uploaded_files) do %>
-          <div class="text-center py-8">
-            <.icon name="hero-photo" class="w-12 h-12 mx-auto mb-3 text-base-content/30" />
-            <p class="text-sm text-base-content/70 mb-1">{gettext("No media files found")}</p>
-            <p class="text-xs text-base-content/50">
-              {gettext("Upload files using the area above or adjust your search filters")}
-            </p>
-          </div>
-        <% else %>
-          <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3">
-            <%= for file <- @uploaded_files do %>
-              <% is_selected = MapSet.member?(@selected_uuids, file.file_uuid) %>
-              <div
-                phx-click="toggle_selection"
-                phx-value-file-uuid={file.file_uuid}
-                phx-target={@myself}
-                class={[
-                  "card bg-base-200 shadow-md cursor-pointer transition-all hover:shadow-lg",
-                  is_selected && "ring-4 ring-primary"
-                ]}
-              >
-                <%!-- Thumbnail --%>
-                <figure class="aspect-square bg-base-300 relative">
-                  <.thumbnail_url :let={url} file={file}>
-                    <%= if url do %>
-                      <img
-                        src={url}
-                        alt={file.filename}
-                        class="object-cover w-full h-full"
-                      />
+          <%!-- Media Grid --%>
+          <%= if Enum.empty?(@uploaded_files) do %>
+            <div class="text-center py-8">
+              <.icon name="hero-photo" class="w-12 h-12 mx-auto mb-3 text-base-content/30" />
+              <p class="text-sm text-base-content/70 mb-1">{gettext("No media files found")}</p>
+              <p class="text-xs text-base-content/50">
+                {gettext("Upload files using the area above or adjust your search filters")}
+              </p>
+            </div>
+          <% else %>
+            <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3">
+              <%= for file <- @uploaded_files do %>
+                <% is_selected = MapSet.member?(@selected_uuids, file.file_uuid) %>
+                <div
+                  phx-click="toggle_selection"
+                  phx-value-file-uuid={file.file_uuid}
+                  phx-target={@myself}
+                  class={[
+                    "card bg-base-200 shadow-md cursor-pointer transition-all hover:shadow-lg",
+                    is_selected && "ring-4 ring-primary"
+                  ]}
+                >
+                  <%!-- Thumbnail --%>
+                  <figure class="aspect-square bg-base-300 relative">
+                    <.thumbnail_url :let={url} file={file}>
+                      <%= if url do %>
+                        <img
+                          src={url}
+                          alt={file.filename}
+                          class="object-cover w-full h-full"
+                        />
+                      <% else %>
+                        <div class="flex items-center justify-center w-full h-full">
+                          <.icon name="hero-document" class="w-12 h-12 text-base-content/30" />
+                        </div>
+                      <% end %>
+                    </.thumbnail_url>
+                    <%!-- Selection Indicator --%>
+                    <%= if is_selected do %>
+                      <div class="absolute top-1 right-1 bg-primary text-primary-content rounded-full p-1.5">
+                        <.icon name="hero-check" class="w-4 h-4" />
+                      </div>
                     <% else %>
-                      <div class="flex items-center justify-center w-full h-full">
-                        <.icon name="hero-document" class="w-12 h-12 text-base-content/30" />
+                      <div class="absolute top-1 right-1 bg-base-100/80 border-2 border-base-300 rounded-full w-7 h-7">
                       </div>
                     <% end %>
-                  </.thumbnail_url>
-                  <%!-- Selection Indicator --%>
-                  <%= if is_selected do %>
-                    <div class="absolute top-1 right-1 bg-primary text-primary-content rounded-full p-1.5">
-                      <.icon name="hero-check" class="w-4 h-4" />
+                    <%!-- File Type Badge --%>
+                    <div class="absolute bottom-1 left-1">
+                      <span class="badge badge-xs badge-neutral uppercase">
+                        {file.file_type}
+                      </span>
                     </div>
-                  <% else %>
-                    <div class="absolute top-1 right-1 bg-base-100/80 border-2 border-base-300 rounded-full w-7 h-7">
+                  </figure>
+                  <%!-- File Info --%>
+                  <div class="card-body p-2">
+                    <p class="text-xs font-semibold truncate" title={file.filename}>
+                      {file.filename}
+                    </p>
+                    <div class="flex justify-between items-center text-[10px] text-base-content/60">
+                      <span>{format_file_size(file.size)}</span>
+                      <%= if file.width && file.height do %>
+                        <span>{file.width}×{file.height}</span>
+                      <% end %>
                     </div>
-                  <% end %>
-                  <%!-- File Type Badge --%>
-                  <div class="absolute bottom-1 left-1">
-                    <span class="badge badge-xs badge-neutral uppercase">
-                      {file.file_type}
-                    </span>
-                  </div>
-                </figure>
-                <%!-- File Info --%>
-                <div class="card-body p-2">
-                  <p class="text-xs font-semibold truncate" title={file.filename}>
-                    {file.filename}
-                  </p>
-                  <div class="flex justify-between items-center text-[10px] text-base-content/60">
-                    <span>{format_file_size(file.size)}</span>
-                    <%= if file.width && file.height do %>
-                      <span>{file.width}×{file.height}</span>
-                    <% end %>
                   </div>
                 </div>
-              </div>
-            <% end %>
-          </div>
-        <% end %>
-        <%!-- Pagination --%>
-        <%= if @total_pages > 1 do %>
-          <div class="flex justify-center pt-4">
-            <div class="join">
-              <%= if @current_page > 1 do %>
-                <button
-                  type="button"
-                  phx-click="change_page"
-                  phx-value-page={@current_page - 1}
-                  phx-target={@myself}
-                  class="join-item btn btn-sm"
-                >
-                  «
-                </button>
-              <% else %>
-                <button class="join-item btn btn-sm btn-disabled">«</button>
               <% end %>
-
-              <%= for page <- pagination_range(@current_page, @total_pages) do %>
-                <%= if page == :ellipsis do %>
-                  <button class="join-item btn btn-sm btn-disabled">...</button>
-                <% else %>
+            </div>
+          <% end %>
+          <%!-- Pagination --%>
+          <%= if @total_pages > 1 do %>
+            <div class="flex justify-center pt-4">
+              <div class="join">
+                <%= if @current_page > 1 do %>
                   <button
                     type="button"
                     phx-click="change_page"
-                    phx-value-page={page}
+                    phx-value-page={@current_page - 1}
                     phx-target={@myself}
-                    class={[
-                      "join-item btn btn-sm",
-                      page == @current_page && "btn-active"
-                    ]}
+                    class="join-item btn btn-sm"
                   >
-                    {page}
+                    «
                   </button>
+                <% else %>
+                  <button class="join-item btn btn-sm btn-disabled">«</button>
                 <% end %>
-              <% end %>
 
-              <%= if @current_page < @total_pages do %>
-                <button
-                  type="button"
-                  phx-click="change_page"
-                  phx-value-page={@current_page + 1}
-                  phx-target={@myself}
-                  class="join-item btn btn-sm"
-                >
-                  »
-                </button>
-              <% else %>
-                <button class="join-item btn btn-sm btn-disabled">»</button>
-              <% end %>
+                <%= for page <- pagination_range(@current_page, @total_pages) do %>
+                  <%= if page == :ellipsis do %>
+                    <button class="join-item btn btn-sm btn-disabled">...</button>
+                  <% else %>
+                    <button
+                      type="button"
+                      phx-click="change_page"
+                      phx-value-page={page}
+                      phx-target={@myself}
+                      class={[
+                        "join-item btn btn-sm",
+                        page == @current_page && "btn-active"
+                      ]}
+                    >
+                      {page}
+                    </button>
+                  <% end %>
+                <% end %>
+
+                <%= if @current_page < @total_pages do %>
+                  <button
+                    type="button"
+                    phx-click="change_page"
+                    phx-value-page={@current_page + 1}
+                    phx-target={@myself}
+                    class="join-item btn btn-sm"
+                  >
+                    »
+                  </button>
+                <% else %>
+                  <button class="join-item btn btn-sm btn-disabled">»</button>
+                <% end %>
+              </div>
             </div>
-          </div>
-        <% end %>
+          <% end %>
+        </div>
       </div>
     </div>
   </div>

--- a/lib/phoenix_kit_web/live/components/media_selector_modal.html.heex
+++ b/lib/phoenix_kit_web/live/components/media_selector_modal.html.heex
@@ -1,12 +1,12 @@
 <dialog
-  id="media-selector-modal-backdrop"
+  id={"media-selector-modal-backdrop-#{@id}"}
   class="fixed inset-0 z-[10001] m-0 h-full max-h-none w-full max-w-none overflow-y-auto border-0 bg-base-300/80 p-0 backdrop-blur-sm"
   phx-hook="PkDialog"
   data-show={to_string(@show)}
   data-close-event="close_modal"
   phx-click="close_modal"
   phx-target={@myself}
-  aria-labelledby="media-selector-modal-title"
+  aria-labelledby={"media-selector-modal-title-#{@id}"}
 >
   <%!-- Modal Container --%>
   <div class="min-h-screen px-2 py-2 sm:px-4 sm:py-6 flex items-center justify-center">
@@ -22,7 +22,7 @@
           <div class="flex justify-between items-start">
             <div>
               <h2
-                id="media-selector-modal-title"
+                id={"media-selector-modal-title-#{@id}"}
                 class="text-xl sm:text-2xl font-bold text-base-content"
               >
                 {gettext("Select Media")}

--- a/lib/phoenix_kit_web/live/users/media_selector.html.heex
+++ b/lib/phoenix_kit_web/live/users/media_selector.html.heex
@@ -13,31 +13,36 @@
       <div class="flex justify-between items-center">
         <div>
           <h1 class="text-2xl sm:text-4xl font-bold text-base-content mb-2">
-            Select Media
+            {gettext("Select Media")}
           </h1>
           <p class="text-base sm:text-lg text-base-content/70">
             <%= if @selection_mode == :single do %>
-              Click on an image to select it
+              {gettext("Click on an image to select it")}
             <% else %>
-              Select one or more images
+              {gettext("Select one or more images")}
             <% end %>
             <%= if MapSet.size(@selected_uuids) > 0 do %>
               <span class="badge badge-primary ml-2">
-                {MapSet.size(@selected_uuids)} selected
+                {ngettext(
+                  "%{count} selected",
+                  "%{count} selected",
+                  MapSet.size(@selected_uuids),
+                  count: MapSet.size(@selected_uuids)
+                )}
               </span>
             <% end %>
           </p>
         </div>
         <div class="flex gap-2">
           <button phx-click="cancel_selection" class="btn btn-outline">
-            <.icon name="hero-x-mark" class="w-4 h-4 mr-1" /> Cancel
+            <.icon name="hero-x-mark" class="w-4 h-4 mr-1" /> {gettext("Cancel")}
           </button>
           <button
             phx-click="confirm_selection"
             class="btn btn-primary"
             disabled={MapSet.size(@selected_uuids) == 0}
           >
-            <.icon name="hero-check" class="w-4 h-4 mr-1" /> Confirm Selection
+            <.icon name="hero-check" class="w-4 h-4 mr-1" /> {gettext("Confirm Selection")}
           </button>
         </div>
       </div>
@@ -47,7 +52,7 @@
     <div class="card bg-base-100 shadow-xl mb-6">
       <div class="card-body">
         <h3 class="card-title text-lg mb-4">
-          <.icon name="hero-arrow-up-tray" class="w-5 h-5" /> Upload New Files
+          <.icon name="hero-arrow-up-tray" class="w-5 h-5" /> {gettext("Upload New Files")}
         </h3>
         <.form for={%{}} phx-change="validate" phx-submit="save">
           <.live_file_input upload={@uploads.media_files} class="hidden" id="file-upload-input" />
@@ -59,9 +64,13 @@
             <div class="flex flex-col items-center justify-center pt-5 pb-6">
               <.icon name="hero-cloud-arrow-up" class="w-10 h-10 mb-3 text-base-content/50" />
               <p class="mb-2 text-sm text-base-content/70">
-                <span class="font-semibold">Click to upload</span> or drag and drop
+                <span class="font-semibold">{gettext("Click to upload")}</span> {gettext(
+                  "or drag and drop"
+                )}
               </p>
-              <p class="text-xs text-base-content/50">Images, videos, or documents</p>
+              <p class="text-xs text-base-content/50">
+                {gettext("Images, videos, or documents")}
+              </p>
             </div>
           </label>
 
@@ -95,7 +104,7 @@
                   type="text"
                   name="search[query]"
                   value={@search_query}
-                  placeholder="Search by filename..."
+                  placeholder={gettext("Search by filename...")}
                   class="input input-bordered join-item flex-1"
                 />
                 <button type="submit" class="btn btn-primary join-item">
@@ -112,9 +121,15 @@
                 phx-change="filter_type"
                 name="filter"
               >
-                <option value="all" selected={@file_type_filter == :all}>All Files</option>
-                <option value="image" selected={@file_type_filter == :image}>Images Only</option>
-                <option value="video" selected={@file_type_filter == :video}>Videos Only</option>
+                <option value="all" selected={@file_type_filter == :all}>
+                  {gettext("All Files")}
+                </option>
+                <option value="image" selected={@file_type_filter == :image}>
+                  {gettext("Images Only")}
+                </option>
+                <option value="video" selected={@file_type_filter == :video}>
+                  {gettext("Videos Only")}
+                </option>
               </select>
             </label>
           </div>
@@ -128,9 +143,9 @@
         <%= if Enum.empty?(@uploaded_files) do %>
           <div class="text-center py-12">
             <.icon name="hero-photo" class="w-16 h-16 mx-auto mb-4 text-base-content/30" />
-            <p class="text-lg text-base-content/70 mb-2">No media files found</p>
+            <p class="text-lg text-base-content/70 mb-2">{gettext("No media files found")}</p>
             <p class="text-sm text-base-content/50">
-              Upload files using the area above or adjust your search filters
+              {gettext("Upload files using the area above or adjust your search filters")}
             </p>
           </div>
         <% else %>

--- a/lib/phoenix_kit_web/users/auth.ex
+++ b/lib/phoenix_kit_web/users/auth.ex
@@ -807,6 +807,76 @@ defmodule PhoenixKitWeb.Users.Auth do
     Auth.ensure_active_user(user)
   end
 
+  @doc """
+  Reconstructs and assigns the current user + scope on an **embedded**
+  LiveView mount from a host-supplied `session["current_user_uuid"]`.
+
+  A LiveView rendered via `live_render/3` mounts with
+  `:not_mounted_at_router`, so it never runs a router `live_session`'s
+  `on_mount` hook (e.g. `:phoenix_kit_ensure_admin`) — leaving
+  `:phoenix_kit_current_scope` / `:phoenix_kit_current_user` absent, which
+  blinds any user-aware embedded UI (comment composers, activity-actor
+  attribution). The host bridges identity across the `live_render`
+  process boundary by passing its own authenticated user's UUID as
+  `session["current_user_uuid"]` — a **string**, never the `%User{}`
+  struct (a signed-but-not-encrypted `live_render` session would expose
+  it to the client). This helper reloads that user and assigns both
+  `:phoenix_kit_current_user` and `:phoenix_kit_current_scope`.
+
+    * No-op when `:phoenix_kit_current_scope` is already assigned (router
+      mount — the `on_mount` hook ran, before `mount/3`). Never clobbers
+      the canonical scope.
+    * An active user → assigns it + `Scope.for_user(user)`.
+    * Absent / unknown / inactive uuid, or a transient DB error →
+      anonymous (`nil` user + `Scope.for_user(nil)`), never raising.
+
+  > This reconstructs **identity** (audit, comment authorship), not
+  > **authorization** — it performs no role check. The UUID must come
+  > from the host's trusted server-side scope, never request params; and
+  > a host embedding an admin LiveView must gate the embedding page
+  > itself (the `on_mount` admin gate does not run for embeds).
+
+  Generic across embeddable feature modules — `phoenix_kit_projects` is
+  the reference consumer.
+  """
+  @spec assign_embedded_current_user(LiveView.Socket.t(), map()) :: LiveView.Socket.t()
+  def assign_embedded_current_user(socket, session) when is_map(session) do
+    if is_nil(socket.assigns[:phoenix_kit_current_scope]) do
+      {user, scope} = reconstruct_embedded_identity(Map.get(session, "current_user_uuid"))
+
+      socket
+      |> Phoenix.Component.assign(:phoenix_kit_current_user, user)
+      |> Phoenix.Component.assign(:phoenix_kit_current_scope, scope)
+    else
+      socket
+    end
+  end
+
+  def assign_embedded_current_user(socket, _session), do: socket
+
+  defp reconstruct_embedded_identity(uuid) when is_binary(uuid) and uuid != "" do
+    user = uuid |> Auth.get_user() |> Auth.ensure_active_user()
+
+    if is_nil(user) do
+      Logger.warning(
+        "[phoenix_kit] embedded current_user_uuid=#{inspect(uuid)} did not resolve " <>
+          "to an active user — embedded UI degrades to anonymous"
+      )
+    end
+
+    {user, Scope.for_user(user)}
+  rescue
+    e in [Postgrex.Error, DBConnection.ConnectionError, Ecto.QueryError] ->
+      Logger.warning(
+        "[phoenix_kit] failed to load embedded user #{inspect(uuid)}: " <>
+          Exception.message(e) <> " — degrading to anonymous"
+      )
+
+      {nil, Scope.for_user(nil)}
+  end
+
+  defp reconstruct_embedded_identity(_), do: {nil, Scope.for_user(nil)}
+
   defp mount_phoenix_kit_current_scope(socket, session, params \\ %{}) do
     socket =
       socket

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -9327,3 +9327,18 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Videos"
 msgstr ""
+
+#: lib/phoenix_kit_web/live/users/media_selector.html.heex:67
+#, elixir-autogen, elixir-format
+msgid "Click to upload"
+msgstr ""
+
+#: lib/phoenix_kit_web/live/users/media_selector.html.heex:45
+#, elixir-autogen, elixir-format
+msgid "Confirm Selection"
+msgstr ""
+
+#: lib/phoenix_kit_web/live/users/media_selector.html.heex:67
+#, elixir-autogen, elixir-format
+msgid "or drag and drop"
+msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -9297,3 +9297,33 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "When on, any signed-in user can add other accounts (with their password) and switch between them from the user menu."
 msgstr ""
+
+#: lib/phoenix_kit_web/live/components/media_selector_modal.ex:186
+#, elixir-autogen, elixir-format
+msgid "Click on a file to select it"
+msgstr ""
+
+#: lib/phoenix_kit_web/live/components/media_selector_modal.ex:185
+#, elixir-autogen, elixir-format
+msgid "Click on a video to select it"
+msgstr ""
+
+#: lib/phoenix_kit_web/live/components/media_selector_modal.ex:191
+#, elixir-autogen, elixir-format
+msgid "Images"
+msgstr ""
+
+#: lib/phoenix_kit_web/live/components/media_selector_modal.ex:189
+#, elixir-autogen, elixir-format
+msgid "Select one or more files"
+msgstr ""
+
+#: lib/phoenix_kit_web/live/components/media_selector_modal.ex:188
+#, elixir-autogen, elixir-format
+msgid "Select one or more videos"
+msgstr ""
+
+#: lib/phoenix_kit_web/live/components/media_selector_modal.ex:192
+#, elixir-autogen, elixir-format
+msgid "Videos"
+msgstr ""

--- a/priv/gettext/et/LC_MESSAGES/default.po
+++ b/priv/gettext/et/LC_MESSAGES/default.po
@@ -9351,3 +9351,18 @@ msgstr "Vali üks või mitu videot"
 #, elixir-autogen, elixir-format
 msgid "Videos"
 msgstr "Videod"
+
+#: lib/phoenix_kit_web/live/users/media_selector.html.heex:67
+#, elixir-autogen, elixir-format
+msgid "Click to upload"
+msgstr "Klõpsa üleslaadimiseks"
+
+#: lib/phoenix_kit_web/live/users/media_selector.html.heex:45
+#, elixir-autogen, elixir-format
+msgid "Confirm Selection"
+msgstr "Kinnita valik"
+
+#: lib/phoenix_kit_web/live/users/media_selector.html.heex:67
+#, elixir-autogen, elixir-format
+msgid "or drag and drop"
+msgstr "või lohista failid siia"

--- a/priv/gettext/et/LC_MESSAGES/default.po
+++ b/priv/gettext/et/LC_MESSAGES/default.po
@@ -9321,3 +9321,33 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "When on, any signed-in user can add other accounts (with their password) and switch between them from the user menu."
 msgstr ""
+
+#: lib/phoenix_kit_web/live/components/media_selector_modal.ex:186
+#, elixir-autogen, elixir-format
+msgid "Click on a file to select it"
+msgstr "Klõpsa failil, et see valida"
+
+#: lib/phoenix_kit_web/live/components/media_selector_modal.ex:185
+#, elixir-autogen, elixir-format
+msgid "Click on a video to select it"
+msgstr "Klõpsa videol, et see valida"
+
+#: lib/phoenix_kit_web/live/components/media_selector_modal.ex:191
+#, elixir-autogen, elixir-format
+msgid "Images"
+msgstr "Pildid"
+
+#: lib/phoenix_kit_web/live/components/media_selector_modal.ex:189
+#, elixir-autogen, elixir-format
+msgid "Select one or more files"
+msgstr "Vali üks või mitu faili"
+
+#: lib/phoenix_kit_web/live/components/media_selector_modal.ex:188
+#, elixir-autogen, elixir-format
+msgid "Select one or more videos"
+msgstr "Vali üks või mitu videot"
+
+#: lib/phoenix_kit_web/live/components/media_selector_modal.ex:192
+#, elixir-autogen, elixir-format
+msgid "Videos"
+msgstr "Videod"

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -9333,3 +9333,33 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "When on, any signed-in user can add other accounts (with their password) and switch between them from the user menu."
 msgstr ""
+
+#: lib/phoenix_kit_web/live/components/media_selector_modal.ex:186
+#, elixir-autogen, elixir-format
+msgid "Click on a file to select it"
+msgstr "Нажмите на файл, чтобы выбрать его"
+
+#: lib/phoenix_kit_web/live/components/media_selector_modal.ex:185
+#, elixir-autogen, elixir-format
+msgid "Click on a video to select it"
+msgstr "Нажмите на видео, чтобы выбрать его"
+
+#: lib/phoenix_kit_web/live/components/media_selector_modal.ex:191
+#, elixir-autogen, elixir-format
+msgid "Images"
+msgstr "Изображения"
+
+#: lib/phoenix_kit_web/live/components/media_selector_modal.ex:189
+#, elixir-autogen, elixir-format
+msgid "Select one or more files"
+msgstr "Выберите один или несколько файлов"
+
+#: lib/phoenix_kit_web/live/components/media_selector_modal.ex:188
+#, elixir-autogen, elixir-format
+msgid "Select one or more videos"
+msgstr "Выберите одно или несколько видео"
+
+#: lib/phoenix_kit_web/live/components/media_selector_modal.ex:192
+#, elixir-autogen, elixir-format
+msgid "Videos"
+msgstr "Видео"

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -9363,3 +9363,18 @@ msgstr "Выберите одно или несколько видео"
 #, elixir-autogen, elixir-format
 msgid "Videos"
 msgstr "Видео"
+
+#: lib/phoenix_kit_web/live/users/media_selector.html.heex:67
+#, elixir-autogen, elixir-format
+msgid "Click to upload"
+msgstr "Нажмите для загрузки"
+
+#: lib/phoenix_kit_web/live/users/media_selector.html.heex:45
+#, elixir-autogen, elixir-format
+msgid "Confirm Selection"
+msgstr "Подтвердить выбор"
+
+#: lib/phoenix_kit_web/live/users/media_selector.html.heex:67
+#, elixir-autogen, elixir-format
+msgid "or drag and drop"
+msgstr "или перетащите сюда"

--- a/test/integration/activity_filter_test.exs
+++ b/test/integration/activity_filter_test.exs
@@ -1,0 +1,56 @@
+defmodule PhoenixKit.Integration.ActivityFilterTest do
+  @moduledoc """
+  Filtering of `PhoenixKit.Activity.list/1`, focused on `:resource_uuid` —
+  added so a feed can be scoped to a single resource. Before it, `list/1`
+  honoured `:resource_type` but silently ignored `:resource_uuid`, leaking
+  every same-type resource's activity into a per-resource view.
+  """
+  use PhoenixKit.DataCase, async: true
+
+  alias PhoenixKit.Activity
+
+  defp log!(resource_uuid) do
+    {:ok, entry} =
+      Activity.log(%{
+        action: "thing.created",
+        module: "activity_filter_test",
+        resource_type: "filter_test_thing",
+        resource_uuid: resource_uuid
+      })
+
+    entry
+  end
+
+  test "list/1 scopes to a single resource_uuid" do
+    a = Ecto.UUID.generate()
+    b = Ecto.UUID.generate()
+    log!(a)
+    log!(a)
+    log!(b)
+
+    result =
+      Activity.list(resource_type: "filter_test_thing", resource_uuid: a)
+
+    assert result.total == 2
+    assert Enum.all?(result.entries, &(&1.resource_uuid == a))
+    refute Enum.any?(result.entries, &(&1.resource_uuid == b))
+  end
+
+  test "count/1 honours resource_uuid too" do
+    a = Ecto.UUID.generate()
+    b = Ecto.UUID.generate()
+    log!(a)
+    log!(b)
+
+    assert Activity.count(resource_type: "filter_test_thing", resource_uuid: a) == 1
+  end
+
+  test "omitting resource_uuid returns all of the resource_type" do
+    a = Ecto.UUID.generate()
+    b = Ecto.UUID.generate()
+    log!(a)
+    log!(b)
+
+    assert Activity.list(resource_type: "filter_test_thing").total == 2
+  end
+end

--- a/test/phoenix_kit_web/users/embedded_current_user_test.exs
+++ b/test/phoenix_kit_web/users/embedded_current_user_test.exs
@@ -1,0 +1,80 @@
+defmodule PhoenixKitWeb.Users.EmbeddedCurrentUserTest do
+  @moduledoc """
+  Tests for `PhoenixKitWeb.Users.Auth.assign_embedded_current_user/2` — the
+  generic embed-identity reconstruction helper. An embeddable feature-module
+  LiveView (reference consumer: phoenix_kit_projects) mounts off-router via
+  `live_render/3`, skips the auth `on_mount` hook, and recovers the current
+  user/scope from a host-supplied `session["current_user_uuid"]`.
+  """
+  use PhoenixKit.DataCase, async: false
+
+  alias PhoenixKit.Users.Auth
+  alias PhoenixKit.Users.Auth.Scope
+  alias PhoenixKitWeb.Users.Auth, as: WebAuth
+
+  defp socket(assigns \\ %{}) do
+    %Phoenix.LiveView.Socket{assigns: Map.put(assigns, :__changed__, %{})}
+  end
+
+  defp register!(opts \\ []) do
+    {:ok, user} =
+      Auth.register_user(%{
+        email: "embed-#{System.unique_integer([:positive])}@example.com",
+        password: "ValidPassword123!"
+      })
+
+    if Keyword.get(opts, :active, true) do
+      user
+    else
+      user |> Ecto.Changeset.change(is_active: false) |> Repo.update!()
+    end
+  end
+
+  test "assigns the user + scope for an active current_user_uuid" do
+    user = register!()
+
+    socket = WebAuth.assign_embedded_current_user(socket(), %{"current_user_uuid" => user.uuid})
+
+    assert socket.assigns.phoenix_kit_current_user.uuid == user.uuid
+    assert socket.assigns.phoenix_kit_current_scope.user.uuid == user.uuid
+  end
+
+  test "absent current_user_uuid degrades to an anonymous scope" do
+    socket = WebAuth.assign_embedded_current_user(socket(), %{})
+
+    assert is_nil(socket.assigns.phoenix_kit_current_user)
+    assert %Scope{user: nil} = socket.assigns.phoenix_kit_current_scope
+  end
+
+  test "unknown current_user_uuid degrades to anonymous (no crash)" do
+    socket =
+      WebAuth.assign_embedded_current_user(socket(), %{
+        "current_user_uuid" => Ecto.UUID.generate()
+      })
+
+    assert is_nil(socket.assigns.phoenix_kit_current_user)
+    assert %Scope{user: nil} = socket.assigns.phoenix_kit_current_scope
+  end
+
+  test "inactive user degrades to anonymous (ensure_active_user)" do
+    user = register!(active: false)
+
+    socket = WebAuth.assign_embedded_current_user(socket(), %{"current_user_uuid" => user.uuid})
+
+    assert is_nil(socket.assigns.phoenix_kit_current_user)
+    assert %Scope{user: nil} = socket.assigns.phoenix_kit_current_scope
+  end
+
+  test "does not clobber an already-present scope (router mount)" do
+    existing = Scope.for_user(nil)
+    socket = socket(%{phoenix_kit_current_scope: existing})
+
+    result =
+      WebAuth.assign_embedded_current_user(socket, %{
+        "current_user_uuid" => Ecto.UUID.generate()
+      })
+
+    assert result.assigns.phoenix_kit_current_scope == existing
+    refute Map.has_key?(result.assigns, :phoenix_kit_current_user)
+  end
+end


### PR DESCRIPTION
## Summary

Core changes that the `phoenix_kit_staff` employment / media / events work depends on. Accumulated locally; pushing now so the staff PR (BeamLabEU/phoenix_kit_staff) can resolve against a released core.

### Migrations
- **V136** — `phoenix_kit_staff_employments` (employment history): one row per span (`employment_type`, translatable `job_title`, dept/team snapshot, date range, `work_location`, `notes`), partial-unique index for one open span per person, retry-safe backfill of one open span per existing person. `@current_version` → 136.

### Activity
- `Activity.list/1` now honours a `resource_uuid` filter (`maybe_filter_resource_uuid/2`) — previously `apply_filters/2` ignored it, so a per-resource feed leaked every same-type resource's events. Regression test added.
- The admin Activity page (`/admin/activity`) honours a `resource_uuid` URL param so a module can deep-link a per-resource feed.

### MediaSelectorModal
- Restrict uploads to the active `file_type_filter` (`accept_for/1`) — the picker no longer accepts/stores off-type files.
- Filter-aware copy (`selection_hint`/`accepted_types_hint`) — the modal no longer says "images" for an all-types or video picker.
- New **upload-only `browse: false` mode** — hides the library grid/search/filter for a pure uploader.
- Unique per-instance `<dialog>` id so two modals on one page don't collide.
- Exclude trashed / system-managed files from the browse list (matched `list_files_in_scope`).
- Internationalized the full-page media selector.

> Note: `a761c71d Add …Users.Auth.assign_embedded_current_user/2` rides along — a pre-existing local commit (the embedded-current-user helper that `phoenix_kit_projects` uses for nested-`live_render` comments). Not part of the staff work but was on the local branch.

## Verification
- `mix compile --warnings-as-errors` clean; targeted tests for the Activity `resource_uuid` filter + the embedded-current-user helper pass.
- Exercised end-to-end by the `phoenix_kit_staff` suite against this core via `PHOENIX_KIT_PATH` (504 tests, 0 failures).

## Test plan
- [x] compile (warnings as errors)
- [x] `test/integration/activity_filter_test.exs` green
- [x] downstream staff suite green against this branch
- [ ] release a new core version so staff can bump its lock off the path-override