### PR TITLE
Activity page: one-row mobile filters, grid/list toggle, and mobile list

### DIFF
--- a/lib/phoenix_kit_web/live/activity/index.ex
+++ b/lib/phoenix_kit_web/live/activity/index.ex
@@ -11,10 +11,15 @@ defmodule PhoenixKitWeb.Live.Activity.Index do
   alias PhoenixKit.Activity
   alias PhoenixKit.PubSub.Manager, as: PubSubManager
   alias PhoenixKit.Settings
+  alias PhoenixKit.Users.Auth
   alias PhoenixKit.Users.Auth.Scope
   alias PhoenixKit.Utils.Date, as: UtilsDate
   alias PhoenixKit.Utils.Routes
   alias PhoenixKit.Utils.Values
+
+  # Per-admin grid/list preference for the activity table, persisted in the
+  # current user's custom_fields (mirrors the users table view toggle).
+  @view_mode_key "activity_view_mode"
 
   @impl true
   def mount(_params, _session, socket) do
@@ -35,6 +40,7 @@ defmodule PhoenixKitWeb.Live.Activity.Index do
         |> assign(:modes, Activity.list_modes())
         |> assign(:action_types, Activity.list_action_types())
         |> assign(:resource_types, Activity.list_resource_types())
+        |> assign(:view_mode, load_user_view_mode(socket.assigns[:phoenix_kit_current_user]))
         |> assign_filter_defaults()
         |> load_activities()
 
@@ -76,6 +82,16 @@ defmodule PhoenixKitWeb.Live.Activity.Index do
   @impl true
   def handle_event("clear_filters", _params, socket) do
     {:noreply, push_patch(socket, to: Routes.path("/admin/activity"))}
+  end
+
+  @impl true
+  def handle_event("set_view_mode", %{"mode" => mode}, socket) when mode in ["card", "table"] do
+    user = persist_user_view_mode(socket.assigns[:phoenix_kit_current_user], mode)
+
+    {:noreply,
+     socket
+     |> assign(:phoenix_kit_current_user, user)
+     |> assign(:view_mode, mode)}
   end
 
   @impl true
@@ -129,6 +145,29 @@ defmodule PhoenixKitWeb.Live.Activity.Index do
   defp maybe_put(map, _key, nil), do: map
   defp maybe_put(map, _key, ""), do: map
   defp maybe_put(map, key, value), do: Map.put(map, key, value)
+
+  # Per-user table/card preference, defaulting to "table". Mirrors the users
+  # table; persisted in the current user's custom_fields.
+  defp load_user_view_mode(%{} = user) do
+    case Auth.get_user_field(user, @view_mode_key) do
+      mode when mode in ["card", "table"] -> mode
+      _ -> "table"
+    end
+  end
+
+  defp load_user_view_mode(_), do: "table"
+
+  defp persist_user_view_mode(%{uuid: uuid} = user, mode) when is_binary(uuid) do
+    fresh = Auth.get_user(uuid) || user
+    merged = Map.put(fresh.custom_fields || %{}, @view_mode_key, mode)
+
+    case Auth.update_user_custom_fields(fresh, merged) do
+      {:ok, updated} -> updated
+      {:error, _} -> user
+    end
+  end
+
+  defp persist_user_view_mode(user, _mode), do: user
 
   # Build a filtered activity path, merging the current filters with `overrides`
   # (a keyword list like `[module: "posts"]`; pass `""` to clear a filter). Used

--- a/lib/phoenix_kit_web/live/activity/index.ex
+++ b/lib/phoenix_kit_web/live/activity/index.ex
@@ -130,6 +130,24 @@ defmodule PhoenixKitWeb.Live.Activity.Index do
   defp maybe_put(map, _key, ""), do: map
   defp maybe_put(map, key, value), do: Map.put(map, key, value)
 
+  # Build a filtered activity path, merging the current filters with `overrides`
+  # (a keyword list like `[module: "posts"]`; pass `""` to clear a filter). Used
+  # by the toolbar filter dropdowns so picking one filter preserves the others.
+  defp filter_path(assigns, overrides) do
+    query =
+      %{
+        "module" => assigns[:filter_module],
+        "mode" => assigns[:filter_mode],
+        "action" => assigns[:filter_action],
+        "resource_type" => assigns[:filter_resource_type]
+      }
+      |> Map.merge(Map.new(overrides, fn {k, v} -> {to_string(k), v} end))
+      |> Enum.reject(fn {_k, v} -> v in [nil, ""] end)
+      |> URI.encode_query()
+
+    Routes.path("/admin/activity" <> if(query == "", do: "", else: "?#{query}"))
+  end
+
   defp parse_int(nil, default), do: default
 
   defp parse_int(str, default) when is_binary(str) do

--- a/lib/phoenix_kit_web/live/activity/index.html.heex
+++ b/lib/phoenix_kit_web/live/activity/index.html.heex
@@ -60,52 +60,172 @@
       }
     >
       <:toolbar_title>
-        <.form for={%{}} phx-change="filter" class="flex flex-wrap items-center gap-2">
-          <span class="text-sm text-base-content/70 whitespace-nowrap">
-            {gettext("Module:")}
-          </span>
-          <select name="filter[module]" class="select select-sm w-36 min-w-0">
-            <option value="">{gettext("All Modules")}</option>
-            <%= for mod <- @modules do %>
-              <option value={mod} selected={@filter_module == mod}>
-                {String.capitalize(mod)}
-              </option>
-            <% end %>
-          </select>
-          <span class="text-sm text-base-content/70 whitespace-nowrap">
-            {gettext("Mode:")}
-          </span>
-          <select name="filter[mode]" class="select select-sm w-32 min-w-0">
-            <option value="">{gettext("All Modes")}</option>
-            <%= for mode <- @modes do %>
-              <option value={mode} selected={@filter_mode == mode}>
-                {String.capitalize(mode)}
-              </option>
-            <% end %>
-          </select>
-          <span class="text-sm text-base-content/70 whitespace-nowrap">
-            {gettext("Action:")}
-          </span>
-          <select name="filter[action]" class="select select-sm w-40 min-w-0">
-            <option value="">{gettext("All Actions")}</option>
-            <%= for action <- @action_types do %>
-              <option value={action} selected={@filter_action == action}>
-                {action}
-              </option>
-            <% end %>
-          </select>
-          <span class="text-sm text-base-content/70 whitespace-nowrap">
-            {gettext("Type:")}
-          </span>
-          <select name="filter[resource_type]" class="select select-sm w-36 min-w-0">
-            <option value="">{gettext("All Types")}</option>
-            <%= for rt <- @resource_types do %>
-              <option value={rt} selected={@filter_resource_type == rt}>
-                {String.capitalize(rt)}
-              </option>
-            <% end %>
-          </select>
-        </.form>
+        <%!-- Filters as compact media-style dropdowns: each shows an icon, with
+             the active value's label (revealed on mobile only when set) so the
+             whole toolbar holds one row. Options are patch links that preserve
+             the other filters via filter_path/2. --%>
+        <div class="flex flex-wrap items-center gap-2">
+          <%!-- Module --%>
+          <div class="dropdown">
+            <div
+              tabindex="0"
+              role="button"
+              class={["btn btn-sm gap-2", @filter_module && "btn-active"]}
+            >
+              <.icon name="hero-cube" class="w-4 h-4" />
+              <span class={["sm:inline", is_nil(@filter_module) && "hidden"]}>
+                {(@filter_module && String.capitalize(@filter_module)) || gettext("Module")}
+              </span>
+              <.icon
+                name="hero-chevron-down"
+                class="hidden sm:inline-block w-3.5 h-3.5 opacity-60"
+              />
+            </div>
+            <ul
+              tabindex="0"
+              onclick="document.activeElement.blur()"
+              class="dropdown-content menu bg-base-100 rounded-box z-20 w-52 p-2 shadow border border-base-200 max-h-72 overflow-y-auto flex-nowrap"
+            >
+              <li>
+                <.link
+                  patch={filter_path(assigns, module: "")}
+                  class={is_nil(@filter_module) && "active"}
+                >
+                  {gettext("All Modules")}
+                </.link>
+              </li>
+              <li :for={mod <- @modules}>
+                <.link
+                  patch={filter_path(assigns, module: mod)}
+                  class={@filter_module == mod && "active"}
+                >
+                  {String.capitalize(mod)}
+                </.link>
+              </li>
+            </ul>
+          </div>
+          <%!-- Mode --%>
+          <div class="dropdown">
+            <div
+              tabindex="0"
+              role="button"
+              class={["btn btn-sm gap-2", @filter_mode && "btn-active"]}
+            >
+              <.icon name="hero-cog-6-tooth" class="w-4 h-4" />
+              <span class={["sm:inline", is_nil(@filter_mode) && "hidden"]}>
+                {(@filter_mode && String.capitalize(@filter_mode)) || gettext("Mode")}
+              </span>
+              <.icon
+                name="hero-chevron-down"
+                class="hidden sm:inline-block w-3.5 h-3.5 opacity-60"
+              />
+            </div>
+            <ul
+              tabindex="0"
+              onclick="document.activeElement.blur()"
+              class="dropdown-content menu bg-base-100 rounded-box z-20 w-52 p-2 shadow border border-base-200 max-h-72 overflow-y-auto flex-nowrap"
+            >
+              <li>
+                <.link
+                  patch={filter_path(assigns, mode: "")}
+                  class={is_nil(@filter_mode) && "active"}
+                >
+                  {gettext("All Modes")}
+                </.link>
+              </li>
+              <li :for={mode <- @modes}>
+                <.link
+                  patch={filter_path(assigns, mode: mode)}
+                  class={@filter_mode == mode && "active"}
+                >
+                  {String.capitalize(mode)}
+                </.link>
+              </li>
+            </ul>
+          </div>
+          <%!-- Action --%>
+          <div class="dropdown">
+            <div
+              tabindex="0"
+              role="button"
+              class={["btn btn-sm gap-2", @filter_action && "btn-active"]}
+            >
+              <.icon name="hero-bolt" class="w-4 h-4" />
+              <span class={[
+                "sm:inline truncate max-w-[10rem]",
+                is_nil(@filter_action) && "hidden"
+              ]}>
+                {@filter_action || gettext("Action")}
+              </span>
+              <.icon
+                name="hero-chevron-down"
+                class="hidden sm:inline-block w-3.5 h-3.5 opacity-60"
+              />
+            </div>
+            <ul
+              tabindex="0"
+              onclick="document.activeElement.blur()"
+              class="dropdown-content menu bg-base-100 rounded-box z-20 w-56 p-2 shadow border border-base-200 max-h-72 overflow-y-auto flex-nowrap"
+            >
+              <li>
+                <.link
+                  patch={filter_path(assigns, action: "")}
+                  class={is_nil(@filter_action) && "active"}
+                >
+                  {gettext("All Actions")}
+                </.link>
+              </li>
+              <li :for={action <- @action_types}>
+                <.link
+                  patch={filter_path(assigns, action: action)}
+                  class={@filter_action == action && "active"}
+                >
+                  {action}
+                </.link>
+              </li>
+            </ul>
+          </div>
+          <%!-- Type --%>
+          <div class="dropdown">
+            <div
+              tabindex="0"
+              role="button"
+              class={["btn btn-sm gap-2", @filter_resource_type && "btn-active"]}
+            >
+              <.icon name="hero-tag" class="w-4 h-4" />
+              <span class={["sm:inline", is_nil(@filter_resource_type) && "hidden"]}>
+                {(@filter_resource_type && String.capitalize(@filter_resource_type)) ||
+                  gettext("Type")}
+              </span>
+              <.icon
+                name="hero-chevron-down"
+                class="hidden sm:inline-block w-3.5 h-3.5 opacity-60"
+              />
+            </div>
+            <ul
+              tabindex="0"
+              onclick="document.activeElement.blur()"
+              class="dropdown-content menu bg-base-100 rounded-box z-20 w-52 p-2 shadow border border-base-200 max-h-72 overflow-y-auto flex-nowrap"
+            >
+              <li>
+                <.link
+                  patch={filter_path(assigns, resource_type: "")}
+                  class={is_nil(@filter_resource_type) && "active"}
+                >
+                  {gettext("All Types")}
+                </.link>
+              </li>
+              <li :for={rt <- @resource_types}>
+                <.link
+                  patch={filter_path(assigns, resource_type: rt)}
+                  class={@filter_resource_type == rt && "active"}
+                >
+                  {String.capitalize(rt)}
+                </.link>
+              </li>
+            </ul>
+          </div>
+        </div>
       </:toolbar_title>
       <:toolbar_actions>
         <span class="text-sm text-base-content/60 whitespace-nowrap">

--- a/lib/phoenix_kit_web/live/activity/index.html.heex
+++ b/lib/phoenix_kit_web/live/activity/index.html.heex
@@ -14,8 +14,11 @@
       id="activity-table"
       variant="zebra"
       size="sm"
-      class="w-full"
+      class="w-full table-fixed md:table-auto"
       toggleable={true}
+      show_toggle={false}
+      view_mode={@view_mode}
+      view_event="set_view_mode"
       items={@entries}
       card_title={fn entry -> entry.action end}
       card_fields={
@@ -65,6 +68,45 @@
              whole toolbar holds one row. Options are patch links that preserve
              the other filters via filter_path/2. --%>
         <div class="flex flex-wrap items-center gap-2">
+          <%!-- Display (grid/list) — media-style dropdown --%>
+          <% display_options = [
+            {"card", gettext("Grid"), "hero-squares-2x2"},
+            {"table", gettext("List"), "hero-bars-3-bottom-left"}
+          ] %>
+          <div class="dropdown">
+            <div tabindex="0" role="button" class="btn btn-sm gap-2">
+              <.icon
+                name={
+                  if @view_mode == "table",
+                    do: "hero-bars-3-bottom-left",
+                    else: "hero-squares-2x2"
+                }
+                class="w-4 h-4"
+              />
+              <span class="hidden sm:inline">
+                {if @view_mode == "table", do: gettext("List"), else: gettext("Grid")}
+              </span>
+              <.icon
+                name="hero-chevron-down"
+                class="hidden sm:inline-block w-3.5 h-3.5 opacity-60"
+              />
+            </div>
+            <ul
+              tabindex="0"
+              onclick="document.activeElement.blur()"
+              class="dropdown-content menu bg-base-100 rounded-box z-20 w-44 p-2 shadow border border-base-200"
+            >
+              <li :for={{val, label, icon} <- display_options}>
+                <button
+                  phx-click="set_view_mode"
+                  phx-value-mode={val}
+                  class={@view_mode == val && "active"}
+                >
+                  <.icon name={icon} class="w-4 h-4" /> {label}
+                </button>
+              </li>
+            </ul>
+          </div>
           <%!-- Module --%>
           <div class="dropdown">
             <div
@@ -254,14 +296,26 @@
 
       <.table_default_header>
         <.table_default_row hover={false}>
-          <.table_default_header_cell>{gettext("Module")}</.table_default_header_cell>
-          <.table_default_header_cell>{gettext("Mode")}</.table_default_header_cell>
+          <.table_default_header_cell class="hidden md:table-cell">
+            {gettext("Module")}
+          </.table_default_header_cell>
+          <.table_default_header_cell class="hidden md:table-cell">
+            {gettext("Mode")}
+          </.table_default_header_cell>
           <.table_default_header_cell>{gettext("Activity")}</.table_default_header_cell>
-          <.table_default_header_cell>{gettext("Actor")}</.table_default_header_cell>
-          <.table_default_header_cell>{gettext("Details")}</.table_default_header_cell>
-          <.table_default_header_cell>{gettext("Subject")}</.table_default_header_cell>
-          <.table_default_header_cell>{gettext("Date")}</.table_default_header_cell>
-          <.table_default_header_cell class="w-12"></.table_default_header_cell>
+          <.table_default_header_cell class="hidden md:table-cell">
+            {gettext("Actor")}
+          </.table_default_header_cell>
+          <.table_default_header_cell class="hidden md:table-cell">
+            {gettext("Details")}
+          </.table_default_header_cell>
+          <.table_default_header_cell class="hidden md:table-cell">
+            {gettext("Subject")}
+          </.table_default_header_cell>
+          <.table_default_header_cell class="hidden md:table-cell">
+            {gettext("Date")}
+          </.table_default_header_cell>
+          <.table_default_header_cell class="w-12 md:w-auto"></.table_default_header_cell>
         </.table_default_row>
       </.table_default_header>
 
@@ -289,14 +343,14 @@
         <% end %>
         <%= for entry <- @entries do %>
           <.table_default_row>
-            <.table_default_cell class="text-sm">
+            <.table_default_cell class="text-sm hidden md:table-cell">
               <%= if entry.module do %>
                 <span class="badge badge-outline badge-xs">{entry.module}</span>
               <% else %>
                 <span class="text-base-content/30">—</span>
               <% end %>
             </.table_default_cell>
-            <.table_default_cell class="text-sm">
+            <.table_default_cell class="text-sm hidden md:table-cell">
               <%= if entry.mode do %>
                 <span class={"badge badge-xs #{mode_badge_color(entry.mode)}"}>
                   {entry.mode}
@@ -309,8 +363,12 @@
               <span class={"badge badge-sm #{action_badge_color(entry.action)}"}>
                 {entry.action}
               </span>
+              <%!-- Actor folded in on mobile (the Actor column is hidden there). --%>
+              <div class="md:hidden text-xs text-base-content/60 truncate mt-0.5">
+                {if entry.actor, do: entry.actor.email, else: gettext("System")}
+              </div>
             </.table_default_cell>
-            <.table_default_cell class="text-sm">
+            <.table_default_cell class="text-sm hidden md:table-cell">
               <%= if entry.actor do %>
                 <span class="font-semibold">{entry.actor.email}</span>
                 <%= if entry.metadata["actor_role"] do %>
@@ -328,7 +386,7 @@
                 <span class="text-base-content/50">{gettext("System")}</span>
               <% end %>
             </.table_default_cell>
-            <.table_default_cell class="text-xs text-base-content/60">
+            <.table_default_cell class="text-xs text-base-content/60 hidden md:table-cell">
               <%= if entry.target && entry.target_uuid != entry.resource_uuid do %>
                 <div class="mb-0.5">
                   <span class="text-base-content/50">&rarr;</span>
@@ -342,7 +400,7 @@
                 <span class="text-base-content/30">—</span>
               <% end %>
             </.table_default_cell>
-            <.table_default_cell>
+            <.table_default_cell class="hidden md:table-cell">
               <%= if entry.resource_type do %>
                 <span class="badge badge-ghost badge-xs">{entry.resource_type}</span>
                 <%= case Map.get(@resource_users, entry.resource_uuid) do %>
@@ -359,7 +417,7 @@
                 <span class="text-base-content/30">—</span>
               <% end %>
             </.table_default_cell>
-            <.table_default_cell class="text-xs text-base-content/60">
+            <.table_default_cell class="text-xs text-base-content/60 hidden md:table-cell">
               <div>{UtilsDate.format_date_with_user_format(entry.inserted_at)}</div>
               <div class="text-base-content/40">
                 {UtilsDate.format_time_with_user_format(entry.inserted_at)}

--- a/lib/phoenix_kit_web/users/user_form.html.heex
+++ b/lib/phoenix_kit_web/users/user_form.html.heex
@@ -665,6 +665,13 @@
           <%!-- Form Actions --%>
           <div class="flex justify-end gap-3 pt-6 border-t border-base-300">
             <button
+              type="button"
+              phx-click="cancel"
+              class="btn btn-outline"
+            >
+              Cancel
+            </button>
+            <button
               type="submit"
               class="btn btn-primary"
               phx-disable-with={
@@ -676,13 +683,6 @@
               <% else %>
                 Update User
               <% end %>
-            </button>
-            <button
-              type="button"
-              phx-click="cancel"
-              class="btn btn-outline"
-            >
-              Cancel
             </button>
           </div>
         </.form>


### PR DESCRIPTION
## Summary

Follow-ups to the admin UI pass (#597, merged), covering the Activity page and a small user-form tweak.

- **Activity filter toolbar fits one row on mobile** — replaced the four label+select filter pairs with compact media-style dropdowns (Module / Mode / Action / Type): icon-only on mobile, label shown when a filter is active, `btn-active` highlight. Options are patch links that preserve the other filters via a `filter_path/2` helper, so no event-handler changes were needed.
- **Activity grid/list toggle (persisted)** — put the activity `table_default` in controlled mode with a media-style Display dropdown that works on every breakpoint and persists to the admin's `custom_fields["activity_view_mode"]` (mirrors the users table).
- **Mobile-friendly activity list** — `table-fixed` on mobile (`md:table-auto` on desktop); collapses to just the Activity column (actor folded in via a `md:hidden` sub-line) plus the View action, the rest `hidden md:table-cell`.
- **User form button order** — Cancel on the left, the primary Create/Update User on the right, matching the rest of the admin UI.

Verified: `mix compile --warnings-as-errors`, `mix credo --strict` (0 issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)