### PR TITLE
Drive the markdown editor with a LiveView hook (CSP-safe, navigation-proof)

### DIFF
--- a/lib/phoenix_kit_web/components/core/markdown_editor.ex
+++ b/lib/phoenix_kit_web/components/core/markdown_editor.ex
@@ -67,16 +67,24 @@ defmodule PhoenixKitWeb.Components.Core.MarkdownEditor do
         text: "<Image file_id=\\"abc123\\" />"
       )
 
-  ## CSP Nonce
+      # Prompt the user (window.prompt) on the client, then insert the value by
+      # substituting `%{value}` in `template` (e.g. a video URL):
+      send_update(PhoenixKitWeb.Components.Core.MarkdownEditor,
+        id: "content-editor",
+        action: :prompt_insert,
+        prompt: "Enter YouTube URL:",
+        template: "\\n![Video](%{value})\\n"
+      )
 
-  If your app uses Content Security Policy, pass the nonce:
+  ## JavaScript / CSP
 
-      <.live_component
-        module={PhoenixKitWeb.Components.Core.MarkdownEditor}
-        id="editor"
-        content={@content}
-        script_nonce={assigns[:csp_nonce] || ""}
-      />
+  All behavior is driven by the `MarkdownEditor` LiveView hook (shipped in
+  `priv/static/assets/phoenix_kit.js` as `window.PhoenixKitHooks.MarkdownEditor`),
+  not by inline `<script>` or `onclick=` handlers. That means it works under a
+  strict Content-Security-Policy with no nonce and survives LiveView navigation.
+  The host only needs the vendored `phoenix_kit.js` loaded (the standard install;
+  `mix phoenix_kit.update` refreshes it) and `window.PhoenixKitHooks` spread into
+  its LiveSocket — exactly like every other PhoenixKit hook.
   """
   use Phoenix.LiveComponent
   use Gettext, backend: PhoenixKitWeb.Gettext
@@ -95,7 +103,6 @@ defmodule PhoenixKitWeb.Components.Core.MarkdownEditor do
      |> assign_new(:height, fn -> "480px" end)
      |> assign_new(:debounce, fn -> 400 end)
      |> assign_new(:protect_navigation, fn -> true end)
-     |> assign_new(:script_nonce, fn -> "" end)
      |> assign_new(:show_save_button, fn -> false end)
      |> assign_new(:readonly, fn -> false end)}
   end
@@ -105,6 +112,20 @@ defmodule PhoenixKitWeb.Components.Core.MarkdownEditor do
     # Trigger JS to insert text at cursor via push_event
     global_id = String.replace(socket.assigns.id, "-", "_")
     {:ok, push_event(socket, "markdown-editor-insert", %{global_id: global_id, text: text})}
+  end
+
+  # Ask the user for a value (window.prompt) on the client, then insert it at the
+  # cursor by substituting `%{value}` in `template`. Lets a host trigger a
+  # client-side prompt (e.g. a video URL) without any inline script of its own.
+  def update(%{action: :prompt_insert} = assigns, socket) do
+    global_id = String.replace(socket.assigns.id, "-", "_")
+
+    {:ok,
+     push_event(socket, "markdown-editor-prompt-insert", %{
+       global_id: global_id,
+       prompt: Map.get(assigns, :prompt, ""),
+       template: Map.get(assigns, :template, "%{value}")
+     })}
   end
 
   def update(assigns, socket) do
@@ -120,332 +141,45 @@ defmodule PhoenixKitWeb.Components.Core.MarkdownEditor do
     <div
       class="markdown-editor"
       id={@id}
+      phx-hook="MarkdownEditor"
       data-markdown-editor="true"
       data-global-id={@global_id}
       data-protect-navigation={@protect_navigation}
+      data-save-status={@save_status}
     >
-      <%!--
-        Global initialization script - uses MutationObserver to detect when
-        markdown editors are added to the DOM (including on LiveView navigation)
-      --%>
-      <script nonce={@script_nonce} data-editor-id={@id}>
-        (function() {
-          window.markdownEditors = window.markdownEditors || {};
-
-          // Define init function globally so MutationObserver can always find it
-          window.phoenixKitInitEditor = window.phoenixKitInitEditor || function(editorEl, attempt) {
-            attempt = attempt || 0;
-            const maxAttempts = 20;
-            const editorId = editorEl.id;
-            const globalId = editorEl.dataset.globalId;
-            const textareaId = editorId + '-textarea';
-            const protectNavigation = editorEl.dataset.protectNavigation === 'true';
-
-            const textarea = document.getElementById(textareaId);
-            const warningEl = document.getElementById(editorId + '-js-warning');
-
-            if (!textarea) {
-              if (attempt >= maxAttempts) {
-                console.error('[MarkdownEditor] Failed to initialize:', editorId, '- textarea not found after', maxAttempts, 'attempts');
-                // Show warning on failure
-                if (warningEl) warningEl.classList.remove('hidden');
-                return;
-              }
-              // Textarea not ready yet, retry shortly
-              setTimeout(function() { window.phoenixKitInitEditor(editorEl, attempt + 1); }, 50);
-              return;
-            }
-
-            // Check if already initialized with current textarea
-            const existing = window.markdownEditors[editorId];
-            if (existing && existing.textarea === textarea && existing.initialized) {
-              return;
-            }
-
-            // Store state in namespaced object
-            const state = {
-              textarea: textarea,
-              lastCursorPosition: 0,
-              hasUnsavedChanges: false,
-              initialized: true
-            };
-            window.markdownEditors[editorId] = state;
-
-            // Setup cursor tracking
-            const events = ['blur', 'select', 'click', 'keyup'];
-            events.forEach(function(event) {
-              textarea.addEventListener(event, function() {
-                const s = window.markdownEditors[editorId];
-                if (s) s.lastCursorPosition = textarea.selectionStart;
-              });
-            });
-
-            // Auto-continue lists on Enter
-            textarea.addEventListener('keydown', function(e) {
-              if (e.key !== 'Enter') return;
-
-              const pos = textarea.selectionStart;
-              const value = textarea.value;
-
-              // Find current line
-              const lineStart = value.lastIndexOf('\n', pos - 1) + 1;
-              const lineEnd = value.indexOf('\n', pos);
-              const currentLine = value.substring(lineStart, lineEnd === -1 ? value.length : lineEnd);
-
-              // Check if cursor is at end of line
-              const cursorInLine = pos - lineStart;
-              if (cursorInLine < currentLine.length) return; // Cursor not at end, let default happen
-
-              // Match bullet list: "  - text" or "  * text" or "  + text"
-              const bulletMatch = currentLine.match(/^(\s*)(-|\*|\+)\s(.*)$/);
-              if (bulletMatch) {
-                e.preventDefault();
-                const [, indent, marker, content] = bulletMatch;
-
-                if (content.trim() === '') {
-                  // Empty list item - remove marker
-                  const newValue = value.substring(0, lineStart) + value.substring(pos);
-                  textarea.value = newValue;
-                  textarea.selectionStart = textarea.selectionEnd = lineStart;
-                } else {
-                  // Continue list
-                  const insertion = '\n' + indent + marker + ' ';
-                  const newValue = value.substring(0, pos) + insertion + value.substring(pos);
-                  textarea.value = newValue;
-                  textarea.selectionStart = textarea.selectionEnd = pos + insertion.length;
-                }
-                const s = window.markdownEditors[editorId];
-                if (s) s.lastCursorPosition = textarea.selectionStart;
-                textarea.dispatchEvent(new KeyboardEvent('keyup', { bubbles: true }));
-                return;
-              }
-
-              // Match numbered list: "  1. text"
-              const numberMatch = currentLine.match(/^(\s*)(\d+)\.\s(.*)$/);
-              if (numberMatch) {
-                e.preventDefault();
-                const [, indent, num, content] = numberMatch;
-
-                if (content.trim() === '') {
-                  // Empty list item - remove marker
-                  const newValue = value.substring(0, lineStart) + value.substring(pos);
-                  textarea.value = newValue;
-                  textarea.selectionStart = textarea.selectionEnd = lineStart;
-                } else {
-                  // Continue with next number
-                  const nextNum = parseInt(num, 10) + 1;
-                  const insertion = '\n' + indent + nextNum + '. ';
-                  const newValue = value.substring(0, pos) + insertion + value.substring(pos);
-                  textarea.value = newValue;
-                  textarea.selectionStart = textarea.selectionEnd = pos + insertion.length;
-                }
-                const s = window.markdownEditors[editorId];
-                if (s) s.lastCursorPosition = textarea.selectionStart;
-                textarea.dispatchEvent(new KeyboardEvent('keyup', { bubbles: true }));
-                return;
-              }
-            });
-
-            // Register global functions
-            window['markdownEditorInsert_' + globalId] = function(text) {
-              const s = window.markdownEditors[editorId];
-              if (!s || !s.textarea) return;
-
-              const start = s.lastCursorPosition || 0;
-              const currentValue = s.textarea.value;
-              const newValue = currentValue.substring(0, start) + text + currentValue.substring(start);
-
-              s.textarea.value = newValue;
-              const newCursorPos = start + text.length;
-              s.textarea.selectionStart = s.textarea.selectionEnd = newCursorPos;
-              s.lastCursorPosition = newCursorPos;
-
-              s.textarea.focus();
-              s.textarea.dispatchEvent(new KeyboardEvent('keyup', { bubbles: true }));
-            };
-
-            window['markdownFormat_' + globalId] = function(prefix, suffix) {
-              const s = window.markdownEditors[editorId];
-              if (!s || !s.textarea) return;
-
-              const start = s.textarea.selectionStart;
-              const end = s.textarea.selectionEnd;
-              const selected = s.textarea.value.substring(start, end);
-              const before = s.textarea.value.substring(0, start);
-              const after = s.textarea.value.substring(end);
-
-              if (selected.length > 0) {
-                s.textarea.value = before + prefix + selected + suffix + after;
-                s.textarea.selectionStart = start + prefix.length;
-                s.textarea.selectionEnd = end + prefix.length;
-              } else {
-                const placeholder = "text";
-                s.textarea.value = before + prefix + placeholder + suffix + after;
-                s.textarea.selectionStart = start + prefix.length;
-                s.textarea.selectionEnd = start + prefix.length + placeholder.length;
-              }
-
-              s.textarea.focus();
-              s.textarea.dispatchEvent(new KeyboardEvent('keyup', { bubbles: true }));
-              s.lastCursorPosition = s.textarea.selectionEnd;
-            };
-
-            window['markdownLinePrefix_' + globalId] = function(prefix) {
-              const s = window.markdownEditors[editorId];
-              if (!s || !s.textarea) return;
-
-              const start = s.textarea.selectionStart;
-              const value = s.textarea.value;
-
-              let lineStart = value.lastIndexOf('\n', start - 1) + 1;
-              const before = value.substring(0, lineStart);
-              const after = value.substring(lineStart);
-
-              s.textarea.value = before + prefix + after;
-              const newPos = start + prefix.length;
-              s.textarea.selectionStart = s.textarea.selectionEnd = newPos;
-
-              s.textarea.focus();
-              s.textarea.dispatchEvent(new KeyboardEvent('keyup', { bubbles: true }));
-              s.lastCursorPosition = newPos;
-            };
-
-            window['markdownLink_' + globalId] = function() {
-              const s = window.markdownEditors[editorId];
-              if (!s || !s.textarea) return;
-
-              const url = prompt('Enter URL:');
-              if (!url || !url.trim()) return;
-
-              const start = s.textarea.selectionStart;
-              const end = s.textarea.selectionEnd;
-              const selected = s.textarea.value.substring(start, end);
-              const linkText = selected.length > 0 ? selected : 'link text';
-
-              const before = s.textarea.value.substring(0, start);
-              const after = s.textarea.value.substring(end);
-
-              s.textarea.value = before + '[' + linkText + '](' + url.trim() + ')' + after;
-
-              const newPos = start + linkText.length + url.trim().length + 4;
-              s.textarea.selectionStart = s.textarea.selectionEnd = newPos;
-
-              s.textarea.focus();
-              s.textarea.dispatchEvent(new KeyboardEvent('keyup', { bubbles: true }));
-              s.lastCursorPosition = newPos;
-            };
-
-            // Browser exit protection
-            if (protectNavigation && !window['markdownEditorBeforeUnload_' + globalId]) {
-              window['markdownEditorBeforeUnload_' + globalId] = true;
-              window.addEventListener('beforeunload', function(e) {
-                const s = window.markdownEditors && window.markdownEditors[editorId];
-                if (s && s.hasUnsavedChanges) {
-                  e.preventDefault();
-                  e.returnValue = '';
-                  return '';
-                }
-              });
-            }
-
-          };
-
-          function initAllEditors() {
-            document.querySelectorAll('[data-markdown-editor="true"]').forEach(window.phoenixKitInitEditor);
-          }
-
-          // CRITICAL: Always init THIS specific editor immediately when script runs
-          // This ensures the editor works even on LiveView navigation
-          var scriptEl = document.currentScript;
-          if (scriptEl && scriptEl.dataset.editorId) {
-            var thisEditor = document.getElementById(scriptEl.dataset.editorId);
-            if (thisEditor) {
-              window.phoenixKitInitEditor(thisEditor);
-            }
-          }
-
-          // Only set up global listeners once
-          if (!window.phoenixKitEditorSystemInit) {
-            window.phoenixKitEditorSystemInit = true;
-
-            // Watch for new editors added to DOM (LiveView navigation)
-            const observer = new MutationObserver(function(mutations) {
-              mutations.forEach(function(mutation) {
-                mutation.addedNodes.forEach(function(node) {
-                  if (node.nodeType === Node.ELEMENT_NODE) {
-                    // Check if the added node is an editor
-                    if (node.dataset && node.dataset.markdownEditor === 'true') {
-                      window.phoenixKitInitEditor(node);
-                    }
-                    // Check children for editors
-                    if (node.querySelectorAll) {
-                      node.querySelectorAll('[data-markdown-editor="true"]').forEach(window.phoenixKitInitEditor);
-                    }
-                  }
-                });
-              });
-            });
-
-            observer.observe(document.body, { childList: true, subtree: true });
-
-            // Also re-init on LiveView page load events as a fallback
-            window.addEventListener('phx:page-loading-stop', function() {
-              setTimeout(initAllEditors, 100);
-            });
-
-            // Listen for insert events from LiveView
-            window.addEventListener('phx:markdown-editor-insert', function(e) {
-              const globalId = e.detail.global_id;
-              const text = e.detail.text;
-              const insertFn = window['markdownEditorInsert_' + globalId];
-              if (insertFn) {
-                insertFn(text);
-              }
-            });
-
-            // Listen for set-content events from LiveView (for collaborative editing sync)
-            window.addEventListener('phx:set-content', function(e) {
-              const content = e.detail.content;
-              // Update all markdown editor textareas on the page
-              document.querySelectorAll('[data-markdown-editor="true"] textarea').forEach(function(textarea) {
-                textarea.value = content;
-              });
-            });
-          }
-        })();
-      </script>
-
-      <%!-- JS Warning Banner - hidden by default, shown only if JS fails to initialize --%>
-      <div
-        id={"#{@id}-js-warning"}
-        class="alert alert-warning mb-2 flex items-start gap-3 hidden"
-        role="alert"
-      >
-        <.icon name="hero-exclamation-triangle" class="w-5 h-5 shrink-0" />
-        <div>
-          <p class="font-semibold text-base-content">
-            {gettext("Interactive editor features need JavaScript")}
-          </p>
-          <p class="text-sm text-base-content/80">
-            {gettext("Enable JavaScript or allow inline scripts for this page.")}
-          </p>
+      <%!-- The toolbars below are hidden by default and revealed by the
+           MarkdownEditor hook on mount, so JS-dependent buttons never show as
+           dead controls. When JS is disabled the hook never runs and this
+           noscript hint explains why the toolbar is absent. --%>
+      <noscript>
+        <div class="alert alert-warning mb-2 flex items-start gap-3" role="alert">
+          <.icon name="hero-exclamation-triangle" class="w-5 h-5 shrink-0" />
+          <div>
+            <p class="font-semibold text-base-content">
+              {gettext("Interactive editor features need JavaScript")}
+            </p>
+            <p class="text-sm text-base-content/80">
+              {gettext("Enable JavaScript to use the toolbar and media insertion.")}
+            </p>
+          </div>
         </div>
-      </div>
+      </noscript>
 
-      <%!-- Formatting Toolbar --%>
+      <%!-- Formatting Toolbar (hidden until the hook reveals it) --%>
       <%= if @show_formatting_toolbar do %>
         <div
-          class="flex flex-wrap items-center gap-1 mb-2 p-2 bg-base-200 rounded-lg"
-          onmousedown="event.preventDefault()"
+          class="flex flex-wrap items-center gap-1 mb-2 p-2 bg-base-200 rounded-lg hidden"
+          data-md-toolbar
         >
           <%!-- Headings --%>
           <div class="flex items-center gap-0.5 mr-2">
             <%= for level <- 1..6 do %>
               <button
                 type="button"
-                onclick={"window.markdownLinePrefix_#{@global_id}('#{"#" |> String.duplicate(level)} ')"}
+                data-md-action="line-prefix"
+                data-md-prefix={String.duplicate("#", level) <> " "}
                 class="btn btn-xs btn-ghost font-bold px-1.5"
-                title={"Heading #{level}"}
+                title={gettext("Heading %{level}", level: level)}
               >
                 H{level}
               </button>
@@ -458,7 +192,9 @@ defmodule PhoenixKitWeb.Components.Core.MarkdownEditor do
           <div class="flex items-center gap-0.5 mr-2">
             <button
               type="button"
-              onclick={"window.markdownFormat_#{@global_id}('**', '**')"}
+              data-md-action="wrap"
+              data-md-prefix="**"
+              data-md-suffix="**"
               class="btn btn-xs btn-ghost font-bold px-2"
               title={gettext("Bold")}
             >
@@ -466,7 +202,9 @@ defmodule PhoenixKitWeb.Components.Core.MarkdownEditor do
             </button>
             <button
               type="button"
-              onclick={"window.markdownFormat_#{@global_id}('*', '*')"}
+              data-md-action="wrap"
+              data-md-prefix="*"
+              data-md-suffix="*"
               class="btn btn-xs btn-ghost italic px-2"
               title={gettext("Italic")}
             >
@@ -474,7 +212,9 @@ defmodule PhoenixKitWeb.Components.Core.MarkdownEditor do
             </button>
             <button
               type="button"
-              onclick={"window.markdownFormat_#{@global_id}('~~', '~~')"}
+              data-md-action="wrap"
+              data-md-prefix="~~"
+              data-md-suffix="~~"
               class="btn btn-xs btn-ghost line-through px-2"
               title={gettext("Strikethrough")}
             >
@@ -482,7 +222,9 @@ defmodule PhoenixKitWeb.Components.Core.MarkdownEditor do
             </button>
             <button
               type="button"
-              onclick={"window.markdownFormat_#{@global_id}('`', '`')"}
+              data-md-action="wrap"
+              data-md-prefix="`"
+              data-md-suffix="`"
               class="btn btn-xs btn-ghost font-mono px-2"
               title={gettext("Inline Code")}
             >
@@ -490,7 +232,8 @@ defmodule PhoenixKitWeb.Components.Core.MarkdownEditor do
             </button>
             <button
               type="button"
-              onclick={"window.markdownEditorInsert_#{@global_id}('<br>')"}
+              data-md-action="insert"
+              data-md-text="<br>"
               class="btn btn-xs btn-ghost px-2"
               title={gettext("Line Break")}
             >
@@ -504,7 +247,7 @@ defmodule PhoenixKitWeb.Components.Core.MarkdownEditor do
           <div class="flex items-center gap-0.5 mr-2">
             <button
               type="button"
-              onclick={"window.markdownLink_#{@global_id}()"}
+              data-md-action="link"
               class="btn btn-xs btn-ghost px-2"
               title={gettext("Insert Link")}
             >
@@ -544,7 +287,8 @@ defmodule PhoenixKitWeb.Components.Core.MarkdownEditor do
           <div class="flex items-center gap-0.5">
             <button
               type="button"
-              onclick={"window.markdownLinePrefix_#{@global_id}('- ')"}
+              data-md-action="line-prefix"
+              data-md-prefix="- "
               class="btn btn-xs btn-ghost px-2"
               title={gettext("Bullet List")}
             >
@@ -552,7 +296,8 @@ defmodule PhoenixKitWeb.Components.Core.MarkdownEditor do
             </button>
             <button
               type="button"
-              onclick={"window.markdownLinePrefix_#{@global_id}('1. ')"}
+              data-md-action="line-prefix"
+              data-md-prefix="1. "
               class="btn btn-xs btn-ghost px-2"
               title={gettext("Numbered List")}
             >
@@ -611,8 +356,8 @@ defmodule PhoenixKitWeb.Components.Core.MarkdownEditor do
           <%!-- Component Toolbar --%>
           <%= if length(@toolbar) > 0 do %>
             <div
-              class="card bg-base-200 border border-base-300"
-              onmousedown="event.preventDefault()"
+              class="card bg-base-200 border border-base-300 hidden"
+              data-md-toolbar
             >
               <div class="card-body p-3">
                 <div class="flex flex-wrap items-center gap-2">
@@ -628,7 +373,6 @@ defmodule PhoenixKitWeb.Components.Core.MarkdownEditor do
                       phx-target={@myself}
                       class="btn btn-xs btn-outline gap-1"
                       title={gettext("Insert Image")}
-                      onmousedown="event.preventDefault()"
                     >
                       <.icon name="hero-photo" class="w-3 h-3" />
                       {gettext("Image")}
@@ -643,7 +387,6 @@ defmodule PhoenixKitWeb.Components.Core.MarkdownEditor do
                       phx-target={@myself}
                       class="btn btn-xs btn-outline gap-1"
                       title={gettext("Insert Video")}
-                      onmousedown="event.preventDefault()"
                     >
                       <.icon name="hero-video-camera" class="w-3 h-3" />
                       {gettext("Video")}

--- a/lib/phoenix_kit_web/components/core/modal.ex
+++ b/lib/phoenix_kit_web/components/core/modal.ex
@@ -348,6 +348,7 @@ defmodule PhoenixKitWeb.Components.Core.Modal do
             type="button"
             class={[@computed_confirm_class, (@confirm_disabled || @loading) && "btn-disabled"]}
             phx-click={@on_confirm}
+            phx-disable-with={@confirm_button_text}
             disabled={@confirm_disabled || @loading}
           >
             <%= if @loading do %>

--- a/priv/static/assets/phoenix_kit.js
+++ b/priv/static/assets/phoenix_kit.js
@@ -1391,6 +1391,263 @@ if (typeof window.Chart === "undefined") {
   };
 
   // ---------------------------------------------------------------------------
+  // MarkdownEditor
+  //
+  // Drives the core MarkdownEditor LiveComponent's textarea: cursor tracking,
+  // list auto-continue, formatting-toolbar actions (data-md-action), insert /
+  // prompt-insert pushed from the server (handleEvent), collaborative
+  // set-content sync, and unsaved-changes browser-exit protection.
+  //
+  // Replaces the component's former inline <script> + inline onclick/onmousedown
+  // handlers. Those broke under a strict Content-Security-Policy (a nonce never
+  // authorizes inline event-handler attributes, and an absent nonce blocks the
+  // <script>) and were unreliable on LiveView navigation (a patched-in <script>
+  // never re-executes). A hook always mounts on navigation and needs no inline
+  // script, so the editor now behaves like every other PhoenixKit feature.
+  // ---------------------------------------------------------------------------
+  window.PhoenixKitHooks.MarkdownEditor = {
+    mounted() {
+      this.globalId = this.el.dataset.globalId;
+      this.protectNavigation = this.el.dataset.protectNavigation === "true";
+      this.lastCursorPosition = 0;
+      this.dirty = false;
+      this._acquireTextarea();
+
+      // Reaching here means JS + the hook ran — reveal the toolbar(s), which are
+      // hidden by default so JS-dependent buttons never show as dead controls.
+      this._revealToolbars();
+
+      // Handle formatting-toolbar actions on mousedown, NOT click. preventDefault
+      // on mousedown stops focus moving to the button, so the textarea keeps its
+      // selection — a click would collapse the selection before we read it, so
+      // bold/italic/link would wrap the wrong range. This is the same reason the
+      // old markup used inline onmousedown="event.preventDefault()".
+      this._onMouseDown = (e) => this._handleToolbarMouseDown(e);
+      this.el.addEventListener("mousedown", this._onMouseDown);
+
+      // Server -> client commands. push_event from a LiveComponent fans out to
+      // EVERY MarkdownEditor hook on the page, so filter by global_id before
+      // acting (a page can host more than one editor).
+      this.handleEvent("markdown-editor-insert", ({ global_id, text }) => {
+        if (global_id === this.globalId) this._insertAtCursor(text);
+      });
+      this.handleEvent("markdown-editor-prompt-insert", ({ global_id, prompt, template }) => {
+        if (global_id !== this.globalId) return;
+        const value = window.prompt(prompt || "");
+        if (value && value.trim()) {
+          this._insertAtCursor((template || "%{value}").replace("%{value}", value.trim()));
+        }
+      });
+      this.handleEvent("set-content", ({ global_id, content }) => {
+        // No global_id → legacy broadcast to the page's editor (back-compat).
+        if (global_id && global_id !== this.globalId) return;
+        if (!this.textarea || this.textarea.value === content) return;
+        // Don't clobber the textarea mid-keystroke (collaborative spectators are
+        // read-only, so this is a safety net rather than a common path).
+        if (document.activeElement === this.textarea) return;
+        this.textarea.value = content;
+        this.lastCursorPosition = content ? content.length : 0;
+        this.dirty = false;
+      });
+      // Back-compat: publishing pushes "changes-status" on every edit. Use it to
+      // drive the unsaved-changes beforeunload guard without touching its many
+      // call sites.
+      this.handleEvent("changes-status", ({ has_changes }) => {
+        this.dirty = !!has_changes;
+      });
+
+      // Browser-exit protection for unsaved changes.
+      if (this.protectNavigation) {
+        this._beforeUnload = (e) => {
+          if (this._hasUnsavedChanges()) {
+            e.preventDefault();
+            e.returnValue = "";
+            return "";
+          }
+        };
+        window.addEventListener("beforeunload", this._beforeUnload);
+      }
+    },
+
+    updated() {
+      // morphdom usually preserves the textarea node (stable id), but re-acquire
+      // defensively in case it was replaced. Re-reveal the toolbar in case a
+      // re-render of the toolbar block restored its default `hidden` class.
+      this._acquireTextarea();
+      this._revealToolbars();
+    },
+
+    destroyed() {
+      if (this._beforeUnload) window.removeEventListener("beforeunload", this._beforeUnload);
+    },
+
+    // --- internals ---------------------------------------------------------
+
+    _revealToolbars() {
+      this.el.querySelectorAll("[data-md-toolbar]").forEach((t) => t.classList.remove("hidden"));
+    },
+
+    _acquireTextarea() {
+      const ta = this.el.querySelector("textarea");
+      if (ta === this.textarea) return;
+      this.textarea = ta;
+      if (!ta) return;
+      ta.addEventListener("blur", () => { this.lastCursorPosition = ta.selectionStart; });
+      ta.addEventListener("select", () => { this.lastCursorPosition = ta.selectionStart; });
+      ta.addEventListener("click", () => { this.lastCursorPosition = ta.selectionStart; });
+      ta.addEventListener("keyup", () => { this.lastCursorPosition = ta.selectionStart; });
+      ta.addEventListener("input", () => { this.dirty = true; });
+      ta.addEventListener("keydown", (e) => this._handleEnter(e));
+    },
+
+    _hasUnsavedChanges() {
+      const status = this.el.dataset.saveStatus;
+      return this.dirty || status === "unsaved" || status === "saving";
+    },
+
+    // Mirror the textarea's phx-keyup binding so LiveView sees the new value.
+    _notifyChange() {
+      this.dirty = true;
+      if (this.textarea) {
+        this.textarea.dispatchEvent(new KeyboardEvent("keyup", { bubbles: true }));
+      }
+    },
+
+    _insertAtCursor(text) {
+      const ta = this.textarea;
+      if (!ta || text == null) return;
+      const start = Math.min(this.lastCursorPosition || 0, ta.value.length);
+      ta.value = ta.value.substring(0, start) + text + ta.value.substring(start);
+      const pos = start + text.length;
+      ta.selectionStart = ta.selectionEnd = pos;
+      this.lastCursorPosition = pos;
+      ta.focus();
+      this._notifyChange();
+    },
+
+    _wrap(prefix, suffix) {
+      const ta = this.textarea;
+      if (!ta) return;
+      const start = ta.selectionStart;
+      const end = ta.selectionEnd;
+      const selected = ta.value.substring(start, end);
+      const before = ta.value.substring(0, start);
+      const after = ta.value.substring(end);
+      if (selected.length > 0) {
+        ta.value = before + prefix + selected + suffix + after;
+        ta.selectionStart = start + prefix.length;
+        ta.selectionEnd = end + prefix.length;
+      } else {
+        const placeholder = "text";
+        ta.value = before + prefix + placeholder + suffix + after;
+        ta.selectionStart = start + prefix.length;
+        ta.selectionEnd = start + prefix.length + placeholder.length;
+      }
+      ta.focus();
+      this.lastCursorPosition = ta.selectionEnd;
+      this._notifyChange();
+    },
+
+    _linePrefix(prefix) {
+      const ta = this.textarea;
+      if (!ta) return;
+      const start = ta.selectionStart;
+      const lineStart = ta.value.lastIndexOf("\n", start - 1) + 1;
+      ta.value = ta.value.substring(0, lineStart) + prefix + ta.value.substring(lineStart);
+      const pos = start + prefix.length;
+      ta.selectionStart = ta.selectionEnd = pos;
+      this.lastCursorPosition = pos;
+      ta.focus();
+      this._notifyChange();
+    },
+
+    _link() {
+      const ta = this.textarea;
+      if (!ta) return;
+      const url = window.prompt("Enter URL:");
+      if (!url || !url.trim()) return;
+      const start = ta.selectionStart;
+      const end = ta.selectionEnd;
+      const selected = ta.value.substring(start, end);
+      const linkText = selected.length > 0 ? selected : "link text";
+      ta.value =
+        ta.value.substring(0, start) +
+        "[" + linkText + "](" + url.trim() + ")" +
+        ta.value.substring(end);
+      const pos = start + linkText.length + url.trim().length + 4;
+      ta.selectionStart = ta.selectionEnd = pos;
+      this.lastCursorPosition = pos;
+      ta.focus();
+      this._notifyChange();
+    },
+
+    _handleToolbarMouseDown(e) {
+      if (e.button !== 0) return;
+      const toolbar = e.target.closest("[data-md-toolbar]");
+      if (!toolbar || !this.el.contains(toolbar)) return;
+      // Keep the textarea focused/selected through the button press.
+      e.preventDefault();
+      const btn = e.target.closest("[data-md-action]");
+      if (!btn) return;
+      switch (btn.dataset.mdAction) {
+        case "wrap":
+          this._wrap(btn.dataset.mdPrefix || "", btn.dataset.mdSuffix || "");
+          break;
+        case "line-prefix":
+          this._linePrefix(btn.dataset.mdPrefix || "");
+          break;
+        case "insert":
+          this._insertAtCursor(btn.dataset.mdText || "");
+          break;
+        case "link":
+          this._link();
+          break;
+      }
+    },
+
+    _handleEnter(e) {
+      if (e.key !== "Enter") return;
+      const ta = this.textarea;
+      const pos = ta.selectionStart;
+      const value = ta.value;
+      const lineStart = value.lastIndexOf("\n", pos - 1) + 1;
+      const lineEnd = value.indexOf("\n", pos);
+      const currentLine = value.substring(lineStart, lineEnd === -1 ? value.length : lineEnd);
+      // Only auto-continue when the cursor is at the end of the line.
+      if (pos - lineStart < currentLine.length) return;
+
+      const bulletMatch = currentLine.match(/^(\s*)(-|\*|\+)\s(.*)$/);
+      if (bulletMatch) {
+        e.preventDefault();
+        const [, indent, marker, content] = bulletMatch;
+        this._continueList(ta, value, pos, lineStart, content, indent + marker + " ");
+        return;
+      }
+      const numberMatch = currentLine.match(/^(\s*)(\d+)\.\s(.*)$/);
+      if (numberMatch) {
+        e.preventDefault();
+        const [, indent, num, content] = numberMatch;
+        const next = parseInt(num, 10) + 1;
+        this._continueList(ta, value, pos, lineStart, content, indent + next + ". ");
+      }
+    },
+
+    _continueList(ta, value, pos, lineStart, content, marker) {
+      if (content.trim() === "") {
+        // Empty list item — remove the marker instead of continuing.
+        ta.value = value.substring(0, lineStart) + value.substring(pos);
+        ta.selectionStart = ta.selectionEnd = lineStart;
+      } else {
+        const insertion = "\n" + marker;
+        ta.value = value.substring(0, pos) + insertion + value.substring(pos);
+        ta.selectionStart = ta.selectionEnd = pos + insertion.length;
+      }
+      this.lastCursorPosition = ta.selectionStart;
+      this._notifyChange();
+    }
+  };
+
+  // ---------------------------------------------------------------------------
   // SelectOnMount
   //
   // Focuses an input and selects all of its current value on mount. Use


### PR DESCRIPTION
## Summary

The `MarkdownEditor` component drove its toolbar and cursor/insert logic from an inline `<script>` plus inline `onclick`/`onmousedown` handlers, gated on a CSP nonce the core never populated. That combination:

- **broke under a strict Content-Security-Policy** — a nonce never authorizes inline event-handler attributes, and an absent nonce blocks the `<script>`; and
- **failed on LiveView navigation** — a patched-in `<script>` never re-executes, so the toolbar and image insertion only worked after a full page refresh (the reported "image insert needs a manual refresh" symptom).

This replaces all of it with a standard `window.PhoenixKitHooks.MarkdownEditor` LiveView hook in `priv/static/assets/phoenix_kit.js`, so the editor behaves like every other PhoenixKit hook.

### Changed
- Toolbar buttons drive the hook via `data-md-action` attributes, handled on **mousedown + preventDefault** so the textarea selection is preserved (a click would collapse it before the handler reads it).
- Server commands (`insert-at-cursor`, `set-content`) arrive via `handleEvent`, filtered by `global_id` so multiple editors on one page don't cross-fire.
- New `:prompt_insert` `update/2` action so a host can trigger a client-side `window.prompt` (e.g. a video URL) and insert the result without any inline script of its own.
- Toolbars ship `hidden` and the hook reveals them on mount, so JS-dependent buttons never render as dead controls; a `<noscript>` hint covers JS-disabled.
- Drops the now-unused `script_nonce` attr; gettext-wraps the heading-button title.

The public component API (`:insert_at_cursor` `send_update`, the `{:editor_content_changed}` host message, the attrs) is unchanged, so existing consumers (publishing, newsletters) need no edits.

## Verification
- `mix compile` + `mix format` + `mix credo --strict` clean on the component.
- Browser-tested through `phoenix_kit_parent`, reached via **live navigation** (the path that was broken): image insert with no refresh, video prompt-insert, all formatting buttons, collaborative set-content, and the newsletters editor (shared component) — 0 console errors.

## Test plan
- [x] Toolbar formatting (bold/italic/headings/lists/link) works under live navigation
- [x] Image insertion inserts immediately (no refresh)
- [x] Toolbar hidden until the hook mounts; `<noscript>` hint when JS is off
- [x] Newsletters editor (shared component) still works with no changes