### PR TITLE
Fix notification click-through links (destinations + prefix/locale)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 1.7.163 - 2026-06-22
+
+### Fixed
+- **Notification click-through links.** `Render.link_for/1` mapped only
+  `"user." <> anything` → `/dashboard/settings` (wrongly catching `user.followed`)
+  and everything else → `nil`, so social notifications (`post.*`, `comment.*`)
+  navigated nowhere and follow notifications opened the settings page. The
+  account-action → settings mapping is now an explicit whitelist;
+  `user.followed` / `post.*` / `comment.*` / `user.deleted` / unknown actions
+  return `nil` so the emitter's `notification_link` metadata drives the deep-link.
+- **Notification links now carry the recipient's locale prefix.**
+  `Render.render/2` accepts a locale that is threaded into `Routes.path`; the
+  notifications bell receives `"locale"` in its session (from `LayoutWrapper`)
+  and passes it at click time. Previously the link was built in the sticky bell's
+  process with no locale, so it used the default locale instead of the user's.
+
 ## 1.7.162 - 2026-06-18
 
 ### Added

--- a/lib/phoenix_kit/notifications/render.ex
+++ b/lib/phoenix_kit/notifications/render.ex
@@ -22,10 +22,18 @@ defmodule PhoenixKit.Notifications.Render do
   @doc """
   Returns the display payload for a notification.
 
-  `notification.activity` must be preloaded.
+  `notification.activity` must be preloaded. `locale` is the recipient's current
+  locale (base code, e.g. `"en"`); it's threaded into the built link so the
+  click-through lands on the right locale-prefixed path. When `nil`, link
+  building falls back to `Routes.path`'s `determine_locale/0` (the process
+  Gettext locale) — used by callers that don't track a locale (e.g. the admin
+  inbox). The metadata `notification_link` override is returned verbatim and is
+  expected to already be prefix/locale-correct (built via `Routes.path/1`).
   """
-  @spec render(Notification.t()) :: render_result()
-  def render(%Notification{activity: %_{} = activity}) do
+  @spec render(Notification.t(), String.t() | nil) :: render_result()
+  def render(notification, locale \\ nil)
+
+  def render(%Notification{activity: %_{} = activity}, locale) do
     meta = activity.metadata || %{}
     {default_icon, default_text} = icon_and_text(activity.action, meta)
 
@@ -34,12 +42,12 @@ defmodule PhoenixKit.Notifications.Render do
     %{
       icon: meta_string(meta, "notification_icon") || default_icon,
       text: meta_string(meta, "notification_text") || default_text,
-      link: meta_string(meta, "notification_link") || link_for(activity),
+      link: meta_string(meta, "notification_link") || link_for(activity, locale),
       actor_uuid: activity.actor_uuid
     }
   end
 
-  def render(%Notification{} = notification) do
+  def render(%Notification{} = notification, _locale) do
     # Standalone notification (V126): `activity` is nil, so this clause —
     # not the `%_{}` activity clause above — matches. (An activity-linked
     # row that wasn't preloaded carries `%Ecto.Association.NotLoaded{}`,
@@ -130,10 +138,26 @@ defmodule PhoenixKit.Notifications.Render do
 
   # ── Action → link ────────────────────────────────────────────────────
 
-  defp link_for(%_{action: "user." <> _verb}), do: Routes.path("/dashboard/settings")
+  # Core account actions that land on the user's settings page. These are the
+  # only links core can build itself; everything else (social/module actions)
+  # must ship a `notification_link` in metadata (see moduledoc). Matched
+  # explicitly — NOT via a broad `"user." <> _` prefix, which used to wrongly
+  # capture `user.followed` (a connections action) and send it to settings.
+  @account_actions ~w(
+    user.roles_updated user.status_changed user.password_changed user.password_reset
+    user.email_changed user.email_confirmed user.avatar_changed user.profile_updated
+    user.note_created user.note_deleted
+  )
 
-  # No default deep-link target: the caller decides what to do when `link` is nil.
-  defp link_for(_activity), do: nil
+  defp link_for(%_{action: action}, locale) when action in @account_actions do
+    Routes.path("/dashboard/settings", locale: locale)
+  end
+
+  # No default deep-link target for module-owned actions (user.followed, post.*,
+  # comment.*) or unknown actions, nor for user.deleted (the account is gone).
+  # The caller decides what to do when `link` is nil; a deep-link must come from
+  # the emitter's `notification_link` metadata.
+  defp link_for(_activity, _locale), do: nil
 
   # ── Helpers ──────────────────────────────────────────────────────────
 

--- a/lib/phoenix_kit_web/components/layout_wrapper.ex
+++ b/lib/phoenix_kit_web/components/layout_wrapper.ex
@@ -372,7 +372,10 @@ defmodule PhoenixKitWeb.Components.LayoutWrapper do
                     {Phoenix.Component.live_render(@socket, PhoenixKitWeb.Live.NotificationsBell,
                       id: "pk-notifications-bell",
                       sticky: true,
-                      session: %{"user_uuid" => bell_user.uuid}
+                      session: %{
+                        "user_uuid" => bell_user.uuid,
+                        "locale" => assigns[:current_locale_base]
+                      }
                     )}
                   <% end %>
                   <.admin_user_dropdown

--- a/lib/phoenix_kit_web/live/notifications_bell.ex
+++ b/lib/phoenix_kit_web/live/notifications_bell.ex
@@ -21,19 +21,23 @@ defmodule PhoenixKitWeb.Live.NotificationsBell do
   alias PhoenixKit.Notifications.Events
   alias PhoenixKit.Notifications.Render
 
-  def mount(_params, %{"user_uuid" => user_uuid}, socket) when is_binary(user_uuid) do
+  def mount(_params, %{"user_uuid" => user_uuid} = session, socket) when is_binary(user_uuid) do
     if connected?(socket), do: Events.subscribe(user_uuid)
 
+    # Recipient's current locale, threaded from the layout so click-through links
+    # land on the right locale-prefixed path (the bell is a sticky nested LV with
+    # no locale of its own — without this, Routes.path would use the default).
     {:ok,
      socket
      |> assign(:user_uuid, user_uuid)
+     |> assign(:locale, session["locale"])
      |> refresh()}
   end
 
   # Graceful fallback for embeddings without a user session — renders an
   # empty element so the layout doesn't crash for anonymous visitors.
   def mount(_params, _session, socket) do
-    {:ok, assign(socket, :user_uuid, nil)}
+    {:ok, socket |> assign(:user_uuid, nil) |> assign(:locale, nil)}
   end
 
   # ── Events ─────────────────────────────────────────────────────────
@@ -43,7 +47,7 @@ defmodule PhoenixKitWeb.Live.NotificationsBell do
 
     case Notifications.mark_seen(user_uuid, uuid) do
       {:ok, notification} ->
-        case Render.render(notification).link do
+        case Render.render(notification, socket.assigns.locale).link do
           nil -> {:noreply, refresh(socket)}
           target -> {:noreply, push_navigate(socket, to: target)}
         end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule PhoenixKit.MixProject do
   use Mix.Project
 
-  @version "1.7.162"
+  @version "1.7.163"
   @description "A foundation for building Elixir Phoenix apps — SaaS, social networks, ERP systems, marketplaces, and more"
   @source_url "https://github.com/BeamLabEU/phoenix_kit"
 

--- a/test/phoenix_kit/notifications/render_test.exs
+++ b/test/phoenix_kit/notifications/render_test.exs
@@ -1,0 +1,89 @@
+defmodule PhoenixKit.Notifications.RenderTest do
+  # DataCase (not plain ExUnit) because Render builds links via Routes.path,
+  # which reads language/prefix settings from the DB.
+  use PhoenixKit.DataCase, async: true
+
+  alias PhoenixKit.Activity.Entry
+  alias PhoenixKit.Notifications.Notification
+  alias PhoenixKit.Notifications.Render
+  alias PhoenixKit.Utils.Routes
+
+  defp notif(action, metadata \\ %{}) do
+    %Notification{
+      activity: %Entry{action: action, metadata: metadata, actor_uuid: "actor-uuid"}
+    }
+  end
+
+  describe "render/2 link — core account actions" do
+    @account_actions ~w(
+      user.roles_updated user.status_changed user.password_changed user.password_reset
+      user.email_changed user.email_confirmed user.avatar_changed user.profile_updated
+      user.note_created user.note_deleted
+    )
+
+    test "each account action links to the prefix/locale-correct settings path" do
+      for action <- @account_actions do
+        assert Render.render(notif(action), "en").link ==
+                 Routes.path("/dashboard/settings", locale: "en"),
+               "expected #{action} to link to the settings page"
+      end
+    end
+
+    test "the locale is threaded into the built link" do
+      en = Render.render(notif("user.note_created"), "en").link
+      ru = Render.render(notif("user.note_created"), "ru").link
+
+      assert en == Routes.path("/dashboard/settings", locale: "en")
+      assert ru == Routes.path("/dashboard/settings", locale: "ru")
+    end
+
+    test "render/1 (no locale) falls back to Routes.path's default-locale resolution" do
+      assert Render.render(notif("user.note_created")).link ==
+               Routes.path("/dashboard/settings")
+    end
+  end
+
+  describe "render/2 link — module-owned / unknown actions return nil" do
+    test "social and account-gone and unknown actions have no core link" do
+      for action <-
+            ~w(user.followed post.liked post.commented comment.liked user.deleted totally.unknown) do
+        assert Render.render(notif(action), "en").link == nil,
+               "expected #{action} to have no core-built link (emitter must set notification_link)"
+      end
+    end
+
+    test "user.followed no longer mis-routes to settings" do
+      refute Render.render(notif("user.followed"), "en").link ==
+               Routes.path("/dashboard/settings", locale: "en")
+    end
+  end
+
+  describe "render/2 link — notification_link metadata override" do
+    test "wins verbatim over a core account link" do
+      link =
+        Render.render(notif("user.note_created", %{"notification_link" => "/p/x"}), "en").link
+
+      assert link == "/p/x"
+    end
+
+    test "supplies the link for module-owned actions that have none" do
+      link = Render.render(notif("post.liked", %{"notification_link" => "/posts/1"}), "en").link
+      assert link == "/posts/1"
+    end
+
+    test "blank override is ignored (falls through to the action link)" do
+      link = Render.render(notif("user.note_created", %{"notification_link" => ""}), "en").link
+      assert link == Routes.path("/dashboard/settings", locale: "en")
+    end
+  end
+
+  describe "render/2 link — standalone notification (no activity)" do
+    test "uses its own metadata notification_link, else nil" do
+      # activity: nil mirrors a preloaded standalone notification (no activity_uuid).
+      assert Render.render(%Notification{activity: nil, metadata: %{"notification_link" => "/s"}}).link ==
+               "/s"
+
+      assert Render.render(%Notification{activity: nil, metadata: %{}}).link == nil
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Clicking a notification often went nowhere or to the wrong page. Two root causes, both fixed in core:

1. **`link_for/1` was threadbare** (`notifications/render.ex`). It mapped only `"user." <> anything` → `/dashboard/settings` (which wrongly captured `user.followed`, a connections action) and everything else → `nil`. So `post.*`/`comment.*` notifications navigated nowhere, and follow notifications opened the settings page.
   - Now an **explicit account-action whitelist** → settings; `user.followed` / `post.*` / `comment.*` / `user.deleted` / unknown → `nil`, so the emitter's `notification_link` metadata drives module-owned deep-links (the documented override, which `render.ex` already prefers).

2. **Links didn't carry the recipient's locale.** They're built by `Routes.path` *inside the notifications bell's process* — a sticky nested LiveView mounted with only `user_uuid`, so `determine_locale()` returned the **default** locale, not the user's. In a multi-locale app every link landed on the wrong/missing locale segment.
   - `Render.render/2` now accepts a locale threaded into `Routes.path`; the bell receives `"locale"` in its session (from `LayoutWrapper`) and passes it at click time. `render/1` is preserved (default `nil` = old behavior) so other callers are unaffected.

Adds a unit test covering per-action links, locale threading, `notification_link` override precedence, and standalone notifications. Bump 1.7.163.

**Scope note:** the actual `post`/`comment`/`follow` *deep-links* require their emitter (host glue) to set `notification_link` via `Routes.path` — core now correctly defers to that metadata, and the hello_world tutorial teaches it (companion PR).

## Verification
`mix quality` green (format, credo 0 issues, dialyzer); new tests 9/9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)