### PR TITLE
Sharper non-full-res thumbnails for grid/stack media cards

### DIFF
--- a/lib/phoenix_kit_web/components/core/media_thumbnail.ex
+++ b/lib/phoenix_kit_web/components/core/media_thumbnail.ex
@@ -11,8 +11,12 @@ defmodule PhoenixKitWeb.Components.Core.MediaThumbnail do
   @doc """
   Resolves the best thumbnail URL for a media file.
 
-  Two size modes:
-  - `:small` (default) — for selectors and grids: prefers thumbnail/small variants
+  Size modes:
+  - `:small` (default) — tiny cells (list rows, selectors): prefers the baked
+    Etcher thumbnail, then the 150px thumbnail
+  - `:card` — large grid/stack cards: prefers the baked Etcher thumbnail (400px),
+    then the 300px `small`; skips the blurry 150px thumbnail and never the
+    full-res original (which would force a live vector overlay)
   - `:medium` — for gallery/preview: prefers medium/thumbnail variants
 
   ## Attributes
@@ -31,7 +35,7 @@ defmodule PhoenixKitWeb.Components.Core.MediaThumbnail do
       </.thumbnail_url>
   """
   attr :file, :map, required: true
-  attr :size, :atom, default: :small, values: [:small, :medium]
+  attr :size, :atom, default: :small, values: [:small, :card, :medium]
   slot :inner_block, required: true
 
   def thumbnail_url(assigns) do
@@ -52,7 +56,7 @@ defmodule PhoenixKitWeb.Components.Core.MediaThumbnail do
       resolve_url(file)           # small thumbnail
       resolve_url(file, :medium)  # medium preview
   """
-  @spec resolve_url(map(), :small | :medium) :: String.t() | nil
+  @spec resolve_url(map(), :small | :card | :medium) :: String.t() | nil
   def resolve_url(file, size \\ :small)
 
   def resolve_url(%{file_type: "video", urls: urls}, _size) do
@@ -60,9 +64,18 @@ defmodule PhoenixKitWeb.Components.Core.MediaThumbnail do
   end
 
   def resolve_url(%{file_type: "image", urls: urls}, :small) do
-    # `thumbnail_annotated` (baked Etcher shapes) wins when present, so the grid
-    # shows the markup; falls back to the plain thumbnail otherwise.
+    # `thumbnail_annotated` (baked Etcher shapes) wins when present, so list rows
+    # show the markup; falls back to the plain 150px thumbnail otherwise.
     urls["thumbnail_annotated"] || urls["thumbnail"] || urls["small"] || urls["original"]
+  end
+
+  def resolve_url(%{file_type: "image", urls: urls}, :card) do
+    # Large grid/stack cards: the baked Etcher thumbnail (400px) when present
+    # shows the markup at the right quality; otherwise the 300px `small`. The
+    # blurry 150px `thumbnail` is skipped, and the full-res `original` (which
+    # would force a live vector overlay) is only the last resort — keeps the
+    # page light.
+    urls["thumbnail_annotated"] || urls["small"] || urls["medium"] || urls["original"]
   end
 
   def resolve_url(%{file_type: "image", urls: urls}, :medium) do
@@ -71,6 +84,10 @@ defmodule PhoenixKitWeb.Components.Core.MediaThumbnail do
 
   def resolve_url(%{urls: urls}, :small) do
     urls["thumbnail"] || urls["small"]
+  end
+
+  def resolve_url(%{urls: urls}, :card) do
+    urls["small"] || urls["thumbnail"] || urls["medium"]
   end
 
   def resolve_url(%{urls: urls}, :medium) do

--- a/lib/phoenix_kit_web/components/media_browser.ex
+++ b/lib/phoenix_kit_web/components/media_browser.ex
@@ -2281,7 +2281,7 @@ defmodule PhoenixKitWeb.Components.MediaBrowser do
               "absolute w-32 h-24 rounded-lg overflow-hidden shadow border border-base-100 bg-base-300",
               stack_offset_class(i)
             ]}>
-              <.thumbnail_url :let={url} file={pf} size={:small}>
+              <.thumbnail_url :let={url} file={pf} size={:card}>
                 <%= if url do %>
                   <img src={url} alt="" class="w-full h-full object-cover" />
                 <% else %>
@@ -2356,7 +2356,7 @@ defmodule PhoenixKitWeb.Components.MediaBrowser do
         phx-value-file-uuid={@file.file_uuid}
         class="block w-full h-full cursor-pointer"
       >
-        <.thumbnail_url :let={url} file={@file} size={:small}>
+        <.thumbnail_url :let={url} file={@file} size={:card}>
           <%= if url do %>
             <img
               src={url}

--- a/lib/phoenix_kit_web/components/media_browser.html.heex
+++ b/lib/phoenix_kit_web/components/media_browser.html.heex
@@ -1435,7 +1435,7 @@
                             phx-value-file-uuid={file.file_uuid}
                             class="block w-full h-full cursor-pointer"
                           >
-                            <.thumbnail_url :let={url} file={file} size={:small}>
+                            <.thumbnail_url :let={url} file={file} size={:card}>
                               <%= if url do %>
                                 <img
                                   src={url}


### PR DESCRIPTION
Follow-up to #608. Fixes blurry media thumbnails in the grid and stacks views without pulling full-res images.

## Problem
Grid and stack cards rendered at `size={:small}`, which for un-annotated images falls back to the **150px** `thumbnail` — visibly blurry in a large card. The only sharper option in that chain was the full-res `original` (which, for Etcher-annotated files, also implies a live vector overlay), hurting page-load speed.

## Fix
Add a `:card` size mode to `thumbnail_url`:
- `:small` (unchanged) — list rows / selectors: `thumbnail_annotated` → `thumbnail`(150) → `small` → `original`
- `:card` (new) — large grid/stack cards: `thumbnail_annotated`(400, baked Etcher) → `small`(300) → `medium` → `original`

`:card` skips the blurry 150px thumbnail and only reaches the full-res `original` as a last resort, so we never pull the full image (with a live overlay) just to fill a card.

Point the large-card views at `:card`; **list rows stay on `:small`** (their cells are ~10×10, so the smallest Etcher thumbnail is correct):

| View | size |
|---|---|
| List rows | `:small` (unchanged) |
| Grid cards | `:card` |
| Stack pile previews | `:card` |
| Expanded-stack `file_card` | `:card` |

Net: Etcher-annotated files show the 400px baked annotation at correct quality; un-annotated files show the 300px `small` instead of the 150px blur; full-res is never loaded for a card.

## Verification (on top of `main` @ 1.7.167)
- `mix compile --warnings-as-errors`, `mix format --check-formatted`, `mix credo --strict` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)