### PR TITLE
V138 CRM v1 tables migration (+ checkbox description slot, storage delete fix)

### DIFF
--- a/lib/modules/storage/storage.ex
+++ b/lib/modules/storage/storage.ex
@@ -1207,13 +1207,22 @@ defmodule PhoenixKit.Modules.Storage do
   defp do_delete_folder_completely(%Folder{} = folder) do
     subtree_uuids = folder_subtree_uuids(folder.uuid)
 
-    # Pull files first (need them for storage-backend cleanup via
-    # `delete_file_completely/1`), then delete bottom-up.
+    # Pull files home in the subtree, then delete bottom-up.
     files =
       from(f in PhoenixKit.Modules.Storage.File, where: f.folder_uuid in ^subtree_uuids)
       |> repo().all()
 
-    Enum.each(files, &delete_file_completely/1)
+    # A file that is ALSO linked (via `FolderLink`) into a folder OUTSIDE this
+    # subtree lives in another folder too — re-home it there (consuming that one
+    # link) so it survives, instead of hard-deleting it. Without this, deleting a
+    # folder silently destroys a file shared into an unrelated folder (and the
+    # `FolderLink.file_uuid` cascade strips it from there). Only files confined
+    # to the subtree are deleted.
+    {to_promote, to_delete} =
+      Enum.split_with(files, &linked_outside_subtree?(&1.uuid, subtree_uuids))
+
+    Enum.each(to_promote, &promote_out_of_subtree(&1, subtree_uuids))
+    Enum.each(to_delete, &delete_file_completely/1)
 
     # Delete folders from deepest first so parent_uuid foreign keys
     # don't break. `folder_subtree_uuids/1` walks breadth-first; reverse
@@ -1226,6 +1235,36 @@ defmodule PhoenixKit.Modules.Storage do
     end)
 
     {:ok, folder}
+  end
+
+  # `FolderLink`s for `file_uuid` that point at folders OUTSIDE `subtree_uuids`.
+  defp links_outside_subtree(file_uuid, subtree_uuids) do
+    from(fl in FolderLink,
+      where: fl.file_uuid == ^file_uuid and fl.folder_uuid not in ^subtree_uuids
+    )
+    |> repo().all()
+  end
+
+  defp linked_outside_subtree?(file_uuid, subtree_uuids),
+    do: links_outside_subtree(file_uuid, subtree_uuids) != []
+
+  # Re-home a file to the first folder that links it from outside the deleted
+  # subtree (consuming that link), so it survives. Any remaining external links
+  # keep pointing at the now-rehomed file; links to subtree folders cascade away
+  # when those folders are deleted.
+  defp promote_out_of_subtree(%PhoenixKit.Modules.Storage.File{} = file, subtree_uuids) do
+    case links_outside_subtree(file.uuid, subtree_uuids) do
+      [%FolderLink{folder_uuid: new_home} = link | _] ->
+        repo().transaction(fn ->
+          file |> Ecto.Changeset.change(folder_uuid: new_home) |> repo().update!()
+          repo().delete!(link)
+        end)
+
+        :ok
+
+      [] ->
+        :ok
+    end
   end
 
   @doc """

--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -529,7 +529,19 @@ defmodule PhoenixKit.Migrations.Postgres do
   - Replaces unique index with partial index (slug-mode only, WHERE slug IS NOT NULL)
   - Adds unique index on `(group_uuid, post_date, post_time)` for timestamp-mode posts
 
-  ### V136 - Staff employment history ⚡ LATEST
+  ### V138 - CRM v1 interaction tracker ⚡ LATEST
+  - Adds five `phoenix_kit_crm_*` tables for the CRM module's first data model:
+    `contacts` (profile + **optional** `user_uuid` login link, partial-unique so
+    it's 1:1 only among linked rows), `companies`, `company_memberships` (M:N
+    contact↔company with free-form `role_in_company` + `department` + `is_primary`
+    on the edge), `interactions` (logged interaction: type/when/body/subject
+    contact/owner user), and `interaction_parties` (flat resolvable "who was
+    involved": `raw_name` always kept, `contact_uuid`/`staff_person_uuid` resolve
+    when matched under an exclusive-arc CHECK, `party_snapshot` JSONB freezes the
+    party's profile as-of-then). `staff_person_uuid` is a soft ref (no FK) so the
+    optional staff module stays optional.
+
+  ### V136 - Staff employment history
   - Adds `phoenix_kit_staff_employments` — a per-person history of employment
     spans (employment type, translatable `job_title`, org placement via
     `primary_department_uuid` + a `primary_team_uuid` snapshot, date range with
@@ -1172,7 +1184,7 @@ defmodule PhoenixKit.Migrations.Postgres do
   use Ecto.Migration
 
   @initial_version 1
-  @current_version 137
+  @current_version 138
   @default_prefix "public"
 
   @doc false

--- a/lib/phoenix_kit/migrations/postgres/v138.ex
+++ b/lib/phoenix_kit/migrations/postgres/v138.ex
@@ -1,0 +1,204 @@
+defmodule PhoenixKit.Migrations.Postgres.V138 do
+  @moduledoc """
+  V138: CRM v1 — interaction tracker (contacts, companies, interactions).
+
+  Five tables for the `phoenix_kit_crm` plugin's first real data model: a
+  Contact (cloned in spirit from staff `Person`, but the user link is
+  **optional**), a Company, the contact↔company membership (carrying free-form
+  role + department on the edge), and the interaction log (entries + their
+  resolvable "involved parties" with an as-of-then profile snapshot).
+
+  ## phoenix_kit_crm_contacts
+  A CRM contact (client/customer). Unlike staff `Person`, `user_uuid` is
+  **nullable** — most contacts never log in. A partial unique index keeps it
+  1:1 (one contact per user) only among the rows that *are* linked.
+
+  ## phoenix_kit_crm_companies
+  A company/organization record (its own data; not a login user).
+
+  ## phoenix_kit_crm_company_memberships
+  Contact↔company link, many-to-many, with free-form `role_in_company` and
+  `department` on the edge + an `is_primary` flag (drives the headline display
+  and the interaction snapshot).
+
+  ## phoenix_kit_crm_interactions
+  A logged interaction ("client called, discussed X"): type, when, body,
+  the subject contact, and the staff user who logged it.
+
+  ## phoenix_kit_crm_interaction_parties
+  Flat, resolvable "who was involved" list per interaction. `raw_name` is
+  always kept; `contact_uuid` / `staff_person_uuid` resolve to records when
+  matched (exclusive-arc: at most one set). `party_snapshot` freezes the
+  party's profile as it was at log time. `staff_person_uuid` is a **soft ref**
+  (no FK) so the optional staff module stays optional.
+
+  All operations are idempotent.
+  """
+
+  use Ecto.Migration
+
+  def up(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    # ── Contacts ──────────────────────────────────────────────────────
+    execute("""
+    CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_crm_contacts (
+      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      name VARCHAR(255),
+      status VARCHAR(50) NOT NULL DEFAULT 'active',
+      email VARCHAR(255),
+      phone VARCHAR(50),
+      notes TEXT,
+      user_uuid UUID REFERENCES #{p}phoenix_kit_users(uuid) ON DELETE SET NULL,
+      metadata JSONB NOT NULL DEFAULT '{}',
+      inserted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+    """)
+
+    # One contact per linked user (only among rows that are actually linked).
+    execute("""
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_crm_contacts_user_uuid
+    ON #{p}phoenix_kit_crm_contacts (user_uuid)
+    WHERE user_uuid IS NOT NULL
+    """)
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS idx_crm_contacts_status
+    ON #{p}phoenix_kit_crm_contacts (status)
+    """)
+
+    # ── Companies ─────────────────────────────────────────────────────
+    execute("""
+    CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_crm_companies (
+      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      name VARCHAR(255),
+      status VARCHAR(50) NOT NULL DEFAULT 'active',
+      website VARCHAR(255),
+      email VARCHAR(255),
+      phone VARCHAR(50),
+      address TEXT,
+      industry VARCHAR(255),
+      notes TEXT,
+      metadata JSONB NOT NULL DEFAULT '{}',
+      inserted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+    """)
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS idx_crm_companies_status
+    ON #{p}phoenix_kit_crm_companies (status)
+    """)
+
+    # ── Contact ↔ Company memberships ─────────────────────────────────
+    execute("""
+    CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_crm_company_memberships (
+      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      contact_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_crm_contacts(uuid) ON DELETE CASCADE,
+      company_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_crm_companies(uuid) ON DELETE CASCADE,
+      role_in_company VARCHAR(255),
+      department VARCHAR(255),
+      is_primary BOOLEAN NOT NULL DEFAULT false,
+      position INTEGER NOT NULL DEFAULT 0,
+      inserted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      CONSTRAINT phoenix_kit_crm_company_memberships_uniq UNIQUE (contact_uuid, company_uuid)
+    )
+    """)
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS idx_crm_memberships_contact
+    ON #{p}phoenix_kit_crm_company_memberships (contact_uuid)
+    """)
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS idx_crm_memberships_company
+    ON #{p}phoenix_kit_crm_company_memberships (company_uuid)
+    """)
+
+    # ── Interactions ──────────────────────────────────────────────────
+    execute("""
+    CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_crm_interactions (
+      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      contact_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_crm_contacts(uuid) ON DELETE CASCADE,
+      interaction_type VARCHAR(50) NOT NULL DEFAULT 'note',
+      occurred_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      subject VARCHAR(255),
+      body TEXT,
+      owner_user_uuid UUID REFERENCES #{p}phoenix_kit_users(uuid) ON DELETE SET NULL,
+      metadata JSONB NOT NULL DEFAULT '{}',
+      inserted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+    """)
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS idx_crm_interactions_contact
+    ON #{p}phoenix_kit_crm_interactions (contact_uuid, occurred_at DESC)
+    """)
+
+    # ── Interaction parties (resolvable mentions) ─────────────────────
+    # raw_name always kept; contact_uuid / staff_person_uuid resolve when
+    # matched (at most one). staff_person_uuid is a SOFT ref (no FK) so the
+    # optional staff module stays optional.
+    execute("""
+    CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_crm_interaction_parties (
+      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      interaction_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_crm_interactions(uuid) ON DELETE CASCADE,
+      raw_name VARCHAR(255) NOT NULL,
+      contact_uuid UUID REFERENCES #{p}phoenix_kit_crm_contacts(uuid) ON DELETE SET NULL,
+      staff_person_uuid UUID,
+      party_snapshot JSONB NOT NULL DEFAULT '{}',
+      position INTEGER NOT NULL DEFAULT 0,
+      inserted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      CONSTRAINT phoenix_kit_crm_party_exclusive_arc
+        CHECK (NOT (contact_uuid IS NOT NULL AND staff_person_uuid IS NOT NULL))
+    )
+    """)
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS idx_crm_parties_interaction
+    ON #{p}phoenix_kit_crm_interaction_parties (interaction_uuid)
+    """)
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS idx_crm_parties_contact
+    ON #{p}phoenix_kit_crm_interaction_parties (contact_uuid)
+    WHERE contact_uuid IS NOT NULL
+    """)
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS idx_crm_parties_staff_person
+    ON #{p}phoenix_kit_crm_interaction_parties (staff_person_uuid)
+    WHERE staff_person_uuid IS NOT NULL
+    """)
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '138'")
+  end
+
+  @doc """
+  Rolls V138 back by dropping the five CRM v1 tables in reverse dependency
+  order.
+
+  **Lossy rollback:** all contacts, companies, memberships, interactions, and
+  party rows are lost. Back up before rolling back in production.
+  """
+  def down(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    execute("DROP TABLE IF EXISTS #{p}phoenix_kit_crm_interaction_parties CASCADE")
+    execute("DROP TABLE IF EXISTS #{p}phoenix_kit_crm_interactions CASCADE")
+    execute("DROP TABLE IF EXISTS #{p}phoenix_kit_crm_company_memberships CASCADE")
+    execute("DROP TABLE IF EXISTS #{p}phoenix_kit_crm_companies CASCADE")
+    execute("DROP TABLE IF EXISTS #{p}phoenix_kit_crm_contacts CASCADE")
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '137'")
+  end
+
+  defp prefix_str("public"), do: "public."
+  defp prefix_str(prefix), do: "#{prefix}."
+end

--- a/lib/phoenix_kit_web/components/core/checkbox.ex
+++ b/lib/phoenix_kit_web/components/core/checkbox.ex
@@ -40,7 +40,10 @@ defmodule PhoenixKitWeb.Components.Core.Checkbox do
   def checkbox(assigns) do
     ~H"""
     <div phx-feedback-for={@name}>
-      <label class="flex items-center gap-4 text-sm leading-6 text-base-content">
+      <label class={[
+        "flex gap-4 text-sm leading-6 text-base-content",
+        (@inner_block != [] && "items-start") || "items-center"
+      ]}>
         <input type="hidden" name={@name} value="false" />
 
         <input
@@ -49,12 +52,15 @@ defmodule PhoenixKitWeb.Components.Core.Checkbox do
           name={@name}
           value="true"
           checked={@checked}
-          class={["checkbox checkbox-primary", @class]}
+          class={["checkbox checkbox-primary", @inner_block != [] && "mt-0.5", @class]}
           {@rest}
         />
 
         <span class="select-none cursor-pointer">
-          {@label}
+          <span class={@inner_block != [] && "font-medium"}>{@label}</span>
+          <span :if={@inner_block != []} class="block text-xs text-base-content/60">
+            {render_slot(@inner_block)}
+          </span>
         </span>
       </label>
       <.error :for={msg <- @errors}>{msg}</.error>

--- a/test/integration/storage/scope_test.exs
+++ b/test/integration/storage/scope_test.exs
@@ -3,6 +3,7 @@ defmodule PhoenixKit.Integration.Storage.ScopeTest do
 
   alias PhoenixKit.Modules.Storage
   alias PhoenixKit.Modules.Storage.File, as: StorageFile
+  alias PhoenixKit.Modules.Storage.FolderLink
   alias PhoenixKit.Users.Auth
 
   # ---------------------------------------------------------------------------
@@ -650,6 +651,31 @@ defmodule PhoenixKit.Integration.Storage.ScopeTest do
 
       assert Storage.get_folder(child_a.uuid) == nil
       assert Storage.get_folder(grandchild.uuid) == nil
+      assert Repo.get(StorageFile, file.uuid) == nil
+    end
+
+    test "promotes a file linked into a folder outside the subtree (doesn't destroy it)" do
+      %{child_a: child_a, grandchild: grandchild, sibling: sibling} = build_tree()
+      file = create_file!(grandchild.uuid)
+      # Same file also lives in a folder OUTSIDE the deleted subtree.
+      {:ok, _link} = Storage.create_folder_link(sibling.uuid, file.uuid)
+
+      assert {:ok, _} = Storage.delete_folder_completely(child_a)
+
+      # Subtree gone, but the shared file survives — re-homed to the external
+      # folder, its consumed link folded into the new home.
+      assert Storage.get_folder(grandchild.uuid) == nil
+      reloaded = Repo.get(StorageFile, file.uuid)
+      assert reloaded, "shared file must not be destroyed by the folder delete"
+      assert reloaded.folder_uuid == sibling.uuid
+      refute Repo.get_by(FolderLink, folder_uuid: sibling.uuid, file_uuid: file.uuid)
+    end
+
+    test "still hard-deletes a file confined to the subtree (no external links)" do
+      %{child_a: child_a, grandchild: grandchild} = build_tree()
+      file = create_file!(grandchild.uuid)
+
+      assert {:ok, _} = Storage.delete_folder_completely(child_a)
       assert Repo.get(StorageFile, file.uuid) == nil
     end
   end


### PR DESCRIPTION
## Summary

Three accumulated core changes — the headline is the CRM v1 tables migration that unblocks `phoenix_kit_crm`.

- **V138 — CRM v1 interaction-tracker tables** — five module-owned tables for `phoenix_kit_crm`: `phoenix_kit_crm_contacts`, `_companies`, `_company_memberships`, `_interactions`, `_interaction_parties`. Bumps `@current_version` to 138 and wires the dispatch; `up` records marker `'138'`, `down` records `'137'`. (Authored as V137, renumbered to V138 since upstream took V137 for the emails dedup indexes.)
- **Checkbox description slot** — the core `checkbox` component renders its `inner_block` slot as a description under the label when one is provided. Backwards-compatible — existing call sites with no inner block are unchanged.
- **Storage: `delete_folder_completely` fix** — stop destroying files that are also shared into other folders when a folder is deleted.

This is the core side of [BeamLabEU/phoenix_kit_crm#8](https://github.com/BeamLabEU/phoenix_kit_crm/pull/8) — that module's integration + LiveView tests require V138, and run green against this branch (`PHOENIX_KIT_PATH=../phoenix_kit mix test`, 154 tests).
