### PR TITLE
Fix V70 migration crash when legacy id columns are absent

### DIFF
--- a/lib/phoenix_kit/migrations/postgres/v70.ex
+++ b/lib/phoenix_kit/migrations/postgres/v70.ex
@@ -109,6 +109,7 @@ defmodule PhoenixKit.Migrations.Postgres.V70 do
 
     if table_exists?(events_table, escaped_prefix) and
          table_exists?(logs_table, escaped_prefix) and
+         column_exists?(events_table, "email_log_id", escaped_prefix) and
          column_exists?(events_table, "email_log_uuid", escaped_prefix) and
          column_exists?(logs_table, "uuid", escaped_prefix) do
       events = prefix_table(events_table, prefix)
@@ -169,6 +170,7 @@ defmodule PhoenixKit.Migrations.Postgres.V70 do
 
     if table_exists?(orphaned_table, escaped_prefix) and
          table_exists?(logs_table, escaped_prefix) and
+         column_exists?(orphaned_table, "matched_email_log_id", escaped_prefix) and
          column_exists?(orphaned_table, "matched_email_log_uuid", escaped_prefix) and
          column_exists?(logs_table, "uuid", escaped_prefix) do
       orphaned = prefix_table(orphaned_table, prefix)


### PR DESCRIPTION
## Summary

V70 re-backfills the UUID FK companion columns (`email_log_uuid`,
`matched_email_log_uuid`) that V56/V63 could silently skip. The backfill
reads from the legacy integer FK columns (`email_log_id`,
`matched_email_log_id`) to map each row to the source `uuid`.

On installs where those legacy `*_id` columns have already been dropped,
the very first statement in each backfill block is a **raw** `execute/1`
UPDATE that references `e.email_log_id` (not wrapped in the `DO $$ ...
EXCEPTION` handler). PostgreSQL raises `column does not exist`, which
aborts the migration transaction (25P02) and rolls the database back —
the DB never advances to v70.

## Change

Guard both re-backfill blocks with a `column_exists?` check for the
legacy id column they read from, alongside the existing table/column
guards:

- `rebackfill_email_log_uuid` — require `email_log_events.email_log_id`
- `rebackfill_matched_email_log_uuid` — require
  `email_orphaned_events.matched_email_log_id`

When the legacy id source column is gone there is nothing to backfill
from anyway, so skipping the block is the correct behaviour. The change
is idempotent and safe on fresh installs.

## Test Plan

- [x] `mix format --check-formatted` on the changed file
- [x] `mix compile --warnings-as-errors` — clean
- [x] `mix docs` — generates cleanly