### PR TITLE
Fix sitemap silent-disable, honor SEO noindex, add reserved-route-prefix callback

### DIFF
--- a/lib/modules/seo/seo.ex
+++ b/lib/modules/seo/seo.ex
@@ -9,6 +9,7 @@ defmodule PhoenixKit.Modules.SEO do
   use PhoenixKit.Module
 
   alias PhoenixKit.Dashboard.Tab
+  alias PhoenixKit.Modules.Sitemap.Generator
   alias PhoenixKit.Settings
 
   @module_enabled_key "seo_module_enabled"
@@ -69,7 +70,23 @@ defmodule PhoenixKit.Modules.SEO do
   Updates the directive to the provided boolean value.
   """
   def update_no_index(enabled?) when is_boolean(enabled?) do
-    Settings.update_boolean_setting_with_module(@no_index_key, enabled?, @module_name)
+    result = Settings.update_boolean_setting_with_module(@no_index_key, enabled?, @module_name)
+
+    # The directive flips what the sitemap must advertise. Drop the cached
+    # sitemap and regenerate so `/sitemap.xml` reflects the new state instead of
+    # serving a stale file. Best-effort — never let it break the toggle.
+    refresh_sitemap()
+
+    result
+  end
+
+  # Invalidate + regenerate the sitemap after a noindex change. Wrapped so a
+  # sitemap/Oban hiccup can never fail the settings write.
+  defp refresh_sitemap do
+    Generator.invalidate_and_regenerate()
+    :ok
+  rescue
+    _ -> :ok
   end
 
   @impl PhoenixKit.Module

--- a/lib/modules/sitemap/generator.ex
+++ b/lib/modules/sitemap/generator.ex
@@ -102,11 +102,17 @@ defmodule PhoenixKit.Modules.Sitemap.Generator do
 
   # When the SEO module's global `noindex` directive is active the site is
   # asking search engines not to index it, so we publish an empty (but valid)
-  # `<urlset>` rather than advertising crawlable URLs. This pairs with the
-  # `<meta name="robots" content="noindex">` directive host layouts emit for
-  # the same setting. Any leftover per-module files are removed.
+  # `<urlset>` rather than advertising crawlable URLs, for both flat and index
+  # modes. Note this makes `/sitemap.xml` serve a `<urlset>` (not a
+  # `<sitemapindex>`) while noindex is on — an empty urlset is schema-valid and
+  # harmless. Any leftover per-module files are removed.
+  #
+  # Keyed on `no_index_enabled?/0` alone (not `module_enabled?/0`) to stay in
+  # lockstep with the `<meta name="robots" content="noindex">` directive host
+  # layouts emit for the same setting — an empty sitemap always pairs with a
+  # noindex meta.
   defp do_generate_no_index(xsl_style, xsl_enabled) do
-    Logger.info("Sitemap: seo_no_index active — publishing empty sitemap")
+    Logger.debug("Sitemap: seo_no_index active — publishing empty sitemap")
 
     xml = build_urlset_xml([], xsl_style, xsl_enabled)
     FileStorage.save_index(xml)
@@ -362,6 +368,11 @@ defmodule PhoenixKit.Modules.Sitemap.Generator do
 
       style not in ["hierarchical", "grouped", "flat"] ->
         {:error, :invalid_style}
+
+      seo_no_index?() ->
+        # noindex active: never advertise URLs and never serve a stale cached
+        # HTML sitemap — render an empty one, bypassing the cache.
+        HtmlGenerator.generate(opts, [], :"html_#{style}", cache: false)
 
       true ->
         cache_key = :"html_#{style}"

--- a/lib/modules/sitemap/generator.ex
+++ b/lib/modules/sitemap/generator.ex
@@ -31,6 +31,7 @@ defmodule PhoenixKit.Modules.Sitemap.Generator do
   require Logger
 
   alias PhoenixKit.Modules.Languages
+  alias PhoenixKit.Modules.SEO
   alias PhoenixKit.Modules.Sitemap
   alias PhoenixKit.Modules.Sitemap.Cache
   alias PhoenixKit.Modules.Sitemap.FileStorage
@@ -86,13 +87,39 @@ defmodule PhoenixKit.Modules.Sitemap.Generator do
   defp do_generate_all(base_url, opts) do
     xsl_style = Keyword.get(opts, :xsl_style, "table")
     xsl_enabled = Keyword.get(opts, :xsl_enabled, true)
-    sources = get_sources()
 
-    if Sitemap.flat_mode?() do
-      do_generate_flat(base_url, opts, sources, xsl_style, xsl_enabled)
-    else
-      do_generate_index(base_url, opts, sources, xsl_style, xsl_enabled)
+    cond do
+      seo_no_index?() ->
+        do_generate_no_index(xsl_style, xsl_enabled)
+
+      Sitemap.flat_mode?() ->
+        do_generate_flat(base_url, opts, get_sources(), xsl_style, xsl_enabled)
+
+      true ->
+        do_generate_index(base_url, opts, get_sources(), xsl_style, xsl_enabled)
     end
+  end
+
+  # When the SEO module's global `noindex` directive is active the site is
+  # asking search engines not to index it, so we publish an empty (but valid)
+  # `<urlset>` rather than advertising crawlable URLs. This pairs with the
+  # `<meta name="robots" content="noindex">` directive host layouts emit for
+  # the same setting. Any leftover per-module files are removed.
+  defp do_generate_no_index(xsl_style, xsl_enabled) do
+    Logger.info("Sitemap: seo_no_index active — publishing empty sitemap")
+
+    xml = build_urlset_xml([], xsl_style, xsl_enabled)
+    FileStorage.save_index(xml)
+    FileStorage.delete_all_modules()
+
+    {:ok, %{index_xml: xml, modules: [], total_urls: 0}}
+  end
+
+  # Defensive: never let an SEO lookup error break sitemap generation.
+  defp seo_no_index? do
+    SEO.no_index_enabled?()
+  rescue
+    _ -> false
   end
 
   defp do_generate_index(base_url, opts, sources, xsl_style, xsl_enabled) do

--- a/lib/modules/sitemap/sources/router_discovery.ex
+++ b/lib/modules/sitemap/sources/router_discovery.ex
@@ -13,6 +13,13 @@ defmodule PhoenixKit.Modules.Sitemap.Sources.RouterDiscovery do
   - `sitemap_router_discovery_include_only` - JSON array of regex patterns for whitelist mode
   - `sitemap_protected_pipelines` - JSON array of pipeline names that require authentication
 
+  ## Pattern Syntax
+
+  Exclude and include-only patterns are **regular expressions** (compiled with
+  `Regex.compile/1`), not shell globs. A bare `"*"` is an invalid regex and is
+  ignored with a logged warning — use `".*"` to match everything or `"^/prefix"`
+  to match a path prefix. Invalid patterns never silently disable the source.
+
   ## Default Exclusions
 
   By default, the following patterns are excluded:
@@ -153,8 +160,8 @@ defmodule PhoenixKit.Modules.Sitemap.Sources.RouterDiscovery do
 
   defp do_collect(opts) do
     base_url = Keyword.get(opts, :base_url)
-    exclude_patterns = get_exclude_patterns()
-    include_only = get_include_only_patterns()
+    exclude_patterns = compile_patterns(get_exclude_patterns(), "exclude")
+    include_only = compile_include_only(get_include_only_patterns())
 
     RouteResolver.get_routes()
     |> Enum.filter(&valid_for_sitemap?(&1, exclude_patterns, include_only))
@@ -256,25 +263,41 @@ defmodule PhoenixKit.Modules.Sitemap.Sources.RouterDiscovery do
     route.verb == :get
   end
 
-  defp excluded?(path, patterns) do
-    Enum.any?(patterns, fn pattern ->
-      case Regex.compile(pattern) do
-        {:ok, regex} -> Regex.match?(regex, path)
-        _ -> false
-      end
-    end)
+  defp excluded?(path, regexes) do
+    Enum.any?(regexes, &Regex.match?(&1, path))
   end
 
-  defp included?(_path, []) do
-    # Empty include_only = include all
-    true
-  end
+  # `:all` means no include-only patterns were configured → include everything.
+  defp included?(_path, :all), do: true
+  defp included?(path, {:whitelist, regexes}), do: Enum.any?(regexes, &Regex.match?(&1, path))
 
-  defp included?(path, patterns) do
-    Enum.any?(patterns, fn pattern ->
+  # An unset/empty whitelist keeps the "include all" behavior; a configured
+  # whitelist is compiled so an all-invalid list still excludes everything
+  # (now with a logged warning) rather than silently flipping to include-all.
+  defp compile_include_only([]), do: :all
+
+  defp compile_include_only(patterns),
+    do: {:whitelist, compile_patterns(patterns, "include_only")}
+
+  # Compile raw pattern strings into `Regex` structs, logging and dropping any
+  # that fail to compile. Patterns are regular expressions (not shell globs):
+  # a bare "*" fails to compile and would otherwise be swallowed silently,
+  # masking a misconfiguration (e.g. an include-only "*" would suppress the
+  # entire source with no diagnostic trail).
+  defp compile_patterns(patterns, context) do
+    Enum.flat_map(patterns, fn pattern ->
       case Regex.compile(pattern) do
-        {:ok, regex} -> Regex.match?(regex, path)
-        _ -> false
+        {:ok, regex} ->
+          [regex]
+
+        {:error, reason} ->
+          Logger.warning(
+            "RouterDiscovery: ignoring invalid #{context} pattern #{inspect(pattern)} " <>
+              "(#{inspect(reason)}). Patterns are regular expressions, not globs — " <>
+              "use \".*\" to match everything or \"^/prefix\" for a path prefix."
+          )
+
+          []
       end
     end)
   end

--- a/lib/phoenix_kit/module.ex
+++ b/lib/phoenix_kit/module.ex
@@ -253,6 +253,31 @@ defmodule PhoenixKit.Module do
   @callback sitemap_sources() :: [module()]
 
   @doc """
+  Returns top-level route path segments this module owns for its own
+  LiveViews/controllers (e.g. a host app declares `live "/legal", LegalLive`
+  and this module IS the "legal" feature).
+
+  Consulted by modules that dispatch requests based on a database-driven
+  path segment (e.g. Publishing's `/:language/:group/*path` catch-all, which
+  treats any first segment matching a stored group slug as one of its own
+  groups) so they don't swallow a route another module owns just because a
+  same-named record happens to exist in their own data. Collected via
+  `PhoenixKit.ModuleRegistry.all_reserved_route_prefixes/0`.
+
+  Segments are compared literally (no leading/trailing slash, e.g. `"legal"`
+  not `"/legal"`).
+
+  ## Example
+
+      @impl PhoenixKit.Module
+      def reserved_route_prefixes, do: ["legal"]
+
+  Modules that don't own a reserved top-level segment skip this callback —
+  the default is `[]`.
+  """
+  @callback reserved_route_prefixes() :: [String.t()]
+
+  @doc """
   Run any one-shot legacy data migrations this module owns.
 
   Two transitions every module that touches Integrations may need:
@@ -307,6 +332,7 @@ defmodule PhoenixKit.Module do
     css_sources: 0,
     js_sources: 0,
     sitemap_sources: 0,
+    reserved_route_prefixes: 0,
     migrate_legacy: 0
   ]
 
@@ -369,6 +395,9 @@ defmodule PhoenixKit.Module do
       def sitemap_sources, do: []
 
       @impl PhoenixKit.Module
+      def reserved_route_prefixes, do: []
+
+      @impl PhoenixKit.Module
       def migrate_legacy, do: :ok
 
       defoverridable get_config: 0,
@@ -387,6 +416,7 @@ defmodule PhoenixKit.Module do
                      css_sources: 0,
                      js_sources: 0,
                      sitemap_sources: 0,
+                     reserved_route_prefixes: 0,
                      migrate_legacy: 0
     end
   end

--- a/lib/phoenix_kit/module_registry.ex
+++ b/lib/phoenix_kit/module_registry.ex
@@ -203,21 +203,41 @@ defmodule PhoenixKit.ModuleRegistry do
   end
 
   @doc """
-  Collect top-level route path segments reserved by all **enabled** modules.
+  Collect top-level route path segments reserved by all installed modules.
 
   Each entry is a literal path segment (no slashes, e.g. `"legal"`) a module
   owns for its own LiveViews/controllers. A dispatcher that routes requests
   based on database-driven path segments (e.g. Publishing's group catch-all)
   should treat any segment in this list as NOT its own, even if it happens to
   have matching data, so it doesn't swallow a route another module owns.
+  Declaring a prefix is passive — it changes nothing unless a dispatcher
+  actively consults this function.
 
-  Iterates `enabled_modules/0` — a disabled module's reservation doesn't
-  apply, mirroring `all_sitemap_sources/0`.
+  Iterates `all_modules/0`, **not** `enabled_modules/0` (unlike
+  `all_sitemap_sources/0`): the route this guards against is normally
+  compiled into the host's router (e.g. `live "/legal", LegalLive`), which
+  exists independent of the owning module's runtime enabled/disabled
+  Settings toggle. Gating on `enabled_modules/0` would drop the reservation
+  the moment a module is disabled while its data (and the host's compiled
+  route) still exist, reopening the exact hijack this is meant to prevent
+  for as long as the module stays disabled.
+
+  Each module's returned segments are trimmed of leading/trailing slashes
+  and non-list/non-string returns are dropped, so a malformed
+  `reserved_route_prefixes/0` implementation (e.g. returning `"/legal"` or a
+  bare string instead of a list) can't silently defeat the reservation or
+  crash this per-request-hot-path aggregation.
   """
   @spec all_reserved_route_prefixes() :: [String.t()]
   def all_reserved_route_prefixes do
-    enabled_modules()
-    |> Enum.flat_map(&safe_call(&1, :reserved_route_prefixes, []))
+    all_modules()
+    |> Enum.flat_map(fn mod ->
+      mod
+      |> safe_call(:reserved_route_prefixes, [])
+      |> List.wrap()
+      |> Enum.filter(&is_binary/1)
+    end)
+    |> Enum.map(&String.trim(&1, "/"))
     |> Enum.uniq()
   end
 

--- a/lib/phoenix_kit/module_registry.ex
+++ b/lib/phoenix_kit/module_registry.ex
@@ -203,6 +203,25 @@ defmodule PhoenixKit.ModuleRegistry do
   end
 
   @doc """
+  Collect top-level route path segments reserved by all **enabled** modules.
+
+  Each entry is a literal path segment (no slashes, e.g. `"legal"`) a module
+  owns for its own LiveViews/controllers. A dispatcher that routes requests
+  based on database-driven path segments (e.g. Publishing's group catch-all)
+  should treat any segment in this list as NOT its own, even if it happens to
+  have matching data, so it doesn't swallow a route another module owns.
+
+  Iterates `enabled_modules/0` — a disabled module's reservation doesn't
+  apply, mirroring `all_sitemap_sources/0`.
+  """
+  @spec all_reserved_route_prefixes() :: [String.t()]
+  def all_reserved_route_prefixes do
+    enabled_modules()
+    |> Enum.flat_map(&safe_call(&1, :reserved_route_prefixes, []))
+    |> Enum.uniq()
+  end
+
+  @doc """
   Collect modules that have versioned migrations.
 
   Returns a list of `{module_name, migration_module}` tuples for all registered

--- a/test/integration/sitemap/no_index_test.exs
+++ b/test/integration/sitemap/no_index_test.exs
@@ -1,0 +1,50 @@
+defmodule PhoenixKit.Integration.Sitemap.NoIndexTest do
+  @moduledoc """
+  Pins the contract that the sitemap generator honors the SEO module's global
+  `noindex` directive.
+
+  When `seo_no_index` is active the site is asking search engines not to index
+  it, so `Generator.generate_all/1` must publish an empty (but valid) `<urlset>`
+  instead of advertising crawlable URLs — regardless of what the individual
+  sources would otherwise emit.
+  """
+  use PhoenixKit.DataCase, async: false
+
+  alias PhoenixKit.Modules.Sitemap.Generator
+  alias PhoenixKit.Settings
+
+  @base_url "https://example.test"
+
+  setup do
+    # Sitemap generation needs the module enabled and a base URL.
+    {:ok, _} = Settings.update_boolean_setting("sitemap_enabled", true)
+    {:ok, _} = Settings.update_setting("site_url", @base_url)
+    :ok
+  end
+
+  describe "generate_all/1 with seo_no_index active" do
+    test "publishes an empty urlset with zero URLs" do
+      {:ok, _} = Settings.update_boolean_setting("seo_no_index", true)
+
+      assert {:ok, %{index_xml: xml, total_urls: 0, modules: []}} =
+               Generator.generate_all(base_url: @base_url)
+
+      # Valid, empty urlset — no crawlable entries advertised.
+      assert xml =~ "<urlset"
+      assert xml =~ "</urlset>"
+      refute xml =~ "<url>"
+      refute xml =~ "<loc>"
+    end
+  end
+
+  describe "generate_all/1 with seo_no_index disabled" do
+    test "does not force an empty sitemap" do
+      {:ok, _} = Settings.update_boolean_setting("seo_no_index", false)
+
+      # The exact URL count depends on seeded content/routes; we only assert the
+      # noindex short-circuit is NOT taken (generation runs normally).
+      assert {:ok, %{total_urls: total}} = Generator.generate_all(base_url: @base_url)
+      assert is_integer(total)
+    end
+  end
+end

--- a/test/phoenix_kit/module_registry_test.exs
+++ b/test/phoenix_kit/module_registry_test.exs
@@ -314,6 +314,49 @@ defmodule PhoenixKit.ModuleRegistryTest do
     end
   end
 
+  describe "all_reserved_route_prefixes/0" do
+    test "returns a list of strings" do
+      prefixes = ModuleRegistry.all_reserved_route_prefixes()
+      assert is_list(prefixes)
+
+      for prefix <- prefixes do
+        assert is_binary(prefix)
+      end
+    end
+
+    test "includes prefixes contributed by an enabled fake module" do
+      defmodule FakeReservedPrefixModule do
+        @moduledoc false
+        def enabled?, do: true
+        def reserved_route_prefixes, do: ["fake_reserved_prefix"]
+      end
+
+      ModuleRegistry.register(FakeReservedPrefixModule)
+
+      try do
+        assert "fake_reserved_prefix" in ModuleRegistry.all_reserved_route_prefixes()
+      after
+        ModuleRegistry.unregister(FakeReservedPrefixModule)
+      end
+    end
+
+    test "excludes prefixes from a disabled fake module" do
+      defmodule FakeDisabledReservedPrefixModule do
+        @moduledoc false
+        def enabled?, do: false
+        def reserved_route_prefixes, do: ["fake_disabled_prefix"]
+      end
+
+      ModuleRegistry.register(FakeDisabledReservedPrefixModule)
+
+      try do
+        refute "fake_disabled_prefix" in ModuleRegistry.all_reserved_route_prefixes()
+      after
+        ModuleRegistry.unregister(FakeDisabledReservedPrefixModule)
+      end
+    end
+  end
+
   describe "enabled_modules/0" do
     test "returns a list of module atoms" do
       modules = ModuleRegistry.enabled_modules()

--- a/test/phoenix_kit/module_registry_test.exs
+++ b/test/phoenix_kit/module_registry_test.exs
@@ -340,7 +340,12 @@ defmodule PhoenixKit.ModuleRegistryTest do
       end
     end
 
-    test "excludes prefixes from a disabled fake module" do
+    test "includes prefixes from a disabled fake module (unlike all_sitemap_sources/0)" do
+      # The route this guards against is normally compiled into the host's
+      # router regardless of a runtime enabled/disabled Settings toggle, so
+      # the reservation must survive disabling the module — otherwise a
+      # disabled-but-installed module's route gets hijacked the moment it's
+      # turned off. Gates on all_modules/0, not enabled_modules/0.
       defmodule FakeDisabledReservedPrefixModule do
         @moduledoc false
         def enabled?, do: false
@@ -350,9 +355,64 @@ defmodule PhoenixKit.ModuleRegistryTest do
       ModuleRegistry.register(FakeDisabledReservedPrefixModule)
 
       try do
-        refute "fake_disabled_prefix" in ModuleRegistry.all_reserved_route_prefixes()
+        assert "fake_disabled_prefix" in ModuleRegistry.all_reserved_route_prefixes()
       after
         ModuleRegistry.unregister(FakeDisabledReservedPrefixModule)
+      end
+    end
+
+    test "normalizes leading/trailing slashes from a fake module's segments" do
+      defmodule FakeSlashyReservedPrefixModule do
+        @moduledoc false
+        def enabled?, do: true
+        def reserved_route_prefixes, do: ["/leading", "trailing/", "/both/"]
+      end
+
+      ModuleRegistry.register(FakeSlashyReservedPrefixModule)
+
+      try do
+        prefixes = ModuleRegistry.all_reserved_route_prefixes()
+        assert "leading" in prefixes
+        assert "trailing" in prefixes
+        assert "both" in prefixes
+      after
+        ModuleRegistry.unregister(FakeSlashyReservedPrefixModule)
+      end
+    end
+
+    test "does not crash when a fake module returns nil instead of a list" do
+      defmodule FakeNilReservedPrefixModule do
+        @moduledoc false
+        def enabled?, do: true
+        # Wrong shape on purpose — a real implementation would return [].
+        def reserved_route_prefixes, do: nil
+      end
+
+      ModuleRegistry.register(FakeNilReservedPrefixModule)
+
+      try do
+        assert is_list(ModuleRegistry.all_reserved_route_prefixes())
+      after
+        ModuleRegistry.unregister(FakeNilReservedPrefixModule)
+      end
+    end
+
+    test "drops non-string entries from a fake module's segment list" do
+      defmodule FakeMixedTypesReservedPrefixModule do
+        @moduledoc false
+        def enabled?, do: true
+        def reserved_route_prefixes, do: [123, :an_atom, "real_prefix"]
+      end
+
+      ModuleRegistry.register(FakeMixedTypesReservedPrefixModule)
+
+      try do
+        prefixes = ModuleRegistry.all_reserved_route_prefixes()
+        assert "real_prefix" in prefixes
+        refute 123 in prefixes
+        refute :an_atom in prefixes
+      after
+        ModuleRegistry.unregister(FakeMixedTypesReservedPrefixModule)
       end
     end
   end


### PR DESCRIPTION
## Summary

Three small, independent, additive core fixes from a production SEO/sitemap audit:

1. **RouterDiscovery no longer silently disables on a bad pattern.** Exclude / include-only patterns were compiled inline with `Regex.compile/1` and compile errors were swallowed by `_ -> false` with no log. A mistaken glob such as `"*"` (an invalid regex) would drop the source to zero URLs in whitelist mode with no diagnostic trail. Patterns are now compiled once, invalid ones are logged and skipped, and the regex-not-glob semantics are documented.

2. **The sitemap now honors the SEO module's global `noindex` directive.** When `seo_no_index` is active, `Generator.generate_all/1` (and `generate_html/1`) publish an empty (but valid) sitemap instead of advertising crawlable URLs. The noindex toggle also now invalidates + regenerates the cached sitemap so it doesn't keep serving a stale file.

3. **New optional `PhoenixKit.Module` callback `reserved_route_prefixes/0`** (mirrors `sitemap_sources/0`), aggregated via `ModuleRegistry.all_reserved_route_prefixes/0`. Lets a module declare top-level route segments it owns for its own LiveViews/controllers, so another module's database-driven dispatch (e.g. Publishing's group catch-all) doesn't swallow a route it doesn't actually own. Companion PRs in `phoenix_kit_legal` (declares `["legal"]`) and `phoenix_kit_publishing` (consults the registry in `RouterDispatch.known_group?/1`) depend on this.

These three ended up in one PR because of a `main`-only workflow — each is independently reviewable (they touch disjoint functions) and none depends on another.

## Changes

- `lib/modules/sitemap/sources/router_discovery.ex` — compile patterns once, log + skip invalid ones, document regex (not glob) syntax.
- `lib/modules/sitemap/generator.ex` — short-circuit to an empty sitemap (XML + HTML) when `SEO.no_index_enabled?()`.
- `lib/modules/seo/seo.ex` — `update_no_index/1` invalidates + regenerates the sitemap.
- `lib/phoenix_kit/module.ex` + `lib/phoenix_kit/module_registry.ex` — `reserved_route_prefixes/0` callback + `all_reserved_route_prefixes/0` aggregator.
- Tests for all of the above.

## Test plan

- [x] `mix compile --warnings-as-errors`
- [x] `mix credo --strict` (0 issues)
- [x] `mix dialyzer` (passed, via pre-commit hook)
- [x] `mix format --check-formatted`
- [x] `mix test test/phoenix_kit/module_registry_test.exs test/phoenix_kit/module_test.exs` (70 tests, 0 failures)
- [ ] Integration tests (sitemap noindex) need PostgreSQL — execute in CI
