### PR TITLE
Prevent RouterDiscovery from masking richer sitemap entries and leaking internal routes

### DIFF
--- a/lib/modules/sitemap/generator.ex
+++ b/lib/modules/sitemap/generator.ex
@@ -468,7 +468,7 @@ defmodule PhoenixKit.Modules.Sitemap.Generator do
       Logger.debug("Sitemap: Collected #{length(entries)} entries from #{inspect(source_module)}")
       entries
     end)
-    |> Enum.uniq_by(& &1.loc)
+    |> dedupe_by_loc()
     |> Enum.sort_by(& &1.loc)
   end
 
@@ -557,7 +557,7 @@ defmodule PhoenixKit.Modules.Sitemap.Generator do
         entry
       end
     end)
-    |> Enum.uniq_by(& &1.loc)
+    |> dedupe_by_loc()
     |> Enum.sort_by(& &1.loc)
   end
 
@@ -573,6 +573,36 @@ defmodule PhoenixKit.Modules.Sitemap.Generator do
       [_, lang] -> lang
       _ -> Routes.get_default_admin_locale()
     end
+  end
+
+  # Deduplicates entries by `loc`, preferring the entry with the richer
+  # sitemap metadata when a URL is emitted by more than one source. This
+  # matters because RouterDiscovery blindly enumerates every GET route and
+  # can emit the same `loc` as a content source (Publishing, Entities, ...)
+  # that also generates a richer entry (canonical_path/alternates for
+  # hreflang, higher priority) for that same URL. A RouterDiscovery entry
+  # always loses to a same-loc entry from any other source: it only carries
+  # generic route metadata (priority 0.5, no hreflang) and must never mask
+  # an authoritative content-source entry. `Enum.uniq_by/2` alone is not
+  # enough here since it keeps whichever entry happens to come first, which
+  # depends on source ordering rather than which entry is actually richer.
+  defp dedupe_by_loc(entries) do
+    entries
+    |> Enum.group_by(& &1.loc)
+    |> Enum.map(fn {_loc, group} -> Enum.max_by(group, &entry_richness/1) end)
+  end
+
+  # RouterDiscovery entries always score lowest (0), so any other source
+  # wins a same-loc collision regardless of its own priority/canonical_path.
+  # Among non-RouterDiscovery entries, richer entries win ties.
+  defp entry_richness(%UrlEntry{source: :router_discovery}), do: 0
+
+  defp entry_richness(%UrlEntry{} = entry) do
+    canonical_bonus = if entry.canonical_path in [nil, ""], do: 0, else: 2
+    alternates_bonus = if entry.alternates in [nil, []], do: 0, else: 2
+    priority = UrlEntry.parse_priority(entry.priority) || 0.0
+
+    1 + canonical_bonus + alternates_bonus + priority
   end
 
   # ── Internal: XML building ─────────────────────────────────────────

--- a/lib/modules/sitemap/sources/router_discovery.ex
+++ b/lib/modules/sitemap/sources/router_discovery.ex
@@ -20,6 +20,9 @@ defmodule PhoenixKit.Modules.Sitemap.Sources.RouterDiscovery do
   - `^/api` - API endpoints
   - `^/phoenix_kit` - PhoenixKit admin routes
   - `^/dev` - Development routes
+  - `^/__` - Internal/technical routes (double-underscore convention, e.g.
+    Publishing's internal dispatch scope)
+  - `^/maintenance$` - PhoenixKit's reserved maintenance page route
   - `:[a-z_]+` - Routes with parameters
   - `\\*` - Wildcard routes
 
@@ -76,6 +79,11 @@ defmodule PhoenixKit.Modules.Sitemap.Sources.RouterDiscovery do
     "^/dev",
     "^/test",
     "^/dashboard",
+    # Internal/technical routes (double-underscore convention, e.g. Publishing's
+    # "/__phoenix_kit_publishing_dispatch" catch-all dispatch scope) and
+    # PhoenixKit's reserved maintenance page - neither is public content
+    "^/__",
+    "^/maintenance$",
     ":[a-z_]+",
     "\\*",
     # Auth pages - should not be indexed by search engines

--- a/test/integration/sitemap/generator_dedupe_test.exs
+++ b/test/integration/sitemap/generator_dedupe_test.exs
@@ -1,0 +1,165 @@
+defmodule PhoenixKit.Integration.Sitemap.GeneratorDedupeTest do
+  @moduledoc """
+  Regression test for a `loc` collision bug: `RouterDiscovery` blindly
+  enumerates every GET route, and when a content source (Publishing,
+  Entities, ...) emits a richer entry for the same URL, the old
+  `Enum.uniq_by(& &1.loc)` dedup kept whichever entry happened to be listed
+  first — which was always the poor `RouterDiscovery` entry, since it is
+  first in `Generator.default_sources/0`. This silently dropped priority
+  and hreflang alternates from the final sitemap for any URL that both a
+  route and a content source produced (observed in production for
+  `/cemented-carbides` and `/legal`).
+  """
+
+  use PhoenixKit.DataCase, async: false
+
+  alias PhoenixKit.Modules.Sitemap.Generator
+  alias PhoenixKit.Modules.Sitemap.UrlEntry
+
+  defmodule FakeRouterDiscoverySource do
+    @moduledoc false
+    @behaviour PhoenixKit.Modules.Sitemap.Sources.Source
+
+    @impl true
+    def source_name, do: :router_discovery
+    @impl true
+    def enabled?, do: true
+
+    @impl true
+    def collect(_opts) do
+      [
+        UrlEntry.new(%{
+          loc: "https://example.com/cemented-carbides",
+          priority: 0.5,
+          changefreq: "weekly",
+          source: :router_discovery
+        })
+      ]
+    end
+  end
+
+  defmodule FakeContentSource do
+    @moduledoc false
+    @behaviour PhoenixKit.Modules.Sitemap.Sources.Source
+
+    @impl true
+    def source_name, do: :fake_content
+    @impl true
+    def enabled?, do: true
+
+    @impl true
+    def collect(_opts) do
+      [
+        UrlEntry.new(%{
+          loc: "https://example.com/cemented-carbides",
+          priority: 0.8,
+          changefreq: "weekly",
+          source: :fake_content,
+          canonical_path: "/cemented-carbides",
+          alternates: [
+            %{hreflang: "en", href: "https://example.com/cemented-carbides"},
+            %{hreflang: "et", href: "https://example.com/et/cemented-carbides"}
+          ]
+        })
+      ]
+    end
+  end
+
+  defmodule FakePlainContentSource do
+    @moduledoc false
+    @behaviour PhoenixKit.Modules.Sitemap.Sources.Source
+
+    @impl true
+    def source_name, do: :fake_plain_content
+    @impl true
+    def enabled?, do: true
+
+    @impl true
+    def collect(_opts) do
+      [
+        UrlEntry.new(%{
+          loc: "https://example.com/legal",
+          priority: 0.3,
+          changefreq: "monthly",
+          source: :fake_plain_content
+        })
+      ]
+    end
+  end
+
+  defmodule FakeRicherLegalSource do
+    @moduledoc false
+    @behaviour PhoenixKit.Modules.Sitemap.Sources.Source
+
+    @impl true
+    def source_name, do: :fake_richer_legal
+    @impl true
+    def enabled?, do: true
+
+    @impl true
+    def collect(_opts) do
+      [
+        UrlEntry.new(%{
+          loc: "https://example.com/legal",
+          priority: 0.8,
+          changefreq: "monthly",
+          source: :fake_richer_legal,
+          canonical_path: "/legal"
+        })
+      ]
+    end
+  end
+
+  describe "collect_all_entries/2 — RouterDiscovery vs. content-source loc collisions" do
+    test "the content-source entry wins when RouterDiscovery collides on the same loc" do
+      entries =
+        Generator.collect_all_entries(
+          [base_url: "https://example.com"],
+          [FakeRouterDiscoverySource, FakeContentSource]
+        )
+
+      assert [entry] = entries
+      assert entry.loc == "https://example.com/cemented-carbides"
+      assert entry.source == :fake_content
+      assert entry.priority == 0.8
+      assert entry.canonical_path == "/cemented-carbides"
+      assert entry.alternates != nil
+    end
+
+    test "source list order does not matter — RouterDiscovery still loses when listed second" do
+      entries =
+        Generator.collect_all_entries(
+          [base_url: "https://example.com"],
+          [FakeContentSource, FakeRouterDiscoverySource]
+        )
+
+      assert [entry] = entries
+      assert entry.source == :fake_content
+    end
+
+    test "a RouterDiscovery entry survives untouched when no other source claims its loc" do
+      entries =
+        Generator.collect_all_entries(
+          [base_url: "https://example.com"],
+          [FakeRouterDiscoverySource]
+        )
+
+      assert [entry] = entries
+      assert entry.source == :router_discovery
+      assert entry.priority == 0.5
+    end
+
+    test "between two non-RouterDiscovery entries, the one with canonical_path wins" do
+      entries =
+        Generator.collect_all_entries(
+          [base_url: "https://example.com"],
+          [FakePlainContentSource, FakeRicherLegalSource]
+        )
+
+      assert [entry] = entries
+      assert entry.loc == "https://example.com/legal"
+      assert entry.source == :fake_richer_legal
+      assert entry.canonical_path == "/legal"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Two RouterDiscovery hygiene fixes surfaced by the same production sitemap audit as #614 (hydroforce.ee):

1. **RouterDiscovery no longer masks richer entries from content sources.** The generator deduplicated same-`loc` entries with `Enum.uniq_by(& &1.loc)`, which keeps whichever entry comes first — an ordering accident, not a preference. In production this meant `/cemented-carbides` and `/legal` (also emitted by the Entities/Publishing sources with `canonical_path`, hreflang alternates and priority 0.7–0.8) were served as bare RouterDiscovery entries: priority 0.5, no hreflang. Dedupe now scores entry richness (RouterDiscovery always loses a same-loc collision; among content sources, canonical_path/alternates/priority win ties).

2. **Internal routes are excluded by default.** `@default_exclude_patterns` gains `"^/__"` (double-underscore internal route convention, e.g. `__hf_news` — a WebSocket-JOIN alias that leaked into the production sitemap as a duplicate of `/news` and was flagged by Search Console as "Duplicate, Google chose different canonical") and `"^/maintenance$"` (PhoenixKit's reserved maintenance route, which is a locale-redirect shim — Search Console flagged it as a redirect/404 chain).

## Relationship to #614

Complements #614 and implements follow-ups its description explicitly lists as out of scope ("RouterDiscovery entries carry no hreflang alternates … can still list redirects/404s"). There is textual overlap in `generator.ex` / `router_discovery.ex` — happy to rebase whichever lands second.

## Test plan

- [x] `mix quality` pre-commit gate: `compile --warnings-as-errors`, `credo --strict`, `dialyzer`, `format --check-formatted` — all green
- [x] New integration test `test/integration/sitemap/generator_dedupe_test.exs` (165 lines): rich-vs-router dedupe, default-pattern exclusion
- [ ] Integration test needs PostgreSQL (no CI in repo) — please run on a machine with a test DB

Behavior note: user-supplied `sitemap_router_discovery_exclude_patterns` in settings still fully replaces the defaults — no behavior change for existing overrides.
