### PR TITLE
Honor seo_no_index on host-app public LiveViews

### DIFF
--- a/lib/phoenix_kit_web/users/auth.ex
+++ b/lib/phoenix_kit_web/users/auth.ex
@@ -44,6 +44,7 @@ defmodule PhoenixKitWeb.Users.Auth do
   alias PhoenixKit.Modules.Languages
   alias PhoenixKit.Modules.Languages.DialectMapper
   alias PhoenixKit.Modules.Maintenance
+  alias PhoenixKit.Modules.SEO
   alias PhoenixKit.Users.Auth
   alias PhoenixKit.Users.Auth.{Scope, User}
   alias PhoenixKit.Users.Permissions
@@ -721,6 +722,14 @@ defmodule PhoenixKitWeb.Users.Auth do
       socket
       |> Phoenix.Component.assign(:url_path, path)
       |> maybe_update_locale_from_params(params)
+      # This hook fires on `handle_params` for every LiveView mounted through
+      # PhoenixKit's on_mount chain (admin and host-app public pages alike),
+      # so it is the one place that can guarantee `:seo_no_index` reaches
+      # root.html.heex's noindex meta tag before the first render — unlike
+      # LayoutWrapper.app_layout_inner/1, which only wraps admin/plugin views
+      # and never runs for a host app's own public LiveViews. assign_new is
+      # a no-op if LayoutWrapper already set it, so this is safe either way.
+      |> Phoenix.Component.assign_new(:seo_no_index, fn -> SEO.no_index_enabled?() end)
 
     {:cont, socket}
   end

--- a/test/phoenix_kit_web/users/auth_seo_no_index_test.exs
+++ b/test/phoenix_kit_web/users/auth_seo_no_index_test.exs
@@ -1,0 +1,58 @@
+defmodule PhoenixKitWeb.Users.AuthSeoNoIndexTest do
+  @moduledoc """
+  Regression test for `seo_no_index` not reaching a host application's own
+  public LiveViews. `PhoenixKitWeb.Components.LayoutWrapper.app_layout_inner/1`
+  is the only place that used to assign `:seo_no_index` — but it only wraps
+  PhoenixKit's own admin/plugin views. A host app's public LiveView (its own
+  layout, not routed through LayoutWrapper) never got the assign, so
+  `root.html.heex`'s `<meta name="robots" content="noindex,nofollow">` never
+  rendered for it even with the directive enabled (observed on Hydroforce's
+  dev environment).
+
+  `PublicHostAppLive` below stands in for such a view: it mounts through
+  PhoenixKit's `:phoenix_kit_mount_current_scope` on_mount (as a host app
+  would, e.g. for current_user/locale support) but renders with its own
+  markup, never calling `LayoutWrapper.app_layout`.
+  """
+
+  use PhoenixKitWeb.ConnCase, async: false
+
+  alias PhoenixKit.Modules.SEO
+
+  defmodule PublicHostAppLive do
+    @moduledoc false
+    use Phoenix.LiveView
+
+    on_mount {PhoenixKitWeb.Users.Auth, :phoenix_kit_mount_current_scope}
+
+    @impl true
+    def render(assigns) do
+      ~H"""
+      <div id="seo-no-index-probe" data-seo-no-index={inspect(assigns[:seo_no_index])}></div>
+      """
+    end
+  end
+
+  setup do
+    on_exit(fn -> SEO.update_no_index(false) end)
+    :ok
+  end
+
+  test "a public host-app LiveView going through PhoenixKit's on_mount gets :seo_no_index=true when the directive is enabled",
+       %{conn: conn} do
+    {:ok, _} = SEO.enable_no_index()
+
+    {:ok, _view, html} = live_isolated(conn, PublicHostAppLive, session: %{})
+
+    assert html =~ ~s(data-seo-no-index="true")
+  end
+
+  test "a public host-app LiveView gets :seo_no_index=false when the directive is disabled",
+       %{conn: conn} do
+    {:ok, _} = SEO.update_no_index(false)
+
+    {:ok, _view, html} = live_isolated(conn, PublicHostAppLive, session: %{})
+
+    assert html =~ ~s(data-seo-no-index="false")
+  end
+end


### PR DESCRIPTION
## Summary

`seo_no_index` never reaches the noindex meta tag on a host application's own public LiveViews.

The only place that assigned `:seo_no_index` was `LayoutWrapper.app_layout_inner/1`, which wraps PhoenixKit's admin/plugin views. A host app's public LiveView renders through the host's own root layout — `root.html.heex`'s conditional `<meta name="robots" content="noindex,nofollow">` block is there, but the assign is never set, so the directive silently does nothing.

Real-world case (same audit as #614): a staging/dev deployment of a PhoenixKit host had `seo_no_index=true` set and was nevertheless fully indexed by Google — including unreleased content that then surfaced on the production domain in Search Console as "Page with redirect" entries.

## Fix

`set_routing_info/3` (the `handle_params` hook attached by `on_mount :phoenix_kit_mount_current_scope`) now does `assign_new(:seo_no_index, fn -> SEO.no_index_enabled?() end)`. That hook already runs for every LiveView mounted through PhoenixKit's on_mount chain — admin and host-app public pages alike — and already owns the sibling concern (`:url_path`). `assign_new/3` keeps it a no-op when `LayoutWrapper` already set the value.

Implements the host-layout follow-up noted in #614 ("`seo_no_index` reaching the real root layout for host apps that supply their own layout").

## Test plan

- [x] `mix quality` pre-commit gate: `compile --warnings-as-errors`, `credo --strict`, `dialyzer`, `format --check-formatted` — all green
- [x] Regression test `test/phoenix_kit_web/users/auth_seo_no_index_test.exs` with a stand-in host-app public LiveView (mounts through the on_mount chain, renders its own markup, never calls LayoutWrapper)
- [ ] Test needs PostgreSQL (no CI in repo) — please run on a machine with a test DB
