### PR TITLE
Add sitemap Advanced settings UI + source settings extension point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+## 1.7.175 - 2026-07-06
+
+### Added
+- **Sitemap settings page now exposes Router Discovery exclude patterns,
+  protected pipelines, custom URLs, and static routes.** These four settings
+  (`sitemap_router_discovery_exclude_patterns`, `sitemap_protected_pipelines`,
+  `sitemap_custom_urls`, `sitemap_static_routes`) previously had no admin UI —
+  changing them required editing the database directly. They're now editable
+  from a new "Advanced" section on `/admin/settings/sitemap`, with the
+  exclude-patterns field validated against `Regex.compile/1` before saving
+  (an invalid pattern is rejected with an inline error instead of being
+  silently dropped later) and pipeline names restricted to identifier-safe
+  characters.
+- **Sitemap sources can now declare their own settings via
+  `PhoenixKit.Modules.Sitemap.Sources.Source.sitemap_settings_schema/0`.**
+  This new optional callback lets a source module (built-in or contributed by
+  another package, e.g. an Entities module) describe boolean/string/integer
+  settings with a label, help text, and default; the sitemap settings page
+  discovers and renders them automatically, reading/writing through
+  `PhoenixKit.Settings` the same way built-in settings work. No core source
+  implements it yet — this is purely an extension point for
+  settings that don't already have a home in the core UI.
+
 ## 1.7.174 - 2026-07-05
 
 ### Fixed

--- a/lib/modules/sitemap/sources/router_discovery.ex
+++ b/lib/modules/sitemap/sources/router_discovery.ex
@@ -166,6 +166,48 @@ defmodule PhoenixKit.Modules.Sitemap.Sources.RouterDiscovery do
       []
   end
 
+  ## Settings UI helpers
+
+  @doc """
+  Returns the subset of `patterns` that fail to compile as regexes.
+
+  Mirrors the same `Regex.compile/1` check `compile_patterns/2` applies at
+  collection time, so a pattern accepted here is guaranteed not to be
+  silently dropped later. Used by the settings UI to reject invalid
+  exclude/include-only patterns before saving, instead of persisting them
+  and only discovering the problem in the logs.
+
+  ## Examples
+
+      iex> PhoenixKit.Modules.Sitemap.Sources.RouterDiscovery.invalid_patterns(["^/admin", "*"])
+      ["*"]
+  """
+  @spec invalid_patterns([String.t()]) :: [String.t()]
+  def invalid_patterns(patterns) when is_list(patterns) do
+    Enum.filter(patterns, &match?({:error, _}, Regex.compile(&1)))
+  end
+
+  @doc """
+  Returns the built-in default exclude patterns.
+
+  These apply whenever `sitemap_router_discovery_exclude_patterns` is unset.
+  Once that setting is saved (even as an empty list), it replaces this list
+  entirely rather than adding to it. Exposed so the settings UI can show
+  admins what's excluded today, before they touch the setting.
+  """
+  @spec default_exclude_patterns() :: [String.t()]
+  def default_exclude_patterns, do: @default_exclude_patterns
+
+  @doc """
+  Returns the built-in default protected pipelines.
+
+  Unlike exclude patterns, `sitemap_protected_pipelines` only *adds* to this
+  list — these defaults always apply. Exposed so the settings UI can show
+  admins which pipelines are already protected without configuration.
+  """
+  @spec default_protected_pipelines() :: [atom()]
+  def default_protected_pipelines, do: @default_protected_pipelines
+
   defp do_collect(opts) do
     base_url = Keyword.get(opts, :base_url)
     exclude_patterns = compile_patterns(get_exclude_patterns(), "exclude")

--- a/lib/modules/sitemap/sources/source.ex
+++ b/lib/modules/sitemap/sources/source.ex
@@ -15,11 +15,30 @@ defmodule PhoenixKit.Modules.Sitemap.Sources.Source do
 
   - `sitemap_filename/0` - Custom filename for the module's sitemap file
   - `sub_sitemaps/1` - Split into multiple sub-sitemap files (e.g., per-blog, per-entity-type)
+  - `sitemap_settings_schema/0` - Declare source-specific settings for the admin UI
   """
 
   require Logger
 
   alias PhoenixKit.Modules.Sitemap.UrlEntry
+
+  @typedoc """
+  Describes one source-specific setting for the admin settings UI.
+
+  - `key` - the `PhoenixKit.Settings` key this field reads/writes
+  - `type` - controls both the input widget and how the stored string is
+    parsed (`:boolean` -> toggle, `:string` -> text input, `:integer` -> number input)
+  - `label` - field label shown to the admin
+  - `help` - optional helper text shown below the label
+  - `default` - value used when the setting has never been saved
+  """
+  @type settings_field :: %{
+          key: String.t(),
+          type: :boolean | :string | :integer,
+          label: String.t(),
+          help: String.t() | nil,
+          default: term()
+        }
 
   @doc """
   Returns the unique name/identifier for this source.
@@ -53,7 +72,36 @@ defmodule PhoenixKit.Modules.Sitemap.Sources.Source do
   """
   @callback sub_sitemaps(opts :: keyword()) :: [{String.t(), [UrlEntry.t()]}] | nil
 
-  @optional_callbacks [sitemap_filename: 0, sub_sitemaps: 1]
+  @doc """
+  Declares source-specific settings for the sitemap admin settings page.
+
+  Optional. A source that implements this returns a list of field
+  descriptors; the settings page renders one input per field (grouped
+  under the source's name), reads/writes each through `PhoenixKit.Settings`
+  using its `key` and `default`, and invalidates the sitemap cache on save
+  — the same way the page's built-in settings work.
+
+  Only add this for settings that don't already have a UI. Don't
+  reimplement fields the core sitemap settings page already exposes (e.g.
+  the built-in `sitemap_include_*` toggles).
+
+  ## Example
+
+      def sitemap_settings_schema do
+        [
+          %{
+            key: "sitemap_entities_include_index",
+            type: :boolean,
+            label: "Include entity index pages",
+            help: "Adds the /entities listing page alongside individual entries",
+            default: true
+          }
+        ]
+      end
+  """
+  @callback sitemap_settings_schema() :: [settings_field()]
+
+  @optional_callbacks [sitemap_filename: 0, sub_sitemaps: 1, sitemap_settings_schema: 0]
 
   @doc """
   Helper function to check if a source module is valid.
@@ -97,6 +145,21 @@ defmodule PhoenixKit.Modules.Sitemap.Sources.Source do
       source_module.sub_sitemaps(opts)
     else
       nil
+    end
+  end
+
+  @doc """
+  Returns the settings schema for a source module.
+
+  Calls the optional `sitemap_settings_schema/0` callback if implemented,
+  otherwise returns `[]` (no source-specific settings to render).
+  """
+  @spec get_settings_schema(module()) :: [settings_field()]
+  def get_settings_schema(source_module) do
+    if function_exported?(source_module, :sitemap_settings_schema, 0) do
+      source_module.sitemap_settings_schema()
+    else
+      []
     end
   end
 

--- a/lib/modules/sitemap/sources/static.ex
+++ b/lib/modules/sitemap/sources/static.ex
@@ -91,6 +91,18 @@ defmodule PhoenixKit.Modules.Sitemap.Sources.Static do
   @impl true
   def sitemap_filename, do: "sitemap-static"
 
+  @doc """
+  Returns the built-in default static routes (always includes the homepage).
+
+  These apply whenever `sitemap_static_routes` is unset. Once that setting
+  is saved (even as an empty list), it replaces this list entirely — so
+  saving `[]` removes the homepage entry too. Exposed so the settings UI can
+  pre-fill the editor with the current effective routes instead of an empty
+  list that looks safe to submit as-is but isn't.
+  """
+  @spec default_static_routes() :: [map()]
+  def default_static_routes, do: @default_static_routes
+
   @impl true
   def collect(opts \\ []) do
     is_default = Keyword.get(opts, :is_default_language, true)

--- a/lib/modules/sitemap/web/settings.ex
+++ b/lib/modules/sitemap/web/settings.ex
@@ -14,10 +14,15 @@ defmodule PhoenixKit.Modules.Sitemap.Web.Settings do
   use PhoenixKitWeb, :live_view
   use Gettext, backend: PhoenixKitWeb.Gettext
 
+  require Logger
+
   alias PhoenixKit.Modules.Sitemap
   alias PhoenixKit.Modules.Sitemap.FileStorage
   alias PhoenixKit.Modules.Sitemap.Generator
   alias PhoenixKit.Modules.Sitemap.SchedulerWorker
+  alias PhoenixKit.Modules.Sitemap.Sources.RouterDiscovery
+  alias PhoenixKit.Modules.Sitemap.Sources.Source
+  alias PhoenixKit.Modules.Sitemap.Sources.Static
   alias PhoenixKit.PubSub.Manager, as: PubSubManager
   alias PhoenixKit.Settings
   alias PhoenixKit.Utils.Date, as: UtilsDate
@@ -56,6 +61,16 @@ defmodule PhoenixKit.Modules.Sitemap.Web.Settings do
       |> assign(:include_registration, Sitemap.include_registration?())
       |> assign(:publishing_split_by_group, Sitemap.publishing_split_by_group?())
       |> assign(:module_enabled, get_module_enabled_status())
+      |> assign(:exclude_patterns_text, exclude_patterns_text())
+      |> assign(:exclude_patterns_error, nil)
+      |> assign(:protected_pipelines_text, protected_pipelines_text())
+      |> assign(:protected_pipelines_defaults_text, protected_pipelines_defaults_text())
+      |> assign(:protected_pipelines_error, nil)
+      |> assign(:custom_urls_text, custom_urls_text())
+      |> assign(:custom_urls_error, nil)
+      |> assign(:static_routes_text, static_routes_text())
+      |> assign(:static_routes_error, nil)
+      |> assign(:extension_sources, build_extension_sources(Generator.get_sources()))
 
     {:ok, socket}
   end
@@ -382,6 +397,156 @@ defmodule PhoenixKit.Modules.Sitemap.Web.Settings do
     end
   end
 
+  @impl true
+  def handle_event("save_exclude_patterns", %{"patterns" => text}, socket) do
+    patterns = parse_lines(text)
+
+    case RouterDiscovery.invalid_patterns(patterns) do
+      [] ->
+        case Settings.update_setting(
+               "sitemap_router_discovery_exclude_patterns",
+               Jason.encode!(patterns)
+             ) do
+          {:ok, _} ->
+            {:noreply,
+             socket
+             |> assign(:exclude_patterns_text, Enum.join(patterns, "\n"))
+             |> assign(:exclude_patterns_error, nil)
+             |> bump_and_broadcast("router_discovery_exclude_patterns")
+             |> put_flash(:info, "Exclude patterns updated")}
+
+          {:error, _} ->
+            {:noreply, put_flash(socket, :error, "Failed to update exclude patterns")}
+        end
+
+      invalid ->
+        {:noreply,
+         socket
+         |> assign(:exclude_patterns_text, text)
+         |> assign(
+           :exclude_patterns_error,
+           "Invalid regex pattern(s), not saved: #{Enum.join(invalid, ", ")}"
+         )}
+    end
+  end
+
+  @impl true
+  def handle_event("save_protected_pipelines", %{"pipelines" => text}, socket) do
+    names = parse_lines(text)
+
+    case invalid_pipeline_names(names) do
+      [] ->
+        case Settings.update_setting("sitemap_protected_pipelines", Jason.encode!(names)) do
+          {:ok, _} ->
+            {:noreply,
+             socket
+             |> assign(:protected_pipelines_text, Enum.join(names, "\n"))
+             |> assign(:protected_pipelines_error, nil)
+             |> bump_and_broadcast("protected_pipelines")
+             |> put_flash(:info, "Protected pipelines updated")}
+
+          {:error, _} ->
+            {:noreply, put_flash(socket, :error, "Failed to update protected pipelines")}
+        end
+
+      invalid ->
+        {:noreply,
+         socket
+         |> assign(:protected_pipelines_text, text)
+         |> assign(
+           :protected_pipelines_error,
+           "Invalid pipeline name(s) — use letters, digits and underscores only, not saved: " <>
+             Enum.join(invalid, ", ")
+         )}
+    end
+  end
+
+  @impl true
+  def handle_event("save_custom_urls", %{"json" => text}, socket) do
+    case decode_object_list(text) do
+      {:ok, list} ->
+        case Settings.update_setting("sitemap_custom_urls", Jason.encode!(list)) do
+          {:ok, _} ->
+            {:noreply,
+             socket
+             |> assign(:custom_urls_text, Jason.encode!(list, pretty: true))
+             |> assign(:custom_urls_error, nil)
+             |> bump_and_broadcast("custom_urls")
+             |> put_flash(:info, "Custom URLs updated")}
+
+          {:error, _} ->
+            {:noreply, put_flash(socket, :error, "Failed to update custom URLs")}
+        end
+
+      {:error, message} ->
+        {:noreply,
+         socket
+         |> assign(:custom_urls_text, text)
+         |> assign(:custom_urls_error, message)}
+    end
+  end
+
+  @impl true
+  def handle_event("save_static_routes", %{"json" => text}, socket) do
+    case decode_object_list(text) do
+      {:ok, list} ->
+        case Settings.update_setting("sitemap_static_routes", Jason.encode!(list)) do
+          {:ok, _} ->
+            {:noreply,
+             socket
+             |> assign(:static_routes_text, Jason.encode!(list, pretty: true))
+             |> assign(:static_routes_error, nil)
+             |> bump_and_broadcast("static_routes")
+             |> put_flash(:info, "Static routes updated")}
+
+          {:error, _} ->
+            {:noreply, put_flash(socket, :error, "Failed to update static routes")}
+        end
+
+      {:error, message} ->
+        {:noreply,
+         socket
+         |> assign(:static_routes_text, text)
+         |> assign(:static_routes_error, message)}
+    end
+  end
+
+  @impl true
+  def handle_event("toggle_extension_setting", %{"key" => key}, socket) do
+    case find_extension_field(socket, key) do
+      %{type: :boolean, default: default} ->
+        current = Settings.get_boolean_setting(key, default)
+
+        case Settings.update_boolean_setting(key, !current) do
+          {:ok, _} ->
+            {:noreply, socket |> refresh_extension_sources() |> bump_and_broadcast(key)}
+
+          {:error, _} ->
+            {:noreply, put_flash(socket, :error, "Failed to update setting")}
+        end
+
+      _ ->
+        {:noreply, put_flash(socket, :error, "Unknown setting")}
+    end
+  end
+
+  @impl true
+  def handle_event("save_extension_setting", %{"key" => key, "value" => raw_value}, socket) do
+    case find_extension_field(socket, key) do
+      %{type: :integer} ->
+        case Integer.parse(raw_value) do
+          {int, _} -> {:noreply, save_extension_value(socket, key, Integer.to_string(int))}
+          :error -> {:noreply, put_flash(socket, :error, "Invalid number")}
+        end
+
+      %{type: :string} ->
+        {:noreply, save_extension_value(socket, key, raw_value)}
+
+      _ ->
+        {:noreply, put_flash(socket, :error, "Unknown setting")}
+    end
+  end
+
   # Handle PubSub message when sitemap generation completes
   @impl true
   def handle_info({:sitemap_generated, %{url_count: count}}, socket) do
@@ -486,6 +651,177 @@ defmodule PhoenixKit.Modules.Sitemap.Web.Settings do
   end
 
   def format_timestamp(_), do: "Never"
+
+  # ============================================================================
+  # Advanced settings (Router Discovery exclude patterns, protected pipelines,
+  # custom URLs, static routes) — raw text <-> stored JSON conversions.
+  # ============================================================================
+
+  # Helper: read a JSON-encoded setting, falling back to `default_term` when
+  # unset or invalid — mirrors the exact fallback each source module already
+  # applies when it reads the same key, so what's shown here matches what's
+  # actually in effect.
+  defp decoded_setting(key, default_term) do
+    case Settings.get_setting(key) do
+      nil ->
+        default_term
+
+      json when is_binary(json) ->
+        case Jason.decode(json) do
+          {:ok, term} -> term
+          _ -> default_term
+        end
+    end
+  end
+
+  def exclude_patterns_text do
+    decoded_setting(
+      "sitemap_router_discovery_exclude_patterns",
+      RouterDiscovery.default_exclude_patterns()
+    )
+    |> Enum.join("\n")
+  end
+
+  def protected_pipelines_text do
+    decoded_setting("sitemap_protected_pipelines", [])
+    |> Enum.map_join("\n", &to_string/1)
+  end
+
+  def protected_pipelines_defaults_text do
+    RouterDiscovery.default_protected_pipelines()
+    |> Enum.map_join(", ", &to_string/1)
+  end
+
+  def custom_urls_text do
+    decoded_setting("sitemap_custom_urls", [])
+    |> Jason.encode!(pretty: true)
+  end
+
+  def static_routes_text do
+    decoded_setting("sitemap_static_routes", Static.default_static_routes())
+    |> Jason.encode!(pretty: true)
+  end
+
+  # Helper: textarea -> trimmed, non-blank lines (one setting value per line)
+  defp parse_lines(text) do
+    text
+    |> String.split("\n")
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
+  end
+
+  @pipeline_name_pattern ~r/^[a-zA-Z_][a-zA-Z0-9_]*$/
+
+  # Pipeline names become atoms via String.to_atom/1 at collection time
+  # (see RouterDiscovery.safe_to_atom/1) — restrict to identifier-safe
+  # characters so a stray typo can't create an arbitrary atom.
+  defp invalid_pipeline_names(names) do
+    Enum.reject(names, &Regex.match?(@pipeline_name_pattern, &1))
+  end
+
+  # Helper: decode a JSON textarea value expected to hold an array of
+  # objects (sitemap_custom_urls / sitemap_static_routes shape).
+  defp decode_object_list(text) do
+    case Jason.decode(text) do
+      {:ok, list} when is_list(list) ->
+        if Enum.all?(list, &is_map/1) do
+          {:ok, list}
+        else
+          {:error, "Must be a JSON array of objects"}
+        end
+
+      {:ok, _other} ->
+        {:error, "Must be a JSON array of objects"}
+
+      {:error, %Jason.DecodeError{} = error} ->
+        {:error, "Invalid JSON: #{Jason.DecodeError.message(error)}"}
+    end
+  end
+
+  # Shared tail for every advanced/extension setting save: bust the generated
+  # sitemap cache, bump the version so connected clients refresh, and notify
+  # other open tabs — the same three steps every other handler in this module
+  # performs inline after a successful Settings update.
+  defp bump_and_broadcast(socket, source_key) do
+    Generator.invalidate_cache()
+    new_version = UtilsDate.utc_now() |> DateTime.to_unix()
+    broadcast_settings_change(:source_changed, %{source: source_key, version: new_version})
+    assign(socket, :sitemap_version, new_version)
+  end
+
+  # ============================================================================
+  # Extension point: source-contributed settings
+  # (PhoenixKit.Modules.Sitemap.Sources.Source.sitemap_settings_schema/0)
+  # ============================================================================
+
+  # Builds the render-ready list of `{source_module, fields}` for every
+  # source that declares a settings schema, with each field's current value
+  # attached. Public (not just used by `mount/3`) so it can be unit tested
+  # directly against a mock source module, without needing a live DB-backed
+  # LiveView mount.
+  def build_extension_sources(source_modules) do
+    source_modules
+    |> Enum.map(fn mod -> {mod, safe_get_settings_schema(mod)} end)
+    |> Enum.reject(fn {_mod, schema} -> schema == [] end)
+    |> Enum.map(fn {mod, schema} ->
+      {mod, Enum.map(schema, &Map.put(&1, :value, read_extension_field(&1)))}
+    end)
+  end
+
+  # A source's schema is arbitrary data from another module — never let a
+  # malformed one crash the settings page for every admin (mirrors the same
+  # safety net `Source.safe_collect/2` applies to sitemap generation).
+  defp safe_get_settings_schema(mod) do
+    Source.get_settings_schema(mod)
+  rescue
+    error ->
+      Logger.warning(
+        "Sitemap source #{inspect(mod)} returned an invalid settings schema: #{inspect(error)}"
+      )
+
+      []
+  end
+
+  defp read_extension_field(field) do
+    case field.type do
+      :boolean -> Settings.get_boolean_setting(field.key, field.default)
+      :integer -> Settings.get_integer_setting(field.key, field.default)
+      :string -> Settings.get_setting(field.key, field.default)
+    end
+  rescue
+    _ -> field.default
+  end
+
+  # Helper: human-readable card title for a source module in the extension
+  # section (e.g. `:router_discovery` -> "Router discovery").
+  def source_display_name(mod) do
+    mod.source_name() |> to_string() |> Phoenix.Naming.humanize()
+  rescue
+    _ -> mod |> to_string() |> String.trim_leading("Elixir.") |> Phoenix.Naming.humanize()
+  end
+
+  defp find_extension_field(socket, key) do
+    Enum.find_value(socket.assigns.extension_sources, fn {_mod, fields} ->
+      Enum.find(fields, &(&1.key == key))
+    end)
+  end
+
+  defp refresh_extension_sources(socket) do
+    assign(socket, :extension_sources, build_extension_sources(Generator.get_sources()))
+  end
+
+  defp save_extension_value(socket, key, value) do
+    case Settings.update_setting(key, value) do
+      {:ok, _} ->
+        socket
+        |> refresh_extension_sources()
+        |> bump_and_broadcast(key)
+        |> put_flash(:info, "Setting updated")
+
+      {:error, _} ->
+        put_flash(socket, :error, "Failed to update setting")
+    end
+  end
 
   # Check which parent modules are actually enabled (not just sitemap toggles)
   defp get_module_enabled_status do

--- a/lib/modules/sitemap/web/settings.html.heex
+++ b/lib/modules/sitemap/web/settings.html.heex
@@ -439,6 +439,59 @@
         </div>
       </div>
 
+      <%!-- Source-Contributed Settings (extension point: Source.sitemap_settings_schema/0) --%>
+      <div :for={{mod, fields} <- @extension_sources} class="card bg-base-200 shadow-md">
+        <div class="card-body">
+          <h2 class="card-title">
+            <.icon name="hero-puzzle-piece" class="w-5 h-5" /> {source_display_name(mod)}
+          </h2>
+
+          <div class="space-y-3 mt-2">
+            <div :for={field <- fields}>
+              <label
+                :if={field.type == :boolean}
+                class="flex items-center justify-between cursor-pointer"
+              >
+                <div>
+                  <span class="label-text font-medium">{field.label}</span>
+                  <span :if={field.help} class="text-xs text-base-content/60 block">
+                    {field.help}
+                  </span>
+                </div>
+                <input
+                  type="checkbox"
+                  class="toggle toggle-sm toggle-primary"
+                  checked={field.value}
+                  phx-click="toggle_extension_setting"
+                  phx-value-key={field.key}
+                />
+              </label>
+
+              <form
+                :if={field.type != :boolean}
+                phx-submit="save_extension_setting"
+                phx-value-key={field.key}
+                class="form-control"
+              >
+                <label class="label">
+                  <span class="label-text font-medium">{field.label}</span>
+                </label>
+                <p :if={field.help} class="text-xs text-base-content/60 mb-1">{field.help}</p>
+                <div class="flex gap-2">
+                  <input
+                    type={if field.type == :integer, do: "number", else: "text"}
+                    name="value"
+                    value={field.value}
+                    class="input input-bordered input-sm w-full"
+                  />
+                  <button type="submit" class="btn btn-sm btn-primary">{gettext("Save")}</button>
+                </div>
+              </form>
+            </div>
+          </div>
+        </div>
+      </div>
+
       <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
         <%!-- Configuration Card --%>
         <div class="card bg-base-200 shadow-md">
@@ -625,6 +678,115 @@
               do: gettext("/sitemap.xml contains all URLs in a single <urlset>"),
               else: gettext("/sitemap.xml is a sitemapindex referencing per-module sitemap files")}
           </p>
+        </div>
+      </div>
+
+      <%!-- Advanced Settings --%>
+      <div class="card bg-base-200 shadow-md">
+        <div class="card-body">
+          <h2 class="card-title">
+            <.icon name="hero-wrench-screwdriver" class="w-5 h-5" /> {gettext("Advanced")}
+          </h2>
+          <p class="text-sm text-base-content/60 mb-2">
+            {gettext(
+              "Low-level Router Discovery and static-page settings. Most sites won't need these — they were previously only reachable by editing the database directly."
+            )}
+          </p>
+
+          <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 mt-2">
+            <%!-- Exclude Patterns --%>
+            <form phx-submit="save_exclude_patterns" class="form-control">
+              <label class="label">
+                <span class="label-text font-medium">
+                  {gettext("Router Discovery: Exclude Patterns")}
+                </span>
+              </label>
+              <p class="text-xs text-base-content/60 mb-1">
+                {gettext(
+                  "One regular expression per line. Replaces the built-in defaults entirely when saved — an empty list means nothing is excluded."
+                )}
+              </p>
+              <textarea
+                name="patterns"
+                rows="6"
+                class="textarea textarea-bordered font-mono text-xs w-full"
+              >{@exclude_patterns_text}</textarea>
+              <div :if={@exclude_patterns_error} class="alert alert-error mt-2 py-2 text-xs">
+                {@exclude_patterns_error}
+              </div>
+              <button type="submit" class="btn btn-sm btn-primary mt-2 self-start">
+                {gettext("Save Exclude Patterns")}
+              </button>
+            </form>
+
+            <%!-- Protected Pipelines --%>
+            <form phx-submit="save_protected_pipelines" class="form-control">
+              <label class="label">
+                <span class="label-text font-medium">{gettext("Protected Pipelines")}</span>
+              </label>
+              <p class="text-xs text-base-content/60 mb-1">
+                {gettext("One pipeline name per line. Added on top of the built-in defaults:")}
+                <span class="font-mono">{@protected_pipelines_defaults_text}</span>
+              </p>
+              <textarea
+                name="pipelines"
+                rows="6"
+                class="textarea textarea-bordered font-mono text-xs w-full"
+              >{@protected_pipelines_text}</textarea>
+              <div :if={@protected_pipelines_error} class="alert alert-error mt-2 py-2 text-xs">
+                {@protected_pipelines_error}
+              </div>
+              <button type="submit" class="btn btn-sm btn-primary mt-2 self-start">
+                {gettext("Save Protected Pipelines")}
+              </button>
+            </form>
+
+            <%!-- Custom URLs --%>
+            <form phx-submit="save_custom_urls" class="form-control">
+              <label class="label">
+                <span class="label-text font-medium">{gettext("Custom URLs")}</span>
+              </label>
+              <p class="text-xs text-base-content/60 mb-1">
+                {gettext(
+                  "JSON array of extra static URL entries (path, priority, changefreq, title, category)."
+                )}
+              </p>
+              <textarea
+                name="json"
+                rows="8"
+                class="textarea textarea-bordered font-mono text-xs w-full"
+              >{@custom_urls_text}</textarea>
+              <div :if={@custom_urls_error} class="alert alert-error mt-2 py-2 text-xs">
+                {@custom_urls_error}
+              </div>
+              <button type="submit" class="btn btn-sm btn-primary mt-2 self-start">
+                {gettext("Save Custom URLs")}
+              </button>
+            </form>
+
+            <%!-- Static Routes --%>
+            <form phx-submit="save_static_routes" class="form-control">
+              <label class="label">
+                <span class="label-text font-medium">{gettext("Static Routes")}</span>
+              </label>
+              <p class="text-xs text-base-content/60 mb-1">
+                {gettext(
+                  "JSON array of route configurations (plug or path, priority, changefreq, title, category). Replaces the built-in defaults entirely when saved — an empty list removes the homepage entry too."
+                )}
+              </p>
+              <textarea
+                name="json"
+                rows="8"
+                class="textarea textarea-bordered font-mono text-xs w-full"
+              >{@static_routes_text}</textarea>
+              <div :if={@static_routes_error} class="alert alert-error mt-2 py-2 text-xs">
+                {@static_routes_error}
+              </div>
+              <button type="submit" class="btn btn-sm btn-primary mt-2 self-start">
+                {gettext("Save Static Routes")}
+              </button>
+            </form>
+          </div>
         </div>
       </div>
     </div>

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule PhoenixKit.MixProject do
   use Mix.Project
 
-  @version "1.7.174"
+  @version "1.7.175"
   @description "A foundation for building Elixir Phoenix apps — SaaS, social networks, ERP systems, marketplaces, and more"
   @source_url "https://github.com/BeamLabEU/phoenix_kit"
 

--- a/test/integration/sitemap/router_discovery_validation_test.exs
+++ b/test/integration/sitemap/router_discovery_validation_test.exs
@@ -1,0 +1,55 @@
+defmodule PhoenixKit.Integration.Sitemap.RouterDiscoveryValidationTest do
+  @moduledoc """
+  Pins the pattern-validation contract the sitemap settings UI relies on:
+  `RouterDiscovery.invalid_patterns/1` must flag exactly the patterns that
+  `compile_patterns/2` would otherwise silently drop (with only a log
+  warning) at collection time, so the settings UI can reject bad input
+  before it's ever saved instead of persisting a pattern that quietly does
+  nothing.
+
+  Pure logic, no database needed.
+  """
+  use ExUnit.Case, async: true
+
+  alias PhoenixKit.Modules.Sitemap.Sources.RouterDiscovery
+
+  describe "invalid_patterns/1" do
+    test "returns an empty list when every pattern compiles" do
+      assert RouterDiscovery.invalid_patterns(["^/admin", "^/api", ".*"]) == []
+    end
+
+    test "flags a bare wildcard — a shell glob, not a valid regex" do
+      assert RouterDiscovery.invalid_patterns(["^/admin", "*"]) == ["*"]
+    end
+
+    test "flags every pattern that fails to compile, preserving input order" do
+      assert RouterDiscovery.invalid_patterns(["*", "^/ok", "("]) == ["*", "("]
+    end
+
+    test "returns an empty list for an empty input" do
+      assert RouterDiscovery.invalid_patterns([]) == []
+    end
+  end
+
+  describe "default_exclude_patterns/0" do
+    test "returns the built-in list of exclude patterns" do
+      defaults = RouterDiscovery.default_exclude_patterns()
+
+      assert is_list(defaults)
+      assert Enum.all?(defaults, &is_binary/1)
+      assert "^/admin" in defaults
+      # Every default must itself compile — the built-ins are never invalid.
+      assert RouterDiscovery.invalid_patterns(defaults) == []
+    end
+  end
+
+  describe "default_protected_pipelines/0" do
+    test "returns the built-in list of protected pipeline names" do
+      defaults = RouterDiscovery.default_protected_pipelines()
+
+      assert is_list(defaults)
+      assert Enum.all?(defaults, &is_atom/1)
+      assert :phoenix_kit_admin_only in defaults
+    end
+  end
+end

--- a/test/integration/sitemap/settings_advanced_test.exs
+++ b/test/integration/sitemap/settings_advanced_test.exs
@@ -1,0 +1,147 @@
+defmodule PhoenixKit.Integration.Sitemap.SettingsAdvancedTest do
+  @moduledoc """
+  Covers the sitemap settings page's "Advanced" section: four core settings
+  that previously had no UI at all and could only be changed by editing the
+  database directly — `sitemap_router_discovery_exclude_patterns`,
+  `sitemap_protected_pipelines`, `sitemap_custom_urls`, `sitemap_static_routes`.
+
+  Exercises the actual LiveView (mount + form submit), so it needs a
+  database — uses `PhoenixKitWeb.ConnCase`.
+  """
+  use PhoenixKitWeb.ConnCase, async: false
+
+  alias PhoenixKit.Settings
+  alias PhoenixKit.Utils.Routes
+
+  @path Routes.path("/admin/settings/sitemap")
+
+  defp setup_admin(%{conn: conn}) do
+    {user, _token} = create_admin_user()
+    conn = log_in_user(conn, user)
+    %{conn: conn, user: user}
+  end
+
+  describe "Router Discovery exclude patterns" do
+    setup :setup_admin
+
+    test "rejects an invalid regex pattern and does not save it", %{conn: conn} do
+      {:ok, view, _html} = live(conn, @path)
+
+      html =
+        view
+        |> form("form[phx-submit='save_exclude_patterns']", %{"patterns" => "^/admin\n*"})
+        |> render_submit()
+
+      assert html =~ "Invalid regex pattern"
+      assert Settings.get_setting("sitemap_router_discovery_exclude_patterns") == nil
+    end
+
+    test "saves a valid list of patterns as a JSON array", %{conn: conn} do
+      {:ok, view, _html} = live(conn, @path)
+
+      view
+      |> form("form[phx-submit='save_exclude_patterns']", %{"patterns" => "^/admin\n^/api"})
+      |> render_submit()
+
+      assert Settings.get_setting("sitemap_router_discovery_exclude_patterns") ==
+               Jason.encode!(["^/admin", "^/api"])
+    end
+  end
+
+  describe "Protected pipelines" do
+    setup :setup_admin
+
+    test "rejects a pipeline name with invalid characters and does not save it", %{conn: conn} do
+      {:ok, view, _html} = live(conn, @path)
+
+      html =
+        view
+        |> form("form[phx-submit='save_protected_pipelines']", %{"pipelines" => "my pipeline"})
+        |> render_submit()
+
+      assert html =~ "Invalid pipeline name"
+      assert Settings.get_setting("sitemap_protected_pipelines") == nil
+    end
+
+    test "saves a valid list of pipeline names as a JSON array", %{conn: conn} do
+      {:ok, view, _html} = live(conn, @path)
+
+      view
+      |> form("form[phx-submit='save_protected_pipelines']", %{
+        "pipelines" => "member_only\napi_key"
+      })
+      |> render_submit()
+
+      assert Settings.get_setting("sitemap_protected_pipelines") ==
+               Jason.encode!(["member_only", "api_key"])
+    end
+  end
+
+  describe "Custom URLs" do
+    setup :setup_admin
+
+    test "rejects invalid JSON and does not save it", %{conn: conn} do
+      {:ok, view, _html} = live(conn, @path)
+
+      html =
+        view
+        |> form("form[phx-submit='save_custom_urls']", %{"json" => "not json"})
+        |> render_submit()
+
+      assert html =~ "Invalid JSON"
+      assert Settings.get_setting("sitemap_custom_urls") == nil
+    end
+
+    test "rejects a JSON value that isn't an array of objects", %{conn: conn} do
+      {:ok, view, _html} = live(conn, @path)
+
+      html =
+        view
+        |> form("form[phx-submit='save_custom_urls']", %{"json" => ~s(["a", "b"])})
+        |> render_submit()
+
+      assert html =~ "Must be a JSON array of objects"
+      assert Settings.get_setting("sitemap_custom_urls") == nil
+    end
+
+    test "saves a valid array of URL objects", %{conn: conn} do
+      {:ok, view, _html} = live(conn, @path)
+      json = Jason.encode!([%{"path" => "/about-us", "title" => "About Us"}])
+
+      view
+      |> form("form[phx-submit='save_custom_urls']", %{"json" => json})
+      |> render_submit()
+
+      assert {:ok, [%{"path" => "/about-us"}]} =
+               "sitemap_custom_urls" |> Settings.get_setting() |> Jason.decode()
+    end
+  end
+
+  describe "Static routes" do
+    setup :setup_admin
+
+    test "rejects invalid JSON and does not save it", %{conn: conn} do
+      {:ok, view, _html} = live(conn, @path)
+
+      html =
+        view
+        |> form("form[phx-submit='save_static_routes']", %{"json" => "{not json"})
+        |> render_submit()
+
+      assert html =~ "Invalid JSON"
+      assert Settings.get_setting("sitemap_static_routes") == nil
+    end
+
+    test "saves a valid array of route objects", %{conn: conn} do
+      {:ok, view, _html} = live(conn, @path)
+      json = Jason.encode!([%{"path" => "/", "title" => "Home"}])
+
+      view
+      |> form("form[phx-submit='save_static_routes']", %{"json" => json})
+      |> render_submit()
+
+      assert {:ok, [%{"path" => "/"}]} =
+               "sitemap_static_routes" |> Settings.get_setting() |> Jason.decode()
+    end
+  end
+end

--- a/test/integration/sitemap/settings_extension_schema_test.exs
+++ b/test/integration/sitemap/settings_extension_schema_test.exs
@@ -1,0 +1,110 @@
+defmodule PhoenixKit.Integration.Sitemap.SettingsExtensionSchemaTest do
+  @moduledoc """
+  Covers the sitemap settings page's extension point: a source module can
+  declare `sitemap_settings_schema/0` and have its fields rendered and
+  editable on the core sitemap settings page, without the core needing to
+  know about that source ahead of time
+  (see `PhoenixKit.Modules.Sitemap.Sources.Source`).
+
+  Uses two in-file fixture source modules — one that declares a schema, one
+  that doesn't — instead of depending on a real optional dependency (like
+  phoenix_kit_entities) being installed in this repo's test suite.
+  """
+  use PhoenixKitWeb.ConnCase, async: false
+
+  alias PhoenixKit.Modules.Sitemap.Web.Settings, as: SitemapSettings
+  alias PhoenixKit.Settings
+  alias PhoenixKit.Utils.Routes
+
+  @path Routes.path("/admin/settings/sitemap")
+
+  defmodule FakeSource do
+    @moduledoc false
+    @behaviour PhoenixKit.Modules.Sitemap.Sources.Source
+
+    @impl true
+    def source_name, do: :fake_entities
+
+    @impl true
+    def enabled?, do: true
+
+    @impl true
+    def collect(_opts), do: []
+
+    @impl true
+    def sitemap_settings_schema do
+      [
+        %{
+          key: "sitemap_fake_entities_include_index",
+          type: :boolean,
+          label: "Include entity index page",
+          help: "Adds the /fake-entities listing page",
+          default: true
+        }
+      ]
+    end
+  end
+
+  defmodule NoSchemaSource do
+    @moduledoc false
+    @behaviour PhoenixKit.Modules.Sitemap.Sources.Source
+
+    @impl true
+    def source_name, do: :no_schema
+
+    @impl true
+    def enabled?, do: true
+
+    @impl true
+    def collect(_opts), do: []
+  end
+
+  describe "build_extension_sources/1 (pure data prep, no LiveView needed)" do
+    test "includes only sources that declare a settings schema, with values attached" do
+      assert [{FakeSource, [field]}] =
+               SitemapSettings.build_extension_sources([NoSchemaSource, FakeSource])
+
+      assert field.key == "sitemap_fake_entities_include_index"
+      assert field.label == "Include entity index page"
+      # Unset in Settings -> falls back to the field's own declared default.
+      assert field.value == true
+    end
+
+    test "reflects a saved value instead of the field's default" do
+      {:ok, _} = Settings.update_boolean_setting("sitemap_fake_entities_include_index", false)
+
+      assert [{FakeSource, [field]}] = SitemapSettings.build_extension_sources([FakeSource])
+      assert field.value == false
+    end
+
+    test "returns an empty list when no source declares a schema" do
+      assert SitemapSettings.build_extension_sources([NoSchemaSource]) == []
+    end
+  end
+
+  describe "rendered on the settings page and toggleable" do
+    setup %{conn: conn} do
+      {user, _token} = create_admin_user()
+      conn = log_in_user(conn, user)
+
+      original_env = Application.get_env(:phoenix_kit, :sitemap, [])
+      Application.put_env(:phoenix_kit, :sitemap, sources: [FakeSource])
+      on_exit(fn -> Application.put_env(:phoenix_kit, :sitemap, original_env) end)
+
+      %{conn: conn}
+    end
+
+    test "renders the field's label/help and lets an admin toggle it", %{conn: conn} do
+      {:ok, view, html} = live(conn, @path)
+
+      assert html =~ "Include entity index page"
+      assert html =~ "Adds the /fake-entities listing page"
+
+      view
+      |> element("input[phx-value-key='sitemap_fake_entities_include_index']")
+      |> render_click()
+
+      assert Settings.get_boolean_setting("sitemap_fake_entities_include_index", true) == false
+    end
+  end
+end


### PR DESCRIPTION
## Motivation

`Sitemap.Web.Settings` (`/admin/settings/sitemap`) only exposes a subset of
the settings the sitemap modules actually read. The prod case that surfaced
this: on hydroforce.ee, `sitemap_entities_include_index` had to be changed
with a raw SQL update because there's no admin UI for it — and there's no
*mechanism* for one, since that setting belongs to the Entities source, not
core `phoenix_kit`. Digging into that turned up several other core settings
in the same boat.

This PR does two things:

## Part 1 — Expose 4 hidden core settings

Adds an "Advanced" section to the sitemap settings page for:

| Setting | Format | Notes |
|---|---|---|
| `sitemap_router_discovery_exclude_patterns` | one regex per line | validated with `Regex.compile/1` before saving (reuses the same check `RouterDiscovery.compile_patterns/2` applies at collection time — see `RouterDiscovery.invalid_patterns/1`); an invalid pattern is rejected with an inline error and **not saved**, instead of being silently dropped later with only a log line |
| `sitemap_protected_pipelines` | one pipeline name per line | restricted to identifier-safe characters (`[a-zA-Z_][a-zA-Z0-9_]*`), since these become atoms via `String.to_atom/1` at collection time |
| `sitemap_custom_urls` | raw JSON array of objects | pretty-printed on save |
| `sitemap_static_routes` | raw JSON array of objects | pretty-printed on save |

Both the exclude-patterns and static-routes fields **replace** their
built-in defaults entirely once saved (even as `[]`), matching existing
read behavior in `RouterDiscovery`/`Static` — the UI pre-fills the editor
with the current effective list (defaults, if unset) rather than an empty
box that looks safe to submit as-is but would wipe out e.g. the homepage
entry. Two small getters (`RouterDiscovery.default_exclude_patterns/0`,
`Static.default_static_routes/0`) were added for this so the defaults
aren't duplicated. `RouterDiscovery.default_protected_pipelines/0` is
exposed the same way, for the read-only "added on top of" hint (protected
pipelines are additive, not a replacement).

Checked `sitemap_include_shop` while I was in there — it's already wired to
the existing generic `toggle_source` handler, no change needed.

Out of scope: `sitemap_router_discovery_include_only` (whitelist mode) has
the same "no UI" gap but wasn't in the requested set of 4 keys, so I left
it alone rather than scope-creep this PR. Happy to add it in a follow-up if
wanted.

## Part 2 — Source settings extension point

Adds an optional callback to `PhoenixKit.Modules.Sitemap.Sources.Source`:

```elixir
@callback sitemap_settings_schema() :: [%{
  key: String.t(),
  type: :boolean | :string | :integer,
  label: String.t(),
  help: String.t() | nil,
  default: term()
}]
```

Any sitemap source (built-in or contributed by another package via
`PhoenixKit.Module.sitemap_sources/0` + `ModuleRegistry.all_sitemap_sources/0`)
can implement this to declare its own settings. The settings page discovers
sources the same way `Generator.get_sources/0` does, renders one input per
declared field grouped under the source's name (boolean → toggle, string/
integer → text/number input + save button), and reads/writes each through
`PhoenixKit.Settings` using the field's `key`/`default` — invalidating the
sitemap cache and bumping the version on save, same as every other setting
on this page.

No built-in source implements the callback (deliberately — that would
duplicate Part 1's settings or things that don't need a schema). This is
purely the extension point. **Companion PR in `phoenix_kit_entities`
(TBD — to be linked here) implements `sitemap_settings_schema/0` on the
Entities source to finally give `sitemap_entities_include_index` a UI.**

A malformed schema/field from a misbehaving source is caught defensively
(`build_extension_sources/1`, `read_extension_field/1`) so it can't take
down the whole settings page for every admin — mirrors the same safety net
`Source.safe_collect/2` already applies to sitemap generation.

## Test plan

- `test/integration/sitemap/router_discovery_validation_test.exs` — pure
  unit tests for `invalid_patterns/1`, `default_exclude_patterns/0`,
  `default_protected_pipelines/0`. No DB needed; ran locally, **6/6 pass**.
- `test/integration/sitemap/settings_advanced_test.exs` — LiveView tests:
  bad regex / bad pipeline name / invalid JSON / non-object JSON array each
  rejected with an inline error and *not* persisted; valid input for all 4
  fields saves correctly as the expected JSON.
- `test/integration/sitemap/settings_extension_schema_test.exs` — unit
  tests for `build_extension_sources/1` against an in-file mock source
  (default fallback, saved-value override, no-schema source excluded), plus
  one full LiveView test that injects the mock source via
  `Application.put_env(:phoenix_kit, :sitemap, sources: [...])`, mounts the
  page, asserts the field's label/help render, and toggles it end-to-end.
- `mix compile --warnings-as-errors --all-warnings`, `mix format
  --check-formatted`, `mix credo --strict`, `mix dialyzer`, `mix precommit`
  all pass clean (including the actual pre-commit git hook, which ran
  compile + docs + credo + dialyzer end-to-end on this commit).

One honesty note: the two DB-backed test files (`settings_advanced_test.exs`,
`settings_extension_schema_test.exs`) compile cleanly but I could not
actually *execute* them in my local dev container — its shared Postgres
service currently rejects the container's own configured credentials (a
pre-existing environment issue: even the 3 already-merged sitemap
integration tests hit the identical auth error locally, unrelated to this
change). CI (`.github/workflows/ci.yml`) spins up its own fresh
`postgres:16` service with matching credentials, so these will actually run
there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



**Companion PR:** BeamLabEU/phoenix_kit_entities#21 (implements `sitemap_settings_schema/0` for the entities source).
