### PR TITLE
Add resource deep-links to the activity feed

### DIFF
--- a/lib/phoenix_kit/resource_links.ex
+++ b/lib/phoenix_kit/resource_links.ex
@@ -1,0 +1,286 @@
+defmodule PhoenixKit.ResourceLinks do
+  @moduledoc """
+  Resolves `(resource_type, resource_uuid)` pairs into navigable deep-links to
+  the underlying resource — the record an action happened on or a comment is
+  attached to.
+
+  Two-tier resolution, tried in order per `resource_type`:
+
+  1. **Handler modules** — a module registered for the type that exports
+     `resolve_comment_resources/1`, returning `%{uuid => %{title, path, thumb_url?}}`
+     with a **raw** phoenix_kit path (`Routes.path/1` is applied once at render
+     time — pre-applying it would double-prefix under a non-root `url_prefix`).
+     Auto-registered when the module is loaded: `"post" => PhoenixKitPosts`,
+     `"file" => PhoenixKit.Annotations`, `"user" => PhoenixKit.Users.CommentResources`.
+     Hosts add more via `config :phoenix_kit, :comment_resource_handlers`.
+
+  2. **String path templates** — the `comment_resource_paths` setting, a no-code
+     JSON map (`%{"shoes" => "/order/shoes/:uuid"}`) with `:uuid` / `:prefix` /
+     `:metadata.<key>` placeholders.
+
+  Shared by the Comments moderation admin (`PhoenixKitComments` delegates here)
+  and the Activity feed. The handler contract and setting name keep the
+  historical `comment_*` naming, but the mechanism is resource-generic — a
+  resource that deep-links in comments deep-links in Activity with no extra
+  config.
+
+  ## Items
+
+  `resolve/1` accepts any list of maps/structs exposing `:resource_type`,
+  `:resource_uuid`, and (optionally) `:metadata` — both `PhoenixKit.Activity.Entry`
+  and comment structs qualify. Items missing a type or uuid are skipped.
+
+  Returns a map keyed by `{resource_type, resource_uuid}`, each value a map:
+
+      %{title: String.t(), full_title: String.t(), path: String.t(),
+        prefixed: boolean(), thumb_url: String.t() (optional)}
+
+  `prefixed: true` means `path` is a raw phoenix_kit route — pass it through
+  `url/1` (→ `Routes.path/1`) and SPA-navigate. `prefixed: false` comes from a
+  host template and should render as a plain `href`.
+  """
+
+  require Logger
+
+  alias PhoenixKit.Settings
+  alias PhoenixKit.Utils.Routes
+
+  @metadata_max_display_length 15
+
+  @doc """
+  Resolves resource context (title + path) for a list of items.
+
+  See the module doc for the item and return shapes.
+  """
+  def resolve(items) do
+    items
+    |> Enum.filter(&(present?(field(&1, :resource_type)) and present?(field(&1, :resource_uuid))))
+    |> Enum.group_by(&field(&1, :resource_type))
+    |> Enum.reduce(%{}, fn {resource_type, type_items}, acc ->
+      resolved = resolve_for_type(resource_type, type_items)
+
+      Enum.reduce(resolved, acc, fn {id, info}, inner ->
+        Map.put(inner, {resource_type, id}, info)
+      end)
+    end)
+  end
+
+  @doc """
+  Looks up a resolved info map for a single `(resource_type, resource_uuid)` pair.
+
+  Returns `nil` when the pair was not resolvable.
+  """
+  def info_for(context, resource_type, resource_uuid) when is_map(context) do
+    Map.get(context, {resource_type, resource_uuid})
+  end
+
+  @doc """
+  Final navigable path for a resolved info map.
+
+  Applies `Routes.path/1` (URL prefix + locale) to raw phoenix_kit paths
+  (`prefixed: true`); returns host-template paths (`prefixed: false`) verbatim.
+  """
+  def url(%{path: path} = info) do
+    if info[:prefixed], do: Routes.path(path), else: path
+  end
+
+  @doc """
+  Gets configured resource path templates (path + optional display title).
+
+  Returns a map of `resource_type => config`, where config is either a plain
+  string (legacy path-only format) or a map with `"path"` and optional `"title"`
+  keys.
+
+      %{"shoes" => "/order/shoes/:uuid"}
+      %{"shoes" => %{"path" => "/order/shoes/:uuid", "title" => ":metadata.name"}}
+  """
+  def get_resource_path_templates do
+    Settings.get_json_setting("comment_resource_paths", %{})
+  rescue
+    e ->
+      Logger.warning("Failed to load resource path templates: #{inspect(e)}")
+      %{}
+  end
+
+  @doc """
+  Updates resource path templates for resource types.
+
+  Accepts both legacy string values and new map values with `"path"` and
+  `"title"` keys.
+  """
+  def update_resource_path_templates(templates) when is_map(templates) do
+    Settings.update_json_setting("comment_resource_paths", templates)
+  end
+
+  @doc """
+  The registered `resource_type => handler_module` map.
+
+  Merges the auto-registered defaults (loaded post/file/user modules) with the
+  host's `config :phoenix_kit, :comment_resource_handlers` overrides. Exposed so
+  other consumers (e.g. the comments notification-callback dispatch) resolve a
+  resource type against the same registry the deep-links use.
+  """
+  def handlers do
+    configured = Application.get_env(:phoenix_kit, :comment_resource_handlers, %{})
+    Map.merge(default_resource_handlers(), configured)
+  end
+
+  # ── Resolution ──────────────────────────────────────────────────────
+
+  defp default_resource_handlers do
+    handlers = %{}
+
+    handlers =
+      if Code.ensure_loaded?(PhoenixKitPosts),
+        do: Map.put(handlers, "post", PhoenixKitPosts),
+        else: handlers
+
+    # File resources (incl. Etcher annotation discussions) resolve to the file's
+    # media page via phoenix_kit core's Annotations context.
+    handlers =
+      if Code.ensure_loaded?(PhoenixKit.Annotations),
+        do: Map.put(handlers, "file", PhoenixKit.Annotations),
+        else: handlers
+
+    # User resources resolve to the user's admin detail page (with avatar) via
+    # phoenix_kit core's Users context.
+    if Code.ensure_loaded?(PhoenixKit.Users.CommentResources),
+      do: Map.put(handlers, "user", PhoenixKit.Users.CommentResources),
+      else: handlers
+  end
+
+  defp resolve_for_type(resource_type, items) do
+    resource_uuids = items |> Enum.map(&field(&1, :resource_uuid)) |> Enum.uniq()
+
+    case resolve_via_handler(resource_type, resource_uuids) do
+      result when map_size(result) > 0 ->
+        Map.new(result, fn {id, info} -> {id, Map.put(info, :prefixed, true)} end)
+
+      _ ->
+        resolve_via_path_template(resource_type, items)
+    end
+  rescue
+    e ->
+      Logger.warning("Resource link resolver error: #{inspect(e)}")
+      %{}
+  end
+
+  defp resolve_via_handler(resource_type, resource_uuids) do
+    case Map.get(handlers(), resource_type) do
+      nil ->
+        %{}
+
+      mod ->
+        if Code.ensure_loaded?(mod) and function_exported?(mod, :resolve_comment_resources, 1) do
+          mod.resolve_comment_resources(resource_uuids)
+        else
+          %{}
+        end
+    end
+  end
+
+  defp resolve_via_path_template(resource_type, items) do
+    templates = get_resource_path_templates()
+
+    case Map.get(templates, resource_type) do
+      nil ->
+        %{}
+
+      config ->
+        path_template = path_from_config(config)
+        title_template = title_from_config(config)
+
+        Map.new(items, fn item ->
+          metadata = field(item, :metadata) || %{}
+          uuid = field(item, :resource_uuid)
+          path = apply_path_template(path_template, uuid, metadata)
+          title = resolve_title(title_template, resource_type, uuid, metadata)
+          full_title = resolve_full_title(title_template, resource_type, uuid, metadata)
+
+          {uuid, %{title: title, full_title: full_title, path: path, prefixed: false}}
+        end)
+    end
+  end
+
+  defp resolve_title(nil, resource_type, uuid, _metadata) do
+    short_id = uuid |> to_string() |> String.slice(0..7)
+    "#{resource_type} #{short_id}..."
+  end
+
+  defp resolve_title(title_template, _resource_type, uuid, metadata) do
+    apply_title_template(title_template, uuid, metadata)
+  end
+
+  defp resolve_full_title(nil, resource_type, uuid, _metadata) do
+    "#{resource_type} #{uuid}"
+  end
+
+  defp resolve_full_title(title_template, _resource_type, uuid, metadata) do
+    title_template
+    |> replace_metadata_placeholders(metadata)
+    |> String.replace(":uuid", to_string(uuid))
+  end
+
+  defp path_from_config(config) when is_binary(config), do: config
+  defp path_from_config(%{"path" => path}), do: path
+  defp path_from_config(_), do: ""
+
+  defp title_from_config(config) when is_binary(config), do: nil
+  defp title_from_config(%{"title" => ""}), do: nil
+  defp title_from_config(%{"title" => title}), do: title
+  defp title_from_config(_), do: nil
+
+  defp apply_path_template(template, resource_uuid, metadata) do
+    template
+    |> replace_metadata_url_placeholders(metadata)
+    |> String.replace(":prefix", prefix_value())
+    |> String.replace(":uuid", url_encode(to_string(resource_uuid)))
+  end
+
+  defp apply_title_template(template, resource_uuid, metadata) do
+    template
+    |> replace_metadata_truncated(metadata)
+    |> String.replace(":uuid", truncate_value(to_string(resource_uuid)))
+  end
+
+  defp prefix_value do
+    prefix = Routes.url_prefix()
+    if prefix == "/", do: "", else: prefix
+  end
+
+  defp replace_metadata_placeholders(template, metadata) do
+    Regex.replace(~r/:metadata\.(\w+)/, template, fn _match, key ->
+      metadata |> Map.get(key, "") |> to_string()
+    end)
+  end
+
+  defp replace_metadata_url_placeholders(template, metadata) do
+    Regex.replace(~r/:metadata\.(\w+)/, template, fn _match, key ->
+      metadata |> Map.get(key, "") |> to_string() |> url_encode()
+    end)
+  end
+
+  defp replace_metadata_truncated(template, metadata) do
+    Regex.replace(~r/:metadata\.(\w+)/, template, fn _match, key ->
+      metadata |> Map.get(key, "") |> to_string() |> truncate_value()
+    end)
+  end
+
+  defp url_encode(value), do: URI.encode(value, &URI.char_unreserved?/1)
+
+  defp truncate_value(value) do
+    if String.length(value) <= @metadata_max_display_length do
+      value
+    else
+      String.slice(value, 0, @metadata_max_display_length) <> "..."
+    end
+  end
+
+  # Struct/map field access that tolerates either atom-keyed structs (Activity
+  # entries, comments) without assuming a specific type.
+  defp field(item, key), do: Map.get(item, key)
+
+  defp present?(nil), do: false
+  defp present?(""), do: false
+  defp present?(_), do: true
+end

--- a/lib/phoenix_kit_web.ex
+++ b/lib/phoenix_kit_web.ex
@@ -126,6 +126,7 @@ defmodule PhoenixKitWeb do
       import PhoenixKitWeb.Components.Core.UserInfo
       import PhoenixKitWeb.Components.Core.Pagination
       import PhoenixKitWeb.Components.Core.FileDisplay
+      import PhoenixKitWeb.Components.Core.ResourceLink
       import PhoenixKitWeb.Components.Core.EmailActivityBadges
       import PhoenixKitWeb.Components.Core.MessageTagBadge
       import PhoenixKitWeb.Components.Core.NumberFormatter

--- a/lib/phoenix_kit_web/components/core/resource_link.ex
+++ b/lib/phoenix_kit_web/components/core/resource_link.ex
@@ -1,0 +1,76 @@
+defmodule PhoenixKitWeb.Components.Core.ResourceLink do
+  @moduledoc """
+  Renders a resolved resource (from `PhoenixKit.ResourceLinks`) as a compact,
+  clickable chip that deep-links to where the resource lives — the record an
+  activity happened on, or a comment is attached to.
+
+  Mirrors the comments moderation chip: a thumbnail (when the handler supplies
+  `thumb_url`) or a type badge, plus the truncated title. Prefixed phoenix_kit
+  routes SPA-navigate; host-template paths render as a real `href` (they may
+  point at a controller page or external URL, where live navigation can't reach).
+
+  Render only when a resolved info map is present:
+
+      <.resource_link :if={@info} info={@info} />
+  """
+  use Phoenix.Component
+
+  import PhoenixKitWeb.Components.Core.Icon, only: [icon: 1]
+
+  alias PhoenixKit.ResourceLinks
+
+  @doc """
+  Renders the resource chip for a resolved `info` map.
+  """
+  attr :info, :map, required: true
+  attr :class, :string, default: ""
+
+  def resource_link(assigns) do
+    ~H"""
+    <.link
+      :if={@info[:prefixed]}
+      navigate={ResourceLinks.url(@info)}
+      class={[chip_class(), @class]}
+      title={@info[:full_title] || @info.title}
+    >
+      <.chip_body info={@info} />
+    </.link>
+    <.link
+      :if={!@info[:prefixed]}
+      href={ResourceLinks.url(@info)}
+      class={[chip_class(), @class]}
+      title={@info[:full_title] || @info.title}
+    >
+      <.chip_body info={@info} />
+    </.link>
+    """
+  end
+
+  defp chip_class do
+    "inline-flex items-center gap-1.5 max-w-[240px] py-0.5 pl-1 pr-2.5 rounded-full " <>
+      "bg-base-200 hover:bg-base-300 transition-colors no-underline align-middle"
+  end
+
+  # The chip's inner content. The thumbnail is a CSS background (not an
+  # `<img onerror=…>`): inline JS is blocked by a strict `script-src` CSP, and a
+  # missing background image simply falls back to the placeholder colour.
+  attr :info, :map, required: true
+
+  defp chip_body(assigns) do
+    ~H"""
+    <span
+      :if={@info[:thumb_url]}
+      class="w-5 h-5 rounded-full bg-base-300 bg-cover bg-center shrink-0"
+      style={"background-image: url('#{@info.thumb_url}')"}
+    ></span>
+    <.icon
+      :if={!@info[:thumb_url]}
+      name="hero-arrow-top-right-on-square"
+      class="w-3.5 h-3.5 text-base-content/50 shrink-0 ml-1"
+    />
+    <span class="truncate text-xs text-base-content/80 min-w-0">
+      {@info.title}
+    </span>
+    """
+  end
+end

--- a/lib/phoenix_kit_web/live/activity/index.ex
+++ b/lib/phoenix_kit_web/live/activity/index.ex
@@ -142,10 +142,12 @@ defmodule PhoenixKitWeb.Live.Activity.Index do
       )
 
     resource_users = Activity.resolve_resource_users(result.entries)
+    resource_links = PhoenixKit.ResourceLinks.resolve(result.entries)
 
     socket
     |> assign(:entries, result.entries)
     |> assign(:resource_users, resource_users)
+    |> assign(:resource_links, resource_links)
     |> assign(:total, result.total)
     |> assign(:total_pages, result.total_pages)
   end

--- a/lib/phoenix_kit_web/live/activity/index.html.heex
+++ b/lib/phoenix_kit_web/live/activity/index.html.heex
@@ -402,16 +402,24 @@
             </.table_default_cell>
             <.table_default_cell class="hidden md:table-cell">
               <%= if entry.resource_type do %>
+                <% link_info =
+                  Map.get(@resource_links, {entry.resource_type, entry.resource_uuid}) %>
                 <span class="badge badge-ghost badge-xs">{entry.resource_type}</span>
-                <%= case Map.get(@resource_users, entry.resource_uuid) do %>
-                  <% %{email: email} -> %>
-                    <span class="text-xs ml-1">{email}</span>
-                  <% _ -> %>
-                    <%= if entry.resource_uuid do %>
-                      <span class="text-xs text-base-content/40 ml-1">
-                        {String.slice(to_string(entry.resource_uuid), 0..7)}
-                      </span>
-                    <% end %>
+                <%!-- Deep-link chip to the underlying resource when it resolves
+                     (same mechanism as the comments moderation admin). Falls
+                     back to the resolved user email or a truncated uuid. --%>
+                <%= cond do %>
+                  <% link_info -> %>
+                    <.resource_link info={link_info} class="ml-1" />
+                  <% match?(%{email: _}, Map.get(@resource_users, entry.resource_uuid)) -> %>
+                    <span class="text-xs ml-1">
+                      {Map.get(@resource_users, entry.resource_uuid).email}
+                    </span>
+                  <% entry.resource_uuid -> %>
+                    <span class="text-xs text-base-content/40 ml-1">
+                      {String.slice(to_string(entry.resource_uuid), 0..7)}
+                    </span>
+                  <% true -> %>
                 <% end %>
               <% else %>
                 <span class="text-base-content/30">—</span>

--- a/lib/phoenix_kit_web/live/activity/show.ex
+++ b/lib/phoenix_kit_web/live/activity/show.ex
@@ -28,12 +28,17 @@ defmodule PhoenixKitWeb.Live.Activity.Show do
           project_title = Settings.get_project_title()
           resource_user = resolve_resource_user(entry)
 
+          resource_link =
+            PhoenixKit.ResourceLinks.resolve([entry])
+            |> PhoenixKit.ResourceLinks.info_for(entry.resource_type, entry.resource_uuid)
+
           socket =
             socket
             |> assign(:page_title, gettext("Activity Detail"))
             |> assign(:project_title, project_title)
             |> assign(:entry, entry)
             |> assign(:resource_user, resource_user)
+            |> assign(:resource_link, resource_link)
 
           {:ok, socket}
       end

--- a/lib/phoenix_kit_web/live/activity/show.html.heex
+++ b/lib/phoenix_kit_web/live/activity/show.html.heex
@@ -114,7 +114,12 @@
               <div class="text-xs text-base-content/50 mb-1">{gettext("ID")}</div>
               <%= if @entry.resource_uuid do %>
                 <div>
-                  <%= if @resource_user do %>
+                  <%!-- Deep-link to the underlying resource when it resolves
+                       (same mechanism as the comments moderation admin). --%>
+                  <div :if={@resource_link} class="mb-1">
+                    <.resource_link info={@resource_link} />
+                  </div>
+                  <%= if @resource_user && is_nil(@resource_link) do %>
                     <span class="font-semibold">{@resource_user.email}</span>
                   <% end %>
                   <div class="text-xs text-base-content/40 mt-0.5">

--- a/test/phoenix_kit/resource_links_test.exs
+++ b/test/phoenix_kit/resource_links_test.exs
@@ -1,0 +1,81 @@
+defmodule PhoenixKit.ResourceLinksTest do
+  @moduledoc """
+  Unit tests for the shared resource deep-link resolver.
+
+  Covers the DB-free paths: item filtering, unknown-type fallthrough, and the
+  `url/1` prefix/raw dispatch. Handler- and template-backed resolution are
+  exercised through the integration suites of their call sites (comments
+  moderation + activity feed).
+  """
+  use ExUnit.Case, async: true
+
+  # These paths deliberately fail open (→ %{}) when no DB connection is checked
+  # out, logging a rescued warning; capture it so the suite output stays clean.
+  @moduletag capture_log: true
+
+  alias PhoenixKit.ResourceLinks
+
+  describe "resolve/1" do
+    test "skips items missing a resource_type or resource_uuid" do
+      items = [
+        %{resource_type: nil, resource_uuid: "abc", metadata: %{}},
+        %{resource_type: "post", resource_uuid: nil, metadata: %{}},
+        %{resource_type: "", resource_uuid: "abc", metadata: %{}}
+      ]
+
+      assert ResourceLinks.resolve(items) == %{}
+    end
+
+    test "returns an empty map for a resource_type with no handler and no template" do
+      items = [%{resource_type: "no_such_type_xyz", resource_uuid: "abc", metadata: %{}}]
+
+      assert ResourceLinks.resolve(items) == %{}
+    end
+
+    test "tolerates items with no metadata key" do
+      items = [%{resource_type: "no_such_type_xyz", resource_uuid: "abc"}]
+
+      assert ResourceLinks.resolve(items) == %{}
+    end
+  end
+
+  describe "info_for/3" do
+    test "looks up a resolved pair, nil when absent" do
+      context = %{{"post", "u1"} => %{title: "Hello", path: "/p/u1", prefixed: true}}
+
+      assert ResourceLinks.info_for(context, "post", "u1") == %{
+               title: "Hello",
+               path: "/p/u1",
+               prefixed: true
+             }
+
+      assert ResourceLinks.info_for(context, "post", "missing") == nil
+    end
+  end
+
+  describe "url/1" do
+    test "returns host-template paths verbatim when not prefixed" do
+      assert ResourceLinks.url(%{path: "https://example.com/x", prefixed: false}) ==
+               "https://example.com/x"
+    end
+
+    test "applies the phoenix_kit prefix to prefixed paths" do
+      # Routes.path/1 prepends the configured url_prefix; with the default root
+      # prefix the path is returned unchanged, but it must not raise and must be
+      # a binary starting from the given raw path.
+      url = ResourceLinks.url(%{path: "/admin/users/view/abc", prefixed: true})
+      assert is_binary(url)
+      assert String.ends_with?(url, "/admin/users/view/abc")
+    end
+  end
+
+  describe "handlers/0" do
+    test "auto-registers the loaded core handlers" do
+      handlers = ResourceLinks.handlers()
+
+      # The user + file handlers ship in core and are always loaded in the suite.
+      assert handlers["user"] == PhoenixKit.Users.CommentResources
+      assert handlers["file"] == PhoenixKit.Annotations
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Activity feed entries now **link to where the action happened** — clicking through to the underlying resource — using the same resolver the comments moderation admin uses.

- **New shared resolver `PhoenixKit.ResourceLinks`** — lifted the two-tier registry out of the `phoenix_kit_comments` package into core so both the comments admin and the activity feed drive off one set of handlers + templates. Resolves `(resource_type, resource_uuid)` → the record's page via auto-registered handlers (`user`/`file`/`post`) or the `comment_resource_paths` no-code templates; prefix/locale via `Routes.path/1`.
- **New core component `<.resource_link>`** — a compact deep-link chip (thumbnail/icon + title), `navigate` for prefixed routes / `href` for host templates.
- **Activity index + detail** render the chip in the Subject cell / card, falling back to the resolved user email then a truncated uuid.
- Unit tests for the DB-free resolver paths.

## Companion change (separate repo)

`phoenix_kit_comments` was updated to **delegate** `resolve_resource_context/1` and the resource-path helpers to `PhoenixKit.ResourceLinks` (identical behavior, ~180 fewer lines). That's committed in the comments package and ships with its next release; this core PR is self-contained.

## Testing

- `mix compile --warnings-as-errors`, credo `--strict`, `mix format` — clean
- New `resource_links_test.exs` passes; activity integration suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MsjUy1HnuJnCSrqdbnANYL