### PR TITLE
Fix broken seo_no_index regression test from #616

### DIFF
--- a/lib/phoenix_kit_web/router.ex
+++ b/lib/phoenix_kit_web/router.ex
@@ -38,6 +38,16 @@ defmodule PhoenixKitWeb.Router do
   # backing test/phoenix_kit_web/users/auth_seo_no_index_test.exs. Needs a
   # real route (not live_isolated/3) because :phoenix_kit_mount_current_scope
   # attaches a :handle_params hook that requires a non-nil socket.router.
+  #
+  # Known, accepted trade-off: the Hex package doesn't ship test/, so a
+  # consumer compiling this dep under MIX_ENV=test (e.g. their own `mix
+  # test`) builds this block referencing a PublicHostAppLive module that
+  # isn't present for them. This is inert, not a build failure — Phoenix's
+  # `live` macro only stores the module as an atom and resolves it at
+  # request time, and this router is never mounted by parent apps (see
+  # moduledoc above) — but it is a latent dead reference. A dedicated
+  # test-only Endpoint+Router pair under test/support/ would avoid it
+  # entirely; not worth the extra scaffolding for a single probe route.
   if Mix.env() == :test do
     scope "/", PhoenixKitWeb.Test do
       pipe_through :browser

--- a/lib/phoenix_kit_web/router.ex
+++ b/lib/phoenix_kit_web/router.ex
@@ -34,6 +34,18 @@ defmodule PhoenixKitWeb.Router do
   # PhoenixKit routes - main integration point
   phoenix_kit_routes()
 
+  # Test-only: a routable stand-in for a host app's own public LiveView,
+  # backing test/phoenix_kit_web/users/auth_seo_no_index_test.exs. Needs a
+  # real route (not live_isolated/3) because :phoenix_kit_mount_current_scope
+  # attaches a :handle_params hook that requires a non-nil socket.router.
+  if Mix.env() == :test do
+    scope "/", PhoenixKitWeb.Test do
+      pipe_through :browser
+
+      live "/__test/seo-no-index-probe", PublicHostAppLive
+    end
+  end
+
   defp ensure_session_uuid(conn, _opts) do
     case Plug.Conn.get_session(conn, :phoenix_kit_session_uuid) do
       nil ->

--- a/test/phoenix_kit_web/users/auth_seo_no_index_test.exs
+++ b/test/phoenix_kit_web/users/auth_seo_no_index_test.exs
@@ -9,50 +9,51 @@ defmodule PhoenixKitWeb.Users.AuthSeoNoIndexTest do
   rendered for it even with the directive enabled (observed on Hydroforce's
   dev environment).
 
-  `PublicHostAppLive` below stands in for such a view: it mounts through
-  PhoenixKit's `:phoenix_kit_mount_current_scope` on_mount (as a host app
-  would, e.g. for current_user/locale support) but renders with its own
-  markup, never calling `LayoutWrapper.app_layout`.
+  `PhoenixKitWeb.Test.PublicHostAppLive` (test/support/public_host_app_live.ex)
+  stands in for such a view: it mounts through PhoenixKit's
+  `:phoenix_kit_mount_current_scope` on_mount (as a host app would, e.g. for
+  current_user/locale support) but renders with its own markup, never calling
+  `LayoutWrapper.app_layout`. It's routed at a real, test-only path (see
+  `PhoenixKitWeb.Router`) rather than mounted via `live_isolated/3`, because
+  the on_mount attaches a `:handle_params` hook that requires a non-nil
+  `socket.router` — `live_isolated/3` never provides one and raises ("the
+  view was not mounted at the router with the live/3 macro").
+
+  Asserts against the actual disconnected/initial HTML response — the
+  document a search engine crawler would see — rather than the raw
+  `:seo_no_index` assign, so this exercises the real root-layout rendering
+  path the reported bug was about, not just that the socket carries the
+  assign.
   """
 
   use PhoenixKitWeb.ConnCase, async: false
 
   alias PhoenixKit.Modules.SEO
 
-  defmodule PublicHostAppLive do
-    @moduledoc false
-    use Phoenix.LiveView
-
-    on_mount {PhoenixKitWeb.Users.Auth, :phoenix_kit_mount_current_scope}
-
-    @impl true
-    def render(assigns) do
-      ~H"""
-      <div id="seo-no-index-probe" data-seo-no-index={inspect(assigns[:seo_no_index])}></div>
-      """
-    end
-  end
+  @probe_path "/__test/seo-no-index-probe"
 
   setup do
     on_exit(fn -> SEO.update_no_index(false) end)
     :ok
   end
 
-  test "a public host-app LiveView going through PhoenixKit's on_mount gets :seo_no_index=true when the directive is enabled",
+  test "a public host-app LiveView's initial render includes the noindex meta when the directive is enabled",
        %{conn: conn} do
     {:ok, _} = SEO.enable_no_index()
 
-    {:ok, _view, html} = live_isolated(conn, PublicHostAppLive, session: %{})
+    html = conn |> get(@probe_path) |> html_response(200)
 
+    assert html =~ ~s(<meta name="robots" content="noindex,nofollow">)
     assert html =~ ~s(data-seo-no-index="true")
   end
 
-  test "a public host-app LiveView gets :seo_no_index=false when the directive is disabled",
+  test "a public host-app LiveView's initial render omits the noindex meta when the directive is disabled",
        %{conn: conn} do
     {:ok, _} = SEO.update_no_index(false)
 
-    {:ok, _view, html} = live_isolated(conn, PublicHostAppLive, session: %{})
+    html = conn |> get(@probe_path) |> html_response(200)
 
+    refute html =~ ~s(<meta name="robots" content="noindex,nofollow">)
     assert html =~ ~s(data-seo-no-index="false")
   end
 end

--- a/test/phoenix_kit_web/users/auth_seo_no_index_test.exs
+++ b/test/phoenix_kit_web/users/auth_seo_no_index_test.exs
@@ -44,6 +44,7 @@ defmodule PhoenixKitWeb.Users.AuthSeoNoIndexTest do
     html = conn |> get(@probe_path) |> html_response(200)
 
     assert html =~ ~s(<meta name="robots" content="noindex,nofollow">)
+    assert html =~ ~s(<meta name="googlebot" content="noindex,nofollow">)
     assert html =~ ~s(data-seo-no-index="true")
   end
 
@@ -54,6 +55,7 @@ defmodule PhoenixKitWeb.Users.AuthSeoNoIndexTest do
     html = conn |> get(@probe_path) |> html_response(200)
 
     refute html =~ ~s(<meta name="robots" content="noindex,nofollow">)
+    refute html =~ ~s(<meta name="googlebot" content="noindex,nofollow">)
     assert html =~ ~s(data-seo-no-index="false")
   end
 end

--- a/test/support/public_host_app_live.ex
+++ b/test/support/public_host_app_live.ex
@@ -1,0 +1,23 @@
+defmodule PhoenixKitWeb.Test.PublicHostAppLive do
+  @moduledoc """
+  Stand-in for a host app's own public LiveView: mounted at a real router
+  path (routing features like `on_mount`'s `:handle_params` hooks require a
+  non-nil `socket.router`, which `Phoenix.LiveViewTest.live_isolated/3`
+  never provides) through `:phoenix_kit_mount_current_scope` — the on_mount
+  a host app uses for current_user/locale support — but rendering with its
+  own markup, never calling `LayoutWrapper.app_layout`.
+
+  Routed only in `Mix.env() == :test` (see `PhoenixKitWeb.Router`); backs
+  `test/phoenix_kit_web/users/auth_seo_no_index_test.exs`.
+  """
+  use Phoenix.LiveView
+
+  on_mount {PhoenixKitWeb.Users.Auth, :phoenix_kit_mount_current_scope}
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div id="seo-no-index-probe" data-seo-no-index={inspect(assigns[:seo_no_index])}></div>
+    """
+  end
+end


### PR DESCRIPTION
## Summary

Fixes the regression test merged with #616 (`Thread seo_no_index to host-app public LiveViews via routing hook`), which raises during mount and breaks `mix test` — confirmed the production fix itself is sound; only its test was broken.

## The bug

`test/phoenix_kit_web/users/auth_seo_no_index_test.exs`'s `PublicHostAppLive` declares `on_mount {PhoenixKitWeb.Users.Auth, :phoenix_kit_mount_current_scope}`, whose `handle_params` hook calls `attach_hook/4` on `:handle_params` — which requires a non-nil `socket.router`. `live_isolated/3` never sets one (`Phoenix.LiveViewTest.__isolated__/4` puts `phoenix_endpoint` into the conn but never `phoenix_router`), so it raises *"the view was not mounted at the router with the live/3 macro"* before either assertion runs. Both test cases error out unconditionally, independent of the database.

## The fix

- Moved `PublicHostAppLive` to `test/support/public_host_app_live.ex` — a real compiled module (a `defmodule` nested inside a `.exs` file only exists at test-runtime, so it can't be referenced from a router that compiles beforehand).
- Added a `Mix.env() == :test`-gated route for it in `PhoenixKitWeb.Router` (the library's own dev/test-only router — its moduledoc already states as much). Compiles out entirely for `:dev`/`:prod` (verified).
- The test now drives it via a real HTTP `GET` instead of `live_isolated/3`, so `socket.router` is non-nil and the on_mount's `handle_params` hook attaches without raising.

This also addresses a second, non-fatal issue from the original PR's review: the old test asserted against the raw `:seo_no_index` **assign** inside the LiveView's own render, which only proves the socket carries the assign — not that the noindex meta tag actually reaches `<head>`. The rewritten test asserts against the real disconnected/initial HTML response (what a crawler would see), exercising the actual root-layout render path the reported bug was about.

## Test plan

- [x] `mix compile --warnings-as-errors` — clean in both `dev` and `prod` (the test-gated route correctly compiles out of `prod`)
- [x] `mix format --check-formatted`
- [x] `mix credo --strict` — 0 issues
- [x] `mix dialyzer` — passed (via pre-commit hook)
- [ ] `mix test test/phoenix_kit_web/users/auth_seo_no_index_test.exs` — **could not execute locally.** `PhoenixKit.DataCase`/`ConnCase`-based tests fail to load their compiled `test/support` beams in this sandbox regardless of the file under test — reproduced against untouched, unrelated files too (`test/integration/storage/scope_test.exs`, `test/integration/users/profile_test.exs`), so this is a pre-existing environment limitation, not specific to this change. Will run in CI.
- [x] Verified the underlying mechanism directly on a real host app instead: toggling `seo_no_index` and hitting a real public host LiveView route (Hydroforce's `/legal`, which mounts through this exact same on_mount) shows the noindex meta present/absent in the actual HTTP response exactly as expected in both states.
