### PR TITLE
Extend activity/notification deep-links + admin notifications list

### DIFF
--- a/lib/phoenix_kit/integrations/integrations.ex
+++ b/lib/phoenix_kit/integrations/integrations.ex
@@ -1270,12 +1270,23 @@ defmodule PhoenixKit.Integrations do
   defp log_activity(action, provider, name, metadata, mode, actor_uuid)
        when is_binary(provider) and is_binary(name) do
     if Code.ensure_loaded?(PhoenixKit.Activity) do
+      # Stamp the storage row's uuid so the activity deep-links to the
+      # connection's edit page (via PhoenixKit.Integrations.ResourceLinks).
+      # nil when the row can't be resolved (e.g. a disconnect that removed it) —
+      # the feed still renders, just without a link.
+      resource_uuid =
+        case find_uuid_by_provider_name({provider, name}) do
+          {:ok, uuid} -> uuid
+          _ -> nil
+        end
+
       PhoenixKit.Activity.log(%{
         action: action,
         module: "integrations",
         mode: mode,
         actor_uuid: actor_uuid,
         resource_type: "integration",
+        resource_uuid: resource_uuid,
         metadata:
           Map.merge(metadata, %{
             "provider" => provider,

--- a/lib/phoenix_kit/integrations/resource_links.ex
+++ b/lib/phoenix_kit/integrations/resource_links.ex
@@ -1,0 +1,58 @@
+defmodule PhoenixKit.Integrations.ResourceLinks do
+  @moduledoc """
+  Resolves `"integration"` resources to their edit page for deep-linking.
+
+  An activity logged against an integration (`resource_type: "integration"`,
+  `resource_uuid:` the storage row's uuid) resolves to the connection's edit
+  page (`/admin/settings/integrations/:uuid`), titled `provider / name`.
+
+  Registered as the `"integration"` handler by `PhoenixKit.ResourceLinks`
+  (gated on this module being loaded). Mirrors
+  `PhoenixKit.Users.CommentResources` — implements the same
+  `resolve_comment_resources/1` contract and returns a **raw** phoenix_kit path
+  (`Routes.path/1` is applied once at render).
+  """
+
+  alias PhoenixKit.Integrations
+
+  @spec resolve_comment_resources([binary()]) :: %{binary() => map()}
+  def resolve_comment_resources(resource_uuids) when is_list(resource_uuids) do
+    resource_uuids
+    |> Enum.uniq()
+    |> Enum.reduce(%{}, fn uuid, acc ->
+      case info_for(uuid) do
+        nil -> acc
+        info -> Map.put(acc, uuid, info)
+      end
+    end)
+  rescue
+    _ -> %{}
+  end
+
+  # Raw path — the caller applies Routes.path/1 (prefix + locale) at render.
+  # The title lookup is best-effort: a transient settings error falls back to a
+  # generic label rather than dropping the (still-valid) deep-link.
+  defp info_for(uuid) when is_binary(uuid) and uuid != "" do
+    %{title: title_for(uuid), path: "/admin/settings/integrations/#{uuid}"}
+  end
+
+  defp info_for(_), do: nil
+
+  defp title_for(uuid) do
+    case Integrations.get_integration_by_uuid(uuid) do
+      {:ok, %{provider: provider, name: name}} -> connection_title(provider, name)
+      _ -> "Integration"
+    end
+  rescue
+    _ -> "Integration"
+  end
+
+  defp connection_title(provider, name) do
+    case {to_string(provider), to_string(name)} do
+      {"", ""} -> "Integration"
+      {p, ""} -> p
+      {"", n} -> n
+      {p, n} -> "#{p} / #{n}"
+    end
+  end
+end

--- a/lib/phoenix_kit/module.ex
+++ b/lib/phoenix_kit/module.ex
@@ -151,6 +151,43 @@ defmodule PhoenixKit.Module do
   @callback notification_types() :: [map()]
 
   @doc """
+  Declares how this module's resource types deep-link to their pages.
+
+  Lets the activity feed, notifications, and the comments moderation admin turn
+  a `(resource_type, resource_uuid)` pair from *this* module into a clickable
+  link to the underlying record — with zero host configuration. Returns a map of
+  `resource_type => resolver`, where a resolver is either:
+
+    * **a module** implementing `resolve_comment_resources/1` (the same contract
+      core's `"user"`/`"file"`/`"post"` handlers use) — for rich resolution with
+      a title and optional thumbnail. Return `%{uuid => %{title:, path:}}` with a
+      **raw** phoenix_kit path (`Routes.path/1` is applied once at render).
+
+    * **a path-template string** — the no-code shortcut, e.g.
+      `"/admin/widgets/:uuid"`. Placeholders: `:uuid` and `:metadata.<key>`
+      (pulled from the activity/comment metadata). Treated as an internal
+      phoenix_kit route (SPA-navigated, prefix/locale applied). Use the map form
+      `%{"path" => "...", "title" => ":metadata.name"}` to set a display title.
+
+  ## Examples
+
+      # No-code: a raw admin route with a uuid segment
+      def resource_links, do: %{"widget" => "/admin/widgets/:uuid"}
+
+      # Titled template
+      def resource_links,
+        do: %{"widget" => %{"path" => "/admin/widgets/:uuid", "title" => ":metadata.name"}}
+
+      # Rich: point at a resolver module (title + thumbnail via a DB lookup)
+      def resource_links, do: %{"widget" => MyApp.WidgetLinks}
+
+  Merges with core's built-in handlers and the host's `comment_resource_paths`
+  setting via `PhoenixKit.ResourceLinks`. Modules with no linkable resources can
+  skip this callback — the default is `%{}`.
+  """
+  @callback resource_links() :: %{optional(String.t()) => module() | String.t() | map()}
+
+  @doc """
   Returns Tailwind CSS source roots for scanning.
 
   Each entry is either:
@@ -329,6 +366,7 @@ defmodule PhoenixKit.Module do
     required_integrations: 0,
     integration_providers: 0,
     notification_types: 0,
+    resource_links: 0,
     css_sources: 0,
     js_sources: 0,
     sitemap_sources: 0,
@@ -386,6 +424,9 @@ defmodule PhoenixKit.Module do
       def notification_types, do: []
 
       @impl PhoenixKit.Module
+      def resource_links, do: %{}
+
+      @impl PhoenixKit.Module
       def css_sources, do: []
 
       @impl PhoenixKit.Module
@@ -413,6 +454,7 @@ defmodule PhoenixKit.Module do
                      required_integrations: 0,
                      integration_providers: 0,
                      notification_types: 0,
+                     resource_links: 0,
                      css_sources: 0,
                      js_sources: 0,
                      sitemap_sources: 0,

--- a/lib/phoenix_kit/notifications/notifications.ex
+++ b/lib/phoenix_kit/notifications/notifications.ex
@@ -241,6 +241,32 @@ defmodule PhoenixKit.Notifications do
   end
 
   @doc """
+  Returns `{notifications, total_count}` across ALL users, newest first, for the
+  admin overview. Recipient and activity(+actor) are preloaded so the admin
+  table can show who each notification is for and what it's about.
+
+  Options: `:page` (default 1) / `:per_page` (default 25).
+  """
+  def admin_list(opts \\ []) do
+    page = Keyword.get(opts, :page, 1)
+    per_page = Keyword.get(opts, :per_page, 25)
+
+    total = repo().aggregate(Notification, :count, :uuid)
+
+    rows =
+      Notification
+      |> order_by([n], desc: n.inserted_at)
+      |> limit(^per_page)
+      |> offset(^((page - 1) * per_page))
+      |> repo().all()
+      |> repo().preload([:recipient, activity: [:actor]])
+
+    {rows, total}
+  rescue
+    _ -> {[], 0}
+  end
+
+  @doc """
   Returns the N most-recent undismissed notifications for a user.
 
   Drives the bell dropdown. Activity (and actor) are preloaded.

--- a/lib/phoenix_kit/resource_links.ex
+++ b/lib/phoenix_kit/resource_links.ex
@@ -115,14 +115,24 @@ defmodule PhoenixKit.ResourceLinks do
   @doc """
   The registered `resource_type => handler_module` map.
 
-  Merges the auto-registered defaults (loaded post/file/user modules) with the
-  host's `config :phoenix_kit, :comment_resource_handlers` overrides. Exposed so
-  other consumers (e.g. the comments notification-callback dispatch) resolve a
-  resource type against the same registry the deep-links use.
+  Merges, in increasing precedence: the auto-registered core defaults (loaded
+  post/file/user/integration modules), the module-declared handlers (the
+  `resource_links/0` `PhoenixKit.Module` callback entries whose value is a
+  resolver module), and the host's `config :phoenix_kit, :comment_resource_handlers`
+  overrides. Exposed so other consumers (e.g. the comments notification-callback
+  dispatch) resolve a resource type against the same registry the deep-links use.
   """
   def handlers do
     configured = Application.get_env(:phoenix_kit, :comment_resource_handlers, %{})
-    Map.merge(default_resource_handlers(), configured)
+
+    module_handlers =
+      module_resolvers()
+      |> Enum.filter(fn {_type, resolver} -> is_atom(resolver) end)
+      |> Map.new()
+
+    default_resource_handlers()
+    |> Map.merge(module_handlers)
+    |> Map.merge(configured)
   end
 
   # ── Resolution ──────────────────────────────────────────────────────
@@ -142,6 +152,12 @@ defmodule PhoenixKit.ResourceLinks do
         do: Map.put(handlers, "file", PhoenixKit.Annotations),
         else: handlers
 
+    # Integration resources resolve to the integration's edit page in Settings.
+    handlers =
+      if Code.ensure_loaded?(PhoenixKit.Integrations.ResourceLinks),
+        do: Map.put(handlers, "integration", PhoenixKit.Integrations.ResourceLinks),
+        else: handlers
+
     # User resources resolve to the user's admin detail page (with avatar) via
     # phoenix_kit core's Users context.
     if Code.ensure_loaded?(PhoenixKit.Users.CommentResources),
@@ -149,15 +165,62 @@ defmodule PhoenixKit.ResourceLinks do
       else: handlers
   end
 
+  # Resolver entries declared by discovered modules via the `resource_links/0`
+  # `PhoenixKit.Module` callback: `%{resource_type => module | template_string
+  # | %{"path" => ..., "title" => ...}}`. Module values become handlers; string/
+  # map values become internal path templates (see `module_templates/0`).
+  defp module_resolvers do
+    if Code.ensure_loaded?(PhoenixKit.ModuleRegistry) do
+      PhoenixKit.ModuleRegistry.all_modules()
+      |> Enum.reduce(%{}, fn mod, acc ->
+        if Code.ensure_loaded?(mod) and function_exported?(mod, :resource_links, 0) do
+          Map.merge(acc, safe_module_resource_links(mod))
+        else
+          acc
+        end
+      end)
+    else
+      %{}
+    end
+  rescue
+    _ -> %{}
+  end
+
+  defp safe_module_resource_links(mod) do
+    case mod.resource_links() do
+      map when is_map(map) -> map
+      _ -> %{}
+    end
+  rescue
+    e ->
+      Logger.warning("[ResourceLinks] #{inspect(mod)}.resource_links/0 failed: #{inspect(e)}")
+      %{}
+  end
+
+  # The non-module (string / map) entries from `resource_links/0` — no-code
+  # internal path templates, resolved as SPA-navigated phoenix_kit routes.
+  defp module_templates do
+    module_resolvers()
+    |> Enum.reject(fn {_type, resolver} -> is_atom(resolver) end)
+    |> Map.new()
+  end
+
+  # Precedence per resource_type: a resolver module (rich, prefixed navigate) →
+  # a module-declared internal template (prefixed navigate) → a host
+  # `comment_resource_paths` setting template (external href).
   defp resolve_for_type(resource_type, items) do
     resource_uuids = items |> Enum.map(&field(&1, :resource_uuid)) |> Enum.uniq()
+    handler = resolve_via_handler(resource_type, resource_uuids)
 
-    case resolve_via_handler(resource_type, resource_uuids) do
-      result when map_size(result) > 0 ->
-        Map.new(result, fn {id, info} -> {id, Map.put(info, :prefixed, true)} end)
+    cond do
+      map_size(handler) > 0 ->
+        Map.new(handler, fn {id, info} -> {id, Map.put(info, :prefixed, true)} end)
 
-      _ ->
-        resolve_via_path_template(resource_type, items)
+      map_size(mod_tpl = resolve_via_module_template(resource_type, items)) > 0 ->
+        mod_tpl
+
+      true ->
+        resolve_via_setting_template(resource_type, items)
     end
   rescue
     e ->
@@ -179,27 +242,37 @@ defmodule PhoenixKit.ResourceLinks do
     end
   end
 
-  defp resolve_via_path_template(resource_type, items) do
-    templates = get_resource_path_templates()
-
-    case Map.get(templates, resource_type) do
-      nil ->
-        %{}
-
-      config ->
-        path_template = path_from_config(config)
-        title_template = title_from_config(config)
-
-        Map.new(items, fn item ->
-          metadata = field(item, :metadata) || %{}
-          uuid = field(item, :resource_uuid)
-          path = apply_path_template(path_template, uuid, metadata)
-          title = resolve_title(title_template, resource_type, uuid, metadata)
-          full_title = resolve_full_title(title_template, resource_type, uuid, metadata)
-
-          {uuid, %{title: title, full_title: full_title, path: path, prefixed: false}}
-        end)
+  # Module-declared templates are internal phoenix_kit routes → prefixed
+  # (Routes.path applied at render, SPA-navigated).
+  defp resolve_via_module_template(resource_type, items) do
+    case Map.get(module_templates(), resource_type) do
+      nil -> %{}
+      config -> resolve_via_template(resource_type, items, config, true)
     end
+  end
+
+  # Host `comment_resource_paths` templates are for controller/external pages →
+  # not prefixed (rendered as a plain href, `:prefix` substituted into the path).
+  defp resolve_via_setting_template(resource_type, items) do
+    case Map.get(get_resource_path_templates(), resource_type) do
+      nil -> %{}
+      config -> resolve_via_template(resource_type, items, config, false)
+    end
+  end
+
+  defp resolve_via_template(resource_type, items, config, prefixed) do
+    path_template = path_from_config(config)
+    title_template = title_from_config(config)
+
+    Map.new(items, fn item ->
+      metadata = field(item, :metadata) || %{}
+      uuid = field(item, :resource_uuid)
+      path = apply_path_template(path_template, uuid, metadata, prefixed)
+      title = resolve_title(title_template, resource_type, uuid, metadata)
+      full_title = resolve_full_title(title_template, resource_type, uuid, metadata)
+
+      {uuid, %{title: title, full_title: full_title, path: path, prefixed: prefixed}}
+    end)
   end
 
   defp resolve_title(nil, resource_type, uuid, _metadata) do
@@ -230,10 +303,13 @@ defmodule PhoenixKit.ResourceLinks do
   defp title_from_config(%{"title" => title}), do: title
   defp title_from_config(_), do: nil
 
-  defp apply_path_template(template, resource_uuid, metadata) do
+  # `prefixed?` = true for internal phoenix_kit routes: leave `:prefix` alone
+  # (Routes.path/1 prepends the url_prefix at render). false for external/host
+  # templates: substitute `:prefix` with the configured prefix here.
+  defp apply_path_template(template, resource_uuid, metadata, prefixed?) do
     template
     |> replace_metadata_url_placeholders(metadata)
-    |> String.replace(":prefix", prefix_value())
+    |> then(fn t -> if prefixed?, do: t, else: String.replace(t, ":prefix", prefix_value()) end)
     |> String.replace(":uuid", url_encode(to_string(resource_uuid)))
   end
 

--- a/lib/phoenix_kit_web/components/core/resource_link.ex
+++ b/lib/phoenix_kit_web/components/core/resource_link.ex
@@ -46,6 +46,39 @@ defmodule PhoenixKitWeb.Components.Core.ResourceLink do
     """
   end
 
+  @doc """
+  Renders a plain-text label (e.g. an email) as a link to a resolved resource,
+  falling back to plain text when `info` is `nil` (unresolved).
+
+  Lighter than `resource_link/1` — no chip/thumbnail — for inline "who did it /
+  who it's for" links in dense tables (the activity feed's actor/target).
+  """
+  attr :info, :map, default: nil
+  attr :label, :string, required: true
+  attr :class, :string, default: ""
+
+  def resource_email_link(assigns) do
+    ~H"""
+    <.link
+      :if={@info && @info[:prefixed]}
+      navigate={ResourceLinks.url(@info)}
+      class={["link link-hover", @class]}
+      title={@info[:full_title] || @info[:title]}
+    >
+      {@label}
+    </.link>
+    <.link
+      :if={@info && !@info[:prefixed]}
+      href={ResourceLinks.url(@info)}
+      class={["link link-hover", @class]}
+      title={@info[:full_title] || @info[:title]}
+    >
+      {@label}
+    </.link>
+    <span :if={is_nil(@info)} class={@class}>{@label}</span>
+    """
+  end
+
   defp chip_class do
     "inline-flex items-center gap-1.5 max-w-[240px] py-0.5 pl-1 pr-2.5 rounded-full " <>
       "bg-base-200 hover:bg-base-300 transition-colors no-underline align-middle"

--- a/lib/phoenix_kit_web/live/activity/index.ex
+++ b/lib/phoenix_kit_web/live/activity/index.ex
@@ -142,7 +142,7 @@ defmodule PhoenixKitWeb.Live.Activity.Index do
       )
 
     resource_users = Activity.resolve_resource_users(result.entries)
-    resource_links = PhoenixKit.ResourceLinks.resolve(result.entries)
+    resource_links = resolve_links(result.entries)
 
     socket
     |> assign(:entries, result.entries)
@@ -150,6 +150,21 @@ defmodule PhoenixKitWeb.Live.Activity.Index do
     |> assign(:resource_links, resource_links)
     |> assign(:total, result.total)
     |> assign(:total_pages, result.total_pages)
+  end
+
+  # Resolve deep-links for both each entry's resource AND its actor/target (both
+  # users). Actor/target are added as synthetic `"user"` items so the resulting
+  # map is keyed by `{resource_type, uuid}` for all three — the template reads
+  # `{"user", actor_uuid}` / `{"user", target_uuid}` to link the who-did/who-for.
+  defp resolve_links(entries) do
+    user_items =
+      entries
+      |> Enum.flat_map(fn e -> [e.actor_uuid, e.target_uuid] end)
+      |> Enum.filter(&is_binary/1)
+      |> Enum.uniq()
+      |> Enum.map(&%{resource_type: "user", resource_uuid: &1})
+
+    PhoenixKit.ResourceLinks.resolve(entries ++ user_items)
   end
 
   defp maybe_put(map, _key, nil), do: map

--- a/lib/phoenix_kit_web/live/activity/index.html.heex
+++ b/lib/phoenix_kit_web/live/activity/index.html.heex
@@ -370,7 +370,11 @@
             </.table_default_cell>
             <.table_default_cell class="text-sm hidden md:table-cell">
               <%= if entry.actor do %>
-                <span class="font-semibold">{entry.actor.email}</span>
+                <.resource_email_link
+                  info={Map.get(@resource_links, {"user", entry.actor_uuid})}
+                  label={entry.actor.email}
+                  class="font-semibold"
+                />
                 <%= if entry.metadata["actor_role"] do %>
                   <span class={[
                     "badge badge-xs ml-1",
@@ -390,7 +394,10 @@
               <%= if entry.target && entry.target_uuid != entry.resource_uuid do %>
                 <div class="mb-0.5">
                   <span class="text-base-content/50">&rarr;</span>
-                  <span>{entry.target.email}</span>
+                  <.resource_email_link
+                    info={Map.get(@resource_links, {"user", entry.target_uuid})}
+                    label={entry.target.email}
+                  />
                 </div>
               <% end %>
               <% summary = summarize_details(entry.metadata) %>

--- a/lib/phoenix_kit_web/live/activity/show.ex
+++ b/lib/phoenix_kit_web/live/activity/show.ex
@@ -28,9 +28,12 @@ defmodule PhoenixKitWeb.Live.Activity.Show do
           project_title = Settings.get_project_title()
           resource_user = resolve_resource_user(entry)
 
-          resource_link =
-            PhoenixKit.ResourceLinks.resolve([entry])
-            |> PhoenixKit.ResourceLinks.info_for(entry.resource_type, entry.resource_uuid)
+          # Resolve deep-links for the resource AND the actor/target (both users),
+          # so the who-did-it / who-it's-for identities are clickable too.
+          links =
+            [entry]
+            |> Enum.concat(user_items(entry))
+            |> PhoenixKit.ResourceLinks.resolve()
 
           socket =
             socket
@@ -38,7 +41,9 @@ defmodule PhoenixKitWeb.Live.Activity.Show do
             |> assign(:project_title, project_title)
             |> assign(:entry, entry)
             |> assign(:resource_user, resource_user)
-            |> assign(:resource_link, resource_link)
+            |> assign(:resource_link, links[{entry.resource_type, entry.resource_uuid}])
+            |> assign(:actor_link, links[{"user", entry.actor_uuid}])
+            |> assign(:target_link, links[{"user", entry.target_uuid}])
 
           {:ok, socket}
       end
@@ -53,6 +58,15 @@ defmodule PhoenixKitWeb.Live.Activity.Show do
   @impl true
   def handle_params(_params, url, socket) do
     {:noreply, assign(socket, :url_path, URI.parse(url).path)}
+  end
+
+  # Synthetic `"user"` items for the actor + target uuids, so ResourceLinks can
+  # resolve them alongside the entry's own resource in one pass.
+  defp user_items(entry) do
+    [entry.actor_uuid, entry.target_uuid]
+    |> Enum.filter(&is_binary/1)
+    |> Enum.uniq()
+    |> Enum.map(&%{resource_type: "user", resource_uuid: &1})
   end
 
   defp resolve_resource_user(entry) do

--- a/lib/phoenix_kit_web/live/activity/show.html.heex
+++ b/lib/phoenix_kit_web/live/activity/show.html.heex
@@ -56,7 +56,11 @@
               </div>
               <%= if @entry.actor do %>
                 <div class="flex items-center gap-2">
-                  <span class="font-semibold">{@entry.actor.email}</span>
+                  <.resource_email_link
+                    info={@actor_link}
+                    label={@entry.actor.email}
+                    class="font-semibold"
+                  />
                   <%= if @entry.metadata["actor_role"] do %>
                     <span class={[
                       "badge badge-xs",
@@ -83,7 +87,11 @@
                 {gettext("Target (who was affected)")}
               </div>
               <%= if @entry.target do %>
-                <div class="font-semibold">{@entry.target.email}</div>
+                <.resource_email_link
+                  info={@target_link}
+                  label={@entry.target.email}
+                  class="font-semibold"
+                />
                 <div class="text-xs text-base-content/40 mt-0.5">
                   {to_string(@entry.target_uuid)}
                 </div>

--- a/lib/phoenix_kit_web/live/modules/notifications/index.ex
+++ b/lib/phoenix_kit_web/live/modules/notifications/index.ex
@@ -1,7 +1,9 @@
 defmodule PhoenixKitWeb.Live.Modules.Notifications.Index do
   @moduledoc """
-  Simple admin overview for the Notifications module — enabled state,
-  retention window, and aggregate counts (total / unread / dismissed).
+  Admin overview for the Notifications module — enabled state, retention
+  window, aggregate counts (total / unread / dismissed), and a paginated
+  list of every notification showing its recipient, what it's about, and
+  its per-user seen/dismissed state.
 
   Read-only. Enabling/disabling the module lives on the Modules page;
   this page redirects there if the module is disabled.
@@ -10,8 +12,12 @@ defmodule PhoenixKitWeb.Live.Modules.Notifications.Index do
   use PhoenixKitWeb, :live_view
 
   alias PhoenixKit.Notifications
+  alias PhoenixKit.Notifications.Render
   alias PhoenixKit.Settings
+  alias PhoenixKit.Utils.Date, as: UtilsDate
   alias PhoenixKit.Utils.Routes
+
+  @per_page 25
 
   @impl true
   def mount(_params, _session, socket) do
@@ -23,6 +29,8 @@ defmodule PhoenixKitWeb.Live.Modules.Notifications.Index do
         |> assign(:url_path, Routes.path("/admin/notifications"))
         |> assign(:retention_days, Notifications.retention_days())
         |> assign(:stats, Notifications.admin_stats())
+        |> assign(:per_page, @per_page)
+        |> assign(:page, 1)
 
       {:ok, socket}
     else
@@ -37,7 +45,66 @@ defmodule PhoenixKitWeb.Live.Modules.Notifications.Index do
   end
 
   @impl true
-  def handle_event("refresh", _params, socket) do
-    {:noreply, assign(socket, :stats, Notifications.admin_stats())}
+  def handle_params(params, url, socket) do
+    # Skip when mount redirected (module disabled) — assigns won't be set up.
+    if socket.assigns[:per_page] do
+      {:noreply,
+       socket
+       |> assign(:page, parse_page(params["page"]))
+       |> assign(:url_path, URI.parse(url).path)
+       |> load_notifications()}
+    else
+      {:noreply, socket}
+    end
   end
+
+  @impl true
+  def handle_event("refresh", _params, socket) do
+    {:noreply,
+     socket
+     |> assign(:stats, Notifications.admin_stats())
+     |> load_notifications()}
+  end
+
+  ## Private
+
+  defp load_notifications(socket) do
+    {rows, total} =
+      Notifications.admin_list(page: socket.assigns.page, per_page: socket.assigns.per_page)
+
+    # Deep-link each recipient to their admin page, via the shared resolver.
+    recipient_links =
+      rows
+      |> Enum.map(&%{resource_type: "user", resource_uuid: &1.recipient_uuid})
+      |> PhoenixKit.ResourceLinks.resolve()
+
+    socket
+    |> assign(:notifications, rows)
+    |> assign(:total, total)
+    |> assign(:total_pages, max(ceil(total / socket.assigns.per_page), 1))
+    |> assign(:recipient_links, recipient_links)
+  end
+
+  defp parse_page(nil), do: 1
+
+  defp parse_page(str) when is_binary(str) do
+    case Integer.parse(str) do
+      {n, _} -> max(n, 1)
+      :error -> 1
+    end
+  end
+
+  # Rendered notification (icon + text) for display, honoring the admin's locale.
+  defp render_notification(notification, locale), do: Render.render(notification, locale)
+
+  # Per-user lifecycle state → a badge label + daisyUI class.
+  defp status_meta(%{dismissed_at: %DateTime{}}), do: {"Dismissed", "badge-ghost"}
+  defp status_meta(%{seen_at: %DateTime{}}), do: {"Seen", "badge-neutral"}
+  defp status_meta(_), do: {"Unread", "badge-primary"}
+
+  defp format_datetime(%DateTime{} = dt) do
+    "#{UtilsDate.format_date_with_user_format(dt)} #{UtilsDate.format_time_with_user_format(dt)}"
+  end
+
+  defp format_datetime(_), do: ""
 end

--- a/lib/phoenix_kit_web/live/modules/notifications/index.html.heex
+++ b/lib/phoenix_kit_web/live/modules/notifications/index.html.heex
@@ -43,6 +43,82 @@
       </div>
     </div>
 
+    <%!-- All notifications (who each is for + what it's about) --%>
+    <div class="card bg-base-100 shadow mb-6">
+      <div class="card-body p-0">
+        <div class="px-4 py-3 border-b border-base-200 flex items-center justify-between">
+          <h3 class="font-semibold text-sm">{gettext("All notifications")}</h3>
+          <span class="text-xs text-base-content/50">
+            {gettext("%{count} total", count: @total)}
+          </span>
+        </div>
+
+        <%= if @notifications == [] do %>
+          <div class="px-4 py-10 text-center text-base-content/50">
+            {gettext("No notifications yet.")}
+          </div>
+        <% else %>
+          <div class="overflow-x-auto">
+            <table class="table table-sm">
+              <thead>
+                <tr>
+                  <th>{gettext("Recipient")}</th>
+                  <th>{gettext("Notification")}</th>
+                  <th>{gettext("Status")}</th>
+                  <th>{gettext("Date")}</th>
+                </tr>
+              </thead>
+              <tbody>
+                <%= for n <- @notifications do %>
+                  <% view = render_notification(n, assigns[:current_locale]) %>
+                  <% {status_label, status_class} = status_meta(n) %>
+                  <tr>
+                    <td>
+                      <%= if n.recipient do %>
+                        <.resource_email_link
+                          info={Map.get(@recipient_links, {"user", n.recipient_uuid})}
+                          label={n.recipient.email}
+                        />
+                      <% else %>
+                        <span class="text-base-content/40">—</span>
+                      <% end %>
+                    </td>
+                    <td>
+                      <div class="flex items-center gap-2">
+                        <.icon name={view.icon} class="w-4 h-4 text-base-content/50 shrink-0" />
+                        <span>{view.text}</span>
+                      </div>
+                    </td>
+                    <td>
+                      <span class={"badge badge-sm #{status_class}"}>{status_label}</span>
+                    </td>
+                    <td class="text-xs text-base-content/60 whitespace-nowrap">
+                      {format_datetime(n.inserted_at)}
+                    </td>
+                  </tr>
+                <% end %>
+              </tbody>
+            </table>
+          </div>
+
+          <%= if @total_pages > 1 do %>
+            <div class="flex justify-center py-4">
+              <div class="join">
+                <%= for page <- max(1, @page - 2)..min(@total_pages, @page + 2) do %>
+                  <.link
+                    patch={Routes.path("/admin/notifications?page=#{page}")}
+                    class={["join-item btn btn-sm", if(page == @page, do: "btn-active", else: "")]}
+                  >
+                    {page}
+                  </.link>
+                <% end %>
+              </div>
+            </div>
+          <% end %>
+        <% end %>
+      </div>
+    </div>
+
     <%!-- Module info --%>
     <div class="card bg-base-100 shadow">
       <div class="card-body p-4">

--- a/test/phoenix_kit/resource_links_test.exs
+++ b/test/phoenix_kit/resource_links_test.exs
@@ -73,9 +73,24 @@ defmodule PhoenixKit.ResourceLinksTest do
     test "auto-registers the loaded core handlers" do
       handlers = ResourceLinks.handlers()
 
-      # The user + file handlers ship in core and are always loaded in the suite.
+      # The user + file + integration handlers ship in core and are always loaded.
       assert handlers["user"] == PhoenixKit.Users.CommentResources
       assert handlers["file"] == PhoenixKit.Annotations
+      assert handlers["integration"] == PhoenixKit.Integrations.ResourceLinks
+    end
+  end
+
+  describe "integration handler" do
+    test "resolves an integration uuid to its edit page (prefixed navigate)" do
+      uuid = "01900000-0000-7000-8000-0000000000ff"
+      items = [%{resource_type: "integration", resource_uuid: uuid, metadata: %{}}]
+
+      info = ResourceLinks.resolve(items) |> ResourceLinks.info_for("integration", uuid)
+
+      assert info.path == "/admin/settings/integrations/#{uuid}"
+      assert info.prefixed == true
+      # Title falls back to a generic label with no DB connection to read.
+      assert is_binary(info.title)
     end
   end
 end


### PR DESCRIPTION
## Summary

Two related pieces building on the activity/notification deep-link system.

### 1. Extensible deep-links (`e208a442`)
- **Actor & target** identities in the activity index + detail now link to the user's admin page, via a new lightweight `<.resource_email_link>` component ("who did it / who it's for").
- **Integrations**: integration activities stamp the connection's uuid as `resource_uuid`, and a new `PhoenixKit.Integrations.ResourceLinks` resolver links them to the connection's edit page.
- **Generic module callback** `PhoenixKit.Module.resource_links/0`: any module can declare how its resource types deep-link — a resolver module, or a no-code `"/path/:uuid"` template — merged by `PhoenixKit.ResourceLinks` alongside core's built-ins and the `comment_resource_paths` setting.

### 2. Admin notifications list (`8ae6548c`)
- `/admin/notifications` was aggregate-stats only. Adds a paginated table of every notification: **recipient** (deep-linked to the user), **what it's about** (rendered icon + text), per-user **Unread/Seen/Dismissed** state, and date.
- New context fn `Notifications.admin_list/1` (all users, newest first, recipient + activity/actor preloaded).

## Testing
- `mix compile --warnings-as-errors`, credo `--strict`, `mix format` — clean
- `resource_links_test.exs` extended; activity + module + integrations suites green
- Verified against a dev DB: actor/target/integration/post resources resolve; admin_list + Render render correctly

No `mix.exs`/`@version`/CHANGELOG changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MsjUy1HnuJnCSrqdbnANYL