### PR TITLE
Fix jobs admin crash on scheduled-job fields

### DIFF
--- a/lib/phoenix_kit_web/live/modules/jobs/index.html.heex
+++ b/lib/phoenix_kit_web/live/modules/jobs/index.html.heex
@@ -307,13 +307,13 @@
                   <.table_default_row
                     class="cursor-pointer hover:bg-base-200"
                     phx-click="show_scheduled_job"
-                    phx-value-id={job.id}
+                    phx-value-id={job.uuid}
                   >
                     <.table_default_cell>
                       <span class="badge badge-sm badge-outline">{job.job_type}</span>
                     </.table_default_cell>
                     <.table_default_cell class="font-mono text-xs">
-                      {job.resource_type}/{String.slice(job.resource_id || "", 0, 8)}...
+                      {job.resource_type}/{String.slice(job.resource_uuid || "", 0, 8)}...
                     </.table_default_cell>
                     <.table_default_cell>
                       <span class={"badge badge-sm #{scheduled_job_badge_class(job.status)}"}>
@@ -511,7 +511,7 @@
             </span>
           </h3>
           <p class="text-xs text-base-content/50 mb-4">
-            {@selected_scheduled_job.resource_type}/{@selected_scheduled_job.resource_id}
+            {@selected_scheduled_job.resource_type}/{@selected_scheduled_job.resource_uuid}
           </p>
 
           <%!-- Basic Info Grid --%>


### PR DESCRIPTION
## Summary

The scheduled-tasks table and detail panel on the Jobs admin page referenced `job.id` and `job.resource_id`, but `ScheduledJob`'s primary key is `uuid` and the field is `resource_uuid`. Rendering the page raised `(KeyError) key :id not found` — the jobs module couldn't load at all.

Use the actual field names (`uuid`, `resource_uuid`). The Oban-jobs table's `.id` references are correct (Oban jobs have integer ids) and are left as-is.

## Testing
`mix compile --warnings-as-errors` clean. Confirmed the schema primary key is `uuid` and the field is `resource_uuid`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MsjUy1HnuJnCSrqdbnANYL