### PR TITLE
Add V139 dashboards config migration, viewport connect-param installer step, daisyUI modal-gutter fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -441,6 +441,27 @@ The mechanism generalizes; for now hardcoded to publishing — lift to a registr
 
 Workspace-tracked items not ready for inline `# TODO` in `lib/`.
 
+### Remove the daisyUI modal-gutter counter-rule after vendored daisyUI upgrades
+
+`layout_wrapper.ex` (admin `<style>` block) and `layouts/root.html.heex` carry an
+unlayered `:root:has(.modal-open, …) { scrollbar-gutter: auto }` rule. It counters
+a **daisyUI 5.0.x** defect: on modal/drawer open, old daisyUI unconditionally
+reserves a scrollbar gutter and paints it with a base-100 trick that mismatches on
+non-base-100 pages — classic-scrollbar users see an uncovered strip at the
+window's right edge. Upstream fixed this properly across 5.1.0→5.6.x
+(`rootscrollgutter.css`: `animation-timeline: scroll()` detects a real scrollbar;
+gutter reserved only then).
+
+Hosts vendor their own `daisyui.js` (parent was on 5.0.35 when this was added), so
+the rule protects any host still on old daisyUI. Once hosts are on daisyUI ≥ 5.6,
+remove the rule from both files — it's redundant there, and in browsers that honor
+`scrollbar-gutter` under `overflow: hidden` it would defeat upstream's smarter
+conditional reservation. The `phoenix_kit_dashboards` module carries a per-page
+copy (`gutter_fix_style/0` in both LiveViews) that's deletable as soon as its core
+pin includes this rule, independent of the daisyUI version. Verified 2026-07-08:
+6-page pixel-diff of 5.0.35 vs 5.6.14 showed only 1-2px badge-padding drift, so
+the vendored upgrade itself is low-risk.
+
 ### Component test coverage for `phoenix_kit_web/components/core/`
 
 Partial coverage exists in `test/phoenix_kit_web/components/core/` — written for the modal-to-native-dialog sweep. Remaining gaps:

--- a/lib/phoenix_kit/install/js_integration.ex
+++ b/lib/phoenix_kit/install/js_integration.ex
@@ -344,14 +344,19 @@ defmodule PhoenixKit.Install.JsIntegration do
   end
 
   defp commented_at?(content, pos) do
-    line_prefix =
-      content
-      |> binary_part(0, pos)
-      |> String.split("\n")
-      |> List.last()
+    before = binary_part(content, 0, pos)
+    line_prefix = before |> String.split("\n") |> List.last()
 
     String.contains?(line_prefix, "//") or String.contains?(line_prefix, "/*") or
-      line_prefix |> String.trim_leading() |> String.starts_with?("*")
+      line_prefix |> String.trim_leading() |> String.starts_with?("*") or
+      inside_block_comment?(before)
+  end
+
+  # An unclosed /* before the position means we're inside a multi-line block
+  # comment (whose lines need no leading *) — e.g. a commented-out example call
+  # would otherwise anchor the patch away from the real call below it.
+  defp inside_block_comment?(before) do
+    length(:binary.matches(before, "/*")) > length(:binary.matches(before, "*/"))
   end
 
   # The first simple `params: {…}` at the TOP level of the LiveSocket options
@@ -379,8 +384,12 @@ defmodule PhoenixKit.Install.JsIntegration do
     end
   end
 
+  # Brace depth of the segment with string literals and comments blanked out
+  # first — a `"}}}"` inside a hook option must not fake depth 1 at a nested
+  # site (that produced a WRONG rewrite in review; imperfect blanking merely
+  # skews depth away from 1, which fails closed to :manual).
   defp brace_depth(segment) do
-    for <<char <- segment>>, reduce: 0 do
+    for <<char <- blank_strings_and_comments(segment)>>, reduce: 0 do
       depth ->
         case char do
           ?{ -> depth + 1
@@ -388,6 +397,16 @@ defmodule PhoenixKit.Install.JsIntegration do
           _ -> depth
         end
     end
+  end
+
+  defp blank_strings_and_comments(segment) do
+    segment
+    |> String.replace(~r/\\./, "")
+    |> String.replace(~r/"[^"]*"/, "\"\"")
+    |> String.replace(~r/'[^']*'/, "''")
+    |> String.replace(~r/`[^`]*`/s, "``")
+    |> String.replace(~r{/\*.*?\*/}s, "")
+    |> String.replace(~r{//[^\n]*}, "")
   end
 
   defp viewport_manual_notice(igniter) do

--- a/lib/phoenix_kit/install/js_integration.ex
+++ b/lib/phoenix_kit/install/js_integration.ex
@@ -308,7 +308,9 @@ defmodule PhoenixKit.Install.JsIntegration do
   #     `// …` would swallow the new code into the comment),
   #   * already a closure / nested braces → no simple-object match → refused.
   def inject_viewport_param(content) do
-    if String.contains?(content, "viewport_width"),
+    # The KEY form specifically — a prose mention in a comment ("add
+    # viewport_width someday") must not make the installer skip the patch.
+    if Regex.match?(~r/viewport_width\s*:/, content),
       do: :already,
       else: rewrite_livesocket_params(content)
   end

--- a/lib/phoenix_kit/install/js_integration.ex
+++ b/lib/phoenix_kit/install/js_integration.ex
@@ -316,12 +316,9 @@ defmodule PhoenixKit.Install.JsIntegration do
   end
 
   defp rewrite_livesocket_params(content) do
-    with [head, rest] <- String.split(content, "new LiveSocket(", parts: 2),
-         [{start, len}, {inner_start, inner_len}] <-
-           Regex.run(~r/params:\s*\{([^{}]*)\}/, rest, return: :index),
-         true <- start <= @viewport_params_window,
-         inner = binary_part(rest, inner_start, inner_len),
-         false <- String.contains?(inner, "//") or String.contains?(inner, "/*") do
+    with {:ok, anchor_end} <- livesocket_anchor(content),
+         rest = binary_part(content, anchor_end, byte_size(content) - anchor_end),
+         {:ok, {start, len}, inner} <- top_level_params(rest) do
       trimmed = inner |> String.trim() |> String.trim_trailing(",")
       prefix = if trimmed == "", do: "", else: trimmed <> ", "
 
@@ -330,9 +327,66 @@ defmodule PhoenixKit.Install.JsIntegration do
           "params: () => ({#{prefix}viewport_width: window.innerWidth})" <>
           binary_part(rest, start + len, byte_size(rest) - start - len)
 
-      {:ok, head <> "new LiveSocket(" <> rewritten}
+      {:ok, binary_part(content, 0, anchor_end) <> rewritten}
     else
       _ -> :manual
+    end
+  end
+
+  # The first `new LiveSocket(` that isn't on a commented line — a documentation
+  # example (`// Example: new LiveSocket(...)`) must not anchor the patch away
+  # from the real call below it.
+  defp livesocket_anchor(content) do
+    :binary.matches(content, "new LiveSocket(")
+    |> Enum.find_value(:manual, fn {pos, len} ->
+      if commented_at?(content, pos), do: nil, else: {:ok, pos + len}
+    end)
+  end
+
+  defp commented_at?(content, pos) do
+    line_prefix =
+      content
+      |> binary_part(0, pos)
+      |> String.split("\n")
+      |> List.last()
+
+    String.contains?(line_prefix, "//") or String.contains?(line_prefix, "/*") or
+      line_prefix |> String.trim_leading() |> String.starts_with?("*")
+  end
+
+  # The first simple `params: {…}` at the TOP level of the LiveSocket options
+  # object (brace depth exactly 1 relative to the call's `(`): a nested
+  # `params:` inside a hook body (`this.pushEvent("load", {params: {page: 1}})`)
+  # must never be rewritten. Comment-bearing objects are refused (appending
+  # after a trailing `// …` would swallow the new code into the comment), as is
+  # anything farther than the window (assumed to belong to something else).
+  defp top_level_params(rest) do
+    ~r/params:\s*\{([^{}]*)\}/
+    |> Regex.scan(rest, return: :index)
+    |> Enum.find_value(:manual, fn [{start, len}, {inner_start, inner_len}] ->
+      inner = binary_part(rest, inner_start, inner_len)
+
+      cond do
+        start > @viewport_params_window -> :manual
+        brace_depth(binary_part(rest, 0, start)) != 1 -> nil
+        String.contains?(inner, "//") or String.contains?(inner, "/*") -> :manual
+        true -> {:ok, {start, len}, inner}
+      end
+    end)
+    |> case do
+      {:ok, _, _} = ok -> ok
+      _ -> :manual
+    end
+  end
+
+  defp brace_depth(segment) do
+    for <<char <- segment>>, reduce: 0 do
+      depth ->
+        case char do
+          ?{ -> depth + 1
+          ?} -> depth - 1
+          _ -> depth
+        end
     end
   end
 

--- a/lib/phoenix_kit/install/js_integration.ex
+++ b/lib/phoenix_kit/install/js_integration.ex
@@ -292,33 +292,45 @@ defmodule PhoenixKit.Install.JsIntegration do
     end
   end
 
+  # A params object further than this from `new LiveSocket(` is assumed to
+  # belong to something else (another socket, a config literal) — manual notice.
+  @viewport_params_window 500
+
   @doc false
   # Pure transform (public for tests): rewrite the common phx.new shape
   # `params: {_csrf_token: csrfToken}` into a closure carrying viewport_width.
-  # Anything fancier (already a function, nested braces) is left alone with a
-  # manual notice — regex surgery on arbitrary host code must stay conservative.
+  # Deliberately conservative — regex surgery on arbitrary host code must not
+  # corrupt it, so anything fancier gets a manual notice instead:
+  #   * only the params object INSIDE the `new LiveSocket(` options is touched
+  #     (an earlier `new Socket("/socket", {params: …})` must not be rewritten
+  #     while the real LiveSocket params stay bare),
+  #   * objects containing comments are refused (appending after a trailing
+  #     `// …` would swallow the new code into the comment),
+  #   * already a closure / nested braces → no simple-object match → refused.
   def inject_viewport_param(content) do
-    cond do
-      String.contains?(content, "viewport_width") ->
-        :already
+    if String.contains?(content, "viewport_width"),
+      do: :already,
+      else: rewrite_livesocket_params(content)
+  end
 
-      Regex.match?(~r/params:\s*\{[^{}]*\}/, content) ->
-        updated =
-          Regex.replace(
-            ~r/params:\s*\{([^{}]*)\}/,
-            content,
-            fn _, inner ->
-              inner = inner |> String.trim() |> String.trim_trailing(",")
-              prefix = if inner == "", do: "", else: inner <> ", "
-              "params: () => ({#{prefix}viewport_width: window.innerWidth})"
-            end,
-            global: false
-          )
+  defp rewrite_livesocket_params(content) do
+    with [head, rest] <- String.split(content, "new LiveSocket(", parts: 2),
+         [{start, len}, {inner_start, inner_len}] <-
+           Regex.run(~r/params:\s*\{([^{}]*)\}/, rest, return: :index),
+         true <- start <= @viewport_params_window,
+         inner = binary_part(rest, inner_start, inner_len),
+         false <- String.contains?(inner, "//") or String.contains?(inner, "/*") do
+      trimmed = inner |> String.trim() |> String.trim_trailing(",")
+      prefix = if trimmed == "", do: "", else: trimmed <> ", "
 
-        {:ok, updated}
+      rewritten =
+        binary_part(rest, 0, start) <>
+          "params: () => ({#{prefix}viewport_width: window.innerWidth})" <>
+          binary_part(rest, start + len, byte_size(rest) - start - len)
 
-      true ->
-        :manual
+      {:ok, head <> "new LiveSocket(" <> rewritten}
+    else
+      _ -> :manual
     end
   end
 

--- a/lib/phoenix_kit/install/js_integration.ex
+++ b/lib/phoenix_kit/install/js_integration.ex
@@ -60,6 +60,7 @@ defmodule PhoenixKit.Install.JsIntegration do
     |> add_js_sources_compiler()
     |> seed_modules_js_file()
     |> add_modules_script_tag_to_layout()
+    |> add_viewport_param_to_app_js()
   end
 
   @doc """
@@ -258,6 +259,83 @@ defmodule PhoenixKit.Install.JsIntegration do
     else
       add_hooks_manual_notice(igniter)
     end
+  end
+
+  # Add `viewport_width` to the LiveSocket connect params (as a closure, so
+  # reconnects re-read the width). PhoenixKit LiveViews with responsive layouts
+  # (e.g. the dashboards builder) use it to pick the right tier server-side on
+  # the FIRST render instead of detecting it with a hook round-trip behind a
+  # loading state. They all degrade gracefully without it.
+  defp add_viewport_param_to_app_js(igniter) do
+    app_js_path = Path.join([File.cwd!(), "assets", "js", "app.js"])
+
+    if File.exists?(app_js_path) do
+      content = File.read!(app_js_path)
+
+      case inject_viewport_param(content) do
+        :already ->
+          igniter
+
+        {:ok, updated} ->
+          File.write!(app_js_path, updated)
+
+          Igniter.add_notice(
+            igniter,
+            "✅ Added viewport_width to the LiveSocket connect params in assets/js/app.js"
+          )
+
+        :manual ->
+          viewport_manual_notice(igniter)
+      end
+    else
+      viewport_manual_notice(igniter)
+    end
+  end
+
+  @doc false
+  # Pure transform (public for tests): rewrite the common phx.new shape
+  # `params: {_csrf_token: csrfToken}` into a closure carrying viewport_width.
+  # Anything fancier (already a function, nested braces) is left alone with a
+  # manual notice — regex surgery on arbitrary host code must stay conservative.
+  def inject_viewport_param(content) do
+    cond do
+      String.contains?(content, "viewport_width") ->
+        :already
+
+      Regex.match?(~r/params:\s*\{[^{}]*\}/, content) ->
+        updated =
+          Regex.replace(
+            ~r/params:\s*\{([^{}]*)\}/,
+            content,
+            fn _, inner ->
+              inner = inner |> String.trim() |> String.trim_trailing(",")
+              prefix = if inner == "", do: "", else: inner <> ", "
+              "params: () => ({#{prefix}viewport_width: window.innerWidth})"
+            end,
+            global: false
+          )
+
+        {:ok, updated}
+
+      true ->
+        :manual
+    end
+  end
+
+  defp viewport_manual_notice(igniter) do
+    Igniter.add_notice(
+      igniter,
+      """
+      ℹ️  Optional: pass the viewport in your LiveSocket connect params so
+      PhoenixKit's responsive LiveViews (e.g. dashboards) load straight into
+      the right layout tier:
+
+          const liveSocket = new LiveSocket("/live", Socket, {
+            params: () => ({_csrf_token: csrfToken, viewport_width: window.innerWidth}),
+            ...
+          })
+      """
+    )
   end
 
   defp add_hooks_manual_notice(igniter) do

--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -1184,7 +1184,7 @@ defmodule PhoenixKit.Migrations.Postgres do
   use Ecto.Migration
 
   @initial_version 1
-  @current_version 138
+  @current_version 139
   @default_prefix "public"
 
   @doc false

--- a/lib/phoenix_kit/migrations/postgres/v139.ex
+++ b/lib/phoenix_kit/migrations/postgres/v139.ex
@@ -1,0 +1,37 @@
+defmodule PhoenixKit.Migrations.Postgres.V139 do
+  @moduledoc """
+  V139: Dashboard-level `config` for the dashboards plugin.
+
+  Adds a JSONB `config` column to `phoenix_kit_dashboards` for per-dashboard
+  presentation settings — currently the layout mode (`"grid"` flow vs `"free"`
+  pixel placement) and pixel-mode zoom. Read/written whole, like `layout`.
+
+  All statements are idempotent (IF NOT EXISTS), safe to re-run.
+  """
+
+  use Ecto.Migration
+
+  def up(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    execute("""
+    ALTER TABLE #{p}phoenix_kit_dashboards
+    ADD COLUMN IF NOT EXISTS config JSONB NOT NULL DEFAULT '{}'
+    """)
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '139'")
+  end
+
+  def down(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    execute("ALTER TABLE #{p}phoenix_kit_dashboards DROP COLUMN IF EXISTS config")
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '138'")
+  end
+
+  defp prefix_str("public"), do: "public."
+  defp prefix_str(prefix), do: "#{prefix}."
+end

--- a/lib/phoenix_kit_web/components/layout_wrapper.ex
+++ b/lib/phoenix_kit_web/components/layout_wrapper.ex
@@ -302,6 +302,17 @@ defmodule PhoenixKitWeb.Components.LayoutWrapper do
               <%= HTML.raw(ThemeConfig.custom_theme_css()) %>
             </style>
             <style>
+              /* daisyUI 5 reserves a scrollbar gutter while a modal/drawer is open
+                 (`:where(:root:has(.modal-open, …)) { scrollbar-gutter: stable }` in
+                 @layer base). On a page without a scrollbar the fixed backdrop can't
+                 cover that reserved strip, so classic-scrollbar users (Firefox, macOS
+                 "always show") see an uncovered gap at the window's right edge whenever
+                 a modal opens. UNLAYERED here, so it beats the layered zero-specificity
+                 original regardless of stylesheet order. */
+              :root:has(.modal-open, .modal[open], .modal:target, .modal-toggle:checked, .drawer:not(.drawer-open) > .drawer-toggle:checked) {
+                scrollbar-gutter: auto;
+              }
+
               /* Custom sidebar control for desktop - override lg:drawer-open grid layout when closed */
               @media (min-width: 1024px) {
                 /* Override the grid to collapse sidebar column when closed */

--- a/lib/phoenix_kit_web/components/layout_wrapper.ex
+++ b/lib/phoenix_kit_web/components/layout_wrapper.ex
@@ -308,7 +308,10 @@ defmodule PhoenixKitWeb.Components.LayoutWrapper do
                  cover that reserved strip, so classic-scrollbar users (Firefox, macOS
                  "always show") see an uncovered gap at the window's right edge whenever
                  a modal opens. UNLAYERED here, so it beats the layered zero-specificity
-                 original regardless of stylesheet order. */
+                 original regardless of stylesheet order. Accepted trade-off: on pages
+                 that DO scroll, classic-scrollbar users see a ~15px reflow when a modal
+                 opens (scrollbar hides, nothing reserves its width) — less jarring than
+                 the mispainted strip, which host background overrides make common. */
               :root:has(.modal-open, .modal[open], .modal:target, .modal-toggle:checked, .drawer:not(.drawer-open) > .drawer-toggle:checked) {
                 scrollbar-gutter: auto;
               }

--- a/lib/phoenix_kit_web/components/layouts/root.html.heex
+++ b/lib/phoenix_kit_web/components/layouts/root.html.heex
@@ -47,6 +47,18 @@
       {assigns[:page_title]}
     </.live_title>
     <link phx-track-static rel="stylesheet" href={~p"/assets/app.css"} />
+    <%!-- daisyUI 5 reserves a scrollbar gutter while a modal/drawer is open
+    (`:where(:root:has(.modal-open, …)) { scrollbar-gutter: stable }` in
+    @layer base). On a page without a scrollbar the fixed backdrop can't cover
+    that reserved strip, so classic-scrollbar users (Firefox, macOS "always
+    show") see an uncovered gap at the window's right edge whenever a modal
+    opens. This UNLAYERED rule beats the layered zero-specificity original
+    regardless of stylesheet order. --%>
+    <style>
+      :root:has(.modal-open, .modal[open], .modal:target, .modal-toggle:checked, .drawer:not(.drawer-open) > .drawer-toggle:checked) {
+        scrollbar-gutter: auto;
+      }
+    </style>
     <script defer phx-track-static type="text/javascript" src={~p"/assets/app.js"}>
     </script>
     <%!-- PhoenixKit Cookie Consent Widget Setup --%>

--- a/test/phoenix_kit/install/js_integration_test.exs
+++ b/test/phoenix_kit/install/js_integration_test.exs
@@ -1,0 +1,132 @@
+defmodule PhoenixKit.Install.JsIntegrationTest do
+  use ExUnit.Case, async: true
+
+  alias PhoenixKit.Install.JsIntegration
+
+  # The pure app.js transform behind the installer's viewport-param step. Every
+  # case here came out of adversarial review — regex surgery on arbitrary host
+  # code must corrupt NOTHING: when in doubt it returns :manual (notice) rather
+  # than a wrong rewrite.
+  describe "inject_viewport_param/1" do
+    test "rewrites the standard phx.new shape into a closure" do
+      content = """
+      const liveSocket = new LiveSocket("/live", Socket, {
+        longPollFallbackMs: 2500,
+        params: {_csrf_token: csrfToken},
+        hooks: {...window.PhoenixKitHooks},
+      })
+      """
+
+      assert {:ok, updated} = JsIntegration.inject_viewport_param(content)
+
+      assert updated =~
+               "params: () => ({_csrf_token: csrfToken, viewport_width: window.innerWidth})"
+
+      # …and the second run is a no-op.
+      assert JsIntegration.inject_viewport_param(updated) == :already
+    end
+
+    test "an empty params object gets no stray comma" do
+      assert {:ok, updated} =
+               JsIntegration.inject_viewport_param(~s|new LiveSocket("/l", Socket, {params: {}})|)
+
+      assert updated =~ "params: () => ({viewport_width: window.innerWidth})"
+    end
+
+    test "multibyte UTF-8 before the call does not corrupt the reassembly" do
+      content = """
+      // © Mäx Dön — app.js …
+      const liveSocket = new LiveSocket("/live", Socket, {
+        params: {_csrf_token: csrfToken},
+      })
+      """
+
+      assert {:ok, updated} = JsIntegration.inject_viewport_param(content)
+      assert updated =~ "// © Mäx Dön"
+      assert updated =~ "params: () => ({_csrf_token: csrfToken, viewport_width:"
+    end
+
+    test "does NOT rewrite a nested params inside a hook body" do
+      content = """
+      const liveSocket = new LiveSocket("/live", Socket, {
+        hooks: {
+          Loader: { mounted(){ this.pushEvent("load", {params: {page: 1}}) } }
+        },
+        params: {_csrf_token: csrfToken}
+      })
+      """
+
+      assert {:ok, updated} = JsIntegration.inject_viewport_param(content)
+      # Hook payload untouched; the real LiveSocket params patched.
+      assert updated =~ ~s|this.pushEvent("load", {params: {page: 1}})|
+      assert updated =~ "params: () => ({_csrf_token: csrfToken, viewport_width:"
+    end
+
+    test "a commented-out example call does not anchor the patch" do
+      content = """
+      // Example: new LiveSocket("/live", Socket, { params: {_csrf_token: csrfToken} })
+      const liveSocket = new LiveSocket("/live", Socket, {
+        params: {_csrf_token: csrfToken}
+      })
+      """
+
+      assert {:ok, updated} = JsIntegration.inject_viewport_param(content)
+      # The comment keeps its plain object; the real call gets the closure.
+      assert updated =~
+               ~s|// Example: new LiveSocket("/live", Socket, { params: {_csrf_token: csrfToken} })|
+
+      assert updated =~ "params: () => ({_csrf_token: csrfToken, viewport_width:"
+    end
+
+    test "an earlier plain Socket's params is never touched" do
+      content = """
+      const userSocket = new Socket("/socket", {params: {token: userToken}})
+      const liveSocket = new LiveSocket("/live", Socket, {
+        params: {_csrf_token: csrfToken},
+      })
+      """
+
+      assert {:ok, updated} = JsIntegration.inject_viewport_param(content)
+      assert updated =~ ~s|new Socket("/socket", {params: {token: userToken}})|
+      assert updated =~ "params: () => ({_csrf_token: csrfToken, viewport_width:"
+    end
+
+    test "a params object containing comments is refused (manual notice)" do
+      content = """
+      const liveSocket = new LiveSocket("/live", Socket, {
+        params: {
+          _csrf_token: csrfToken, // standard csrf
+        },
+      })
+      """
+
+      assert JsIntegration.inject_viewport_param(content) == :manual
+    end
+
+    test "params already a closure is refused rather than guessed at" do
+      assert JsIntegration.inject_viewport_param(
+               ~s|new LiveSocket("/live", Socket, {params: () => ({_csrf_token: t})})|
+             ) == :manual
+    end
+
+    test "no LiveSocket call at all is refused" do
+      assert JsIntegration.inject_viewport_param(~s|const x = {params: {a: 1}}|) == :manual
+    end
+
+    test "a prose mention of viewport_width does not fake idempotency" do
+      content = """
+      // TODO: add viewport_width someday
+      const liveSocket = new LiveSocket("/live", Socket, {params: {_csrf_token: t}})
+      """
+
+      assert {:ok, updated} = JsIntegration.inject_viewport_param(content)
+      assert updated =~ "viewport_width: window.innerWidth"
+    end
+
+    test "the key form anywhere means already patched" do
+      assert JsIntegration.inject_viewport_param(
+               ~s|new LiveSocket("/l", Socket, {params: () => ({t: 1, viewport_width: window.innerWidth})})|
+             ) == :already
+    end
+  end
+end

--- a/test/phoenix_kit/install/js_integration_test.exs
+++ b/test/phoenix_kit/install/js_integration_test.exs
@@ -91,6 +91,43 @@ defmodule PhoenixKit.Install.JsIntegrationTest do
       assert updated =~ "params: () => ({_csrf_token: csrfToken, viewport_width:"
     end
 
+    test "braces inside string literals cannot fake depth at a nested site" do
+      content = """
+      const liveSocket = new LiveSocket("/live", Socket, {
+        metadata: {
+          click: (e, el) => {
+            const close = "}}}";
+            return {params: {source: "click"}}
+          }
+        },
+        params: {_csrf_token: csrfToken}
+      })
+      """
+
+      assert {:ok, updated} = JsIntegration.inject_viewport_param(content)
+      # The nested return payload stays byte-identical; only the real one moves.
+      assert updated =~ ~s|return {params: {source: "click"}}|
+      assert updated =~ "params: () => ({_csrf_token: csrfToken, viewport_width:"
+    end
+
+    test "a BLOCK-commented example call does not anchor the patch" do
+      content = """
+      /*
+      Example:
+      new LiveSocket("/live", Socket, {
+        params: {_csrf_token: fake}
+      })
+      */
+      const liveSocket = new LiveSocket("/live", Socket, {
+        params: {_csrf_token: csrfToken}
+      })
+      """
+
+      assert {:ok, updated} = JsIntegration.inject_viewport_param(content)
+      assert updated =~ "params: {_csrf_token: fake}"
+      assert updated =~ "params: () => ({_csrf_token: csrfToken, viewport_width:"
+    end
+
     test "a params object containing comments is refused (manual notice)" do
       content = """
       const liveSocket = new LiveSocket("/live", Socket, {


### PR DESCRIPTION
## Summary

Three core additions in service of the dashboards module (BeamLabEU/phoenix_kit_dashboards#1), each useful ecosystem-wide.

### V139 migration — per-dashboard `config` column
- `phoenix_kit_dashboards.config` JSONB (`v139.ex` + registration): dashboard-level state (type fixed at creation, home tier, per-tier customized markers). The dashboards module's Hex pin floor stays at the V133 release until this ships in a core release.

### Installer: `viewport_width` LiveSocket connect param
- `mix phoenix_kit.install` / `mix phoenix_kit.update` add `viewport_width: window.innerWidth` to the host's LiveSocket `params:` (rewritten into a closure so reconnects re-read the width). Responsive PhoenixKit LiveViews — e.g. the dashboards builder — use it to resolve the right layout tier server-side on the FIRST render instead of a client hook round-trip behind a loading state; everything degrades gracefully without it.
- The rewrite is deliberately conservative and was hardened through three adversarial review rounds: it anchors on the real `new LiveSocket(` call (block/line-commented example calls are skipped), only patches a `params:` object at brace depth 1 of the call's options (a nested `params:` inside a hook's `pushEvent` payload is never touched; string literals and comments are blanked before depth counting so a `"}}}"` can't fake the depth), refuses comment-bearing objects and anything else ambiguous with a manual-instructions notice, and is idempotent on the key form. **Every attack shape found in review is pinned in `test/phoenix_kit/install/js_integration_test.exs` (13 cases).**

### daisyUI 5.0.x modal-gutter fix
- daisyUI 5.0.x reserves a scrollbar gutter while any modal/drawer is open and paints it with a base-100 trick that mismatches on non-base-100 pages — classic-scrollbar users see an uncovered strip at the window's right edge on every admin page, in every host. One unlayered counter-rule in the admin `LayoutWrapper` (and core's own root layout) beats the layered zero-specificity original regardless of stylesheet order. Documented trade-off in the rule comment: scrollable pages get a small reflow on modal open instead of the mispainted strip.
- Upstream daisyUI fixed this properly across 5.1.0–5.6.x (scroll-state-driven gutter). An AGENTS.md TODO documents removing this rule once hosts' vendored daisyUI is upgraded — verified against 5.6.14 with a 6-page pixel-diff (only 1–2px badge-padding drift, so the vendored upgrade itself is low-risk when the time comes).

## Verification

- New installer tests: 13/13 green (`test/phoenix_kit/install/js_integration_test.exs`)
- Full core suite: failing set byte-identical to the pre-change baseline (verified by running the suite on the merge-base commit in a throwaway worktree — the ~30 pre-existing MultiSession failures on main are untouched; this PR adds 13 passing tests and breaks nothing)
- `mix credo lib/phoenix_kit/install/js_integration.ex --strict`: 0 issues; compile warnings-as-errors clean
- Gutter fix browser-verified on admin pages (computed `scrollbar-gutter` flips to `auto` with a modal open; backdrop flush to the window edge)

## Test plan

- [x] 13 installer transform cases (nested hook params, commented example calls, earlier plain Socket, UTF-8 reassembly, string-literal braces, comment-bearing objects, closures, idempotency)
- [x] Pre-existing-failure baseline comparison (no new failures)
- [x] Browser verification of the modal gutter on core admin pages