### PR TITLE
Add fine-grained sub-permissions; make Admin genuinely permission-gated (+ V141 calendar events)

### DIFF
--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -529,7 +529,15 @@ defmodule PhoenixKit.Migrations.Postgres do
   - Replaces unique index with partial index (slug-mode only, WHERE slug IS NOT NULL)
   - Adds unique index on `(group_uuid, post_date, post_time)` for timestamp-mode posts
 
-  ### V139 - Dashboard `config` column ⚡ LATEST
+  ### V140 - Wider role-permission keys ⚡ LATEST
+  - Widens `phoenix_kit_role_permissions.module_key` from `VARCHAR(50)` to
+    `VARCHAR(120)` so fine-grained sub-permissions can be stored as composed
+    dotted keys (`"calendar.view_others"` — base and sub parts are each
+    capped at 50 chars, so a composed key can reach 101).
+  - Rollback deletes rows over 50 chars (sub-permission grants are additive
+    and re-grantable) before narrowing the column back.
+
+  ### V139 - Dashboard `config` column
   - Adds a JSONB `config` column (`NOT NULL DEFAULT '{}'`) to
     `phoenix_kit_dashboards` for per-dashboard presentation settings, read and
     written whole like `layout`. Backs the dashboards plugin module.
@@ -1190,7 +1198,7 @@ defmodule PhoenixKit.Migrations.Postgres do
   use Ecto.Migration
 
   @initial_version 1
-  @current_version 139
+  @current_version 140
   @default_prefix "public"
 
   @doc false

--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -529,7 +529,15 @@ defmodule PhoenixKit.Migrations.Postgres do
   - Replaces unique index with partial index (slug-mode only, WHERE slug IS NOT NULL)
   - Adds unique index on `(group_uuid, post_date, post_time)` for timestamp-mode posts
 
-  ### V140 - Wider role-permission keys ⚡ LATEST
+  ### V141 - Calendar events ⚡ LATEST
+  - Adds `phoenix_kit_calendar_events` for the `phoenix_kit_calendar` module:
+    one implicit personal calendar per user (`owner_uuid` FK, CASCADE on user
+    delete). Timed events use an exclusive-end UTC pair; all-day events use an
+    exclusive-end DATE pair; a CHECK enforces exactly one pair per row matching
+    the `all_day` flag, with end > start. Status is confirmed/cancelled.
+  - Rollback drops the table.
+
+  ### V140 - Wider role-permission keys
   - Widens `phoenix_kit_role_permissions.module_key` from `VARCHAR(50)` to
     `VARCHAR(120)` so fine-grained sub-permissions can be stored as composed
     dotted keys (`"calendar.view_others"` — base and sub parts are each
@@ -1198,7 +1206,7 @@ defmodule PhoenixKit.Migrations.Postgres do
   use Ecto.Migration
 
   @initial_version 1
-  @current_version 140
+  @current_version 141
   @default_prefix "public"
 
   @doc false

--- a/lib/phoenix_kit/migrations/postgres/v140.ex
+++ b/lib/phoenix_kit/migrations/postgres/v140.ex
@@ -1,0 +1,49 @@
+defmodule PhoenixKit.Migrations.Postgres.V140 do
+  @moduledoc """
+  V140: Widen role-permission keys for fine-grained sub-permissions.
+
+  Sub-permissions are stored in `phoenix_kit_role_permissions.module_key` as
+  composed dotted keys (`"calendar.view_others"`). Base and sub parts are
+  each capped at 50 chars, so a composed key can reach 101 — the original
+  V53 `VARCHAR(50)` is too narrow. Widen to `VARCHAR(120)`.
+
+  All statements are idempotent, safe to re-run.
+  """
+
+  use Ecto.Migration
+
+  def up(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    execute("""
+    ALTER TABLE #{p}phoenix_kit_role_permissions
+    ALTER COLUMN module_key TYPE VARCHAR(120)
+    """)
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '140'")
+  end
+
+  def down(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    # Dotted sub-permission rows may exceed 50 chars; drop them before
+    # narrowing so the type change cannot fail mid-rollback. Sub-permission
+    # grants are additive and re-grantable, so removing them is safe.
+    execute("""
+    DELETE FROM #{p}phoenix_kit_role_permissions
+    WHERE LENGTH(module_key) > 50
+    """)
+
+    execute("""
+    ALTER TABLE #{p}phoenix_kit_role_permissions
+    ALTER COLUMN module_key TYPE VARCHAR(50)
+    """)
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '139'")
+  end
+
+  defp prefix_str("public"), do: "public."
+  defp prefix_str(prefix), do: "#{prefix}."
+end

--- a/lib/phoenix_kit/migrations/postgres/v141.ex
+++ b/lib/phoenix_kit/migrations/postgres/v141.ex
@@ -1,0 +1,90 @@
+defmodule PhoenixKit.Migrations.Postgres.V141 do
+  @moduledoc """
+  V141: Personal calendar events for the `phoenix_kit_calendar` module.
+
+  One implicit personal calendar per user — events are keyed by
+  `owner_uuid` (no calendars table in v1; recurrence is deliberately
+  deferred).
+
+  Time model (mirrors `phoenix_live_calendar`'s Event semantics):
+
+  - Timed events use the `starts_at`/`ends_at` UTC pair; `ends_at` is
+    EXCLUSIVE (`[start, end)`, iCal/RFC 5545 style).
+  - All-day events use the `starts_on`/`ends_on` DATE pair (also
+    end-exclusive) — proper date semantics instead of UTC-midnight
+    instants, so a "day" never shifts across timezones/DST.
+  - A CHECK constraint enforces exactly one pair per row, matching the
+    `all_day` flag, with end > start on both pairs.
+
+  `owner_uuid` cascades on user delete — a personal calendar follows its
+  account's lifecycle.
+
+  All statements are idempotent, safe to re-run.
+  """
+
+  use Ecto.Migration
+
+  def up(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    execute("""
+    CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_calendar_events (
+      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      owner_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_users(uuid) ON DELETE CASCADE,
+      title VARCHAR(255) NOT NULL,
+      description TEXT,
+      location VARCHAR(255),
+      all_day BOOLEAN NOT NULL DEFAULT FALSE,
+      starts_at TIMESTAMP(0),
+      ends_at TIMESTAMP(0),
+      starts_on DATE,
+      ends_on DATE,
+      color VARCHAR(50),
+      status VARCHAR(20) NOT NULL DEFAULT 'confirmed',
+      inserted_at TIMESTAMP(0) NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMP(0) NOT NULL DEFAULT NOW(),
+      CONSTRAINT calendar_event_time_shape CHECK (
+        (
+          all_day = FALSE
+          AND starts_at IS NOT NULL AND ends_at IS NOT NULL
+          AND starts_on IS NULL AND ends_on IS NULL
+          AND ends_at > starts_at
+        )
+        OR
+        (
+          all_day = TRUE
+          AND starts_on IS NOT NULL AND ends_on IS NOT NULL
+          AND starts_at IS NULL AND ends_at IS NULL
+          AND ends_on > starts_on
+        )
+      ),
+      CONSTRAINT calendar_event_status CHECK (status IN ('confirmed', 'cancelled'))
+    )
+    """)
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS idx_calendar_events_owner_starts_at
+    ON #{p}phoenix_kit_calendar_events (owner_uuid, starts_at)
+    """)
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS idx_calendar_events_owner_starts_on
+    ON #{p}phoenix_kit_calendar_events (owner_uuid, starts_on)
+    """)
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '141'")
+  end
+
+  def down(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    execute("DROP TABLE IF EXISTS #{p}phoenix_kit_calendar_events")
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '140'")
+  end
+
+  defp prefix_str("public"), do: "public."
+  defp prefix_str(prefix), do: "#{prefix}."
+end

--- a/lib/phoenix_kit/module.ex
+++ b/lib/phoenix_kit/module.ex
@@ -35,7 +35,17 @@ defmodule PhoenixKit.Module do
             key: "hello_world",
             label: "Hello World",
             icon: "hero-hand-raised",
-            description: "A demo module"
+            description: "A demo module",
+            # Optional fine-grained permissions under the base key.
+            # Stored/checked as "hello_world.moderate"; only effective
+            # while the module is enabled.
+            sub_permissions: [
+              %{
+                key: "moderate",
+                label: "Moderate content",
+                description: "Approve or reject other users' entries"
+              }
+            ]
           }
         end
 
@@ -85,12 +95,35 @@ defmodule PhoenixKit.Module do
   - `integration_providers/0` - Additional provider definitions this module contributes (default: `[]`).
   """
 
-  @typedoc "Permission metadata for the module"
-  @type permission_meta :: %{
+  @typedoc """
+  A fine-grained permission a module declares under its base key.
+
+  `:key` is the short action name (e.g. `"view_others"`); it is stored and
+  checked as the composed dotted key `"<module_key>.<key>"` (e.g.
+  `"calendar.view_others"`). Both parts must match `~r/^[a-z][a-z0-9_]*$/`,
+  so a composed key always contains exactly one dot.
+  """
+  @type sub_permission :: %{
           key: String.t(),
           label: String.t(),
-          icon: String.t(),
           description: String.t()
+        }
+
+  @typedoc """
+  Permission metadata for the module.
+
+  `:sub_permissions` (optional) declares fine-grained permissions under the
+  module's base key. The base key gates access to the module's admin pages;
+  sub-permissions are additive grants the module checks itself (via
+  `PhoenixKit.Users.Auth.Scope.can?/2`) for specific in-module capabilities.
+  A sub-permission is only effective while its parent module is enabled.
+  """
+  @type permission_meta :: %{
+          required(:key) => String.t(),
+          required(:label) => String.t(),
+          required(:icon) => String.t(),
+          required(:description) => String.t(),
+          optional(:sub_permissions) => [sub_permission()]
         }
 
   # Required callbacks

--- a/lib/phoenix_kit/module_registry.ex
+++ b/lib/phoenix_kit/module_registry.ex
@@ -345,6 +345,78 @@ defmodule PhoenixKit.ModuleRegistry do
     |> Enum.sort()
   end
 
+  @valid_sub_key_pattern ~r/^[a-z][a-z0-9_]*$/
+  @max_sub_key_length 50
+
+  @doc """
+  Returns the sub-permissions declared by registered modules, keyed by the
+  parent module key. Each entry carries the COMPOSED dotted key
+  (`"calendar.view_others"`) plus its label and description.
+
+  Malformed declarations (bad key format, missing fields, key over
+  #{@max_sub_key_length} chars, duplicate keys within one module) are dropped
+  with a logged warning rather than raising — a broken module must not take
+  down permission resolution for everyone else.
+  """
+  @spec sub_permission_map() :: %{String.t() => [map()]}
+  def sub_permission_map do
+    all_permission_metadata()
+    |> Enum.reduce(%{}, fn meta, acc ->
+      case valid_sub_permissions(meta) do
+        [] -> acc
+        subs -> Map.put(acc, meta.key, subs)
+      end
+    end)
+  end
+
+  defp valid_sub_permissions(%{key: base, sub_permissions: subs}) when is_list(subs) do
+    subs
+    |> Enum.filter(&valid_sub_permission?(base, &1))
+    |> Enum.uniq_by(& &1.key)
+    |> Enum.map(fn sub ->
+      %{
+        key: "#{base}.#{sub.key}",
+        label: sub.label,
+        description: Map.get(sub, :description, "")
+      }
+    end)
+  end
+
+  defp valid_sub_permissions(_meta), do: []
+
+  defp valid_sub_permission?(base, %{key: key, label: label})
+       when is_binary(key) and is_binary(label) do
+    cond do
+      not Regex.match?(@valid_sub_key_pattern, key) ->
+        Logger.warning(
+          "[ModuleRegistry] Dropping sub-permission #{inspect(key)} of #{inspect(base)}: " <>
+            "key must match ~r/^[a-z][a-z0-9_]*$/"
+        )
+
+        false
+
+      String.length(key) > @max_sub_key_length ->
+        Logger.warning(
+          "[ModuleRegistry] Dropping sub-permission #{inspect(key)} of #{inspect(base)}: " <>
+            "key exceeds max length of #{@max_sub_key_length}"
+        )
+
+        false
+
+      true ->
+        true
+    end
+  end
+
+  defp valid_sub_permission?(base, sub) do
+    Logger.warning(
+      "[ModuleRegistry] Dropping malformed sub-permission #{inspect(sub)} of #{inspect(base)}: " <>
+        "expected %{key: binary, label: binary, description: binary}"
+    )
+
+    false
+  end
+
   @doc "Returns permission labels map from registered modules."
   @spec permission_labels() :: %{String.t() => String.t()}
   def permission_labels do

--- a/lib/phoenix_kit/supervisor.ex
+++ b/lib/phoenix_kit/supervisor.ex
@@ -5,6 +5,7 @@ defmodule PhoenixKit.Supervisor do
   use Supervisor
 
   alias PhoenixKit.Modules.Languages
+  alias PhoenixKit.Users.Permissions
 
   def start_link(init_arg) do
     Supervisor.start_link(__MODULE__, init_arg, name: __MODULE__)
@@ -53,6 +54,29 @@ defmodule PhoenixKit.Supervisor do
       # Dashboard tab registry for user dashboard navigation.
       # Starts after settings_cache so module enabled? checks hit cache rather than DB.
       PhoenixKit.Dashboard.Registry,
+      # Grant the Admin role any permission keys it has never been auto-granted
+      # before (newly installed feature modules, new sub-permissions). Per-key
+      # settings flags make an Owner's revocation stick across restarts. Runs
+      # after ModuleRegistry (key discovery) and the settings cache (flag
+      # reads); idempotent and a silent no-op when the table doesn't exist yet.
+      # Modules registered at runtime (ModuleRegistry.register/1) are picked
+      # up on the next boot.
+      Supervisor.child_spec(
+        {Task,
+         fn ->
+           try do
+             Permissions.auto_grant_new_keys_to_admin()
+           rescue
+             error ->
+               require Logger
+
+               Logger.error(
+                 "[PhoenixKit] Failed to auto-grant permission keys to Admin at startup: #{inspect(error)}"
+               )
+           end
+         end},
+        id: :auto_grant_admin_permissions
+      ),
       # Normalize legacy admin_languages setting into unified languages_config
       # Runs once after settings cache is warmed; idempotent no-op if already migrated
       Supervisor.child_spec(

--- a/lib/phoenix_kit/users/auth/scope.ex
+++ b/lib/phoenix_kit/users/auth/scope.ex
@@ -37,11 +37,13 @@ defmodule PhoenixKit.Users.Auth.Scope do
   ## Module-Level Permissions
 
   Permissions are cached in the scope when it is built via `for_user/1`
-  (on mount and on PubSub-triggered refresh). Owner gets all 25 keys
-  automatically. Admin with no explicit permissions gets full access
-  (backward compat before V53 migration).
+  (on mount and on PubSub-triggered refresh). Owner gets every key
+  automatically. Admin defaults to all keys via seeding/auto-grant but is
+  genuinely gated by its rows — the full-access fallback applies only on an
+  unseeded install (no permission rows exist at all).
 
-      Scope.has_module_access?(scope, "billing")          # Single key check
+      Scope.has_module_access?(scope, "billing")          # Single key check (pure cache)
+      Scope.can?(scope, "calendar.view_others")           # Key held AND module enabled
       Scope.has_any_module_access?(scope, ["billing", "shop"])  # Any of these?
       Scope.has_all_module_access?(scope, ["billing", "shop"])  # All of these?
       Scope.accessible_modules(scope)                     # MapSet of granted keys
@@ -111,11 +113,22 @@ defmodule PhoenixKit.Users.Auth.Scope do
 
         roles.admin in cached_roles ->
           case Permissions.get_permissions_for_user(user) do
-            # Admin with no explicit permissions gets full access.
-            # This handles backward compat before V53 migration is applied
-            # (V53 seeds Admin with all 25 permission keys by default).
-            [] -> MapSet.new(Permissions.all_module_keys())
-            perms -> MapSet.new(perms)
+            # Admin with no explicit permissions falls back to full access
+            # ONLY on a genuinely unseeded install (no permission rows at
+            # all — pre-V53, or migrations not yet run). On a seeded
+            # install, zero rows means an Owner deliberately revoked
+            # everything from this admin's roles, and that must stick —
+            # otherwise revoking the last key would ironically restore
+            # full access.
+            [] ->
+              if Permissions.any_permissions_exist?() do
+                MapSet.new()
+              else
+                MapSet.new(Permissions.all_module_keys())
+              end
+
+            perms ->
+              MapSet.new(perms)
           end
 
         true ->
@@ -410,6 +423,30 @@ defmodule PhoenixKit.Users.Auth.Scope do
   end
 
   def has_module_access?(_, _), do: false
+
+  @doc """
+  Checks whether the user holds a permission key AND that key is currently
+  effective — the module behind it (or behind its parent, for sub-permission
+  keys like `"calendar.view_others"`) is enabled.
+
+  This is the check modules should use for fine-grained, in-page
+  authorization. Unlike `has_module_access?/2` (a pure cache lookup used on
+  hot paths where enablement is enforced separately at mount), `can?/2`
+  consults live module-enablement state, so a scope snapshotted before a
+  module was disabled cannot keep authorizing its actions.
+
+  ## Examples
+
+      Scope.can?(scope, "calendar.edit_others")
+      Scope.can?(scope, "calendar")
+  """
+  @spec can?(t(), String.t()) :: boolean()
+  def can?(%__MODULE__{cached_permissions: perms}, key)
+      when is_binary(key) and not is_nil(perms) do
+    MapSet.member?(perms, key) and Permissions.feature_enabled?(key)
+  end
+
+  def can?(_, _), do: false
 
   @doc """
   Returns the set of module keys the user can access.

--- a/lib/phoenix_kit/users/permissions.ex
+++ b/lib/phoenix_kit/users/permissions.ex
@@ -13,6 +13,24 @@ defmodule PhoenixKit.Users.Permissions do
     ai, publishing, sitemap, seo, maintenance, storage,
     languages, connections, legal, db, jobs
 
+  ## Sub-Permissions (fine-grained)
+
+  A module may declare fine-grained permissions under its base key via the
+  optional `sub_permissions` field of `permission_metadata/0`. They live in
+  the same table as composed dotted keys (`"calendar.view_others"`):
+
+  - The base key gates the module's admin pages; sub-keys are additive
+    grants the module checks itself via `Scope.can?/2`.
+  - A sub-key implies its base: granting a sub auto-grants the base,
+    revoking the base cascades its subs, and `set_permissions/3` normalizes
+    the desired set — no path can persist an orphan sub-key row.
+  - A sub-key is enabled iff its parent module is enabled.
+
+      Permissions.sub_permission_keys()          # ["calendar.edit_others", ...]
+      Permissions.sub_permissions_for("calendar") # [%{key:, label:, description:}]
+      Permissions.parent_key("calendar.view_others") # "calendar"
+      Permissions.expand_with_parents(keys)      # keys ∪ implied base keys
+
   ## Constants & Metadata
 
       Permissions.all_module_keys()        # 25 built-in + any custom keys
@@ -266,11 +284,77 @@ defmodule PhoenixKit.Users.Permissions do
     :persistent_term.get(@custom_views_pterm, %{})
   end
 
+  # --- Sub-Permissions ---
+  #
+  # Modules declare fine-grained permissions under their base key via the
+  # optional `sub_permissions` field of `permission_metadata/0`. They are
+  # stored in the same phoenix_kit_role_permissions table as composed dotted
+  # keys ("calendar.view_others"). The base key gates the module's admin
+  # pages; sub-keys are additive grants the module checks itself via
+  # `Scope.can?/2`. Base and sub parts each match ~r/^[a-z][a-z0-9_]*$/, so a
+  # composed key contains exactly one dot — plain keys never contain dots.
+
+  @doc """
+  Returns all composed sub-permission keys (`"calendar.view_others"`)
+  declared by registered modules.
+  """
+  @spec sub_permission_keys() :: [String.t()]
+  def sub_permission_keys do
+    ModuleRegistry.sub_permission_map()
+    |> Enum.flat_map(fn {_base, subs} -> Enum.map(subs, & &1.key) end)
+    |> Enum.sort()
+  end
+
+  @doc """
+  Returns the sub-permission metadata declared under a base module key.
+  Each entry is `%{key: composed_key, label: label, description: description}`.
+  """
+  @spec sub_permissions_for(String.t()) :: [map()]
+  def sub_permissions_for(base_key) when is_binary(base_key) do
+    ModuleRegistry.sub_permission_map() |> Map.get(base_key, [])
+  end
+
+  @doc """
+  Returns the base module key a composed sub-permission key belongs to, or
+  `nil` when the key is not a registered sub-permission. Registry-driven —
+  never inferred by string splitting.
+  """
+  @spec parent_key(String.t()) :: String.t() | nil
+  def parent_key(key) when is_binary(key) do
+    if String.contains?(key, ".") do
+      ModuleRegistry.sub_permission_map()
+      |> Enum.find_value(fn {base, subs} ->
+        if Enum.any?(subs, &(&1.key == key)), do: base
+      end)
+    end
+  end
+
+  def parent_key(_), do: nil
+
+  @doc """
+  Expands a set of permission keys with the base keys its sub-permissions
+  imply (a sub-permission is meaningless without module access). Used by the
+  grant paths to keep the "no orphan sub-key" invariant, and by the admin
+  UIs to compute the full set a grant would create before authorizing it.
+  """
+  @spec expand_with_parents(Enumerable.t()) :: MapSet.t()
+  def expand_with_parents(keys) do
+    keys = MapSet.new(keys)
+
+    parents =
+      keys
+      |> Enum.map(&parent_key/1)
+      |> Enum.reject(&is_nil/1)
+
+    MapSet.union(keys, MapSet.new(parents))
+  end
+
   # --- Constants ---
 
-  @doc "Returns all built-in and custom permission keys as a list. See `enabled_module_keys/0` for filtered MapSet variant."
+  @doc "Returns all built-in, sub-permission, and custom permission keys as a list. See `enabled_module_keys/0` for filtered MapSet variant."
   @spec all_module_keys() :: [String.t()]
-  def all_module_keys, do: @core_section_keys ++ feature_module_keys() ++ custom_keys()
+  def all_module_keys,
+    do: @core_section_keys ++ feature_module_keys() ++ sub_permission_keys() ++ custom_keys()
 
   @doc "Returns the 5 core section keys."
   @spec core_section_keys() :: [String.t()]
@@ -294,14 +378,22 @@ defmodule PhoenixKit.Users.Permissions do
       feature_module_keys()
       |> Enum.filter(&do_feature_enabled?/1)
 
-    MapSet.new(@core_section_keys ++ enabled_features ++ custom_keys())
+    sub_map = ModuleRegistry.sub_permission_map()
+
+    enabled_subs =
+      Enum.flat_map(enabled_features, fn base ->
+        sub_map |> Map.get(base, []) |> Enum.map(& &1.key)
+      end)
+
+    MapSet.new(@core_section_keys ++ enabled_features ++ enabled_subs ++ custom_keys())
   end
 
-  @doc "Checks whether `key` is a known permission key (built-in or custom)."
+  @doc "Checks whether `key` is a known permission key (built-in, sub-permission, or custom)."
   @spec valid_module_key?(String.t()) :: boolean()
   def valid_module_key?(key) when is_binary(key) do
     key in @core_section_keys or
       key in ModuleRegistry.all_feature_keys() or
+      not is_nil(parent_key(key)) or
       Map.has_key?(custom_keys_map(), key)
   end
 
@@ -312,6 +404,7 @@ defmodule PhoenixKit.Users.Permissions do
 
   Core section keys always return `true`. Feature module keys return the
   result of calling the module's `enabled?/0` (or equivalent) function.
+  Sub-permission keys are enabled iff their parent module is enabled.
   Custom permission keys are always enabled (no module toggle).
   Returns `false` for unknown keys.
   """
@@ -324,8 +417,11 @@ defmodule PhoenixKit.Users.Permissions do
         Code.ensure_loaded?(mod) && apply(mod, fun, [])
 
       nil ->
-        # Custom keys are always "enabled" (no module toggle)
-        Map.has_key?(custom_keys_map(), key)
+        case parent_key(key) do
+          # Custom keys are always "enabled" (no module toggle)
+          nil -> Map.has_key?(custom_keys_map(), key)
+          parent -> feature_enabled?(parent)
+        end
     end
   rescue
     _ -> false
@@ -372,35 +468,49 @@ defmodule PhoenixKit.Users.Permissions do
     "db" => "Database explorer and schema inspection"
   }
 
-  @doc "Returns a human-readable label for a module key."
+  @doc "Returns a human-readable label for a module key (sub-permission keys resolve to the sub's own label)."
   @spec module_label(String.t()) :: String.t()
   def module_label(key) do
     Map.get_lazy(@core_labels, key, fn ->
       case Map.get(ModuleRegistry.permission_labels(), key) do
-        nil -> custom_key_metadata(key)[:label] || String.capitalize(key)
-        label -> label
+        nil ->
+          sub_permission_metadata(key)[:label] ||
+            custom_key_metadata(key)[:label] || String.capitalize(key)
+
+        label ->
+          label
       end
     end)
   end
 
-  @doc "Returns a Heroicon name for a module key."
+  @doc "Returns a Heroicon name for a module key (sub-permission keys inherit the parent module's icon)."
   @spec module_icon(String.t()) :: String.t()
   def module_icon(key) do
     Map.get_lazy(@core_icons, key, fn ->
       case Map.get(ModuleRegistry.permission_icons(), key) do
-        nil -> custom_key_metadata(key)[:icon] || "hero-squares-2x2"
-        icon -> icon
+        nil ->
+          case parent_key(key) do
+            nil -> custom_key_metadata(key)[:icon] || "hero-squares-2x2"
+            parent -> module_icon(parent)
+          end
+
+        icon ->
+          icon
       end
     end)
   end
 
-  @doc "Returns a short description for a module key."
+  @doc "Returns a short description for a module key (sub-permission keys resolve to the sub's own description)."
   @spec module_description(String.t()) :: String.t()
   def module_description(key) do
     Map.get_lazy(@core_descriptions, key, fn ->
       case Map.get(ModuleRegistry.permission_descriptions(), key) do
-        nil -> custom_key_metadata(key)[:description] || ""
-        desc -> desc
+        nil ->
+          sub_permission_metadata(key)[:description] ||
+            custom_key_metadata(key)[:description] || ""
+
+        desc ->
+          desc
       end
     end)
   end
@@ -438,6 +548,22 @@ defmodule PhoenixKit.Users.Permissions do
       end
 
       []
+  end
+
+  @doc """
+  Returns true when at least one permission row exists (any role, any key).
+
+  Used to distinguish a genuinely unseeded install (pre-V53 / migrations not
+  yet run — the Admin role falls back to full access) from a seeded install
+  where an Owner has deliberately revoked keys. Returns `false` when the
+  table is missing.
+  """
+  @spec any_permissions_exist?() :: boolean()
+  def any_permissions_exist? do
+    repo = RepoHelper.repo()
+    repo.exists?(from(rp in RolePermission, select: true))
+  rescue
+    _ -> false
   end
 
   @doc """
@@ -587,19 +713,41 @@ defmodule PhoenixKit.Users.Permissions do
 
   @doc """
   Grants a single permission to a role. Uses upsert to be idempotent.
+
+  Granting a sub-permission key (`"calendar.view_others"`) also grants its
+  base module key in the same transaction — a sub-permission row must never
+  exist without module access, regardless of which code path grants it.
   """
   @spec grant_permission(integer() | String.t(), String.t(), integer() | String.t() | nil) ::
-          {:ok, RolePermission.t()} | {:error, Ecto.Changeset.t()}
+          {:ok, RolePermission.t()} | {:error, Ecto.Changeset.t() | :role_not_found}
   def grant_permission(role_uuid, module_key, granted_by_uuid \\ nil) do
     repo = RepoHelper.repo()
 
     role_uuid = resolve_role_uuid(role_uuid)
 
-    if is_nil(role_uuid) do
-      {:error, :role_not_found}
-    else
-      grant_permission_insert(repo, role_uuid, module_key, granted_by_uuid)
+    cond do
+      is_nil(role_uuid) ->
+        {:error, :role_not_found}
+
+      parent = parent_key(module_key) ->
+        grant_sub_with_parent(repo, role_uuid, parent, module_key, granted_by_uuid)
+
+      true ->
+        grant_permission_insert(repo, role_uuid, module_key, granted_by_uuid)
     end
+  end
+
+  # Grants base + sub atomically. The base insert is an idempotent upsert, so
+  # a role that already holds the base key is unaffected by it.
+  defp grant_sub_with_parent(repo, role_uuid, parent, module_key, granted_by_uuid) do
+    repo.transaction(fn ->
+      with {:ok, _base} <- grant_permission_insert(repo, role_uuid, parent, granted_by_uuid),
+           {:ok, sub} <- grant_permission_insert(repo, role_uuid, module_key, granted_by_uuid) do
+        sub
+      else
+        {:error, changeset} -> repo.rollback(changeset)
+      end
+    end)
   end
 
   defp grant_permission_insert(repo, role_uuid, module_key, granted_by_uuid) do
@@ -627,6 +775,10 @@ defmodule PhoenixKit.Users.Permissions do
 
   @doc """
   Revokes a single permission from a role.
+
+  Revoking a base module key also revokes all of its sub-permission keys in
+  the same statement — a sub-permission row must never outlive module access.
+  Revoking a sub-permission key removes only that key.
   """
   @spec revoke_permission(integer() | String.t(), String.t()) :: :ok | {:error, :not_found}
   def revoke_permission(role_uuid, module_key) do
@@ -634,8 +786,12 @@ defmodule PhoenixKit.Users.Permissions do
 
     role_uuid = resolve_role_uuid(role_uuid)
 
+    keys_to_remove = [
+      module_key | Enum.map(sub_permissions_for(module_key), & &1.key)
+    ]
+
     from(rp in RolePermission,
-      where: rp.role_uuid == ^role_uuid and rp.module_key == ^module_key
+      where: rp.role_uuid == ^role_uuid and rp.module_key in ^keys_to_remove
     )
     |> repo.delete_all()
     |> case do
@@ -652,6 +808,10 @@ defmodule PhoenixKit.Users.Permissions do
   @doc """
   Syncs permissions for a role: grants missing keys, revokes extras.
   Runs in a transaction.
+
+  The desired set is normalized before applying: every sub-permission key in
+  it pulls in its base module key (a sub-permission implies module access),
+  so no code path can persist an orphan sub-key row.
   """
   @spec set_permissions(integer() | String.t(), [String.t()], integer() | String.t() | nil) ::
           :ok | {:error, term()}
@@ -673,8 +833,12 @@ defmodule PhoenixKit.Users.Permissions do
         |> repo.all()
         |> MapSet.new()
 
-      # Filter out any invalid keys before processing
-      desired_set = desired_keys |> MapSet.new() |> MapSet.intersection(valid_keys)
+      # Filter out any invalid keys, then pull in base keys implied by subs
+      desired_set =
+        desired_keys
+        |> MapSet.new()
+        |> MapSet.intersection(valid_keys)
+        |> expand_with_parents()
 
       # Keys to add
       to_add = MapSet.difference(desired_set, current_keys)
@@ -820,6 +984,15 @@ defmodule PhoenixKit.Users.Permissions do
     Map.get(custom_keys_map(), key)
   end
 
+  # Returns %{key:, label:, description:} for a composed sub-permission key,
+  # or nil if the key is not a registered sub-permission.
+  defp sub_permission_metadata(key) do
+    case parent_key(key) do
+      nil -> nil
+      parent -> Enum.find(sub_permissions_for(parent), &(&1.key == key))
+    end
+  end
+
   defp do_feature_enabled?(key) do
     case Map.get(ModuleRegistry.feature_enabled_checks(), key) do
       {mod, fun} ->
@@ -877,6 +1050,26 @@ defmodule PhoenixKit.Users.Permissions do
     Settings.update_setting("auto_granted_perm:#{key}", nil)
   rescue
     _ -> :ok
+  end
+
+  @doc """
+  Grants every known built-in permission key (core sections, feature-module
+  keys, sub-permission keys) to the Admin system role, skipping keys that
+  were auto-granted before (per-key settings flag) so an Owner's later
+  revocation is never overridden. Custom keys go through the same mechanism
+  at `register_custom_key/2` time.
+
+  Called after module discovery. This is also the repair path for installs
+  whose V53 seeding predates newer modules: the first boot after upgrade
+  fills the Admin role's missing keys, after which revocations stick
+  per-key. Idempotent; safe when the table doesn't exist yet.
+  """
+  @spec auto_grant_new_keys_to_admin() :: :ok
+  def auto_grant_new_keys_to_admin do
+    (@core_section_keys ++ feature_module_keys() ++ sub_permission_keys())
+    |> Enum.each(&auto_grant_to_admin_roles/1)
+
+    :ok
   end
 
   @doc """

--- a/lib/phoenix_kit_web/live/users/permissions_matrix.ex
+++ b/lib/phoenix_kit_web/live/users/permissions_matrix.ex
@@ -83,7 +83,11 @@ defmodule PhoenixKitWeb.Live.Users.PermissionsMatrix do
           do: MapSet.new(Permissions.all_module_keys()),
           else: Scope.accessible_modules(scope)
 
-      if MapSet.member?(grantable, key) do
+      # Granting a sub-permission auto-grants its base key, so the editor
+      # must hold every key the toggle implies — not just the clicked one.
+      # Otherwise an editor holding only "calendar.view_others" could smuggle
+      # in a "calendar" base grant they don't hold themselves.
+      if MapSet.subset?(Permissions.expand_with_parents([key]), grantable) do
         toggle_role_permission(socket, role, key, scope)
       else
         {:noreply, put_flash(socket, :error, gettext("You can only manage permissions you have"))}
@@ -185,9 +189,21 @@ defmodule PhoenixKitWeb.Live.Users.PermissionsMatrix do
     enabled_feature_keys =
       Enum.filter(Permissions.feature_module_keys(), &MapSet.member?(enabled, &1))
 
+    # Sub-permissions render as indented rows under their (enabled) module row
+    sub_permissions =
+      enabled_feature_keys
+      |> Enum.map(&{&1, Permissions.sub_permissions_for(&1)})
+      |> Enum.reject(fn {_key, subs} -> subs == [] end)
+      |> Map.new()
+
+    enabled_sub_keys =
+      sub_permissions |> Map.values() |> List.flatten() |> Enum.map(& &1.key)
+
     core_keys = Permissions.core_section_keys()
     custom_keys = Permissions.custom_keys()
-    visible_keys = MapSet.new(core_keys ++ enabled_feature_keys ++ custom_keys)
+
+    visible_keys =
+      MapSet.new(core_keys ++ enabled_feature_keys ++ enabled_sub_keys ++ custom_keys)
 
     # Determine which roles can't be edited by the current user
     scope = socket.assigns[:phoenix_kit_current_scope]
@@ -204,6 +220,7 @@ defmodule PhoenixKitWeb.Live.Users.PermissionsMatrix do
     |> assign(:matrix, matrix)
     |> assign(:core_keys, core_keys)
     |> assign(:feature_keys, enabled_feature_keys)
+    |> assign(:sub_permissions, sub_permissions)
     |> assign(:custom_keys, custom_keys)
     |> assign(:visible_keys, visible_keys)
     |> assign(:uneditable_role_uuids, uneditable_role_uuids)
@@ -213,6 +230,67 @@ defmodule PhoenixKitWeb.Live.Users.PermissionsMatrix do
   defp refresh_matrix(socket) do
     matrix = Permissions.get_permissions_matrix()
     assign(socket, :matrix, matrix)
+  end
+
+  # --- Template Components ---
+
+  attr :key, :string, required: true
+  attr :label, :string, required: true
+  attr :sub, :boolean, default: false
+  attr :roles, :list, required: true
+  attr :matrix, :map, required: true
+  attr :uneditable_role_uuids, :any, required: true
+
+  # One matrix row: label cell + a toggle/read-only cell per role.
+  # `sub` renders the indented variant used for sub-permission keys.
+  defp permission_row(assigns) do
+    ~H"""
+    <tr>
+      <td class={[
+        "sticky left-0 z-[1] whitespace-nowrap",
+        (@sub && "pl-8 text-sm text-base-content/80") || "font-medium"
+      ]}>
+        <.icon
+          :if={@sub}
+          name="hero-arrow-turn-down-right"
+          class="w-3.5 h-3.5 text-base-content/40 mr-1"
+        />{@label}
+      </td>
+      <td :for={role <- @roles} class="text-center">
+        <%= if role.name == "Owner" do %>
+          <span class="badge badge-sm badge-primary badge-outline">
+            {gettext("always")}
+          </span>
+        <% else %>
+          <%= if MapSet.member?(@uneditable_role_uuids, to_string(role.uuid)) do %>
+            <%!-- Read-only: user's own role or Admin (non-Owner) --%>
+            <%= if granted?(@matrix, role, @key) do %>
+              <.icon name="hero-check-circle" class="w-5 h-5 text-success/50" />
+            <% else %>
+              <.icon name="hero-x-circle" class="w-5 h-5 text-base-content/10" />
+            <% end %>
+          <% else %>
+            <button
+              phx-click="toggle_permission"
+              phx-value-role_uuid={role.uuid}
+              phx-value-key={@key}
+              class="cursor-pointer hover:opacity-70 transition-opacity"
+            >
+              <%= if granted?(@matrix, role, @key) do %>
+                <.icon name="hero-check-circle" class="w-5 h-5 text-success" />
+              <% else %>
+                <.icon name="hero-x-circle" class="w-5 h-5 text-base-content/20" />
+              <% end %>
+            </button>
+          <% end %>
+        <% end %>
+      </td>
+    </tr>
+    """
+  end
+
+  defp granted?(matrix, role, key) do
+    Map.get(matrix, to_string(role.uuid), MapSet.new()) |> MapSet.member?(key)
   end
 
   defp permission_error_message(:not_authenticated), do: gettext("Not authenticated")

--- a/lib/phoenix_kit_web/live/users/permissions_matrix.html.heex
+++ b/lib/phoenix_kit_web/live/users/permissions_matrix.html.heex
@@ -35,44 +35,14 @@
                 {gettext("Core Sections")}
               </td>
             </tr>
-            <%= for {key, _idx} <- Enum.with_index(@core_keys) do %>
-              <tr>
-                <td class="sticky left-0 z-[1] font-medium whitespace-nowrap">
-                  {PhoenixKit.Users.Permissions.module_label(key)}
-                </td>
-                <%= for role <- @roles do %>
-                  <td class="text-center">
-                    <%= if role.name == "Owner" do %>
-                      <span class="badge badge-sm badge-primary badge-outline">
-                        {gettext("always")}
-                      </span>
-                    <% else %>
-                      <%= if MapSet.member?(@uneditable_role_uuids, to_string(role.uuid)) do %>
-                        <%!-- Read-only: user's own role or Admin (non-Owner) --%>
-                        <%= if Map.get(@matrix, to_string(role.uuid), MapSet.new()) |> MapSet.member?(key) do %>
-                          <.icon name="hero-check-circle" class="w-5 h-5 text-success/50" />
-                        <% else %>
-                          <.icon name="hero-x-circle" class="w-5 h-5 text-base-content/10" />
-                        <% end %>
-                      <% else %>
-                        <button
-                          phx-click="toggle_permission"
-                          phx-value-role_uuid={role.uuid}
-                          phx-value-key={key}
-                          class="cursor-pointer hover:opacity-70 transition-opacity"
-                        >
-                          <%= if Map.get(@matrix, to_string(role.uuid), MapSet.new()) |> MapSet.member?(key) do %>
-                            <.icon name="hero-check-circle" class="w-5 h-5 text-success" />
-                          <% else %>
-                            <.icon name="hero-x-circle" class="w-5 h-5 text-base-content/20" />
-                          <% end %>
-                        </button>
-                      <% end %>
-                    <% end %>
-                  </td>
-                <% end %>
-              </tr>
-            <% end %>
+            <.permission_row
+              :for={key <- @core_keys}
+              key={key}
+              label={PhoenixKit.Users.Permissions.module_label(key)}
+              roles={@roles}
+              matrix={@matrix}
+              uneditable_role_uuids={@uneditable_role_uuids}
+            />
 
             <%!-- Feature Modules Header --%>
             <tr class="bg-primary/10">
@@ -83,43 +53,26 @@
                 {gettext("Feature Modules")}
               </td>
             </tr>
-            <%= for {key, _idx} <- Enum.with_index(@feature_keys) do %>
-              <tr>
-                <td class="sticky left-0 z-[1] font-medium whitespace-nowrap">
-                  {PhoenixKit.Users.Permissions.module_label(key)}
-                </td>
-                <%= for role <- @roles do %>
-                  <td class="text-center">
-                    <%= if role.name == "Owner" do %>
-                      <span class="badge badge-sm badge-primary badge-outline">
-                        {gettext("always")}
-                      </span>
-                    <% else %>
-                      <%= if MapSet.member?(@uneditable_role_uuids, to_string(role.uuid)) do %>
-                        <%!-- Read-only: user's own role or Admin (non-Owner) --%>
-                        <%= if Map.get(@matrix, to_string(role.uuid), MapSet.new()) |> MapSet.member?(key) do %>
-                          <.icon name="hero-check-circle" class="w-5 h-5 text-success/50" />
-                        <% else %>
-                          <.icon name="hero-x-circle" class="w-5 h-5 text-base-content/10" />
-                        <% end %>
-                      <% else %>
-                        <button
-                          phx-click="toggle_permission"
-                          phx-value-role_uuid={role.uuid}
-                          phx-value-key={key}
-                          class="cursor-pointer hover:opacity-70 transition-opacity"
-                        >
-                          <%= if Map.get(@matrix, to_string(role.uuid), MapSet.new()) |> MapSet.member?(key) do %>
-                            <.icon name="hero-check-circle" class="w-5 h-5 text-success" />
-                          <% else %>
-                            <.icon name="hero-x-circle" class="w-5 h-5 text-base-content/20" />
-                          <% end %>
-                        </button>
-                      <% end %>
-                    <% end %>
-                  </td>
-                <% end %>
-              </tr>
+            <%= for key <- @feature_keys do %>
+              <.permission_row
+                key={key}
+                label={PhoenixKit.Users.Permissions.module_label(key)}
+                roles={@roles}
+                matrix={@matrix}
+                uneditable_role_uuids={@uneditable_role_uuids}
+              />
+              <%!-- Fine-grained sub-permissions, indented under their module.
+                   Granting one auto-grants the module key; revoking the module
+                   key cascades these off. --%>
+              <.permission_row
+                :for={sub <- Map.get(@sub_permissions, key, [])}
+                key={sub.key}
+                label={sub.label}
+                sub
+                roles={@roles}
+                matrix={@matrix}
+                uneditable_role_uuids={@uneditable_role_uuids}
+              />
             <% end %>
             <%!-- Custom (permission keys registered by parent app) --%>
             <%= if length(@custom_keys) > 0 do %>
@@ -131,44 +84,14 @@
                   {gettext("Custom")}
                 </td>
               </tr>
-              <%= for {key, _idx} <- Enum.with_index(@custom_keys) do %>
-                <tr>
-                  <td class="sticky left-0 z-[1] font-medium whitespace-nowrap">
-                    {PhoenixKit.Users.Permissions.module_label(key)}
-                  </td>
-                  <%= for role <- @roles do %>
-                    <td class="text-center">
-                      <%= if role.name == "Owner" do %>
-                        <span class="badge badge-sm badge-primary badge-outline">
-                          {gettext("always")}
-                        </span>
-                      <% else %>
-                        <%= if MapSet.member?(@uneditable_role_uuids, to_string(role.uuid)) do %>
-                          <%!-- Read-only: user's own role or Admin (non-Owner) --%>
-                          <%= if Map.get(@matrix, to_string(role.uuid), MapSet.new()) |> MapSet.member?(key) do %>
-                            <.icon name="hero-check-circle" class="w-5 h-5 text-success/50" />
-                          <% else %>
-                            <.icon name="hero-x-circle" class="w-5 h-5 text-base-content/10" />
-                          <% end %>
-                        <% else %>
-                          <button
-                            phx-click="toggle_permission"
-                            phx-value-role_uuid={role.uuid}
-                            phx-value-key={key}
-                            class="cursor-pointer hover:opacity-70 transition-opacity"
-                          >
-                            <%= if Map.get(@matrix, to_string(role.uuid), MapSet.new()) |> MapSet.member?(key) do %>
-                              <.icon name="hero-check-circle" class="w-5 h-5 text-success" />
-                            <% else %>
-                              <.icon name="hero-x-circle" class="w-5 h-5 text-base-content/20" />
-                            <% end %>
-                          </button>
-                        <% end %>
-                      <% end %>
-                    </td>
-                  <% end %>
-                </tr>
-              <% end %>
+              <.permission_row
+                :for={key <- @custom_keys}
+                key={key}
+                label={PhoenixKit.Users.Permissions.module_label(key)}
+                roles={@roles}
+                matrix={@matrix}
+                uneditable_role_uuids={@uneditable_role_uuids}
+              />
             <% end %>
 
             <%!-- Summary Row --%>
@@ -201,6 +124,11 @@
         <p class="text-sm">
           {gettext(
             "Click any check or cross icon to toggle a permission for that role. The Owner role always has full access and cannot be modified. You cannot edit permissions for your own role or for roles with higher authority. You can only grant or revoke permissions that your own role has."
+          )}
+        </p>
+        <p class="text-sm mt-1">
+          {gettext(
+            "Indented rows are fine-grained permissions within a module. Granting one also grants the module itself; revoking a module removes its fine-grained permissions with it."
           )}
         </p>
       </div>

--- a/lib/phoenix_kit_web/live/users/roles.ex
+++ b/lib/phoenix_kit_web/live/users/roles.ex
@@ -243,18 +243,27 @@ defmodule PhoenixKitWeb.Live.Users.Roles do
   def handle_event("toggle_permission", %{"key" => key}, socket) do
     if can_manage_permissions?(socket) do
       grantable = socket.assigns.permissions_grantable_keys
+      keys = socket.assigns.permissions_role_keys
 
-      if MapSet.member?(grantable, key) do
-        keys = socket.assigns.permissions_role_keys
+      cond do
+        # Unchecking: drop the key and (for a base module key) the
+        # sub-permissions it carries — a sub-key must not outlive its module.
+        MapSet.member?(keys, key) and MapSet.member?(grantable, key) ->
+          implied_subs = key |> Permissions.sub_permissions_for() |> Enum.map(& &1.key)
+          new_keys = MapSet.difference(keys, MapSet.new([key | implied_subs]))
+          {:noreply, assign(socket, :permissions_role_keys, new_keys)}
 
-        new_keys =
-          if MapSet.member?(keys, key),
-            do: MapSet.delete(keys, key),
-            else: MapSet.put(keys, key)
+        # Checking: pull in the base key a sub-permission implies. The editor
+        # must hold EVERY key the check implies, not just the clicked one —
+        # otherwise holding only the sub would smuggle in a base grant.
+        not MapSet.member?(keys, key) and
+            MapSet.subset?(Permissions.expand_with_parents([key]), grantable) ->
+          new_keys = MapSet.union(keys, Permissions.expand_with_parents([key]))
+          {:noreply, assign(socket, :permissions_role_keys, new_keys)}
 
-        {:noreply, assign(socket, :permissions_role_keys, new_keys)}
-      else
-        {:noreply, put_flash(socket, :error, gettext("You can only manage permissions you have"))}
+        true ->
+          {:noreply,
+           put_flash(socket, :error, gettext("You can only manage permissions you have"))}
       end
     else
       {:noreply,

--- a/lib/phoenix_kit_web/live/users/roles.html.heex
+++ b/lib/phoenix_kit_web/live/users/roles.html.heex
@@ -387,6 +387,21 @@
                 />
                 <span class="text-sm">{PhoenixKit.Users.Permissions.module_label(key)}</span>
               </label>
+              <%!-- Fine-grained sub-permissions, indented under their module.
+                   Checking one also checks the module; unchecking the module
+                   unchecks these with it (mirrors the save-time invariant). --%>
+              <%= for sub <- PhoenixKit.Users.Permissions.sub_permissions_for(key), MapSet.member?(@permissions_grantable_keys, sub.key) do %>
+                <label class="flex items-center gap-3 cursor-pointer p-2 pl-8 rounded-lg hover:bg-base-200 transition-colors">
+                  <input
+                    type="checkbox"
+                    class="checkbox checkbox-xs checkbox-primary"
+                    checked={MapSet.member?(@permissions_role_keys, sub.key)}
+                    phx-click="toggle_permission"
+                    phx-value-key={sub.key}
+                  />
+                  <span class="text-sm text-base-content/80">{sub.label}</span>
+                </label>
+              <% end %>
             <% end %>
           </div>
         </div>

--- a/lib/phoenix_kit_web/users/auth.ex
+++ b/lib/phoenix_kit_web/users/auth.ex
@@ -18,12 +18,14 @@ defmodule PhoenixKitWeb.Users.Auth do
   ## on_mount Hooks
 
   - `:phoenix_kit_ensure_admin` — Requires Owner/Admin role, or a custom role
-    with at least one permission. For custom roles, also checks the specific
-    permission key mapped to the current admin view. Unmapped views deny
-    custom roles but allow Owner/Admin.
-  - `:phoenix_kit_ensure_module_access` — For custom roles, checks that the
-    feature module is both enabled and permitted. Owner/Admin bypass both
-    the enabled and permission checks.
+    with at least one permission. Every role is then checked against the
+    permission key mapped to the current admin view: Owner passes because its
+    scope holds every key by construction; Admin holds keys as real,
+    Owner-revocable rows (seeded/auto-granted by default). Disabled modules
+    block everyone. Views that resolve to no permission key allow Owner/Admin
+    and deny custom roles (fail-closed where a key could exist).
+  - `:phoenix_kit_ensure_module_access` — Checks that the feature module is
+    permitted for the scope and (for custom roles) enabled.
 
   ## Usage
 
@@ -1185,11 +1187,12 @@ defmodule PhoenixKitWeb.Users.Auth do
           not module_enabled ->
             deny_module_disabled(socket, module_key)
 
-          # System roles (Owner/Admin) bypass permission checks
-          Scope.system_role?(scope) ->
-            {:cont, socket}
-
-          # Custom roles need explicit permission
+          # Every role — Admin included — needs the permission key. Owner
+          # passes because its scope holds every key by construction; Admin
+          # holds keys as real rows (seeded/auto-granted, Owner-revocable).
+          # The old system-role bypass here made Owner's revocations on the
+          # Admin role effective everywhere EXCEPT fresh mounts — sidebar,
+          # plugs, and the mid-session PubSub kick all honored them already.
           Scope.has_module_access?(scope, module_key) ->
             {:cont, socket}
 

--- a/test/integration/users/permissions_cascade_test.exs
+++ b/test/integration/users/permissions_cascade_test.exs
@@ -1,0 +1,237 @@
+defmodule PhoenixKit.Integration.Users.PermissionsCascadeTest do
+  # async: false — registers a fake module in the global ModuleRegistry and
+  # mutates the Admin system role's permissions (sandboxed, but the registry
+  # entry itself is process-global).
+  use PhoenixKit.DataCase, async: false
+
+  alias PhoenixKit.ModuleRegistry
+  alias PhoenixKit.Settings
+  alias PhoenixKit.Users.Auth
+  alias PhoenixKit.Users.Auth.Scope
+  alias PhoenixKit.Users.Permissions
+  alias PhoenixKit.Users.RolePermission
+  alias PhoenixKit.Users.Roles
+
+  defmodule FakeCalendar do
+    def module_key, do: "fake_calendar"
+    def module_name, do: "Fake Calendar"
+    def enabled?, do: true
+
+    def permission_metadata do
+      %{
+        key: "fake_calendar",
+        label: "Fake Calendar",
+        icon: "hero-calendar-days",
+        description: "Fake module for cascade tests",
+        sub_permissions: [
+          %{key: "view_others", label: "View others", description: ""},
+          %{key: "edit_others", label: "Edit others", description: ""}
+        ]
+      }
+    end
+  end
+
+  @base "fake_calendar"
+  @sub_view "fake_calendar.view_others"
+  @sub_edit "fake_calendar.edit_others"
+
+  setup do
+    ModuleRegistry.register(FakeCalendar)
+    on_exit(fn -> ModuleRegistry.unregister(FakeCalendar) end)
+    :ok
+  end
+
+  defp unique_email, do: "cascade_#{System.unique_integer([:positive])}@example.com"
+
+  defp create_user do
+    {:ok, user} = Auth.register_user(%{email: unique_email(), password: "ValidPassword123!"})
+    user
+  end
+
+  defp get_role_uuid(role_name) do
+    role = Enum.find(Roles.list_roles(), &(&1.name == role_name))
+    role.uuid
+  end
+
+  describe "grant_permission/3 with sub keys" do
+    test "granting a sub key auto-grants its base key" do
+      role_uuid = get_role_uuid("User")
+
+      assert {:ok, _} = Permissions.grant_permission(role_uuid, @sub_view)
+
+      perms = Permissions.get_permissions_for_role(role_uuid)
+      assert @sub_view in perms
+      assert @base in perms
+    end
+
+    test "granting a sub when the base is already held stays idempotent" do
+      role_uuid = get_role_uuid("User")
+
+      assert {:ok, _} = Permissions.grant_permission(role_uuid, @base)
+      assert {:ok, _} = Permissions.grant_permission(role_uuid, @sub_view)
+      assert {:ok, _} = Permissions.grant_permission(role_uuid, @sub_view)
+
+      perms = Permissions.get_permissions_for_role(role_uuid)
+      assert Enum.sort(perms) == Enum.sort([@base, @sub_view])
+    end
+  end
+
+  describe "revoke_permission/2 with sub keys" do
+    test "revoking the base key cascades its sub keys off" do
+      role_uuid = get_role_uuid("User")
+      :ok = Permissions.set_permissions(role_uuid, [@base, @sub_view, @sub_edit])
+
+      assert :ok = Permissions.revoke_permission(role_uuid, @base)
+      assert Permissions.get_permissions_for_role(role_uuid) == []
+    end
+
+    test "revoking a sub key leaves the base key in place" do
+      role_uuid = get_role_uuid("User")
+      :ok = Permissions.set_permissions(role_uuid, [@base, @sub_view, @sub_edit])
+
+      assert :ok = Permissions.revoke_permission(role_uuid, @sub_view)
+
+      perms = Permissions.get_permissions_for_role(role_uuid)
+      assert @base in perms
+      assert @sub_edit in perms
+      refute @sub_view in perms
+    end
+  end
+
+  describe "set_permissions/3 normalization" do
+    test "a requested sub key pulls in its base key" do
+      role_uuid = get_role_uuid("User")
+
+      assert :ok = Permissions.set_permissions(role_uuid, [@sub_edit])
+
+      perms = Permissions.get_permissions_for_role(role_uuid)
+      assert @base in perms
+      assert @sub_edit in perms
+    end
+
+    test "dropping base and subs from the desired set removes all of them" do
+      role_uuid = get_role_uuid("User")
+      :ok = Permissions.set_permissions(role_uuid, [@base, @sub_view])
+
+      assert :ok = Permissions.set_permissions(role_uuid, ["dashboard"])
+      assert Permissions.get_permissions_for_role(role_uuid) == ["dashboard"]
+    end
+  end
+
+  describe "any_permissions_exist?/0" do
+    test "true on a seeded install, false once all rows are gone" do
+      # V53 seeded the Admin role, so the test DB starts seeded
+      assert Permissions.any_permissions_exist?()
+
+      Repo.delete_all(RolePermission)
+      refute Permissions.any_permissions_exist?()
+    end
+  end
+
+  describe "auto_grant_new_keys_to_admin/0" do
+    test "grants unseen keys to Admin; an Owner revocation then sticks" do
+      admin_uuid = get_role_uuid("Admin")
+
+      # V53 never saw this module's keys
+      refute @base in Permissions.get_permissions_for_role(admin_uuid)
+
+      assert :ok = Permissions.auto_grant_new_keys_to_admin()
+
+      perms = Permissions.get_permissions_for_role(admin_uuid)
+      assert @base in perms
+      assert @sub_view in perms
+      assert @sub_edit in perms
+      assert Settings.get_setting("auto_granted_perm:#{@base}") == "true"
+
+      # Owner revokes one sub key — the flag must keep the next boot's
+      # auto-grant from silently restoring it
+      assert :ok = Permissions.revoke_permission(admin_uuid, @sub_edit)
+      assert :ok = Permissions.auto_grant_new_keys_to_admin()
+
+      perms = Permissions.get_permissions_for_role(admin_uuid)
+      assert @sub_view in perms
+      refute @sub_edit in perms
+    end
+
+    test "is idempotent — repeated runs create no duplicate rows" do
+      admin_uuid = get_role_uuid("Admin")
+
+      assert :ok = Permissions.auto_grant_new_keys_to_admin()
+      count_first = Permissions.count_permissions_for_role(admin_uuid)
+
+      assert :ok = Permissions.auto_grant_new_keys_to_admin()
+      assert Permissions.count_permissions_for_role(admin_uuid) == count_first
+    end
+  end
+
+  describe "Scope.for_user/1 Admin fallback scoping" do
+    setup do
+      _owner = create_user()
+      admin_user = create_user()
+      {:ok, _} = Roles.assign_role(admin_user, "Admin")
+      %{admin_user: admin_user}
+    end
+
+    test "admin uses its rows on a seeded install", %{admin_user: admin_user} do
+      scope = Scope.for_user(admin_user)
+
+      # V53 seeded rows — present, but NOT the registry-wide key list
+      assert Scope.has_module_access?(scope, "dashboard")
+      refute MapSet.member?(Scope.accessible_modules(scope), @base)
+    end
+
+    test "revoking everything from Admin sticks on a seeded install",
+         %{admin_user: admin_user} do
+      admin_uuid = get_role_uuid("Admin")
+
+      # keep the table non-empty via a role the admin user does NOT hold
+      # (permissions join across ALL of a user's roles — the default "User"
+      # role would leak its grants into this scope)
+      {:ok, keeper} = Roles.create_role(%{name: "Keeper #{System.unique_integer([:positive])}"})
+      {:ok, _} = Permissions.grant_permission(keeper.uuid, "dashboard")
+      :ok = Permissions.revoke_all_permissions(admin_uuid)
+
+      scope = Scope.for_user(admin_user)
+
+      # the old per-user fallback would ironically restore FULL access here
+      assert Scope.accessible_modules(scope) == MapSet.new()
+      refute Scope.has_module_access?(scope, "dashboard")
+      # still admin? (holds the role) — shell access, but every gated view denies
+      assert Scope.admin?(scope)
+    end
+
+    test "genuinely unseeded install falls back to full access",
+         %{admin_user: admin_user} do
+      Repo.delete_all(RolePermission)
+
+      scope = Scope.for_user(admin_user)
+
+      assert Scope.has_module_access?(scope, "dashboard")
+      assert Scope.has_module_access?(scope, @base)
+      assert Scope.has_module_access?(scope, @sub_edit)
+    end
+
+    test "Owner always holds every key regardless of rows" do
+      # first registered user became Owner in setup
+      owner = Auth.get_user_by_email(hd(owner_emails()))
+      Repo.delete_all(RolePermission)
+
+      scope = Scope.for_user(owner)
+      assert Scope.has_module_access?(scope, @base)
+      assert Scope.has_module_access?(scope, @sub_view)
+    end
+  end
+
+  defp owner_emails do
+    Repo.all(
+      from(u in PhoenixKit.Users.Auth.User,
+        join: ra in PhoenixKit.Users.RoleAssignment,
+        on: ra.user_uuid == u.uuid,
+        join: r in PhoenixKit.Users.Role,
+        on: r.uuid == ra.role_uuid,
+        where: r.name == "Owner",
+        select: u.email
+      )
+    )
+  end
+end

--- a/test/phoenix_kit/users/permissions_sub_keys_test.exs
+++ b/test/phoenix_kit/users/permissions_sub_keys_test.exs
@@ -1,0 +1,267 @@
+defmodule PhoenixKit.Users.PermissionsSubKeysTest do
+  # async: false — registers fake modules in the global ModuleRegistry.
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  alias PhoenixKit.ModuleRegistry
+  alias PhoenixKit.Users.Auth.Scope
+  alias PhoenixKit.Users.Auth.User
+  alias PhoenixKit.Users.Permissions
+  alias PhoenixKit.Users.RolePermission
+
+  defmodule FakeCalendar do
+    def module_key, do: "fake_calendar"
+    def module_name, do: "Fake Calendar"
+    def enabled?, do: true
+
+    def permission_metadata do
+      %{
+        key: "fake_calendar",
+        label: "Fake Calendar",
+        icon: "hero-calendar-days",
+        description: "Fake module for sub-permission tests",
+        sub_permissions: [
+          %{key: "view_others", label: "View others' calendars", description: "Read-only"},
+          %{key: "edit_others", label: "Edit others' calendars", description: "Write"}
+        ]
+      }
+    end
+  end
+
+  defmodule FakeDisabled do
+    def module_key, do: "fake_disabled"
+    def module_name, do: "Fake Disabled"
+    def enabled?, do: false
+
+    def permission_metadata do
+      %{
+        key: "fake_disabled",
+        label: "Fake Disabled",
+        icon: "hero-no-symbol",
+        description: "Disabled module with a sub-permission",
+        sub_permissions: [
+          %{key: "manage", label: "Manage", description: ""}
+        ]
+      }
+    end
+  end
+
+  defmodule FakeMalformedSubs do
+    def module_key, do: "fake_malformed"
+    def module_name, do: "Fake Malformed"
+    def enabled?, do: true
+
+    def permission_metadata do
+      %{
+        key: "fake_malformed",
+        label: "Fake Malformed",
+        icon: "hero-bug-ant",
+        description: "Declares invalid sub-permissions",
+        sub_permissions: [
+          # dot in the sub part — must be dropped (would compose a 2-dot key)
+          %{key: "bad.key", label: "Bad"},
+          # uppercase — fails the key regex
+          %{key: "BadCase", label: "Bad case"},
+          # missing :label — malformed shape
+          %{key: "no_label"},
+          # valid — must survive
+          %{key: "ok_sub", label: "OK sub", description: "Valid"}
+        ]
+      }
+    end
+  end
+
+  setup do
+    ModuleRegistry.register(FakeCalendar)
+    ModuleRegistry.register(FakeDisabled)
+
+    on_exit(fn ->
+      ModuleRegistry.unregister(FakeCalendar)
+      ModuleRegistry.unregister(FakeDisabled)
+      ModuleRegistry.unregister(FakeMalformedSubs)
+    end)
+
+    :ok
+  end
+
+  defp scope_with(perms) do
+    %Scope{
+      user: %User{uuid: "0193a5e4-0000-7000-8000-000000000001", email: "sub@example.com"},
+      authenticated?: true,
+      cached_roles: ["SomeCustomRole"],
+      cached_permissions: MapSet.new(perms)
+    }
+  end
+
+  describe "registry sub_permission_map/0" do
+    test "collects composed keys with metadata" do
+      map = ModuleRegistry.sub_permission_map()
+
+      assert [edit, view] = Enum.sort_by(map["fake_calendar"], & &1.key)
+      assert edit.key == "fake_calendar.edit_others"
+      assert view.key == "fake_calendar.view_others"
+      assert view.label == "View others' calendars"
+      assert view.description == "Read-only"
+    end
+
+    test "drops malformed sub-permissions with a warning, keeps valid ones" do
+      log =
+        capture_log(fn ->
+          ModuleRegistry.register(FakeMalformedSubs)
+          map = ModuleRegistry.sub_permission_map()
+
+          assert [%{key: "fake_malformed.ok_sub"}] = map["fake_malformed"]
+        end)
+
+      assert log =~ "bad.key"
+      assert log =~ "BadCase"
+      assert log =~ "no_label"
+    end
+
+    test "modules without sub_permissions don't appear in the map" do
+      refute Map.has_key?(ModuleRegistry.sub_permission_map(), "fake_no_subs")
+    end
+  end
+
+  describe "sub-permission key lists" do
+    test "sub_permission_keys/0 returns composed keys" do
+      keys = Permissions.sub_permission_keys()
+      assert "fake_calendar.view_others" in keys
+      assert "fake_calendar.edit_others" in keys
+    end
+
+    test "all_module_keys/0 includes sub keys alongside base keys" do
+      keys = Permissions.all_module_keys()
+      assert "fake_calendar" in keys
+      assert "fake_calendar.view_others" in keys
+    end
+
+    test "feature_module_keys/0 does NOT include sub keys" do
+      keys = Permissions.feature_module_keys()
+      assert "fake_calendar" in keys
+      refute Enum.any?(keys, &String.contains?(&1, "."))
+    end
+
+    test "sub_permissions_for/1 returns [] for keys without subs" do
+      assert Permissions.sub_permissions_for("dashboard") == []
+      assert Permissions.sub_permissions_for("nonexistent") == []
+    end
+  end
+
+  describe "parent_key/1" do
+    test "resolves a composed key to its base" do
+      assert Permissions.parent_key("fake_calendar.view_others") == "fake_calendar"
+    end
+
+    test "returns nil for base keys, unknown dotted keys, and non-binaries" do
+      assert Permissions.parent_key("fake_calendar") == nil
+      assert Permissions.parent_key("fake_calendar.nonexistent") == nil
+      assert Permissions.parent_key("unknown.sub") == nil
+      assert Permissions.parent_key(nil) == nil
+    end
+  end
+
+  describe "expand_with_parents/1" do
+    test "adds the base key implied by a sub key" do
+      assert Permissions.expand_with_parents(["fake_calendar.view_others"]) ==
+               MapSet.new(["fake_calendar.view_others", "fake_calendar"])
+    end
+
+    test "leaves base keys and unknown keys untouched" do
+      keys = ["dashboard", "unknown.sub"]
+      assert Permissions.expand_with_parents(keys) == MapSet.new(keys)
+    end
+  end
+
+  describe "valid_module_key?/1 with sub keys" do
+    test "accepts registered sub keys, rejects unknown dotted keys" do
+      assert Permissions.valid_module_key?("fake_calendar.view_others")
+      refute Permissions.valid_module_key?("fake_calendar.nonexistent")
+      refute Permissions.valid_module_key?("nonexistent.view_others")
+    end
+  end
+
+  describe "sub-key metadata resolution" do
+    test "module_label/1 resolves the sub's own label" do
+      assert Permissions.module_label("fake_calendar.view_others") ==
+               "View others' calendars"
+    end
+
+    test "module_description/1 resolves the sub's own description" do
+      assert Permissions.module_description("fake_calendar.edit_others") == "Write"
+    end
+
+    test "module_icon/1 inherits the parent module's icon" do
+      assert Permissions.module_icon("fake_calendar.view_others") == "hero-calendar-days"
+    end
+  end
+
+  describe "feature_enabled?/1 with sub keys" do
+    test "sub key follows the parent module's enabled state" do
+      assert Permissions.feature_enabled?("fake_calendar.view_others")
+      refute Permissions.feature_enabled?("fake_disabled.manage")
+    end
+
+    test "unknown dotted keys are not enabled" do
+      refute Permissions.feature_enabled?("unknown.sub")
+    end
+  end
+
+  describe "enabled_module_keys/0 with sub keys" do
+    test "includes subs of enabled modules, excludes subs of disabled ones" do
+      enabled = Permissions.enabled_module_keys()
+      assert MapSet.member?(enabled, "fake_calendar.view_others")
+      refute MapSet.member?(enabled, "fake_disabled.manage")
+      # the disabled base key is excluded as before
+      refute MapSet.member?(enabled, "fake_disabled")
+    end
+  end
+
+  describe "RolePermission.changeset/2 with sub keys" do
+    test "accepts a registered sub key" do
+      changeset =
+        RolePermission.changeset(%RolePermission{}, %{
+          role_uuid: UUIDv7.generate(),
+          module_key: "fake_calendar.view_others"
+        })
+
+      assert changeset.valid?
+    end
+
+    test "rejects an unregistered dotted key" do
+      changeset =
+        RolePermission.changeset(%RolePermission{}, %{
+          role_uuid: UUIDv7.generate(),
+          module_key: "fake_calendar.nonexistent"
+        })
+
+      refute changeset.valid?
+    end
+  end
+
+  describe "Scope.can?/2" do
+    test "true when the key is held and its parent module is enabled" do
+      scope = scope_with(["fake_calendar", "fake_calendar.view_others"])
+      assert Scope.can?(scope, "fake_calendar.view_others")
+      assert Scope.can?(scope, "fake_calendar")
+    end
+
+    test "false when the key is not held" do
+      scope = scope_with(["fake_calendar"])
+      refute Scope.can?(scope, "fake_calendar.view_others")
+    end
+
+    test "false when the parent module is disabled, even if the key is cached" do
+      # a scope snapshotted before the module was disabled must not keep
+      # authorizing its actions
+      scope = scope_with(["fake_disabled", "fake_disabled.manage"])
+      refute Scope.can?(scope, "fake_disabled.manage")
+      refute Scope.can?(scope, "fake_disabled")
+    end
+
+    test "false for anonymous scope" do
+      refute Scope.can?(Scope.for_user(nil), "fake_calendar.view_others")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Two related changes to the permission system, plus the events table for the new `phoenix_kit_calendar` module (its first consumer).

### 1. Fine-grained sub-permissions

Modules can now declare permissions *within* their module key via `permission_metadata/0`:

```elixir
def permission_metadata do
  %{key: "calendar", label: "Calendar", icon: "hero-calendar-days",
    description: "Personal calendars",
    sub_permissions: [
      %{key: "view_others", label: "View others' calendars", description: "..."},
      %{key: "edit_others", label: "Edit others' calendars", description: "..."}
    ]}
end
```

- Stored as composed dotted keys (`"calendar.view_others"`) in the existing `phoenix_kit_role_permissions` table — **V140** widens `module_key` to VARCHAR(120).
- The base key keeps its exact current meaning (module/page access); sub-keys are additive grants a module checks itself via the new **`Scope.can?/2`**, which also requires the parent module to be enabled — a scope snapshotted before a module was disabled can't keep authorizing its actions.
- **Sub-implies-base invariant enforced at the context layer**, not just the UI: granting a sub auto-grants its base in the same transaction, revoking a base cascades its subs off, and `set_permissions/3` normalizes the desired set. No code path can persist an orphan sub-key row.
- The permissions matrix and the roles editor render indented sub-rows; the "you can only grant keys you hold" guard now also covers the base key a sub-grant implies (closes an escalation edge where an editor holding only the sub could smuggle in a base grant).
- Registry-driven parent↔sub resolution (never string-splitting); both key parts validated against the existing `~r/^[a-z][a-z0-9_]*$/`, so a composed key has exactly one dot and can't collide with custom keys (which forbid dots).

### 2. ⚠️ Behavior change: Admin is now genuinely gated by its permission rows

`enforce_admin_view_permission` had a `system_role?` bypass (rode along in 65ab7ef5, whose subject was disabled-module centralization; no tests pinned it). The result was inconsistent: an Owner revoking a key from the Admin role was honored by the sidebar, the `require_module_access` plug, and the mid-session PubSub kick — but a fresh mount let the Admin right back in. Revoking Admin permissions was effectively cosmetic.

This PR removes the Admin half of the bypass:

- **Admin = a role that DEFAULTS to all permissions but is genuinely Owner-editable.** Owner behavior is unchanged (its scope holds every key by construction). Views that resolve to no permission key still allow system roles only (unchanged, documented).
- The Admin zero-rows full-access fallback now applies only to genuinely unseeded installs (no permission rows at all) — previously, revoking Admin's *last* key ironically restored full access.
- To keep "Admin defaults to everything" without the bypass, a startup task **auto-grants Admin any permission key it has never been granted** (newly installed modules, new sub-permissions), guarded by per-key settings flags so an Owner's revocation sticks across restarts. This doubles as the repair path for installs whose V53 seeding predates newer modules — verified on a real upgrade boot (Admin 0 → 42 keys, then a revocation stayed revoked across restart).
- **Install impact:** on installs where an Owner had revoked keys from Admin, those revocations now actually block fresh mounts. That is the intended semantic; flagging it since it changes what Admin can reach.

### 3. V141 — `phoenix_kit_calendar_events`

Table for the new `phoenix_kit_calendar` module (personal calendar per user; the reference consumer of sub-permissions). Exclusive-end pairs (timed UTC pair / all-day DATE pair, CHECK-enforced against the `all_day` flag), `owner_uuid` FK CASCADE, confirmed/cancelled status.

## Testing

- 37 new tests: sub-key semantics + registry validation (24 unit), grant/revoke/set cascades, auto-grant idempotency + flag behavior, fallback scoping, Owner invariance (13 DB).
- Full suite: 42 failures — identical to clean `main` (stash-verified baseline; 31 multi-session + 11 sitemap-settings pre-existing). Zero new failures.
- `mix precommit` green (format, compile --warnings-as-errors, credo --strict, dialyzer).
- Browser-verified on the parent app: matrix sub-rows with live grant/revoke cascades, Admin auto-grant on boot, calendar module end-to-end.