### PR TITLE
Add fine-grained sub-permissions, calendar events migration, and reusable UI components

### DIFF
--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -529,7 +529,15 @@ defmodule PhoenixKit.Migrations.Postgres do
   - Replaces unique index with partial index (slug-mode only, WHERE slug IS NOT NULL)
   - Adds unique index on `(group_uuid, post_date, post_time)` for timestamp-mode posts
 
-  ### V140 - Warehouse module tables ⚡ LATEST
+  ### V142 - Wider role-permission keys ⚡ LATEST
+  - Widens `phoenix_kit_role_permissions.module_key` from `VARCHAR(50)` to
+    `VARCHAR(120)` so fine-grained sub-permissions can be stored as composed
+    dotted keys (`"calendar.view_others"` — base and sub parts are each
+    capped at 50 chars, so a composed key can reach 101).
+  - Rollback deletes rows over 50 chars (sub-permission grants are additive
+    and re-grantable) before narrowing the column back.
+
+  ### V140 - Warehouse module tables
   - Creates `phoenix_kit_warehouse_stock`, `phoenix_kit_warehouse_inventory_documents`,
     `phoenix_kit_warehouse_internal_orders`, `phoenix_kit_warehouse_supplier_orders`,
     `phoenix_kit_warehouse_goods_receipts`, and `phoenix_kit_warehouse_goods_issues` —

--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -1233,7 +1233,7 @@ defmodule PhoenixKit.Migrations.Postgres do
   use Ecto.Migration
 
   @initial_version 1
-  @current_version 141
+  @current_version 142
   @default_prefix "public"
 
   @doc false

--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -542,7 +542,7 @@ defmodule PhoenixKit.Migrations.Postgres do
     one implicit personal calendar per user (`owner_uuid` FK, CASCADE on user
     delete). Timed events use an exclusive-end UTC pair; all-day events use an
     exclusive-end DATE pair; a CHECK enforces exactly one pair per row matching
-    the `all_day` flag, with end > start. Status is confirmed/cancelled.
+    the `all_day` flag, with end > start. Status is active/cancelled.
     `location_uuid` loosely links a stored location (name snapshotted into the
     `location` string — no cross-module FK).
   - Adds `phoenix_kit_calendar_event_participants`: loose `kind` + `target_uuid`

--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -537,6 +537,14 @@ defmodule PhoenixKit.Migrations.Postgres do
   - Rollback deletes rows over 50 chars (sub-permission grants are additive
     and re-grantable) before narrowing the column back.
 
+  ### V141 - Calendar events
+  - Adds `phoenix_kit_calendar_events` for the `phoenix_kit_calendar` module:
+    one implicit personal calendar per user (`owner_uuid` FK, CASCADE on user
+    delete). Timed events use an exclusive-end UTC pair; all-day events use an
+    exclusive-end DATE pair; a CHECK enforces exactly one pair per row matching
+    the `all_day` flag, with end > start. Status is confirmed/cancelled.
+  - Rollback drops the table.
+
   ### V140 - Warehouse module tables
   - Creates `phoenix_kit_warehouse_stock`, `phoenix_kit_warehouse_inventory_documents`,
     `phoenix_kit_warehouse_internal_orders`, `phoenix_kit_warehouse_supplier_orders`,
@@ -1216,7 +1224,7 @@ defmodule PhoenixKit.Migrations.Postgres do
   use Ecto.Migration
 
   @initial_version 1
-  @current_version 140
+  @current_version 141
   @default_prefix "public"
 
   @doc false

--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -537,13 +537,22 @@ defmodule PhoenixKit.Migrations.Postgres do
   - Rollback deletes rows over 50 chars (sub-permission grants are additive
     and re-grantable) before narrowing the column back.
 
-  ### V141 - Calendar events
+  ### V141 - Calendar events + participants
   - Adds `phoenix_kit_calendar_events` for the `phoenix_kit_calendar` module:
     one implicit personal calendar per user (`owner_uuid` FK, CASCADE on user
     delete). Timed events use an exclusive-end UTC pair; all-day events use an
     exclusive-end DATE pair; a CHECK enforces exactly one pair per row matching
     the `all_day` flag, with end > start. Status is confirmed/cancelled.
-  - Rollback drops the table.
+    `location_uuid` loosely links a stored location (name snapshotted into the
+    `location` string — no cross-module FK).
+  - Adds `phoenix_kit_calendar_event_participants`: loose `kind` + `target_uuid`
+    references (user / staff_person / crm_contact / crm_company / free_text)
+    with a `display_name` snapshot and `added_by_uuid` audit. Visibility is
+    resolved LIVE at query time against the physical staff/CRM tables, so a
+    company participant means "current members" and no module code is needed.
+    Partial uniques dedup targets per event and free-text case-insensitively.
+  - Extended in place while unreleased (idempotent-additive statements).
+  - Rollback drops both tables.
 
   ### V140 - Warehouse module tables
   - Creates `phoenix_kit_warehouse_stock`, `phoenix_kit_warehouse_inventory_documents`,

--- a/lib/phoenix_kit/migrations/postgres/v141.ex
+++ b/lib/phoenix_kit/migrations/postgres/v141.ex
@@ -1,0 +1,90 @@
+defmodule PhoenixKit.Migrations.Postgres.V141 do
+  @moduledoc """
+  V141: Personal calendar events for the `phoenix_kit_calendar` module.
+
+  One implicit personal calendar per user — events are keyed by
+  `owner_uuid` (no calendars table in v1; recurrence is deliberately
+  deferred).
+
+  Time model (mirrors `phoenix_live_calendar`'s Event semantics):
+
+  - Timed events use the `starts_at`/`ends_at` UTC pair; `ends_at` is
+    EXCLUSIVE (`[start, end)`, iCal/RFC 5545 style).
+  - All-day events use the `starts_on`/`ends_on` DATE pair (also
+    end-exclusive) — proper date semantics instead of UTC-midnight
+    instants, so a "day" never shifts across timezones/DST.
+  - A CHECK constraint enforces exactly one pair per row, matching the
+    `all_day` flag, with end > start on both pairs.
+
+  `owner_uuid` cascades on user delete — a personal calendar follows its
+  account's lifecycle.
+
+  All statements are idempotent, safe to re-run.
+  """
+
+  use Ecto.Migration
+
+  def up(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    execute("""
+    CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_calendar_events (
+      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      owner_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_users(uuid) ON DELETE CASCADE,
+      title VARCHAR(255) NOT NULL,
+      description TEXT,
+      location VARCHAR(255),
+      all_day BOOLEAN NOT NULL DEFAULT FALSE,
+      starts_at TIMESTAMP(0),
+      ends_at TIMESTAMP(0),
+      starts_on DATE,
+      ends_on DATE,
+      color VARCHAR(50),
+      status VARCHAR(20) NOT NULL DEFAULT 'confirmed',
+      inserted_at TIMESTAMP(0) NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMP(0) NOT NULL DEFAULT NOW(),
+      CONSTRAINT calendar_event_time_shape CHECK (
+        (
+          all_day = FALSE
+          AND starts_at IS NOT NULL AND ends_at IS NOT NULL
+          AND starts_on IS NULL AND ends_on IS NULL
+          AND ends_at > starts_at
+        )
+        OR
+        (
+          all_day = TRUE
+          AND starts_on IS NOT NULL AND ends_on IS NOT NULL
+          AND starts_at IS NULL AND ends_at IS NULL
+          AND ends_on > starts_on
+        )
+      ),
+      CONSTRAINT calendar_event_status CHECK (status IN ('confirmed', 'cancelled'))
+    )
+    """)
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS idx_calendar_events_owner_starts_at
+    ON #{p}phoenix_kit_calendar_events (owner_uuid, starts_at)
+    """)
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS idx_calendar_events_owner_starts_on
+    ON #{p}phoenix_kit_calendar_events (owner_uuid, starts_on)
+    """)
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '141'")
+  end
+
+  def down(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    execute("DROP TABLE IF EXISTS #{p}phoenix_kit_calendar_events")
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '140'")
+  end
+
+  defp prefix_str("public"), do: "public."
+  defp prefix_str(prefix), do: "#{prefix}."
+end

--- a/lib/phoenix_kit/migrations/postgres/v141.ex
+++ b/lib/phoenix_kit/migrations/postgres/v141.ex
@@ -64,7 +64,7 @@ defmodule PhoenixKit.Migrations.Postgres.V141 do
       starts_on DATE,
       ends_on DATE,
       color VARCHAR(50),
-      status VARCHAR(20) NOT NULL DEFAULT 'confirmed',
+      status VARCHAR(20) NOT NULL DEFAULT 'active',
       inserted_at TIMESTAMP(0) NOT NULL DEFAULT NOW(),
       updated_at TIMESTAMP(0) NOT NULL DEFAULT NOW(),
       CONSTRAINT calendar_event_time_shape CHECK (
@@ -82,8 +82,30 @@ defmodule PhoenixKit.Migrations.Postgres.V141 do
           AND ends_on > starts_on
         )
       ),
-      CONSTRAINT calendar_event_status CHECK (status IN ('confirmed', 'cancelled'))
+      CONSTRAINT calendar_event_status CHECK (status IN ('active', 'cancelled'))
     )
+    """)
+
+    # Status vocabulary: the only meaningful states are active vs cancelled
+    # (there was never a "tentative"), so 'confirmed' was renamed to 'active'.
+    # Idempotent + safe for BOTH fresh installs (the drop+re-add nets to the
+    # same constraint the CREATE TABLE above already made) and existing ones
+    # (migrates legacy rows and swaps the CHECK). Runs on each up/1.
+    execute(
+      "ALTER TABLE #{p}phoenix_kit_calendar_events DROP CONSTRAINT IF EXISTS calendar_event_status"
+    )
+
+    execute(
+      "UPDATE #{p}phoenix_kit_calendar_events SET status = 'active' WHERE status = 'confirmed'"
+    )
+
+    execute(
+      "ALTER TABLE #{p}phoenix_kit_calendar_events ALTER COLUMN status SET DEFAULT 'active'"
+    )
+
+    execute("""
+    ALTER TABLE #{p}phoenix_kit_calendar_events
+    ADD CONSTRAINT calendar_event_status CHECK (status IN ('active', 'cancelled'))
     """)
 
     # Loose link to a stored location (locations module); the name is

--- a/lib/phoenix_kit/migrations/postgres/v141.ex
+++ b/lib/phoenix_kit/migrations/postgres/v141.ex
@@ -1,6 +1,7 @@
 defmodule PhoenixKit.Migrations.Postgres.V141 do
   @moduledoc """
-  V141: Personal calendar events for the `phoenix_kit_calendar` module.
+  V141: Personal calendar events + participants for the
+  `phoenix_kit_calendar` module.
 
   One implicit personal calendar per user — events are keyed by
   `owner_uuid` (no calendars table in v1; recurrence is deliberately
@@ -17,9 +18,31 @@ defmodule PhoenixKit.Migrations.Postgres.V141 do
     `all_day` flag, with end > start on both pairs.
 
   `owner_uuid` cascades on user delete — a personal calendar follows its
-  account's lifecycle.
+  account's lifecycle. `location_uuid` optionally links a stored location
+  from the locations module (loose uuid reference, NO cross-module FK —
+  the location NAME is snapshotted into the `location` string at save, so
+  rendering never needs the locations module).
 
-  All statements are idempotent, safe to re-run.
+  ## Participants
+
+  `phoenix_kit_calendar_event_participants` attaches people to an event.
+  Loose `kind` + `target_uuid` references (activity-feed pattern — no
+  cross-module FKs) with a `display_name` snapshot frozen at save, so
+  participants render even if a source module is later disabled or the
+  record deleted. Kinds: `user`, `staff_person`, `crm_contact`,
+  `crm_company`, `free_text` (free text has no target and grants no
+  visibility).
+
+  Visibility is resolved LIVE at query time by joining the PHYSICAL
+  staff/CRM tables (they exist in every install via these core
+  migrations, so no module code is required and empty tables no-op):
+  a company participant means "whoever is a member of that company NOW",
+  and a staff person / CRM contact resolves through its current
+  `user_uuid` link. `added_by_uuid` records who attached the participant.
+
+  All statements are idempotent AND additive — this migration was
+  extended in place while unreleased (per project policy); re-running it
+  on a database that has the earlier shape adds only the missing pieces.
   """
 
   use Ecto.Migration
@@ -63,6 +86,13 @@ defmodule PhoenixKit.Migrations.Postgres.V141 do
     )
     """)
 
+    # Loose link to a stored location (locations module); the name is
+    # snapshotted into `location`, so this is enrichment only.
+    execute("""
+    ALTER TABLE #{p}phoenix_kit_calendar_events
+    ADD COLUMN IF NOT EXISTS location_uuid UUID
+    """)
+
     execute("""
     CREATE INDEX IF NOT EXISTS idx_calendar_events_owner_starts_at
     ON #{p}phoenix_kit_calendar_events (owner_uuid, starts_at)
@@ -73,6 +103,52 @@ defmodule PhoenixKit.Migrations.Postgres.V141 do
     ON #{p}phoenix_kit_calendar_events (owner_uuid, starts_on)
     """)
 
+    execute("""
+    CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_calendar_event_participants (
+      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      event_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_calendar_events(uuid) ON DELETE CASCADE,
+      kind VARCHAR(20) NOT NULL,
+      target_uuid UUID,
+      display_name VARCHAR(255) NOT NULL,
+      added_by_uuid UUID REFERENCES #{p}phoenix_kit_users(uuid) ON DELETE SET NULL,
+      inserted_at TIMESTAMP(0) NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMP(0) NOT NULL DEFAULT NOW(),
+      CONSTRAINT calendar_participant_kind CHECK (
+        kind IN ('user', 'staff_person', 'crm_contact', 'crm_company', 'free_text')
+      ),
+      CONSTRAINT calendar_participant_shape CHECK (
+        (kind = 'free_text' AND target_uuid IS NULL)
+        OR (kind <> 'free_text' AND target_uuid IS NOT NULL)
+      )
+    )
+    """)
+
+    # One row per (event, kind, target); free-text dedups case-insensitively
+    execute("""
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_calendar_participants_target
+    ON #{p}phoenix_kit_calendar_event_participants (event_uuid, kind, target_uuid)
+    WHERE target_uuid IS NOT NULL
+    """)
+
+    execute("""
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_calendar_participants_free_text
+    ON #{p}phoenix_kit_calendar_event_participants (event_uuid, LOWER(display_name))
+    WHERE kind = 'free_text'
+    """)
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS idx_calendar_participants_event
+    ON #{p}phoenix_kit_calendar_event_participants (event_uuid)
+    """)
+
+    # Reverse direction: "which events does this person participate in" —
+    # drives the live visibility resolution on personal calendars
+    execute("""
+    CREATE INDEX IF NOT EXISTS idx_calendar_participants_kind_target
+    ON #{p}phoenix_kit_calendar_event_participants (kind, target_uuid)
+    WHERE target_uuid IS NOT NULL
+    """)
+
     execute("COMMENT ON TABLE #{p}phoenix_kit IS '141'")
   end
 
@@ -80,6 +156,7 @@ defmodule PhoenixKit.Migrations.Postgres.V141 do
     prefix = Map.get(opts, :prefix, "public")
     p = prefix_str(prefix)
 
+    execute("DROP TABLE IF EXISTS #{p}phoenix_kit_calendar_event_participants")
     execute("DROP TABLE IF EXISTS #{p}phoenix_kit_calendar_events")
 
     execute("COMMENT ON TABLE #{p}phoenix_kit IS '140'")

--- a/lib/phoenix_kit/migrations/postgres/v142.ex
+++ b/lib/phoenix_kit/migrations/postgres/v142.ex
@@ -1,0 +1,49 @@
+defmodule PhoenixKit.Migrations.Postgres.V142 do
+  @moduledoc """
+  V142: Widen role-permission keys for fine-grained sub-permissions.
+
+  Sub-permissions are stored in `phoenix_kit_role_permissions.module_key` as
+  composed dotted keys (`"calendar.view_others"`). Base and sub parts are
+  each capped at 50 chars, so a composed key can reach 101 — the original
+  V53 `VARCHAR(50)` is too narrow. Widen to `VARCHAR(120)`.
+
+  All statements are idempotent, safe to re-run.
+  """
+
+  use Ecto.Migration
+
+  def up(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    execute("""
+    ALTER TABLE #{p}phoenix_kit_role_permissions
+    ALTER COLUMN module_key TYPE VARCHAR(120)
+    """)
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '142'")
+  end
+
+  def down(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    # Dotted sub-permission rows may exceed 50 chars; drop them before
+    # narrowing so the type change cannot fail mid-rollback. Sub-permission
+    # grants are additive and re-grantable, so removing them is safe.
+    execute("""
+    DELETE FROM #{p}phoenix_kit_role_permissions
+    WHERE LENGTH(module_key) > 50
+    """)
+
+    execute("""
+    ALTER TABLE #{p}phoenix_kit_role_permissions
+    ALTER COLUMN module_key TYPE VARCHAR(50)
+    """)
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '141'")
+  end
+
+  defp prefix_str("public"), do: "public."
+  defp prefix_str(prefix), do: "#{prefix}."
+end

--- a/lib/phoenix_kit/module.ex
+++ b/lib/phoenix_kit/module.ex
@@ -35,7 +35,17 @@ defmodule PhoenixKit.Module do
             key: "hello_world",
             label: "Hello World",
             icon: "hero-hand-raised",
-            description: "A demo module"
+            description: "A demo module",
+            # Optional fine-grained permissions under the base key.
+            # Stored/checked as "hello_world.moderate"; only effective
+            # while the module is enabled.
+            sub_permissions: [
+              %{
+                key: "moderate",
+                label: "Moderate content",
+                description: "Approve or reject other users' entries"
+              }
+            ]
           }
         end
 
@@ -85,12 +95,35 @@ defmodule PhoenixKit.Module do
   - `integration_providers/0` - Additional provider definitions this module contributes (default: `[]`).
   """
 
-  @typedoc "Permission metadata for the module"
-  @type permission_meta :: %{
+  @typedoc """
+  A fine-grained permission a module declares under its base key.
+
+  `:key` is the short action name (e.g. `"view_others"`); it is stored and
+  checked as the composed dotted key `"<module_key>.<key>"` (e.g.
+  `"calendar.view_others"`). Both parts must match `~r/^[a-z][a-z0-9_]*$/`,
+  so a composed key always contains exactly one dot.
+  """
+  @type sub_permission :: %{
           key: String.t(),
           label: String.t(),
-          icon: String.t(),
           description: String.t()
+        }
+
+  @typedoc """
+  Permission metadata for the module.
+
+  `:sub_permissions` (optional) declares fine-grained permissions under the
+  module's base key. The base key gates access to the module's admin pages;
+  sub-permissions are additive grants the module checks itself (via
+  `PhoenixKit.Users.Auth.Scope.can?/2`) for specific in-module capabilities.
+  A sub-permission is only effective while its parent module is enabled.
+  """
+  @type permission_meta :: %{
+          required(:key) => String.t(),
+          required(:label) => String.t(),
+          required(:icon) => String.t(),
+          required(:description) => String.t(),
+          optional(:sub_permissions) => [sub_permission()]
         }
 
   # Required callbacks

--- a/lib/phoenix_kit/module_registry.ex
+++ b/lib/phoenix_kit/module_registry.ex
@@ -345,6 +345,78 @@ defmodule PhoenixKit.ModuleRegistry do
     |> Enum.sort()
   end
 
+  @valid_sub_key_pattern ~r/^[a-z][a-z0-9_]*$/
+  @max_sub_key_length 50
+
+  @doc """
+  Returns the sub-permissions declared by registered modules, keyed by the
+  parent module key. Each entry carries the COMPOSED dotted key
+  (`"calendar.view_others"`) plus its label and description.
+
+  Malformed declarations (bad key format, missing fields, key over
+  #{@max_sub_key_length} chars, duplicate keys within one module) are dropped
+  with a logged warning rather than raising — a broken module must not take
+  down permission resolution for everyone else.
+  """
+  @spec sub_permission_map() :: %{String.t() => [map()]}
+  def sub_permission_map do
+    all_permission_metadata()
+    |> Enum.reduce(%{}, fn meta, acc ->
+      case valid_sub_permissions(meta) do
+        [] -> acc
+        subs -> Map.put(acc, meta.key, subs)
+      end
+    end)
+  end
+
+  defp valid_sub_permissions(%{key: base, sub_permissions: subs}) when is_list(subs) do
+    subs
+    |> Enum.filter(&valid_sub_permission?(base, &1))
+    |> Enum.uniq_by(& &1.key)
+    |> Enum.map(fn sub ->
+      %{
+        key: "#{base}.#{sub.key}",
+        label: sub.label,
+        description: Map.get(sub, :description, "")
+      }
+    end)
+  end
+
+  defp valid_sub_permissions(_meta), do: []
+
+  defp valid_sub_permission?(base, %{key: key, label: label})
+       when is_binary(key) and is_binary(label) do
+    cond do
+      not Regex.match?(@valid_sub_key_pattern, key) ->
+        Logger.warning(
+          "[ModuleRegistry] Dropping sub-permission #{inspect(key)} of #{inspect(base)}: " <>
+            "key must match ~r/^[a-z][a-z0-9_]*$/"
+        )
+
+        false
+
+      String.length(key) > @max_sub_key_length ->
+        Logger.warning(
+          "[ModuleRegistry] Dropping sub-permission #{inspect(key)} of #{inspect(base)}: " <>
+            "key exceeds max length of #{@max_sub_key_length}"
+        )
+
+        false
+
+      true ->
+        true
+    end
+  end
+
+  defp valid_sub_permission?(base, sub) do
+    Logger.warning(
+      "[ModuleRegistry] Dropping malformed sub-permission #{inspect(sub)} of #{inspect(base)}: " <>
+        "expected %{key: binary, label: binary, description: binary}"
+    )
+
+    false
+  end
+
   @doc "Returns permission labels map from registered modules."
   @spec permission_labels() :: %{String.t() => String.t()}
   def permission_labels do

--- a/lib/phoenix_kit/module_registry.ex
+++ b/lib/phoenix_kit/module_registry.ex
@@ -342,11 +342,32 @@ defmodule PhoenixKit.ModuleRegistry do
   def all_feature_keys do
     all_permission_metadata()
     |> Enum.map(& &1.key)
+    |> Enum.filter(&valid_base_key?/1)
     |> Enum.sort()
   end
 
   @valid_sub_key_pattern ~r/^[a-z][a-z0-9_]*$/
   @max_sub_key_length 50
+
+  # A base permission key must NOT contain a dot: the dot composes base+sub
+  # into a sub-key ("calendar" + "view_others" = "calendar.view_others"). A
+  # base literally named "calendar.view_others" would be indistinguishable
+  # from that composed sub-key — granting one would cascade the other's base,
+  # and revoking a base would delete the other module's row. Same pattern as
+  # sub-keys, dot excluded.
+  @valid_base_key_pattern ~r/^[a-z][a-z0-9_]*$/
+
+  @doc """
+  Whether a module base permission key is well-formed (lowercase, no dots,
+  within length). A dotted base key would collide with composed sub-keys, so
+  the permission plumbing ignores base keys that fail this check.
+  """
+  @spec valid_base_key?(String.t()) :: boolean()
+  def valid_base_key?(key) when is_binary(key) do
+    Regex.match?(@valid_base_key_pattern, key) and String.length(key) <= @max_sub_key_length
+  end
+
+  def valid_base_key?(_), do: false
 
   @doc """
   Returns the sub-permissions declared by registered modules, keyed by the
@@ -369,7 +390,23 @@ defmodule PhoenixKit.ModuleRegistry do
     end)
   end
 
-  defp valid_sub_permissions(%{key: base, sub_permissions: subs}) when is_list(subs) do
+  defp valid_sub_permissions(%{key: base, sub_permissions: subs})
+       when is_list(subs) and is_binary(base) do
+    if valid_base_key?(base) do
+      valid_sub_permissions_for(base, subs)
+    else
+      Logger.warning(
+        "[ModuleRegistry] Dropping sub-permissions of #{inspect(base)}: " <>
+          "base key must not contain a dot (collides with composed sub-keys)"
+      )
+
+      []
+    end
+  end
+
+  defp valid_sub_permissions(_meta), do: []
+
+  defp valid_sub_permissions_for(base, subs) do
     subs
     |> Enum.filter(&valid_sub_permission?(base, &1))
     |> Enum.uniq_by(& &1.key)
@@ -381,8 +418,6 @@ defmodule PhoenixKit.ModuleRegistry do
       }
     end)
   end
-
-  defp valid_sub_permissions(_meta), do: []
 
   defp valid_sub_permission?(base, %{key: key, label: label})
        when is_binary(key) and is_binary(label) do

--- a/lib/phoenix_kit/supervisor.ex
+++ b/lib/phoenix_kit/supervisor.ex
@@ -5,6 +5,7 @@ defmodule PhoenixKit.Supervisor do
   use Supervisor
 
   alias PhoenixKit.Modules.Languages
+  alias PhoenixKit.Users.Permissions
 
   def start_link(init_arg) do
     Supervisor.start_link(__MODULE__, init_arg, name: __MODULE__)
@@ -53,6 +54,29 @@ defmodule PhoenixKit.Supervisor do
       # Dashboard tab registry for user dashboard navigation.
       # Starts after settings_cache so module enabled? checks hit cache rather than DB.
       PhoenixKit.Dashboard.Registry,
+      # Grant the Admin role any permission keys it has never been auto-granted
+      # before (newly installed feature modules, new sub-permissions). Per-key
+      # settings flags make an Owner's revocation stick across restarts. Runs
+      # after ModuleRegistry (key discovery) and the settings cache (flag
+      # reads); idempotent and a silent no-op when the table doesn't exist yet.
+      # Modules registered at runtime (ModuleRegistry.register/1) are picked
+      # up on the next boot.
+      Supervisor.child_spec(
+        {Task,
+         fn ->
+           try do
+             Permissions.auto_grant_new_keys_to_admin()
+           rescue
+             error ->
+               require Logger
+
+               Logger.error(
+                 "[PhoenixKit] Failed to auto-grant permission keys to Admin at startup: #{inspect(error)}"
+               )
+           end
+         end},
+        id: :auto_grant_admin_permissions
+      ),
       # Normalize legacy admin_languages setting into unified languages_config
       # Runs once after settings cache is warmed; idempotent no-op if already migrated
       Supervisor.child_spec(

--- a/lib/phoenix_kit/users/auth/scope.ex
+++ b/lib/phoenix_kit/users/auth/scope.ex
@@ -37,11 +37,13 @@ defmodule PhoenixKit.Users.Auth.Scope do
   ## Module-Level Permissions
 
   Permissions are cached in the scope when it is built via `for_user/1`
-  (on mount and on PubSub-triggered refresh). Owner gets all 25 keys
-  automatically. Admin with no explicit permissions gets full access
-  (backward compat before V53 migration).
+  (on mount and on PubSub-triggered refresh). Owner gets every key
+  automatically. Admin defaults to all keys via seeding/auto-grant but is
+  genuinely gated by its rows — the full-access fallback applies only on an
+  unseeded install (no permission rows exist at all).
 
-      Scope.has_module_access?(scope, "billing")          # Single key check
+      Scope.has_module_access?(scope, "billing")          # Single key check (pure cache)
+      Scope.can?(scope, "calendar.view_others")           # Key held AND module enabled
       Scope.has_any_module_access?(scope, ["billing", "shop"])  # Any of these?
       Scope.has_all_module_access?(scope, ["billing", "shop"])  # All of these?
       Scope.accessible_modules(scope)                     # MapSet of granted keys
@@ -111,11 +113,22 @@ defmodule PhoenixKit.Users.Auth.Scope do
 
         roles.admin in cached_roles ->
           case Permissions.get_permissions_for_user(user) do
-            # Admin with no explicit permissions gets full access.
-            # This handles backward compat before V53 migration is applied
-            # (V53 seeds Admin with all 25 permission keys by default).
-            [] -> MapSet.new(Permissions.all_module_keys())
-            perms -> MapSet.new(perms)
+            # Admin with no explicit permissions falls back to full access
+            # ONLY on a genuinely unseeded install (no permission rows at
+            # all — pre-V53, or migrations not yet run). On a seeded
+            # install, zero rows means an Owner deliberately revoked
+            # everything from this admin's roles, and that must stick —
+            # otherwise revoking the last key would ironically restore
+            # full access.
+            [] ->
+              if Permissions.any_permissions_exist?() do
+                MapSet.new()
+              else
+                MapSet.new(Permissions.all_module_keys())
+              end
+
+            perms ->
+              MapSet.new(perms)
           end
 
         true ->
@@ -410,6 +423,30 @@ defmodule PhoenixKit.Users.Auth.Scope do
   end
 
   def has_module_access?(_, _), do: false
+
+  @doc """
+  Checks whether the user holds a permission key AND that key is currently
+  effective — the module behind it (or behind its parent, for sub-permission
+  keys like `"calendar.view_others"`) is enabled.
+
+  This is the check modules should use for fine-grained, in-page
+  authorization. Unlike `has_module_access?/2` (a pure cache lookup used on
+  hot paths where enablement is enforced separately at mount), `can?/2`
+  consults live module-enablement state, so a scope snapshotted before a
+  module was disabled cannot keep authorizing its actions.
+
+  ## Examples
+
+      Scope.can?(scope, "calendar.edit_others")
+      Scope.can?(scope, "calendar")
+  """
+  @spec can?(t(), String.t()) :: boolean()
+  def can?(%__MODULE__{cached_permissions: perms}, key)
+      when is_binary(key) and not is_nil(perms) do
+    MapSet.member?(perms, key) and Permissions.feature_enabled?(key)
+  end
+
+  def can?(_, _), do: false
 
   @doc """
   Returns the set of module keys the user can access.

--- a/lib/phoenix_kit/users/auth/scope.ex
+++ b/lib/phoenix_kit/users/auth/scope.ex
@@ -444,10 +444,23 @@ defmodule PhoenixKit.Users.Auth.Scope do
   @spec can?(t(), String.t()) :: boolean()
   def can?(%__MODULE__{cached_permissions: perms}, key)
       when is_binary(key) and not is_nil(perms) do
-    MapSet.member?(perms, key) and Permissions.feature_enabled?(key)
+    MapSet.member?(perms, key) and base_held?(perms, key) and Permissions.feature_enabled?(key)
   end
 
   def can?(_, _), do: false
+
+  # A sub-permission is only effective while its BASE is also held. The cascade
+  # guarantees this in normal operation (granting a sub grants its base), so
+  # this is defensive: it closes the orphan case where a sub row survives its
+  # base being removed (e.g. a module/sub-key temporarily leaves the registry
+  # and returns) — without it, `can?/2` would honor a dotted key whose base
+  # the role no longer holds.
+  defp base_held?(perms, key) do
+    case Permissions.parent_key(key) do
+      nil -> true
+      base -> MapSet.member?(perms, base)
+    end
+  end
 
   @doc """
   Returns the set of module keys the user can access.

--- a/lib/phoenix_kit/users/auth/scope.ex
+++ b/lib/phoenix_kit/users/auth/scope.ex
@@ -114,14 +114,15 @@ defmodule PhoenixKit.Users.Auth.Scope do
         roles.admin in cached_roles ->
           case Permissions.get_permissions_for_user(user) do
             # Admin with no explicit permissions falls back to full access
-            # ONLY on a genuinely unseeded install (no permission rows at
-            # all — pre-V53, or migrations not yet run). On a seeded
-            # install, zero rows means an Owner deliberately revoked
-            # everything from this admin's roles, and that must stick —
-            # otherwise revoking the last key would ironically restore
-            # full access.
+            # ONLY when the permissions table is genuinely MISSING (pre-V53
+            # / migrations not yet run). Once the table exists, zero rows
+            # means an Owner deliberately revoked everything from this
+            # admin's roles, and that must stick — keyed on table presence,
+            # NOT row count, so stripping every role bare can never restore
+            # full access, and a transient query error fails closed to
+            # empty rather than escalating.
             [] ->
-              if Permissions.any_permissions_exist?() do
+              if Permissions.permissions_table_ready?() do
                 MapSet.new()
               else
                 MapSet.new(Permissions.all_module_keys())

--- a/lib/phoenix_kit/users/permissions.ex
+++ b/lib/phoenix_kit/users/permissions.ex
@@ -13,6 +13,24 @@ defmodule PhoenixKit.Users.Permissions do
     ai, publishing, sitemap, seo, maintenance, storage,
     languages, connections, legal, db, jobs
 
+  ## Sub-Permissions (fine-grained)
+
+  A module may declare fine-grained permissions under its base key via the
+  optional `sub_permissions` field of `permission_metadata/0`. They live in
+  the same table as composed dotted keys (`"calendar.view_others"`):
+
+  - The base key gates the module's admin pages; sub-keys are additive
+    grants the module checks itself via `Scope.can?/2`.
+  - A sub-key implies its base: granting a sub auto-grants the base,
+    revoking the base cascades its subs, and `set_permissions/3` normalizes
+    the desired set — no path can persist an orphan sub-key row.
+  - A sub-key is enabled iff its parent module is enabled.
+
+      Permissions.sub_permission_keys()          # ["calendar.edit_others", ...]
+      Permissions.sub_permissions_for("calendar") # [%{key:, label:, description:}]
+      Permissions.parent_key("calendar.view_others") # "calendar"
+      Permissions.expand_with_parents(keys)      # keys ∪ implied base keys
+
   ## Constants & Metadata
 
       Permissions.all_module_keys()        # 25 built-in + any custom keys
@@ -266,11 +284,77 @@ defmodule PhoenixKit.Users.Permissions do
     :persistent_term.get(@custom_views_pterm, %{})
   end
 
+  # --- Sub-Permissions ---
+  #
+  # Modules declare fine-grained permissions under their base key via the
+  # optional `sub_permissions` field of `permission_metadata/0`. They are
+  # stored in the same phoenix_kit_role_permissions table as composed dotted
+  # keys ("calendar.view_others"). The base key gates the module's admin
+  # pages; sub-keys are additive grants the module checks itself via
+  # `Scope.can?/2`. Base and sub parts each match ~r/^[a-z][a-z0-9_]*$/, so a
+  # composed key contains exactly one dot — plain keys never contain dots.
+
+  @doc """
+  Returns all composed sub-permission keys (`"calendar.view_others"`)
+  declared by registered modules.
+  """
+  @spec sub_permission_keys() :: [String.t()]
+  def sub_permission_keys do
+    ModuleRegistry.sub_permission_map()
+    |> Enum.flat_map(fn {_base, subs} -> Enum.map(subs, & &1.key) end)
+    |> Enum.sort()
+  end
+
+  @doc """
+  Returns the sub-permission metadata declared under a base module key.
+  Each entry is `%{key: composed_key, label: label, description: description}`.
+  """
+  @spec sub_permissions_for(String.t()) :: [map()]
+  def sub_permissions_for(base_key) when is_binary(base_key) do
+    ModuleRegistry.sub_permission_map() |> Map.get(base_key, [])
+  end
+
+  @doc """
+  Returns the base module key a composed sub-permission key belongs to, or
+  `nil` when the key is not a registered sub-permission. Registry-driven —
+  never inferred by string splitting.
+  """
+  @spec parent_key(String.t()) :: String.t() | nil
+  def parent_key(key) when is_binary(key) do
+    if String.contains?(key, ".") do
+      ModuleRegistry.sub_permission_map()
+      |> Enum.find_value(fn {base, subs} ->
+        if Enum.any?(subs, &(&1.key == key)), do: base
+      end)
+    end
+  end
+
+  def parent_key(_), do: nil
+
+  @doc """
+  Expands a set of permission keys with the base keys its sub-permissions
+  imply (a sub-permission is meaningless without module access). Used by the
+  grant paths to keep the "no orphan sub-key" invariant, and by the admin
+  UIs to compute the full set a grant would create before authorizing it.
+  """
+  @spec expand_with_parents(Enumerable.t()) :: MapSet.t()
+  def expand_with_parents(keys) do
+    keys = MapSet.new(keys)
+
+    parents =
+      keys
+      |> Enum.map(&parent_key/1)
+      |> Enum.reject(&is_nil/1)
+
+    MapSet.union(keys, MapSet.new(parents))
+  end
+
   # --- Constants ---
 
-  @doc "Returns all built-in and custom permission keys as a list. See `enabled_module_keys/0` for filtered MapSet variant."
+  @doc "Returns all built-in, sub-permission, and custom permission keys as a list. See `enabled_module_keys/0` for filtered MapSet variant."
   @spec all_module_keys() :: [String.t()]
-  def all_module_keys, do: @core_section_keys ++ feature_module_keys() ++ custom_keys()
+  def all_module_keys,
+    do: @core_section_keys ++ feature_module_keys() ++ sub_permission_keys() ++ custom_keys()
 
   @doc "Returns the 5 core section keys."
   @spec core_section_keys() :: [String.t()]
@@ -294,14 +378,22 @@ defmodule PhoenixKit.Users.Permissions do
       feature_module_keys()
       |> Enum.filter(&do_feature_enabled?/1)
 
-    MapSet.new(@core_section_keys ++ enabled_features ++ custom_keys())
+    sub_map = ModuleRegistry.sub_permission_map()
+
+    enabled_subs =
+      Enum.flat_map(enabled_features, fn base ->
+        sub_map |> Map.get(base, []) |> Enum.map(& &1.key)
+      end)
+
+    MapSet.new(@core_section_keys ++ enabled_features ++ enabled_subs ++ custom_keys())
   end
 
-  @doc "Checks whether `key` is a known permission key (built-in or custom)."
+  @doc "Checks whether `key` is a known permission key (built-in, sub-permission, or custom)."
   @spec valid_module_key?(String.t()) :: boolean()
   def valid_module_key?(key) when is_binary(key) do
     key in @core_section_keys or
       key in ModuleRegistry.all_feature_keys() or
+      not is_nil(parent_key(key)) or
       Map.has_key?(custom_keys_map(), key)
   end
 
@@ -312,6 +404,7 @@ defmodule PhoenixKit.Users.Permissions do
 
   Core section keys always return `true`. Feature module keys return the
   result of calling the module's `enabled?/0` (or equivalent) function.
+  Sub-permission keys are enabled iff their parent module is enabled.
   Custom permission keys are always enabled (no module toggle).
   Returns `false` for unknown keys.
   """
@@ -324,8 +417,11 @@ defmodule PhoenixKit.Users.Permissions do
         Code.ensure_loaded?(mod) && apply(mod, fun, [])
 
       nil ->
-        # Custom keys are always "enabled" (no module toggle)
-        Map.has_key?(custom_keys_map(), key)
+        case parent_key(key) do
+          # Custom keys are always "enabled" (no module toggle)
+          nil -> Map.has_key?(custom_keys_map(), key)
+          parent -> feature_enabled?(parent)
+        end
     end
   rescue
     _ -> false
@@ -372,35 +468,49 @@ defmodule PhoenixKit.Users.Permissions do
     "db" => "Database explorer and schema inspection"
   }
 
-  @doc "Returns a human-readable label for a module key."
+  @doc "Returns a human-readable label for a module key (sub-permission keys resolve to the sub's own label)."
   @spec module_label(String.t()) :: String.t()
   def module_label(key) do
     Map.get_lazy(@core_labels, key, fn ->
       case Map.get(ModuleRegistry.permission_labels(), key) do
-        nil -> custom_key_metadata(key)[:label] || String.capitalize(key)
-        label -> label
+        nil ->
+          sub_permission_metadata(key)[:label] ||
+            custom_key_metadata(key)[:label] || String.capitalize(key)
+
+        label ->
+          label
       end
     end)
   end
 
-  @doc "Returns a Heroicon name for a module key."
+  @doc "Returns a Heroicon name for a module key (sub-permission keys inherit the parent module's icon)."
   @spec module_icon(String.t()) :: String.t()
   def module_icon(key) do
     Map.get_lazy(@core_icons, key, fn ->
       case Map.get(ModuleRegistry.permission_icons(), key) do
-        nil -> custom_key_metadata(key)[:icon] || "hero-squares-2x2"
-        icon -> icon
+        nil ->
+          case parent_key(key) do
+            nil -> custom_key_metadata(key)[:icon] || "hero-squares-2x2"
+            parent -> module_icon(parent)
+          end
+
+        icon ->
+          icon
       end
     end)
   end
 
-  @doc "Returns a short description for a module key."
+  @doc "Returns a short description for a module key (sub-permission keys resolve to the sub's own description)."
   @spec module_description(String.t()) :: String.t()
   def module_description(key) do
     Map.get_lazy(@core_descriptions, key, fn ->
       case Map.get(ModuleRegistry.permission_descriptions(), key) do
-        nil -> custom_key_metadata(key)[:description] || ""
-        desc -> desc
+        nil ->
+          sub_permission_metadata(key)[:description] ||
+            custom_key_metadata(key)[:description] || ""
+
+        desc ->
+          desc
       end
     end)
   end
@@ -438,6 +548,22 @@ defmodule PhoenixKit.Users.Permissions do
       end
 
       []
+  end
+
+  @doc """
+  Returns true when at least one permission row exists (any role, any key).
+
+  Used to distinguish a genuinely unseeded install (pre-V53 / migrations not
+  yet run — the Admin role falls back to full access) from a seeded install
+  where an Owner has deliberately revoked keys. Returns `false` when the
+  table is missing.
+  """
+  @spec any_permissions_exist?() :: boolean()
+  def any_permissions_exist? do
+    repo = RepoHelper.repo()
+    repo.exists?(from(rp in RolePermission, select: true))
+  rescue
+    _ -> false
   end
 
   @doc """
@@ -587,19 +713,41 @@ defmodule PhoenixKit.Users.Permissions do
 
   @doc """
   Grants a single permission to a role. Uses upsert to be idempotent.
+
+  Granting a sub-permission key (`"calendar.view_others"`) also grants its
+  base module key in the same transaction — a sub-permission row must never
+  exist without module access, regardless of which code path grants it.
   """
   @spec grant_permission(integer() | String.t(), String.t(), integer() | String.t() | nil) ::
-          {:ok, RolePermission.t()} | {:error, Ecto.Changeset.t()}
+          {:ok, RolePermission.t()} | {:error, Ecto.Changeset.t() | :role_not_found}
   def grant_permission(role_uuid, module_key, granted_by_uuid \\ nil) do
     repo = RepoHelper.repo()
 
     role_uuid = resolve_role_uuid(role_uuid)
 
-    if is_nil(role_uuid) do
-      {:error, :role_not_found}
-    else
-      grant_permission_insert(repo, role_uuid, module_key, granted_by_uuid)
+    cond do
+      is_nil(role_uuid) ->
+        {:error, :role_not_found}
+
+      parent = parent_key(module_key) ->
+        grant_sub_with_parent(repo, role_uuid, parent, module_key, granted_by_uuid)
+
+      true ->
+        grant_permission_insert(repo, role_uuid, module_key, granted_by_uuid)
     end
+  end
+
+  # Grants base + sub atomically. The base insert is an idempotent upsert, so
+  # a role that already holds the base key is unaffected by it.
+  defp grant_sub_with_parent(repo, role_uuid, parent, module_key, granted_by_uuid) do
+    repo.transaction(fn ->
+      with {:ok, _base} <- grant_permission_insert(repo, role_uuid, parent, granted_by_uuid),
+           {:ok, sub} <- grant_permission_insert(repo, role_uuid, module_key, granted_by_uuid) do
+        sub
+      else
+        {:error, changeset} -> repo.rollback(changeset)
+      end
+    end)
   end
 
   defp grant_permission_insert(repo, role_uuid, module_key, granted_by_uuid) do
@@ -627,6 +775,10 @@ defmodule PhoenixKit.Users.Permissions do
 
   @doc """
   Revokes a single permission from a role.
+
+  Revoking a base module key also revokes all of its sub-permission keys in
+  the same statement — a sub-permission row must never outlive module access.
+  Revoking a sub-permission key removes only that key.
   """
   @spec revoke_permission(integer() | String.t(), String.t()) :: :ok | {:error, :not_found}
   def revoke_permission(role_uuid, module_key) do
@@ -634,8 +786,12 @@ defmodule PhoenixKit.Users.Permissions do
 
     role_uuid = resolve_role_uuid(role_uuid)
 
+    keys_to_remove = [
+      module_key | Enum.map(sub_permissions_for(module_key), & &1.key)
+    ]
+
     from(rp in RolePermission,
-      where: rp.role_uuid == ^role_uuid and rp.module_key == ^module_key
+      where: rp.role_uuid == ^role_uuid and rp.module_key in ^keys_to_remove
     )
     |> repo.delete_all()
     |> case do
@@ -652,6 +808,10 @@ defmodule PhoenixKit.Users.Permissions do
   @doc """
   Syncs permissions for a role: grants missing keys, revokes extras.
   Runs in a transaction.
+
+  The desired set is normalized before applying: every sub-permission key in
+  it pulls in its base module key (a sub-permission implies module access),
+  so no code path can persist an orphan sub-key row.
   """
   @spec set_permissions(integer() | String.t(), [String.t()], integer() | String.t() | nil) ::
           :ok | {:error, term()}
@@ -673,8 +833,12 @@ defmodule PhoenixKit.Users.Permissions do
         |> repo.all()
         |> MapSet.new()
 
-      # Filter out any invalid keys before processing
-      desired_set = desired_keys |> MapSet.new() |> MapSet.intersection(valid_keys)
+      # Filter out any invalid keys, then pull in base keys implied by subs
+      desired_set =
+        desired_keys
+        |> MapSet.new()
+        |> MapSet.intersection(valid_keys)
+        |> expand_with_parents()
 
       # Keys to add
       to_add = MapSet.difference(desired_set, current_keys)
@@ -820,6 +984,15 @@ defmodule PhoenixKit.Users.Permissions do
     Map.get(custom_keys_map(), key)
   end
 
+  # Returns %{key:, label:, description:} for a composed sub-permission key,
+  # or nil if the key is not a registered sub-permission.
+  defp sub_permission_metadata(key) do
+    case parent_key(key) do
+      nil -> nil
+      parent -> Enum.find(sub_permissions_for(parent), &(&1.key == key))
+    end
+  end
+
   defp do_feature_enabled?(key) do
     case Map.get(ModuleRegistry.feature_enabled_checks(), key) do
       {mod, fun} ->
@@ -877,6 +1050,26 @@ defmodule PhoenixKit.Users.Permissions do
     Settings.update_setting("auto_granted_perm:#{key}", nil)
   rescue
     _ -> :ok
+  end
+
+  @doc """
+  Grants every known built-in permission key (core sections, feature-module
+  keys, sub-permission keys) to the Admin system role, skipping keys that
+  were auto-granted before (per-key settings flag) so an Owner's later
+  revocation is never overridden. Custom keys go through the same mechanism
+  at `register_custom_key/2` time.
+
+  Called after module discovery. This is also the repair path for installs
+  whose V53 seeding predates newer modules: the first boot after upgrade
+  fills the Admin role's missing keys, after which revocations stick
+  per-key. Idempotent; safe when the table doesn't exist yet.
+  """
+  @spec auto_grant_new_keys_to_admin() :: :ok
+  def auto_grant_new_keys_to_admin do
+    (@core_section_keys ++ feature_module_keys() ++ sub_permission_keys())
+    |> Enum.each(&auto_grant_to_admin_roles/1)
+
+    :ok
   end
 
   @doc """

--- a/lib/phoenix_kit/users/permissions.ex
+++ b/lib/phoenix_kit/users/permissions.ex
@@ -1105,17 +1105,7 @@ defmodule PhoenixKit.Users.Permissions do
     else
       case Roles.get_role_by_name(Role.system_roles().admin) do
         %{uuid: admin_uuid} when not is_nil(admin_uuid) ->
-          case grant_permission(admin_uuid, key, nil) do
-            {:ok, _} ->
-              Settings.update_setting(flag_key, "true")
-
-            {:error, _} ->
-              Logger.warning(
-                "[Permissions] grant_permission failed for Admin role on key #{inspect(key)}, will retry next boot"
-              )
-          end
-
-          :ok
+          maybe_auto_grant(admin_uuid, key, flag_key)
 
         _ ->
           # Admin role not found (pre-V53 or missing), skip
@@ -1133,6 +1123,33 @@ defmodule PhoenixKit.Users.Permissions do
       end
 
       :ok
+  end
+
+  # Auto-grant one key, but never let a NEW sub-key resurrect a base that an
+  # Owner has revoked from Admin. Granting a sub normally cascades a grant of
+  # its base (grant_sub_with_parent); at boot that would silently undo the
+  # revocation. So a sub is auto-granted only while Admin still holds its
+  # base — and when it doesn't, we skip WITHOUT flagging, so a later
+  # re-grant of the base lets the sub auto-grant on a subsequent boot.
+  defp maybe_auto_grant(admin_uuid, key, flag_key) do
+    parent = parent_key(key)
+
+    if parent && not role_has_permission?(admin_uuid, parent) do
+      :ok
+    else
+      case grant_permission(admin_uuid, key, nil) do
+        {:ok, _} ->
+          Settings.update_setting(flag_key, "true")
+          :ok
+
+        {:error, _} ->
+          Logger.warning(
+            "[Permissions] grant_permission failed for Admin role on key #{inspect(key)}, will retry next boot"
+          )
+
+          :ok
+      end
+    end
   end
 
   # Coerces a value to a string, returning the default for nil.

--- a/lib/phoenix_kit/users/permissions.ex
+++ b/lib/phoenix_kit/users/permissions.ex
@@ -551,13 +551,31 @@ defmodule PhoenixKit.Users.Permissions do
   end
 
   @doc """
-  Returns true when at least one permission row exists (any role, any key).
+  Whether the permissions table is present (migrated), regardless of how many
+  rows it holds.
 
-  Used to distinguish a genuinely unseeded install (pre-V53 / migrations not
-  yet run — the Admin role falls back to full access) from a seeded install
-  where an Owner has deliberately revoked keys. Returns `false` when the
-  table is missing.
+  This is the ONLY signal that unlocks the Admin full-access fallback: a
+  genuinely unmigrated install (pre-V53, table missing) returns `false`, and
+  scope treats that as "not yet seeded → grant Admin everything". Once the
+  table exists, zero rows for an Admin means an Owner deliberately revoked
+  them — no access — and that must stick; row COUNT must never re-open the
+  fallback (the old `any_permissions_exist?` did, so stripping every role
+  bare ironically restored full access).
+
+  Fails CLOSED: a transient/other query error returns `true` (table assumed
+  present), so a DB blip de-privileges an Admin to their explicit rows rather
+  than escalating them to full access.
   """
+  @spec permissions_table_ready?() :: boolean()
+  def permissions_table_ready? do
+    repo = RepoHelper.repo()
+    _ = repo.exists?(from(rp in RolePermission, select: true))
+    true
+  rescue
+    e -> not table_missing_error?(e)
+  end
+
+  @deprecated "Use permissions_table_ready?/0 — count-based checks re-open the full-access fallback"
   @spec any_permissions_exist?() :: boolean()
   def any_permissions_exist? do
     repo = RepoHelper.repo()

--- a/lib/phoenix_kit/users/permissions.ex
+++ b/lib/phoenix_kit/users/permissions.ex
@@ -743,29 +743,50 @@ defmodule PhoenixKit.Users.Permissions do
 
     role_uuid = resolve_role_uuid(role_uuid)
 
-    cond do
-      is_nil(role_uuid) ->
-        {:error, :role_not_found}
+    if is_nil(role_uuid) do
+      {:error, :role_not_found}
+    else
+      # Take the same advisory lock as revoke, so a base revoke's
+      # authorize-then-cascade can't interleave a concurrent sub grant. A
+      # sub-permission also pulls in its base — a sub row must never exist
+      # without module access, whatever path grants it. The base insert is an
+      # idempotent upsert, so an already-held base is unaffected.
+      base = base_key_of(module_key)
 
-      parent = parent_key(module_key) ->
-        grant_sub_with_parent(repo, role_uuid, parent, module_key, granted_by_uuid)
+      repo.transaction(fn ->
+        lock_role_module(repo, role_uuid, base)
 
-      true ->
-        grant_permission_insert(repo, role_uuid, module_key, granted_by_uuid)
+        outcome =
+          case parent_key(module_key) do
+            nil ->
+              grant_permission_insert(repo, role_uuid, module_key, granted_by_uuid)
+
+            parent ->
+              with {:ok, _base} <-
+                     grant_permission_insert(repo, role_uuid, parent, granted_by_uuid),
+                   {:ok, sub} <-
+                     grant_permission_insert(repo, role_uuid, module_key, granted_by_uuid) do
+                {:ok, sub}
+              end
+          end
+
+        case outcome do
+          {:ok, record} -> record
+          {:error, changeset} -> repo.rollback(changeset)
+        end
+      end)
     end
   end
 
-  # Grants base + sub atomically. The base insert is an idempotent upsert, so
-  # a role that already holds the base key is unaffected by it.
-  defp grant_sub_with_parent(repo, role_uuid, parent, module_key, granted_by_uuid) do
-    repo.transaction(fn ->
-      with {:ok, _base} <- grant_permission_insert(repo, role_uuid, parent, granted_by_uuid),
-           {:ok, sub} <- grant_permission_insert(repo, role_uuid, module_key, granted_by_uuid) do
-        sub
-      else
-        {:error, changeset} -> repo.rollback(changeset)
-      end
-    end)
+  defp base_key_of(module_key), do: parent_key(module_key) || module_key
+
+  # Transaction-scoped advisory lock serializing grant/revoke of one role's
+  # module tree (base + its sub-keys). Released automatically on commit/rollback.
+  defp lock_role_module(repo, role_uuid, base_key) do
+    repo.query!(
+      "SELECT pg_advisory_xact_lock(hashtext($1))",
+      ["pk_role_perm:#{role_uuid}:#{base_key}"]
+    )
   end
 
   defp grant_permission_insert(repo, role_uuid, module_key, granted_by_uuid) do
@@ -797,29 +818,63 @@ defmodule PhoenixKit.Users.Permissions do
   Revoking a base module key also revokes all of its sub-permission keys in
   the same statement — a sub-permission row must never outlive module access.
   Revoking a sub-permission key removes only that key.
+
+  Pass `authorized_keys: MapSet.t()` to restrict the revoke to keys the caller
+  is allowed to manage: the role's currently-held keys among the cascade are
+  read **inside the transaction under an advisory lock**, and if any falls
+  outside `authorized_keys` the whole revoke is rejected with `:unauthorized`.
+  This closes the race where a caller's cached view misses a concurrently
+  granted sub-key it doesn't hold. Omitted (or `:all`) skips the check — for
+  system/internal callers.
   """
-  @spec revoke_permission(integer() | String.t(), String.t()) :: :ok | {:error, :not_found}
-  def revoke_permission(role_uuid, module_key) do
+  @spec revoke_permission(integer() | String.t(), String.t(), keyword()) ::
+          :ok | {:error, :not_found | :unauthorized}
+  def revoke_permission(role_uuid, module_key, opts \\ []) do
     repo = RepoHelper.repo()
-
     role_uuid = resolve_role_uuid(role_uuid)
+    authorized = Keyword.get(opts, :authorized_keys, :all)
+    base = base_key_of(module_key)
 
-    keys_to_remove = [
-      module_key | Enum.map(sub_permissions_for(module_key), & &1.key)
-    ]
+    keys_to_remove = [module_key | Enum.map(sub_permissions_for(module_key), & &1.key)]
 
-    from(rp in RolePermission,
-      where: rp.role_uuid == ^role_uuid and rp.module_key in ^keys_to_remove
-    )
-    |> repo.delete_all()
+    repo.transaction(fn ->
+      # Serialize with concurrent grants of this role's module tree, then read
+      # what the role ACTUALLY holds under the lock — so authorization can't
+      # miss a sub-key granted after the caller's (cached) view was built, and
+      # the base's cascade can't drop a key the caller isn't allowed to manage.
+      lock_role_module(repo, role_uuid, base)
+
+      present =
+        from(rp in RolePermission,
+          where: rp.role_uuid == ^role_uuid and rp.module_key in ^keys_to_remove,
+          select: rp.module_key
+        )
+        |> repo.all()
+
+      cond do
+        present == [] ->
+          repo.rollback(:not_found)
+
+        authorized != :all and not MapSet.subset?(MapSet.new(present), authorized) ->
+          repo.rollback(:unauthorized)
+
+        true ->
+          from(rp in RolePermission,
+            where: rp.role_uuid == ^role_uuid and rp.module_key in ^keys_to_remove
+          )
+          |> repo.delete_all()
+
+          :revoked
+      end
+    end)
     |> case do
-      {0, _} ->
-        {:error, :not_found}
-
-      {_, _} ->
+      {:ok, :revoked} ->
         Events.broadcast_permission_revoked(role_uuid, module_key)
         notify_affected_users(role_uuid)
         :ok
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 

--- a/lib/phoenix_kit/users/permissions.ex
+++ b/lib/phoenix_kit/users/permissions.ex
@@ -840,6 +840,15 @@ defmodule PhoenixKit.Users.Permissions do
     repo.transaction(fn ->
       role_uuid = resolve_role_uuid(role_uuid)
 
+      # Lock the ROLE row FOR UPDATE first. Locking only the permission rows
+      # (below) is insufficient when the role currently has ZERO of them —
+      # there is nothing to lock, so two concurrent set_permissions calls both
+      # observe an empty set and insert disjoint desired sets, leaving their
+      # union rather than either requested state. The role-row lock serializes
+      # them regardless of how many permission rows exist.
+      from(r in Role, where: r.uuid == ^role_uuid, select: r.uuid, lock: "FOR UPDATE")
+      |> repo.one()
+
       # Lock existing permission rows FOR UPDATE to prevent concurrent set_permissions
       # from reading the same state and computing conflicting diffs.
       current_keys =

--- a/lib/phoenix_kit/users/roles.ex
+++ b/lib/phoenix_kit/users/roles.ex
@@ -888,6 +888,12 @@ defmodule PhoenixKit.Users.Roles do
   end
 
   defp count_remaining_owners(repo, excluding_user_uuid) do
+    # Serialize EVERY Owner-removal decision at this shared chokepoint (sync,
+    # safely_remove_role/demote all count here before removing an Owner), so two
+    # concurrent removals can't both observe one remaining Owner and leave zero.
+    # Transaction-scoped advisory lock, released on the outer commit/rollback.
+    repo.query!("SELECT pg_advisory_xact_lock(hashtext('phoenix_kit_last_owner_guard'))")
+
     roles = Role.system_roles()
 
     repo.one(
@@ -1021,6 +1027,13 @@ defmodule PhoenixKit.Users.Roles do
     actor = Keyword.get(opts, :actor, :system)
 
     case repo.transaction(fn ->
+           # Serialize concurrent role edits for THIS user (per-user key, so
+           # different users never contend), so before/after reflect only this
+           # transaction's changes — an exact audit, and no interleaving.
+           repo.query!("SELECT pg_advisory_xact_lock(hashtext($1))", [
+             "pk_user_roles:#{user.uuid}"
+           ])
+
            # The role set BEFORE this transaction's changes (read inside the
            # transaction, so it's the true baseline for an exact audit diff).
            roles_before = get_user_roles(user)
@@ -1081,17 +1094,10 @@ defmodule PhoenixKit.Users.Roles do
   defp guard_last_owner_removal(repo, %User{} = user, roles_to_remove) do
     owner = Role.system_roles().owner
 
-    if owner in roles_to_remove do
-      # Serialize concurrent Owner removals: without this, two transactions each
-      # removing a *different* Owner both count one other Owner remaining and
-      # both commit, leaving zero. The transaction-scoped advisory lock (released
-      # on commit/rollback) makes the count-then-delete atomic across sessions,
-      # so the second remover observes the first's committed deletion.
-      repo.query!("SELECT pg_advisory_xact_lock(hashtext('phoenix_kit_last_owner_guard'))")
-
-      if count_remaining_owners(repo, user.uuid) < 1 do
-        repo.rollback(:cannot_remove_last_owner)
-      end
+    # count_remaining_owners/2 takes the shared advisory lock, so the
+    # count-then-delete here is atomic against every other Owner-removal path.
+    if owner in roles_to_remove and count_remaining_owners(repo, user.uuid) < 1 do
+      repo.rollback(:cannot_remove_last_owner)
     end
   end
 

--- a/lib/phoenix_kit/users/roles.ex
+++ b/lib/phoenix_kit/users/roles.ex
@@ -981,18 +981,38 @@ defmodule PhoenixKit.Users.Roles do
 
   This function ensures the user has exactly the specified roles.
 
+  ## Authorization (`:actor` option)
+
+  This is the authorization boundary for role changes — **never** trust the
+  caller UI to have gated it. Pass `actor: %User{}` (the acting admin) and:
+
+  - Changes to the **system roles** (Owner, Admin) are applied only when the
+    actor is an Owner. A non-Owner's attempt to grant Owner/Admin to another
+    account (privilege escalation) or to strip them (the disabled-checkbox
+    form drops Owner from the submitted set, which would otherwise read as a
+    removal) is DROPPED — that role is left exactly as it was.
+  - The **last Owner** can never be removed, regardless of actor, via the
+    same guard as `safely_remove_role/2`.
+
+  Omitting `:actor` (or `actor: :system`) skips the actor gate — for
+  seeding/system callers only — but the last-Owner guard still applies.
+
   ## Parameters
 
   - `user`: The user to synchronize roles for
   - `role_names`: List of role names the user should have
+  - `opts`: `:actor` — the acting `%User{}` (see above)
 
   ## Examples
 
-      iex> sync_user_roles(user, ["Admin", "Manager"])
+      iex> sync_user_roles(user, ["Admin", "Manager"], actor: current_user)
       {:ok, [%RoleAssignment{}, %RoleAssignment{}]}
   """
-  def sync_user_roles(%User{} = user, role_names) when is_list(role_names) do
+  def sync_user_roles(user, role_names, opts \\ [])
+
+  def sync_user_roles(%User{} = user, role_names, opts) when is_list(role_names) do
     repo = RepoHelper.repo()
+    actor = Keyword.get(opts, :actor, :system)
 
     case repo.transaction(fn ->
            # Get current user roles
@@ -1001,6 +1021,16 @@ defmodule PhoenixKit.Users.Roles do
            # Determine roles to add and remove
            roles_to_add = role_names -- current_roles
            roles_to_remove = current_roles -- role_names
+
+           # Drop changes the actor isn't authorized to make (system-role
+           # grants/revocations require Owner). Silently leaving them
+           # unchanged matches the disabled-checkbox UI intent and blocks
+           # both escalation and the Owner-wipe.
+           roles_to_add = authorize_role_changes(roles_to_add, actor)
+           roles_to_remove = authorize_role_changes(roles_to_remove, actor)
+
+           # Guard the last Owner before any removal runs
+           guard_last_owner_removal(repo, user, roles_to_remove)
 
            # Remove roles that should not be present
            Enum.each(roles_to_remove, &remove_role_or_rollback(user, &1, repo))
@@ -1020,6 +1050,31 @@ defmodule PhoenixKit.Users.Roles do
 
       {:error, reason} ->
         {:error, reason}
+    end
+  end
+
+  # A system caller (:system) may change any role. A real actor may only
+  # change the system roles (Owner/Admin) if they are themselves an Owner.
+  defp authorize_role_changes(role_names, :system), do: role_names
+
+  defp authorize_role_changes(role_names, %User{} = actor) do
+    if owner?(actor) do
+      role_names
+    else
+      system = Role.system_roles()
+      privileged = [system.owner, system.admin]
+      Enum.reject(role_names, &(&1 in privileged))
+    end
+  end
+
+  defp owner?(%User{} = user), do: Role.system_roles().owner in get_user_roles(user)
+
+  # Blocks removing the final active Owner, mirroring safely_remove_role/2.
+  defp guard_last_owner_removal(repo, %User{} = user, roles_to_remove) do
+    owner = Role.system_roles().owner
+
+    if owner in roles_to_remove and count_remaining_owners(repo, user.uuid) < 1 do
+      repo.rollback(:cannot_remove_last_owner)
     end
   end
 

--- a/lib/phoenix_kit/users/roles.ex
+++ b/lib/phoenix_kit/users/roles.ex
@@ -1003,10 +1003,16 @@ defmodule PhoenixKit.Users.Roles do
   - `role_names`: List of role names the user should have
   - `opts`: `:actor` — the acting `%User{}` (see above)
 
+  Returns `{:ok, %{assignments: [...], roles_before: [...], roles_after: [...]}}`
+  on success — `roles_before`/`roles_after` are the role-name lists captured
+  inside the transaction, so callers can audit the exact delta this transaction
+  applied (which can differ from what was submitted when unauthorized changes
+  are dropped or a concurrent edit intervened).
+
   ## Examples
 
       iex> sync_user_roles(user, ["Admin", "Manager"], actor: current_user)
-      {:ok, [%RoleAssignment{}, %RoleAssignment{}]}
+      {:ok, %{assignments: [%RoleAssignment{}], roles_before: ["Manager"], roles_after: ["Admin", "Manager"]}}
   """
   def sync_user_roles(user, role_names, opts \\ [])
 
@@ -1015,12 +1021,13 @@ defmodule PhoenixKit.Users.Roles do
     actor = Keyword.get(opts, :actor, :system)
 
     case repo.transaction(fn ->
-           # Get current user roles
-           current_roles = get_user_roles(user)
+           # The role set BEFORE this transaction's changes (read inside the
+           # transaction, so it's the true baseline for an exact audit diff).
+           roles_before = get_user_roles(user)
 
            # Determine roles to add and remove
-           roles_to_add = role_names -- current_roles
-           roles_to_remove = current_roles -- role_names
+           roles_to_add = role_names -- roles_before
+           roles_to_remove = roles_before -- role_names
 
            # Drop changes the actor isn't authorized to make (system-role
            # grants/revocations require Owner). Silently leaving them
@@ -1038,15 +1045,16 @@ defmodule PhoenixKit.Users.Roles do
            # Add roles that should be present
            assignments = Enum.map(roles_to_add, &assign_role_or_rollback(user, &1, repo))
 
-           new_user_roles = get_user_roles(user)
+           # The role set AFTER, still inside the transaction.
+           roles_after = get_user_roles(user)
 
-           %{assignments: assignments, new_user_roles: new_user_roles}
+           %{assignments: assignments, roles_before: roles_before, roles_after: roles_after}
          end) do
-      {:ok, %{assignments: assignments, new_user_roles: new_user_roles}} ->
-        Events.broadcast_user_roles_synced(user, new_user_roles)
+      {:ok, %{roles_after: roles_after} = result} ->
+        Events.broadcast_user_roles_synced(user, roles_after)
         ScopeNotifier.broadcast_roles_updated(user)
 
-        {:ok, assignments}
+        {:ok, result}
 
       {:error, reason} ->
         {:error, reason}
@@ -1073,8 +1081,17 @@ defmodule PhoenixKit.Users.Roles do
   defp guard_last_owner_removal(repo, %User{} = user, roles_to_remove) do
     owner = Role.system_roles().owner
 
-    if owner in roles_to_remove and count_remaining_owners(repo, user.uuid) < 1 do
-      repo.rollback(:cannot_remove_last_owner)
+    if owner in roles_to_remove do
+      # Serialize concurrent Owner removals: without this, two transactions each
+      # removing a *different* Owner both count one other Owner remaining and
+      # both commit, leaving zero. The transaction-scoped advisory lock (released
+      # on commit/rollback) makes the count-then-delete atomic across sessions,
+      # so the second remover observes the first's committed deletion.
+      repo.query!("SELECT pg_advisory_xact_lock(hashtext('phoenix_kit_last_owner_guard'))")
+
+      if count_remaining_owners(repo, user.uuid) < 1 do
+        repo.rollback(:cannot_remove_last_owner)
+      end
     end
   end
 

--- a/lib/phoenix_kit_web.ex
+++ b/lib/phoenix_kit_web.ex
@@ -149,6 +149,7 @@ defmodule PhoenixKitWeb do
       import PhoenixKitWeb.Components.Core.PkLink
       import PhoenixKitWeb.Components.Core.Modal
       import PhoenixKitWeb.Components.Core.PopoverPanel
+      import PhoenixKitWeb.Components.Core.SearchPicker
       import PhoenixKitWeb.Components.Core.MediaThumbnail
       import PhoenixKitWeb.Components.Core.AdminPageHeader
       import PhoenixKitWeb.Components.Core.UserDashboardHeader

--- a/lib/phoenix_kit_web.ex
+++ b/lib/phoenix_kit_web.ex
@@ -148,6 +148,7 @@ defmodule PhoenixKitWeb do
       import PhoenixKitWeb.Components.Core.DraggableList
       import PhoenixKitWeb.Components.Core.PkLink
       import PhoenixKitWeb.Components.Core.Modal
+      import PhoenixKitWeb.Components.Core.PopoverPanel
       import PhoenixKitWeb.Components.Core.MediaThumbnail
       import PhoenixKitWeb.Components.Core.AdminPageHeader
       import PhoenixKitWeb.Components.Core.UserDashboardHeader

--- a/lib/phoenix_kit_web/components/core/admin_page_header.ex
+++ b/lib/phoenix_kit_web/components/core/admin_page_header.ex
@@ -55,12 +55,20 @@ defmodule PhoenixKitWeb.Components.Core.AdminPageHeader do
   attr :title, :string, default: nil
   attr :subtitle, :string, default: nil
 
+  attr :class, :string,
+    default: nil,
+    doc: """
+    Replaces the header's default bottom margin (`"mb-3 sm:mb-6"`) when set —
+    pass e.g. `"mb-0"` when the page layout controls spacing itself (a flex
+    gap), so margins don't compound.
+    """
+
   slot :inner_block
   slot :actions
 
   def admin_page_header(assigns) do
     ~H"""
-    <header class="mb-3 sm:mb-6">
+    <header class={@class || "mb-3 sm:mb-6"}>
       <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
         <div class="flex items-center gap-3 min-w-0">
           <div class="min-w-0">

--- a/lib/phoenix_kit_web/components/core/checkbox.ex
+++ b/lib/phoenix_kit_web/components/core/checkbox.ex
@@ -16,7 +16,11 @@ defmodule PhoenixKitWeb.Components.Core.Checkbox do
   attr :name, :any
   attr :label, :string, default: nil
   attr :errors, :list, default: []
-  attr :checked, :boolean, default: false
+  # nil (the default) means "derive from the field's value". A non-nil
+  # default would defeat that: attr defaults are materialized into assigns
+  # before the component runs, so `assign_new` in the field clause would
+  # never fire and a field-bound checkbox would ALWAYS render unchecked.
+  attr :checked, :boolean, default: nil
 
   attr :class, :any,
     default: nil,
@@ -28,12 +32,12 @@ defmodule PhoenixKitWeb.Components.Core.Checkbox do
   slot :inner_block
 
   def checkbox(%{field: %Phoenix.HTML.FormField{} = field} = assigns) do
-    checked = Form.normalize_value("checkbox", field.value)
+    derived = Form.normalize_value("checkbox", field.value)
 
     assigns
     |> assign(field: nil, id: assigns.id || field.id)
     |> assign_new(:name, fn -> field.name end)
-    |> assign_new(:checked, fn -> checked end)
+    |> assign(:checked, if(is_nil(assigns.checked), do: derived, else: assigns.checked))
     |> checkbox()
   end
 

--- a/lib/phoenix_kit_web/components/core/popover_panel.ex
+++ b/lib/phoenix_kit_web/components/core/popover_panel.ex
@@ -1,0 +1,109 @@
+defmodule PhoenixKitWeb.Components.Core.PopoverPanel do
+  @moduledoc """
+  An anchored popover panel for arbitrary rich content — filter panels,
+  pickers, mini-forms — with click-away and Escape-to-close.
+
+  Unlike `TableRowMenu` (a JS-hook dropdown for short action lists), this
+  is LiveView-state-driven and holds any markup: forms, search inputs,
+  scrollable checklists. The open/close state lives in the caller's
+  assigns, so the panel survives re-renders and interacting with inputs
+  inside it never closes it.
+
+  ## Layout contract
+
+  Render the panel INSIDE a `relative` wrapper next to its trigger; on
+  `sm+` screens the card anchors under the trigger (aligned via `:align`),
+  while on small screens it becomes a full-screen overlay with a dimmed
+  backdrop. The click-away backdrop always paints BELOW the card (the card
+  is `relative z-10` over the `fixed` backdrop — keeping that ordering is
+  what makes clicks and scrolls inside the panel safe).
+
+  ## Example
+
+      <div class="relative">
+        <button type="button" phx-click="toggle_panel" class="btn btn-sm">
+          Filters
+        </button>
+
+        <.popover_panel :if={@panel_open} id="my-filters" on_close="close_panel">
+          <form phx-change="search">…</form>
+          <ul class="max-h-80 overflow-y-auto">…</ul>
+        </.popover_panel>
+      </div>
+
+  The caller owns the state:
+
+      def handle_event("toggle_panel", _p, socket),
+        do: {:noreply, assign(socket, :panel_open, not socket.assigns.panel_open)}
+
+      def handle_event("close_panel", _p, socket),
+        do: {:noreply, assign(socket, :panel_open, false)}
+  """
+
+  use Phoenix.Component
+
+  @doc """
+  Renders the anchored popover panel.
+
+  ## Attributes
+
+  - `id` - DOM id (required)
+  - `on_close` - event pushed on backdrop click and Escape (required)
+  - `align` - which trigger edge the card hugs on `sm+`: `"end"` (right,
+    default) or `"start"` (left)
+  - `width_class` - card width on `sm+` (default `"sm:w-96"`); complete
+    class strings only (Tailwind purge)
+  - `class` - extra classes merged onto the card
+
+  ## Slots
+
+  - `inner_block` - the panel content (required)
+  """
+  attr :id, :string, required: true
+  attr :on_close, :string, required: true
+  attr :align, :string, default: "end", values: ["end", "start"]
+  attr :width_class, :string, default: "sm:w-96"
+  attr :class, :string, default: nil
+
+  slot :inner_block, required: true
+
+  def popover_panel(assigns) do
+    ~H"""
+    <div
+      id={@id}
+      class={[
+        "fixed inset-0 z-40 sm:absolute sm:inset-auto sm:top-full sm:mt-2",
+        align_class(@align)
+      ]}
+      phx-window-keydown={@on_close}
+      phx-key="escape"
+      role="dialog"
+      aria-modal="true"
+    >
+      <%!-- click-away backdrop: dims on mobile, invisible on desktop.
+           It must stay BELOW the card (see moduledoc). --%>
+      <div
+        class="fixed inset-0 bg-base-content/30 sm:bg-transparent"
+        phx-click={@on_close}
+        aria-hidden="true"
+      >
+      </div>
+
+      <div class={[
+        "absolute inset-x-2 top-12 z-10",
+        "sm:relative sm:inset-auto sm:top-auto",
+        @width_class,
+        "card bg-base-100 shadow-xl border border-base-content/10",
+        @class
+      ]}>
+        {render_slot(@inner_block)}
+      </div>
+    </div>
+    """
+  end
+
+  # The wrapper is a full-viewport fixed layer on mobile; on sm+ it collapses
+  # to an absolute anchor under the trigger, hugging the chosen edge.
+  defp align_class("start"), do: "sm:left-0"
+  defp align_class(_end), do: "sm:right-0"
+end

--- a/lib/phoenix_kit_web/components/core/popover_panel.ex
+++ b/lib/phoenix_kit_web/components/core/popover_panel.ex
@@ -66,7 +66,8 @@ defmodule PhoenixKitWeb.Components.Core.PopoverPanel do
   def hide_popover(js \\ %JS{}, id) do
     JS.hide(js,
       to: "##{id}",
-      transition: {"transition ease-in duration-75", "opacity-100 scale-100", "opacity-0 scale-95"}
+      transition:
+        {"transition ease-in duration-75", "opacity-100 scale-100", "opacity-0 scale-95"}
     )
   end
 

--- a/lib/phoenix_kit_web/components/core/popover_panel.ex
+++ b/lib/phoenix_kit_web/components/core/popover_panel.ex
@@ -1,54 +1,82 @@
 defmodule PhoenixKitWeb.Components.Core.PopoverPanel do
   @moduledoc """
   An anchored popover panel for arbitrary rich content — filter panels,
-  pickers, mini-forms — with click-away and Escape-to-close.
+  pickers, mini-forms — that opens INSTANTLY.
+
+  Open/close is pure client-side (`Phoenix.LiveView.JS`): the panel is
+  always rendered (hidden), and the trigger toggles it without a server
+  round-trip, so there is no perceptible delay and nothing to spin on.
+  Backdrop click and Escape hide it the same way. LiveView's JS commands
+  are DOM-patch aware, so server re-renders (e.g. the panel's own
+  interactions updating assigns) don't flip the panel shut.
 
   Unlike `TableRowMenu` (a JS-hook dropdown for short action lists), this
-  is LiveView-state-driven and holds any markup: forms, search inputs,
-  scrollable checklists. The open/close state lives in the caller's
-  assigns, so the panel survives re-renders and interacting with inputs
-  inside it never closes it.
+  holds any markup: forms, search inputs, scrollable checklists —
+  interacting inside never closes it (the click-away backdrop paints
+  BELOW the card; keep that stacking).
 
   ## Layout contract
 
   Render the panel INSIDE a `relative` wrapper next to its trigger; on
   `sm+` screens the card anchors under the trigger (aligned via `:align`),
   while on small screens it becomes a full-screen overlay with a dimmed
-  backdrop. The click-away backdrop always paints BELOW the card (the card
-  is `relative z-10` over the `fixed` backdrop — keeping that ordering is
-  what makes clicks and scrolls inside the panel safe).
+  backdrop.
 
   ## Example
 
       <div class="relative">
-        <button type="button" phx-click="toggle_panel" class="btn btn-sm">
+        <button type="button" phx-click={toggle_popover("my-filters")} class="btn btn-sm">
           Filters
         </button>
 
-        <.popover_panel :if={@panel_open} id="my-filters" on_close="close_panel">
+        <.popover_panel id="my-filters">
           <form phx-change="search">…</form>
           <ul class="max-h-80 overflow-y-auto">…</ul>
         </.popover_panel>
       </div>
 
-  The caller owns the state:
+  Since content inside still talks to the server, give those interactions
+  their own loading affordances, e.g. a spinner revealed by the form's
+  `phx-change-loading` class:
 
-      def handle_event("toggle_panel", _p, socket),
-        do: {:noreply, assign(socket, :panel_open, not socket.assigns.panel_open)}
-
-      def handle_event("close_panel", _p, socket),
-        do: {:noreply, assign(socket, :panel_open, false)}
+      <span class={["loading loading-spinner loading-xs invisible",
+                    "[.phx-change-loading_&]:visible"]} />
   """
 
   use Phoenix.Component
 
+  alias Phoenix.LiveView.JS
+
   @doc """
-  Renders the anchored popover panel.
+  Client-side command that toggles the panel with a quick fade/scale.
+  Attach to the trigger's `phx-click` (composable with other JS commands).
+  """
+  def toggle_popover(js \\ %JS{}, id) do
+    JS.toggle(js,
+      to: "##{id}",
+      in: {"transition ease-out duration-100", "opacity-0 scale-95", "opacity-100 scale-100"},
+      out: {"transition ease-in duration-75", "opacity-100 scale-100", "opacity-0 scale-95"}
+    )
+  end
+
+  @doc """
+  Client-side command that hides the panel. Used internally by the
+  backdrop and Escape; exposed for custom close buttons inside the panel.
+  """
+  def hide_popover(js \\ %JS{}, id) do
+    JS.hide(js,
+      to: "##{id}",
+      transition: {"transition ease-in duration-75", "opacity-100 scale-100", "opacity-0 scale-95"}
+    )
+  end
+
+  @doc """
+  Renders the (initially hidden) popover panel. Toggle it with
+  `toggle_popover/2` on the trigger.
 
   ## Attributes
 
-  - `id` - DOM id (required)
-  - `on_close` - event pushed on backdrop click and Escape (required)
+  - `id` - DOM id (required; the toggle/hide commands target it)
   - `align` - which trigger edge the card hugs on `sm+`: `"end"` (right,
     default) or `"start"` (left)
   - `width_class` - card width on `sm+` (default `"sm:w-96"`); complete
@@ -60,7 +88,6 @@ defmodule PhoenixKitWeb.Components.Core.PopoverPanel do
   - `inner_block` - the panel content (required)
   """
   attr :id, :string, required: true
-  attr :on_close, :string, required: true
   attr :align, :string, default: "end", values: ["end", "start"]
   attr :width_class, :string, default: "sm:w-96"
   attr :class, :string, default: nil
@@ -72,19 +99,20 @@ defmodule PhoenixKitWeb.Components.Core.PopoverPanel do
     <div
       id={@id}
       class={[
-        "fixed inset-0 z-40 sm:absolute sm:inset-auto sm:top-full sm:mt-2",
+        "hidden fixed inset-0 z-40 sm:absolute sm:inset-auto sm:top-full sm:mt-2",
         align_class(@align)
       ]}
-      phx-window-keydown={@on_close}
+      phx-window-keydown={hide_popover(@id)}
       phx-key="escape"
       role="dialog"
       aria-modal="true"
     >
       <%!-- click-away backdrop: dims on mobile, invisible on desktop.
-           It must stay BELOW the card (see moduledoc). --%>
+           It must stay BELOW the card — with the card static the backdrop
+           paints on top and swallows every click/scroll inside the panel. --%>
       <div
         class="fixed inset-0 bg-base-content/30 sm:bg-transparent"
-        phx-click={@on_close}
+        phx-click={hide_popover(@id)}
         aria-hidden="true"
       >
       </div>

--- a/lib/phoenix_kit_web/components/core/search_picker.ex
+++ b/lib/phoenix_kit_web/components/core/search_picker.ex
@@ -37,10 +37,13 @@ defmodule PhoenixKitWeb.Components.Core.SearchPicker do
       <.search_picker
         id="party-search"
         dropdown_id="party-dropdown"
-        target={"#\#{@id}"}
         text_event="stage_text"
         placeholder={gettext("Type a name…")}
       />
+
+  Events auto-route to the closest LiveComponent/LiveView containing the
+  input — no target needed when the picker renders inside the component
+  that handles its events.
 
   The chips themselves stay consumer-rendered — their look and remove
   semantics differ per feature.
@@ -55,9 +58,12 @@ defmodule PhoenixKitWeb.Components.Core.SearchPicker do
 
   - `id` — input DOM id (required; must be page-unique)
   - `dropdown_id` — dropdown DOM id (required)
-  - `target` — CSS selector of the element whose LiveComponent should
-    receive the pushed events (e.g. `"#my-component"`). Omit to auto-route
-    to the closest LiveComponent/LiveView containing the input.
+  - `target` — CSS selector of an element inside the LiveComponent that
+    should receive the pushed events. ONLY needed when the picker renders
+    OUTSIDE that component's DOM tree; omitted, events auto-route to the
+    closest LiveComponent/LiveView containing the input (the usual case).
+    The selector must actually match an element or every push is dropped
+    with a console error.
   - `mode` — `"multi"` (default) or `"single"` (see moduledoc)
   - `name`/`value` — form field wiring for single mode
   - `search_event` / `results_event` / `pick_event` / `text_event` /

--- a/lib/phoenix_kit_web/components/core/search_picker.ex
+++ b/lib/phoenix_kit_web/components/core/search_picker.ex
@@ -24,6 +24,15 @@ defmodule PhoenixKitWeb.Components.Core.SearchPicker do
     `%{"name" => text}` — the "Add … as text" row renders only when this
     attr is set.
 
+  ## Multiple pickers in one view
+
+  `push_event` replies broadcast to EVERY hook listening on the event
+  name, so two pickers sharing names would cross-populate (and a staged
+  confirm would clear both). Give each picker distinct event names — or
+  keep shared names and echo the `id` the hook sends with every push
+  (`%{"id" => input_id}`) back in the results/staged payloads; when
+  present, each instance drops payloads addressed to another `id`.
+
   ## Single-select mode
 
   `mode="single"` turns the picker into a suggestion box for ONE value: a

--- a/lib/phoenix_kit_web/components/core/search_picker.ex
+++ b/lib/phoenix_kit_web/components/core/search_picker.ex
@@ -74,6 +74,11 @@ defmodule PhoenixKitWeb.Components.Core.SearchPicker do
     The selector must actually match an element or every push is dropped
     with a console error.
   - `mode` — `"multi"` (default) or `"single"` (see moduledoc)
+  - `direction` — `"down"` (default) or `"up"`. Use `"up"` when the input
+    sits near the BOTTOM of a scrollable container (e.g. the last field
+    of a modal): a downward dropdown there extends the container's
+    scroll area instead of floating, so the suggestions end up below the
+    fold — users read that as "no suggestions".
   - `name`/`value` — form field wiring for single mode
   - `search_event` / `results_event` / `pick_event` / `text_event` /
     `staged_event` — event-name overrides (defaults in moduledoc;
@@ -85,6 +90,7 @@ defmodule PhoenixKitWeb.Components.Core.SearchPicker do
   attr :dropdown_id, :string, required: true
   attr :target, :any, default: nil
   attr :mode, :string, default: "multi", values: ["multi", "single"]
+  attr :direction, :string, default: "down", values: ["down", "up"]
   attr :name, :string, default: nil
   attr :value, :string, default: nil
   attr :search_event, :string, default: "picker_search"
@@ -135,7 +141,10 @@ defmodule PhoenixKitWeb.Components.Core.SearchPicker do
       <div
         id={@dropdown_id}
         phx-update="ignore"
-        class="hidden absolute left-0 right-0 z-20 mt-1 border border-base-200 rounded-box bg-base-100 shadow overflow-hidden"
+        class={[
+          "hidden absolute left-0 right-0 z-20 border border-base-200 rounded-box bg-base-100 shadow overflow-hidden",
+          if(@direction == "up", do: "bottom-full mb-1", else: "top-full mt-1")
+        ]}
       >
       </div>
       <%!-- Keep the hook's client-rendered classes in the CSS bundle. --%>

--- a/lib/phoenix_kit_web/components/core/search_picker.ex
+++ b/lib/phoenix_kit_web/components/core/search_picker.ex
@@ -1,0 +1,129 @@
+defmodule PhoenixKitWeb.Components.Core.SearchPicker do
+  @moduledoc """
+  A generic instant typeahead for "search a source, pick an entry" fields —
+  extracted from `phoenix_kit_crm`'s involved-parties picker.
+
+  The dropdown opens, spins, and renders ENTIRELY client-side (the
+  `SearchPicker` hook in `phoenix_kit.js`); the server only executes the
+  actual search and returns rows via `push_event`. Nothing visual waits on
+  a round-trip.
+
+  ## Contract
+
+  The consumer (LiveView or LiveComponent) implements:
+
+  - a **search event** (`search_event`, default `"picker_search"`) receiving
+    `%{"q" => query, "limit" => limit}` and answering with
+    `push_event(socket, results_event, %{q: query, results: rows, has_more: bool})`
+    where each row is `%{kind:, uuid:, label:, sublabel?, icon?}` (icon =
+    a heroicon class, defaults to `hero-user`);
+  - a **pick event** (`pick_event`, default `"picker_pick"`) receiving
+    `%{"kind" =>, "uuid" =>, "label" =>}` — stage your chip, then confirm
+    with `push_event(socket, staged_event, %{})` so the hook clears the input;
+  - optionally a **free-text event** (`text_event`) receiving
+    `%{"name" => text}` — the "Add … as text" row renders only when this
+    attr is set.
+
+  ## Single-select mode
+
+  `mode="single"` turns the picker into a suggestion box for ONE value: a
+  pick sets the input's value client-side and fires a synthetic input event
+  so a surrounding form's `phx-change` (and any server-side value→id
+  mapping) sees it. No pick/staged events, no chips — give the input a form
+  `name` and it submits like any field.
+
+  ## Example (multi, inside a LiveComponent)
+
+      <.search_picker
+        id="party-search"
+        dropdown_id="party-dropdown"
+        target={"#\#{@id}"}
+        text_event="stage_text"
+        placeholder={gettext("Type a name…")}
+      />
+
+  The chips themselves stay consumer-rendered — their look and remove
+  semantics differ per feature.
+  """
+
+  use Phoenix.Component
+
+  @doc """
+  Renders the picker input + its client-rendered dropdown container.
+
+  ## Attributes
+
+  - `id` — input DOM id (required; must be page-unique)
+  - `dropdown_id` — dropdown DOM id (required)
+  - `target` — CSS selector of the element whose LiveComponent should
+    receive the pushed events (e.g. `"#my-component"`). Omit to auto-route
+    to the closest LiveComponent/LiveView containing the input.
+  - `mode` — `"multi"` (default) or `"single"` (see moduledoc)
+  - `name`/`value` — form field wiring for single mode
+  - `search_event` / `results_event` / `pick_event` / `text_event` /
+    `staged_event` — event-name overrides (defaults in moduledoc;
+    `text_event` nil = no free-text row)
+  - `placeholder`, `class` — input presentation
+  - `searching_label` etc. — translated strings for the client-rendered rows
+  """
+  attr :id, :string, required: true
+  attr :dropdown_id, :string, required: true
+  attr :target, :any, default: nil
+  attr :mode, :string, default: "multi", values: ["multi", "single"]
+  attr :name, :string, default: nil
+  attr :value, :string, default: nil
+  attr :search_event, :string, default: "picker_search"
+  attr :results_event, :string, default: "picker_results"
+  attr :pick_event, :string, default: "picker_pick"
+  attr :text_event, :string, default: nil
+  attr :staged_event, :string, default: "picker_staged"
+  attr :placeholder, :string, default: nil
+  attr :class, :any, default: "input input-bordered w-full"
+  attr :searching_label, :string, default: "Searching…"
+  attr :add_prefix_label, :string, default: "Add"
+  attr :add_suffix_label, :string, default: "as text"
+  attr :adding_label, :string, default: "Adding…"
+  attr :more_label, :string, default: "Load more"
+  attr :loading_more_label, :string, default: "Loading…"
+  attr :rest, :global
+
+  def search_picker(assigns) do
+    ~H"""
+    <div class="relative">
+      <input
+        type="text"
+        id={@id}
+        name={@name}
+        value={@value}
+        phx-hook="SearchPicker"
+        data-target={@target}
+        data-dropdown={@dropdown_id}
+        data-mode={@mode}
+        data-search-event={@search_event}
+        data-results-event={@results_event}
+        data-pick-event={@pick_event}
+        data-text-event={@text_event}
+        data-staged-event={@staged_event}
+        data-t-searching={@searching_label}
+        data-t-add-prefix={@add_prefix_label}
+        data-t-add-suffix={@add_suffix_label}
+        data-t-adding={@adding_label}
+        data-t-more={@more_label}
+        data-t-loading-more={@loading_more_label}
+        placeholder={@placeholder}
+        class={@class}
+        autocomplete="off"
+        {@rest}
+      />
+      <div
+        id={@dropdown_id}
+        phx-update="ignore"
+        class="hidden absolute left-0 right-0 z-20 mt-1 border border-base-200 rounded-box bg-base-100 shadow overflow-hidden"
+      >
+      </div>
+      <%!-- Keep the hook's client-rendered classes in the CSS bundle. --%>
+      <span class="hidden loading loading-spinner loading-xs hero-user hero-plus-mini"></span>
+    </div>
+    """
+  end
+end

--- a/lib/phoenix_kit_web/components/core/search_picker.ex
+++ b/lib/phoenix_kit_web/components/core/search_picker.ex
@@ -100,6 +100,7 @@ defmodule PhoenixKitWeb.Components.Core.SearchPicker do
   attr :adding_label, :string, default: "Adding…"
   attr :more_label, :string, default: "Load more"
   attr :loading_more_label, :string, default: "Loading…"
+  attr :no_matches_label, :string, default: "No matches"
   attr :rest, :global
 
   def search_picker(assigns) do
@@ -125,6 +126,7 @@ defmodule PhoenixKitWeb.Components.Core.SearchPicker do
         data-t-adding={@adding_label}
         data-t-more={@more_label}
         data-t-loading-more={@loading_more_label}
+        data-t-no-matches={@no_matches_label}
         placeholder={@placeholder}
         class={@class}
         autocomplete="off"

--- a/lib/phoenix_kit_web/live/users/permissions_matrix.ex
+++ b/lib/phoenix_kit_web/live/users/permissions_matrix.ex
@@ -83,7 +83,11 @@ defmodule PhoenixKitWeb.Live.Users.PermissionsMatrix do
           do: MapSet.new(Permissions.all_module_keys()),
           else: Scope.accessible_modules(scope)
 
-      if MapSet.member?(grantable, key) do
+      # Granting a sub-permission auto-grants its base key, so the editor
+      # must hold every key the toggle implies — not just the clicked one.
+      # Otherwise an editor holding only "calendar.view_others" could smuggle
+      # in a "calendar" base grant they don't hold themselves.
+      if MapSet.subset?(Permissions.expand_with_parents([key]), grantable) do
         toggle_role_permission(socket, role, key, scope)
       else
         {:noreply, put_flash(socket, :error, gettext("You can only manage permissions you have"))}
@@ -185,9 +189,21 @@ defmodule PhoenixKitWeb.Live.Users.PermissionsMatrix do
     enabled_feature_keys =
       Enum.filter(Permissions.feature_module_keys(), &MapSet.member?(enabled, &1))
 
+    # Sub-permissions render as indented rows under their (enabled) module row
+    sub_permissions =
+      enabled_feature_keys
+      |> Enum.map(&{&1, Permissions.sub_permissions_for(&1)})
+      |> Enum.reject(fn {_key, subs} -> subs == [] end)
+      |> Map.new()
+
+    enabled_sub_keys =
+      sub_permissions |> Map.values() |> List.flatten() |> Enum.map(& &1.key)
+
     core_keys = Permissions.core_section_keys()
     custom_keys = Permissions.custom_keys()
-    visible_keys = MapSet.new(core_keys ++ enabled_feature_keys ++ custom_keys)
+
+    visible_keys =
+      MapSet.new(core_keys ++ enabled_feature_keys ++ enabled_sub_keys ++ custom_keys)
 
     # Determine which roles can't be edited by the current user
     scope = socket.assigns[:phoenix_kit_current_scope]
@@ -204,6 +220,7 @@ defmodule PhoenixKitWeb.Live.Users.PermissionsMatrix do
     |> assign(:matrix, matrix)
     |> assign(:core_keys, core_keys)
     |> assign(:feature_keys, enabled_feature_keys)
+    |> assign(:sub_permissions, sub_permissions)
     |> assign(:custom_keys, custom_keys)
     |> assign(:visible_keys, visible_keys)
     |> assign(:uneditable_role_uuids, uneditable_role_uuids)
@@ -213,6 +230,67 @@ defmodule PhoenixKitWeb.Live.Users.PermissionsMatrix do
   defp refresh_matrix(socket) do
     matrix = Permissions.get_permissions_matrix()
     assign(socket, :matrix, matrix)
+  end
+
+  # --- Template Components ---
+
+  attr :key, :string, required: true
+  attr :label, :string, required: true
+  attr :sub, :boolean, default: false
+  attr :roles, :list, required: true
+  attr :matrix, :map, required: true
+  attr :uneditable_role_uuids, :any, required: true
+
+  # One matrix row: label cell + a toggle/read-only cell per role.
+  # `sub` renders the indented variant used for sub-permission keys.
+  defp permission_row(assigns) do
+    ~H"""
+    <tr>
+      <td class={[
+        "sticky left-0 z-[1] whitespace-nowrap",
+        (@sub && "pl-8 text-sm text-base-content/80") || "font-medium"
+      ]}>
+        <.icon
+          :if={@sub}
+          name="hero-arrow-turn-down-right"
+          class="w-3.5 h-3.5 text-base-content/40 mr-1"
+        />{@label}
+      </td>
+      <td :for={role <- @roles} class="text-center">
+        <%= if role.name == "Owner" do %>
+          <span class="badge badge-sm badge-primary badge-outline">
+            {gettext("always")}
+          </span>
+        <% else %>
+          <%= if MapSet.member?(@uneditable_role_uuids, to_string(role.uuid)) do %>
+            <%!-- Read-only: user's own role or Admin (non-Owner) --%>
+            <%= if granted?(@matrix, role, @key) do %>
+              <.icon name="hero-check-circle" class="w-5 h-5 text-success/50" />
+            <% else %>
+              <.icon name="hero-x-circle" class="w-5 h-5 text-base-content/10" />
+            <% end %>
+          <% else %>
+            <button
+              phx-click="toggle_permission"
+              phx-value-role_uuid={role.uuid}
+              phx-value-key={@key}
+              class="cursor-pointer hover:opacity-70 transition-opacity"
+            >
+              <%= if granted?(@matrix, role, @key) do %>
+                <.icon name="hero-check-circle" class="w-5 h-5 text-success" />
+              <% else %>
+                <.icon name="hero-x-circle" class="w-5 h-5 text-base-content/20" />
+              <% end %>
+            </button>
+          <% end %>
+        <% end %>
+      </td>
+    </tr>
+    """
+  end
+
+  defp granted?(matrix, role, key) do
+    Map.get(matrix, to_string(role.uuid), MapSet.new()) |> MapSet.member?(key)
   end
 
   defp permission_error_message(:not_authenticated), do: gettext("Not authenticated")

--- a/lib/phoenix_kit_web/live/users/permissions_matrix.ex
+++ b/lib/phoenix_kit_web/live/users/permissions_matrix.ex
@@ -91,7 +91,7 @@ defmodule PhoenixKitWeb.Live.Users.PermissionsMatrix do
       # too, or an editor without "calendar.edit_others" could strip it from a
       # role by revoking the "calendar" base.
       if MapSet.subset?(affected_keys(key, role_key_set), grantable) do
-        toggle_role_permission(socket, role, key, scope)
+        toggle_role_permission(socket, role, key, scope, grantable)
       else
         {:noreply, put_flash(socket, :error, gettext("You can only manage permissions you have"))}
       end
@@ -131,14 +131,18 @@ defmodule PhoenixKitWeb.Live.Users.PermissionsMatrix do
     end
   end
 
-  defp toggle_role_permission(socket, role, key, scope) do
+  defp toggle_role_permission(socket, role, key, scope, grantable) do
     granted_by_uuid = Scope.user_uuid(scope)
     role_uuid = to_string(role.uuid)
     role_keys = Map.get(socket.assigns.matrix, role_uuid, MapSet.new())
     label = Permissions.module_label(key)
 
     if MapSet.member?(role_keys, key) do
-      case Permissions.revoke_permission(role_uuid, key) do
+      # Authoritative, race-free revoke authorization: the context re-checks the
+      # role's actual held keys under a lock (the cached matrix above can be
+      # stale). `:unauthorized` means a concurrently-granted sub-key would have
+      # been cascaded — refresh so the editor sees the current state.
+      case Permissions.revoke_permission(role_uuid, key, authorized_keys: grantable) do
         :ok ->
           {:noreply,
            socket
@@ -149,6 +153,12 @@ defmodule PhoenixKitWeb.Live.Users.PermissionsMatrix do
                role_name: role.name
              )
            )
+           |> refresh_matrix()}
+
+        {:error, :unauthorized} ->
+          {:noreply,
+           socket
+           |> put_flash(:error, gettext("You can only manage permissions you have"))
            |> refresh_matrix()}
 
         {:error, _reason} ->

--- a/lib/phoenix_kit_web/live/users/permissions_matrix.ex
+++ b/lib/phoenix_kit_web/live/users/permissions_matrix.ex
@@ -83,11 +83,14 @@ defmodule PhoenixKitWeb.Live.Users.PermissionsMatrix do
           do: MapSet.new(Permissions.all_module_keys()),
           else: Scope.accessible_modules(scope)
 
-      # Granting a sub-permission auto-grants its base key, so the editor
-      # must hold every key the toggle implies — not just the clicked one.
-      # Otherwise an editor holding only "calendar.view_others" could smuggle
-      # in a "calendar" base grant they don't hold themselves.
-      if MapSet.subset?(Permissions.expand_with_parents([key]), grantable) do
+      role_key_set = Map.get(socket.assigns.matrix, to_string(role.uuid), MapSet.new())
+
+      # The editor must hold every key the toggle actually TOUCHES, not just the
+      # clicked one. Granting a sub auto-grants its base; revoking a base
+      # cascade-revokes the target's subs — so the editor must hold those subs
+      # too, or an editor without "calendar.edit_others" could strip it from a
+      # role by revoking the "calendar" base.
+      if MapSet.subset?(affected_keys(key, role_key_set), grantable) do
         toggle_role_permission(socket, role, key, scope)
       else
         {:noreply, put_flash(socket, :error, gettext("You can only manage permissions you have"))}
@@ -106,6 +109,27 @@ defmodule PhoenixKitWeb.Live.Users.PermissionsMatrix do
   end
 
   # --- Helpers ---
+
+  # Keys an editor's toggle of `key` actually affects, given the role's current
+  # keys. Grant (key absent) pulls in the base via `expand_with_parents`; revoke
+  # (key present) cascade-revokes the role's existing sub-keys of that base, so
+  # those must be authorized too. A sub-key has no children, so revoking it only
+  # affects itself.
+  defp affected_keys(key, role_key_set) do
+    if MapSet.member?(role_key_set, key) do
+      child_keys =
+        key
+        |> Permissions.sub_permissions_for()
+        |> Enum.map(& &1.key)
+        |> MapSet.new()
+
+      role_key_set
+      |> MapSet.intersection(child_keys)
+      |> MapSet.put(key)
+    else
+      Permissions.expand_with_parents([key])
+    end
+  end
 
   defp toggle_role_permission(socket, role, key, scope) do
     granted_by_uuid = Scope.user_uuid(scope)

--- a/lib/phoenix_kit_web/live/users/permissions_matrix.html.heex
+++ b/lib/phoenix_kit_web/live/users/permissions_matrix.html.heex
@@ -35,44 +35,14 @@
                 {gettext("Core Sections")}
               </td>
             </tr>
-            <%= for {key, _idx} <- Enum.with_index(@core_keys) do %>
-              <tr>
-                <td class="sticky left-0 z-[1] font-medium whitespace-nowrap">
-                  {PhoenixKit.Users.Permissions.module_label(key)}
-                </td>
-                <%= for role <- @roles do %>
-                  <td class="text-center">
-                    <%= if role.name == "Owner" do %>
-                      <span class="badge badge-sm badge-primary badge-outline">
-                        {gettext("always")}
-                      </span>
-                    <% else %>
-                      <%= if MapSet.member?(@uneditable_role_uuids, to_string(role.uuid)) do %>
-                        <%!-- Read-only: user's own role or Admin (non-Owner) --%>
-                        <%= if Map.get(@matrix, to_string(role.uuid), MapSet.new()) |> MapSet.member?(key) do %>
-                          <.icon name="hero-check-circle" class="w-5 h-5 text-success/50" />
-                        <% else %>
-                          <.icon name="hero-x-circle" class="w-5 h-5 text-base-content/10" />
-                        <% end %>
-                      <% else %>
-                        <button
-                          phx-click="toggle_permission"
-                          phx-value-role_uuid={role.uuid}
-                          phx-value-key={key}
-                          class="cursor-pointer hover:opacity-70 transition-opacity"
-                        >
-                          <%= if Map.get(@matrix, to_string(role.uuid), MapSet.new()) |> MapSet.member?(key) do %>
-                            <.icon name="hero-check-circle" class="w-5 h-5 text-success" />
-                          <% else %>
-                            <.icon name="hero-x-circle" class="w-5 h-5 text-base-content/20" />
-                          <% end %>
-                        </button>
-                      <% end %>
-                    <% end %>
-                  </td>
-                <% end %>
-              </tr>
-            <% end %>
+            <.permission_row
+              :for={key <- @core_keys}
+              key={key}
+              label={PhoenixKit.Users.Permissions.module_label(key)}
+              roles={@roles}
+              matrix={@matrix}
+              uneditable_role_uuids={@uneditable_role_uuids}
+            />
 
             <%!-- Feature Modules Header --%>
             <tr class="bg-primary/10">
@@ -83,43 +53,26 @@
                 {gettext("Feature Modules")}
               </td>
             </tr>
-            <%= for {key, _idx} <- Enum.with_index(@feature_keys) do %>
-              <tr>
-                <td class="sticky left-0 z-[1] font-medium whitespace-nowrap">
-                  {PhoenixKit.Users.Permissions.module_label(key)}
-                </td>
-                <%= for role <- @roles do %>
-                  <td class="text-center">
-                    <%= if role.name == "Owner" do %>
-                      <span class="badge badge-sm badge-primary badge-outline">
-                        {gettext("always")}
-                      </span>
-                    <% else %>
-                      <%= if MapSet.member?(@uneditable_role_uuids, to_string(role.uuid)) do %>
-                        <%!-- Read-only: user's own role or Admin (non-Owner) --%>
-                        <%= if Map.get(@matrix, to_string(role.uuid), MapSet.new()) |> MapSet.member?(key) do %>
-                          <.icon name="hero-check-circle" class="w-5 h-5 text-success/50" />
-                        <% else %>
-                          <.icon name="hero-x-circle" class="w-5 h-5 text-base-content/10" />
-                        <% end %>
-                      <% else %>
-                        <button
-                          phx-click="toggle_permission"
-                          phx-value-role_uuid={role.uuid}
-                          phx-value-key={key}
-                          class="cursor-pointer hover:opacity-70 transition-opacity"
-                        >
-                          <%= if Map.get(@matrix, to_string(role.uuid), MapSet.new()) |> MapSet.member?(key) do %>
-                            <.icon name="hero-check-circle" class="w-5 h-5 text-success" />
-                          <% else %>
-                            <.icon name="hero-x-circle" class="w-5 h-5 text-base-content/20" />
-                          <% end %>
-                        </button>
-                      <% end %>
-                    <% end %>
-                  </td>
-                <% end %>
-              </tr>
+            <%= for key <- @feature_keys do %>
+              <.permission_row
+                key={key}
+                label={PhoenixKit.Users.Permissions.module_label(key)}
+                roles={@roles}
+                matrix={@matrix}
+                uneditable_role_uuids={@uneditable_role_uuids}
+              />
+              <%!-- Fine-grained sub-permissions, indented under their module.
+                   Granting one auto-grants the module key; revoking the module
+                   key cascades these off. --%>
+              <.permission_row
+                :for={sub <- Map.get(@sub_permissions, key, [])}
+                key={sub.key}
+                label={sub.label}
+                sub
+                roles={@roles}
+                matrix={@matrix}
+                uneditable_role_uuids={@uneditable_role_uuids}
+              />
             <% end %>
             <%!-- Custom (permission keys registered by parent app) --%>
             <%= if length(@custom_keys) > 0 do %>
@@ -131,44 +84,14 @@
                   {gettext("Custom")}
                 </td>
               </tr>
-              <%= for {key, _idx} <- Enum.with_index(@custom_keys) do %>
-                <tr>
-                  <td class="sticky left-0 z-[1] font-medium whitespace-nowrap">
-                    {PhoenixKit.Users.Permissions.module_label(key)}
-                  </td>
-                  <%= for role <- @roles do %>
-                    <td class="text-center">
-                      <%= if role.name == "Owner" do %>
-                        <span class="badge badge-sm badge-primary badge-outline">
-                          {gettext("always")}
-                        </span>
-                      <% else %>
-                        <%= if MapSet.member?(@uneditable_role_uuids, to_string(role.uuid)) do %>
-                          <%!-- Read-only: user's own role or Admin (non-Owner) --%>
-                          <%= if Map.get(@matrix, to_string(role.uuid), MapSet.new()) |> MapSet.member?(key) do %>
-                            <.icon name="hero-check-circle" class="w-5 h-5 text-success/50" />
-                          <% else %>
-                            <.icon name="hero-x-circle" class="w-5 h-5 text-base-content/10" />
-                          <% end %>
-                        <% else %>
-                          <button
-                            phx-click="toggle_permission"
-                            phx-value-role_uuid={role.uuid}
-                            phx-value-key={key}
-                            class="cursor-pointer hover:opacity-70 transition-opacity"
-                          >
-                            <%= if Map.get(@matrix, to_string(role.uuid), MapSet.new()) |> MapSet.member?(key) do %>
-                              <.icon name="hero-check-circle" class="w-5 h-5 text-success" />
-                            <% else %>
-                              <.icon name="hero-x-circle" class="w-5 h-5 text-base-content/20" />
-                            <% end %>
-                          </button>
-                        <% end %>
-                      <% end %>
-                    </td>
-                  <% end %>
-                </tr>
-              <% end %>
+              <.permission_row
+                :for={key <- @custom_keys}
+                key={key}
+                label={PhoenixKit.Users.Permissions.module_label(key)}
+                roles={@roles}
+                matrix={@matrix}
+                uneditable_role_uuids={@uneditable_role_uuids}
+              />
             <% end %>
 
             <%!-- Summary Row --%>
@@ -201,6 +124,11 @@
         <p class="text-sm">
           {gettext(
             "Click any check or cross icon to toggle a permission for that role. The Owner role always has full access and cannot be modified. You cannot edit permissions for your own role or for roles with higher authority. You can only grant or revoke permissions that your own role has."
+          )}
+        </p>
+        <p class="text-sm mt-1">
+          {gettext(
+            "Indented rows are fine-grained permissions within a module. Granting one also grants the module itself; revoking a module removes its fine-grained permissions with it."
           )}
         </p>
       </div>

--- a/lib/phoenix_kit_web/live/users/roles.ex
+++ b/lib/phoenix_kit_web/live/users/roles.ex
@@ -243,18 +243,27 @@ defmodule PhoenixKitWeb.Live.Users.Roles do
   def handle_event("toggle_permission", %{"key" => key}, socket) do
     if can_manage_permissions?(socket) do
       grantable = socket.assigns.permissions_grantable_keys
+      keys = socket.assigns.permissions_role_keys
 
-      if MapSet.member?(grantable, key) do
-        keys = socket.assigns.permissions_role_keys
+      cond do
+        # Unchecking: drop the key and (for a base module key) the
+        # sub-permissions it carries — a sub-key must not outlive its module.
+        MapSet.member?(keys, key) and MapSet.member?(grantable, key) ->
+          implied_subs = key |> Permissions.sub_permissions_for() |> Enum.map(& &1.key)
+          new_keys = MapSet.difference(keys, MapSet.new([key | implied_subs]))
+          {:noreply, assign(socket, :permissions_role_keys, new_keys)}
 
-        new_keys =
-          if MapSet.member?(keys, key),
-            do: MapSet.delete(keys, key),
-            else: MapSet.put(keys, key)
+        # Checking: pull in the base key a sub-permission implies. The editor
+        # must hold EVERY key the check implies, not just the clicked one —
+        # otherwise holding only the sub would smuggle in a base grant.
+        not MapSet.member?(keys, key) and
+            MapSet.subset?(Permissions.expand_with_parents([key]), grantable) ->
+          new_keys = MapSet.union(keys, Permissions.expand_with_parents([key]))
+          {:noreply, assign(socket, :permissions_role_keys, new_keys)}
 
-        {:noreply, assign(socket, :permissions_role_keys, new_keys)}
-      else
-        {:noreply, put_flash(socket, :error, gettext("You can only manage permissions you have"))}
+        true ->
+          {:noreply,
+           put_flash(socket, :error, gettext("You can only manage permissions you have"))}
       end
     else
       {:noreply,

--- a/lib/phoenix_kit_web/live/users/roles.html.heex
+++ b/lib/phoenix_kit_web/live/users/roles.html.heex
@@ -387,6 +387,21 @@
                 />
                 <span class="text-sm">{PhoenixKit.Users.Permissions.module_label(key)}</span>
               </label>
+              <%!-- Fine-grained sub-permissions, indented under their module.
+                   Checking one also checks the module; unchecking the module
+                   unchecks these with it (mirrors the save-time invariant). --%>
+              <%= for sub <- PhoenixKit.Users.Permissions.sub_permissions_for(key), MapSet.member?(@permissions_grantable_keys, sub.key) do %>
+                <label class="flex items-center gap-3 cursor-pointer p-2 pl-8 rounded-lg hover:bg-base-200 transition-colors">
+                  <input
+                    type="checkbox"
+                    class="checkbox checkbox-xs checkbox-primary"
+                    checked={MapSet.member?(@permissions_role_keys, sub.key)}
+                    phx-click="toggle_permission"
+                    phx-value-key={sub.key}
+                  />
+                  <span class="text-sm text-base-content/80">{sub.label}</span>
+                </label>
+              <% end %>
             <% end %>
           </div>
         </div>

--- a/lib/phoenix_kit_web/live/users/users.ex
+++ b/lib/phoenix_kit_web/live/users/users.ex
@@ -221,8 +221,9 @@ defmodule PhoenixKitWeb.Live.Users.Users do
     current_roles = socket.assigns.user_roles
     selected_roles = Map.get(params, "roles", %{})
     role_names = Map.values(selected_roles)
+    actor = socket.assigns.phoenix_kit_current_user
 
-    case Roles.sync_user_roles(user, role_names) do
+    case Roles.sync_user_roles(user, role_names, actor: actor) do
       {:ok, _assignments} ->
         admin = socket.assigns.phoenix_kit_current_user
         added = role_names -- current_roles

--- a/lib/phoenix_kit_web/live/users/users.ex
+++ b/lib/phoenix_kit_web/live/users/users.ex
@@ -218,25 +218,23 @@ defmodule PhoenixKitWeb.Live.Users.Users do
 
   def handle_event("sync_user_roles", params, socket) do
     user = socket.assigns.managing_user
-    current_roles = socket.assigns.user_roles
     selected_roles = Map.get(params, "roles", %{})
     role_names = Map.values(selected_roles)
     actor = socket.assigns.phoenix_kit_current_user
 
     case Roles.sync_user_roles(user, role_names, actor: actor) do
-      {:ok, _assignments} ->
+      {:ok, %{roles_before: roles_before, roles_after: roles_after}} ->
         admin = socket.assigns.phoenix_kit_current_user
 
-        # Audit what was ACTUALLY applied, not what was submitted — the context
-        # silently drops role changes the actor isn't authorized to make (and
-        # preserves the last Owner), so the submitted set can differ from reality.
-        # Reads fresh by uuid (returns [] if the user was deleted mid-op — no crash).
-        applied_roles = Roles.get_user_roles(user)
-        added = applied_roles -- current_roles
-        removed = current_roles -- applied_roles
+        # Audit the exact delta this transaction applied — the context captures
+        # before/after inside the transaction and silently drops changes the
+        # actor isn't authorized to make (and preserves the last Owner), so the
+        # applied delta can differ from what was submitted.
+        added = roles_after -- roles_before
+        removed = roles_before -- roles_after
 
         if added != [] or removed != [] do
-          log_roles_updated(admin, user, current_roles, applied_roles, added, removed)
+          log_roles_updated(admin, user, roles_before, roles_after, added, removed)
         end
 
         socket =
@@ -286,7 +284,11 @@ defmodule PhoenixKitWeb.Live.Users.Users do
       socket = put_flash(socket, :error, gettext("Cannot modify your own roles"))
       {:noreply, socket}
     else
-      handle_role_toggle_result(toggle_user_role(user, role_name, current_user), role_name, socket)
+      handle_role_toggle_result(
+        toggle_user_role(user, role_name, current_user),
+        role_name,
+        socket
+      )
     end
   end
 
@@ -851,8 +853,8 @@ defmodule PhoenixKitWeb.Live.Users.Users do
         else: [role_name | get_user_roles(user)]
 
     case Roles.sync_user_roles(user, desired_roles, actor: actor) do
-      {:ok, _assignments} ->
-        now_has? = role_name in Roles.get_user_roles(user)
+      {:ok, %{roles_after: roles_after}} ->
+        now_has? = role_name in roles_after
 
         cond do
           now_has? and not had_role? -> {:ok, :added}

--- a/lib/phoenix_kit_web/live/users/users.ex
+++ b/lib/phoenix_kit_web/live/users/users.ex
@@ -230,7 +230,8 @@ defmodule PhoenixKitWeb.Live.Users.Users do
         # Audit what was ACTUALLY applied, not what was submitted — the context
         # silently drops role changes the actor isn't authorized to make (and
         # preserves the last Owner), so the submitted set can differ from reality.
-        applied_roles = user.uuid |> Auth.get_user_with_roles() |> Roles.get_user_roles()
+        # Reads fresh by uuid (returns [] if the user was deleted mid-op — no crash).
+        applied_roles = Roles.get_user_roles(user)
         added = applied_roles -- current_roles
         removed = current_roles -- applied_roles
 

--- a/lib/phoenix_kit_web/live/users/users.ex
+++ b/lib/phoenix_kit_web/live/users/users.ex
@@ -226,11 +226,16 @@ defmodule PhoenixKitWeb.Live.Users.Users do
     case Roles.sync_user_roles(user, role_names, actor: actor) do
       {:ok, _assignments} ->
         admin = socket.assigns.phoenix_kit_current_user
-        added = role_names -- current_roles
-        removed = current_roles -- role_names
+
+        # Audit what was ACTUALLY applied, not what was submitted — the context
+        # silently drops role changes the actor isn't authorized to make (and
+        # preserves the last Owner), so the submitted set can differ from reality.
+        applied_roles = user.uuid |> Auth.get_user_with_roles() |> Roles.get_user_roles()
+        added = applied_roles -- current_roles
+        removed = current_roles -- applied_roles
 
         if added != [] or removed != [] do
-          log_roles_updated(admin, user, current_roles, role_names, added, removed)
+          log_roles_updated(admin, user, current_roles, applied_roles, added, removed)
         end
 
         socket =
@@ -280,7 +285,7 @@ defmodule PhoenixKitWeb.Live.Users.Users do
       socket = put_flash(socket, :error, gettext("Cannot modify your own roles"))
       {:noreply, socket}
     else
-      handle_role_toggle_result(toggle_user_role(user, role_name), role_name, socket)
+      handle_role_toggle_result(toggle_user_role(user, role_name, current_user), role_name, socket)
     end
   end
 
@@ -831,22 +836,46 @@ defmodule PhoenixKitWeb.Live.Users.Users do
     role_name in get_user_roles(user)
   end
 
-  defp toggle_user_role(user, role_name) do
-    if user_has_role?(user, role_name) do
-      case Roles.remove_role(user, role_name) do
-        {:ok, _} -> {:ok, :removed}
-        {:error, reason} -> {:error, reason}
-      end
-    else
-      case Roles.assign_role(user, role_name) do
-        {:ok, _} -> {:ok, :added}
-        {:error, reason} -> {:error, reason}
-      end
+  # Route through sync_user_roles/3 so the quick toggle enforces the SAME actor
+  # authorization + last-Owner guard as the full role modal — a `users`-permission
+  # holder can't use this shortcut to grant Owner/Admin or wipe the last Owner.
+  # Unauthorized system-role changes are silently dropped by the context, so we
+  # re-read the actual role set to report what truly happened.
+  defp toggle_user_role(user, role_name, actor) do
+    had_role? = user_has_role?(user, role_name)
+
+    desired_roles =
+      if had_role?,
+        do: get_user_roles(user) -- [role_name],
+        else: [role_name | get_user_roles(user)]
+
+    case Roles.sync_user_roles(user, desired_roles, actor: actor) do
+      {:ok, _assignments} ->
+        now_has? = role_name in Roles.get_user_roles(user)
+
+        cond do
+          now_has? and not had_role? -> {:ok, :added}
+          not now_has? and had_role? -> {:ok, :removed}
+          true -> {:ok, :unchanged}
+        end
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 
   defp handle_role_toggle_result(result, role_name, socket) do
     case result do
+      {:ok, :unchanged} ->
+        socket =
+          put_flash(
+            socket,
+            :error,
+            gettext("You are not allowed to change the %{role} role", role: role_name)
+          )
+
+        {:noreply, socket}
+
       {:ok, action} ->
         role_flash_msg =
           if action == :added,

--- a/lib/phoenix_kit_web/users/auth.ex
+++ b/lib/phoenix_kit_web/users/auth.ex
@@ -18,12 +18,14 @@ defmodule PhoenixKitWeb.Users.Auth do
   ## on_mount Hooks
 
   - `:phoenix_kit_ensure_admin` — Requires Owner/Admin role, or a custom role
-    with at least one permission. For custom roles, also checks the specific
-    permission key mapped to the current admin view. Unmapped views deny
-    custom roles but allow Owner/Admin.
-  - `:phoenix_kit_ensure_module_access` — For custom roles, checks that the
-    feature module is both enabled and permitted. Owner/Admin bypass both
-    the enabled and permission checks.
+    with at least one permission. Every role is then checked against the
+    permission key mapped to the current admin view: Owner passes because its
+    scope holds every key by construction; Admin holds keys as real,
+    Owner-revocable rows (seeded/auto-granted by default). Disabled modules
+    block everyone. Views that resolve to no permission key allow Owner/Admin
+    and deny custom roles (fail-closed where a key could exist).
+  - `:phoenix_kit_ensure_module_access` — Checks that the feature module is
+    permitted for the scope and (for custom roles) enabled.
 
   ## Usage
 
@@ -1185,11 +1187,12 @@ defmodule PhoenixKitWeb.Users.Auth do
           not module_enabled ->
             deny_module_disabled(socket, module_key)
 
-          # System roles (Owner/Admin) bypass permission checks
-          Scope.system_role?(scope) ->
-            {:cont, socket}
-
-          # Custom roles need explicit permission
+          # Every role — Admin included — needs the permission key. Owner
+          # passes because its scope holds every key by construction; Admin
+          # holds keys as real rows (seeded/auto-granted, Owner-revocable).
+          # The old system-role bypass here made Owner's revocations on the
+          # Admin role effective everywhere EXCEPT fresh mounts — sidebar,
+          # plugs, and the mid-session PubSub kick all honored them already.
           Scope.has_module_access?(scope, module_key) ->
             {:cont, socket}
 

--- a/lib/phoenix_kit_web/users/auth.ex
+++ b/lib/phoenix_kit_web/users/auth.ex
@@ -652,7 +652,7 @@ defmodule PhoenixKitWeb.Users.Auth do
         {:halt, socket}
 
       Scope.has_module_access?(scope, module_key) and
-          (Scope.system_role?(scope) or
+          (Scope.owner?(scope) or
              MapSet.member?(Permissions.enabled_module_keys(), module_key)) ->
         socket = attach_locale_hook(socket)
         {:cont, socket}
@@ -1164,7 +1164,12 @@ defmodule PhoenixKitWeb.Users.Auth do
   defp enforce_admin_view_permission(socket, scope) do
     case permission_key_for_admin_view(socket.view) do
       nil ->
-        # Unmapped views: fail-closed for custom roles, allow Admin/Owner
+        # Unmapped views: fail-closed for custom roles, allow Admin/Owner.
+        # This deliberately keeps `system_role?` (not `owner?`): an unmapped
+        # view has NO permission key and NO module to enable, so Admin here
+        # isn't bypassing a revocation or a disabled module — it's the
+        # no-mapping fallback. Restricting it to Owner would lock Admin out
+        # of legitimately-unmapped core admin views with no security gain.
         Logger.debug(
           "[Auth] Admin view #{inspect(socket.view)} has no permission mapping — " <>
             "allowing system roles, denying custom roles"
@@ -1708,7 +1713,7 @@ defmodule PhoenixKitWeb.Users.Auth do
             |> halt()
 
           Scope.has_module_access?(scope, module_key) and
-              (Scope.system_role?(scope) or
+              (Scope.owner?(scope) or
                  MapSet.member?(Permissions.enabled_module_keys(), module_key)) ->
             conn
 

--- a/lib/phoenix_kit_web/users/user_form.ex
+++ b/lib/phoenix_kit_web/users/user_form.ex
@@ -931,9 +931,13 @@ defmodule PhoenixKitWeb.Users.UserForm do
       true ->
         case Roles.sync_user_roles(user, pending_roles, actor: current_user) do
           {:ok, _} = result ->
-            added = pending_roles -- current_roles
-            removed = current_roles -- pending_roles
-            log_roles_updated(current_user, user, current_roles, pending_roles, added, removed)
+            # Audit what was ACTUALLY applied, not what was submitted — the
+            # context silently drops changes the actor isn't authorized to make
+            # (and preserves the last Owner), so re-read the real role set.
+            applied_roles = user.uuid |> Auth.get_user_with_roles() |> Roles.get_user_roles()
+            added = applied_roles -- current_roles
+            removed = current_roles -- applied_roles
+            log_roles_updated(current_user, user, current_roles, applied_roles, added, removed)
             result
 
           error ->

--- a/lib/phoenix_kit_web/users/user_form.ex
+++ b/lib/phoenix_kit_web/users/user_form.ex
@@ -930,19 +930,17 @@ defmodule PhoenixKitWeb.Users.UserForm do
       # Roles have changed and it's allowed, update them
       true ->
         case Roles.sync_user_roles(user, pending_roles, actor: current_user) do
-          {:ok, _} = result ->
-            # Audit what was ACTUALLY applied, not what was submitted — the
-            # context silently drops changes the actor isn't authorized to make
-            # (and preserves the last Owner), so re-read the real role set (fresh
-            # by uuid; [] if the user was deleted mid-op — no crash). Skip the
-            # log entirely when nothing actually changed (e.g. a fully-rejected
-            # unauthorized submission), mirroring the LiveView role modal.
-            applied_roles = Roles.get_user_roles(user)
-            added = applied_roles -- current_roles
-            removed = current_roles -- applied_roles
+          {:ok, %{roles_before: roles_before, roles_after: roles_after}} = result ->
+            # Audit the exact delta the transaction applied (before/after captured
+            # inside it), not the submitted set — the context silently drops
+            # changes the actor isn't authorized to make. Skip the log when
+            # nothing actually changed (e.g. a fully-rejected submission),
+            # mirroring the LiveView role modal.
+            added = roles_after -- roles_before
+            removed = roles_before -- roles_after
 
             if added != [] or removed != [] do
-              log_roles_updated(current_user, user, current_roles, applied_roles, added, removed)
+              log_roles_updated(current_user, user, roles_before, roles_after, added, removed)
             end
 
             result

--- a/lib/phoenix_kit_web/users/user_form.ex
+++ b/lib/phoenix_kit_web/users/user_form.ex
@@ -223,7 +223,7 @@ defmodule PhoenixKitWeb.Users.UserForm do
     else
       role_names = socket.assigns.pending_roles
 
-      case Roles.sync_user_roles(user, role_names) do
+      case Roles.sync_user_roles(user, role_names, actor: current_user) do
         {:ok, _assignments} ->
           socket =
             socket
@@ -265,7 +265,7 @@ defmodule PhoenixKitWeb.Users.UserForm do
         |> Enum.filter(fn {_key, value} -> value != "false" end)
         |> Enum.map(fn {key, _value} -> key end)
 
-      case Roles.sync_user_roles(user, role_names) do
+      case Roles.sync_user_roles(user, role_names, actor: current_user) do
         {:ok, _assignments} ->
           socket =
             socket
@@ -929,7 +929,7 @@ defmodule PhoenixKitWeb.Users.UserForm do
 
       # Roles have changed and it's allowed, update them
       true ->
-        case Roles.sync_user_roles(user, pending_roles) do
+        case Roles.sync_user_roles(user, pending_roles, actor: current_user) do
           {:ok, _} = result ->
             added = pending_roles -- current_roles
             removed = current_roles -- pending_roles

--- a/lib/phoenix_kit_web/users/user_form.ex
+++ b/lib/phoenix_kit_web/users/user_form.ex
@@ -933,11 +933,18 @@ defmodule PhoenixKitWeb.Users.UserForm do
           {:ok, _} = result ->
             # Audit what was ACTUALLY applied, not what was submitted — the
             # context silently drops changes the actor isn't authorized to make
-            # (and preserves the last Owner), so re-read the real role set.
-            applied_roles = user.uuid |> Auth.get_user_with_roles() |> Roles.get_user_roles()
+            # (and preserves the last Owner), so re-read the real role set (fresh
+            # by uuid; [] if the user was deleted mid-op — no crash). Skip the
+            # log entirely when nothing actually changed (e.g. a fully-rejected
+            # unauthorized submission), mirroring the LiveView role modal.
+            applied_roles = Roles.get_user_roles(user)
             added = applied_roles -- current_roles
             removed = current_roles -- applied_roles
-            log_roles_updated(current_user, user, current_roles, applied_roles, added, removed)
+
+            if added != [] or removed != [] do
+              log_roles_updated(current_user, user, current_roles, applied_roles, added, removed)
+            end
+
             result
 
           error ->

--- a/priv/static/assets/phoenix_kit.js
+++ b/priv/static/assets/phoenix_kit.js
@@ -2291,6 +2291,106 @@ if (typeof window.Chart === "undefined") {
     }
   };
 
+  // PkDialogDraft — preserves an in-progress form across a LiveView RECONNECT
+  // (a websocket drop, e.g. on flaky/slow internet). A reconnect re-mounts the
+  // LiveView with fresh assigns, so a modal driven by a server flag collapses
+  // and the typed data is lost — LiveView's native form recovery can't help
+  // because the form isn't rendered after remount (a skeleton is). This hook
+  // keeps a live snapshot of the form in a JS variable (memory only — cleared
+  // on close and on unload, so a tab close / refresh is NOT preserved, by
+  // design) and, once reconnected, pushes it back so the server rebuilds the
+  // modal exactly where the user left off.
+  //
+  // Attach to a STABLE element that is always rendered (NOT the <dialog>,
+  // which already carries PkDialog and whose body is conditionally rendered):
+  //   <div phx-hook="PkDialogDraft" id="…"
+  //        data-draft-form="calendar-event-form"   (the <form> id to snapshot)
+  //        data-draft-restore-event="restore_event_draft"
+  //        data-draft-scope="#calendar-event-modal" (where owner/tz inputs live,
+  //                                                   outside the <form>)
+  //        data-draft-active="true|false"           (server: modal open + editable)
+  //        data-draft-key="new|<uuid>">             (which event)
+  var pkDialogDrafts = {};
+  var pkWasDisconnected = false;
+  if (typeof window !== "undefined") {
+    window.addEventListener("phx:disconnected", function () {
+      pkWasDisconnected = true;
+    });
+  }
+
+  window.PhoenixKitHooks.PkDialogDraft = {
+    mounted() {
+      var self = this;
+      this.formId = this.el.dataset.draftForm;
+      this.restoreEvent = this.el.dataset.draftRestoreEvent || "restore_draft";
+      this.scopeSel = this.el.dataset.draftScope;
+
+      this._snapshot = function () {
+        if (self.el.dataset.draftActive !== "true") {
+          delete pkDialogDrafts[self.el.id];
+          return;
+        }
+        var form = document.getElementById(self.formId);
+        if (!form) return;
+        var ev = {};
+        new FormData(form).forEach(function (v, k) {
+          var m = k.match(/^event\[(.+)\]$/);
+          if (m) ev[m[1]] = v;
+        });
+        // owner / owner_tz_entry live OUTSIDE the <form> (in the modal box)
+        var scope = self.scopeSel ? document.querySelector(self.scopeSel) : document;
+        var owner = scope && scope.querySelector('[name="owner"]');
+        var ownerTz = scope && scope.querySelector('[name="owner_tz_entry"]');
+        pkDialogDrafts[self.el.id] = {
+          key: self.el.dataset.draftKey || "new",
+          event: ev,
+          owner: owner ? owner.value : null,
+          owner_tz_entry: ownerTz && ownerTz.checked ? "true" : null,
+        };
+      };
+
+      this._onInput = function () {
+        self._snapshot();
+      };
+      // capture on every edit (bubbles up from the form's inputs)
+      document.addEventListener("input", this._onInput, true);
+      document.addEventListener("change", this._onInput, true);
+
+      this._onUnload = function () {
+        delete pkDialogDrafts[self.el.id];
+      };
+      window.addEventListener("beforeunload", this._onUnload);
+
+      // Reconnect restore: mounted() runs again after a reconnect re-mount.
+      // If we were disconnected and still hold a draft, hand it back so the
+      // server can reopen the modal with the user's data.
+      this._maybeRestore();
+    },
+
+    updated() {
+      this._maybeRestore();
+    },
+
+    _maybeRestore() {
+      if (!pkWasDisconnected) return;
+      var draft = pkDialogDrafts[this.el.id];
+      if (!draft) {
+        pkWasDisconnected = false;
+        return;
+      }
+      // only restore into a modal the server hasn't already reopened
+      if (this.el.dataset.draftActive === "true") return;
+      pkWasDisconnected = false;
+      this.pushEvent(this.restoreEvent, draft);
+    },
+
+    destroyed() {
+      document.removeEventListener("input", this._onInput, true);
+      document.removeEventListener("change", this._onInput, true);
+      window.removeEventListener("beforeunload", this._onUnload);
+    },
+  };
+
   window.PhoenixKitHooks.AnnotationComposerPosition = {
     mounted() {
       this._reposition = () => this.reposition();

--- a/priv/static/assets/phoenix_kit.js
+++ b/priv/static/assets/phoenix_kit.js
@@ -4847,7 +4847,7 @@ if (typeof window.Chart === "undefined") {
 //                        dispatches an input event (so a surrounding form's
 //                        phx-change sees it) and closes; no staging round-trip
 //   data-t-*             translated strings (searching/add-prefix/add-suffix/
-//                        adding/more/loading-more)
+//                        adding/more/loading-more/no-matches)
 (function () {
   function esc(s) {
     var d = document.createElement("div");
@@ -5058,6 +5058,7 @@ if (typeof window.Chart === "undefined") {
       var tAddSuffix = esc(this.el.dataset.tAddSuffix || "as text");
       var tMore = esc(this.el.dataset.tMore || "Load more");
       var tLoadingMore = esc(this.el.dataset.tLoadingMore || "Loading…");
+      var tNoMatches = esc(this.el.dataset.tNoMatches || "No matches");
 
       var top = "";
       if (this.searching) {
@@ -5089,6 +5090,10 @@ if (typeof window.Chart === "undefined") {
           esc(r.sublabel || "") +
           "</span></button>";
       });
+      if (!this.searching && !this.loadingMore && this.results.length === 0 && q) {
+        list +=
+          '<div class="px-3 py-2 text-sm text-base-content/50">' + tNoMatches + "</div>";
+      }
       if (this.loadingMore) {
         list +=
           '<div class="flex items-center justify-center gap-2 px-3 py-2 text-xs text-base-content/50">' +

--- a/priv/static/assets/phoenix_kit.js
+++ b/priv/static/assets/phoenix_kit.js
@@ -5090,7 +5090,7 @@ if (typeof window.Chart === "undefined") {
           esc(r.sublabel || "") +
           "</span></button>";
       });
-      if (!this.searching && !this.loadingMore && this.results.length === 0 && q) {
+      if (!this.searching && !this.loadingMore && this.results.length === 0) {
         list +=
           '<div class="px-3 py-2 text-sm text-base-content/50">' + tNoMatches + "</div>";
       }

--- a/priv/static/assets/phoenix_kit.js
+++ b/priv/static/assets/phoenix_kit.js
@@ -4906,18 +4906,11 @@ if (typeof window.Chart === "undefined") {
         if (payload.id && payload.id !== this.el.id) return;
         if (this.stagingNow) return;
         if (this.el.value.trim() !== (payload.q || "")) return; // stale
-        var incoming = payload.results || [];
-        if (this.loadingMore) {
-          var seen = {};
-          this.results.forEach((r) => {
-            seen[r.kind + ":" + r.uuid] = true;
-          });
-          this.results = this.results.concat(
-            incoming.filter((r) => !seen[r.kind + ":" + r.uuid])
-          );
-        } else {
-          this.results = incoming;
-        }
+        // The server always answers with the FULL page for the requested
+        // limit — REPLACE the list, never merge: merging by kind+uuid can
+        // duplicate a person whose row legitimately changed source between
+        // pages (server-side dedup upgraded it, e.g. staff row -> user row).
+        this.results = payload.results || [];
         this.hasMore = !!payload.has_more;
         this.searching = false;
         this.loadingMore = false;

--- a/priv/static/assets/phoenix_kit.js
+++ b/priv/static/assets/phoenix_kit.js
@@ -2190,6 +2190,40 @@ if (typeof window.Chart === "undefined") {
       this.el.addEventListener("close", self._onClose);
       this.el.addEventListener("click", self._onClick);
 
+      // Instant client-side open: a trigger can dispatch this custom
+      // event (Phoenix.LiveView.JS.dispatch("pk:dialog-show", to: "#id"))
+      // ALONGSIDE its server push, so the dialog appears the same frame
+      // as the click while the server round-trip fills the content in.
+      // The subsequent LV patch (data-show=true) finds the dialog already
+      // open and no-ops; server-driven close keeps working unchanged.
+      self._onShowEvent = function() {
+        if (
+          !isDialogOpenInBrowser(self.el) &&
+          typeof self.el.showModal === "function"
+        ) {
+          self.el.showModal();
+          if (!self._opened) {
+            self._opened = true;
+            self._onOpened();
+          }
+        }
+      };
+      this.el.addEventListener("pk:dialog-show", self._onShowEvent);
+
+      // Server-initiated close for a dialog that was opened CLIENT-side
+      // (pk:dialog-show) but whose content the server declined to load —
+      // without this, an error path that never flips data-show would
+      // leave the skeleton dialog open forever. LV removes hook
+      // handleEvent listeners automatically on destroy.
+      this.handleEvent("pk:dialog-close", function(payload) {
+        if (payload && payload.id && payload.id !== self.el.id) return;
+        if (isDialogOpenInBrowser(self.el)) {
+          if (!self.el.open) self.el.setAttribute("open", "");
+          self._closeFromLV = true;
+          self.el.close();
+        }
+      });
+
       this._sync();
     },
     updated() {
@@ -2221,6 +2255,39 @@ if (typeof window.Chart === "undefined") {
       if (this._onCancel) this.el.removeEventListener("cancel", this._onCancel);
       if (this._onClose) this.el.removeEventListener("close", this._onClose);
       if (this._onClick) this.el.removeEventListener("click", this._onClick);
+      if (this._onShowEvent) this.el.removeEventListener("pk:dialog-show", this._onShowEvent);
+    }
+  };
+
+  // PkDialogTrigger — makes a REGION instant-open a kept-in-DOM PkDialog.
+  // Attach to a container whose descendants push server events that end in
+  // a modal (e.g. a calendar grid where event/date clicks open an editor):
+  //
+  //   <div phx-hook="PkDialogTrigger" id="grid"
+  //        data-dialog="my-modal"
+  //        data-trigger=".cal-event, .cal-day-cell">
+  //
+  // On click it finds the closest [phx-click] ancestor — the SAME element
+  // LiveView will hand the event to — and, if that element matches
+  // data-trigger, dispatches pk:dialog-show to the dialog so it opens in
+  // the same frame while the server round-trip fills the content in.
+  // Elements with their own phx-click that don't match (a "+N more" link)
+  // correctly don't open the dialog.
+  window.PhoenixKitHooks.PkDialogTrigger = {
+    mounted() {
+      this._onTriggerClick = (e) => {
+        var sel = this.el.dataset.trigger;
+        var dlg = document.getElementById(this.el.dataset.dialog);
+        if (!sel || !dlg) return;
+        var clickEl = e.target.closest("[phx-click]");
+        if (clickEl && this.el.contains(clickEl) && clickEl.matches(sel)) {
+          dlg.dispatchEvent(new CustomEvent("pk:dialog-show"));
+        }
+      };
+      this.el.addEventListener("click", this._onTriggerClick);
+    },
+    destroyed() {
+      this.el.removeEventListener("click", this._onTriggerClick);
     }
   };
 
@@ -4755,6 +4822,318 @@ if (typeof window.Chart === "undefined") {
 // the wrappers above don't explicitly cover (e.g. a future hook added by
 // one of the libs). No-ops when the global is missing.
 // ===========================================================================
+
+// SearchPicker — generic instant typeahead for "search a source, pick an
+// entry" fields (extracted from phoenix_kit_crm's involved-parties picker).
+// The dropdown is rendered and shown ENTIRELY client-side (opening, the
+// optional "Add … as free text" row, spinners), so nothing visual waits on
+// the server; the server only runs the actual search and returns rows via
+// push_event. Rows: {kind, uuid, label, sublabel?, icon?}.
+//
+// Configured via data attributes on the input:
+//   data-dropdown        id of the dropdown container (phx-update="ignore")
+//   data-search-event    pushed as {q, limit}            (default "picker_search")
+//   data-results-event   handleEvent name for rows       (default "picker_results";
+//                        payload {q, results, has_more})
+//   data-pick-event      pushed as {kind, uuid, label}   (default "picker_pick")
+//   data-text-event      pushed as {name}; free-text row only renders when set
+//   data-staged-event    handleEvent confirming a pick   (default "picker_staged")
+//   data-search-on-focus when present, focusing/clicking the input runs a
+//                        search immediately (empty query included) so the
+//                        full list opens on click — suits short curated
+//                        sources like locations
+//   data-mode            "multi" (default) or "single" — single sets the
+//                        input's value to the picked label client-side,
+//                        dispatches an input event (so a surrounding form's
+//                        phx-change sees it) and closes; no staging round-trip
+//   data-t-*             translated strings (searching/add-prefix/add-suffix/
+//                        adding/more/loading-more)
+(function () {
+  function esc(s) {
+    var d = document.createElement("div");
+    d.textContent = s == null ? "" : String(s);
+    return d.innerHTML;
+  }
+  function escAttr(s) {
+    return esc(s).replace(/"/g, "&quot;");
+  }
+
+  window.PhoenixKitHooks.SearchPicker = {
+    mounted() {
+      this.dd = document.getElementById(this.el.dataset.dropdown);
+      this.target = this.el.dataset.target || this.el;
+      this.mode = this.el.dataset.mode === "single" ? "single" : "multi";
+      this.searchOnFocus = this.el.dataset.searchOnFocus != null;
+      this.evSearch = this.el.dataset.searchEvent || "picker_search";
+      this.evResults = this.el.dataset.resultsEvent || "picker_results";
+      this.evPick = this.el.dataset.pickEvent || "picker_pick";
+      this.evText = this.el.dataset.textEvent || null;
+      this.evStaged = this.el.dataset.stagedEvent || "picker_staged";
+      this.results = [];
+      this.searching = false;
+      this.limit = 8;
+      this.hasMore = false;
+      this.loadingMore = false;
+
+      this.el.addEventListener("input", (e) => {
+        if (e._pkPickerSynthetic) return;
+        this.onInput();
+      });
+      this.el.addEventListener("keydown", (e) => this.onKeydown(e));
+      this.el.addEventListener("focus", () => {
+        if (this.searchOnFocus) this.kickSearch();
+        else if (this.el.value.trim()) this.render();
+      });
+      if (this.searchOnFocus) {
+        this.el.addEventListener("click", () => {
+          if (this.dd.classList.contains("hidden")) this.kickSearch();
+        });
+      }
+
+      this._docClick = (e) => {
+        if (!this.el.contains(e.target) && !this.dd.contains(e.target)) this.close();
+      };
+      document.addEventListener("click", this._docClick);
+
+      // mousedown (not click) so a pick registers before the input's blur.
+      this.dd.addEventListener("mousedown", (e) => this.onPick(e));
+
+      this.handleEvent(this.evResults, (payload) => {
+        if (this.stagingNow) return;
+        if (this.el.value.trim() !== (payload.q || "")) return; // stale
+        var incoming = payload.results || [];
+        if (this.loadingMore) {
+          var seen = {};
+          this.results.forEach((r) => {
+            seen[r.kind + ":" + r.uuid] = true;
+          });
+          this.results = this.results.concat(
+            incoming.filter((r) => !seen[r.kind + ":" + r.uuid])
+          );
+        } else {
+          this.results = incoming;
+        }
+        this.hasMore = !!payload.has_more;
+        this.searching = false;
+        this.loadingMore = false;
+        this.render();
+      });
+
+      this.handleEvent(this.evStaged, () => {
+        this.stagingNow = false;
+        clearTimeout(this.stageT);
+        this.clear();
+      });
+    },
+
+    destroyed() {
+      document.removeEventListener("click", this._docClick);
+      clearTimeout(this.t);
+      clearTimeout(this.stageT);
+    },
+
+    onInput() {
+      var q = this.el.value.trim();
+      if (!q && !this.searchOnFocus) {
+        this.close();
+        return;
+      }
+      this.searching = true;
+      this.results = [];
+      this.limit = 8;
+      this.hasMore = false;
+      this.loadingMore = false;
+      this._restoreScroll = null;
+      this.render();
+      clearTimeout(this.t);
+      this.t = setTimeout(() => this.search(q), 180);
+    },
+
+    search(q) {
+      this.pushEventTo(this.target, this.evSearch, { q: q, limit: this.limit });
+    },
+
+    kickSearch() {
+      this.searching = true;
+      this.results = [];
+      this.limit = 8;
+      this.hasMore = false;
+      this.loadingMore = false;
+      this._restoreScroll = null;
+      this.render();
+      clearTimeout(this.t);
+      this.t = setTimeout(() => this.search(this.el.value.trim()), 100);
+    },
+
+    loadMore() {
+      this.limit += 8;
+      this.loadingMore = true;
+      this._restoreScroll = this.scrollEl ? this.scrollEl.scrollTop : null;
+      this.render();
+      clearTimeout(this.t);
+      this.search(this.el.value.trim());
+    },
+
+    onKeydown(e) {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        var q = this.el.value.trim();
+        if (q && this.evText && this.mode !== "single") {
+          this.pushEventTo(this.target, this.evText, { name: q });
+          this.staging();
+        }
+      } else if (e.key === "Escape") {
+        this.close();
+      }
+    },
+
+    onPick(e) {
+      var btn = e.target.closest("[data-pick]");
+      if (!btn) return;
+      e.preventDefault();
+      if (btn.dataset.pick === "more") {
+        this.loadMore();
+        return;
+      }
+      if (this.mode === "single") {
+        // client-side value set; a synthetic input event lets a surrounding
+        // form's phx-change (and its server-side value mapping) see it
+        this.el.value = btn.dataset.label || "";
+        var ev = new Event("input", { bubbles: true });
+        ev._pkPickerSynthetic = true;
+        this.el.dispatchEvent(ev);
+        this.close();
+        return;
+      }
+      if (btn.dataset.pick === "text") {
+        var q = this.el.value.trim();
+        if (!q || !this.evText) return;
+        this.pushEventTo(this.target, this.evText, { name: q });
+      } else {
+        this.pushEventTo(this.target, this.evPick, {
+          kind: btn.dataset.kind,
+          uuid: btn.dataset.uuid,
+          label: btn.dataset.label,
+        });
+      }
+      this.staging();
+    },
+
+    staging() {
+      this.stagingNow = true;
+      clearTimeout(this.t);
+      var tAdding = esc(this.el.dataset.tAdding || "Adding…");
+      this.dd.innerHTML =
+        '<div class="flex items-center gap-2 px-3 py-2 text-sm text-base-content/60">' +
+        '<span class="loading loading-spinner loading-xs"></span>' +
+        tAdding +
+        "</div>";
+      this.open();
+      clearTimeout(this.stageT);
+      this.stageT = setTimeout(() => {
+        this.stagingNow = false;
+        this.clear();
+      }, 3000);
+    },
+
+    render() {
+      var q = this.el.value.trim();
+      if (!q && !this.searchOnFocus) {
+        this.close();
+        return;
+      }
+      var tSearching = esc(this.el.dataset.tSearching || "Searching…");
+      var tAddPrefix = esc(this.el.dataset.tAddPrefix || "Add");
+      var tAddSuffix = esc(this.el.dataset.tAddSuffix || "as text");
+      var tMore = esc(this.el.dataset.tMore || "Load more");
+      var tLoadingMore = esc(this.el.dataset.tLoadingMore || "Loading…");
+
+      var top = "";
+      if (this.searching) {
+        top +=
+          '<div class="flex items-center gap-2 px-3 py-2 text-sm text-base-content/60 border-b border-base-200">' +
+          '<span class="loading loading-spinner loading-xs"></span>' +
+          tSearching +
+          "</div>";
+      }
+
+      var list = "";
+      this.results.forEach((r) => {
+        list +=
+          '<button type="button" data-pick="result" data-kind="' +
+          escAttr(r.kind) +
+          '" data-uuid="' +
+          escAttr(r.uuid) +
+          '" data-label="' +
+          escAttr(r.label) +
+          '" class="flex items-center justify-between w-full px-3 py-2 hover:bg-base-200 text-left">' +
+          '<span class="flex items-center gap-2 min-w-0">' +
+          '<span class="' +
+          escAttr(r.icon || "hero-user") +
+          ' w-4 h-4 shrink-0 text-base-content/50"></span>' +
+          '<span class="truncate">' +
+          esc(r.label) +
+          "</span></span>" +
+          '<span class="text-xs text-base-content/50 shrink-0 ml-2 truncate">' +
+          esc(r.sublabel || "") +
+          "</span></button>";
+      });
+      if (this.loadingMore) {
+        list +=
+          '<div class="flex items-center justify-center gap-2 px-3 py-2 text-xs text-base-content/50">' +
+          '<span class="loading loading-spinner loading-xs"></span>' +
+          tLoadingMore +
+          "</div>";
+      } else if (this.hasMore) {
+        list +=
+          '<button type="button" data-pick="more" class="w-full px-3 py-2 text-xs text-center text-primary hover:bg-base-200">' +
+          tMore +
+          "</button>";
+      }
+
+      var bottom = "";
+      if (q && this.evText && this.mode !== "single") {
+        bottom =
+          '<button type="button" data-pick="text" class="flex items-center gap-2 w-full px-3 py-2 hover:bg-base-200 text-left border-t border-base-200">' +
+          '<span class="hero-plus-mini w-4 h-4 shrink-0 text-base-content/50"></span>' +
+          "<span>" +
+          tAddPrefix +
+          ' "' +
+          esc(q) +
+          '" ' +
+          tAddSuffix +
+          "</span></button>";
+      }
+
+      this.dd.innerHTML =
+        top + '<div data-scroll class="max-h-56 overflow-y-auto">' + list + "</div>" + bottom;
+
+      this.scrollEl = this.dd.querySelector("[data-scroll]");
+      if (this._restoreScroll != null && this.scrollEl) {
+        this.scrollEl.scrollTop = this._restoreScroll;
+        if (!this.loadingMore) this._restoreScroll = null;
+      }
+      this.open();
+    },
+
+    open() {
+      this.dd.classList.remove("hidden");
+    },
+    close() {
+      this.dd.classList.add("hidden");
+      this.dd.innerHTML = "";
+    },
+    clear() {
+      this.el.value = "";
+      this.results = [];
+      this.searching = false;
+      this.stagingNow = false;
+      clearTimeout(this.stageT);
+      this.close();
+      this.el.focus();
+    },
+  };
+})();
 
 (function() {
   if (typeof window === "undefined") return;

--- a/priv/static/assets/phoenix_kit.js
+++ b/priv/static/assets/phoenix_kit.js
@@ -4858,6 +4858,13 @@ if (typeof window.Chart === "undefined") {
     return esc(s).replace(/"/g, "&quot;");
   }
 
+  // Stable identity for de-duplicating rows across "Load more" pages. The
+  // server may send `dedup_id` (a PERSON identity that survives a row
+  // changing source/kind between pages); otherwise fall back to kind:uuid.
+  function dedupKey(r) {
+    return r.dedup_id != null ? "d:" + r.dedup_id : r.kind + ":" + r.uuid;
+  }
+
   window.PhoenixKitHooks.SearchPicker = {
     mounted() {
       this.dd = document.getElementById(this.el.dataset.dropdown);
@@ -4906,11 +4913,32 @@ if (typeof window.Chart === "undefined") {
         if (payload.id && payload.id !== this.el.id) return;
         if (this.stagingNow) return;
         if (this.el.value.trim() !== (payload.q || "")) return; // stale
-        // The server always answers with the FULL page for the requested
-        // limit — REPLACE the list, never merge: merging by kind+uuid can
-        // duplicate a person whose row legitimately changed source between
-        // pages (server-side dedup upgraded it, e.g. staff row -> user row).
-        this.results = payload.results || [];
+        var incoming = payload.results || [];
+
+        if (this.loadingMore) {
+          // "Load more" grows a per-source page, so a naive replace would
+          // re-order the flattened list (new rows land BETWEEN sources) and
+          // the user loses their place. APPEND only rows not already shown,
+          // so everything on screen stays put and the new ones arrive at the
+          // end. Dedup by `dedup_id` (a stable PERSON identity the server
+          // sends) rather than kind+uuid, so a person whose row flips source
+          // between pages (staff -> user once their user row enters the
+          // window) isn't shown twice. Falls back to kind:uuid when the
+          // server doesn't send dedup_id.
+          var seen = {};
+          this.results.forEach((r) => {
+            seen[dedupKey(r)] = true;
+          });
+          incoming.forEach((r) => {
+            if (!seen[dedupKey(r)]) {
+              this.results.push(r);
+              seen[dedupKey(r)] = true;
+            }
+          });
+        } else {
+          this.results = incoming;
+        }
+
         this.hasMore = !!payload.has_more;
         this.searching = false;
         this.loadingMore = false;

--- a/priv/static/assets/phoenix_kit.js
+++ b/priv/static/assets/phoenix_kit.js
@@ -4899,6 +4899,11 @@ if (typeof window.Chart === "undefined") {
       this.dd.addEventListener("mousedown", (e) => this.onPick(e));
 
       this.handleEvent(this.evResults, (payload) => {
+        // push_event broadcasts to every hook listening on this name — a
+        // second picker sharing the event name would render our rows.
+        // Servers echoing back the `id` we send get exact routing; the
+        // check is skipped when absent for backwards compatibility.
+        if (payload.id && payload.id !== this.el.id) return;
         if (this.stagingNow) return;
         if (this.el.value.trim() !== (payload.q || "")) return; // stale
         var incoming = payload.results || [];
@@ -4919,7 +4924,8 @@ if (typeof window.Chart === "undefined") {
         this.render();
       });
 
-      this.handleEvent(this.evStaged, () => {
+      this.handleEvent(this.evStaged, (payload) => {
+        if (payload && payload.id && payload.id !== this.el.id) return;
         this.stagingNow = false;
         clearTimeout(this.stageT);
         this.clear();
@@ -4950,7 +4956,11 @@ if (typeof window.Chart === "undefined") {
     },
 
     search(q) {
-      this.pushEventTo(this.target, this.evSearch, { q: q, limit: this.limit });
+      this.pushEventTo(this.target, this.evSearch, {
+        q: q,
+        limit: this.limit,
+        id: this.el.id,
+      });
     },
 
     kickSearch() {
@@ -4979,7 +4989,7 @@ if (typeof window.Chart === "undefined") {
         e.preventDefault();
         var q = this.el.value.trim();
         if (q && this.evText && this.mode !== "single") {
-          this.pushEventTo(this.target, this.evText, { name: q });
+          this.pushEventTo(this.target, this.evText, { name: q, id: this.el.id });
           this.staging();
         }
       } else if (e.key === "Escape") {
@@ -5008,12 +5018,13 @@ if (typeof window.Chart === "undefined") {
       if (btn.dataset.pick === "text") {
         var q = this.el.value.trim();
         if (!q || !this.evText) return;
-        this.pushEventTo(this.target, this.evText, { name: q });
+        this.pushEventTo(this.target, this.evText, { name: q, id: this.el.id });
       } else {
         this.pushEventTo(this.target, this.evPick, {
           kind: btn.dataset.kind,
           uuid: btn.dataset.uuid,
           label: btn.dataset.label,
+          id: this.el.id,
         });
       }
       this.staging();

--- a/test/integration/users/permissions_cascade_test.exs
+++ b/test/integration/users/permissions_cascade_test.exs
@@ -1,0 +1,237 @@
+defmodule PhoenixKit.Integration.Users.PermissionsCascadeTest do
+  # async: false — registers a fake module in the global ModuleRegistry and
+  # mutates the Admin system role's permissions (sandboxed, but the registry
+  # entry itself is process-global).
+  use PhoenixKit.DataCase, async: false
+
+  alias PhoenixKit.ModuleRegistry
+  alias PhoenixKit.Settings
+  alias PhoenixKit.Users.Auth
+  alias PhoenixKit.Users.Auth.Scope
+  alias PhoenixKit.Users.Permissions
+  alias PhoenixKit.Users.RolePermission
+  alias PhoenixKit.Users.Roles
+
+  defmodule FakeCalendar do
+    def module_key, do: "fake_calendar"
+    def module_name, do: "Fake Calendar"
+    def enabled?, do: true
+
+    def permission_metadata do
+      %{
+        key: "fake_calendar",
+        label: "Fake Calendar",
+        icon: "hero-calendar-days",
+        description: "Fake module for cascade tests",
+        sub_permissions: [
+          %{key: "view_others", label: "View others", description: ""},
+          %{key: "edit_others", label: "Edit others", description: ""}
+        ]
+      }
+    end
+  end
+
+  @base "fake_calendar"
+  @sub_view "fake_calendar.view_others"
+  @sub_edit "fake_calendar.edit_others"
+
+  setup do
+    ModuleRegistry.register(FakeCalendar)
+    on_exit(fn -> ModuleRegistry.unregister(FakeCalendar) end)
+    :ok
+  end
+
+  defp unique_email, do: "cascade_#{System.unique_integer([:positive])}@example.com"
+
+  defp create_user do
+    {:ok, user} = Auth.register_user(%{email: unique_email(), password: "ValidPassword123!"})
+    user
+  end
+
+  defp get_role_uuid(role_name) do
+    role = Enum.find(Roles.list_roles(), &(&1.name == role_name))
+    role.uuid
+  end
+
+  describe "grant_permission/3 with sub keys" do
+    test "granting a sub key auto-grants its base key" do
+      role_uuid = get_role_uuid("User")
+
+      assert {:ok, _} = Permissions.grant_permission(role_uuid, @sub_view)
+
+      perms = Permissions.get_permissions_for_role(role_uuid)
+      assert @sub_view in perms
+      assert @base in perms
+    end
+
+    test "granting a sub when the base is already held stays idempotent" do
+      role_uuid = get_role_uuid("User")
+
+      assert {:ok, _} = Permissions.grant_permission(role_uuid, @base)
+      assert {:ok, _} = Permissions.grant_permission(role_uuid, @sub_view)
+      assert {:ok, _} = Permissions.grant_permission(role_uuid, @sub_view)
+
+      perms = Permissions.get_permissions_for_role(role_uuid)
+      assert Enum.sort(perms) == Enum.sort([@base, @sub_view])
+    end
+  end
+
+  describe "revoke_permission/2 with sub keys" do
+    test "revoking the base key cascades its sub keys off" do
+      role_uuid = get_role_uuid("User")
+      :ok = Permissions.set_permissions(role_uuid, [@base, @sub_view, @sub_edit])
+
+      assert :ok = Permissions.revoke_permission(role_uuid, @base)
+      assert Permissions.get_permissions_for_role(role_uuid) == []
+    end
+
+    test "revoking a sub key leaves the base key in place" do
+      role_uuid = get_role_uuid("User")
+      :ok = Permissions.set_permissions(role_uuid, [@base, @sub_view, @sub_edit])
+
+      assert :ok = Permissions.revoke_permission(role_uuid, @sub_view)
+
+      perms = Permissions.get_permissions_for_role(role_uuid)
+      assert @base in perms
+      assert @sub_edit in perms
+      refute @sub_view in perms
+    end
+  end
+
+  describe "set_permissions/3 normalization" do
+    test "a requested sub key pulls in its base key" do
+      role_uuid = get_role_uuid("User")
+
+      assert :ok = Permissions.set_permissions(role_uuid, [@sub_edit])
+
+      perms = Permissions.get_permissions_for_role(role_uuid)
+      assert @base in perms
+      assert @sub_edit in perms
+    end
+
+    test "dropping base and subs from the desired set removes all of them" do
+      role_uuid = get_role_uuid("User")
+      :ok = Permissions.set_permissions(role_uuid, [@base, @sub_view])
+
+      assert :ok = Permissions.set_permissions(role_uuid, ["dashboard"])
+      assert Permissions.get_permissions_for_role(role_uuid) == ["dashboard"]
+    end
+  end
+
+  describe "any_permissions_exist?/0" do
+    test "true on a seeded install, false once all rows are gone" do
+      # V53 seeded the Admin role, so the test DB starts seeded
+      assert Permissions.any_permissions_exist?()
+
+      Repo.delete_all(RolePermission)
+      refute Permissions.any_permissions_exist?()
+    end
+  end
+
+  describe "auto_grant_new_keys_to_admin/0" do
+    test "grants unseen keys to Admin; an Owner revocation then sticks" do
+      admin_uuid = get_role_uuid("Admin")
+
+      # V53 never saw this module's keys
+      refute @base in Permissions.get_permissions_for_role(admin_uuid)
+
+      assert :ok = Permissions.auto_grant_new_keys_to_admin()
+
+      perms = Permissions.get_permissions_for_role(admin_uuid)
+      assert @base in perms
+      assert @sub_view in perms
+      assert @sub_edit in perms
+      assert Settings.get_setting("auto_granted_perm:#{@base}") == "true"
+
+      # Owner revokes one sub key — the flag must keep the next boot's
+      # auto-grant from silently restoring it
+      assert :ok = Permissions.revoke_permission(admin_uuid, @sub_edit)
+      assert :ok = Permissions.auto_grant_new_keys_to_admin()
+
+      perms = Permissions.get_permissions_for_role(admin_uuid)
+      assert @sub_view in perms
+      refute @sub_edit in perms
+    end
+
+    test "is idempotent — repeated runs create no duplicate rows" do
+      admin_uuid = get_role_uuid("Admin")
+
+      assert :ok = Permissions.auto_grant_new_keys_to_admin()
+      count_first = Permissions.count_permissions_for_role(admin_uuid)
+
+      assert :ok = Permissions.auto_grant_new_keys_to_admin()
+      assert Permissions.count_permissions_for_role(admin_uuid) == count_first
+    end
+  end
+
+  describe "Scope.for_user/1 Admin fallback scoping" do
+    setup do
+      _owner = create_user()
+      admin_user = create_user()
+      {:ok, _} = Roles.assign_role(admin_user, "Admin")
+      %{admin_user: admin_user}
+    end
+
+    test "admin uses its rows on a seeded install", %{admin_user: admin_user} do
+      scope = Scope.for_user(admin_user)
+
+      # V53 seeded rows — present, but NOT the registry-wide key list
+      assert Scope.has_module_access?(scope, "dashboard")
+      refute MapSet.member?(Scope.accessible_modules(scope), @base)
+    end
+
+    test "revoking everything from Admin sticks on a seeded install",
+         %{admin_user: admin_user} do
+      admin_uuid = get_role_uuid("Admin")
+
+      # keep the table non-empty via a role the admin user does NOT hold
+      # (permissions join across ALL of a user's roles — the default "User"
+      # role would leak its grants into this scope)
+      {:ok, keeper} = Roles.create_role(%{name: "Keeper #{System.unique_integer([:positive])}"})
+      {:ok, _} = Permissions.grant_permission(keeper.uuid, "dashboard")
+      :ok = Permissions.revoke_all_permissions(admin_uuid)
+
+      scope = Scope.for_user(admin_user)
+
+      # the old per-user fallback would ironically restore FULL access here
+      assert Scope.accessible_modules(scope) == MapSet.new()
+      refute Scope.has_module_access?(scope, "dashboard")
+      # still admin? (holds the role) — shell access, but every gated view denies
+      assert Scope.admin?(scope)
+    end
+
+    test "genuinely unseeded install falls back to full access",
+         %{admin_user: admin_user} do
+      Repo.delete_all(RolePermission)
+
+      scope = Scope.for_user(admin_user)
+
+      assert Scope.has_module_access?(scope, "dashboard")
+      assert Scope.has_module_access?(scope, @base)
+      assert Scope.has_module_access?(scope, @sub_edit)
+    end
+
+    test "Owner always holds every key regardless of rows" do
+      # first registered user became Owner in setup
+      owner = Auth.get_user_by_email(hd(owner_emails()))
+      Repo.delete_all(RolePermission)
+
+      scope = Scope.for_user(owner)
+      assert Scope.has_module_access?(scope, @base)
+      assert Scope.has_module_access?(scope, @sub_view)
+    end
+  end
+
+  defp owner_emails do
+    Repo.all(
+      from(u in PhoenixKit.Users.Auth.User,
+        join: ra in PhoenixKit.Users.RoleAssignment,
+        on: ra.user_uuid == u.uuid,
+        join: r in PhoenixKit.Users.Role,
+        on: r.uuid == ra.role_uuid,
+        where: r.name == "Owner",
+        select: u.email
+      )
+    )
+  end
+end

--- a/test/integration/users/permissions_cascade_test.exs
+++ b/test/integration/users/permissions_cascade_test.exs
@@ -172,6 +172,31 @@ defmodule PhoenixKit.Integration.Users.PermissionsCascadeTest do
       assert :ok = Permissions.auto_grant_new_keys_to_admin()
       assert Permissions.count_permissions_for_role(admin_uuid) == count_first
     end
+
+    test "a NEW sub-key does not resurrect a base the Owner revoked" do
+      admin_uuid = get_role_uuid("Admin")
+
+      # first boot: base + subs granted, flags set
+      assert :ok = Permissions.auto_grant_new_keys_to_admin()
+      assert @base in Permissions.get_permissions_for_role(admin_uuid)
+
+      # Owner revokes the whole module from Admin (cascades subs off) and it
+      # must STICK — mark the base as manually revoked by clearing its rows
+      assert :ok = Permissions.revoke_permission(admin_uuid, @base)
+      refute @base in Permissions.get_permissions_for_role(admin_uuid)
+
+      # simulate a later release adding a brand-new sub-key: clear only its
+      # auto-grant flag so the next boot treats it as unseen
+      Settings.update_setting("auto_granted_perm:#{@sub_view}", "false")
+
+      assert :ok = Permissions.auto_grant_new_keys_to_admin()
+
+      perms = Permissions.get_permissions_for_role(admin_uuid)
+      # the sub's cascade must NOT re-insert the revoked base...
+      refute @base in perms
+      # ...and the sub itself is withheld while the base is revoked
+      refute @sub_view in perms
+    end
   end
 
   describe "Scope.for_user/1 Admin fallback scoping" do

--- a/test/integration/users/permissions_cascade_test.exs
+++ b/test/integration/users/permissions_cascade_test.exs
@@ -98,6 +98,41 @@ defmodule PhoenixKit.Integration.Users.PermissionsCascadeTest do
     end
   end
 
+  describe "revoke_permission/3 authorization" do
+    test "revoking a base is rejected when the actor can't manage a cascaded sub" do
+      role_uuid = get_role_uuid("User")
+      :ok = Permissions.set_permissions(role_uuid, [@base, @sub_view, @sub_edit])
+
+      # The actor may manage the base + view_others, but NOT edit_others.
+      grantable = MapSet.new([@base, @sub_view])
+
+      assert {:error, :unauthorized} =
+               Permissions.revoke_permission(role_uuid, @base, authorized_keys: grantable)
+
+      # The whole revoke rolled back — nothing was removed.
+      assert Enum.sort(Permissions.get_permissions_for_role(role_uuid)) ==
+               Enum.sort([@base, @sub_view, @sub_edit])
+    end
+
+    test "revoking a base succeeds when the actor can manage every cascaded key" do
+      role_uuid = get_role_uuid("User")
+      :ok = Permissions.set_permissions(role_uuid, [@base, @sub_view, @sub_edit])
+
+      grantable = MapSet.new([@base, @sub_view, @sub_edit])
+
+      assert :ok = Permissions.revoke_permission(role_uuid, @base, authorized_keys: grantable)
+      assert Permissions.get_permissions_for_role(role_uuid) == []
+    end
+
+    test "omitting authorized_keys skips the check (system caller)" do
+      role_uuid = get_role_uuid("User")
+      :ok = Permissions.set_permissions(role_uuid, [@base, @sub_view])
+
+      assert :ok = Permissions.revoke_permission(role_uuid, @base)
+      assert Permissions.get_permissions_for_role(role_uuid) == []
+    end
+  end
+
   describe "set_permissions/3 normalization" do
     test "a requested sub key pulls in its base key" do
       role_uuid = get_role_uuid("User")

--- a/test/integration/users/permissions_cascade_test.exs
+++ b/test/integration/users/permissions_cascade_test.exs
@@ -118,13 +118,23 @@ defmodule PhoenixKit.Integration.Users.PermissionsCascadeTest do
     end
   end
 
-  describe "any_permissions_exist?/0" do
+  describe "any_permissions_exist?/0 (deprecated)" do
     test "true on a seeded install, false once all rows are gone" do
       # V53 seeded the Admin role, so the test DB starts seeded
       assert Permissions.any_permissions_exist?()
 
       Repo.delete_all(RolePermission)
       refute Permissions.any_permissions_exist?()
+    end
+  end
+
+  describe "permissions_table_ready?/0" do
+    test "stays true whether the table has rows or not (keys on presence)" do
+      assert Permissions.permissions_table_ready?()
+
+      Repo.delete_all(RolePermission)
+      # unlike any_permissions_exist?/0, an empty-but-present table is READY
+      assert Permissions.permissions_table_ready?()
     end
   end
 
@@ -200,15 +210,23 @@ defmodule PhoenixKit.Integration.Users.PermissionsCascadeTest do
       assert Scope.admin?(scope)
     end
 
-    test "genuinely unseeded install falls back to full access",
+    test "emptying the table (present, migrated) does NOT restore Admin full access",
          %{admin_user: admin_user} do
+      # The old count-based fallback treated zero rows as 'unseeded' and
+      # restored full access — so an Owner stripping every role bare
+      # ironically re-privileged Admin. The fallback is now keyed on table
+      # PRESENCE, not row count.
       Repo.delete_all(RolePermission)
 
-      scope = Scope.for_user(admin_user)
+      # the table is still present/migrated
+      assert Permissions.permissions_table_ready?()
 
-      assert Scope.has_module_access?(scope, "dashboard")
-      assert Scope.has_module_access?(scope, @base)
-      assert Scope.has_module_access?(scope, @sub_edit)
+      scope = Scope.for_user(admin_user)
+      assert Scope.accessible_modules(scope) == MapSet.new()
+      refute Scope.has_module_access?(scope, "dashboard")
+      refute Scope.has_module_access?(scope, @base)
+      # only a genuinely MISSING table (pre-V53) unlocks the full-access
+      # escape hatch — see permissions_table_ready?/0.
     end
 
     test "Owner always holds every key regardless of rows" do

--- a/test/integration/users/roles_test.exs
+++ b/test/integration/users/roles_test.exs
@@ -184,6 +184,56 @@ defmodule PhoenixKit.Integration.Users.RolesTest do
     end
   end
 
+  describe "sync_user_roles/3 authorization" do
+    # first-created user is the seed Owner; make some named actors
+    defp make(actor_roles) do
+      _seed_owner = create_user()
+      user = create_user()
+      Enum.each(actor_roles, fn r -> {:ok, _} = Roles.assign_role(user, r) end)
+      user
+    end
+
+    test "a non-Owner cannot grant Owner or Admin to another account (no escalation)" do
+      editor = make([])
+      target = create_user()
+
+      {:ok, _} = Roles.sync_user_roles(target, ["Admin"], actor: editor)
+      refute Roles.user_has_role?(target, "Admin")
+
+      # Owner is additionally un-assignable system-wide; either way it never lands
+      _ = Roles.sync_user_roles(target, ["Owner"], actor: editor)
+      refute Roles.user_has_role?(target, "Owner")
+    end
+
+    test "a non-Owner CAN manage custom roles" do
+      editor = make([])
+      {:ok, _} = Roles.create_role(%{name: "Manager", description: "d"})
+      target = create_user()
+
+      {:ok, _} = Roles.sync_user_roles(target, ["Manager"], actor: editor)
+      assert Roles.user_has_role?(target, "Manager")
+    end
+
+    test "a non-Owner submitting an Owner's modal cannot strip Owner (disabled-checkbox wipe)" do
+      # seed owner is the FIRST user; the target here is that seed owner
+      seed_owner = create_user()
+      editor = create_user()
+      # the disabled Owner checkbox never submits → role_names lacks Owner
+      {:ok, _} = Roles.sync_user_roles(seed_owner, [], actor: editor)
+      assert Roles.user_has_role?(seed_owner, "Owner")
+    end
+
+    test "the last Owner cannot be removed even by an Owner actor" do
+      seed_owner = create_user()
+      assert Roles.user_has_role?(seed_owner, "Owner")
+
+      assert {:error, :cannot_remove_last_owner} =
+               Roles.sync_user_roles(seed_owner, [], actor: seed_owner)
+
+      assert Roles.user_has_role?(seed_owner, "Owner")
+    end
+  end
+
   describe "custom role CRUD" do
     test "create_role/1 creates a custom role" do
       assert {:ok, role} = Roles.create_role(%{name: "Editor", description: "Can edit content"})

--- a/test/integration/users/roles_test.exs
+++ b/test/integration/users/roles_test.exs
@@ -214,6 +214,20 @@ defmodule PhoenixKit.Integration.Users.RolesTest do
       assert Roles.user_has_role?(target, "Manager")
     end
 
+    test "returns the before/after role sets captured in the transaction (exact audit)" do
+      {:ok, _} = Roles.create_role(%{name: "Manager", description: "d"})
+      target = create_user()
+      before_roles = Roles.get_user_roles(target)
+
+      {:ok, result} =
+        Roles.sync_user_roles(target, before_roles ++ ["Manager"], actor: :system)
+
+      assert %{roles_before: rb, roles_after: ra, assignments: _} = result
+      assert Enum.sort(rb) == Enum.sort(before_roles)
+      assert "Manager" in ra
+      refute "Manager" in rb
+    end
+
     test "a non-Owner submitting an Owner's modal cannot strip Owner (disabled-checkbox wipe)" do
       # seed owner is the FIRST user; the target here is that seed owner
       seed_owner = create_user()

--- a/test/phoenix_kit/users/permissions_sub_keys_test.exs
+++ b/test/phoenix_kit/users/permissions_sub_keys_test.exs
@@ -1,0 +1,267 @@
+defmodule PhoenixKit.Users.PermissionsSubKeysTest do
+  # async: false — registers fake modules in the global ModuleRegistry.
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  alias PhoenixKit.ModuleRegistry
+  alias PhoenixKit.Users.Auth.Scope
+  alias PhoenixKit.Users.Auth.User
+  alias PhoenixKit.Users.Permissions
+  alias PhoenixKit.Users.RolePermission
+
+  defmodule FakeCalendar do
+    def module_key, do: "fake_calendar"
+    def module_name, do: "Fake Calendar"
+    def enabled?, do: true
+
+    def permission_metadata do
+      %{
+        key: "fake_calendar",
+        label: "Fake Calendar",
+        icon: "hero-calendar-days",
+        description: "Fake module for sub-permission tests",
+        sub_permissions: [
+          %{key: "view_others", label: "View others' calendars", description: "Read-only"},
+          %{key: "edit_others", label: "Edit others' calendars", description: "Write"}
+        ]
+      }
+    end
+  end
+
+  defmodule FakeDisabled do
+    def module_key, do: "fake_disabled"
+    def module_name, do: "Fake Disabled"
+    def enabled?, do: false
+
+    def permission_metadata do
+      %{
+        key: "fake_disabled",
+        label: "Fake Disabled",
+        icon: "hero-no-symbol",
+        description: "Disabled module with a sub-permission",
+        sub_permissions: [
+          %{key: "manage", label: "Manage", description: ""}
+        ]
+      }
+    end
+  end
+
+  defmodule FakeMalformedSubs do
+    def module_key, do: "fake_malformed"
+    def module_name, do: "Fake Malformed"
+    def enabled?, do: true
+
+    def permission_metadata do
+      %{
+        key: "fake_malformed",
+        label: "Fake Malformed",
+        icon: "hero-bug-ant",
+        description: "Declares invalid sub-permissions",
+        sub_permissions: [
+          # dot in the sub part — must be dropped (would compose a 2-dot key)
+          %{key: "bad.key", label: "Bad"},
+          # uppercase — fails the key regex
+          %{key: "BadCase", label: "Bad case"},
+          # missing :label — malformed shape
+          %{key: "no_label"},
+          # valid — must survive
+          %{key: "ok_sub", label: "OK sub", description: "Valid"}
+        ]
+      }
+    end
+  end
+
+  setup do
+    ModuleRegistry.register(FakeCalendar)
+    ModuleRegistry.register(FakeDisabled)
+
+    on_exit(fn ->
+      ModuleRegistry.unregister(FakeCalendar)
+      ModuleRegistry.unregister(FakeDisabled)
+      ModuleRegistry.unregister(FakeMalformedSubs)
+    end)
+
+    :ok
+  end
+
+  defp scope_with(perms) do
+    %Scope{
+      user: %User{uuid: "0193a5e4-0000-7000-8000-000000000001", email: "sub@example.com"},
+      authenticated?: true,
+      cached_roles: ["SomeCustomRole"],
+      cached_permissions: MapSet.new(perms)
+    }
+  end
+
+  describe "registry sub_permission_map/0" do
+    test "collects composed keys with metadata" do
+      map = ModuleRegistry.sub_permission_map()
+
+      assert [edit, view] = Enum.sort_by(map["fake_calendar"], & &1.key)
+      assert edit.key == "fake_calendar.edit_others"
+      assert view.key == "fake_calendar.view_others"
+      assert view.label == "View others' calendars"
+      assert view.description == "Read-only"
+    end
+
+    test "drops malformed sub-permissions with a warning, keeps valid ones" do
+      log =
+        capture_log(fn ->
+          ModuleRegistry.register(FakeMalformedSubs)
+          map = ModuleRegistry.sub_permission_map()
+
+          assert [%{key: "fake_malformed.ok_sub"}] = map["fake_malformed"]
+        end)
+
+      assert log =~ "bad.key"
+      assert log =~ "BadCase"
+      assert log =~ "no_label"
+    end
+
+    test "modules without sub_permissions don't appear in the map" do
+      refute Map.has_key?(ModuleRegistry.sub_permission_map(), "fake_no_subs")
+    end
+  end
+
+  describe "sub-permission key lists" do
+    test "sub_permission_keys/0 returns composed keys" do
+      keys = Permissions.sub_permission_keys()
+      assert "fake_calendar.view_others" in keys
+      assert "fake_calendar.edit_others" in keys
+    end
+
+    test "all_module_keys/0 includes sub keys alongside base keys" do
+      keys = Permissions.all_module_keys()
+      assert "fake_calendar" in keys
+      assert "fake_calendar.view_others" in keys
+    end
+
+    test "feature_module_keys/0 does NOT include sub keys" do
+      keys = Permissions.feature_module_keys()
+      assert "fake_calendar" in keys
+      refute Enum.any?(keys, &String.contains?(&1, "."))
+    end
+
+    test "sub_permissions_for/1 returns [] for keys without subs" do
+      assert Permissions.sub_permissions_for("dashboard") == []
+      assert Permissions.sub_permissions_for("nonexistent") == []
+    end
+  end
+
+  describe "parent_key/1" do
+    test "resolves a composed key to its base" do
+      assert Permissions.parent_key("fake_calendar.view_others") == "fake_calendar"
+    end
+
+    test "returns nil for base keys, unknown dotted keys, and non-binaries" do
+      assert Permissions.parent_key("fake_calendar") == nil
+      assert Permissions.parent_key("fake_calendar.nonexistent") == nil
+      assert Permissions.parent_key("unknown.sub") == nil
+      assert Permissions.parent_key(nil) == nil
+    end
+  end
+
+  describe "expand_with_parents/1" do
+    test "adds the base key implied by a sub key" do
+      assert Permissions.expand_with_parents(["fake_calendar.view_others"]) ==
+               MapSet.new(["fake_calendar.view_others", "fake_calendar"])
+    end
+
+    test "leaves base keys and unknown keys untouched" do
+      keys = ["dashboard", "unknown.sub"]
+      assert Permissions.expand_with_parents(keys) == MapSet.new(keys)
+    end
+  end
+
+  describe "valid_module_key?/1 with sub keys" do
+    test "accepts registered sub keys, rejects unknown dotted keys" do
+      assert Permissions.valid_module_key?("fake_calendar.view_others")
+      refute Permissions.valid_module_key?("fake_calendar.nonexistent")
+      refute Permissions.valid_module_key?("nonexistent.view_others")
+    end
+  end
+
+  describe "sub-key metadata resolution" do
+    test "module_label/1 resolves the sub's own label" do
+      assert Permissions.module_label("fake_calendar.view_others") ==
+               "View others' calendars"
+    end
+
+    test "module_description/1 resolves the sub's own description" do
+      assert Permissions.module_description("fake_calendar.edit_others") == "Write"
+    end
+
+    test "module_icon/1 inherits the parent module's icon" do
+      assert Permissions.module_icon("fake_calendar.view_others") == "hero-calendar-days"
+    end
+  end
+
+  describe "feature_enabled?/1 with sub keys" do
+    test "sub key follows the parent module's enabled state" do
+      assert Permissions.feature_enabled?("fake_calendar.view_others")
+      refute Permissions.feature_enabled?("fake_disabled.manage")
+    end
+
+    test "unknown dotted keys are not enabled" do
+      refute Permissions.feature_enabled?("unknown.sub")
+    end
+  end
+
+  describe "enabled_module_keys/0 with sub keys" do
+    test "includes subs of enabled modules, excludes subs of disabled ones" do
+      enabled = Permissions.enabled_module_keys()
+      assert MapSet.member?(enabled, "fake_calendar.view_others")
+      refute MapSet.member?(enabled, "fake_disabled.manage")
+      # the disabled base key is excluded as before
+      refute MapSet.member?(enabled, "fake_disabled")
+    end
+  end
+
+  describe "RolePermission.changeset/2 with sub keys" do
+    test "accepts a registered sub key" do
+      changeset =
+        RolePermission.changeset(%RolePermission{}, %{
+          role_uuid: UUIDv7.generate(),
+          module_key: "fake_calendar.view_others"
+        })
+
+      assert changeset.valid?
+    end
+
+    test "rejects an unregistered dotted key" do
+      changeset =
+        RolePermission.changeset(%RolePermission{}, %{
+          role_uuid: UUIDv7.generate(),
+          module_key: "fake_calendar.nonexistent"
+        })
+
+      refute changeset.valid?
+    end
+  end
+
+  describe "Scope.can?/2" do
+    test "true when the key is held and its parent module is enabled" do
+      scope = scope_with(["fake_calendar", "fake_calendar.view_others"])
+      assert Scope.can?(scope, "fake_calendar.view_others")
+      assert Scope.can?(scope, "fake_calendar")
+    end
+
+    test "false when the key is not held" do
+      scope = scope_with(["fake_calendar"])
+      refute Scope.can?(scope, "fake_calendar.view_others")
+    end
+
+    test "false when the parent module is disabled, even if the key is cached" do
+      # a scope snapshotted before the module was disabled must not keep
+      # authorizing its actions
+      scope = scope_with(["fake_disabled", "fake_disabled.manage"])
+      refute Scope.can?(scope, "fake_disabled.manage")
+      refute Scope.can?(scope, "fake_disabled")
+    end
+
+    test "false for anonymous scope" do
+      refute Scope.can?(Scope.for_user(nil), "fake_calendar.view_others")
+    end
+  end
+end

--- a/test/phoenix_kit/users/permissions_sub_keys_test.exs
+++ b/test/phoenix_kit/users/permissions_sub_keys_test.exs
@@ -72,6 +72,23 @@ defmodule PhoenixKit.Users.PermissionsSubKeysTest do
     end
   end
 
+  defmodule FakeDottedBase do
+    # A module whose BASE key illegally contains a dot — it would collide
+    # with FakeCalendar's composed "fake_calendar.view_others" sub-key.
+    def module_key, do: "fake_calendar.view_others"
+    def module_name, do: "Fake Dotted Base"
+    def enabled?, do: true
+
+    def permission_metadata do
+      %{
+        key: "fake_calendar.view_others",
+        label: "Dotted Base",
+        icon: "hero-bug-ant",
+        description: "Illegal dotted base key"
+      }
+    end
+  end
+
   setup do
     ModuleRegistry.register(FakeCalendar)
     ModuleRegistry.register(FakeDisabled)
@@ -80,6 +97,7 @@ defmodule PhoenixKit.Users.PermissionsSubKeysTest do
       ModuleRegistry.unregister(FakeCalendar)
       ModuleRegistry.unregister(FakeDisabled)
       ModuleRegistry.unregister(FakeMalformedSubs)
+      ModuleRegistry.unregister(FakeDottedBase)
     end)
 
     :ok
@@ -252,6 +270,18 @@ defmodule PhoenixKit.Users.PermissionsSubKeysTest do
       refute Scope.can?(scope, "fake_calendar.view_others")
     end
 
+    test "false for a sub whose BASE is not held (orphan sub)" do
+      # the cascade keeps this from happening normally, but a sub row can
+      # outlive its base if a module/sub temporarily leaves the registry —
+      # can?/2 must not honor a dotted key whose base the role lacks
+      scope = scope_with(["fake_calendar.view_others"])
+      refute Scope.can?(scope, "fake_calendar.view_others")
+
+      # holding the base too makes it effective again
+      scope = scope_with(["fake_calendar", "fake_calendar.view_others"])
+      assert Scope.can?(scope, "fake_calendar.view_others")
+    end
+
     test "false when the parent module is disabled, even if the key is cached" do
       # a scope snapshotted before the module was disabled must not keep
       # authorizing its actions
@@ -262,6 +292,37 @@ defmodule PhoenixKit.Users.PermissionsSubKeysTest do
 
     test "false for anonymous scope" do
       refute Scope.can?(Scope.for_user(nil), "fake_calendar.view_others")
+    end
+  end
+
+  describe "dotted base key rejection" do
+    test "a module base key containing a dot is not a valid feature key" do
+      ModuleRegistry.register(FakeDottedBase)
+
+      refute "fake_calendar.view_others" in ModuleRegistry.all_feature_keys()
+      # ...and the legit sub of the same string still resolves to its base
+      assert Permissions.parent_key("fake_calendar.view_others") == "fake_calendar"
+    end
+
+    test "valid_base_key?/1 rejects dots, uppercase, and overlength" do
+      assert ModuleRegistry.valid_base_key?("calendar")
+      refute ModuleRegistry.valid_base_key?("calendar.view_others")
+      refute ModuleRegistry.valid_base_key?("Calendar")
+      refute ModuleRegistry.valid_base_key?(String.duplicate("a", 60))
+    end
+
+    test "a dotted-base module cannot declare composing sub-permissions" do
+      # If FakeDottedBase declared subs, "fake_calendar.view_others.x" would
+      # compose ambiguously — its subs must be dropped entirely.
+      import ExUnit.CaptureLog
+
+      log =
+        capture_log(fn ->
+          ModuleRegistry.register(FakeDottedBase)
+          refute Map.has_key?(ModuleRegistry.sub_permission_map(), "fake_calendar.view_others")
+        end)
+
+      _ = log
     end
   end
 end

--- a/test/phoenix_kit_web/components/core/checkbox_test.exs
+++ b/test/phoenix_kit_web/components/core/checkbox_test.exs
@@ -1,0 +1,60 @@
+defmodule PhoenixKitWeb.Components.Core.CheckboxTest do
+  use ExUnit.Case, async: true
+
+  import Phoenix.Component, only: [sigil_H: 2, to_form: 2]
+  import Phoenix.LiveViewTest, only: [rendered_to_string: 1]
+  import PhoenixKitWeb.Components.Core.Checkbox
+
+  defp render(template), do: rendered_to_string(template)
+
+  defp form(values), do: to_form(values, as: "event")
+
+  test "a field-bound checkbox derives checked from the field's value" do
+    # Regression: `attr :checked, default: false` used to materialize into
+    # assigns before the field clause ran, so assign_new never derived from
+    # the field and a truthy value STILL rendered unchecked — the classic
+    # "toggling visually unchecks itself on the next patch" symptom.
+    assigns = %{form: form(%{"all_day" => "true"})}
+
+    html =
+      render(~H"""
+      <.checkbox field={@form[:all_day]} label="All day" />
+      """)
+
+    assert html =~ ~s(type="checkbox")
+    assert html =~ "checked"
+
+    assigns = %{form: form(%{"all_day" => "false"})}
+
+    html =
+      render(~H"""
+      <.checkbox field={@form[:all_day]} label="All day" />
+      """)
+
+    refute html =~ ~s(<input type="checkbox" checked)
+    refute html =~ ~s(checked="checked")
+  end
+
+  test "an explicit checked= overrides the field's value" do
+    assigns = %{form: form(%{"all_day" => "true"})}
+
+    html =
+      render(~H"""
+      <.checkbox field={@form[:all_day]} checked={false} label="All day" />
+      """)
+
+    refute html =~ ~s(checked="checked")
+  end
+
+  test "a raw (non-field) checkbox still renders without passing checked" do
+    assigns = %{}
+
+    html =
+      render(~H"""
+      <.checkbox name="agree" label="Agree" />
+      """)
+
+    assert html =~ ~s(name="agree")
+    refute html =~ ~s(checked="checked")
+  end
+end

--- a/test/phoenix_kit_web/components/core/popover_panel_test.exs
+++ b/test/phoenix_kit_web/components/core/popover_panel_test.exs
@@ -7,24 +7,34 @@ defmodule PhoenixKitWeb.Components.Core.PopoverPanelTest do
 
   defp render(template), do: rendered_to_string(template)
 
-  test "renders the panel with content, backdrop, and close wiring" do
+  test "renders hidden by default with content and close wiring" do
     assigns = %{}
 
     html =
       render(~H"""
-      <.popover_panel id="test-panel" on_close="close_it">
+      <.popover_panel id="test-panel">
         <p>Panel content</p>
       </.popover_panel>
       """)
 
     assert html =~ ~s(id="test-panel")
     assert html =~ "Panel content"
-    # Escape closes
-    assert html =~ ~s(phx-window-keydown="close_it")
+    # closed until the client-side toggle runs — no server round-trip to open
+    assert html =~ ~s(class="hidden fixed)
+    # Escape hides client-side (a JS command, not a named server event)
+    assert html =~ ~s(phx-window-keydown)
     assert html =~ ~s(phx-key="escape")
-    # backdrop click closes
-    assert html =~ ~s(phx-click="close_it")
     assert html =~ ~s(role="dialog")
+  end
+
+  test "toggle_popover/2 and hide_popover/2 emit client-side JS targeting the id" do
+    toggle = toggle_popover("test-panel") |> Phoenix.json_library().encode!()
+    hide = hide_popover("test-panel") |> Phoenix.json_library().encode!()
+
+    assert toggle =~ "toggle"
+    assert toggle =~ "#test-panel"
+    assert hide =~ "hide"
+    assert hide =~ "#test-panel"
   end
 
   test "the card stacks ABOVE the click-away backdrop" do
@@ -35,15 +45,11 @@ defmodule PhoenixKitWeb.Components.Core.PopoverPanelTest do
 
     html =
       render(~H"""
-      <.popover_panel id="stack-panel" on_close="close_it">
+      <.popover_panel id="stack-panel">
         <p>content</p>
       </.popover_panel>
       """)
 
-    [_before, card_and_after] = String.split(html, "card bg-base-100", parts: 2)
-    _ = card_and_after
-
-    # the card div carries z-10 + positioning in BOTH breakpoints
     assert html =~ "absolute inset-x-2 top-12 z-10"
     assert html =~ "sm:relative"
   end
@@ -53,12 +59,12 @@ defmodule PhoenixKitWeb.Components.Core.PopoverPanelTest do
 
     end_html =
       render(~H"""
-      <.popover_panel id="p1" on_close="x">content</.popover_panel>
+      <.popover_panel id="p1">content</.popover_panel>
       """)
 
     start_html =
       render(~H"""
-      <.popover_panel id="p2" on_close="x" align="start">content</.popover_panel>
+      <.popover_panel id="p2" align="start">content</.popover_panel>
       """)
 
     assert end_html =~ "sm:right-0"
@@ -70,7 +76,7 @@ defmodule PhoenixKitWeb.Components.Core.PopoverPanelTest do
 
     html =
       render(~H"""
-      <.popover_panel id="p3" on_close="x" width_class="sm:w-72" class="p-1">
+      <.popover_panel id="p3" width_class="sm:w-72" class="p-1">
         content
       </.popover_panel>
       """)

--- a/test/phoenix_kit_web/components/core/popover_panel_test.exs
+++ b/test/phoenix_kit_web/components/core/popover_panel_test.exs
@@ -1,0 +1,81 @@
+defmodule PhoenixKitWeb.Components.Core.PopoverPanelTest do
+  use ExUnit.Case, async: true
+
+  import Phoenix.Component, only: [sigil_H: 2]
+  import Phoenix.LiveViewTest, only: [rendered_to_string: 1]
+  import PhoenixKitWeb.Components.Core.PopoverPanel
+
+  defp render(template), do: rendered_to_string(template)
+
+  test "renders the panel with content, backdrop, and close wiring" do
+    assigns = %{}
+
+    html =
+      render(~H"""
+      <.popover_panel id="test-panel" on_close="close_it">
+        <p>Panel content</p>
+      </.popover_panel>
+      """)
+
+    assert html =~ ~s(id="test-panel")
+    assert html =~ "Panel content"
+    # Escape closes
+    assert html =~ ~s(phx-window-keydown="close_it")
+    assert html =~ ~s(phx-key="escape")
+    # backdrop click closes
+    assert html =~ ~s(phx-click="close_it")
+    assert html =~ ~s(role="dialog")
+  end
+
+  test "the card stacks ABOVE the click-away backdrop" do
+    # Regression: the card must be a positioned element with a z-index over
+    # the fixed backdrop, or every click/scroll inside the panel lands on
+    # the backdrop and closes it.
+    assigns = %{}
+
+    html =
+      render(~H"""
+      <.popover_panel id="stack-panel" on_close="close_it">
+        <p>content</p>
+      </.popover_panel>
+      """)
+
+    [_before, card_and_after] = String.split(html, "card bg-base-100", parts: 2)
+    _ = card_and_after
+
+    # the card div carries z-10 + positioning in BOTH breakpoints
+    assert html =~ "absolute inset-x-2 top-12 z-10"
+    assert html =~ "sm:relative"
+  end
+
+  test "align start/end picks the anchored edge" do
+    assigns = %{}
+
+    end_html =
+      render(~H"""
+      <.popover_panel id="p1" on_close="x">content</.popover_panel>
+      """)
+
+    start_html =
+      render(~H"""
+      <.popover_panel id="p2" on_close="x" align="start">content</.popover_panel>
+      """)
+
+    assert end_html =~ "sm:right-0"
+    assert start_html =~ "sm:left-0"
+  end
+
+  test "width_class and class merge onto the card" do
+    assigns = %{}
+
+    html =
+      render(~H"""
+      <.popover_panel id="p3" on_close="x" width_class="sm:w-72" class="p-1">
+        content
+      </.popover_panel>
+      """)
+
+    assert html =~ "sm:w-72"
+    assert html =~ "p-1"
+  end
+end

--- a/test/phoenix_kit_web/components/core/search_picker_test.exs
+++ b/test/phoenix_kit_web/components/core/search_picker_test.exs
@@ -23,6 +23,20 @@ defmodule PhoenixKitWeb.Components.Core.SearchPickerTest do
     assert html =~ ~s(id="party-dropdown")
     assert html =~ ~s(phx-update="ignore")
     assert html =~ "hidden absolute"
+    # default direction: opens downward
+    assert html =~ "top-full mt-1"
+  end
+
+  test "direction=up floats the dropdown above the input (bottom-of-modal fields)" do
+    assigns = %{}
+
+    html =
+      render(~H"""
+      <.search_picker id="p" dropdown_id="d" direction="up" />
+      """)
+
+    assert html =~ "bottom-full mb-1"
+    refute html =~ "top-full"
   end
 
   test "default event names cover the full multi-select contract" do

--- a/test/phoenix_kit_web/components/core/search_picker_test.exs
+++ b/test/phoenix_kit_web/components/core/search_picker_test.exs
@@ -1,0 +1,118 @@
+defmodule PhoenixKitWeb.Components.Core.SearchPickerTest do
+  use ExUnit.Case, async: true
+
+  import Phoenix.Component, only: [sigil_H: 2]
+  import Phoenix.LiveViewTest, only: [rendered_to_string: 1]
+  import PhoenixKitWeb.Components.Core.SearchPicker
+
+  defp render(template), do: rendered_to_string(template)
+
+  test "renders the hook input + a hidden client-owned dropdown" do
+    assigns = %{}
+
+    html =
+      render(~H"""
+      <.search_picker id="party-search" dropdown_id="party-dropdown" />
+      """)
+
+    assert html =~ ~s(phx-hook="SearchPicker")
+    assert html =~ ~s(id="party-search")
+    assert html =~ ~s(autocomplete="off")
+    # the dropdown is rendered/toggled entirely by the hook — LV must not
+    # touch it, and it starts hidden (no server round-trip to open)
+    assert html =~ ~s(id="party-dropdown")
+    assert html =~ ~s(phx-update="ignore")
+    assert html =~ "hidden absolute"
+  end
+
+  test "default event names cover the full multi-select contract" do
+    assigns = %{}
+
+    html =
+      render(~H"""
+      <.search_picker id="p" dropdown_id="d" />
+      """)
+
+    assert html =~ ~s(data-search-event="picker_search")
+    assert html =~ ~s(data-results-event="picker_results")
+    assert html =~ ~s(data-pick-event="picker_pick")
+    assert html =~ ~s(data-staged-event="picker_staged")
+    assert html =~ ~s(data-mode="multi")
+    # no free-text row unless the consumer opts in with text_event
+    refute html =~ "data-text-event"
+  end
+
+  test "event names, target selector, and free-text opt-in are overridable" do
+    assigns = %{}
+
+    html =
+      render(~H"""
+      <.search_picker
+        id="p"
+        dropdown_id="d"
+        target="#my-component"
+        search_event="search_party"
+        results_event="crm_party_results"
+        pick_event="stage_party"
+        text_event="stage_text"
+        staged_event="crm_party_staged"
+      />
+      """)
+
+    assert html =~ ~s(data-target="#my-component")
+    assert html =~ ~s(data-search-event="search_party")
+    assert html =~ ~s(data-results-event="crm_party_results")
+    assert html =~ ~s(data-pick-event="stage_party")
+    assert html =~ ~s(data-text-event="stage_text")
+    assert html =~ ~s(data-staged-event="crm_party_staged")
+  end
+
+  test "single mode wires the input as a form field" do
+    assigns = %{}
+
+    html =
+      render(~H"""
+      <.search_picker
+        id="loc"
+        dropdown_id="loc-dd"
+        mode="single"
+        name="event[location]"
+        value="HQ"
+        data-search-on-focus
+        phx-debounce="300"
+      />
+      """)
+
+    assert html =~ ~s(data-mode="single")
+    assert html =~ ~s(name="event[location]")
+    assert html =~ ~s(value="HQ")
+    # global attrs pass through for search-on-focus + LV form debounce
+    assert html =~ "data-search-on-focus"
+    assert html =~ ~s(phx-debounce="300")
+  end
+
+  test "translated labels reach the hook as data attributes" do
+    assigns = %{}
+
+    html =
+      render(~H"""
+      <.search_picker
+        id="p"
+        dropdown_id="d"
+        searching_label="Otsin…"
+        add_prefix_label="Lisa"
+        add_suffix_label="tekstina"
+        adding_label="Lisan…"
+        more_label="Veel"
+        loading_more_label="Laen…"
+      />
+      """)
+
+    assert html =~ ~s(data-t-searching="Otsin…")
+    assert html =~ ~s(data-t-add-prefix="Lisa")
+    assert html =~ ~s(data-t-add-suffix="tekstina")
+    assert html =~ ~s(data-t-adding="Lisan…")
+    assert html =~ ~s(data-t-more="Veel")
+    assert html =~ ~s(data-t-loading-more="Laen…")
+  end
+end


### PR DESCRIPTION
## Summary

Fine-grained **sub-permissions** for the role system, the core building blocks the `phoenix_kit_calendar` module needs (a calendar-events migration + three reusable UI components), and a round of authorization hardening.

Rebased onto current `main`; the only overlap with upstream was the migration numbering (see **Migrations** below).

## Highlights

### Fine-grained sub-permissions + real Admin gating
- Permissions can now be **composed dotted keys** (`"calendar.view_others"`, `"calendar.edit_others"`) stored in `phoenix_kit_role_permissions.module_key`. A sub-permission implies its base — `Scope.can?/2` requires the base to be held for a dotted key, and no code path can persist an orphan sub-key row.
- **Admin is now genuinely permission-gated**: only `Owner` is hard-coded as all-access. Admin (and every other role) is governed by the permission matrix.
- `V142` widens `module_key` `VARCHAR(50) → VARCHAR(120)` so composed keys fit.

### Calendar module support
- `V141` adds `phoenix_kit_calendar_events` (+ event participants and a loose location link) for the standalone `phoenix_kit_calendar` package — one implicit personal calendar per user, timed/all-day exclusive-end pairs with a CHECK, cascade on user delete.

### Reusable core UI components
- **SearchPicker** — client-instant typeahead with a browse-on-focus mode, per-instance event scoping, `direction=up`, cross-source dedup, and load-more paging.
- **PopoverPanel** — anchored rich-content popover that opens instantly via client-side JS commands with click-away.
- **PkDialogDraft** — preserves an open form's draft across a LiveView reconnect.

### Authorization hardening
- Role changes are authorized **in the context** (`sync_user_roles/3` with an `:actor`): a non-Owner can't grant Owner/Admin, and the **last Owner can never be removed**.
- The quick role-toggle and base-permission revoke were routed through the same guards (a `users`-permission holder can't escalate or strip cascaded sub-keys they don't hold).
- Permission checks **fail closed** when the permissions table isn't ready; Admin's full-access fallback keys on table presence, not row count.
- Role-edit audit logs record the roles **actually applied**, not the submitted set.

## Migrations

Upstream's `V140` (warehouse tables) is kept as-is. Our two migrations sit above it:

| Version | Migration |
|---|---|
| V140 | warehouse tables *(upstream, unchanged)* |
| V141 | calendar events + participants |
| V142 | wider role-permission keys |

Markers form a contiguous chain (139←140←141←142), `@current_version = 142`, and a fresh database migrates **0→142 cleanly**.

### Authorization hardening — concurrency

The role/permission mutations were also hardened against concurrent-admin races (transaction-scoped Postgres advisory locks + in-transaction re-reads):

- **Last Owner can never reach zero** — the guard's owner-count runs under a shared advisory lock at its chokepoint (`count_remaining_owners`), so every removal path (role sync, `safely_remove_role`, `demote`) serializes.
- **Revoke authorization is race-free in the permission matrix** — `revoke_permission/3` re-reads the role's held keys under a `(role, base)` lock and rejects (`:unauthorized`) if a cascaded sub-key falls outside the actor's grantable set; `grant_permission` takes the same lock.
- **Exact audit** — `sync_user_roles/3` serializes per-user and returns the in-transaction before/after sets, so audit logs reflect the delta actually applied.

## Known limitations / follow-up

Two narrow, pre-existing concurrency edges remain (not regressions — they exist on `main` today), tracked for a dedicated pass:

- The revoke-authorization re-read covers the matrix UI (grant/revoke); the **bulk** permission paths (`set_permissions`, `grant_all`, `revoke_all`, `copy_permissions`) don't yet take the `(role, base)` lock, so the same TOCTOU is reachable through them.
- The role modal and quick-toggle submit a full desired set computed from a UI snapshot (last-write-wins), so a concurrent same-user edit can be reversed. Closing this needs optimistic concurrency (version tokens), out of scope here.

## Testing

- `mix test` for the new permission/sub-key/role behavior is green (incl. new regression tests for the revoke authorization gate + the before/after return shape).
- Pre-existing suite failures in `multi_session` / `session_multi` / `sitemap` / `media` are unrelated to this change — they stem from the Phoenix 1.8.9 / LiveView 1.2.6 upgrade and fail identically on `main` without these commits.
