### PR TITLE
Fix prefixed migrations: schema-qualified index names + cross-schema existence checks

### DIFF
--- a/lib/phoenix_kit/migrations/postgres/v102.ex
+++ b/lib/phoenix_kit/migrations/postgres/v102.ex
@@ -166,6 +166,7 @@ defmodule PhoenixKit.Migrations.Postgres.V102 do
       IF NOT EXISTS (
         SELECT FROM pg_constraint
         WHERE conname = 'phoenix_kit_cat_catalogues_kind_check'
+        AND conrelid = '#{p}phoenix_kit_cat_catalogues'::regclass
       ) THEN
         ALTER TABLE #{p}phoenix_kit_cat_catalogues
           ADD CONSTRAINT phoenix_kit_cat_catalogues_kind_check
@@ -175,6 +176,7 @@ defmodule PhoenixKit.Migrations.Postgres.V102 do
       IF NOT EXISTS (
         SELECT FROM pg_constraint
         WHERE conname = 'phoenix_kit_cat_catalogues_discount_pct_check'
+        AND conrelid = '#{p}phoenix_kit_cat_catalogues'::regclass
       ) THEN
         ALTER TABLE #{p}phoenix_kit_cat_catalogues
           ADD CONSTRAINT phoenix_kit_cat_catalogues_discount_pct_check
@@ -184,6 +186,7 @@ defmodule PhoenixKit.Migrations.Postgres.V102 do
       IF NOT EXISTS (
         SELECT FROM pg_constraint
         WHERE conname = 'phoenix_kit_cat_items_discount_pct_check'
+        AND conrelid = '#{p}phoenix_kit_cat_items'::regclass
       ) THEN
         ALTER TABLE #{p}phoenix_kit_cat_items
           ADD CONSTRAINT phoenix_kit_cat_items_discount_pct_check
@@ -194,6 +197,7 @@ defmodule PhoenixKit.Migrations.Postgres.V102 do
       IF NOT EXISTS (
         SELECT FROM pg_constraint
         WHERE conname = 'phoenix_kit_cat_items_default_value_check'
+        AND conrelid = '#{p}phoenix_kit_cat_items'::regclass
       ) THEN
         ALTER TABLE #{p}phoenix_kit_cat_items
           ADD CONSTRAINT phoenix_kit_cat_items_default_value_check
@@ -203,6 +207,7 @@ defmodule PhoenixKit.Migrations.Postgres.V102 do
       IF NOT EXISTS (
         SELECT FROM pg_constraint
         WHERE conname = 'phoenix_kit_cat_item_catalogue_rules_value_check'
+        AND conrelid = '#{p}phoenix_kit_cat_item_catalogue_rules'::regclass
       ) THEN
         ALTER TABLE #{p}phoenix_kit_cat_item_catalogue_rules
           ADD CONSTRAINT phoenix_kit_cat_item_catalogue_rules_value_check

--- a/lib/phoenix_kit/migrations/postgres/v113.ex
+++ b/lib/phoenix_kit/migrations/postgres/v113.ex
@@ -84,6 +84,7 @@ defmodule PhoenixKit.Migrations.Postgres.V113 do
       IF NOT EXISTS (
         SELECT 1 FROM pg_constraint
         WHERE conname = 'phoenix_kit_files_parent_file_uuid_fkey'
+        AND conrelid = '#{p}phoenix_kit_files'::regclass
       ) THEN
         ALTER TABLE #{p}phoenix_kit_files
           ADD CONSTRAINT phoenix_kit_files_parent_file_uuid_fkey
@@ -143,6 +144,7 @@ defmodule PhoenixKit.Migrations.Postgres.V113 do
       IF NOT EXISTS (
         SELECT 1 FROM pg_constraint
         WHERE conname = 'phoenix_kit_files_user_or_parent_check'
+        AND conrelid = '#{p}phoenix_kit_files'::regclass
       ) THEN
         ALTER TABLE #{p}phoenix_kit_files
           ADD CONSTRAINT phoenix_kit_files_user_or_parent_check

--- a/lib/phoenix_kit/migrations/postgres/v115.ex
+++ b/lib/phoenix_kit/migrations/postgres/v115.ex
@@ -97,6 +97,7 @@ defmodule PhoenixKit.Migrations.Postgres.V115 do
       IF NOT EXISTS (
         SELECT 1 FROM pg_constraint
         WHERE conname = 'phoenix_kit_annotations_kind_check'
+        AND conrelid = '#{p}phoenix_kit_annotations'::regclass
       ) THEN
         ALTER TABLE #{p}phoenix_kit_annotations
           ADD CONSTRAINT phoenix_kit_annotations_kind_check

--- a/lib/phoenix_kit/migrations/postgres/v118.ex
+++ b/lib/phoenix_kit/migrations/postgres/v118.ex
@@ -44,6 +44,7 @@ defmodule PhoenixKit.Migrations.Postgres.V118 do
       IF NOT EXISTS (
         SELECT 1 FROM pg_constraint
         WHERE conname = 'phoenix_kit_annotations_kind_check'
+        AND conrelid = '#{p}phoenix_kit_annotations'::regclass
       ) THEN
         ALTER TABLE #{p}phoenix_kit_annotations
           ADD CONSTRAINT phoenix_kit_annotations_kind_check
@@ -73,6 +74,7 @@ defmodule PhoenixKit.Migrations.Postgres.V118 do
       IF NOT EXISTS (
         SELECT 1 FROM pg_constraint
         WHERE conname = 'phoenix_kit_annotations_kind_check'
+        AND conrelid = '#{p}phoenix_kit_annotations'::regclass
       ) THEN
         ALTER TABLE #{p}phoenix_kit_annotations
           ADD CONSTRAINT phoenix_kit_annotations_kind_check

--- a/lib/phoenix_kit/migrations/postgres/v119.ex
+++ b/lib/phoenix_kit/migrations/postgres/v119.ex
@@ -63,6 +63,7 @@ defmodule PhoenixKit.Migrations.Postgres.V119 do
       IF NOT EXISTS (
         SELECT 1 FROM pg_constraint
         WHERE conname = 'phoenix_kit_annotations_kind_check'
+        AND conrelid = '#{p}phoenix_kit_annotations'::regclass
       ) THEN
         ALTER TABLE #{p}phoenix_kit_annotations
           ADD CONSTRAINT phoenix_kit_annotations_kind_check
@@ -88,6 +89,7 @@ defmodule PhoenixKit.Migrations.Postgres.V119 do
       IF NOT EXISTS (
         SELECT 1 FROM pg_constraint
         WHERE conname = 'phoenix_kit_annotations_kind_check'
+        AND conrelid = '#{p}phoenix_kit_annotations'::regclass
       ) THEN
         ALTER TABLE #{p}phoenix_kit_annotations
           ADD CONSTRAINT phoenix_kit_annotations_kind_check

--- a/lib/phoenix_kit/migrations/postgres/v35.ex
+++ b/lib/phoenix_kit/migrations/postgres/v35.ex
@@ -237,6 +237,7 @@ defmodule PhoenixKit.Migrations.Postgres.V35 do
       IF NOT EXISTS (
         SELECT 1 FROM pg_constraint
         WHERE conname = 'phoenix_kit_ticket_attachments_parent_check'
+        AND conrelid = '#{prefix_table_name("phoenix_kit_ticket_attachments", prefix)}'::regclass
       ) THEN
         ALTER TABLE #{prefix_table_name("phoenix_kit_ticket_attachments", prefix)}
         ADD CONSTRAINT phoenix_kit_ticket_attachments_parent_check

--- a/lib/phoenix_kit/migrations/postgres/v56.ex
+++ b/lib/phoenix_kit/migrations/postgres/v56.ex
@@ -496,10 +496,11 @@ defmodule PhoenixKit.Migrations.Postgres.V56 do
       if table_exists?(table, escaped_prefix) do
         table_name = prefix_table_name(Atom.to_string(table), prefix)
         cols = Enum.join(columns, ", ")
-        idx = if prefix && prefix != "public", do: "#{prefix}.#{index_name}", else: index_name
 
+        # CREATE INDEX forbids a schema-qualified index name — the index
+        # always lands in the (qualified) table's schema.
         execute("""
-        CREATE UNIQUE INDEX IF NOT EXISTS #{idx}
+        CREATE UNIQUE INDEX IF NOT EXISTS #{index_name}
         ON #{table_name}(#{cols})
         """)
       end

--- a/lib/phoenix_kit/migrations/postgres/v57.ex
+++ b/lib/phoenix_kit/migrations/postgres/v57.ex
@@ -53,10 +53,11 @@ defmodule PhoenixKit.Migrations.Postgres.V57 do
       if table_exists?(table, escaped_prefix) do
         table_name = prefix_table_name(Atom.to_string(table), prefix)
         cols = Enum.join(columns, ", ")
-        idx = if prefix && prefix != "public", do: "#{prefix}.#{index_name}", else: index_name
 
+        # CREATE INDEX forbids a schema-qualified index name — the index
+        # always lands in the (qualified) table's schema.
         execute("""
-        CREATE UNIQUE INDEX IF NOT EXISTS #{idx}
+        CREATE UNIQUE INDEX IF NOT EXISTS #{index_name}
         ON #{table_name}(#{cols})
         """)
       end

--- a/lib/phoenix_kit/migrations/postgres/v95.ex
+++ b/lib/phoenix_kit/migrations/postgres/v95.ex
@@ -11,6 +11,7 @@ defmodule PhoenixKit.Migrations.Postgres.V95 do
 
   def up(opts) do
     prefix = Map.get(opts, :prefix, "public")
+    escaped_prefix = Map.get(opts, :escaped_prefix, prefix)
     p = prefix_str(prefix)
 
     # Folders table
@@ -54,9 +55,10 @@ defmodule PhoenixKit.Migrations.Postgres.V95 do
     create_if_not_exists(index(:phoenix_kit_media_folders, [:parent_uuid], prefix: prefix))
     create_if_not_exists(index(:phoenix_kit_media_folders, [:user_uuid], prefix: prefix))
 
-    # Unique folder name per parent (COALESCE handles NULL parent for root-level uniqueness)
+    # Unique folder name per parent (COALESCE handles NULL parent for root-level uniqueness).
+    # The index name must stay bare — CREATE INDEX forbids schema-qualifying it.
     execute("""
-    CREATE UNIQUE INDEX IF NOT EXISTS #{p}phoenix_kit_media_folders_name_parent_idx
+    CREATE UNIQUE INDEX IF NOT EXISTS phoenix_kit_media_folders_name_parent_idx
     ON #{p}phoenix_kit_media_folders (name, COALESCE(parent_uuid, '00000000-0000-0000-0000-000000000000'))
     """)
 
@@ -105,7 +107,8 @@ defmodule PhoenixKit.Migrations.Postgres.V95 do
     BEGIN
       IF NOT EXISTS (
         SELECT FROM information_schema.columns
-        WHERE table_name = 'phoenix_kit_files' AND column_name = 'folder_uuid'
+        WHERE table_schema = '#{escaped_prefix}'
+          AND table_name = 'phoenix_kit_files' AND column_name = 'folder_uuid'
       ) THEN
         ALTER TABLE #{p}phoenix_kit_files
           ADD COLUMN folder_uuid UUID

--- a/lib/phoenix_kit/migrations/uuid_fk_columns.ex
+++ b/lib/phoenix_kit/migrations/uuid_fk_columns.ex
@@ -473,13 +473,10 @@ defmodule PhoenixKit.Migrations.UUIDFKColumns do
            column_exists?(ref_table, ref_col, escaped_prefix) and
            not unique_index_exists?(ref_table, ref_col, escaped_prefix) do
         table_name = prefix_table_name(ref_table, prefix)
-        index_name = "#{ref_table}_#{ref_col}_idx"
 
-        index_name =
-          case prefix do
-            "public" -> index_name
-            p -> "#{p}.#{index_name}"
-          end
+        # CREATE INDEX forbids a schema-qualified index name — the index
+        # always lands in the (qualified) table's schema.
+        index_name = "#{ref_table}_#{ref_col}_idx"
 
         execute("""
         CREATE UNIQUE INDEX IF NOT EXISTS #{index_name}
@@ -645,16 +642,12 @@ defmodule PhoenixKit.Migrations.UUIDFKColumns do
 
   defp create_uuid_fk_index(table_str, uuid_fk, prefix, escaped_prefix) do
     table_name = prefix_table_name(table_str, prefix)
+
+    # CREATE INDEX forbids a schema-qualified index name — the index
+    # always lands in the (qualified) table's schema.
     index_name = "#{table_str}_#{uuid_fk}_idx"
 
-    index_name =
-      case prefix do
-        nil -> index_name
-        "public" -> index_name
-        p -> "#{p}.#{index_name}"
-      end
-
-    unless index_exists?(table_str, "#{table_str}_#{uuid_fk}_idx", escaped_prefix) do
+    unless index_exists?(table_str, index_name, escaped_prefix) do
       execute("""
       CREATE INDEX IF NOT EXISTS #{index_name}
       ON #{table_name}(#{uuid_fk})

--- a/test/integration/prefix_migration_test.exs
+++ b/test/integration/prefix_migration_test.exs
@@ -1,0 +1,121 @@
+defmodule PhoenixKit.Integration.PrefixMigrationTest do
+  @moduledoc """
+  Runs the full versioned migration chain into a named (non-`public`)
+  schema — the `--prefix` install path.
+
+  Regression coverage for the CREATE INDEX schema-qualification bug
+  (fixed 2026-07-11): several migration helpers qualified the *index
+  name* with the prefix (`CREATE INDEX prefix.name ON prefix.table`),
+  which Postgres rejects outright — an index always lands in its
+  table's schema, so only the table may be qualified. The default
+  `public` path never executes those qualification branches, so only a
+  full prefixed chain exercises this class of bug.
+
+  ## Why sandbox `:auto` mode instead of a checkout
+
+  `Ecto.Migrator` spawns its own runner process with its own
+  connections, so a sandbox checkout can't cover it (see
+  `PhoenixKit.MigrationTest` moduledoc). And running the chain through
+  a second non-sandbox repo instance doesn't work either: V08's data
+  backfill calls `Ecto.Adapters.SQL.query(RepoHelper.repo(), ...)`,
+  which resolves the repo *module* name to the named instance and
+  bypasses `put_dynamic_repo/1`. So this test mirrors the boot path
+  instead: `test_helper.exs` runs `ensure_current/2` through the named
+  repo while the sandbox is still in `:auto` mode — we flip back to
+  `:auto` for the duration of the test and restore `:manual` after.
+  Safe because `async: false` tests run serially, after all async
+  tests have finished.
+  """
+
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureIO
+
+  alias Ecto.Adapters.SQL.Sandbox
+  alias PhoenixKit.Migrations.Postgres
+  alias PhoenixKit.Test.Repo
+
+  @moduletag :integration
+  # The full chain is 140+ versions — well past the default 60s.
+  @moduletag timeout: :timer.minutes(5)
+
+  @schema "pk_prefix_migration_test"
+
+  test "full migration chain applies cleanly into a named schema" do
+    Sandbox.mode(Repo, :auto)
+
+    on_exit(fn ->
+      # Restore :manual even if the schema drop raises — leaving the
+      # sandbox in :auto would poison every later sync test.
+      try do
+        Repo.query!("DROP SCHEMA IF EXISTS #{@schema} CASCADE")
+      after
+        Sandbox.mode(Repo, :manual)
+      end
+    end)
+
+    Repo.query!("DROP SCHEMA IF EXISTS #{@schema} CASCADE")
+    # Ecto's migrator needs the schema to pre-exist for its own
+    # schema_migrations bookkeeping table.
+    Repo.query!("CREATE SCHEMA #{@schema}")
+
+    # The multi-step runner prints a progress bar unconditionally;
+    # capture it so the suite output stays clean.
+    capture_io(fn ->
+      assert :ok =
+               PhoenixKit.Migration.ensure_current(Repo,
+                 prefix: @schema,
+                 log: false
+               )
+    end)
+
+    # The version marker must report the chain fully applied.
+    %{rows: [[version_comment]]} =
+      Repo.query!("SELECT obj_description('#{@schema}.phoenix_kit'::regclass, 'pg_class')")
+
+    assert version_comment ==
+             to_string(Postgres.current_version())
+
+    # Spot-check the indexes built by the once-buggy CREATE sites
+    # (uuid_fk_columns.ex, V56/V57 add_uuid_unique_indexes, V95): they
+    # must exist and must live in the prefixed schema.
+    %{rows: rows} =
+      Repo.query!(
+        """
+        SELECT indexname FROM pg_indexes
+        WHERE schemaname = $1 AND indexname = ANY($2)
+        """,
+        [
+          @schema,
+          [
+            "phoenix_kit_users_tokens_user_uuid_idx",
+            "phoenix_kit_role_assignments_user_uuid_role_uuid_idx",
+            "phoenix_kit_role_permissions_role_uuid_module_key_idx",
+            "phoenix_kit_oauth_providers_user_uuid_provider_idx",
+            "phoenix_kit_media_folders_name_parent_idx"
+          ]
+        ]
+      )
+
+    found = rows |> List.flatten() |> Enum.sort()
+
+    assert found == [
+             "phoenix_kit_media_folders_name_parent_idx",
+             "phoenix_kit_oauth_providers_user_uuid_provider_idx",
+             "phoenix_kit_role_assignments_user_uuid_role_uuid_idx",
+             "phoenix_kit_role_permissions_role_uuid_module_key_idx",
+             "phoenix_kit_users_tokens_user_uuid_idx"
+           ]
+
+    # And the chain must have built a full complement of indexes in the
+    # prefixed schema (142 versions produce 700+; a low count would mean
+    # part of the chain silently skipped).
+    %{rows: [[index_count]]} =
+      Repo.query!(
+        "SELECT count(*) FROM pg_indexes WHERE schemaname = $1 AND tablename LIKE 'phoenix_kit%'",
+        [@schema]
+      )
+
+    assert index_count > 500
+  end
+end


### PR DESCRIPTION
## Summary

An external user running the full migration chain into a named schema (`--prefix "companyplexus"`) hit a hard failure. Investigating it surfaced two bug families in the versioned migrations, both invisible on the default `public` path:

**1. Schema-qualified index names on CREATE INDEX (hard failure).** Postgres rejects `CREATE INDEX schema.name ...` outright — an index always lands in its table's schema, so only the table may be qualified. (`DROP INDEX schema.name` *is* valid, which is why the drop helpers using the same idiom never failed — those are untouched.) With a non-public prefix the chain died with `syntax error at or near "."`. Five sites fixed: `ensure_fk_target_unique_indexes/2` and `create_uuid_fk_index/4` in `uuid_fk_columns.ex`, `add_uuid_unique_indexes` in V56 and V57, and the V95 media-folders unique index. Note these errors surface at a *later* version's `flush()` (V61), not the version that queued the SQL.

**2. Cross-schema-leaky idempotency checks (silent skips).** Existence checks that don't anchor to a schema see objects from *every* schema. When a prefixed install runs in a database that also carries a public install, the check finds public's object and silently skips creating the prefixed one — the prefixed schema ends up missing columns/constraints (or hard-fails downstream, which is how the new test caught it). Fixed: V95's `information_schema.columns` check gained a `table_schema` filter, and 13 `pg_constraint` `conname` checks gained the `AND conrelid = '<prefixed table>'::regclass` anchor (V51's existing idiom): V35, V102 ×5, V113 ×2, V115, V118 up+down, V119 up+down. The other 43 `pg_constraint` sites were already anchored.

**3. Regression test.** `test/integration/prefix_migration_test.exs` runs the full 142-version chain into a scratch schema on the test database and asserts the version marker, the once-buggy indexes' placement, and a full index complement. Because the test DB also carries a public install, it fails on either bug family. It flips the sandbox to `:auto` for the run (the same boot path `test_helper.exs` uses) — a sandbox checkout can't host `Ecto.Migrator`'s own runner connections, and a dynamic non-sandbox repo instance doesn't work either because V08's backfill resolves the repo by module name (`Ecto.Adapters.SQL.query(RepoHelper.repo(), ...)`), bypassing `put_dynamic_repo/1`. Details in the test moduledoc.

## Verification

- Fresh scratch DB, `prefix: "companyplexus"`: chain previously died at V61; now completes with all 730 phoenix_kit indexes in the prefixed schema, none leaked to public
- Fresh scratch DB, default public: completes (no regression)
- Prefixed chain into a DB with an existing public install (the new test): passes in ~5s
- Permissions/migration/smoke test files: 159 tests, 0 failures
- `mix precommit` (format + compile + credo --strict + dialyzer): green
- Reviewed by Codex: confirmed no missed sites of either family, `::regclass` casts safe (every target table is guaranteed to exist at its check), and prefixed-vs-public semantics correct; its one finding (test cleanup could leave the sandbox in `:auto` if the schema drop raises) is fixed with `try/after`