### PR TITLE
Fix prefixed migrations + tooling for low-privilege multi-schema installs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ mix test          # run all (migrations auto via test_helper)
 mix test.reset    # drop + recreate
 ```
 
-Test DB `phoenix_kit_test` uses embedded `PhoenixKit.Test.Repo` (`test/support/test_repo.ex`). Migrations live in `test/support/postgres/migrations/`.
+Test DB `phoenix_kit_test` uses embedded `PhoenixKit.Test.Repo` (`test/support/test_repo.ex`). Schema comes from the versioned migration chain — `test_helper.exs` runs `PhoenixKit.Migration.ensure_current/2` on every boot (there is no `test/support/postgres/migrations/` directory; that per-file approach was retired 2026-05-05).
 
 **Without PostgreSQL:** integration tests are auto-excluded; unit tests still run. `mix test` will print a banner and continue.
 
@@ -92,6 +92,32 @@ ast-grep --lang elixir --pattern 'def $FUNC($$$ARGS) do $$$BODY end' lib/
 - Schemas use `@primary_key {:uuid, UUIDv7, autogenerate: true}`
 - New migrations use `uuid_generate_v7()` (NOT `gen_random_uuid()`)
 - Oban-style versioned migrations in `lib/phoenix_kit/migrations/postgres/`
+
+### Prefix-safe migrations (named-schema installs)
+
+The chain supports running into a named Postgres schema (`prefix:` opt /
+`--prefix`). Two bug families broke it in 2026-07 (both fixed, PR #628);
+any new `execute`-built SQL can regress them:
+
+- **Index names stay bare on CREATE.** Postgres rejects
+  `CREATE INDEX schema.name ...` — the index always lands in the
+  (schema-qualified) table's schema. Qualifying the *name* is only valid
+  on `DROP INDEX`.
+- **Every existence check needs a schema anchor.** `information_schema.*`
+  checks need `table_schema = '#{escaped_prefix}'`, `pg_indexes` needs
+  `schemaname`, and `pg_constraint` `conname` checks need
+  `AND conrelid = '#{p}table'::regclass` (V51's idiom). An unanchored
+  check sees `public`'s objects, so a prefixed install into a database
+  that also carries a public install silently skips creating the
+  prefixed object.
+- **Failures surface late.** Ecto queues `execute` calls; bad SQL queued
+  by one version often blows up at a *later* version's `flush()`.
+
+`test/integration/prefix_migration_test.exs` is the oracle: it runs the
+full chain into a scratch schema on the test DB (which also has a public
+install, so it catches both families). It flips the sandbox to `:auto`
+for the run — see its moduledoc for why neither a sandbox checkout nor a
+dynamic repo instance can host the migrator.
 
 ## Integrations System
 
@@ -168,6 +194,27 @@ The canonical toolkit for admin list views — DnD reorder, bulk-select, sort, s
 ## Built-in Dashboard
 
 Tabs, subtabs, badges, context selectors: see `lib/phoenix_kit/dashboard/README.md`.
+
+## Permissions
+
+`PhoenixKit.Users.Permissions` — allowlist model (row present = granted,
+absent = denied); Owner always has full access, enforced in code. The
+moduledoc is the source of truth; highlights:
+
+- **Module keys** gate admin sections/feature modules (`"billing"`,
+  `"calendar"`, …). Custom keys via `register_custom_key/2`.
+- **Sub-permissions** (added 1.7.182): fine-grained dotted keys under a
+  base (`"calendar.view_others"`), declared in the optional
+  `sub_permissions` field of `permission_metadata/0`. The base key gates
+  the module's admin pages; sub-keys are additive grants the module
+  checks itself via `Scope.can?/2`. A sub implies its base — granting a
+  sub auto-grants the base, revoking the base cascades its subs, and
+  `set_permissions/3` normalizes the set so no path persists an orphan
+  sub row. A sub-key is enabled iff its parent module is enabled.
+- **Edit protection**: `can_edit_role_permissions?/2` — users cannot edit
+  their own role; only Owner can edit Admin.
+- Grant/revoke run under a per-`{role, base-key}` advisory lock so a base
+  revoke's cascade can't interleave a concurrent sub grant.
 
 ## Activity Feed
 
@@ -468,10 +515,10 @@ Partial coverage exists in `test/phoenix_kit_web/components/core/` — written f
 
 - `<.draggable_list>` — three-axis coverage: (a) `:draggable=false` → no SortableJS hook, no `cursor-grab`; (b) `:draggable=true, :sortable_handle=nil` → SortableJS hook + full-item `cursor-grab`; (c) `:draggable=true, :sortable_handle=".pk-drag-handle"` → SortableJS hook + `data-sortable-handle` attribute set, **no** `cursor-grab` on the item wrapper (caller's responsibility). All three branches need rendered-HTML asserts.
 - `<.table_default>` card-view branch — `:on_reorder` / `:reorder_scope` / `:reorder_group` / `:item_id` wire card-view as sortable target. Need to pin `phx-hook="SortableGrid"`, `data-sortable-*`, `data-id`, `class="sortable-item"`, drag-handle footer.
-- `<.input>`, `<.select>`, `<.textarea>`, `<.checkbox>` — inline error rendering, daisyUI variant classes, FormField vs raw `name=`/`value=` dispatch.
+- `<.input>`, `<.select>`, `<.textarea>` — inline error rendering, daisyUI variant classes, FormField vs raw `name=`/`value=` dispatch. (`<.checkbox>` gained a test — `checkbox_test.exs`.)
 - `<.flash>` if complexity has grown.
 
-Surfaced 2026-05-02 by C12 triage during V108 / DnD core work. Partially closed 2026-05-23 (`bulk_select`, `sortable`, `reorder_modal`, `load_more`, `sort_selector`, `modal` keep_in_dom, `table_default` row + drag_handle). Fold the rest into a future component-coverage sweep.
+Surfaced 2026-05-02 by C12 triage during V108 / DnD core work. Partially closed 2026-05-23 (`bulk_select`, `sortable`, `reorder_modal`, `load_more`, `sort_selector`, `modal` keep_in_dom, `table_default` row + drag_handle); `checkbox` closed since. Fold the rest into a future component-coverage sweep.
 
 ### Signed file-URL hardening (`modules/storage`)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -484,30 +484,34 @@ Publishing's `/:language/:group/*path` catch-all matches every 2+ segment URL an
 
 The mechanism generalizes; for now hardcoded to publishing — lift to a registry shape when a second module needs it.
 
+## daisyUI version expectations (host-owned)
+
+The daisyUI plugin lives in the **host** app (`assets/vendor/daisyui.js` +
+`daisyui-theme.js`, scaffolded by `mix phx.new`, upgraded manually by the
+host) — PhoenixKit does not vendor, pin, or overwrite it (a custody/auto-sync
+design was built and rejected 2026-07-12; the host owns its assets). Instead
+core declares a **designed-for minimum** in `PhoenixKit.Install.DaisyUI`
+(`minimum_version/0`, currently 5.6.0; verified against 5.6.17) and warns when
+the host is behind: `mix phoenix_kit.install` (Igniter warning),
+`mix phoenix_kit.update` (shell warning), `mix phoenix_kit.doctor` ("daisyUI
+Version" check). Advisory only — nothing touches the host's files.
+
+History: daisyUI 5.0.x reserved the modal scrollbar gutter unconditionally,
+and core carried compensations (an unlayered `:root:has(.modal-open, …) {
+scrollbar-gutter: auto }` counter-rule in `layout_wrapper.ex` +
+`layouts/root.html.heex`, plus an inline PkDialog override). Those killed the
+phantom right-edge strip on non-scrolling pages but made content reflow ~15px
+around every modal open/close on pages that DO scroll (user-reported via the
+dashboards create modal's Cancel). daisyUI ≥ 5.1 reserves the gutter only when
+the page really has a scrollbar (`rootscrollgutter.css`), so **all
+compensations were removed 2026-07-12** — do NOT re-add scrollbar-gutter
+overrides in layouts, PkDialog, or modules. Hosts still on daisyUI < 5.1 get
+daisyUI's stock old behavior (the strip) plus the warnings above; the cure is
+updating their vendored files, not core CSS.
+
 ## TODOs
 
 Workspace-tracked items not ready for inline `# TODO` in `lib/`.
-
-### Remove the daisyUI modal-gutter counter-rule after vendored daisyUI upgrades
-
-`layout_wrapper.ex` (admin `<style>` block) and `layouts/root.html.heex` carry an
-unlayered `:root:has(.modal-open, …) { scrollbar-gutter: auto }` rule. It counters
-a **daisyUI 5.0.x** defect: on modal/drawer open, old daisyUI unconditionally
-reserves a scrollbar gutter and paints it with a base-100 trick that mismatches on
-non-base-100 pages — classic-scrollbar users see an uncovered strip at the
-window's right edge. Upstream fixed this properly across 5.1.0→5.6.x
-(`rootscrollgutter.css`: `animation-timeline: scroll()` detects a real scrollbar;
-gutter reserved only then).
-
-Hosts vendor their own `daisyui.js` (parent was on 5.0.35 when this was added), so
-the rule protects any host still on old daisyUI. Once hosts are on daisyUI ≥ 5.6,
-remove the rule from both files — it's redundant there, and in browsers that honor
-`scrollbar-gutter` under `overflow: hidden` it would defeat upstream's smarter
-conditional reservation. The `phoenix_kit_dashboards` module carries a per-page
-copy (`gutter_fix_style/0` in both LiveViews) that's deletable as soon as its core
-pin includes this rule, independent of the daisyUI version. Verified 2026-07-08:
-6-page pixel-diff of 5.0.35 vs 5.6.14 showed only 1-2px badge-padding drift, so
-the vendored upgrade itself is low-risk.
 
 ### Component test coverage for `phoenix_kit_web/components/core/`
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,11 +113,59 @@ any new `execute`-built SQL can regress them:
 - **Failures surface late.** Ecto queues `execute` calls; bad SQL queued
   by one version often blows up at a *later* version's `flush()`.
 
+A 2026-07-12 field report from a hardened multi-schema install (schema
+pre-created by a DBA, app role without CREATE on the database, PG 15+
+non-writable `public`) surfaced four more families — all fixed; the
+rules for new migration code:
+
+- **Functions are created schema-qualified.** `uuid_generate_v7()` is
+  created as `<prefix>.uuid_generate_v7()` and every call site
+  (`DEFAULT`, backfill `UPDATE`s, `fragment/1`) qualifies it too — an
+  unqualified `CREATE OR REPLACE FUNCTION` lands wherever `search_path`
+  points (pollutes `public`; fails outright on PG15+). Use
+  `PhoenixKit.Migrations.Postgres.Helpers.ensure_uuid_v7_function/1` +
+  `uuid_v7_call/1`. `Postgres.up/1` re-ensures the function at the
+  prefix for upgrade chains starting ≥ V40 (which skip the creation
+  sites).
+- **Never bare `CREATE EXTENSION IF NOT EXISTS`** — Postgres checks the
+  CREATE privilege *before* the IF-NOT-EXISTS short-circuit, so it fails
+  for low-privilege roles even when the extension is installed. Use
+  `Helpers.ensure_extension!/1` (checks `pg_extension` first; raises an
+  operator-facing message listing citext/pgcrypto/pg_trgm when genuinely
+  missing and uncreatable).
+- **Same story for `CREATE SCHEMA`.** V01 checks
+  `information_schema.schemata` first and only creates when missing
+  (raising a clear error if missing + `create_schema: false`). External
+  migrators must have the flag threaded: V27 passes
+  `create_schema: false` to `Oban.Migration.up/1` — without it Oban
+  re-defaults to true for non-public prefixes and executes the failing
+  statement mid-chain.
+- **The prefix is validated at the `up/down` entry points**
+  (`Helpers.validate_prefix!/1`, `[a-z_][a-z0-9_]*`) because it is
+  interpolated into SQL mostly unquoted.
+- **Tooling resolves the prefix from config.** The installer persists
+  `config :phoenix_kit, prefix:` for non-public installs
+  (`PhoenixKit.Install.PrefixConfig`); update/status/gen.migration
+  resolve `--prefix` → config → `"public"` (`resolve_prefix/1`). And
+  `Install.Common` no longer fabricates `{:current_version, 1}` from
+  the mere existence of migration *files* — that once made
+  `phoenix_kit.update` emit a from-scratch v01→vN migration into the
+  wrong schema. Update-migration generators always emit
+  `create_schema: false` (updating implies the schema exists).
+
 `test/integration/prefix_migration_test.exs` is the oracle: it runs the
 full chain into a scratch schema on the test DB (which also has a public
 install, so it catches both families). It flips the sandbox to `:auto`
 for the run — see its moduledoc for why neither a sandbox checkout nor a
-dynamic repo instance can host the migrator.
+dynamic repo instance can host the migrator. (The privilege-sensitive
+paths — pre-created schema + low-privilege role — can't run under the
+suite's superuser connection; re-verify those manually against the
+recipe in the 2026-07-12 field report if you touch them.)
+
+Note: runtime code does NOT read `config :phoenix_kit, :prefix` — Ecto
+queries run unprefixed, so a prefixed install additionally needs the DB
+role's `search_path` to include the schema. Known gap, out of scope of
+the 2026-07 fixes.
 
 ## Integrations System
 

--- a/lib/mix/tasks/phoenix_kit.doctor.ex
+++ b/lib/mix/tasks/phoenix_kit.doctor.ex
@@ -32,6 +32,7 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
    12. **Oban Configuration** — Queues and plugins that consume pool connections
    13. **Supervisor Children** — What's running (update_mode vs full)?
    14. **Update Mode** — Is update_mode active?
+   15. **daisyUI Version** — Is the host's vendored daisyUI recent enough?
   """
 
   use Mix.Task
@@ -71,7 +72,8 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
       run_check("Orphaned Connections", fn -> check_orphaned_connections() end),
       run_check("Oban Configuration", fn -> check_oban_config() end),
       run_check("PhoenixKit Supervisor", fn -> check_supervisor_state() end),
-      run_check("Update Mode", fn -> check_update_mode() end)
+      run_check("Update Mode", fn -> check_update_mode() end),
+      run_check("daisyUI Version", fn -> check_daisyui() end)
     ]
 
     IO.puts("")
@@ -699,6 +701,37 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
   end
 
   defp extract_host_from_url(_), do: nil
+
+  # The host owns assets/vendor/daisyui.js (scaffolded by phx.new, upgraded
+  # manually). PhoenixKit's modals rely on daisyUI >= the minimum for correct
+  # modal scrollbar-gutter handling — this check is where a host finds out
+  # it's behind (install/update print the same warning).
+  defp check_daisyui do
+    alias PhoenixKit.Install.DaisyUI
+
+    minimum = DaisyUI.minimum_version()
+
+    case DaisyUI.check() do
+      :ok ->
+        {:pass, "daisyUI #{DaisyUI.installed_version(DaisyUI.host_path())} (>= #{minimum})"}
+
+      {:outdated, version} ->
+        {:warn,
+         "Vendored daisyUI is #{version}; PhoenixKit is designed against #{minimum}+ " <>
+           "(modal scrollbar-gutter handling). Update assets/vendor/daisyui.js + " <>
+           "daisyui-theme.js from https://github.com/saadeghi/daisyui/releases and rebuild assets."}
+
+      :unversioned ->
+        {:warn,
+         "assets/vendor/daisyui.js carries no version marker — cannot verify it against " <>
+           "PhoenixKit's designed-for minimum (#{minimum})."}
+
+      :missing ->
+        {:warn,
+         "No assets/vendor/daisyui.js — custom daisyUI setup? PhoenixKit is designed " <>
+           "against daisyUI #{minimum}+; make sure your setup matches."}
+    end
+  end
 
   # ── Display ─────────────────────────────────────────────────────────
 

--- a/lib/mix/tasks/phoenix_kit.gen.migration.ex
+++ b/lib/mix/tasks/phoenix_kit.gen.migration.ex
@@ -24,6 +24,7 @@ defmodule Mix.Tasks.PhoenixKit.Gen.Migration do
       mix phoenix_kit.gen.migration --prefix my_schema
 
   """
+  alias PhoenixKit.Install.PrefixConfig
   alias PhoenixKit.Migrations.Postgres, as: PkMigrations
 
   @shortdoc "Generate PhoenixKit versioned migration"
@@ -31,7 +32,7 @@ defmodule Mix.Tasks.PhoenixKit.Gen.Migration do
   @impl Mix.Task
   def run(args) do
     opts = parse_args(args)
-    prefix = opts[:prefix] || "public"
+    prefix = PrefixConfig.resolve_prefix(opts)
 
     from_version = detect_current_version()
     to_version = PkMigrations.current_version()
@@ -110,7 +111,10 @@ defmodule Mix.Tasks.PhoenixKit.Gen.Migration do
 
   defp migration_content(app_module, slug, from_version, to_version, prefix) do
     module_name = Macro.camelize(slug)
-    create_schema = prefix != "public"
+    # This task only generates UPGRADE migrations (from_version > 0), so the
+    # schema already exists — never ask the chain to create it (CREATE SCHEMA
+    # fails for low-privilege roles even with IF NOT EXISTS).
+    create_schema = false
 
     """
     defmodule #{app_module}.Repo.Migrations.#{module_name} do

--- a/lib/mix/tasks/phoenix_kit.install.ex
+++ b/lib/mix/tasks/phoenix_kit.install.ex
@@ -78,6 +78,7 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
       MigrationStrategy,
       OAuthConfig,
       ObanConfig,
+      PrefixConfig,
       RateLimiterConfig,
       RepoDetection,
       RouterIntegration
@@ -114,6 +115,7 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
       igniter
       |> BasicConfiguration.add_basic_config()
       |> RepoDetection.add_phoenix_kit_configuration(opts[:repo])
+      |> PrefixConfig.add_prefix_configuration(opts[:prefix])
       |> MailerConfig.add_mailer_configuration()
       |> RateLimiterConfig.add_rate_limiter_configuration()
       |> OAuthConfig.add_oauth_configuration()

--- a/lib/mix/tasks/phoenix_kit.install.ex
+++ b/lib/mix/tasks/phoenix_kit.install.ex
@@ -68,6 +68,7 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
       BrowserPipelineIntegration,
       Common,
       CssIntegration,
+      DaisyUI,
       DbConnectionCheck,
       DemoFiles,
       EndpointIntegration,
@@ -127,6 +128,7 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
       ])
       |> CssIntegration.add_automatic_css_integration()
       |> JsIntegration.add_js_integration()
+      |> warn_if_daisyui_outdated()
       |> DemoFiles.copy_test_demo_files()
       |> RouterIntegration.add_router_integration(opts[:router_path])
       |> BrowserPipelineIntegration.add_integration_to_browser_pipeline()
@@ -438,6 +440,19 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
         end)
 
       has_oban_config and has_queues
+    end
+
+    # PhoenixKit relies on the host's vendored daisyUI being reasonably modern
+    # (modal scrollbar-gutter handling; see PhoenixKit.Install.DaisyUI). The
+    # host owns that file — we only warn, never touch it.
+    defp warn_if_daisyui_outdated(igniter) do
+      case DaisyUI.check() do
+        {:outdated, version} ->
+          Igniter.add_warning(igniter, DaisyUI.outdated_warning(version))
+
+        _ ->
+          igniter
+      end
     end
 
     # Add completion notice with essential next steps (reduced duplication)

--- a/lib/mix/tasks/phoenix_kit.status.ex
+++ b/lib/mix/tasks/phoenix_kit.status.ex
@@ -42,6 +42,7 @@ defmodule Mix.Tasks.PhoenixKit.Status do
 
   alias PhoenixKit.Config
   alias PhoenixKit.Install.Common
+  alias PhoenixKit.Install.PrefixConfig
   alias PhoenixKit.Migrations.Postgres
 
   @impl Mix.Task
@@ -72,7 +73,10 @@ defmodule Mix.Tasks.PhoenixKit.Status do
 
     {opts, _argv, _errors} = OptionParser.parse(argv, switches: @switches, aliases: @aliases)
 
-    prefix = opts[:prefix] || "public"
+    # --prefix option → config :phoenix_kit, :prefix → "public", so a
+    # prefixed install doesn't report "Not installed" when the flag is
+    # omitted.
+    prefix = PrefixConfig.resolve_prefix(opts)
     verbose = opts[:verbose] || false
 
     show_comprehensive_status(prefix, verbose)

--- a/lib/mix/tasks/phoenix_kit.update.ex
+++ b/lib/mix/tasks/phoenix_kit.update.ex
@@ -95,6 +95,7 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
       IgniterHelpers,
       JsIntegration,
       ObanConfig,
+      PrefixConfig,
       RateLimiterConfig
     }
 
@@ -360,8 +361,15 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
 
     # Perform the igniter-based update logic
     defp perform_igniter_update(igniter, opts) do
-      prefix = opts[:prefix] || "public"
+      # --prefix option → config :phoenix_kit, :prefix → "public".
+      # Checking the wrong prefix here is dangerous: a prefixed install
+      # looks "not installed" at public.
+      prefix = PrefixConfig.resolve_prefix(opts)
       force = opts[:force] || false
+
+      # Backfill the config entry for installs made before the installer
+      # started persisting --prefix (no-op when already configured).
+      igniter = PrefixConfig.add_prefix_configuration(igniter, opts[:prefix])
 
       # Validate and fix Ueberauth configuration before update
       igniter = validate_and_fix_ueberauth_config(igniter)
@@ -403,7 +411,7 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
           # Second pass: Configuration exists, app is started, proceed with migration
           case Common.check_installation_status(prefix) do
             {:not_installed} ->
-              add_not_installed_notice(igniter)
+              add_not_installed_notice(igniter, prefix)
 
             {:current_version, current_version} ->
               target_version = Common.current_version()
@@ -438,7 +446,10 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
            force,
            opts
          ) do
-      create_schema = prefix != "public"
+      # An update implies an existing installation, so the schema exists —
+      # never ask the chain to create it (CREATE SCHEMA fails for
+      # low-privilege roles even with IF NOT EXISTS).
+      create_schema = false
 
       # Generate timestamp and migration file name using Ecto format
       timestamp = Common.generate_timestamp()
@@ -517,12 +528,18 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
     end
 
     # Add notices for different scenarios
-    defp add_not_installed_notice(igniter) do
+    defp add_not_installed_notice(igniter, prefix) do
       notice = """
 
-      ❌ PhoenixKit is not installed.
+      ❌ No PhoenixKit installation found at schema prefix #{inspect(prefix)}.
 
-      Please run: mix igniter.install phoenix_kit
+      If PhoenixKit IS installed but under a different schema prefix, pass it
+      explicitly (and persist it in config so future runs resolve it):
+
+        mix phoenix_kit.update --prefix your_schema
+        config :phoenix_kit, prefix: "your_schema"
+
+      If PhoenixKit is not installed yet, run: mix igniter.install phoenix_kit
       (or `mix phoenix_kit.install` if the dep is already in mix.exs)
       """
 
@@ -593,7 +610,7 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
 
     # Handle tasks that need to run after igniter completes
     defp post_igniter_tasks(opts) do
-      prefix = Keyword.get(opts, :prefix, "public")
+      prefix = PrefixConfig.resolve_prefix(opts)
 
       # CRITICAL: Run UUID repair BEFORE migrations
       # This fixes upgrade path from PhoenixKit < 1.7.0 where uuid columns
@@ -840,7 +857,7 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
     # implement `migration_module/0`. Generates an incremental migration file
     # in the parent app for each module that needs updating, then runs migrations.
     defp run_module_migrations(opts) do
-      prefix = Keyword.get(opts, :prefix, "public")
+      prefix = PrefixConfig.resolve_prefix(opts)
 
       modules =
         try do
@@ -945,7 +962,7 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
 
     # Show current installation status and available updates
     defp show_status(opts) do
-      prefix = opts[:prefix] || "public"
+      prefix = PrefixConfig.resolve_prefix(opts)
 
       # Use the status command to show current status
       args = if prefix == "public", do: [], else: ["--prefix=#{prefix}"]

--- a/lib/mix/tasks/phoenix_kit.update.ex
+++ b/lib/mix/tasks/phoenix_kit.update.ex
@@ -89,6 +89,7 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
       BootHook,
       Common,
       CssIntegration,
+      DaisyUI,
       DbConnectionCheck,
       EndpointIntegration,
       IgniterHelpers,
@@ -603,6 +604,10 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
       # Update CSS integration (enables daisyUI themes if disabled)
       update_css_integration()
 
+      # Warn when the host's vendored daisyUI is older than what PhoenixKit's
+      # UI is designed against (the host owns the file; we never touch it)
+      warn_if_daisyui_outdated()
+
       # Update JS hooks file
       JsIntegration.update_js_file()
 
@@ -945,6 +950,16 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
       # Use the status command to show current status
       args = if prefix == "public", do: [], else: ["--prefix=#{prefix}"]
       Mix.Task.run("phoenix_kit.status", args)
+    end
+
+    # Advisory only — the host owns assets/vendor/daisyui.js; PhoenixKit's
+    # modals rely on daisyUI >= DaisyUI.minimum_version() for correct modal
+    # scrollbar-gutter handling (see PhoenixKit.Install.DaisyUI).
+    defp warn_if_daisyui_outdated do
+      case DaisyUI.check() do
+        {:outdated, version} -> Mix.shell().info(DaisyUI.outdated_warning(version))
+        _ -> :ok
+      end
     end
 
     # Update CSS integration during PhoenixKit updates

--- a/lib/phoenix_kit/install/common.ex
+++ b/lib/phoenix_kit/install/common.ex
@@ -179,21 +179,21 @@ defmodule PhoenixKit.Install.Common do
   end
 
   # Alternative version detection when primary method fails
-  defp check_alternative_version_detection(prefix, opts) do
-    # Strategy 1: Try direct database query (like status command does)
+  #
+  # Migration FILES existing in the project say nothing about what is
+  # installed in the DATABASE at this prefix. This used to fall back to a
+  # fabricated {:current_version, 1} whenever migration files were present,
+  # which made `mix phoenix_kit.update` generate a from-scratch v01→vN
+  # migration into the wrong schema when the prefix was misresolved (e.g.
+  # installed under a custom prefix but checked at "public"). Report
+  # honestly instead.
+  defp check_alternative_version_detection(_prefix, opts) do
     case try_direct_database_version_check(opts) do
-      version when version > 0 ->
+      version when is_integer(version) and version > 0 ->
         {:current_version, version}
 
       _ ->
-        # Strategy 2: Check if tables exist and try to infer version
-        case check_installation_from_tables(prefix) do
-          {:current_version, version} ->
-            {:current_version, version}
-
-          {:not_installed} ->
-            {:not_installed}
-        end
+        {:not_installed}
     end
   end
 
@@ -243,19 +243,6 @@ defmodule PhoenixKit.Install.Common do
     end
   rescue
     _ -> 0
-  end
-
-  # Check installation based on table presence and schema analysis
-  defp check_installation_from_tables(_prefix) do
-    case find_existing_phoenix_kit_migrations() do
-      [] ->
-        {:not_installed}
-
-      _migrations ->
-        # Migration files exist - try to determine actual version from database
-        # This is a last resort, assume recent version if tables are expected to exist
-        {:current_version, 1}
-    end
   end
 
   @doc """

--- a/lib/phoenix_kit/install/daisyui.ex
+++ b/lib/phoenix_kit/install/daisyui.ex
@@ -1,0 +1,101 @@
+defmodule PhoenixKit.Install.DaisyUI do
+  @moduledoc """
+  Advisory check of the host's vendored daisyUI version.
+
+  PhoenixKit's UI is styled by daisyUI, which lives in the HOST app
+  (`assets/vendor/daisyui.js` + `daisyui-theme.js`, scaffolded by
+  `mix phx.new` and loaded from the host's `app.css`). The host owns that
+  file — PhoenixKit does not manage or replace it; it only **checks** it.
+  `mix phoenix_kit.install`, `mix phoenix_kit.update`, and
+  `mix phoenix_kit.doctor` warn when the vendored copy is older than
+  `minimum_version/0`, with upgrade instructions.
+
+  Why the minimum matters: daisyUI < 5.1 reserves the modal scrollbar gutter
+  UNCONDITIONALLY while a modal/drawer is open, which either leaves a phantom
+  right-edge strip on non-scrolling pages or (when countered) makes content
+  reflow ~15px around every modal open/close on scrolling pages. daisyUI
+  ≥ 5.1 reserves the gutter only when the page really has a scrollbar
+  (`rootscrollgutter.css`), so PhoenixKit ships **no** scrollbar-gutter
+  compensations of its own (removed 2026-07-12) and relies on a modern
+  daisyUI instead. Hosts on an old copy see daisyUI's stock old behavior
+  until they upgrade — that's what the warning is for.
+  """
+
+  # The oldest daisyUI whose modal scrollbar-gutter handling PhoenixKit's
+  # modals rely on. The upstream fix matured across 5.1.0 → 5.6.x; PhoenixKit
+  # is verified against 5.6.17, and 5.6.0 is the floor we recommend.
+  @minimum_version "5.6.0"
+
+  @doc "The minimum daisyUI version PhoenixKit's UI is designed against."
+  @spec minimum_version() :: String.t()
+  def minimum_version, do: @minimum_version
+
+  @doc "The host-side path of the vendored daisyUI plugin."
+  @spec host_path() :: Path.t()
+  def host_path, do: Path.join([File.cwd!(), "assets", "vendor", "daisyui.js"])
+
+  @doc """
+  Parse the daisyUI version out of a plugin bundle, or `nil` when the file is
+  missing or carries no `version = "x.y.z"` marker.
+  """
+  @spec installed_version(Path.t()) :: String.t() | nil
+  def installed_version(path) do
+    with {:ok, content} <- File.read(path),
+         [_, version] <- Regex.run(~r/version = "([\d.]+)"/, content) do
+      version
+    else
+      _ -> nil
+    end
+  end
+
+  @doc """
+  Check the host's vendored daisyUI against `minimum_version/0`.
+
+  - `:ok` — present and at/above the minimum
+  - `{:outdated, version}` — present but older than the minimum
+  - `:unversioned` — present but carries no parseable version marker
+  - `:missing` — no `assets/vendor/daisyui.js` (npm or custom setup)
+  """
+  @spec check() :: :ok | {:outdated, String.t()} | :unversioned | :missing
+  def check do
+    path = host_path()
+
+    cond do
+      not File.exists?(path) ->
+        :missing
+
+      version = installed_version(path) ->
+        if outdated?(version), do: {:outdated, version}, else: :ok
+
+      true ->
+        :unversioned
+    end
+  end
+
+  @doc "Whether a daisyUI version string is below `minimum_version/0`."
+  @spec outdated?(String.t()) :: boolean()
+  def outdated?(version) when is_binary(version) do
+    case {Version.parse(version), Version.parse(@minimum_version)} do
+      {{:ok, installed}, {:ok, minimum}} -> Version.compare(installed, minimum) == :lt
+      # Unparseable → don't claim it's outdated; check/0 reports :unversioned.
+      _ -> false
+    end
+  end
+
+  @doc "Human warning for an outdated vendored daisyUI, with upgrade steps."
+  @spec outdated_warning(String.t()) :: String.t()
+  def outdated_warning(version) do
+    """
+    ⚠️  Your vendored daisyUI is #{version}; PhoenixKit is designed against #{@minimum_version}+.
+    On daisyUI < 5.1, opening any modal/drawer mishandles the scrollbar gutter
+    (a phantom right-edge strip, or content shifting ~15px on scrolling pages).
+    Update the two files in assets/vendor/ and rebuild assets:
+
+        cd assets/vendor
+        curl -sLO https://github.com/saadeghi/daisyui/releases/latest/download/daisyui.js
+        curl -sLO https://github.com/saadeghi/daisyui/releases/latest/download/daisyui-theme.js
+
+    Changelog: https://daisyui.com/docs/changelog/
+    """
+  end
+end

--- a/lib/phoenix_kit/install/migration_strategy.ex
+++ b/lib/phoenix_kit/install/migration_strategy.ex
@@ -12,6 +12,7 @@ defmodule PhoenixKit.Install.MigrationStrategy do
 
   alias Igniter.Project.Application
   alias PhoenixKit.Install.Common
+  alias PhoenixKit.Install.PrefixConfig
   alias PhoenixKit.Migrations.Postgres
   alias PhoenixKit.Utils.Routes
 
@@ -26,7 +27,7 @@ defmodule PhoenixKit.Install.MigrationStrategy do
   Updated igniter with migration files created or appropriate notices.
   """
   def create_phoenix_kit_migration_only(igniter, opts) do
-    prefix = opts[:prefix] || "public"
+    prefix = PrefixConfig.resolve_prefix(opts)
     create_schema = opts[:create_schema] != false && prefix != "public"
 
     # Check if this is a new installation or existing installation
@@ -78,7 +79,7 @@ defmodule PhoenixKit.Install.MigrationStrategy do
   end
 
   # Determine whether this is a new install, upgrade, or already up to date
-  defp determine_migration_strategy(igniter, _prefix) do
+  defp determine_migration_strategy(igniter, prefix) do
     case Application.app_name(igniter) do
       nil ->
         {:error, igniter, "Could not determine app name"}
@@ -92,10 +93,7 @@ defmodule PhoenixKit.Install.MigrationStrategy do
             {:new_install, igniter}
 
           _existing_migrations ->
-            # Check current and target versions using proper DB method
-            # Default prefix for install
-            prefix = "public"
-
+            # Check current and target versions at the install's prefix
             try do
               current_version = Common.migrated_version(prefix)
               target_version = Postgres.current_version()
@@ -122,7 +120,7 @@ defmodule PhoenixKit.Install.MigrationStrategy do
 
   # Determine migration strategy outside of igniter context
   defp determine_migration_strategy_simple(opts) do
-    prefix = opts[:prefix] || "public"
+    prefix = PrefixConfig.resolve_prefix(opts)
     migrations_dir = Path.join(["priv", "repo", "migrations"])
 
     case find_phoenix_kit_migrations(migrations_dir) do
@@ -402,7 +400,7 @@ defmodule PhoenixKit.Install.MigrationStrategy do
 
   # Show upgrade needed notice (simple version)
   defp show_upgrade_needed_notice(opts, current_version, target_version) do
-    prefix = opts[:prefix] || "public"
+    prefix = PrefixConfig.resolve_prefix(opts)
     prefix_option = if prefix != "public", do: " --prefix=#{prefix}", else: ""
 
     IO.puts("""
@@ -419,7 +417,7 @@ defmodule PhoenixKit.Install.MigrationStrategy do
 
   # Show up to date notice (simple version)
   defp show_up_to_date_notice(opts) do
-    prefix = opts[:prefix] || "public"
+    prefix = PrefixConfig.resolve_prefix(opts)
     prefix_option = if prefix != "public", do: " --prefix=#{prefix}", else: ""
 
     IO.puts("""
@@ -460,9 +458,10 @@ defmodule PhoenixKit.Install.MigrationStrategy do
   # public schema doesn't need create_schema
   defp migration_opts("public", true), do: "[]"
 
+  # Always emit create_schema explicitly for non-public prefixes — omitting
+  # it means the migration chain re-defaults the flag to true, silently
+  # discarding --create-schema=false.
   defp migration_opts(prefix, create_schema) when is_binary(prefix) do
-    opts = [prefix: prefix]
-    opts = if create_schema, do: Keyword.put(opts, :create_schema, true), else: opts
-    inspect(opts)
+    inspect(prefix: prefix, create_schema: create_schema)
   end
 end

--- a/lib/phoenix_kit/install/prefix_config.ex
+++ b/lib/phoenix_kit/install/prefix_config.ex
@@ -1,0 +1,63 @@
+defmodule PhoenixKit.Install.PrefixConfig do
+  @moduledoc """
+  Persists the `--prefix` install option into the host's config files.
+
+  `mix phoenix_kit.install --prefix "auth"` bakes the prefix into the
+  generated migration, but the migration docs also tell hosts to set
+
+      config :phoenix_kit, prefix: "auth"
+
+  Without that config entry, later tooling (`mix phoenix_kit.update`,
+  `mix phoenix_kit.status`) defaults to `"public"`, reports the install
+  as missing, and — worst case — generates a from-scratch migration
+  into the wrong schema. This module writes the config entry whenever
+  a non-public prefix is used, mirroring how the repo config is added.
+  """
+  use PhoenixKit.Install.IgniterCompat
+
+  alias Igniter.Project.Config
+
+  @doc """
+  Resolves the effective schema prefix for phoenix_kit mix tasks.
+
+  Order: explicit `--prefix` option → `config :phoenix_kit, :prefix` →
+  `"public"`.
+  """
+  def resolve_prefix(opts) do
+    opts[:prefix] || configured_prefix() || "public"
+  end
+
+  defp configured_prefix do
+    case Elixir.Application.get_env(:phoenix_kit, :prefix) do
+      prefix when is_binary(prefix) and prefix != "" -> prefix
+      _ -> nil
+    end
+  rescue
+    _ -> nil
+  end
+
+  @doc """
+  Adds `config :phoenix_kit, prefix: prefix` to config.exs and test.exs
+  when installing with a non-public prefix. No-op for the default
+  `"public"` prefix (or when no prefix option was given).
+  """
+  def add_prefix_configuration(igniter, prefix) when prefix in [nil, "public"], do: igniter
+
+  def add_prefix_configuration(igniter, prefix) when is_binary(prefix) do
+    igniter
+    |> Config.configure_new("config.exs", :phoenix_kit, [:prefix], prefix)
+    |> Config.configure_new("test.exs", :phoenix_kit, [:prefix], prefix)
+  rescue
+    _ ->
+      Igniter.add_notice(igniter, """
+      ⚠️  Could not persist the schema prefix automatically.
+
+      Please add this to config/config.exs (and config/test.exs):
+
+        config :phoenix_kit, prefix: #{inspect(prefix)}
+
+      Without it, mix phoenix_kit.update / status will look for the
+      installation in the "public" schema.
+      """)
+  end
+end

--- a/lib/phoenix_kit/install/repo_detection.ex
+++ b/lib/phoenix_kit/install/repo_detection.ex
@@ -30,15 +30,23 @@ defmodule PhoenixKit.Install.RepoDetection do
         warning = create_repo_not_found_warning()
         Igniter.add_warning(igniter, warning)
 
+      {:multiple, igniter, repos} ->
+        warning = create_multiple_repos_warning(repos)
+        Igniter.add_warning(igniter, warning)
+
       {igniter, repo_module} ->
         {updated_igniter, _} = validate_postgresql_adapter(igniter, repo_module)
         add_repo_config_to_files(updated_igniter, repo_module)
     end
   end
 
-  # Find specified repo or auto-detect from project
+  # Find specified repo or auto-detect from project.
+  #
+  # When more than one Ecto.Repo is detected, we deliberately do NOT
+  # pick one — a project may define migration-only or replica repos,
+  # and silently wiring the wrong one into `config :phoenix_kit, repo:`
+  # is far worse than asking for an explicit --repo.
   defp find_or_detect_repo(igniter, nil) do
-    # Try multiple methods to find repos
     with {igniter, nil} <- try_igniter_ecto_list(igniter),
          {igniter, nil} <- try_application_config(igniter) do
       try_naming_patterns(igniter)
@@ -61,7 +69,8 @@ defmodule PhoenixKit.Install.RepoDetection do
   # Method 1: Use Igniter's Ecto lib
   defp try_igniter_ecto_list(igniter) do
     case Ecto.list_repos(igniter) do
-      {igniter, [repo | _]} -> validate_postgres_adapter(igniter, repo)
+      {igniter, [repo]} -> validate_postgres_adapter(igniter, repo)
+      {igniter, [_ | _] = repos} -> {:multiple, igniter, repos}
       {igniter, []} -> {igniter, nil}
     end
   end
@@ -71,7 +80,8 @@ defmodule PhoenixKit.Install.RepoDetection do
     parent_app_name = IgniterHelpers.get_parent_app_name(igniter)
 
     case Elixir.Application.get_env(parent_app_name, :ecto_repos, []) do
-      [repo | _] -> validate_postgres_adapter(igniter, repo)
+      [repo] -> validate_postgres_adapter(igniter, repo)
+      [_ | _] = repos -> {:multiple, igniter, repos}
       [] -> {igniter, nil}
     end
   rescue
@@ -272,6 +282,23 @@ defmodule PhoenixKit.Install.RepoDetection do
     """
 
     Igniter.add_notice(igniter, notice)
+  end
+
+  # Create warning message when more than one repository is detected
+  defp create_multiple_repos_warning(repos) do
+    """
+    Multiple Ecto repos detected — PhoenixKit will not pick one automatically:
+
+    #{Enum.map_join(repos, "\n", fn repo -> "  - #{inspect(repo)}" end)}
+
+    Re-run with the repo your application uses at runtime:
+
+      mix phoenix_kit.install --repo #{inspect(List.first(repos))}
+
+    Or manually add to config/config.exs (and config/test.exs):
+
+      config :phoenix_kit, repo: YourApp.Repo
+    """
   end
 
   # Create warning message when repository cannot be found

--- a/lib/phoenix_kit/migration.ex
+++ b/lib/phoenix_kit/migration.ex
@@ -101,6 +101,25 @@ defmodule PhoenixKit.Migration do
   end
   ```
 
+  The prefix must be a conventional lower-case identifier (`[a-z_][a-z0-9_]*`) —
+  it is interpolated into SQL, and anything else is rejected at the `up`/`down`
+  entry points.
+
+  ## Required Postgres extensions
+
+  The migration chain needs three extensions: `citext` (case-insensitive
+  emails), `pgcrypto` (UUIDv7 generation), and `pg_trgm` (trigram search).
+  When they are already installed the chain never issues `CREATE EXTENSION`
+  (so no database-level CREATE privilege is needed). When one is missing, the
+  migrating role must be allowed to create it — on locked-down databases have
+  a DBA pre-provision them instead:
+
+  ```sql
+  CREATE EXTENSION IF NOT EXISTS citext;
+  CREATE EXTENSION IF NOT EXISTS pgcrypto;
+  CREATE EXTENSION IF NOT EXISTS pg_trgm;
+  ```
+
   ## Migrating Without Ecto
 
   If your application uses something other than Ecto for migrations, be it an external system or

--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -1232,9 +1232,17 @@ defmodule PhoenixKit.Migrations.Postgres do
 
   use Ecto.Migration
 
+  alias PhoenixKit.Migrations.Postgres.Helpers
+
   @initial_version 1
   @current_version 142
   @default_prefix "public"
+
+  # First version whose SQL references uuid_generate_v7(). Chains that
+  # start at or above it never hit the V40/V56/V61/V63 creation sites,
+  # so the entry point has to guarantee the function exists in the
+  # install's schema before any newer version's DDL calls it.
+  @uuid_fn_version 40
 
   @doc false
   def initial_version, do: @initial_version
@@ -1252,6 +1260,7 @@ defmodule PhoenixKit.Migrations.Postgres do
         change(@initial_version..opts.version, :up, opts)
 
       initial < opts.version ->
+        if initial >= @uuid_fn_version, do: Helpers.ensure_uuid_v7_function(opts.prefix)
         change((initial + 1)..opts.version, :up, opts)
 
       true ->
@@ -1263,6 +1272,8 @@ defmodule PhoenixKit.Migrations.Postgres do
   def down(opts) do
     # For down operations, don't set a default version - let target_version logic handle it
     opts = Enum.into(opts, %{prefix: @default_prefix})
+
+    Helpers.validate_prefix!(opts.prefix)
 
     opts =
       opts
@@ -1596,6 +1607,8 @@ defmodule PhoenixKit.Migrations.Postgres do
 
   defp with_defaults(opts, version) do
     opts = Enum.into(opts, %{prefix: @default_prefix, version: version})
+
+    Helpers.validate_prefix!(opts.prefix)
 
     opts
     |> Map.put(:quoted_prefix, inspect(opts.prefix))

--- a/lib/phoenix_kit/migrations/postgres/helpers.ex
+++ b/lib/phoenix_kit/migrations/postgres/helpers.ex
@@ -1,0 +1,229 @@
+defmodule PhoenixKit.Migrations.Postgres.Helpers do
+  @moduledoc """
+  Shared SQL helpers for the versioned Postgres migration chain.
+
+  Centralizes the prefix-sensitive patterns that individual version
+  modules used to hand-roll (and get subtly wrong in independent ways):
+
+    * `qualify_table/2` — schema-qualified table reference for raw SQL.
+      Index **names** must stay bare on `CREATE INDEX` (Postgres rejects
+      `CREATE INDEX schema.name`); only `DROP INDEX schema.name` accepts
+      a qualified name.
+    * `validate_prefix!/1` — rejects prefixes that can't be interpolated
+      into SQL safely. Called at the `up/down` entry points.
+    * `ensure_extension!/1` — privilege-aware replacement for a bare
+      `CREATE EXTENSION IF NOT EXISTS`. Postgres checks the CREATE
+      privilege *before* the IF-NOT-EXISTS short-circuit, so the bare
+      statement fails for low-privilege roles even when the extension is
+      already installed. This helper checks `pg_extension` first and
+      only attempts creation when the extension is genuinely missing.
+    * `ensure_uuid_v7_function/1` — creates `uuid_generate_v7()` inside
+      the install's schema (never wherever `search_path` happens to
+      point, which pollutes `public` and fails outright on PG15+ where
+      `public` isn't world-writable).
+
+  Functions without a `repo` argument run in `Ecto.Migration` context
+  (immediate existence checks via `repo().query/3`, DDL queued via
+  `execute/1`). The `repo`-taking variants are for runtime callers such
+  as `PhoenixKit.Migrations.UUIDRepair`.
+  """
+
+  @prefix_format ~r/^[a-z_][a-z0-9_]*$/
+
+  @required_extensions %{
+    "citext" => "case-insensitive email storage (V01)",
+    "pgcrypto" => "UUIDv7 generation via gen_random_bytes (V26/V40)",
+    "pg_trgm" => "trigram search on PDF page content (V111)"
+  }
+
+  @uuid_v7_function_body """
+  RETURNS uuid AS $$
+  DECLARE
+    unix_ts_ms bytea;
+    uuid_bytes bytea;
+  BEGIN
+    -- Get current timestamp in milliseconds
+    unix_ts_ms := substring(int8send(floor(extract(epoch FROM clock_timestamp()) * 1000)::bigint) FROM 3);
+
+    -- Build UUIDv7: 6 bytes timestamp + 2 bytes random (with version) + 8 bytes random (with variant)
+    uuid_bytes := unix_ts_ms || gen_random_bytes(10);
+
+    -- Set version 7 (0111xxxx in byte 7)
+    uuid_bytes := set_byte(uuid_bytes, 6, (get_byte(uuid_bytes, 6) & 15) | 112);
+
+    -- Set variant (10xxxxxx in byte 9)
+    uuid_bytes := set_byte(uuid_bytes, 8, (get_byte(uuid_bytes, 8) & 63) | 128);
+
+    RETURN encode(uuid_bytes, 'hex')::uuid;
+  END
+  $$ LANGUAGE plpgsql VOLATILE;
+  """
+
+  @doc """
+  Schema-qualified table reference for raw SQL interpolation.
+
+  `nil` and `"public"` both qualify explicitly as `public.` — an
+  explicit schema never depends on the connection's `search_path`.
+  """
+  @spec qualify_table(String.t() | atom(), String.t() | nil) :: String.t()
+  def qualify_table(table, nil), do: "public.#{table}"
+  def qualify_table(table, prefix), do: "#{prefix}.#{table}"
+
+  @doc """
+  Schema-qualified `uuid_generate_v7()` call for SQL interpolation.
+  """
+  @spec uuid_v7_call(String.t() | nil) :: String.t()
+  def uuid_v7_call(prefix), do: "#{schema(prefix)}.uuid_generate_v7()"
+
+  @doc """
+  Validates a schema prefix before it is interpolated into SQL.
+
+  The migration chain interpolates the prefix into hundreds of
+  statements, mostly unquoted, so only conventional lower-case
+  identifiers are supported: `#{inspect(@prefix_format.source)}`.
+  Raises `ArgumentError` for anything else (including uppercase or
+  dashed names, which only ever half-worked).
+  """
+  @spec validate_prefix!(term()) :: :ok
+  def validate_prefix!(prefix) when is_binary(prefix) do
+    if Regex.match?(@prefix_format, prefix) do
+      :ok
+    else
+      raise ArgumentError, """
+      invalid PhoenixKit schema prefix: #{inspect(prefix)}
+
+      The prefix is interpolated into SQL identifiers, so it must match
+      #{inspect(@prefix_format.source)} (lower-case letters, digits and
+      underscores, not starting with a digit) — e.g. "auth" or "my_app".
+      """
+    end
+  end
+
+  def validate_prefix!(prefix) do
+    raise ArgumentError,
+          "invalid PhoenixKit schema prefix: expected a string, got #{inspect(prefix)}"
+  end
+
+  @doc """
+  Ensures a Postgres extension is available, in migration context.
+
+  * already installed → no-op (skips the `CREATE EXTENSION` privilege
+    check entirely, so pre-provisioned low-privilege setups pass)
+  * missing + role can create → queues `CREATE EXTENSION IF NOT EXISTS`
+  * missing + role cannot create → raises an operator-facing error
+    listing the extensions to pre-create as a privileged role
+  """
+  @spec ensure_extension!(String.t()) :: :ok
+  def ensure_extension!(name) do
+    do_ensure_extension!(Ecto.Migration.repo(), name, &Ecto.Migration.execute/1)
+  end
+
+  @doc """
+  Runtime variant of `ensure_extension!/1` for callers outside migration
+  context (statements run immediately on `repo`).
+  """
+  @spec ensure_extension!(Ecto.Repo.t(), String.t()) :: :ok
+  def ensure_extension!(repo, name) do
+    do_ensure_extension!(repo, name, fn sql -> repo.query!(sql, [], log: false) end)
+  end
+
+  @doc """
+  Ensures `uuid_generate_v7()` exists in the install's schema, in
+  migration context.
+
+  Checks `pg_proc` first (so an existing function — possibly owned by a
+  different role — is never re-created) and queues a schema-qualified
+  `CREATE OR REPLACE FUNCTION` only when missing. The schema must exist
+  when this runs; V01 owns schema creation, so callers on the upgrade
+  path (installed version > 0) are always safe.
+  """
+  @spec ensure_uuid_v7_function(String.t() | nil) :: :ok
+  def ensure_uuid_v7_function(prefix) do
+    do_ensure_uuid_v7_function(Ecto.Migration.repo(), prefix, &Ecto.Migration.execute/1)
+  end
+
+  @doc """
+  Runtime variant of `ensure_uuid_v7_function/1` (statements run
+  immediately on `repo`).
+  """
+  @spec ensure_uuid_v7_function(Ecto.Repo.t(), String.t() | nil) :: :ok
+  def ensure_uuid_v7_function(repo, prefix) do
+    do_ensure_uuid_v7_function(repo, prefix, fn sql -> repo.query!(sql, [], log: false) end)
+  end
+
+  defp do_ensure_uuid_v7_function(repo, prefix, executor) do
+    unless uuid_v7_function_exists?(repo, prefix) do
+      executor.("""
+      CREATE OR REPLACE FUNCTION #{schema(prefix)}.uuid_generate_v7()
+      #{@uuid_v7_function_body}
+      """)
+    end
+
+    :ok
+  end
+
+  defp uuid_v7_function_exists?(repo, prefix) do
+    query = """
+    SELECT EXISTS (
+      SELECT FROM pg_proc p
+      JOIN pg_namespace n ON n.oid = p.pronamespace
+      WHERE p.proname = 'uuid_generate_v7'
+      AND n.nspname = $1
+    )
+    """
+
+    case repo.query(query, [schema(prefix)], log: false) do
+      {:ok, %{rows: [[true]]}} -> true
+      _ -> false
+    end
+  end
+
+  defp do_ensure_extension!(repo, name, executor) do
+    cond do
+      extension_exists?(repo, name) ->
+        :ok
+
+      can_create_extension?(repo) ->
+        executor.("CREATE EXTENSION IF NOT EXISTS #{name}")
+        :ok
+
+      true ->
+        raise """
+        PhoenixKit requires the Postgres extension '#{name}', which is not
+        installed, and the current database role cannot create it.
+
+        Pre-create the required extensions as a privileged role:
+
+        #{Enum.map_join(@required_extensions, "\n", fn {ext, why} -> "    CREATE EXTENSION IF NOT EXISTS #{ext};  -- #{why}" end)}
+
+        then re-run the migration.
+        """
+    end
+  end
+
+  defp extension_exists?(repo, name) do
+    case repo.query("SELECT 1 FROM pg_extension WHERE extname = $1", [name], log: false) do
+      {:ok, %{num_rows: rows}} -> rows > 0
+      _ -> false
+    end
+  end
+
+  # Trusted extensions (citext/pgcrypto/pg_trgm on PG13+) need CREATE on
+  # the current database; superusers can always create. When in doubt
+  # (query failure), report "can create" so the original CREATE EXTENSION
+  # path — and its native error message — is preserved.
+  defp can_create_extension?(repo) do
+    query = """
+    SELECT rolsuper OR has_database_privilege(current_database(), 'CREATE')
+    FROM pg_roles WHERE rolname = current_user
+    """
+
+    case repo.query(query, [], log: false) do
+      {:ok, %{rows: [[allowed]]}} -> allowed == true
+      _ -> true
+    end
+  end
+
+  defp schema(nil), do: "public"
+  defp schema(prefix), do: prefix
+end

--- a/lib/phoenix_kit/migrations/postgres/v01.ex
+++ b/lib/phoenix_kit/migrations/postgres/v01.ex
@@ -3,14 +3,36 @@ defmodule PhoenixKit.Migrations.Postgres.V01 do
 
   use Ecto.Migration
 
+  alias PhoenixKit.Migrations.Postgres.Helpers
+
   def up(%{create_schema: create?, prefix: prefix} = opts) do
     %{quoted_prefix: quoted} = opts
 
-    # Only create schema if it's not 'public' and create_schema is true
-    if create? && prefix != "public", do: execute("CREATE SCHEMA IF NOT EXISTS #{quoted}")
+    # Only attempt schema creation when the schema is actually missing.
+    # Postgres checks the CREATE-on-database privilege BEFORE the
+    # IF-NOT-EXISTS short-circuit, so executing the statement against a
+    # pre-created schema fails for low-privilege roles that own the
+    # schema but not the database.
+    if prefix != "public" && !schema_exists?(prefix) do
+      if create? do
+        execute("CREATE SCHEMA IF NOT EXISTS #{quoted}")
+      else
+        raise """
+        PhoenixKit: schema #{inspect(prefix)} does not exist and the migration
+        was called with create_schema: false.
 
-    # Create citext extension if not exists
-    execute "CREATE EXTENSION IF NOT EXISTS citext"
+        Create it as a privileged role first:
+
+            CREATE SCHEMA #{prefix} AUTHORIZATION your_app_role;
+
+        or drop the create_schema: false option to let the migration create it.
+        """
+      end
+    end
+
+    # Create citext extension if not exists (skips the statement — and its
+    # privilege check — when the extension is already installed)
+    Helpers.ensure_extension!("citext")
 
     # Create version tracking table (phoenix_kit)
     create_if_not_exists table(:phoenix_kit, primary_key: false, prefix: prefix) do
@@ -133,6 +155,18 @@ defmodule PhoenixKit.Migrations.Postgres.V01 do
   # Helper function to build table name with prefix
   defp prefix_table_name(table_name, nil), do: table_name
   defp prefix_table_name(table_name, prefix), do: "#{prefix}.#{table_name}"
+
+  # Immediate check (repo().query/3 executes outside the migration
+  # command queue) — safe here because nothing queued before V01 could
+  # create the schema.
+  defp schema_exists?(prefix) do
+    query = "SELECT EXISTS (SELECT FROM information_schema.schemata WHERE schema_name = $1)"
+
+    case repo().query(query, [prefix], log: false) do
+      {:ok, %{rows: [[true]]}} -> true
+      _ -> false
+    end
+  end
 
   def down(%{prefix: prefix}) do
     # Drop tables in correct order (foreign key dependencies)

--- a/lib/phoenix_kit/migrations/postgres/v100.ex
+++ b/lib/phoenix_kit/migrations/postgres/v100.ex
@@ -26,7 +26,7 @@ defmodule PhoenixKit.Migrations.Postgres.V100 do
 
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_staff_departments (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       name VARCHAR(255) NOT NULL,
       description TEXT,
       inserted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
@@ -41,7 +41,7 @@ defmodule PhoenixKit.Migrations.Postgres.V100 do
 
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_staff_teams (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       department_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_staff_departments(uuid) ON DELETE CASCADE,
       name VARCHAR(255) NOT NULL,
       description TEXT,
@@ -62,7 +62,7 @@ defmodule PhoenixKit.Migrations.Postgres.V100 do
 
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_staff_people (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       user_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_users(uuid) ON DELETE CASCADE,
       primary_department_uuid UUID REFERENCES #{p}phoenix_kit_staff_departments(uuid) ON DELETE SET NULL,
       status VARCHAR(20) NOT NULL DEFAULT 'active',
@@ -103,7 +103,7 @@ defmodule PhoenixKit.Migrations.Postgres.V100 do
 
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_staff_team_memberships (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       team_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_staff_teams(uuid) ON DELETE CASCADE,
       staff_person_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_staff_people(uuid) ON DELETE CASCADE,
       inserted_at TIMESTAMPTZ NOT NULL DEFAULT NOW()

--- a/lib/phoenix_kit/migrations/postgres/v101.ex
+++ b/lib/phoenix_kit/migrations/postgres/v101.ex
@@ -30,7 +30,7 @@ defmodule PhoenixKit.Migrations.Postgres.V101 do
 
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_project_tasks (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       title VARCHAR(255) NOT NULL,
       description TEXT,
       estimated_duration INTEGER,
@@ -52,7 +52,7 @@ defmodule PhoenixKit.Migrations.Postgres.V101 do
 
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_projects (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       name VARCHAR(255) NOT NULL,
       description TEXT,
       status VARCHAR(20) NOT NULL DEFAULT 'active',
@@ -79,7 +79,7 @@ defmodule PhoenixKit.Migrations.Postgres.V101 do
 
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_project_assignments (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       project_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_projects(uuid) ON DELETE CASCADE,
       task_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_project_tasks(uuid) ON DELETE CASCADE,
       status VARCHAR(20) NOT NULL DEFAULT 'todo',
@@ -143,7 +143,7 @@ defmodule PhoenixKit.Migrations.Postgres.V101 do
 
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_project_dependencies (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       assignment_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_project_assignments(uuid) ON DELETE CASCADE,
       depends_on_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_project_assignments(uuid) ON DELETE CASCADE,
       inserted_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
@@ -164,7 +164,7 @@ defmodule PhoenixKit.Migrations.Postgres.V101 do
 
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_project_task_dependencies (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       task_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_project_tasks(uuid) ON DELETE CASCADE,
       depends_on_task_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_project_tasks(uuid) ON DELETE CASCADE,
       inserted_at TIMESTAMPTZ NOT NULL DEFAULT NOW()

--- a/lib/phoenix_kit/migrations/postgres/v102.ex
+++ b/lib/phoenix_kit/migrations/postgres/v102.ex
@@ -129,7 +129,7 @@ defmodule PhoenixKit.Migrations.Postgres.V102 do
     # ── Smart rules table ───────────────────────────────────────
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_cat_item_catalogue_rules (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       item_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_cat_items(uuid) ON DELETE CASCADE,
       referenced_catalogue_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_cat_catalogues(uuid) ON DELETE CASCADE,
       value DECIMAL(12, 4),

--- a/lib/phoenix_kit/migrations/postgres/v104.ex
+++ b/lib/phoenix_kit/migrations/postgres/v104.ex
@@ -35,7 +35,7 @@ defmodule PhoenixKit.Migrations.Postgres.V104 do
 
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_notifications (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       activity_uuid UUID NOT NULL
         REFERENCES #{p}phoenix_kit_activities(uuid) ON DELETE CASCADE,
       recipient_uuid UUID NOT NULL

--- a/lib/phoenix_kit/migrations/postgres/v105.ex
+++ b/lib/phoenix_kit/migrations/postgres/v105.ex
@@ -48,7 +48,7 @@ defmodule PhoenixKit.Migrations.Postgres.V105 do
 
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_crm_user_role_view (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       user_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_users(uuid) ON DELETE CASCADE,
       scope VARCHAR(100) NOT NULL,
       view_config JSONB NOT NULL DEFAULT '{}',

--- a/lib/phoenix_kit/migrations/postgres/v111.ex
+++ b/lib/phoenix_kit/migrations/postgres/v111.ex
@@ -43,6 +43,8 @@ defmodule PhoenixKit.Migrations.Postgres.V111 do
 
   use Ecto.Migration
 
+  alias PhoenixKit.Migrations.Postgres.Helpers
+
   def up(opts) do
     prefix = Map.get(opts, :prefix, "public")
     p = prefix_str(prefix)
@@ -55,12 +57,12 @@ defmodule PhoenixKit.Migrations.Postgres.V111 do
     execute("DROP TABLE IF EXISTS #{p}phoenix_kit_cat_pdf_extractions CASCADE")
     execute("DROP TABLE IF EXISTS #{p}phoenix_kit_cat_pdf_page_contents CASCADE")
 
-    execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+    Helpers.ensure_extension!("pg_trgm")
 
     # ── per-upload row ─────────────────────────────────────────────────
 
     create table(:phoenix_kit_cat_pdfs, primary_key: false, prefix: prefix) do
-      add(:uuid, :uuid, primary_key: true, default: fragment("uuid_generate_v7()"))
+      add(:uuid, :uuid, primary_key: true, default: fragment("#{prefix}.uuid_generate_v7()"))
 
       add(
         :file_uuid,

--- a/lib/phoenix_kit/migrations/postgres/v113.ex
+++ b/lib/phoenix_kit/migrations/postgres/v113.ex
@@ -166,7 +166,7 @@ defmodule PhoenixKit.Migrations.Postgres.V113 do
                          ) do
       add(:uuid, :uuid,
         primary_key: true,
-        default: fragment("uuid_generate_v7()"),
+        default: fragment("#{prefix}.uuid_generate_v7()"),
         null: false
       )
 

--- a/lib/phoenix_kit/migrations/postgres/v115.ex
+++ b/lib/phoenix_kit/migrations/postgres/v115.ex
@@ -46,7 +46,7 @@ defmodule PhoenixKit.Migrations.Postgres.V115 do
                          ) do
       add(:uuid, :uuid,
         primary_key: true,
-        default: fragment("uuid_generate_v7()"),
+        default: fragment("#{prefix}.uuid_generate_v7()"),
         null: false
       )
 

--- a/lib/phoenix_kit/migrations/postgres/v117.ex
+++ b/lib/phoenix_kit/migrations/postgres/v117.ex
@@ -51,7 +51,7 @@ defmodule PhoenixKit.Migrations.Postgres.V117 do
                          ) do
       add(:uuid, :uuid,
         primary_key: true,
-        default: fragment("uuid_generate_v7()"),
+        default: fragment("#{prefix}.uuid_generate_v7()"),
         null: false
       )
 
@@ -100,7 +100,7 @@ defmodule PhoenixKit.Migrations.Postgres.V117 do
     # `:map` DSL can't express — use raw SQL for that column's default.
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_doc_template_presets (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7() NOT NULL,
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7() NOT NULL,
       name VARCHAR NOT NULL,
       description TEXT,
       category VARCHAR,

--- a/lib/phoenix_kit/migrations/postgres/v120.ex
+++ b/lib/phoenix_kit/migrations/postgres/v120.ex
@@ -36,7 +36,7 @@ defmodule PhoenixKit.Migrations.Postgres.V120 do
                            primary_key: false,
                            prefix: prefix
                          ) do
-      add(:uuid, :uuid, primary_key: true, default: fragment("uuid_generate_v7()"))
+      add(:uuid, :uuid, primary_key: true, default: fragment("#{prefix}.uuid_generate_v7()"))
       add(:name, :string, null: false)
       add(:description, :text)
       add(:position, :integer, null: false, default: 0)
@@ -53,7 +53,7 @@ defmodule PhoenixKit.Migrations.Postgres.V120 do
                            primary_key: false,
                            prefix: prefix
                          ) do
-      add(:uuid, :uuid, primary_key: true, default: fragment("uuid_generate_v7()"))
+      add(:uuid, :uuid, primary_key: true, default: fragment("#{prefix}.uuid_generate_v7()"))
       add(:name, :string, null: false)
       add(:description, :text)
       add(:position, :integer, null: false, default: 0)
@@ -147,7 +147,7 @@ defmodule PhoenixKit.Migrations.Postgres.V120 do
             WHEN 'technical' THEN 'Technical'
             ELSE upper(substr(rec.sample, 1, 1)) || substr(rec.sample, 2)
           END;
-          new_uuid := uuid_generate_v7();
+          new_uuid := #{prefix}.uuid_generate_v7();
           INSERT INTO #{p}phoenix_kit_doc_categories
             (uuid, name, position, status, data, inserted_at, updated_at)
           VALUES

--- a/lib/phoenix_kit/migrations/postgres/v122.ex
+++ b/lib/phoenix_kit/migrations/postgres/v122.ex
@@ -72,7 +72,7 @@ defmodule PhoenixKit.Migrations.Postgres.V122 do
                            primary_key: false,
                            prefix: prefix
                          ) do
-      add(:uuid, :uuid, primary_key: true, default: fragment("uuid_generate_v7()"))
+      add(:uuid, :uuid, primary_key: true, default: fragment("#{prefix}.uuid_generate_v7()"))
       add(:name, :string, null: false, size: 255)
       add(:description, :text)
       add(:public_notes, :text)
@@ -103,7 +103,7 @@ defmodule PhoenixKit.Migrations.Postgres.V122 do
                            primary_key: false,
                            prefix: prefix
                          ) do
-      add(:uuid, :uuid, primary_key: true, default: fragment("uuid_generate_v7()"))
+      add(:uuid, :uuid, primary_key: true, default: fragment("#{prefix}.uuid_generate_v7()"))
 
       add(
         :location_uuid,

--- a/lib/phoenix_kit/migrations/postgres/v123.ex
+++ b/lib/phoenix_kit/migrations/postgres/v123.ex
@@ -38,7 +38,7 @@ defmodule PhoenixKit.Migrations.Postgres.V123 do
                            primary_key: false,
                            prefix: prefix
                          ) do
-      add(:uuid, :uuid, primary_key: true, default: fragment("uuid_generate_v7()"))
+      add(:uuid, :uuid, primary_key: true, default: fragment("#{prefix}.uuid_generate_v7()"))
       add(:name, :string, null: false)
 
       add(

--- a/lib/phoenix_kit/migrations/postgres/v125.ex
+++ b/lib/phoenix_kit/migrations/postgres/v125.ex
@@ -119,7 +119,7 @@ defmodule PhoenixKit.Migrations.Postgres.V125 do
   defp create_project_statuses_table(p) do
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_project_statuses (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{p}uuid_generate_v7(),
       project_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_projects(uuid) ON DELETE CASCADE,
       label VARCHAR(255) NOT NULL,
       slug VARCHAR(255) NOT NULL,

--- a/lib/phoenix_kit/migrations/postgres/v133.ex
+++ b/lib/phoenix_kit/migrations/postgres/v133.ex
@@ -22,7 +22,7 @@ defmodule PhoenixKit.Migrations.Postgres.V133 do
 
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_dashboards (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       title VARCHAR(255) NOT NULL,
       slug VARCHAR(255) NOT NULL,
       owner_user_uuid UUID REFERENCES #{p}phoenix_kit_users(uuid) ON DELETE CASCADE,

--- a/lib/phoenix_kit/migrations/postgres/v135.ex
+++ b/lib/phoenix_kit/migrations/postgres/v135.ex
@@ -45,7 +45,7 @@ defmodule PhoenixKit.Migrations.Postgres.V135 do
     # 1. Skills entity (translatable, flat — no parent).
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_staff_skills (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       name VARCHAR(255) NOT NULL,
       description TEXT,
       translations JSONB NOT NULL DEFAULT '{}'::jsonb,
@@ -64,7 +64,7 @@ defmodule PhoenixKit.Migrations.Postgres.V135 do
     # 2. person ↔ skill join + nullable proficiency level.
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_staff_person_skills (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       staff_person_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_staff_people(uuid) ON DELETE CASCADE,
       skill_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_staff_skills(uuid) ON DELETE CASCADE,
       proficiency_levels JSONB NOT NULL DEFAULT '[]'::jsonb,

--- a/lib/phoenix_kit/migrations/postgres/v136.ex
+++ b/lib/phoenix_kit/migrations/postgres/v136.ex
@@ -48,7 +48,7 @@ defmodule PhoenixKit.Migrations.Postgres.V136 do
     # 1. Employment spans — a person's employment history.
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_staff_employments (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       staff_person_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_staff_people(uuid) ON DELETE CASCADE,
       employment_type VARCHAR(50),
       job_title VARCHAR(255),

--- a/lib/phoenix_kit/migrations/postgres/v138.ex
+++ b/lib/phoenix_kit/migrations/postgres/v138.ex
@@ -44,7 +44,7 @@ defmodule PhoenixKit.Migrations.Postgres.V138 do
     # ── Contacts ──────────────────────────────────────────────────────
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_crm_contacts (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       name VARCHAR(255),
       status VARCHAR(50) NOT NULL DEFAULT 'active',
       email VARCHAR(255),
@@ -72,7 +72,7 @@ defmodule PhoenixKit.Migrations.Postgres.V138 do
     # ── Companies ─────────────────────────────────────────────────────
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_crm_companies (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       name VARCHAR(255),
       status VARCHAR(50) NOT NULL DEFAULT 'active',
       website VARCHAR(255),
@@ -95,7 +95,7 @@ defmodule PhoenixKit.Migrations.Postgres.V138 do
     # ── Contact ↔ Company memberships ─────────────────────────────────
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_crm_company_memberships (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       contact_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_crm_contacts(uuid) ON DELETE CASCADE,
       company_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_crm_companies(uuid) ON DELETE CASCADE,
       role_in_company VARCHAR(255),
@@ -121,7 +121,7 @@ defmodule PhoenixKit.Migrations.Postgres.V138 do
     # ── Interactions ──────────────────────────────────────────────────
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_crm_interactions (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       contact_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_crm_contacts(uuid) ON DELETE CASCADE,
       interaction_type VARCHAR(50) NOT NULL DEFAULT 'note',
       occurred_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
@@ -145,7 +145,7 @@ defmodule PhoenixKit.Migrations.Postgres.V138 do
     # optional staff module stays optional.
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_crm_interaction_parties (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       interaction_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_crm_interactions(uuid) ON DELETE CASCADE,
       raw_name VARCHAR(255) NOT NULL,
       contact_uuid UUID REFERENCES #{p}phoenix_kit_crm_contacts(uuid) ON DELETE SET NULL,

--- a/lib/phoenix_kit/migrations/postgres/v140.ex
+++ b/lib/phoenix_kit/migrations/postgres/v140.ex
@@ -47,7 +47,7 @@ defmodule PhoenixKit.Migrations.Postgres.V140 do
     # 1. Stock — per (item, location) balance.
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_warehouse_stock (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{p}uuid_generate_v7(),
       item_uuid UUID NOT NULL,
       location_uuid UUID NOT NULL,
       quantity NUMERIC NOT NULL DEFAULT 0,
@@ -91,7 +91,7 @@ defmodule PhoenixKit.Migrations.Postgres.V140 do
 
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_warehouse_inventory_documents (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{p}uuid_generate_v7(),
       number BIGINT NOT NULL DEFAULT nextval('#{p}phoenix_kit_warehouse_inventory_documents_number_seq'),
       status VARCHAR(20) NOT NULL DEFAULT 'draft',
       track_value BOOLEAN NOT NULL DEFAULT false,
@@ -139,7 +139,7 @@ defmodule PhoenixKit.Migrations.Postgres.V140 do
 
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_warehouse_internal_orders (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{p}uuid_generate_v7(),
       number BIGINT NOT NULL DEFAULT nextval('#{p}phoenix_kit_warehouse_internal_orders_number_seq'),
       status VARCHAR(20) NOT NULL DEFAULT 'draft',
       location_uuid UUID NOT NULL,
@@ -229,7 +229,7 @@ defmodule PhoenixKit.Migrations.Postgres.V140 do
 
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_warehouse_supplier_orders (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{p}uuid_generate_v7(),
       number BIGINT NOT NULL DEFAULT nextval('#{p}phoenix_kit_warehouse_supplier_orders_number_seq'),
       status VARCHAR(20) NOT NULL DEFAULT 'draft',
       supplier_uuid UUID,
@@ -295,7 +295,7 @@ defmodule PhoenixKit.Migrations.Postgres.V140 do
 
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_warehouse_goods_receipts (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{p}uuid_generate_v7(),
       number BIGINT NOT NULL DEFAULT nextval('#{p}phoenix_kit_warehouse_goods_receipts_number_seq'),
       status VARCHAR(20) NOT NULL DEFAULT 'draft',
       supplier_order_uuid UUID REFERENCES #{p}phoenix_kit_warehouse_supplier_orders(uuid) ON DELETE SET NULL,
@@ -356,7 +356,7 @@ defmodule PhoenixKit.Migrations.Postgres.V140 do
 
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_warehouse_goods_issues (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{p}uuid_generate_v7(),
       number BIGINT NOT NULL DEFAULT nextval('#{p}phoenix_kit_warehouse_goods_issues_number_seq'),
       status VARCHAR(20) NOT NULL DEFAULT 'draft',
       internal_order_uuid UUID REFERENCES #{p}phoenix_kit_warehouse_internal_orders(uuid) ON DELETE SET NULL,

--- a/lib/phoenix_kit/migrations/postgres/v141.ex
+++ b/lib/phoenix_kit/migrations/postgres/v141.ex
@@ -53,7 +53,7 @@ defmodule PhoenixKit.Migrations.Postgres.V141 do
 
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_calendar_events (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       owner_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_users(uuid) ON DELETE CASCADE,
       title VARCHAR(255) NOT NULL,
       description TEXT,
@@ -127,7 +127,7 @@ defmodule PhoenixKit.Migrations.Postgres.V141 do
 
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_calendar_event_participants (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       event_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_calendar_events(uuid) ON DELETE CASCADE,
       kind VARCHAR(20) NOT NULL,
       target_uuid UUID,

--- a/lib/phoenix_kit/migrations/postgres/v26.ex
+++ b/lib/phoenix_kit/migrations/postgres/v26.ex
@@ -25,9 +25,12 @@ defmodule PhoenixKit.Migrations.Postgres.V26 do
 
   use Ecto.Migration
 
+  alias PhoenixKit.Migrations.Postgres.Helpers
+
   def up(%{prefix: prefix} = _opts) do
-    # Enable pgcrypto extension for digest function
-    execute "CREATE EXTENSION IF NOT EXISTS pgcrypto"
+    # Enable pgcrypto extension for digest function (skips the statement —
+    # and its privilege check — when the extension is already installed)
+    Helpers.ensure_extension!("pgcrypto")
 
     # Drop the unique index on checksum (from V24)
     drop_if_exists unique_index(:phoenix_kit_files, [:checksum], prefix: prefix)

--- a/lib/phoenix_kit/migrations/postgres/v27.ex
+++ b/lib/phoenix_kit/migrations/postgres/v27.ex
@@ -46,7 +46,14 @@ defmodule PhoenixKit.Migrations.Postgres.V27 do
   def up(%{prefix: prefix} = _opts) do
     # Run Oban migrations to create required tables
     # Uses latest Oban schema version automatically (forward-compatible)
-    Oban.Migration.up(prefix: prefix)
+    #
+    # create_schema: false is load-bearing: without it Oban's migrator
+    # defaults the flag to true for any non-public prefix and executes
+    # CREATE SCHEMA IF NOT EXISTS — which fails for low-privilege roles
+    # even when the schema exists (Postgres checks the CREATE privilege
+    # before the IF-NOT-EXISTS short-circuit). By V27 the schema always
+    # exists (V01 owns schema creation), so never ask Oban to create it.
+    Oban.Migration.up(prefix: prefix, create_schema: false)
 
     # Set version comment on phoenix_kit table for version tracking
     execute "COMMENT ON TABLE #{prefix_table_name("phoenix_kit", prefix)} IS '27'"

--- a/lib/phoenix_kit/migrations/postgres/v40.ex
+++ b/lib/phoenix_kit/migrations/postgres/v40.ex
@@ -105,6 +105,8 @@ defmodule PhoenixKit.Migrations.Postgres.V40 do
   """
   use Ecto.Migration
 
+  alias PhoenixKit.Migrations.Postgres.Helpers
+
   @tables_to_migrate [
     # Core Auth (V01)
     :phoenix_kit_users,
@@ -178,34 +180,14 @@ defmodule PhoenixKit.Migrations.Postgres.V40 do
     # executes immediately and won't see unbuffered tables.
     flush()
 
-    # Step 1: Ensure pgcrypto extension exists
-    execute("CREATE EXTENSION IF NOT EXISTS pgcrypto")
+    # Step 1: Ensure pgcrypto extension exists (skips the statement — and
+    # its privilege check — when the extension is already installed)
+    Helpers.ensure_extension!("pgcrypto")
 
-    # Step 2: Create UUIDv7 generation function if it doesn't exist
-    # UUIDv7 format: timestamp (48 bits) + version (4 bits) + random (12 bits) + variant (2 bits) + random (62 bits)
-    execute("""
-    CREATE OR REPLACE FUNCTION uuid_generate_v7()
-    RETURNS uuid AS $$
-    DECLARE
-      unix_ts_ms bytea;
-      uuid_bytes bytea;
-    BEGIN
-      -- Get current timestamp in milliseconds
-      unix_ts_ms := substring(int8send(floor(extract(epoch FROM clock_timestamp()) * 1000)::bigint) FROM 3);
-
-      -- Build UUIDv7: 6 bytes timestamp + 2 bytes random (with version) + 8 bytes random (with variant)
-      uuid_bytes := unix_ts_ms || gen_random_bytes(10);
-
-      -- Set version 7 (0111xxxx in byte 7)
-      uuid_bytes := set_byte(uuid_bytes, 6, (get_byte(uuid_bytes, 6) & 15) | 112);
-
-      -- Set variant (10xxxxxx in byte 9)
-      uuid_bytes := set_byte(uuid_bytes, 8, (get_byte(uuid_bytes, 8) & 63) | 128);
-
-      RETURN encode(uuid_bytes, 'hex')::uuid;
-    END
-    $$ LANGUAGE plpgsql VOLATILE;
-    """)
+    # Step 2: Create UUIDv7 generation function inside the install's schema
+    # (never wherever search_path points — that pollutes public and fails
+    # on PG15+ where public isn't world-writable)
+    Helpers.ensure_uuid_v7_function(prefix)
 
     # Step 3: Process each table
     for table <- @tables_to_migrate do
@@ -244,18 +226,18 @@ defmodule PhoenixKit.Migrations.Postgres.V40 do
         # Ecto changesets will generate UUIDv7 in Elixir, which takes precedence.
         execute("""
         ALTER TABLE #{table_name}
-        ADD COLUMN uuid UUID DEFAULT uuid_generate_v7()
+        ADD COLUMN uuid UUID DEFAULT #{prefix}.uuid_generate_v7()
         """)
 
         # Step 2: Backfill existing records with UUIDv7
         # Use batched updates for large tables to avoid long locks
         if table in @large_tables do
-          backfill_uuids_batched(table_name)
+          backfill_uuids_batched(table_name, prefix)
         else
           # Small tables can be updated in one go
           execute("""
           UPDATE #{table_name}
-          SET uuid = uuid_generate_v7()
+          SET uuid = #{prefix}.uuid_generate_v7()
           WHERE uuid IS NULL
           """)
         end
@@ -281,7 +263,7 @@ defmodule PhoenixKit.Migrations.Postgres.V40 do
   end
 
   # Backfill UUIDs in batches to avoid long locks on large tables
-  defp backfill_uuids_batched(table_name) do
+  defp backfill_uuids_batched(table_name, prefix) do
     # Use a loop to update in batches
     # This is done via a DO block to handle it in a single migration step
     execute("""
@@ -292,7 +274,7 @@ defmodule PhoenixKit.Migrations.Postgres.V40 do
     BEGIN
       LOOP
         UPDATE #{table_name}
-        SET uuid = uuid_generate_v7()
+        SET uuid = #{prefix}.uuid_generate_v7()
         WHERE id IN (
           SELECT id FROM #{table_name}
           WHERE uuid IS NULL

--- a/lib/phoenix_kit/migrations/postgres/v56.ex
+++ b/lib/phoenix_kit/migrations/postgres/v56.ex
@@ -88,6 +88,8 @@ defmodule PhoenixKit.Migrations.Postgres.V56 do
 
   use Ecto.Migration
 
+  alias PhoenixKit.Migrations.Postgres.Helpers
+
   alias PhoenixKit.Migrations.UUIDFKColumns
 
   # Tables missing the uuid column entirely (schema expects it, migration never created it)
@@ -199,22 +201,8 @@ defmodule PhoenixKit.Migrations.Postgres.V56 do
     # Flush pending commands so repo().query() table checks see all tables
     flush()
 
-    # Ensure uuid_generate_v7() function exists (created in V40, but be safe)
-    execute("""
-    CREATE OR REPLACE FUNCTION uuid_generate_v7()
-    RETURNS uuid AS $$
-    DECLARE
-      unix_ts_ms bytea;
-      uuid_bytes bytea;
-    BEGIN
-      unix_ts_ms := substring(int8send(floor(extract(epoch FROM clock_timestamp()) * 1000)::bigint) FROM 3);
-      uuid_bytes := unix_ts_ms || gen_random_bytes(10);
-      uuid_bytes := set_byte(uuid_bytes, 6, (get_byte(uuid_bytes, 6) & 15) | 112);
-      uuid_bytes := set_byte(uuid_bytes, 8, (get_byte(uuid_bytes, 8) & 63) | 128);
-      RETURN encode(uuid_bytes, 'hex')::uuid;
-    END
-    $$ LANGUAGE plpgsql VOLATILE;
-    """)
+    # Ensure #{prefix}.uuid_generate_v7() function exists (created in V40, but be safe)
+    Helpers.ensure_uuid_v7_function(prefix)
 
     # Fix 0: Add missing uuid columns (V43 consent_logs)
     for table <- @tables_missing_column do
@@ -334,26 +322,26 @@ defmodule PhoenixKit.Migrations.Postgres.V56 do
     if table_exists?(table, escaped_prefix) do
       execute("""
       ALTER TABLE #{table_name}
-      ADD COLUMN IF NOT EXISTS uuid UUID DEFAULT uuid_generate_v7()
+      ADD COLUMN IF NOT EXISTS uuid UUID DEFAULT #{prefix}.uuid_generate_v7()
       """)
 
       # Backfill existing rows
       execute("""
       UPDATE #{table_name}
-      SET uuid = uuid_generate_v7()
+      SET uuid = #{prefix}.uuid_generate_v7()
       WHERE uuid IS NULL
       """)
     end
   end
 
-  # Fix 1: Set DEFAULT to uuid_generate_v7()
+  # Fix 1: Set DEFAULT to #{prefix}.uuid_generate_v7()
   defp fix_uuid_default(table, prefix, escaped_prefix) do
     table_name = prefix_table_name(Atom.to_string(table), prefix)
 
     if table_exists?(table, escaped_prefix) and column_exists?(table, :uuid, escaped_prefix) do
       execute("""
       ALTER TABLE #{table_name}
-      ALTER COLUMN uuid SET DEFAULT uuid_generate_v7()
+      ALTER COLUMN uuid SET DEFAULT #{prefix}.uuid_generate_v7()
       """)
     end
   end
@@ -366,7 +354,7 @@ defmodule PhoenixKit.Migrations.Postgres.V56 do
       # Backfill any NULL uuid values with UUIDv7
       execute("""
       UPDATE #{table_name}
-      SET uuid = uuid_generate_v7()
+      SET uuid = #{prefix}.uuid_generate_v7()
       WHERE uuid IS NULL
       """)
 
@@ -398,7 +386,7 @@ defmodule PhoenixKit.Migrations.Postgres.V56 do
     if table_exists?(table, escaped_prefix) and column_exists?(table, :id, escaped_prefix) do
       execute("""
       ALTER TABLE #{table_name}
-      ALTER COLUMN id SET DEFAULT uuid_generate_v7()
+      ALTER COLUMN id SET DEFAULT #{prefix}.uuid_generate_v7()
       """)
     end
   end

--- a/lib/phoenix_kit/migrations/postgres/v59.ex
+++ b/lib/phoenix_kit/migrations/postgres/v59.ex
@@ -39,7 +39,7 @@ defmodule PhoenixKit.Migrations.Postgres.V59 do
 
     execute("""
     CREATE TABLE IF NOT EXISTS #{prefix_str}phoenix_kit_publishing_groups (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       name VARCHAR(255) NOT NULL,
       slug VARCHAR(255) NOT NULL,
       mode VARCHAR(20) NOT NULL DEFAULT 'timestamp',
@@ -61,7 +61,7 @@ defmodule PhoenixKit.Migrations.Postgres.V59 do
 
     execute("""
     CREATE TABLE IF NOT EXISTS #{prefix_str}phoenix_kit_publishing_posts (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       group_id UUID NOT NULL,
       slug VARCHAR(500) NOT NULL,
       status VARCHAR(20) NOT NULL DEFAULT 'draft',
@@ -148,7 +148,7 @@ defmodule PhoenixKit.Migrations.Postgres.V59 do
 
     execute("""
     CREATE TABLE IF NOT EXISTS #{prefix_str}phoenix_kit_publishing_versions (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       post_id UUID NOT NULL,
       version_number INTEGER NOT NULL,
       status VARCHAR(20) NOT NULL DEFAULT 'draft',
@@ -198,7 +198,7 @@ defmodule PhoenixKit.Migrations.Postgres.V59 do
 
     execute("""
     CREATE TABLE IF NOT EXISTS #{prefix_str}phoenix_kit_publishing_contents (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       version_id UUID NOT NULL,
       language VARCHAR(10) NOT NULL,
       title VARCHAR(500) NOT NULL,

--- a/lib/phoenix_kit/migrations/postgres/v61.ex
+++ b/lib/phoenix_kit/migrations/postgres/v61.ex
@@ -48,6 +48,8 @@ defmodule PhoenixKit.Migrations.Postgres.V61 do
 
   use Ecto.Migration
 
+  alias PhoenixKit.Migrations.Postgres.Helpers
+
   @tables_missing_uuid [
     :phoenix_kit_admin_notes,
     :phoenix_kit_ai_requests,
@@ -63,24 +65,10 @@ defmodule PhoenixKit.Migrations.Postgres.V61 do
     # Flush any pending commands from earlier versions
     flush()
 
-    # Ensure uuid_generate_v7() exists (created in V40, but be safe)
-    execute("""
-    CREATE OR REPLACE FUNCTION uuid_generate_v7()
-    RETURNS uuid AS $$
-    DECLARE
-      unix_ts_ms bytea;
-      uuid_bytes bytea;
-    BEGIN
-      unix_ts_ms := substring(int8send(floor(extract(epoch FROM clock_timestamp()) * 1000)::bigint) FROM 3);
-      uuid_bytes := unix_ts_ms || gen_random_bytes(10);
-      uuid_bytes := set_byte(uuid_bytes, 6, (get_byte(uuid_bytes, 6) & 15) | 112);
-      uuid_bytes := set_byte(uuid_bytes, 8, (get_byte(uuid_bytes, 8) & 63) | 128);
-      RETURN encode(uuid_bytes, 'hex')::uuid;
-    END
-    $$ LANGUAGE plpgsql VOLATILE;
-    """)
+    # Ensure #{prefix}.uuid_generate_v7() exists (created in V40, but be safe)
+    Helpers.ensure_uuid_v7_function(prefix)
 
-    # Need to flush uuid_generate_v7() creation before using it
+    # Need to flush #{prefix}.uuid_generate_v7() creation before using it
     flush()
 
     # Add uuid column to each missing table
@@ -115,12 +103,12 @@ defmodule PhoenixKit.Migrations.Postgres.V61 do
       unless column_exists?(table, :uuid, escaped_prefix) do
         execute("""
         ALTER TABLE #{table_name}
-        ADD COLUMN uuid UUID DEFAULT uuid_generate_v7()
+        ADD COLUMN uuid UUID DEFAULT #{prefix}.uuid_generate_v7()
         """)
 
         execute("""
         UPDATE #{table_name}
-        SET uuid = uuid_generate_v7()
+        SET uuid = #{prefix}.uuid_generate_v7()
         WHERE uuid IS NULL
         """)
 

--- a/lib/phoenix_kit/migrations/postgres/v63.ex
+++ b/lib/phoenix_kit/migrations/postgres/v63.ex
@@ -37,30 +37,18 @@ defmodule PhoenixKit.Migrations.Postgres.V63 do
 
   use Ecto.Migration
 
+  alias PhoenixKit.Migrations.Postgres.Helpers
+
   def up(%{prefix: prefix} = opts) do
     escaped_prefix = Map.get(opts, :escaped_prefix, prefix)
 
     # Flush any pending migration commands from earlier versions
     flush()
 
-    # Ensure uuid_generate_v7() exists (created in V40, be defensive)
-    execute("""
-    CREATE OR REPLACE FUNCTION uuid_generate_v7()
-    RETURNS uuid AS $$
-    DECLARE
-      unix_ts_ms bytea;
-      uuid_bytes bytea;
-    BEGIN
-      unix_ts_ms := substring(int8send(floor(extract(epoch FROM clock_timestamp()) * 1000)::bigint) FROM 3);
-      uuid_bytes := unix_ts_ms || gen_random_bytes(10);
-      uuid_bytes := set_byte(uuid_bytes, 6, (get_byte(uuid_bytes, 6) & 15) | 112);
-      uuid_bytes := set_byte(uuid_bytes, 8, (get_byte(uuid_bytes, 8) & 63) | 128);
-      RETURN encode(uuid_bytes, 'hex')::uuid;
-    END
-    $$ LANGUAGE plpgsql VOLATILE;
-    """)
+    # Ensure #{prefix}.uuid_generate_v7() exists (created in V40, be defensive)
+    Helpers.ensure_uuid_v7_function(prefix)
 
-    # Flush so uuid_generate_v7() is available for subsequent queries
+    # Flush so #{prefix}.uuid_generate_v7() is available for subsequent queries
     flush()
 
     # 1. Add uuid column to ai_accounts (must come before account_uuid backfill)
@@ -114,8 +102,11 @@ defmodule PhoenixKit.Migrations.Postgres.V63 do
          not column_exists?(table, :uuid, escaped_prefix) do
       table_name = prefix_table("phoenix_kit_ai_accounts", prefix)
 
-      execute("ALTER TABLE #{table_name} ADD COLUMN uuid UUID DEFAULT uuid_generate_v7()")
-      execute("UPDATE #{table_name} SET uuid = uuid_generate_v7() WHERE uuid IS NULL")
+      execute(
+        "ALTER TABLE #{table_name} ADD COLUMN uuid UUID DEFAULT #{prefix}.uuid_generate_v7()"
+      )
+
+      execute("UPDATE #{table_name} SET uuid = #{prefix}.uuid_generate_v7() WHERE uuid IS NULL")
 
       execute("""
       CREATE UNIQUE INDEX IF NOT EXISTS phoenix_kit_ai_accounts_uuid_idx

--- a/lib/phoenix_kit/migrations/postgres/v75.ex
+++ b/lib/phoenix_kit/migrations/postgres/v75.ex
@@ -54,7 +54,7 @@ defmodule PhoenixKit.Migrations.Postgres.V75 do
     phoenix_kit_user_follows_history
   )
 
-  # Tables where uuid DEFAULT is gen_random_uuid() (wrong — should be uuid_generate_v7())
+  # Tables where uuid DEFAULT is gen_random_uuid() (wrong — should be #{prefix}.uuid_generate_v7())
   @wrong_default_tables ~w(
     phoenix_kit_comments
     phoenix_kit_comments_dislikes
@@ -71,7 +71,7 @@ defmodule PhoenixKit.Migrations.Postgres.V75 do
     for table <- @missing_default_tables do
       if table_exists?(table, escaped_prefix) do
         execute(
-          "ALTER TABLE #{prefix_table(table, prefix)} ALTER COLUMN uuid SET DEFAULT uuid_generate_v7()"
+          "ALTER TABLE #{prefix_table(table, prefix)} ALTER COLUMN uuid SET DEFAULT #{prefix}.uuid_generate_v7()"
         )
       end
     end
@@ -80,7 +80,7 @@ defmodule PhoenixKit.Migrations.Postgres.V75 do
     for table <- @wrong_default_tables do
       if table_exists?(table, escaped_prefix) do
         execute(
-          "ALTER TABLE #{prefix_table(table, prefix)} ALTER COLUMN uuid SET DEFAULT uuid_generate_v7()"
+          "ALTER TABLE #{prefix_table(table, prefix)} ALTER COLUMN uuid SET DEFAULT #{prefix}.uuid_generate_v7()"
         )
       end
     end

--- a/lib/phoenix_kit/migrations/postgres/v78.ex
+++ b/lib/phoenix_kit/migrations/postgres/v78.ex
@@ -125,10 +125,10 @@ defmodule PhoenixKit.Migrations.Postgres.V78 do
 
     execute("""
     ALTER TABLE #{full_table}
-    ADD COLUMN IF NOT EXISTS uuid UUID DEFAULT uuid_generate_v7()
+    ADD COLUMN IF NOT EXISTS uuid UUID DEFAULT #{prefix}.uuid_generate_v7()
     """)
 
-    execute("UPDATE #{full_table} SET uuid = uuid_generate_v7() WHERE uuid IS NULL")
+    execute("UPDATE #{full_table} SET uuid = #{prefix}.uuid_generate_v7() WHERE uuid IS NULL")
 
     execute("ALTER TABLE #{full_table} ALTER COLUMN uuid SET NOT NULL")
 

--- a/lib/phoenix_kit/migrations/postgres/v79.ex
+++ b/lib/phoenix_kit/migrations/postgres/v79.ex
@@ -22,7 +22,7 @@ defmodule PhoenixKit.Migrations.Postgres.V79 do
 
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_newsletters_lists (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       name VARCHAR(255) NOT NULL,
       slug VARCHAR(255) NOT NULL,
       description TEXT,
@@ -45,7 +45,7 @@ defmodule PhoenixKit.Migrations.Postgres.V79 do
 
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_newsletters_list_members (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       user_uuid UUID NOT NULL,
       list_uuid UUID NOT NULL,
       status VARCHAR(20) NOT NULL DEFAULT 'active',
@@ -78,7 +78,7 @@ defmodule PhoenixKit.Migrations.Postgres.V79 do
 
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_newsletters_broadcasts (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       subject VARCHAR(998) NOT NULL,
       markdown_body TEXT,
       html_body TEXT,
@@ -133,7 +133,7 @@ defmodule PhoenixKit.Migrations.Postgres.V79 do
 
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_newsletters_deliveries (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       broadcast_uuid UUID NOT NULL,
       user_uuid UUID NOT NULL,
       status VARCHAR(20) NOT NULL DEFAULT 'pending',

--- a/lib/phoenix_kit/migrations/postgres/v86.ex
+++ b/lib/phoenix_kit/migrations/postgres/v86.ex
@@ -19,7 +19,7 @@ defmodule PhoenixKit.Migrations.Postgres.V86 do
                            primary_key: false,
                            prefix: prefix
                          ) do
-      add(:uuid, :uuid, primary_key: true, default: fragment("uuid_generate_v7()"))
+      add(:uuid, :uuid, primary_key: true, default: fragment("#{prefix}.uuid_generate_v7()"))
       add(:name, :string, null: false, size: 255)
       add(:type, :string, null: false, default: "header", size: 20)
       add(:html, :text, default: "")
@@ -39,7 +39,7 @@ defmodule PhoenixKit.Migrations.Postgres.V86 do
                            primary_key: false,
                            prefix: prefix
                          ) do
-      add(:uuid, :uuid, primary_key: true, default: fragment("uuid_generate_v7()"))
+      add(:uuid, :uuid, primary_key: true, default: fragment("#{prefix}.uuid_generate_v7()"))
       add(:name, :string, null: false, size: 255)
       add(:slug, :string, size: 255)
       add(:description, :text)
@@ -87,7 +87,7 @@ defmodule PhoenixKit.Migrations.Postgres.V86 do
                            primary_key: false,
                            prefix: prefix
                          ) do
-      add(:uuid, :uuid, primary_key: true, default: fragment("uuid_generate_v7()"))
+      add(:uuid, :uuid, primary_key: true, default: fragment("#{prefix}.uuid_generate_v7()"))
       add(:name, :string, null: false, size: 255)
 
       add(

--- a/lib/phoenix_kit/migrations/postgres/v87.ex
+++ b/lib/phoenix_kit/migrations/postgres/v87.ex
@@ -22,7 +22,7 @@ defmodule PhoenixKit.Migrations.Postgres.V87 do
                            primary_key: false,
                            prefix: prefix
                          ) do
-      add(:uuid, :uuid, primary_key: true, default: fragment("uuid_generate_v7()"))
+      add(:uuid, :uuid, primary_key: true, default: fragment("#{prefix}.uuid_generate_v7()"))
       add(:name, :string, null: false, size: 255)
       add(:description, :text)
       add(:website, :string, size: 500)
@@ -42,7 +42,7 @@ defmodule PhoenixKit.Migrations.Postgres.V87 do
                            primary_key: false,
                            prefix: prefix
                          ) do
-      add(:uuid, :uuid, primary_key: true, default: fragment("uuid_generate_v7()"))
+      add(:uuid, :uuid, primary_key: true, default: fragment("#{prefix}.uuid_generate_v7()"))
       add(:name, :string, null: false, size: 255)
       add(:description, :text)
       add(:website, :string, size: 500)
@@ -61,7 +61,7 @@ defmodule PhoenixKit.Migrations.Postgres.V87 do
                            primary_key: false,
                            prefix: prefix
                          ) do
-      add(:uuid, :uuid, primary_key: true, default: fragment("uuid_generate_v7()"))
+      add(:uuid, :uuid, primary_key: true, default: fragment("#{prefix}.uuid_generate_v7()"))
 
       add(
         :manufacturer_uuid,
@@ -101,7 +101,7 @@ defmodule PhoenixKit.Migrations.Postgres.V87 do
                            primary_key: false,
                            prefix: prefix
                          ) do
-      add(:uuid, :uuid, primary_key: true, default: fragment("uuid_generate_v7()"))
+      add(:uuid, :uuid, primary_key: true, default: fragment("#{prefix}.uuid_generate_v7()"))
       add(:name, :string, null: false, size: 255)
       add(:description, :text)
       add(:status, :string, default: "active", size: 20)
@@ -117,7 +117,7 @@ defmodule PhoenixKit.Migrations.Postgres.V87 do
                            primary_key: false,
                            prefix: prefix
                          ) do
-      add(:uuid, :uuid, primary_key: true, default: fragment("uuid_generate_v7()"))
+      add(:uuid, :uuid, primary_key: true, default: fragment("#{prefix}.uuid_generate_v7()"))
       add(:name, :string, null: false, size: 255)
       add(:description, :text)
       add(:position, :integer, default: 0)
@@ -152,7 +152,7 @@ defmodule PhoenixKit.Migrations.Postgres.V87 do
                            primary_key: false,
                            prefix: prefix
                          ) do
-      add(:uuid, :uuid, primary_key: true, default: fragment("uuid_generate_v7()"))
+      add(:uuid, :uuid, primary_key: true, default: fragment("#{prefix}.uuid_generate_v7()"))
       add(:name, :string, null: false, size: 255)
       add(:description, :text)
       add(:sku, :string, size: 100)

--- a/lib/phoenix_kit/migrations/postgres/v90.ex
+++ b/lib/phoenix_kit/migrations/postgres/v90.ex
@@ -16,7 +16,7 @@ defmodule PhoenixKit.Migrations.Postgres.V90 do
                            primary_key: false,
                            prefix: prefix
                          ) do
-      add(:uuid, :uuid, primary_key: true, default: fragment("uuid_generate_v7()"))
+      add(:uuid, :uuid, primary_key: true, default: fragment("#{prefix}.uuid_generate_v7()"))
       add(:action, :string, null: false, size: 100)
       add(:module, :string, size: 50)
       add(:mode, :string, size: 20)

--- a/lib/phoenix_kit/migrations/postgres/v91.ex
+++ b/lib/phoenix_kit/migrations/postgres/v91.ex
@@ -20,7 +20,7 @@ defmodule PhoenixKit.Migrations.Postgres.V91 do
                            primary_key: false,
                            prefix: prefix
                          ) do
-      add(:uuid, :uuid, primary_key: true, default: fragment("uuid_generate_v7()"))
+      add(:uuid, :uuid, primary_key: true, default: fragment("#{prefix}.uuid_generate_v7()"))
       add(:name, :string, null: false, size: 255)
       add(:description, :text)
       add(:status, :string, default: "active", size: 20)
@@ -36,7 +36,7 @@ defmodule PhoenixKit.Migrations.Postgres.V91 do
                            primary_key: false,
                            prefix: prefix
                          ) do
-      add(:uuid, :uuid, primary_key: true, default: fragment("uuid_generate_v7()"))
+      add(:uuid, :uuid, primary_key: true, default: fragment("#{prefix}.uuid_generate_v7()"))
       add(:name, :string, null: false, size: 255)
       add(:description, :text)
       add(:public_notes, :text)
@@ -74,7 +74,7 @@ defmodule PhoenixKit.Migrations.Postgres.V91 do
                            primary_key: false,
                            prefix: prefix
                          ) do
-      add(:uuid, :uuid, primary_key: true, default: fragment("uuid_generate_v7()"))
+      add(:uuid, :uuid, primary_key: true, default: fragment("#{prefix}.uuid_generate_v7()"))
 
       add(
         :location_uuid,

--- a/lib/phoenix_kit/migrations/postgres/v92.ex
+++ b/lib/phoenix_kit/migrations/postgres/v92.ex
@@ -89,7 +89,7 @@ defmodule PhoenixKit.Migrations.Postgres.V92 do
           AND table_name = 'phoenix_kit_organization_invitations'
       ) THEN
         CREATE TABLE #{p}phoenix_kit_organization_invitations (
-          uuid UUID NOT NULL DEFAULT uuid_generate_v7() PRIMARY KEY,
+          uuid UUID NOT NULL DEFAULT #{prefix}.uuid_generate_v7() PRIMARY KEY,
           organization_uuid UUID NOT NULL
             REFERENCES #{p}phoenix_kit_users(uuid) ON DELETE CASCADE,
           email VARCHAR(160) NOT NULL,

--- a/lib/phoenix_kit/migrations/postgres/v95.ex
+++ b/lib/phoenix_kit/migrations/postgres/v95.ex
@@ -19,7 +19,7 @@ defmodule PhoenixKit.Migrations.Postgres.V95 do
                            primary_key: false,
                            prefix: prefix
                          ) do
-      add(:uuid, :uuid, primary_key: true, default: fragment("uuid_generate_v7()"))
+      add(:uuid, :uuid, primary_key: true, default: fragment("#{prefix}.uuid_generate_v7()"))
       add(:name, :string, null: false, size: 255)
       add(:color, :string, size: 20)
 
@@ -67,7 +67,7 @@ defmodule PhoenixKit.Migrations.Postgres.V95 do
                            primary_key: false,
                            prefix: prefix
                          ) do
-      add(:uuid, :uuid, primary_key: true, default: fragment("uuid_generate_v7()"))
+      add(:uuid, :uuid, primary_key: true, default: fragment("#{prefix}.uuid_generate_v7()"))
 
       add(
         :folder_uuid,

--- a/lib/phoenix_kit/migrations/uuid_fk_columns.ex
+++ b/lib/phoenix_kit/migrations/uuid_fk_columns.ex
@@ -668,7 +668,7 @@ defmodule PhoenixKit.Migrations.UUIDFKColumns do
       # (e.g. created_by references a deleted user with no CASCADE constraint)
       execute("""
       UPDATE #{table_name}
-      SET #{uuid_fk} = uuid_generate_v7()
+      SET #{uuid_fk} = #{prefix}.uuid_generate_v7()
       WHERE #{uuid_fk} IS NULL
       """)
 

--- a/lib/phoenix_kit/migrations/uuid_repair.ex
+++ b/lib/phoenix_kit/migrations/uuid_repair.ex
@@ -42,6 +42,8 @@ defmodule PhoenixKit.Migrations.UUIDRepair do
 
   require Logger
 
+  alias PhoenixKit.Migrations.Postgres.Helpers
+
   @tables_needing_repair [
     # Auth tables (V01) - CRITICAL for login/registration
     :phoenix_kit_users,
@@ -147,7 +149,7 @@ defmodule PhoenixKit.Migrations.UUIDRepair do
     ensure_pgcrypto(repo)
 
     # Ensure uuid_generate_v7() function exists (V40 creates it, but we run before V40)
-    ensure_uuid_generate_v7(repo)
+    ensure_uuid_generate_v7(repo, prefix)
 
     # Repair each table that needs it
     results =
@@ -167,27 +169,11 @@ defmodule PhoenixKit.Migrations.UUIDRepair do
   end
 
   defp ensure_pgcrypto(repo) do
-    repo.query("CREATE EXTENSION IF NOT EXISTS pgcrypto", [], log: false)
+    Helpers.ensure_extension!(repo, "pgcrypto")
   end
 
-  defp ensure_uuid_generate_v7(repo) do
-    query = """
-    CREATE OR REPLACE FUNCTION uuid_generate_v7()
-    RETURNS uuid AS $$
-    DECLARE
-      unix_ts_ms bytea;
-      uuid_bytes bytea;
-    BEGIN
-      unix_ts_ms := substring(int8send(floor(extract(epoch FROM clock_timestamp()) * 1000)::bigint) FROM 3);
-      uuid_bytes := unix_ts_ms || gen_random_bytes(10);
-      uuid_bytes := set_byte(uuid_bytes, 6, (get_byte(uuid_bytes, 6) & 15) | 112);
-      uuid_bytes := set_byte(uuid_bytes, 8, (get_byte(uuid_bytes, 8) & 63) | 128);
-      RETURN encode(uuid_bytes, 'hex')::uuid;
-    END
-    $$ LANGUAGE plpgsql VOLATILE;
-    """
-
-    repo.query(query, [], log: false)
+  defp ensure_uuid_generate_v7(repo, prefix) do
+    Helpers.ensure_uuid_v7_function(repo, prefix)
   end
 
   defp repair_table(repo, table, prefix) do
@@ -206,14 +192,16 @@ defmodule PhoenixKit.Migrations.UUIDRepair do
         # Need to add uuid column
         Logger.info("[PhoenixKit] Adding uuid column to #{table_name}...")
 
+        uuid_v7 = Helpers.uuid_v7_call(prefix)
+
         add_uuid_query = """
         ALTER TABLE #{table_name}
-        ADD COLUMN uuid UUID DEFAULT uuid_generate_v7()
+        ADD COLUMN uuid UUID DEFAULT #{uuid_v7}
         """
 
         backfill_query = """
         UPDATE #{table_name}
-        SET uuid = uuid_generate_v7()
+        SET uuid = #{uuid_v7}
         WHERE uuid IS NULL
         """
 

--- a/lib/phoenix_kit_web/components/layout_wrapper.ex
+++ b/lib/phoenix_kit_web/components/layout_wrapper.ex
@@ -315,20 +315,6 @@ defmodule PhoenixKitWeb.Components.LayoutWrapper do
               <%= HTML.raw(ThemeConfig.custom_theme_css()) %>
             </style>
             <style>
-              /* daisyUI 5 reserves a scrollbar gutter while a modal/drawer is open
-                 (`:where(:root:has(.modal-open, …)) { scrollbar-gutter: stable }` in
-                 @layer base). On a page without a scrollbar the fixed backdrop can't
-                 cover that reserved strip, so classic-scrollbar users (Firefox, macOS
-                 "always show") see an uncovered gap at the window's right edge whenever
-                 a modal opens. UNLAYERED here, so it beats the layered zero-specificity
-                 original regardless of stylesheet order. Accepted trade-off: on pages
-                 that DO scroll, classic-scrollbar users see a ~15px reflow when a modal
-                 opens (scrollbar hides, nothing reserves its width) — less jarring than
-                 the mispainted strip, which host background overrides make common. */
-              :root:has(.modal-open, .modal[open], .modal:target, .modal-toggle:checked, .drawer:not(.drawer-open) > .drawer-toggle:checked) {
-                scrollbar-gutter: auto;
-              }
-
               /* Custom sidebar control for desktop - override lg:drawer-open grid layout when closed */
               @media (min-width: 1024px) {
                 /* Override the grid to collapse sidebar column when closed */

--- a/lib/phoenix_kit_web/components/layouts/root.html.heex
+++ b/lib/phoenix_kit_web/components/layouts/root.html.heex
@@ -47,18 +47,6 @@
       {assigns[:page_title]}
     </.live_title>
     <link phx-track-static rel="stylesheet" href={~p"/assets/app.css"} />
-    <%!-- daisyUI 5 reserves a scrollbar gutter while a modal/drawer is open
-    (`:where(:root:has(.modal-open, …)) { scrollbar-gutter: stable }` in
-    @layer base). On a page without a scrollbar the fixed backdrop can't cover
-    that reserved strip, so classic-scrollbar users (Firefox, macOS "always
-    show") see an uncovered gap at the window's right edge whenever a modal
-    opens. This UNLAYERED rule beats the layered zero-specificity original
-    regardless of stylesheet order. --%>
-    <style>
-      :root:has(.modal-open, .modal[open], .modal:target, .modal-toggle:checked, .drawer:not(.drawer-open) > .drawer-toggle:checked) {
-        scrollbar-gutter: auto;
-      }
-    </style>
     <script defer phx-track-static type="text/javascript" src={~p"/assets/app.js"}>
     </script>
     <%!-- PhoenixKit Cookie Consent Widget Setup --%>

--- a/priv/static/assets/phoenix_kit.js
+++ b/priv/static/assets/phoenix_kit.js
@@ -1798,11 +1798,6 @@ if (typeof window.Chart === "undefined") {
   //                    closeable.
   // ---------------------------------------------------------------------------
 
-  // Refcount of open PkDialog modals. Used to know when to restore the
-  // html's scrollbar-gutter (only when the LAST modal closes, since
-  // multiple <dialog> can be open simultaneously).
-  window._PkDialogOpenCount = window._PkDialogOpenCount || 0;
-
   // ---------------------------------------------------------------------------
   // PkCheckboxIndeterminate — applies the `indeterminate` property to a
   // checkbox based on `data-indeterminate="true"`. HTML has no attribute
@@ -2074,34 +2069,16 @@ if (typeof window.Chart === "undefined") {
     }
   }
 
+  // NOTE: no scrollbar-gutter games here. Old daisyUI (5.0.x) reserved a
+  // scrollbar gutter unconditionally while a modal was open, and this hook
+  // used to counter it with an inline `scrollbar-gutter: auto` override —
+  // which traded the phantom right-edge strip on non-scrolling pages for a
+  // ~15px content reflow on pages that DO scroll (classic-scrollbar users saw
+  // the scrollbar pop in/out around every modal). daisyUI >= 5.1 reserves the
+  // gutter only when the page really has a scrollbar (rootscrollgutter.css),
+  // which handles both page types correctly — PhoenixKit pins such a version
+  // (see PhoenixKit.Install.DaisyUI), so the override is gone. Don't re-add it.
   window.PhoenixKitHooks.PkDialog = {
-    _onOpened() {
-      // daisyUI 5 ships a `:where(:root:has(.modal[open])) { scrollbar-gutter: stable }`
-      // rule that prevents body layout jump when a modal opens but ALSO
-      // reduces the layout viewport by ~15px, leaving a strip on the right
-      // where the dialog/backdrop don't reach. Override per modal open so
-      // the dialog can cover the full visual viewport. Refcounted so
-      // concurrent modals don't fight each other.
-      if (window._PkDialogOpenCount === 0) {
-        const html = document.documentElement;
-        html.dataset.pkPrevScrollbarGutter = html.style.scrollbarGutter || "";
-        html.style.setProperty("scrollbar-gutter", "auto", "important");
-      }
-      window._PkDialogOpenCount += 1;
-    },
-    _onClosed() {
-      window._PkDialogOpenCount = Math.max(0, window._PkDialogOpenCount - 1);
-      if (window._PkDialogOpenCount === 0) {
-        const html = document.documentElement;
-        const prev = html.dataset.pkPrevScrollbarGutter;
-        if (prev) {
-          html.style.scrollbarGutter = prev;
-        } else {
-          html.style.removeProperty("scrollbar-gutter");
-        }
-        delete html.dataset.pkPrevScrollbarGutter;
-      }
-    },
     _isCloseable() {
       return this.el.dataset.closeable !== "false";
     },
@@ -2137,10 +2114,6 @@ if (typeof window.Chart === "undefined") {
         typeof this.el.showModal === "function"
       ) {
         this.el.showModal();
-        if (!this._opened) {
-          this._opened = true;
-          this._onOpened();
-        }
       } else if (wantOpen && isOpenForBrowser) {
         // Dialog is in the top layer but the `open` attribute may have
         // been stripped by Phoenix LV's DOM patch (the server template
@@ -2151,12 +2124,6 @@ if (typeof window.Chart === "undefined") {
         // the top layer. Restore the attribute so the dialog renders.
         if (!this.el.open) {
           this.el.setAttribute("open", "");
-        }
-        // Also track that the dialog is open (it may have been opened
-        // externally — e.g. BulkSelectScope — before this hook saw it).
-        if (!this._opened) {
-          this._opened = true;
-          this._onOpened();
         }
       } else if (!wantOpen && isOpenForBrowser) {
         // LV-driven close. If morphdom stripped the `open` attr after
@@ -2174,13 +2141,6 @@ if (typeof window.Chart === "undefined") {
     },
     mounted() {
       const self = this;
-      // `_opened` tracks whether we've incremented the global refcount,
-      // so the close event handler can decrement exactly once regardless
-      // of whether the close originated from Esc, backdrop, programmatic
-      // close, or destroyed(). Without this, a user-driven close would
-      // leave the gutter override sticky until `destroyed()` ran — and
-      // if LV didn't process the on_close event, that could be forever.
-      this._opened = false;
       this._closeFromLV = false;
 
       self._onCancel = function(e) {
@@ -2188,13 +2148,8 @@ if (typeof window.Chart === "undefined") {
       };
       // 'close' fires for every close path: Esc, our own el.close() in
       // destroyed(), backdrop click (via _onClick → el.close()), and
-      // form `method="dialog"` submits. This is the ONE place that
-      // decrements the refcount.
+      // form `method="dialog"` submits.
       self._onClose = function() {
-        if (self._opened) {
-          self._onClosed();
-          self._opened = false;
-        }
         if (!self._closeFromLV) self._pushClose();
         // Reset the LV-initiated flag now that the close event has
         // been fully processed. The next user-initiated close (Esc,
@@ -2224,10 +2179,6 @@ if (typeof window.Chart === "undefined") {
           typeof self.el.showModal === "function"
         ) {
           self.el.showModal();
-          if (!self._opened) {
-            self._opened = true;
-            self._onOpened();
-          }
         }
       };
       this.el.addEventListener("pk:dialog-show", self._onShowEvent);
@@ -2255,24 +2206,14 @@ if (typeof window.Chart === "undefined") {
       // LV is removing the element. Tell _onClose not to echo a close
       // event back (LV already initiated this).
       this._closeFromLV = true;
-      // Try the friendly path first (fires 'close' which decrements via
-      // _onClose). But if the element is already detached from the DOM
-      // when destroyed runs, close() may not fire 'close' on every UA —
-      // so always decrement defensively. _opened gates so we never
-      // double-decrement (whoever runs first wins).
-      //
-      // Use the same "is the browser holding this dialog open?"
-      // predicate as `_sync()` — `el.open` alone is unreliable when
-      // morphdom stripped the attribute earlier. Restore `open`
-      // first if needed so `close()` can release the top layer
-      // cleanly.
+      // Close the dialog so the browser releases it from the top layer.
+      // Use the same "is the browser holding this dialog open?" predicate
+      // as `_sync()` — `el.open` alone is unreliable when morphdom stripped
+      // the attribute earlier. Restore `open` first if needed so `close()`
+      // can release the top layer cleanly.
       if (isDialogOpenInBrowser(this.el)) {
         if (!this.el.open) this.el.setAttribute("open", "");
         this.el.close();
-      }
-      if (this._opened) {
-        this._onClosed();
-        this._opened = false;
       }
       if (this._onCancel) this.el.removeEventListener("cancel", this._onCancel);
       if (this._onClose) this.el.removeEventListener("close", this._onClose);

--- a/test/integration/prefix_migration_test.exs
+++ b/test/integration/prefix_migration_test.exs
@@ -117,5 +117,36 @@ defmodule PhoenixKit.Integration.PrefixMigrationTest do
       )
 
     assert index_count > 500
+
+    # uuid_generate_v7() must live in the prefixed schema, not wherever
+    # search_path pointed (2026-07-12 field report: unqualified CREATE
+    # FUNCTION polluted public / failed on PG15+ low-privilege roles).
+    %{rows: [[fn_in_prefix]]} =
+      Repo.query!(
+        """
+        SELECT EXISTS (
+          SELECT FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+          WHERE p.proname = 'uuid_generate_v7' AND n.nspname = $1
+        )
+        """,
+        [@schema]
+      )
+
+    assert fn_in_prefix,
+           "uuid_generate_v7() was not created in the prefixed schema"
+
+    # And uuid DEFAULTs must be pinned to that schema-qualified function —
+    # an unqualified default would have resolved via search_path to
+    # public's copy, breaking installs where public has no function.
+    %{rows: [[default_expr]]} =
+      Repo.query!(
+        """
+        SELECT column_default FROM information_schema.columns
+        WHERE table_schema = $1 AND table_name = 'phoenix_kit_projects' AND column_name = 'uuid'
+        """,
+        [@schema]
+      )
+
+    assert default_expr =~ "#{@schema}.uuid_generate_v7()"
   end
 end

--- a/test/phoenix_kit/install/daisyui_test.exs
+++ b/test/phoenix_kit/install/daisyui_test.exs
@@ -1,0 +1,63 @@
+defmodule PhoenixKit.Install.DaisyUITest do
+  use ExUnit.Case, async: true
+
+  alias PhoenixKit.Install.DaisyUI
+
+  describe "installed_version/1" do
+    @tag :tmp_dir
+    test "parses the version marker out of a plugin bundle", %{tmp_dir: tmp} do
+      path = Path.join(tmp, "daisyui.js")
+      File.write!(path, ~s|/** daisyUI */\nvar version = "5.0.35";\nmodule.exports = {};|)
+
+      assert DaisyUI.installed_version(path) == "5.0.35"
+    end
+
+    @tag :tmp_dir
+    test "returns nil when the file has no version marker", %{tmp_dir: tmp} do
+      path = Path.join(tmp, "daisyui.js")
+      File.write!(path, "module.exports = {};")
+
+      assert DaisyUI.installed_version(path) == nil
+    end
+
+    test "returns nil for a missing file" do
+      assert DaisyUI.installed_version("/nonexistent/daisyui.js") == nil
+    end
+  end
+
+  describe "outdated?/1" do
+    test "versions below the minimum are outdated" do
+      assert DaisyUI.outdated?("5.0.35")
+      assert DaisyUI.outdated?("5.1.0")
+    end
+
+    test "the minimum and above are not outdated" do
+      refute DaisyUI.outdated?(DaisyUI.minimum_version())
+      refute DaisyUI.outdated?("5.6.17")
+      # semver comparison, not string comparison
+      refute DaisyUI.outdated?("5.10.0")
+      refute DaisyUI.outdated?("6.0.0")
+    end
+
+    test "unparseable versions are not claimed outdated" do
+      refute DaisyUI.outdated?("not-a-version")
+    end
+  end
+
+  describe "minimum_version/0" do
+    test "is a valid semver string" do
+      assert {:ok, _} = Version.parse(DaisyUI.minimum_version())
+    end
+  end
+
+  describe "outdated_warning/1" do
+    test "names the installed and minimum versions and the upgrade path" do
+      warning = DaisyUI.outdated_warning("5.0.35")
+
+      assert warning =~ "5.0.35"
+      assert warning =~ DaisyUI.minimum_version()
+      assert warning =~ "assets/vendor"
+      assert warning =~ "daisyui.js"
+    end
+  end
+end

--- a/test/phoenix_kit/install/prefix_config_test.exs
+++ b/test/phoenix_kit/install/prefix_config_test.exs
@@ -1,0 +1,44 @@
+defmodule PhoenixKit.Install.PrefixConfigTest do
+  # async: false — mutates the :phoenix_kit application env.
+  use ExUnit.Case, async: false
+
+  alias PhoenixKit.Install.PrefixConfig
+
+  setup do
+    original = Application.get_env(:phoenix_kit, :prefix)
+
+    on_exit(fn ->
+      case original do
+        nil -> Application.delete_env(:phoenix_kit, :prefix)
+        value -> Application.put_env(:phoenix_kit, :prefix, value)
+      end
+    end)
+
+    :ok
+  end
+
+  describe "resolve_prefix/1" do
+    test "explicit --prefix option wins" do
+      Application.put_env(:phoenix_kit, :prefix, "from_config")
+      assert PrefixConfig.resolve_prefix(prefix: "from_flag") == "from_flag"
+    end
+
+    test "falls back to config :phoenix_kit, :prefix" do
+      Application.put_env(:phoenix_kit, :prefix, "companyplexus")
+      assert PrefixConfig.resolve_prefix([]) == "companyplexus"
+    end
+
+    test "defaults to public when neither is set" do
+      Application.delete_env(:phoenix_kit, :prefix)
+      assert PrefixConfig.resolve_prefix([]) == "public"
+    end
+
+    test "ignores blank or non-binary config values" do
+      Application.put_env(:phoenix_kit, :prefix, "")
+      assert PrefixConfig.resolve_prefix([]) == "public"
+
+      Application.put_env(:phoenix_kit, :prefix, :auth)
+      assert PrefixConfig.resolve_prefix([]) == "public"
+    end
+  end
+end

--- a/test/phoenix_kit/migrations/postgres_helpers_test.exs
+++ b/test/phoenix_kit/migrations/postgres_helpers_test.exs
@@ -1,0 +1,57 @@
+defmodule PhoenixKit.Migrations.Postgres.HelpersTest do
+  use ExUnit.Case, async: true
+
+  alias PhoenixKit.Migrations.Postgres.Helpers
+
+  describe "validate_prefix!/1" do
+    test "accepts conventional lower-case identifiers" do
+      assert :ok = Helpers.validate_prefix!("public")
+      assert :ok = Helpers.validate_prefix!("auth")
+      assert :ok = Helpers.validate_prefix!("companyplexus")
+      assert :ok = Helpers.validate_prefix!("my_app_2")
+      assert :ok = Helpers.validate_prefix!("_private")
+    end
+
+    test "rejects identifiers that need quoting" do
+      for bad <- ["MyApp", "my-app", "1schema", "sp ace", "we\"ird", ""] do
+        assert_raise ArgumentError, ~r/invalid PhoenixKit schema prefix/, fn ->
+          Helpers.validate_prefix!(bad)
+        end
+      end
+    end
+
+    test "rejects SQL-injection shaped prefixes" do
+      assert_raise ArgumentError, fn ->
+        Helpers.validate_prefix!("public; DROP TABLE phoenix_kit_users;--")
+      end
+    end
+
+    test "rejects non-binary values" do
+      assert_raise ArgumentError, ~r/expected a string/, fn ->
+        Helpers.validate_prefix!(nil)
+      end
+
+      assert_raise ArgumentError, ~r/expected a string/, fn ->
+        Helpers.validate_prefix!(:auth)
+      end
+    end
+  end
+
+  describe "qualify_table/2" do
+    test "qualifies with the prefix" do
+      assert Helpers.qualify_table("phoenix_kit_users", "auth") == "auth.phoenix_kit_users"
+    end
+
+    test "nil prefix qualifies explicitly as public" do
+      assert Helpers.qualify_table("phoenix_kit_users", nil) == "public.phoenix_kit_users"
+    end
+  end
+
+  describe "uuid_v7_call/1" do
+    test "always schema-qualifies the function call" do
+      assert Helpers.uuid_v7_call("auth") == "auth.uuid_generate_v7()"
+      assert Helpers.uuid_v7_call("public") == "public.uuid_generate_v7()"
+      assert Helpers.uuid_v7_call(nil) == "public.uuid_generate_v7()"
+    end
+  end
+end


### PR DESCRIPTION
Follow-up to #628, driven by a field report from a hardened multi-schema install (schema pre-created by a DBA and owned by the app role, **no CREATE on the database**, PG 15+ non-writable `public`, PgBouncer). The report confirmed #628's index/existence-check fixes and surfaced five more bug families — all reproduced against source and fixed here, plus three adjacent bugs found while verifying.

## Migration chain

- **`CREATE EXTENSION` / `CREATE SCHEMA` fail on privilege *before* the IF-NOT-EXISTS short-circuit.** All five extension sites (V01 citext, V26/V40 pgcrypto, V111 pg_trgm, UUIDRepair) and V01's schema creation now check `pg_extension` / `information_schema.schemata` first and only attempt creation when the object is genuinely missing. A missing extension that the role cannot create raises an operator-facing message listing the three required extensions (also documented in `PhoenixKit.Migration`'s moduledoc for DBAs to pre-provision).
- **V27 dropped the caller's `create_schema` flag at the Oban handoff** — `Oban.Migration.up(prefix: prefix)` re-defaults it to true for any non-public prefix and executed the failing `CREATE SCHEMA` mid-chain (the report's "dies around v27–v31"; queued SQL surfaces at a later flush). V27 now passes `create_schema: false` — by V27 the schema always exists, V01 owns creation.
- **`uuid_generate_v7()` was created unqualified** — it landed wherever `search_path` pointed, polluting `public` on prefixed installs and failing outright where `public` isn't writable. The function is now created inside the install's schema (all 4 creation sites + UUIDRepair) and all ~89 call sites across 35 files (`DEFAULT`s, backfill `UPDATE`s, `fragment/1`) are schema-qualified. For upgrade chains starting ≥ V40 (which skip the creation sites), `Postgres.up/1` re-ensures the function at the prefix before running steps. Existing installs are unaffected: existing columns keep their OID-pinned defaults; the ensure step only creates the function where missing (never `REPLACE`s a function owned by someone else).
- **The prefix is now validated at the `up`/`down` entry points** (`[a-z_][a-z0-9_]*`) — it's interpolated into hundreds of statements, mostly unquoted, so anything needing quoting only ever half-worked.
- New `PhoenixKit.Migrations.Postgres.Helpers` centralizes these patterns (`qualify_table/2`, `uuid_v7_call/1`, `ensure_extension!/1-2`, `ensure_uuid_v7_function/1-2`, `validate_prefix!/1`) — the per-version hand-rolled helpers were exactly why #628's index bug existed in four independent places. Migrating old versions to it is opportunistic; new code should use it.

## Tooling

- **`mix phoenix_kit.install --prefix X` now persists `config :phoenix_kit, prefix: "X"`** (new `PhoenixKit.Install.PrefixConfig`) — the migration docs always told hosts to add it, but nothing did, so `update`/`status` looked at `public` and reported a prefixed install as "Not installed".
- **`update`/`status`/`gen.migration` resolve the prefix** as `--prefix` → `config :phoenix_kit, :prefix` → `"public"`.
- **`Install.Common` no longer fabricates `{:current_version, 1}`** from the mere existence of migration *files* when the DB has no marker at the prefix — that fallback made `mix phoenix_kit.update` generate a from-scratch v01→v142 migration into the wrong schema (the report caught it by eye before running it). The not-installed notice now names the resolved prefix and hints at `--prefix`/the config key.
- **Update-migration generators always emit `create_schema: false`** — updating implies the schema exists. Also fixed: `MigrationStrategy` hardcoded `"public"` when version-checking an existing install, and `migration_opts/2` silently dropped `--create-schema=false` (omitting the key let the chain re-default it to true).
- **Repo auto-detection refuses to silently pick among multiple detected Ecto repos** (the report's project had a migration-only `CoreRepo` that got wired into `config :phoenix_kit, repo:`); it now lists them and requires `--repo`.

## Verification

- `test/integration/prefix_migration_test.exs` extended: asserts `uuid_generate_v7` lives in the prefixed schema and uuid `DEFAULT`s are pinned to it. Full chain into a scratch schema passes.
- Fresh **public** install from a dropped DB: full v01→v142 clean (extension-creation path exercised).
- **The report's exact repro (section D) now passes end-to-end**: role with no superuser and no database CREATE, pre-created schema, pre-provisioned extensions → full v01→v142 chain, marker `142`, function + Oban tables in the prefix, **zero objects created in `public`**.
- New unit tests for `Helpers` (prefix validation, qualification) and `PrefixConfig.resolve_prefix/1`.
- `mix precommit` clean; full suite failures identical to the pre-existing multi-session/sitemap/settings set (verified by stash-rerun on the same base).

## Notes for the reviewer

- The report flags two *correct* qualified-name sites — `uuid_fk_columns.ex` `drop_uuid_fk_index/4` and V56 `drop_uuid_unique_indexes` (`DROP INDEX schema.name` is valid) — deliberately untouched.
- Known gap, out of scope: runtime code never reads `config :phoenix_kit, :prefix` — Ecto queries run unprefixed, so prefixed installs still need the DB role's `search_path` to include the schema (the report's setup relied on this). Documented in AGENTS.md.
- This branch also carries two earlier local commits: the daisyUI advisory-warning approach (vendored-plugin custody replaced by install/update/doctor version warnings) and an AGENTS.md refresh.