### PR TITLE
Prefix hardening for low-privilege multi-schema installs, runtime schema-prefix support + daisyUI modal-gutter fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,10 +162,32 @@ paths — pre-created schema + low-privilege role — can't run under the
 suite's superuser connection; re-verify those manually against the
 recipe in the 2026-07-12 field report if you touch them.)
 
-Note: runtime code does NOT read `config :phoenix_kit, :prefix` — Ecto
-queries run unprefixed, so a prefixed install additionally needs the DB
-role's `search_path` to include the schema. Known gap, out of scope of
-the 2026-07 fixes.
+**Runtime prefix support (2026-07-12):** every table-backed core schema
+`use`s `PhoenixKit.SchemaPrefix`, which sets `@schema_prefix` from
+`Application.compile_env(:phoenix_kit, :prefix)` — so on a prefixed
+install ALL runtime queries (delegated, direct `repo()` calls,
+`update_all`/`insert_all`, Multi steps, preloads, joins) target the
+named schema with no `search_path` requirement on the DB role. Rules:
+
+- **New table-backed schemas must add `use PhoenixKit.SchemaPrefix`**
+  right after `use Ecto.Schema` — `test/phoenix_kit/schema_prefix_test.exs`
+  enforces it by scanning for `schema "phoenix_kit` files. Embedded
+  schemas don't need it.
+- The prefix is **compile-time** config (`config.exs`, never
+  `runtime.exs`); Mix recompiles the dep when it changes. It can't be
+  flipped per-test — the e2e check is manual: temporarily append
+  `config :phoenix_kit, prefix: "..."` to `config/test.exs`, recompile,
+  run a script exercising `register_user` against a scratch schema
+  (needs `PhoenixKit.Users.RateLimiter.Backend.start_link` +
+  `PhoenixKit.PubSub.Manager.start_link` + `:phoenix_pubsub`/`:hammer`
+  apps started), then revert + recompile.
+- **Oban rides the same prefix** — V27 creates `oban_jobs` inside the
+  named schema, so the host's `config :app, Oban` must carry
+  `prefix: "..."`. The installer writes it for new prefixed installs;
+  `mix phoenix_kit.update` warns when an existing Oban config lacks it.
+- Feature modules' own schemas (`phoenix_kit_catalogue` etc.) do NOT get
+  the prefix from core — prefixed installs using feature modules need
+  the same treatment there (open item, per-module).
 
 ## Integrations System
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ mix test          # run all (migrations auto via test_helper)
 mix test.reset    # drop + recreate
 ```
 
-Test DB `phoenix_kit_test` uses embedded `PhoenixKit.Test.Repo` (`test/support/test_repo.ex`). Migrations live in `test/support/postgres/migrations/`.
+Test DB `phoenix_kit_test` uses embedded `PhoenixKit.Test.Repo` (`test/support/test_repo.ex`). Schema comes from the versioned migration chain — `test_helper.exs` runs `PhoenixKit.Migration.ensure_current/2` on every boot (there is no `test/support/postgres/migrations/` directory; that per-file approach was retired 2026-05-05).
 
 **Without PostgreSQL:** integration tests are auto-excluded; unit tests still run. `mix test` will print a banner and continue.
 
@@ -92,6 +92,32 @@ ast-grep --lang elixir --pattern 'def $FUNC($$$ARGS) do $$$BODY end' lib/
 - Schemas use `@primary_key {:uuid, UUIDv7, autogenerate: true}`
 - New migrations use `uuid_generate_v7()` (NOT `gen_random_uuid()`)
 - Oban-style versioned migrations in `lib/phoenix_kit/migrations/postgres/`
+
+### Prefix-safe migrations (named-schema installs)
+
+The chain supports running into a named Postgres schema (`prefix:` opt /
+`--prefix`). Two bug families broke it in 2026-07 (both fixed, PR #628);
+any new `execute`-built SQL can regress them:
+
+- **Index names stay bare on CREATE.** Postgres rejects
+  `CREATE INDEX schema.name ...` — the index always lands in the
+  (schema-qualified) table's schema. Qualifying the *name* is only valid
+  on `DROP INDEX`.
+- **Every existence check needs a schema anchor.** `information_schema.*`
+  checks need `table_schema = '#{escaped_prefix}'`, `pg_indexes` needs
+  `schemaname`, and `pg_constraint` `conname` checks need
+  `AND conrelid = '#{p}table'::regclass` (V51's idiom). An unanchored
+  check sees `public`'s objects, so a prefixed install into a database
+  that also carries a public install silently skips creating the
+  prefixed object.
+- **Failures surface late.** Ecto queues `execute` calls; bad SQL queued
+  by one version often blows up at a *later* version's `flush()`.
+
+`test/integration/prefix_migration_test.exs` is the oracle: it runs the
+full chain into a scratch schema on the test DB (which also has a public
+install, so it catches both families). It flips the sandbox to `:auto`
+for the run — see its moduledoc for why neither a sandbox checkout nor a
+dynamic repo instance can host the migrator.
 
 ## Integrations System
 
@@ -168,6 +194,27 @@ The canonical toolkit for admin list views — DnD reorder, bulk-select, sort, s
 ## Built-in Dashboard
 
 Tabs, subtabs, badges, context selectors: see `lib/phoenix_kit/dashboard/README.md`.
+
+## Permissions
+
+`PhoenixKit.Users.Permissions` — allowlist model (row present = granted,
+absent = denied); Owner always has full access, enforced in code. The
+moduledoc is the source of truth; highlights:
+
+- **Module keys** gate admin sections/feature modules (`"billing"`,
+  `"calendar"`, …). Custom keys via `register_custom_key/2`.
+- **Sub-permissions** (added 1.7.182): fine-grained dotted keys under a
+  base (`"calendar.view_others"`), declared in the optional
+  `sub_permissions` field of `permission_metadata/0`. The base key gates
+  the module's admin pages; sub-keys are additive grants the module
+  checks itself via `Scope.can?/2`. A sub implies its base — granting a
+  sub auto-grants the base, revoking the base cascades its subs, and
+  `set_permissions/3` normalizes the set so no path persists an orphan
+  sub row. A sub-key is enabled iff its parent module is enabled.
+- **Edit protection**: `can_edit_role_permissions?/2` — users cannot edit
+  their own role; only Owner can edit Admin.
+- Grant/revoke run under a per-`{role, base-key}` advisory lock so a base
+  revoke's cascade can't interleave a concurrent sub grant.
 
 ## Activity Feed
 
@@ -468,10 +515,10 @@ Partial coverage exists in `test/phoenix_kit_web/components/core/` — written f
 
 - `<.draggable_list>` — three-axis coverage: (a) `:draggable=false` → no SortableJS hook, no `cursor-grab`; (b) `:draggable=true, :sortable_handle=nil` → SortableJS hook + full-item `cursor-grab`; (c) `:draggable=true, :sortable_handle=".pk-drag-handle"` → SortableJS hook + `data-sortable-handle` attribute set, **no** `cursor-grab` on the item wrapper (caller's responsibility). All three branches need rendered-HTML asserts.
 - `<.table_default>` card-view branch — `:on_reorder` / `:reorder_scope` / `:reorder_group` / `:item_id` wire card-view as sortable target. Need to pin `phx-hook="SortableGrid"`, `data-sortable-*`, `data-id`, `class="sortable-item"`, drag-handle footer.
-- `<.input>`, `<.select>`, `<.textarea>`, `<.checkbox>` — inline error rendering, daisyUI variant classes, FormField vs raw `name=`/`value=` dispatch.
+- `<.input>`, `<.select>`, `<.textarea>` — inline error rendering, daisyUI variant classes, FormField vs raw `name=`/`value=` dispatch. (`<.checkbox>` gained a test — `checkbox_test.exs`.)
 - `<.flash>` if complexity has grown.
 
-Surfaced 2026-05-02 by C12 triage during V108 / DnD core work. Partially closed 2026-05-23 (`bulk_select`, `sortable`, `reorder_modal`, `load_more`, `sort_selector`, `modal` keep_in_dom, `table_default` row + drag_handle). Fold the rest into a future component-coverage sweep.
+Surfaced 2026-05-02 by C12 triage during V108 / DnD core work. Partially closed 2026-05-23 (`bulk_select`, `sortable`, `reorder_modal`, `load_more`, `sort_selector`, `modal` keep_in_dom, `table_default` row + drag_handle); `checkbox` closed since. Fold the rest into a future component-coverage sweep.
 
 ### Signed file-URL hardening (`modules/storage`)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -554,30 +554,23 @@ Publishing's `/:language/:group/*path` catch-all matches every 2+ segment URL an
 
 The mechanism generalizes; for now hardcoded to publishing — lift to a registry shape when a second module needs it.
 
-## daisyUI version expectations (host-owned)
+## daisyUI version (host-owned; advisory warnings only)
 
 The daisyUI plugin lives in the **host** app (`assets/vendor/daisyui.js` +
 `daisyui-theme.js`, scaffolded by `mix phx.new`, upgraded manually by the
-host) — PhoenixKit does not vendor, pin, or overwrite it (a custody/auto-sync
-design was built and rejected 2026-07-12; the host owns its assets). Instead
-core declares a **designed-for minimum** in `PhoenixKit.Install.DaisyUI`
-(`minimum_version/0`, currently 5.6.0; verified against 5.6.17) and warns when
-the host is behind: `mix phoenix_kit.install` (Igniter warning),
-`mix phoenix_kit.update` (shell warning), `mix phoenix_kit.doctor` ("daisyUI
-Version" check). Advisory only — nothing touches the host's files.
+host). Core only declares a designed-for minimum
+(`PhoenixKit.Install.DaisyUI.minimum_version/0`, currently 5.6.0) and warns
+below it from `phoenix_kit.install` / `phoenix_kit.update` /
+`phoenix_kit.doctor` — advisory, never touching host files. All modal
+scrollbar-gutter compensations were removed 2026-07-12 (daisyUI ≥ 5.1 handles
+the gutter conditionally); **do NOT re-add `scrollbar-gutter` overrides in
+layouts, PkDialog, or modules**.
 
-History: daisyUI 5.0.x reserved the modal scrollbar gutter unconditionally,
-and core carried compensations (an unlayered `:root:has(.modal-open, …) {
-scrollbar-gutter: auto }` counter-rule in `layout_wrapper.ex` +
-`layouts/root.html.heex`, plus an inline PkDialog override). Those killed the
-phantom right-edge strip on non-scrolling pages but made content reflow ~15px
-around every modal open/close on pages that DO scroll (user-reported via the
-dashboards create modal's Cancel). daisyUI ≥ 5.1 reserves the gutter only when
-the page really has a scrollbar (`rootscrollgutter.css`), so **all
-compensations were removed 2026-07-12** — do NOT re-add scrollbar-gutter
-overrides in layouts, PkDialog, or modules. Hosts still on daisyUI < 5.1 get
-daisyUI's stock old behavior (the strip) plus the warnings above; the cure is
-updating their vendored files, not core CSS.
+**daisyUI version-control problem: researched in full — a vendor-in-core
+custody/auto-sync design was built, verified, and deliberately NOT
+implemented** (hosts own their assets). Full investigation, options analysis,
+and measurement gotchas:
+`dev_docs/investigations/2026-07-12-daisyui-version-management-investigation.md`.
 
 ## TODOs
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -484,30 +484,34 @@ Publishing's `/:language/:group/*path` catch-all matches every 2+ segment URL an
 
 The mechanism generalizes; for now hardcoded to publishing — lift to a registry shape when a second module needs it.
 
+## daisyUI version expectations (host-owned)
+
+The daisyUI plugin lives in the **host** app (`assets/vendor/daisyui.js` +
+`daisyui-theme.js`, scaffolded by `mix phx.new`, upgraded manually by the
+host) — PhoenixKit does not vendor, pin, or overwrite it (a custody/auto-sync
+design was built and rejected 2026-07-12; the host owns its assets). Instead
+core declares a **designed-for minimum** in `PhoenixKit.Install.DaisyUI`
+(`minimum_version/0`, currently 5.6.0; verified against 5.6.17) and warns when
+the host is behind: `mix phoenix_kit.install` (Igniter warning),
+`mix phoenix_kit.update` (shell warning), `mix phoenix_kit.doctor` ("daisyUI
+Version" check). Advisory only — nothing touches the host's files.
+
+History: daisyUI 5.0.x reserved the modal scrollbar gutter unconditionally,
+and core carried compensations (an unlayered `:root:has(.modal-open, …) {
+scrollbar-gutter: auto }` counter-rule in `layout_wrapper.ex` +
+`layouts/root.html.heex`, plus an inline PkDialog override). Those killed the
+phantom right-edge strip on non-scrolling pages but made content reflow ~15px
+around every modal open/close on pages that DO scroll (user-reported via the
+dashboards create modal's Cancel). daisyUI ≥ 5.1 reserves the gutter only when
+the page really has a scrollbar (`rootscrollgutter.css`), so **all
+compensations were removed 2026-07-12** — do NOT re-add scrollbar-gutter
+overrides in layouts, PkDialog, or modules. Hosts still on daisyUI < 5.1 get
+daisyUI's stock old behavior (the strip) plus the warnings above; the cure is
+updating their vendored files, not core CSS.
+
 ## TODOs
 
 Workspace-tracked items not ready for inline `# TODO` in `lib/`.
-
-### Remove the daisyUI modal-gutter counter-rule after vendored daisyUI upgrades
-
-`layout_wrapper.ex` (admin `<style>` block) and `layouts/root.html.heex` carry an
-unlayered `:root:has(.modal-open, …) { scrollbar-gutter: auto }` rule. It counters
-a **daisyUI 5.0.x** defect: on modal/drawer open, old daisyUI unconditionally
-reserves a scrollbar gutter and paints it with a base-100 trick that mismatches on
-non-base-100 pages — classic-scrollbar users see an uncovered strip at the
-window's right edge. Upstream fixed this properly across 5.1.0→5.6.x
-(`rootscrollgutter.css`: `animation-timeline: scroll()` detects a real scrollbar;
-gutter reserved only then).
-
-Hosts vendor their own `daisyui.js` (parent was on 5.0.35 when this was added), so
-the rule protects any host still on old daisyUI. Once hosts are on daisyUI ≥ 5.6,
-remove the rule from both files — it's redundant there, and in browsers that honor
-`scrollbar-gutter` under `overflow: hidden` it would defeat upstream's smarter
-conditional reservation. The `phoenix_kit_dashboards` module carries a per-page
-copy (`gutter_fix_style/0` in both LiveViews) that's deletable as soon as its core
-pin includes this rule, independent of the daisyUI version. Verified 2026-07-08:
-6-page pixel-diff of 5.0.35 vs 5.6.14 showed only 1-2px badge-padding drift, so
-the vendored upgrade itself is low-risk.
 
 ### Component test coverage for `phoenix_kit_web/components/core/`
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,11 +113,59 @@ any new `execute`-built SQL can regress them:
 - **Failures surface late.** Ecto queues `execute` calls; bad SQL queued
   by one version often blows up at a *later* version's `flush()`.
 
+A 2026-07-12 field report from a hardened multi-schema install (schema
+pre-created by a DBA, app role without CREATE on the database, PG 15+
+non-writable `public`) surfaced four more families — all fixed; the
+rules for new migration code:
+
+- **Functions are created schema-qualified.** `uuid_generate_v7()` is
+  created as `<prefix>.uuid_generate_v7()` and every call site
+  (`DEFAULT`, backfill `UPDATE`s, `fragment/1`) qualifies it too — an
+  unqualified `CREATE OR REPLACE FUNCTION` lands wherever `search_path`
+  points (pollutes `public`; fails outright on PG15+). Use
+  `PhoenixKit.Migrations.Postgres.Helpers.ensure_uuid_v7_function/1` +
+  `uuid_v7_call/1`. `Postgres.up/1` re-ensures the function at the
+  prefix for upgrade chains starting ≥ V40 (which skip the creation
+  sites).
+- **Never bare `CREATE EXTENSION IF NOT EXISTS`** — Postgres checks the
+  CREATE privilege *before* the IF-NOT-EXISTS short-circuit, so it fails
+  for low-privilege roles even when the extension is installed. Use
+  `Helpers.ensure_extension!/1` (checks `pg_extension` first; raises an
+  operator-facing message listing citext/pgcrypto/pg_trgm when genuinely
+  missing and uncreatable).
+- **Same story for `CREATE SCHEMA`.** V01 checks
+  `information_schema.schemata` first and only creates when missing
+  (raising a clear error if missing + `create_schema: false`). External
+  migrators must have the flag threaded: V27 passes
+  `create_schema: false` to `Oban.Migration.up/1` — without it Oban
+  re-defaults to true for non-public prefixes and executes the failing
+  statement mid-chain.
+- **The prefix is validated at the `up/down` entry points**
+  (`Helpers.validate_prefix!/1`, `[a-z_][a-z0-9_]*`) because it is
+  interpolated into SQL mostly unquoted.
+- **Tooling resolves the prefix from config.** The installer persists
+  `config :phoenix_kit, prefix:` for non-public installs
+  (`PhoenixKit.Install.PrefixConfig`); update/status/gen.migration
+  resolve `--prefix` → config → `"public"` (`resolve_prefix/1`). And
+  `Install.Common` no longer fabricates `{:current_version, 1}` from
+  the mere existence of migration *files* — that once made
+  `phoenix_kit.update` emit a from-scratch v01→vN migration into the
+  wrong schema. Update-migration generators always emit
+  `create_schema: false` (updating implies the schema exists).
+
 `test/integration/prefix_migration_test.exs` is the oracle: it runs the
 full chain into a scratch schema on the test DB (which also has a public
 install, so it catches both families). It flips the sandbox to `:auto`
 for the run — see its moduledoc for why neither a sandbox checkout nor a
-dynamic repo instance can host the migrator.
+dynamic repo instance can host the migrator. (The privilege-sensitive
+paths — pre-created schema + low-privilege role — can't run under the
+suite's superuser connection; re-verify those manually against the
+recipe in the 2026-07-12 field report if you touch them.)
+
+Note: runtime code does NOT read `config :phoenix_kit, :prefix` — Ecto
+queries run unprefixed, so a prefixed install additionally needs the DB
+role's `search_path` to include the schema. Known gap, out of scope of
+the 2026-07 fixes.
 
 ## Integrations System
 

--- a/dev_docs/investigations/2026-07-12-daisyui-version-management-investigation.md
+++ b/dev_docs/investigations/2026-07-12-daisyui-version-management-investigation.md
@@ -1,0 +1,183 @@
+# daisyUI version management — investigation, custody experiment, and the advisory outcome
+
+**Date:** 2026-07-12
+**Trigger:** user bug report on `phoenix_kit_dashboards`' create modal
+**Outcome:** scrollbar-gutter compensations removed from core; a full
+vendor-in-core custody implementation was built, verified, and **rejected**
+(hosts own their assets); shipped instead as advisory minimum-version warnings
+(`PhoenixKit.Install.DaisyUI` + install/update/doctor).
+
+---
+
+## 1. The bug report
+
+> "On the new dashboard popup, when they clicked the cancel button a scroll
+> bar showed up instead."
+
+Reproduced in `phoenix_kit_parent` with classic (space-taking) scrollbars on
+the dashboards list page (a normal flowing page tall enough to scroll the
+document). Frame-by-frame capture of the create-modal cycle:
+
+| moment            | scrollbar gutter | document scrollbar | layout |
+|-------------------|------------------|--------------------|--------|
+| baseline          | —                | visible (15px)     | content in `viewport − 15px` |
+| modal open        | forced `auto`    | hidden by page lock| content expands 15px wider |
+| after Cancel      | restored         | back               | content shrinks 15px, scrollbar pops in |
+
+The scrollbar was never *added* by Cancel — it was legitimately there, got
+hidden for the modal's lifetime, and its return was maximally visible because
+the space it needs had been given away while it was gone.
+
+## 2. Root cause — two fixes fighting each other
+
+1. **daisyUI 5.0.x** (what every host vendored): on modal/drawer open it sets
+   `overflow: hidden` on `:root` (the page lock) **plus** an unconditional
+   `scrollbar-gutter: stable` — deliberately reserving the hidden scrollbar's
+   15px so content doesn't reflow. Correct on scrolling pages; on
+   *non-scrolling* pages the reservation is pure artifact — the modal backdrop
+   sizes against the reduced viewport and a phantom grey/white strip shows at
+   the window's right edge (painted base-100 by daisyUI, which mismatches any
+   non-base-100 host background).
+2. **Core's compensations**, accreted over time to kill that strip:
+   - since 1.0.0: `class="[scrollbar-gutter:stable]"` on `<html>` in core's
+     two standalone root layouts (latent in host-shell mode — the host's root
+     layout renders instead);
+   - 2026-05-23 (`43ab0990`, the modal→native-`<dialog>` sweep): PkDialog's
+     refcounted inline `scrollbar-gutter: auto !important` on open;
+   - 2026-07-08 (`9bfed196`, released 1.7.179): the unlayered
+     `:root:has(.modal-open, …) { scrollbar-gutter: auto }` counter-rule in
+     the admin LayoutWrapper + `layouts/root.html.heex`, covering all daisyUI
+     modal patterns and the drawer. Its comment *documented the trade-off*:
+     "on pages that DO scroll, classic-scrollbar users see a ~15px reflow when
+     a modal opens … less jarring than the mispainted strip."
+     (`phoenix_kit_dashboards` had carried its own per-page copy of the same
+     rule and deleted it the same day in favor of core's.)
+
+The user report was that documented trade-off being hit in the wild. Why it
+survived browser verification: on default macOS, scrollbars are overlays that
+occupy zero layout width — both the reservation and the override are visual
+no-ops. You need a space-taking scrollbar AND a page that scrolls.
+
+## 3. Ecosystem research
+
+- **Who owns daisyUI:** the HOST app. `mix phx.new` (Phoenix 1.8, no npm)
+  vendors `assets/vendor/daisyui.js` + `daisyui-theme.js` at project creation;
+  the host's `app.css` loads them via `@plugin` with host-owned theme config
+  blocks. phoenix_kit never installed, checked, or pinned it — its only
+  mention was a themes-disabled regex in the update task. Contrast:
+  `phoenix_kit.js` IS custodied (copied by install, refreshed by update,
+  cache-busted).
+- **Fleet survey:** every host in the workspace with a vendored copy was on
+  **5.0.35** (phoenix_kit_parent, polymarket_bot, farm_keeper_new,
+  printer_farm_receiver) — whatever phx.new scaffolded; nobody had ever
+  upgraded one.
+- **Upstream:** daisyUI was at 5.6.17 (now 5.6.18; very active cadence).
+  The gutter defect was fixed across 5.1.0→5.6.x in `rootscrollgutter.css`,
+  verified by inspecting the 5.6.17 bundle: a scroll-driven animation
+  (`animation-timeline: scroll()`) sets `--page-has-scroll` only when the page
+  really scrolls, and the rule computes
+  `scrollbar-gutter: var(--page-has-scroll) var(--page-scroll-lock) stable`
+  (the space-toggle trick) — gutter reserved **only** when a modal is open AND
+  there was a real scrollbar to hide. Handles both page types and the drawer.
+- **Key insight:** core wasn't "hoping daisyUI is up to date" — its
+  compensations *assumed daisyUI is old*. A host that diligently upgraded to
+  5.6 would have behaved WORSE (core's unconditional `auto` forcing defeats
+  upstream's conditional reservation → the jump returns). Silent version
+  coupling, calibrated to the stale version, invisible by construction.
+
+## 4. Options analysis for version management
+
+| option | verdict |
+|---|---|
+| **npm dependency** | Phoenix 1.8 deliberately dropped npm; reintroducing Node as a build requirement for one file is a regression. |
+| **Version pin + download at install** (the `tailwind`/`esbuild` hex-package pattern) | That pattern exists because platform-specific multi-MB binaries *can't* ship in a hex package. daisyUI is a ~330KB platform-independent text file — exactly what hex packages are for. Downloading adds network-at-build-time (offline/CI breakage), supply-chain surface (GitHub release assets are **mutable** — a tag's file can be re-uploaded), and availability coupling. |
+| **`@plugin` straight from the dep** (`deps/phoenix_kit/priv/vendor/...`) | Dies on plumbing: **path deps never materialize under `deps/`** (verified — the parent has no `deps/phoenix_kit`), `_build/<env>/...` paths are MIX_ENV-specific, and emitting the `@plugin` into the generated `_phoenix_kit_sources.css` fails because plugin *config* (themes) is attached to the invocation and must stay host-owned. |
+| **Vendor in core + copy into host** ("custody") | Works for every dep type and env; the copy is the pointer, enforced identical on every compile. Built and verified — then **rejected** (below). |
+| **Advisory warnings only** | What shipped. |
+
+## 5. The custody experiment (built, verified, rejected)
+
+Implementation (commits `8b77f6c9` + `a7578c9f`, pushed to the fork then
+retired; the fork's main was later reset past them):
+
+- daisyUI 5.6.17 (`daisyui.js` + `daisyui-theme.js`, MIT) vendored in core's
+  `priv/vendor/`; `pinned_version/0` parsed out of the bundle itself.
+- Synced over the host's `assets/vendor/` copies at four touchpoints:
+  `phoenix_kit.install` (Igniter step), `phoenix_kit.update` (before its asset
+  rebuild), the `:phoenix_kit_css_sources` compiler on **every host compile**
+  (the no-drift enforcement backstop), and a `phoenix_kit.doctor` check.
+  Only when the host file existed; `manage_daisyui: false` opt-out.
+- All gutter compensations deleted (see §6).
+
+Verified end-to-end in the parent (native classic scrollbars): zero reflow
+through the whole open→cancel cycle on the scrolling page; no phantom strip on
+the viewport-locked builder; doctor `PASS daisyUI 5.6.17 (pinned by
+PhoenixKit)`; precommit green.
+
+**Rejected by the maintainer:** hosts own their assets — core must not
+overwrite files in the host's repo. The custody machinery (vendored files,
+sync, compiler hook, config flag) was fully removed.
+
+## 6. What shipped (commit `d571a55c`)
+
+1. **Compensations removed** — both CSS counter-rules (LayoutWrapper +
+   `root.html.heex`) and PkDialog's inline override + `_PkDialogOpenCount`
+   refcount machinery (~90 lines of JS). With daisyUI ≥ 5.1 the conditional
+   gutter makes them obsolete; on scrolling pages they *caused* the reported
+   bug. **Do not re-add `scrollbar-gutter` overrides in core layouts,
+   PkDialog, or modules.**
+2. **Advisory warnings** — `PhoenixKit.Install.DaisyUI` declares
+   `minimum_version/0` (**5.6.0**; verified against 5.6.17/5.6.18) and
+   `check/0` → `:ok | {:outdated, v} | :unversioned | :missing`. Warned from:
+   - `mix phoenix_kit.install` — Igniter warning with curl upgrade steps
+   - `mix phoenix_kit.update` — shell warning next to its CSS/JS refresh steps
+   - `mix phoenix_kit.doctor` — "daisyUI Version" check (four states)
+
+   Advisory only; nothing ever touches host files. Unit tests:
+   `test/phoenix_kit/install/daisyui_test.exs`.
+3. **Host consequences** — a host on daisyUI < 5.1 gets daisyUI's *stock* old
+   behavior (the gutter strip while a modal is open on non-scrolling pages;
+   no jump on scrolling pages) plus the warning; the cure is updating the two
+   vendored files, not core CSS. phoenix_kit_parent was hand-upgraded to
+   5.6.18 (the exact procedure the warning prescribes); the other workspace
+   hosts will warn until their files are curled forward.
+
+## 7. Measurement gotchas (keep these — they cost real time)
+
+- **`clientWidth` does not count a reserved gutter.** Under
+  `overflow: hidden` + `scrollbar-gutter: stable`, Chromium reports
+  `clientWidth == innerWidth` even though layout stays narrower. Measure
+  `body.getBoundingClientRect().width` / a centered container's `x` for
+  user-visible reflow — the gap metric produced a false "fix didn't work."
+- **A `::-webkit-scrollbar { width: 15px }` sim** makes real scrollbars take
+  space (good for demoing the *old* bug on overlay-scrollbar macOS) but does
+  NOT make `scrollbar-gutter: stable` reserve anything — the reservation uses
+  the platform scrollbar width (0 for overlay). You cannot verify the fix
+  with the sim; you need real classic scrollbars.
+- **macOS "Show scroll bars: Always"** gives real classic scrollbars — but a
+  long-lived Playwright/Chromium instance may predate the observed setting;
+  relaunch the browser before trusting its scrollbar mode. Probe with
+  `div{overflow:scroll}` `offsetWidth - clientWidth`.
+- **Playwright-bundled Chromium quirk (2026-07):** with *overlay* scrollbars,
+  that build reserves ~15px under `scrollbar-gutter: stable` anyway (root
+  element shrinks while a modal is open) — against the spec (overlay ⇒
+  nothing to reserve). This is stock-daisyUI-≥5.1-behavior × browser quirk,
+  identical on 5.6.17 and 5.6.18 (mechanisms byte-diffed), NOT caused by
+  phoenix_kit. If a default-macOS user ever reports a small modal-open shift,
+  this is the trail — upstream daisyUI/Chromium territory, not core CSS.
+- **Playwright MCP full-page screenshots** timed out on these admin pages
+  ("waiting for element to be stable") with zero animations present — tool
+  quirk; fall back to programmatic computed-style checks.
+
+## 8. Conclusion
+
+The daisyUI version-control problem was researched in full and a complete
+custody/pinning implementation was built and verified — **we decided not to
+implement it** (maintainer call: hosts own their assets). What remains in
+core is the minimal correct stance: rely on modern daisyUI's own conditional
+gutter (compensations deleted, never to return) and tell hosts when their
+vendored copy is too old to deliver it (`PhoenixKit.Install.DaisyUI`,
+minimum 5.6.0, warnings in install/update/doctor). If Tailwind ever grows
+package-resolved plugin references (or Phoenix reintroduces a JS package
+manager), direct consumption of a core-shipped plugin becomes possible and
+this file is the starting point.

--- a/lib/mix/tasks/phoenix_kit.doctor.ex
+++ b/lib/mix/tasks/phoenix_kit.doctor.ex
@@ -32,6 +32,7 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
    12. **Oban Configuration** — Queues and plugins that consume pool connections
    13. **Supervisor Children** — What's running (update_mode vs full)?
    14. **Update Mode** — Is update_mode active?
+   15. **daisyUI Version** — Is the host's vendored daisyUI recent enough?
   """
 
   use Mix.Task
@@ -71,7 +72,8 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
       run_check("Orphaned Connections", fn -> check_orphaned_connections() end),
       run_check("Oban Configuration", fn -> check_oban_config() end),
       run_check("PhoenixKit Supervisor", fn -> check_supervisor_state() end),
-      run_check("Update Mode", fn -> check_update_mode() end)
+      run_check("Update Mode", fn -> check_update_mode() end),
+      run_check("daisyUI Version", fn -> check_daisyui() end)
     ]
 
     IO.puts("")
@@ -699,6 +701,37 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
   end
 
   defp extract_host_from_url(_), do: nil
+
+  # The host owns assets/vendor/daisyui.js (scaffolded by phx.new, upgraded
+  # manually). PhoenixKit's modals rely on daisyUI >= the minimum for correct
+  # modal scrollbar-gutter handling — this check is where a host finds out
+  # it's behind (install/update print the same warning).
+  defp check_daisyui do
+    alias PhoenixKit.Install.DaisyUI
+
+    minimum = DaisyUI.minimum_version()
+
+    case DaisyUI.check() do
+      :ok ->
+        {:pass, "daisyUI #{DaisyUI.installed_version(DaisyUI.host_path())} (>= #{minimum})"}
+
+      {:outdated, version} ->
+        {:warn,
+         "Vendored daisyUI is #{version}; PhoenixKit is designed against #{minimum}+ " <>
+           "(modal scrollbar-gutter handling). Update assets/vendor/daisyui.js + " <>
+           "daisyui-theme.js from https://github.com/saadeghi/daisyui/releases and rebuild assets."}
+
+      :unversioned ->
+        {:warn,
+         "assets/vendor/daisyui.js carries no version marker — cannot verify it against " <>
+           "PhoenixKit's designed-for minimum (#{minimum})."}
+
+      :missing ->
+        {:warn,
+         "No assets/vendor/daisyui.js — custom daisyUI setup? PhoenixKit is designed " <>
+           "against daisyUI #{minimum}+; make sure your setup matches."}
+    end
+  end
 
   # ── Display ─────────────────────────────────────────────────────────
 

--- a/lib/mix/tasks/phoenix_kit.gen.migration.ex
+++ b/lib/mix/tasks/phoenix_kit.gen.migration.ex
@@ -24,6 +24,7 @@ defmodule Mix.Tasks.PhoenixKit.Gen.Migration do
       mix phoenix_kit.gen.migration --prefix my_schema
 
   """
+  alias PhoenixKit.Install.PrefixConfig
   alias PhoenixKit.Migrations.Postgres, as: PkMigrations
 
   @shortdoc "Generate PhoenixKit versioned migration"
@@ -31,7 +32,7 @@ defmodule Mix.Tasks.PhoenixKit.Gen.Migration do
   @impl Mix.Task
   def run(args) do
     opts = parse_args(args)
-    prefix = opts[:prefix] || "public"
+    prefix = PrefixConfig.resolve_prefix(opts)
 
     from_version = detect_current_version()
     to_version = PkMigrations.current_version()
@@ -110,7 +111,10 @@ defmodule Mix.Tasks.PhoenixKit.Gen.Migration do
 
   defp migration_content(app_module, slug, from_version, to_version, prefix) do
     module_name = Macro.camelize(slug)
-    create_schema = prefix != "public"
+    # This task only generates UPGRADE migrations (from_version > 0), so the
+    # schema already exists — never ask the chain to create it (CREATE SCHEMA
+    # fails for low-privilege roles even with IF NOT EXISTS).
+    create_schema = false
 
     """
     defmodule #{app_module}.Repo.Migrations.#{module_name} do

--- a/lib/mix/tasks/phoenix_kit.gen.migration.ex
+++ b/lib/mix/tasks/phoenix_kit.gen.migration.ex
@@ -109,12 +109,17 @@ defmodule Mix.Tasks.PhoenixKit.Gen.Migration do
     |> Macro.camelize()
   end
 
-  defp migration_content(app_module, slug, from_version, to_version, prefix) do
+  # Public for testability (mix task internals otherwise); @doc false.
+  @doc false
+  def migration_content(app_module, slug, from_version, to_version, prefix) do
     module_name = Macro.camelize(slug)
-    # This task only generates UPGRADE migrations (from_version > 0), so the
-    # schema already exists — never ask the chain to create it (CREATE SCHEMA
-    # fails for low-privilege roles even with IF NOT EXISTS).
-    create_schema = false
+    # An upgrade (from_version > 0) implies the schema exists — never ask
+    # the chain to create it (CREATE SCHEMA fails for low-privilege roles
+    # even with IF NOT EXISTS; V01 skips it when the schema is present).
+    # But from_version == 0 means no prior PhoenixKit migration exists in
+    # the project: that's a fresh install and a non-public schema may
+    # genuinely need creating.
+    create_schema = from_version == 0 and prefix != "public"
 
     """
     defmodule #{app_module}.Repo.Migrations.#{module_name} do

--- a/lib/mix/tasks/phoenix_kit.gen.migration.ex
+++ b/lib/mix/tasks/phoenix_kit.gen.migration.ex
@@ -13,7 +13,11 @@ defmodule Mix.Tasks.PhoenixKit.Gen.Migration do
 
   ## Options
 
-    * `--prefix` - Database schema prefix (default: "public")
+    * `--prefix` - Database schema prefix. When omitted, resolves from
+      `config :phoenix_kit, :prefix`, then defaults to "public" (validated:
+      `[a-z_][a-z0-9_]*`). The generated migration passes
+      `create_schema: true` only for a fresh install (no prior PhoenixKit
+      migration in the project) with a non-public prefix.
 
   ## Examples
 

--- a/lib/mix/tasks/phoenix_kit.install.ex
+++ b/lib/mix/tasks/phoenix_kit.install.ex
@@ -119,7 +119,7 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
       |> MailerConfig.add_mailer_configuration()
       |> RateLimiterConfig.add_rate_limiter_configuration()
       |> OAuthConfig.add_oauth_configuration()
-      |> ObanConfig.add_oban_configuration(opts[:prefix])
+      |> ObanConfig.add_oban_configuration(PrefixConfig.resolve_prefix(opts))
       |> ApplicationSupervisor.add_supervisor()
       |> BootHook.add_boot_hook()
       |> ObanConfig.add_oban_supervisor()

--- a/lib/mix/tasks/phoenix_kit.install.ex
+++ b/lib/mix/tasks/phoenix_kit.install.ex
@@ -78,6 +78,7 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
       MigrationStrategy,
       OAuthConfig,
       ObanConfig,
+      PrefixConfig,
       RateLimiterConfig,
       RepoDetection,
       RouterIntegration
@@ -114,6 +115,7 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
       igniter
       |> BasicConfiguration.add_basic_config()
       |> RepoDetection.add_phoenix_kit_configuration(opts[:repo])
+      |> PrefixConfig.add_prefix_configuration(opts[:prefix])
       |> MailerConfig.add_mailer_configuration()
       |> RateLimiterConfig.add_rate_limiter_configuration()
       |> OAuthConfig.add_oauth_configuration()

--- a/lib/mix/tasks/phoenix_kit.install.ex
+++ b/lib/mix/tasks/phoenix_kit.install.ex
@@ -68,6 +68,7 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
       BrowserPipelineIntegration,
       Common,
       CssIntegration,
+      DaisyUI,
       DbConnectionCheck,
       DemoFiles,
       EndpointIntegration,
@@ -127,6 +128,7 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
       ])
       |> CssIntegration.add_automatic_css_integration()
       |> JsIntegration.add_js_integration()
+      |> warn_if_daisyui_outdated()
       |> DemoFiles.copy_test_demo_files()
       |> RouterIntegration.add_router_integration(opts[:router_path])
       |> BrowserPipelineIntegration.add_integration_to_browser_pipeline()
@@ -438,6 +440,19 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
         end)
 
       has_oban_config and has_queues
+    end
+
+    # PhoenixKit relies on the host's vendored daisyUI being reasonably modern
+    # (modal scrollbar-gutter handling; see PhoenixKit.Install.DaisyUI). The
+    # host owns that file — we only warn, never touch it.
+    defp warn_if_daisyui_outdated(igniter) do
+      case DaisyUI.check() do
+        {:outdated, version} ->
+          Igniter.add_warning(igniter, DaisyUI.outdated_warning(version))
+
+        _ ->
+          igniter
+      end
     end
 
     # Add completion notice with essential next steps (reduced duplication)

--- a/lib/mix/tasks/phoenix_kit.install.ex
+++ b/lib/mix/tasks/phoenix_kit.install.ex
@@ -38,13 +38,19 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
 
     * `--repo` - Specify Ecto repo module (auto-detected if not provided)
     * `--router-path` - Specify custom path to router.ex file
-    * `--prefix` - Specify PostgreSQL schema prefix (defaults to "public")
+    * `--prefix` - Specify PostgreSQL schema prefix (defaults to "public").
+      Must match `[a-z_][a-z0-9_]*` (validated; the install aborts otherwise).
+      A non-public prefix is persisted as `config :phoenix_kit, prefix:` (in
+      config.exs and test.exs), baked into the generated migration, and
+      written into the generated Oban config as `prefix:`.
     * `--create-schema` - Create schema if using custom prefix (default: true for non-public prefixes)
 
     ## Auto-detection
 
     The installer will automatically:
-    - Detect Ecto repo from `:ecto_repos` config or common naming patterns (MyApp.Repo)
+    - Detect Ecto repo from `:ecto_repos` config or common naming patterns (MyApp.Repo).
+      With MULTIPLE repos detected, the install halts and requires `--repo`
+      (guessing between e.g. a runtime repo and a migration-only repo is unsafe)
     - Find main router using Phoenix conventions (MyAppWeb.Router)
     - Configure Swoosh.Adapters.Local for development in config/dev.exs
     - Provide production mailer setup instructions
@@ -136,7 +142,7 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
       |> BrowserPipelineIntegration.add_integration_to_browser_pipeline()
       |> EndpointIntegration.add_endpoint_integration()
       |> MigrationStrategy.create_phoenix_kit_migration_only(opts)
-      |> add_completion_notice()
+      |> add_completion_notice(opts)
     end
 
     # Override run/1 to handle post-igniter interactive migration
@@ -228,7 +234,7 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
             Please check config/config.exs manually and ensure it contains:
             - config :ueberauth, Ueberauth (with providers: [])
             - config :hammer (with backend and expiry_ms)
-            - config :phoenix_kit, Oban (with queues configuration)
+            - config :your_app, Oban (with queues configuration)
 
             Then run: mix phoenix_kit.install #{Enum.join(argv, " ")}
             """)
@@ -274,12 +280,13 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
                                 Default: "public" (standard PostgreSQL schema)
                                 Use custom prefix for table isolation
                                 Example: --prefix "auth"
+                                Validated ([a-z_][a-z0-9_]*); persisted into
+                                config :phoenix_kit, prefix: and the generated
+                                Oban config. Runtime schemas compile it in —
+                                any later mix compile/phx.server picks it up.
 
         --create-schema         Create schema if using custom prefix
                                 Default: true for non-public prefixes
-
-                                        Adds 35+ themes support with theme controller
-                                Default: false
 
         --skip-assets           Skip automatic asset rebuild check
                                 Default: false
@@ -458,7 +465,22 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
     end
 
     # Add completion notice with essential next steps (reduced duplication)
-    defp add_completion_notice(igniter) do
+    defp add_completion_notice(igniter, opts) do
+      prefix_note =
+        case opts[:prefix] do
+          prefix when is_binary(prefix) and prefix != "public" ->
+            """
+              • Prefixed install: the schema prefix compiles into PhoenixKit's
+                Ecto schemas. The next mix compile / ecto.migrate / phx.server
+                picks it up automatically; a build compiled before this config
+                change fails loudly at boot (compile-env check) rather than
+                silently querying public.
+            """
+
+          _ ->
+            ""
+        end
+
       notice = """
 
       ✅ PhoenixKit ready! Next:
@@ -466,6 +488,7 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
         • mix phx.server
         • Visit /users/register (or with your configured URL prefix)
         • Test: /test-current-user, /test-ensure-auth
+      #{prefix_note}
       """
 
       Igniter.add_notice(igniter, notice)

--- a/lib/mix/tasks/phoenix_kit.install.ex
+++ b/lib/mix/tasks/phoenix_kit.install.ex
@@ -119,7 +119,7 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
       |> MailerConfig.add_mailer_configuration()
       |> RateLimiterConfig.add_rate_limiter_configuration()
       |> OAuthConfig.add_oauth_configuration()
-      |> ObanConfig.add_oban_configuration()
+      |> ObanConfig.add_oban_configuration(opts[:prefix])
       |> ApplicationSupervisor.add_supervisor()
       |> BootHook.add_boot_hook()
       |> ObanConfig.add_oban_supervisor()

--- a/lib/mix/tasks/phoenix_kit.status.ex
+++ b/lib/mix/tasks/phoenix_kit.status.ex
@@ -124,6 +124,9 @@ defmodule Mix.Tasks.PhoenixKit.Status do
       {:not_installed} ->
         {:not_installed}
 
+      {:unreachable, reason} ->
+        {:unreachable, reason}
+
       {:current_version, version} ->
         target_version = Postgres.current_version()
 
@@ -212,6 +215,10 @@ defmodule Mix.Tasks.PhoenixKit.Status do
     {:install, "mix igniter.install phoenix_kit"}
   end
 
+  defp determine_next_action({:unreachable, _reason}, _prefix) do
+    {:fix_connection, "Fix the database connection, then re-run mix phoenix_kit.status"}
+  end
+
   defp determine_next_action({:needs_update, _current, _target}, prefix) do
     cmd =
       if prefix != "public",
@@ -228,6 +235,10 @@ defmodule Mix.Tasks.PhoenixKit.Status do
   # Format installation status for display
   defp format_installation_status({:not_installed}) do
     "#{IO.ANSI.red()}Not installed#{IO.ANSI.reset()}"
+  end
+
+  defp format_installation_status({:unreachable, _reason}) do
+    "#{IO.ANSI.yellow()}Unknown — database unreachable#{IO.ANSI.reset()}"
   end
 
   defp format_installation_status({:up_to_date, version}) do
@@ -272,6 +283,10 @@ defmodule Mix.Tasks.PhoenixKit.Status do
     "#{IO.ANSI.green()}#{message}#{IO.ANSI.reset()}"
   end
 
+  defp format_next_action({:fix_connection, message}) do
+    "#{IO.ANSI.yellow()}#{message}#{IO.ANSI.reset()}"
+  end
+
   # Display status information in tree format
   defp display_status_tree(items) do
     items
@@ -301,6 +316,9 @@ defmodule Mix.Tasks.PhoenixKit.Status do
     case status do
       {:not_installed} ->
         IO.puts("  Migration files: #{inspect(Common.find_existing_phoenix_kit_migrations())}")
+
+      {:unreachable, reason} ->
+        IO.puts("  Database unreachable: #{inspect(reason)}")
 
       {:up_to_date, version} ->
         IO.puts("  Current version: V#{pad_version(version)}")

--- a/lib/mix/tasks/phoenix_kit.status.ex
+++ b/lib/mix/tasks/phoenix_kit.status.ex
@@ -42,6 +42,7 @@ defmodule Mix.Tasks.PhoenixKit.Status do
 
   alias PhoenixKit.Config
   alias PhoenixKit.Install.Common
+  alias PhoenixKit.Install.PrefixConfig
   alias PhoenixKit.Migrations.Postgres
 
   @impl Mix.Task
@@ -72,7 +73,10 @@ defmodule Mix.Tasks.PhoenixKit.Status do
 
     {opts, _argv, _errors} = OptionParser.parse(argv, switches: @switches, aliases: @aliases)
 
-    prefix = opts[:prefix] || "public"
+    # --prefix option → config :phoenix_kit, :prefix → "public", so a
+    # prefixed install doesn't report "Not installed" when the flag is
+    # omitted.
+    prefix = PrefixConfig.resolve_prefix(opts)
     verbose = opts[:verbose] || false
 
     show_comprehensive_status(prefix, verbose)

--- a/lib/mix/tasks/phoenix_kit.status.ex
+++ b/lib/mix/tasks/phoenix_kit.status.ex
@@ -13,7 +13,8 @@ defmodule Mix.Tasks.PhoenixKit.Status do
 
   ## Options
 
-    * `--prefix` - Database schema prefix (default: "public")
+    * `--prefix` - Database schema prefix. When omitted, resolves from
+      `config :phoenix_kit, :prefix`, then defaults to "public".
     * `--verbose` - Show detailed diagnostic information
 
   ## Examples

--- a/lib/mix/tasks/phoenix_kit.update.ex
+++ b/lib/mix/tasks/phoenix_kit.update.ex
@@ -95,6 +95,7 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
       IgniterHelpers,
       JsIntegration,
       ObanConfig,
+      PrefixConfig,
       RateLimiterConfig
     }
 
@@ -360,8 +361,15 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
 
     # Perform the igniter-based update logic
     defp perform_igniter_update(igniter, opts) do
-      prefix = opts[:prefix] || "public"
+      # --prefix option → config :phoenix_kit, :prefix → "public".
+      # Checking the wrong prefix here is dangerous: a prefixed install
+      # looks "not installed" at public.
+      prefix = PrefixConfig.resolve_prefix(opts)
       force = opts[:force] || false
+
+      # Backfill the config entry for installs made before the installer
+      # started persisting --prefix (no-op when already configured).
+      igniter = PrefixConfig.add_prefix_configuration(igniter, opts[:prefix])
 
       # Validate and fix Ueberauth configuration before update
       igniter = validate_and_fix_ueberauth_config(igniter)
@@ -403,7 +411,7 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
           # Second pass: Configuration exists, app is started, proceed with migration
           case Common.check_installation_status(prefix) do
             {:not_installed} ->
-              add_not_installed_notice(igniter)
+              add_not_installed_notice(igniter, prefix)
 
             {:current_version, current_version} ->
               target_version = Common.current_version()
@@ -438,7 +446,10 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
            force,
            opts
          ) do
-      create_schema = prefix != "public"
+      # An update implies an existing installation, so the schema exists —
+      # never ask the chain to create it (CREATE SCHEMA fails for
+      # low-privilege roles even with IF NOT EXISTS).
+      create_schema = false
 
       # Generate timestamp and migration file name using Ecto format
       timestamp = Common.generate_timestamp()
@@ -517,12 +528,18 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
     end
 
     # Add notices for different scenarios
-    defp add_not_installed_notice(igniter) do
+    defp add_not_installed_notice(igniter, prefix) do
       notice = """
 
-      ❌ PhoenixKit is not installed.
+      ❌ No PhoenixKit installation found at schema prefix #{inspect(prefix)}.
 
-      Please run: mix igniter.install phoenix_kit
+      If PhoenixKit IS installed but under a different schema prefix, pass it
+      explicitly (and persist it in config so future runs resolve it):
+
+        mix phoenix_kit.update --prefix your_schema
+        config :phoenix_kit, prefix: "your_schema"
+
+      If PhoenixKit is not installed yet, run: mix igniter.install phoenix_kit
       (or `mix phoenix_kit.install` if the dep is already in mix.exs)
       """
 
@@ -593,7 +610,7 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
 
     # Handle tasks that need to run after igniter completes
     defp post_igniter_tasks(opts) do
-      prefix = Keyword.get(opts, :prefix, "public")
+      prefix = PrefixConfig.resolve_prefix(opts)
 
       # CRITICAL: Run UUID repair BEFORE migrations
       # This fixes upgrade path from PhoenixKit < 1.7.0 where uuid columns
@@ -840,7 +857,7 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
     # implement `migration_module/0`. Generates an incremental migration file
     # in the parent app for each module that needs updating, then runs migrations.
     defp run_module_migrations(opts) do
-      prefix = Keyword.get(opts, :prefix, "public")
+      prefix = PrefixConfig.resolve_prefix(opts)
 
       modules =
         try do
@@ -945,7 +962,7 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
 
     # Show current installation status and available updates
     defp show_status(opts) do
-      prefix = opts[:prefix] || "public"
+      prefix = PrefixConfig.resolve_prefix(opts)
 
       # Use the status command to show current status
       args = if prefix == "public", do: [], else: ["--prefix=#{prefix}"]

--- a/lib/mix/tasks/phoenix_kit.update.ex
+++ b/lib/mix/tasks/phoenix_kit.update.ex
@@ -378,7 +378,7 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
       igniter = validate_and_add_hammer_config(igniter)
 
       # Ensure Oban configuration exists
-      igniter = validate_and_add_oban_config(igniter)
+      igniter = validate_and_add_oban_config(igniter, prefix)
 
       # CRITICAL FIX: Ensure correct supervisor ordering in application.ex
       # This must run AFTER add_oban_supervisor to fix installations with wrong order
@@ -1606,7 +1606,7 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
       Igniter.add_notice(igniter, String.trim(notice))
     end
 
-    defp validate_and_add_oban_config(igniter) do
+    defp validate_and_add_oban_config(igniter, prefix) do
       config_exists = ObanConfig.oban_config_exists?(igniter)
       supervisor_exists = ObanConfig.oban_supervisor_exists?(igniter)
 
@@ -1615,8 +1615,9 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
       # - Updating existing configuration with new queues (posts, sitemap, sqs_polling)
       igniter =
         igniter
-        |> ObanConfig.add_oban_configuration()
+        |> ObanConfig.add_oban_configuration(prefix)
         |> maybe_add_oban_config_notice(config_exists)
+        |> warn_if_oban_config_missing_prefix(config_exists, prefix)
 
       # Check and add supervisor separately
       if supervisor_exists do
@@ -1627,6 +1628,33 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
         |> add_oban_supervisor_added_notice()
       end
     end
+
+    # An existing Oban config on a prefixed install must carry prefix: —
+    # V27 put oban_jobs into the named schema, and without the option Oban
+    # looks for public.oban_jobs. add_oban_configuration only writes fresh
+    # config blocks, so warn instead of rewriting the host's existing one.
+    defp warn_if_oban_config_missing_prefix(igniter, true = _config_existed, prefix)
+         when prefix not in [nil, "public"] do
+      content = File.read!("config/config.exs")
+
+      if String.contains?(content, ", Oban") and
+           not Regex.match?(~r/prefix:\s*"#{Regex.escape(prefix)}"/, content) do
+        Igniter.add_warning(igniter, """
+        Your Oban config appears to lack the schema prefix of this install.
+        PhoenixKit's Oban tables live in the "#{prefix}" schema — add:
+
+          config :your_app, Oban,
+            prefix: "#{prefix}",
+            ...
+        """)
+      else
+        igniter
+      end
+    rescue
+      _ -> igniter
+    end
+
+    defp warn_if_oban_config_missing_prefix(igniter, _config_existed, _prefix), do: igniter
 
     # Add appropriate notice based on whether config existed
     defp maybe_add_oban_config_notice(igniter, config_existed) do

--- a/lib/mix/tasks/phoenix_kit.update.ex
+++ b/lib/mix/tasks/phoenix_kit.update.ex
@@ -37,7 +37,10 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
 
     ## Options
 
-      * `--prefix` - Database schema prefix (default: "public")
+      * `--prefix` - Database schema prefix. When omitted, resolves from
+        `config :phoenix_kit, :prefix`, then defaults to "public". Passing it
+        explicitly also persists the config entry. On prefixed installs the
+        task warns when your existing Oban config lacks the `prefix:` key.
       * `--status` - Show current installation status and available updates
       * `--force` - Force update even if already up to date
       * `--skip-assets` - Skip automatic asset rebuild check
@@ -65,10 +68,8 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
     PhoenixKit uses a versioned migration system. Each version contains specific
     database schema changes that can be applied incrementally.
 
-    Current version: V17 (latest version with comprehensive features)
-    - V01: Basic authentication with role system
-    - V02: Remove is_active column from role assignments (direct deletion)
-    - V03-V17: Additional features and improvements (see migration files for details)
+    Run `mix phoenix_kit.status` to see the currently installed and latest
+    available migration versions.
 
     ## Safe Updates
 
@@ -762,8 +763,9 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
 
       OPTIONS
         --prefix SCHEMA         Database schema prefix for PhoenixKit tables
-                                Default: "public" (standard PostgreSQL schema)
-                                Must match prefix used during installation
+                                Omitted: resolves from config :phoenix_kit,
+                                :prefix, then defaults to "public" — so a
+                                configured prefixed install needs no flag.
                                 Example: --prefix "auth"
 
         --status, -s            Show current installation status and available updates
@@ -805,12 +807,7 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
         Each version contains specific database schema changes that can
         be applied incrementally.
 
-        Current latest version: V17
-        • V01: Basic authentication with role system
-        • V02: Remove is_active column from role assignments
-        • V03-V06: Additional features and improvements
-        • V07: Email system tables (logs, events, blocklist)
-        • V08-V17: Settings, OAuth, magic links, and more
+        Run mix phoenix_kit.status for the installed and latest versions.
 
       SAFE UPDATES
         All PhoenixKit updates are designed to be:

--- a/lib/mix/tasks/phoenix_kit.update.ex
+++ b/lib/mix/tasks/phoenix_kit.update.ex
@@ -89,6 +89,7 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
       BootHook,
       Common,
       CssIntegration,
+      DaisyUI,
       DbConnectionCheck,
       EndpointIntegration,
       IgniterHelpers,
@@ -603,6 +604,10 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
       # Update CSS integration (enables daisyUI themes if disabled)
       update_css_integration()
 
+      # Warn when the host's vendored daisyUI is older than what PhoenixKit's
+      # UI is designed against (the host owns the file; we never touch it)
+      warn_if_daisyui_outdated()
+
       # Update JS hooks file
       JsIntegration.update_js_file()
 
@@ -945,6 +950,16 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
       # Use the status command to show current status
       args = if prefix == "public", do: [], else: ["--prefix=#{prefix}"]
       Mix.Task.run("phoenix_kit.status", args)
+    end
+
+    # Advisory only — the host owns assets/vendor/daisyui.js; PhoenixKit's
+    # modals rely on daisyUI >= DaisyUI.minimum_version() for correct modal
+    # scrollbar-gutter handling (see PhoenixKit.Install.DaisyUI).
+    defp warn_if_daisyui_outdated do
+      case DaisyUI.check() do
+        {:outdated, version} -> Mix.shell().info(DaisyUI.outdated_warning(version))
+        _ -> :ok
+      end
     end
 
     # Update CSS integration during PhoenixKit updates

--- a/lib/mix/tasks/phoenix_kit.update.ex
+++ b/lib/mix/tasks/phoenix_kit.update.ex
@@ -416,6 +416,15 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
             {:not_installed} ->
               add_not_installed_notice(igniter, prefix)
 
+            {:unreachable, reason} ->
+              Igniter.add_warning(igniter, """
+              ❌ Cannot reach the database to determine the installed PhoenixKit
+              version (#{inspect(reason)}).
+
+              Not generating an update migration — fix the database connection
+              and re-run mix phoenix_kit.update.
+              """)
+
             {:current_version, current_version} ->
               target_version = Common.current_version()
 

--- a/lib/mix/tasks/phoenix_kit.update.ex
+++ b/lib/mix/tasks/phoenix_kit.update.ex
@@ -367,8 +367,10 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
       prefix = PrefixConfig.resolve_prefix(opts)
       force = opts[:force] || false
 
-      # Backfill the config entry for installs made before the installer
-      # started persisting --prefix (no-op when already configured).
+      # When --prefix is passed explicitly, persist it into config (covers
+      # installs made before the installer started writing it; no-op when
+      # already configured). Without the flag there is nothing to backfill
+      # from — config either already has it or the install is public.
       igniter = PrefixConfig.add_prefix_configuration(igniter, opts[:prefix])
 
       # Validate and fix Ueberauth configuration before update
@@ -664,11 +666,11 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
              You may need to add uuid columns manually before running migrations.
 
              Manual fix (run in psql or your database client):
-               ALTER TABLE phoenix_kit_settings
-               ADD COLUMN IF NOT EXISTS uuid UUID DEFAULT uuid_generate_v7();
+               ALTER TABLE #{prefix}.phoenix_kit_settings
+               ADD COLUMN IF NOT EXISTS uuid UUID DEFAULT #{prefix}.uuid_generate_v7();
 
-               ALTER TABLE phoenix_kit_email_templates
-               ADD COLUMN IF NOT EXISTS uuid UUID DEFAULT uuid_generate_v7();
+               ALTER TABLE #{prefix}.phoenix_kit_email_templates
+               ADD COLUMN IF NOT EXISTS uuid UUID DEFAULT #{prefix}.uuid_generate_v7();
           """)
       end
     rescue
@@ -1617,7 +1619,6 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
         igniter
         |> ObanConfig.add_oban_configuration(prefix)
         |> maybe_add_oban_config_notice(config_exists)
-        |> warn_if_oban_config_missing_prefix(config_exists, prefix)
 
       # Check and add supervisor separately
       if supervisor_exists do
@@ -1628,33 +1629,6 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
         |> add_oban_supervisor_added_notice()
       end
     end
-
-    # An existing Oban config on a prefixed install must carry prefix: —
-    # V27 put oban_jobs into the named schema, and without the option Oban
-    # looks for public.oban_jobs. add_oban_configuration only writes fresh
-    # config blocks, so warn instead of rewriting the host's existing one.
-    defp warn_if_oban_config_missing_prefix(igniter, true = _config_existed, prefix)
-         when prefix not in [nil, "public"] do
-      content = File.read!("config/config.exs")
-
-      if String.contains?(content, ", Oban") and
-           not Regex.match?(~r/prefix:\s*"#{Regex.escape(prefix)}"/, content) do
-        Igniter.add_warning(igniter, """
-        Your Oban config appears to lack the schema prefix of this install.
-        PhoenixKit's Oban tables live in the "#{prefix}" schema — add:
-
-          config :your_app, Oban,
-            prefix: "#{prefix}",
-            ...
-        """)
-      else
-        igniter
-      end
-    rescue
-      _ -> igniter
-    end
-
-    defp warn_if_oban_config_missing_prefix(igniter, _config_existed, _prefix), do: igniter
 
     # Add appropriate notice based on whether config existed
     defp maybe_add_oban_config_notice(igniter, config_existed) do

--- a/lib/modules/storage/schemas/bucket.ex
+++ b/lib/modules/storage/schemas/bucket.ex
@@ -71,6 +71,7 @@ defmodule PhoenixKit.Modules.Storage.Bucket do
       }
   """
   use Ecto.Schema
+  use PhoenixKit.SchemaPrefix
   import Ecto.Changeset
 
   @primary_key {:uuid, UUIDv7, autogenerate: true}

--- a/lib/modules/storage/schemas/dimension.ex
+++ b/lib/modules/storage/schemas/dimension.ex
@@ -70,6 +70,7 @@ defmodule PhoenixKit.Modules.Storage.Dimension do
       }
   """
   use Ecto.Schema
+  use PhoenixKit.SchemaPrefix
   import Ecto.Changeset
 
   @primary_key {:uuid, UUIDv7, autogenerate: true}

--- a/lib/modules/storage/schemas/file.ex
+++ b/lib/modules/storage/schemas/file.ex
@@ -87,6 +87,7 @@ defmodule PhoenixKit.Modules.Storage.File do
       }
   """
   use Ecto.Schema
+  use PhoenixKit.SchemaPrefix
   import Ecto.Changeset
 
   @primary_key {:uuid, UUIDv7, autogenerate: true}

--- a/lib/modules/storage/schemas/file_instance.ex
+++ b/lib/modules/storage/schemas/file_instance.ex
@@ -78,6 +78,7 @@ defmodule PhoenixKit.Modules.Storage.FileInstance do
       }
   """
   use Ecto.Schema
+  use PhoenixKit.SchemaPrefix
   import Ecto.Changeset
 
   @primary_key {:uuid, UUIDv7, autogenerate: true}

--- a/lib/modules/storage/schemas/file_location.ex
+++ b/lib/modules/storage/schemas/file_location.ex
@@ -65,6 +65,7 @@ defmodule PhoenixKit.Modules.Storage.FileLocation do
       }
   """
   use Ecto.Schema
+  use PhoenixKit.SchemaPrefix
   import Ecto.Changeset
 
   @primary_key {:uuid, UUIDv7, autogenerate: true}

--- a/lib/modules/storage/schemas/folder.ex
+++ b/lib/modules/storage/schemas/folder.ex
@@ -7,6 +7,7 @@ defmodule PhoenixKit.Modules.Storage.Folder do
   """
 
   use Ecto.Schema
+  use PhoenixKit.SchemaPrefix
   import Ecto.Changeset
 
   @primary_key {:uuid, UUIDv7, autogenerate: true}

--- a/lib/modules/storage/schemas/folder_link.ex
+++ b/lib/modules/storage/schemas/folder_link.ex
@@ -8,6 +8,7 @@ defmodule PhoenixKit.Modules.Storage.FolderLink do
   """
 
   use Ecto.Schema
+  use PhoenixKit.SchemaPrefix
   import Ecto.Changeset
 
   @primary_key {:uuid, UUIDv7, autogenerate: true}

--- a/lib/phoenix_kit/activity/entry.ex
+++ b/lib/phoenix_kit/activity/entry.ex
@@ -15,6 +15,7 @@ defmodule PhoenixKit.Activity.Entry do
   - `metadata` — Flexible JSONB context (title, old_value, new_value, etc.)
   """
   use Ecto.Schema
+  use PhoenixKit.SchemaPrefix
   import Ecto.Changeset
 
   @primary_key {:uuid, UUIDv7, autogenerate: true}

--- a/lib/phoenix_kit/annotations/annotation.ex
+++ b/lib/phoenix_kit/annotations/annotation.ex
@@ -18,6 +18,7 @@ defmodule PhoenixKit.Annotations.Annotation do
   side, and a thread is created lazily when the first comment is posted.
   """
   use Ecto.Schema
+  use PhoenixKit.SchemaPrefix
   import Ecto.Changeset
 
   @primary_key {:uuid, UUIDv7, autogenerate: true}

--- a/lib/phoenix_kit/audit_log/entry.ex
+++ b/lib/phoenix_kit/audit_log/entry.ex
@@ -16,6 +16,7 @@ defmodule PhoenixKit.AuditLog.Entry do
   """
 
   use Ecto.Schema
+  use PhoenixKit.SchemaPrefix
   import Ecto.Changeset
 
   @type t :: %__MODULE__{

--- a/lib/phoenix_kit/install/common.ex
+++ b/lib/phoenix_kit/install/common.ex
@@ -12,6 +12,7 @@ defmodule PhoenixKit.Install.Common do
 
   alias PhoenixKit.Config
   alias PhoenixKit.Migrations.Postgres
+  alias PhoenixKit.Migrations.Postgres.Helpers
 
   @doc """
   Ensures every atom in `compiler_names` is present in the host's `mix.exs`
@@ -152,6 +153,10 @@ defmodule PhoenixKit.Install.Common do
       {:not_installed}
   """
   def check_installation_status(prefix \\ "public") do
+    # Fail fast on an invalid prefix — it is interpolated into SQL in the
+    # fallback paths below, and the migration chain would reject it anyway.
+    Helpers.validate_prefix!(prefix)
+
     # Use the same version detection logic as the migration system
     opts = %{
       prefix: prefix,
@@ -216,9 +221,9 @@ defmodule PhoenixKit.Install.Common do
   defp query_version_directly(repo, escaped_prefix) do
     # Check if phoenix_kit table exists first
     table_check =
-      "SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = 'phoenix_kit' AND table_schema = '#{escaped_prefix}')"
+      "SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = 'phoenix_kit' AND table_schema = $1)"
 
-    case repo.query(table_check, [], log: false) do
+    case repo.query(table_check, [escaped_prefix], log: false) do
       {:ok, %{rows: [[true]]}} ->
         # Table exists, get version comment
         version_query = """
@@ -226,10 +231,10 @@ defmodule PhoenixKit.Install.Common do
         FROM pg_class
         LEFT JOIN pg_namespace ON pg_namespace.oid = pg_class.relnamespace
         WHERE pg_class.relname = 'phoenix_kit'
-        AND pg_namespace.nspname = '#{escaped_prefix}'
+        AND pg_namespace.nspname = $1
         """
 
-        case repo.query(version_query, [], log: false) do
+        case repo.query(version_query, [escaped_prefix], log: false) do
           {:ok, %{rows: [[version]]}} when is_binary(version) ->
             String.to_integer(version)
 
@@ -324,6 +329,7 @@ defmodule PhoenixKit.Install.Common do
     opts = %{prefix: prefix, escaped_prefix: String.replace(prefix, "'", "\\'")}
     Postgres.migrated_version_runtime(opts)
   rescue
+    e in ArgumentError -> reraise(e, __STACKTRACE__)
     _ -> 0
   end
 

--- a/lib/phoenix_kit/install/common.ex
+++ b/lib/phoenix_kit/install/common.ex
@@ -179,21 +179,21 @@ defmodule PhoenixKit.Install.Common do
   end
 
   # Alternative version detection when primary method fails
-  defp check_alternative_version_detection(prefix, opts) do
-    # Strategy 1: Try direct database query (like status command does)
+  #
+  # Migration FILES existing in the project say nothing about what is
+  # installed in the DATABASE at this prefix. This used to fall back to a
+  # fabricated {:current_version, 1} whenever migration files were present,
+  # which made `mix phoenix_kit.update` generate a from-scratch v01→vN
+  # migration into the wrong schema when the prefix was misresolved (e.g.
+  # installed under a custom prefix but checked at "public"). Report
+  # honestly instead.
+  defp check_alternative_version_detection(_prefix, opts) do
     case try_direct_database_version_check(opts) do
-      version when version > 0 ->
+      version when is_integer(version) and version > 0 ->
         {:current_version, version}
 
       _ ->
-        # Strategy 2: Check if tables exist and try to infer version
-        case check_installation_from_tables(prefix) do
-          {:current_version, version} ->
-            {:current_version, version}
-
-          {:not_installed} ->
-            {:not_installed}
-        end
+        {:not_installed}
     end
   end
 
@@ -243,19 +243,6 @@ defmodule PhoenixKit.Install.Common do
     end
   rescue
     _ -> 0
-  end
-
-  # Check installation based on table presence and schema analysis
-  defp check_installation_from_tables(_prefix) do
-    case find_existing_phoenix_kit_migrations() do
-      [] ->
-        {:not_installed}
-
-      _migrations ->
-        # Migration files exist - try to determine actual version from database
-        # This is a last resort, assume recent version if tables are expected to exist
-        {:current_version, 1}
-    end
   end
 
   @doc """

--- a/lib/phoenix_kit/install/common.ex
+++ b/lib/phoenix_kit/install/common.ex
@@ -138,8 +138,10 @@ defmodule PhoenixKit.Install.Common do
   Checks the current installation status for a given prefix.
 
   Returns one of:
-  - `{:not_installed}` - PhoenixKit is not installed
+  - `{:not_installed}` - the database is reachable and has no PhoenixKit install at the prefix
   - `{:current_version, version}` - PhoenixKit is installed with given version
+  - `{:unreachable, reason}` - the database cannot be queried, so the install
+    state is UNKNOWN — callers must not treat this as "not installed"
 
   ## Parameters
   - `prefix` - Database schema prefix (default: "public")
@@ -198,8 +200,29 @@ defmodule PhoenixKit.Install.Common do
         {:current_version, version}
 
       _ ->
-        {:not_installed}
+        # "No version found" is only "not installed" when we can actually
+        # reach the database — a down DB must not masquerade as an absent
+        # install (the update task drives migration generation off this).
+        case database_reachable?() do
+          :ok -> {:not_installed}
+          {:error, reason} -> {:unreachable, reason}
+        end
     end
+  end
+
+  defp database_reachable? do
+    case Config.get(:repo, nil) do
+      nil ->
+        {:error, :no_repo_configured}
+
+      repo ->
+        case repo.query("SELECT 1", [], log: false) do
+          {:ok, _} -> :ok
+          {:error, reason} -> {:error, reason}
+        end
+    end
+  rescue
+    error -> {:error, error}
   end
 
   # Try direct database connection (similar to what status command does)
@@ -344,11 +367,15 @@ defmodule PhoenixKit.Install.Common do
   - `{:up_to_date, current_version}` - Already up to date
   - `{:update_needed, current_version, target_version}` - Update available
   - `{:not_installed}` - PhoenixKit not installed
+  - `{:unreachable, reason}` - database cannot be queried (state unknown)
   """
   def check_update_needed(prefix \\ "public", force \\ false) do
     case check_installation_status(prefix) do
       {:not_installed} ->
         {:not_installed}
+
+      {:unreachable, reason} ->
+        {:unreachable, reason}
 
       {:current_version, current_version} ->
         target_version = current_version()

--- a/lib/phoenix_kit/install/daisyui.ex
+++ b/lib/phoenix_kit/install/daisyui.ex
@@ -1,0 +1,101 @@
+defmodule PhoenixKit.Install.DaisyUI do
+  @moduledoc """
+  Advisory check of the host's vendored daisyUI version.
+
+  PhoenixKit's UI is styled by daisyUI, which lives in the HOST app
+  (`assets/vendor/daisyui.js` + `daisyui-theme.js`, scaffolded by
+  `mix phx.new` and loaded from the host's `app.css`). The host owns that
+  file — PhoenixKit does not manage or replace it; it only **checks** it.
+  `mix phoenix_kit.install`, `mix phoenix_kit.update`, and
+  `mix phoenix_kit.doctor` warn when the vendored copy is older than
+  `minimum_version/0`, with upgrade instructions.
+
+  Why the minimum matters: daisyUI < 5.1 reserves the modal scrollbar gutter
+  UNCONDITIONALLY while a modal/drawer is open, which either leaves a phantom
+  right-edge strip on non-scrolling pages or (when countered) makes content
+  reflow ~15px around every modal open/close on scrolling pages. daisyUI
+  ≥ 5.1 reserves the gutter only when the page really has a scrollbar
+  (`rootscrollgutter.css`), so PhoenixKit ships **no** scrollbar-gutter
+  compensations of its own (removed 2026-07-12) and relies on a modern
+  daisyUI instead. Hosts on an old copy see daisyUI's stock old behavior
+  until they upgrade — that's what the warning is for.
+  """
+
+  # The oldest daisyUI whose modal scrollbar-gutter handling PhoenixKit's
+  # modals rely on. The upstream fix matured across 5.1.0 → 5.6.x; PhoenixKit
+  # is verified against 5.6.17, and 5.6.0 is the floor we recommend.
+  @minimum_version "5.6.0"
+
+  @doc "The minimum daisyUI version PhoenixKit's UI is designed against."
+  @spec minimum_version() :: String.t()
+  def minimum_version, do: @minimum_version
+
+  @doc "The host-side path of the vendored daisyUI plugin."
+  @spec host_path() :: Path.t()
+  def host_path, do: Path.join([File.cwd!(), "assets", "vendor", "daisyui.js"])
+
+  @doc """
+  Parse the daisyUI version out of a plugin bundle, or `nil` when the file is
+  missing or carries no `version = "x.y.z"` marker.
+  """
+  @spec installed_version(Path.t()) :: String.t() | nil
+  def installed_version(path) do
+    with {:ok, content} <- File.read(path),
+         [_, version] <- Regex.run(~r/version = "([\d.]+)"/, content) do
+      version
+    else
+      _ -> nil
+    end
+  end
+
+  @doc """
+  Check the host's vendored daisyUI against `minimum_version/0`.
+
+  - `:ok` — present and at/above the minimum
+  - `{:outdated, version}` — present but older than the minimum
+  - `:unversioned` — present but carries no parseable version marker
+  - `:missing` — no `assets/vendor/daisyui.js` (npm or custom setup)
+  """
+  @spec check() :: :ok | {:outdated, String.t()} | :unversioned | :missing
+  def check do
+    path = host_path()
+
+    cond do
+      not File.exists?(path) ->
+        :missing
+
+      version = installed_version(path) ->
+        if outdated?(version), do: {:outdated, version}, else: :ok
+
+      true ->
+        :unversioned
+    end
+  end
+
+  @doc "Whether a daisyUI version string is below `minimum_version/0`."
+  @spec outdated?(String.t()) :: boolean()
+  def outdated?(version) when is_binary(version) do
+    case {Version.parse(version), Version.parse(@minimum_version)} do
+      {{:ok, installed}, {:ok, minimum}} -> Version.compare(installed, minimum) == :lt
+      # Unparseable → don't claim it's outdated; check/0 reports :unversioned.
+      _ -> false
+    end
+  end
+
+  @doc "Human warning for an outdated vendored daisyUI, with upgrade steps."
+  @spec outdated_warning(String.t()) :: String.t()
+  def outdated_warning(version) do
+    """
+    ⚠️  Your vendored daisyUI is #{version}; PhoenixKit is designed against #{@minimum_version}+.
+    On daisyUI < 5.1, opening any modal/drawer mishandles the scrollbar gutter
+    (a phantom right-edge strip, or content shifting ~15px on scrolling pages).
+    Update the two files in assets/vendor/ and rebuild assets:
+
+        cd assets/vendor
+        curl -sLO https://github.com/saadeghi/daisyui/releases/latest/download/daisyui.js
+        curl -sLO https://github.com/saadeghi/daisyui/releases/latest/download/daisyui-theme.js
+
+    Changelog: https://daisyui.com/docs/changelog/
+    """
+  end
+end

--- a/lib/phoenix_kit/install/migration_strategy.ex
+++ b/lib/phoenix_kit/install/migration_strategy.ex
@@ -12,6 +12,7 @@ defmodule PhoenixKit.Install.MigrationStrategy do
 
   alias Igniter.Project.Application
   alias PhoenixKit.Install.Common
+  alias PhoenixKit.Install.PrefixConfig
   alias PhoenixKit.Migrations.Postgres
   alias PhoenixKit.Utils.Routes
 
@@ -26,7 +27,7 @@ defmodule PhoenixKit.Install.MigrationStrategy do
   Updated igniter with migration files created or appropriate notices.
   """
   def create_phoenix_kit_migration_only(igniter, opts) do
-    prefix = opts[:prefix] || "public"
+    prefix = PrefixConfig.resolve_prefix(opts)
     create_schema = opts[:create_schema] != false && prefix != "public"
 
     # Check if this is a new installation or existing installation
@@ -78,7 +79,7 @@ defmodule PhoenixKit.Install.MigrationStrategy do
   end
 
   # Determine whether this is a new install, upgrade, or already up to date
-  defp determine_migration_strategy(igniter, _prefix) do
+  defp determine_migration_strategy(igniter, prefix) do
     case Application.app_name(igniter) do
       nil ->
         {:error, igniter, "Could not determine app name"}
@@ -92,10 +93,7 @@ defmodule PhoenixKit.Install.MigrationStrategy do
             {:new_install, igniter}
 
           _existing_migrations ->
-            # Check current and target versions using proper DB method
-            # Default prefix for install
-            prefix = "public"
-
+            # Check current and target versions at the install's prefix
             try do
               current_version = Common.migrated_version(prefix)
               target_version = Postgres.current_version()
@@ -122,7 +120,7 @@ defmodule PhoenixKit.Install.MigrationStrategy do
 
   # Determine migration strategy outside of igniter context
   defp determine_migration_strategy_simple(opts) do
-    prefix = opts[:prefix] || "public"
+    prefix = PrefixConfig.resolve_prefix(opts)
     migrations_dir = Path.join(["priv", "repo", "migrations"])
 
     case find_phoenix_kit_migrations(migrations_dir) do
@@ -402,7 +400,7 @@ defmodule PhoenixKit.Install.MigrationStrategy do
 
   # Show upgrade needed notice (simple version)
   defp show_upgrade_needed_notice(opts, current_version, target_version) do
-    prefix = opts[:prefix] || "public"
+    prefix = PrefixConfig.resolve_prefix(opts)
     prefix_option = if prefix != "public", do: " --prefix=#{prefix}", else: ""
 
     IO.puts("""
@@ -419,7 +417,7 @@ defmodule PhoenixKit.Install.MigrationStrategy do
 
   # Show up to date notice (simple version)
   defp show_up_to_date_notice(opts) do
-    prefix = opts[:prefix] || "public"
+    prefix = PrefixConfig.resolve_prefix(opts)
     prefix_option = if prefix != "public", do: " --prefix=#{prefix}", else: ""
 
     IO.puts("""
@@ -460,9 +458,10 @@ defmodule PhoenixKit.Install.MigrationStrategy do
   # public schema doesn't need create_schema
   defp migration_opts("public", true), do: "[]"
 
+  # Always emit create_schema explicitly for non-public prefixes — omitting
+  # it means the migration chain re-defaults the flag to true, silently
+  # discarding --create-schema=false.
   defp migration_opts(prefix, create_schema) when is_binary(prefix) do
-    opts = [prefix: prefix]
-    opts = if create_schema, do: Keyword.put(opts, :create_schema, true), else: opts
-    inspect(opts)
+    inspect(prefix: prefix, create_schema: create_schema)
   end
 end

--- a/lib/phoenix_kit/install/migration_strategy.ex
+++ b/lib/phoenix_kit/install/migration_strategy.ex
@@ -453,15 +453,19 @@ defmodule PhoenixKit.Install.MigrationStrategy do
     _ -> []
   end
 
-  # Generate migration options (same as phoenix_kit.install.ex)
-  defp migration_opts("public", false), do: "[]"
+  # Generate migration options (same as phoenix_kit.install.ex).
+  # Public for testability; @doc false.
+  @doc false
+  def migration_opts("public", false), do: "[]"
   # public schema doesn't need create_schema
-  defp migration_opts("public", true), do: "[]"
+  @doc false
+  def migration_opts("public", true), do: "[]"
 
   # Always emit create_schema explicitly for non-public prefixes — omitting
   # it means the migration chain re-defaults the flag to true, silently
   # discarding --create-schema=false.
-  defp migration_opts(prefix, create_schema) when is_binary(prefix) do
+  @doc false
+  def migration_opts(prefix, create_schema) when is_binary(prefix) do
     inspect(prefix: prefix, create_schema: create_schema)
   end
 end

--- a/lib/phoenix_kit/install/oban_config.ex
+++ b/lib/phoenix_kit/install/oban_config.ex
@@ -41,9 +41,9 @@ defmodule PhoenixKit.Install.ObanConfig do
   ## Returns
   Updated igniter with Oban configuration and notices.
   """
-  def add_oban_configuration(igniter) do
+  def add_oban_configuration(igniter, prefix \\ nil) do
     igniter
-    |> add_oban_config()
+    |> add_oban_config(prefix)
     |> add_oban_configuration_notice()
   end
 
@@ -99,7 +99,7 @@ defmodule PhoenixKit.Install.ObanConfig do
   end
 
   # Add Oban configuration to config.exs
-  defp add_oban_config(igniter) do
+  defp add_oban_config(igniter, prefix) do
     # First, clean up any broken syntax from previous failed updates
     cleanup_oban_config_syntax()
 
@@ -107,12 +107,21 @@ defmodule PhoenixKit.Install.ObanConfig do
     app_name = IgniterHelpers.get_parent_app_name(igniter)
     repo_module = get_repo_module(igniter)
 
+    # Prefixed installs put oban_jobs into the named schema (V27), so Oban
+    # must be pointed at it — without this it looks for public.oban_jobs.
+    prefix_line =
+      if prefix in [nil, "public"] do
+        ""
+      else
+        "\n  prefix: \"#{prefix}\","
+      end
+
     oban_config = """
 
     # Configure Oban for PhoenixKit background jobs
     # Required for file processing (storage system), posts, and sitemap
     config :#{app_name}, Oban,
-      repo: #{repo_module},
+      repo: #{repo_module},#{prefix_line}
       queues: [
         default: 10,           # General purpose queue
         file_processing: 20,   # File variant generation (storage system)

--- a/lib/phoenix_kit/install/oban_config.ex
+++ b/lib/phoenix_kit/install/oban_config.ex
@@ -59,6 +59,7 @@ defmodule PhoenixKit.Install.ObanConfig do
   `System.get_env(...)`. Returns false when the content has no Oban
   block at all (nothing to judge).
   """
+  @spec oban_block_missing_prefix?(String.t()) :: boolean()
   def oban_block_missing_prefix?(content) when is_binary(content) do
     case Regex.scan(
            ~r/config\s+:\w+,\s+Oban\b(.*?)(?=\n(?:config\s|import_config\s)|\z)/s,

--- a/lib/phoenix_kit/install/oban_config.ex
+++ b/lib/phoenix_kit/install/oban_config.ex
@@ -44,7 +44,68 @@ defmodule PhoenixKit.Install.ObanConfig do
   def add_oban_configuration(igniter, prefix \\ nil) do
     igniter
     |> add_oban_config(prefix)
+    |> maybe_warn_missing_oban_prefix(prefix)
     |> add_oban_configuration_notice()
+  end
+
+  @doc """
+  Whether the given config content has a `config :app, Oban` block that
+  lacks a `prefix:` key.
+
+  Scoped to the Oban block on purpose: a whole-file scan is defeated by
+  the `config :phoenix_kit, prefix: "..."` entry (which matches a naive
+  `prefix:` grep) and false-positives on unrelated config. Any `prefix:`
+  inside the block counts — including computed values like
+  `System.get_env(...)`. Returns false when the content has no Oban
+  block at all (nothing to judge).
+  """
+  def oban_block_missing_prefix?(content) when is_binary(content) do
+    case Regex.scan(
+           ~r/config\s+:\w+,\s+Oban\b(.*?)(?=\n(?:config\s|import_config\s)|\z)/s,
+           content
+         ) do
+      [] -> false
+      blocks -> Enum.all?(blocks, fn [_, body] -> not String.contains?(body, "prefix:") end)
+    end
+  end
+
+  # Existing Oban configs on a prefixed install must carry prefix: — the
+  # migrations put oban_jobs into the named schema, and without the option
+  # Oban looks for public.oban_jobs. add_oban_config only injects prefix:
+  # into freshly generated blocks, so warn about pre-existing ones. Reads
+  # from disk (the igniter buffer isn't flushed yet), which is exactly
+  # right: a freshly generated block isn't on disk and produces no
+  # false warning.
+  defp maybe_warn_missing_oban_prefix(igniter, prefix) when prefix in [nil, "public"], do: igniter
+
+  defp maybe_warn_missing_oban_prefix(igniter, prefix) do
+    contents =
+      ["config/config.exs", "config/runtime.exs"]
+      |> Enum.filter(&File.exists?/1)
+      |> Enum.map(&File.read!/1)
+
+    has_block? = fn content -> Regex.match?(~r/config\s+:\w+,\s+Oban\b/, content) end
+    any_block = Enum.any?(contents, has_block?)
+
+    any_block_with_prefix =
+      Enum.any?(contents, fn content ->
+        has_block?.(content) and not oban_block_missing_prefix?(content)
+      end)
+
+    if any_block and not any_block_with_prefix do
+      Igniter.add_warning(igniter, """
+      Your existing Oban config appears to lack this install's schema prefix.
+      PhoenixKit's Oban tables live in the "#{prefix}" schema — add:
+
+        config :your_app, Oban,
+          prefix: "#{prefix}",
+          ...
+      """)
+    else
+      igniter
+    end
+  rescue
+    _ -> igniter
   end
 
   @doc """

--- a/lib/phoenix_kit/install/prefix_config.ex
+++ b/lib/phoenix_kit/install/prefix_config.ex
@@ -26,6 +26,7 @@ defmodule PhoenixKit.Install.PrefixConfig do
   would reject anyway (empty string, uppercase, dashes, injection
   shapes) — failing at the task boundary beats failing mid-migration.
   """
+  @spec resolve_prefix(keyword() | map()) :: String.t()
   def resolve_prefix(opts) do
     prefix = opts[:prefix] || configured_prefix() || "public"
     Helpers.validate_prefix!(prefix)
@@ -44,6 +45,7 @@ defmodule PhoenixKit.Install.PrefixConfig do
   when installing with a non-public prefix. No-op for the default
   `"public"` prefix (or when no prefix option was given).
   """
+  @spec add_prefix_configuration(term(), String.t() | nil) :: term()
   def add_prefix_configuration(igniter, prefix) when prefix in [nil, "public"], do: igniter
 
   def add_prefix_configuration(igniter, prefix) when is_binary(prefix) do

--- a/lib/phoenix_kit/install/prefix_config.ex
+++ b/lib/phoenix_kit/install/prefix_config.ex
@@ -16,15 +16,20 @@ defmodule PhoenixKit.Install.PrefixConfig do
   use PhoenixKit.Install.IgniterCompat
 
   alias Igniter.Project.Config
+  alias PhoenixKit.Migrations.Postgres.Helpers
 
   @doc """
   Resolves the effective schema prefix for phoenix_kit mix tasks.
 
   Order: explicit `--prefix` option → `config :phoenix_kit, :prefix` →
-  `"public"`.
+  `"public"`. Raises `ArgumentError` for a prefix the migration chain
+  would reject anyway (empty string, uppercase, dashes, injection
+  shapes) — failing at the task boundary beats failing mid-migration.
   """
   def resolve_prefix(opts) do
-    opts[:prefix] || configured_prefix() || "public"
+    prefix = opts[:prefix] || configured_prefix() || "public"
+    Helpers.validate_prefix!(prefix)
+    prefix
   end
 
   defp configured_prefix do
@@ -32,8 +37,6 @@ defmodule PhoenixKit.Install.PrefixConfig do
       prefix when is_binary(prefix) and prefix != "" -> prefix
       _ -> nil
     end
-  rescue
-    _ -> nil
   end
 
   @doc """
@@ -44,6 +47,16 @@ defmodule PhoenixKit.Install.PrefixConfig do
   def add_prefix_configuration(igniter, prefix) when prefix in [nil, "public"], do: igniter
 
   def add_prefix_configuration(igniter, prefix) when is_binary(prefix) do
+    # Fail at install time, not at mix ecto.migrate time — the chain
+    # rejects anything outside [a-z_][a-z0-9_]* and we'd otherwise
+    # persist the bad value into config + the generated migration.
+    # Deliberately OUTSIDE persist_prefix_config/2's rescue: a validation
+    # failure must abort, not degrade into the "add it manually" notice.
+    Helpers.validate_prefix!(prefix)
+    persist_prefix_config(igniter, prefix)
+  end
+
+  defp persist_prefix_config(igniter, prefix) do
     igniter
     |> Config.configure_new("config.exs", :phoenix_kit, [:prefix], prefix)
     |> Config.configure_new("test.exs", :phoenix_kit, [:prefix], prefix)

--- a/lib/phoenix_kit/install/prefix_config.ex
+++ b/lib/phoenix_kit/install/prefix_config.ex
@@ -1,0 +1,63 @@
+defmodule PhoenixKit.Install.PrefixConfig do
+  @moduledoc """
+  Persists the `--prefix` install option into the host's config files.
+
+  `mix phoenix_kit.install --prefix "auth"` bakes the prefix into the
+  generated migration, but the migration docs also tell hosts to set
+
+      config :phoenix_kit, prefix: "auth"
+
+  Without that config entry, later tooling (`mix phoenix_kit.update`,
+  `mix phoenix_kit.status`) defaults to `"public"`, reports the install
+  as missing, and — worst case — generates a from-scratch migration
+  into the wrong schema. This module writes the config entry whenever
+  a non-public prefix is used, mirroring how the repo config is added.
+  """
+  use PhoenixKit.Install.IgniterCompat
+
+  alias Igniter.Project.Config
+
+  @doc """
+  Resolves the effective schema prefix for phoenix_kit mix tasks.
+
+  Order: explicit `--prefix` option → `config :phoenix_kit, :prefix` →
+  `"public"`.
+  """
+  def resolve_prefix(opts) do
+    opts[:prefix] || configured_prefix() || "public"
+  end
+
+  defp configured_prefix do
+    case Elixir.Application.get_env(:phoenix_kit, :prefix) do
+      prefix when is_binary(prefix) and prefix != "" -> prefix
+      _ -> nil
+    end
+  rescue
+    _ -> nil
+  end
+
+  @doc """
+  Adds `config :phoenix_kit, prefix: prefix` to config.exs and test.exs
+  when installing with a non-public prefix. No-op for the default
+  `"public"` prefix (or when no prefix option was given).
+  """
+  def add_prefix_configuration(igniter, prefix) when prefix in [nil, "public"], do: igniter
+
+  def add_prefix_configuration(igniter, prefix) when is_binary(prefix) do
+    igniter
+    |> Config.configure_new("config.exs", :phoenix_kit, [:prefix], prefix)
+    |> Config.configure_new("test.exs", :phoenix_kit, [:prefix], prefix)
+  rescue
+    _ ->
+      Igniter.add_notice(igniter, """
+      ⚠️  Could not persist the schema prefix automatically.
+
+      Please add this to config/config.exs (and config/test.exs):
+
+        config :phoenix_kit, prefix: #{inspect(prefix)}
+
+      Without it, mix phoenix_kit.update / status will look for the
+      installation in the "public" schema.
+      """)
+  end
+end

--- a/lib/phoenix_kit/install/repo_detection.ex
+++ b/lib/phoenix_kit/install/repo_detection.ex
@@ -52,6 +52,10 @@ defmodule PhoenixKit.Install.RepoDetection do
     with {igniter, nil} <- try_igniter_ecto_list(igniter),
          {igniter, nil} <- try_application_config(igniter) do
       try_naming_patterns(igniter)
+    else
+      # {igniter, repo} (found) or {:multiple, igniter, repos} — both
+      # short-circuit the detection chain and are handled by the caller.
+      result -> result
     end
   end
 

--- a/lib/phoenix_kit/install/repo_detection.ex
+++ b/lib/phoenix_kit/install/repo_detection.ex
@@ -30,15 +30,23 @@ defmodule PhoenixKit.Install.RepoDetection do
         warning = create_repo_not_found_warning()
         Igniter.add_warning(igniter, warning)
 
+      {:multiple, igniter, repos} ->
+        warning = create_multiple_repos_warning(repos)
+        Igniter.add_warning(igniter, warning)
+
       {igniter, repo_module} ->
         {updated_igniter, _} = validate_postgresql_adapter(igniter, repo_module)
         add_repo_config_to_files(updated_igniter, repo_module)
     end
   end
 
-  # Find specified repo or auto-detect from project
+  # Find specified repo or auto-detect from project.
+  #
+  # When more than one Ecto.Repo is detected, we deliberately do NOT
+  # pick one — a project may define migration-only or replica repos,
+  # and silently wiring the wrong one into `config :phoenix_kit, repo:`
+  # is far worse than asking for an explicit --repo.
   defp find_or_detect_repo(igniter, nil) do
-    # Try multiple methods to find repos
     with {igniter, nil} <- try_igniter_ecto_list(igniter),
          {igniter, nil} <- try_application_config(igniter) do
       try_naming_patterns(igniter)
@@ -61,7 +69,8 @@ defmodule PhoenixKit.Install.RepoDetection do
   # Method 1: Use Igniter's Ecto lib
   defp try_igniter_ecto_list(igniter) do
     case Ecto.list_repos(igniter) do
-      {igniter, [repo | _]} -> validate_postgres_adapter(igniter, repo)
+      {igniter, [repo]} -> validate_postgres_adapter(igniter, repo)
+      {igniter, [_ | _] = repos} -> {:multiple, igniter, repos}
       {igniter, []} -> {igniter, nil}
     end
   end
@@ -71,7 +80,8 @@ defmodule PhoenixKit.Install.RepoDetection do
     parent_app_name = IgniterHelpers.get_parent_app_name(igniter)
 
     case Elixir.Application.get_env(parent_app_name, :ecto_repos, []) do
-      [repo | _] -> validate_postgres_adapter(igniter, repo)
+      [repo] -> validate_postgres_adapter(igniter, repo)
+      [_ | _] = repos -> {:multiple, igniter, repos}
       [] -> {igniter, nil}
     end
   rescue
@@ -272,6 +282,23 @@ defmodule PhoenixKit.Install.RepoDetection do
     """
 
     Igniter.add_notice(igniter, notice)
+  end
+
+  # Create warning message when more than one repository is detected
+  defp create_multiple_repos_warning(repos) do
+    """
+    Multiple Ecto repos detected — PhoenixKit will not pick one automatically:
+
+    #{Enum.map_join(repos, "\n", fn repo -> "  - #{inspect(repo)}" end)}
+
+    Re-run with the repo your application uses at runtime:
+
+      mix phoenix_kit.install --repo #{inspect(List.first(repos))}
+
+    Or manually add to config/config.exs (and config/test.exs):
+
+      config :phoenix_kit, repo: YourApp.Repo
+    """
   end
 
   # Create warning message when repository cannot be found

--- a/lib/phoenix_kit/install/repo_detection.ex
+++ b/lib/phoenix_kit/install/repo_detection.ex
@@ -31,8 +31,10 @@ defmodule PhoenixKit.Install.RepoDetection do
         Igniter.add_warning(igniter, warning)
 
       {:multiple, igniter, repos} ->
-        warning = create_multiple_repos_warning(repos)
-        Igniter.add_warning(igniter, warning)
+        # A hard issue, not a warning: without a repo choice the rest of
+        # the install pipeline (Oban config, migration strategy) would
+        # proceed on guesses and fail incoherently downstream.
+        Igniter.add_issue(igniter, create_multiple_repos_warning(repos))
 
       {igniter, repo_module} ->
         {updated_igniter, _} = validate_postgresql_adapter(igniter, repo_module)

--- a/lib/phoenix_kit/migration.ex
+++ b/lib/phoenix_kit/migration.ex
@@ -101,6 +101,25 @@ defmodule PhoenixKit.Migration do
   end
   ```
 
+  The prefix must be a conventional lower-case identifier (`[a-z_][a-z0-9_]*`) —
+  it is interpolated into SQL, and anything else is rejected at the `up`/`down`
+  entry points.
+
+  ## Required Postgres extensions
+
+  The migration chain needs three extensions: `citext` (case-insensitive
+  emails), `pgcrypto` (UUIDv7 generation), and `pg_trgm` (trigram search).
+  When they are already installed the chain never issues `CREATE EXTENSION`
+  (so no database-level CREATE privilege is needed). When one is missing, the
+  migrating role must be allowed to create it — on locked-down databases have
+  a DBA pre-provision them instead:
+
+  ```sql
+  CREATE EXTENSION IF NOT EXISTS citext;
+  CREATE EXTENSION IF NOT EXISTS pgcrypto;
+  CREATE EXTENSION IF NOT EXISTS pg_trgm;
+  ```
+
   ## Migrating Without Ecto
 
   If your application uses something other than Ecto for migrations, be it an external system or

--- a/lib/phoenix_kit/migration.ex
+++ b/lib/phoenix_kit/migration.ex
@@ -94,7 +94,11 @@ defmodule PhoenixKit.Migration do
       writes hit `auth.phoenix_kit_*` directly — no `search_path` setup on
       the database role is needed for core. This is compile-time
       configuration: set it in `config/config.exs` (not `runtime.exs`);
-      changing it recompiles the phoenix_kit dependency.
+      changing it recompiles the phoenix_kit dependency on the next
+      `mix compile`. A build compiled before the config change refuses
+      to boot with a clear compile-env mismatch error (it never silently
+      queries `public`) — any `mix phx.server`, `ecto.migrate`, or
+      release build after the install triggers the recompile.
 
       Caveat: PhoenixKit *feature modules* (`phoenix_kit_catalogue`,
       `phoenix_kit_projects`, …) define their own Ecto schemas, which

--- a/lib/phoenix_kit/migration.ex
+++ b/lib/phoenix_kit/migration.ex
@@ -86,6 +86,41 @@ defmodule PhoenixKit.Migration do
     ...
   ```
 
+  That config entry is written automatically by
+  `mix phoenix_kit.install --prefix "auth"` and does two things:
+
+    * **Runtime queries target the schema.** Every PhoenixKit Ecto schema
+      compiles the prefix in (via `PhoenixKit.SchemaPrefix`), so reads and
+      writes hit `auth.phoenix_kit_*` directly — no `search_path` setup on
+      the database role is needed for core. This is compile-time
+      configuration: set it in `config/config.exs` (not `runtime.exs`);
+      changing it recompiles the phoenix_kit dependency.
+
+      Caveat: PhoenixKit *feature modules* (`phoenix_kit_catalogue`,
+      `phoenix_kit_projects`, …) define their own Ecto schemas, which
+      only honor the prefix once that module also adopts
+      `PhoenixKit.SchemaPrefix`. Until the modules you use have it, a
+      prefixed install running feature modules still needs the schema on
+      the role's `search_path`:
+
+      ```sql
+      ALTER ROLE my_app_role SET search_path = auth, public;
+      ```
+    * **Tooling finds the install.** `mix phoenix_kit.update` / `status` /
+      `gen.migration` resolve the prefix from config when `--prefix`
+      isn't passed.
+
+  Oban needs the prefix too — its tables are created inside the same
+  schema, so the host's Oban config must carry it (the installer adds
+  this for new prefixed installs):
+
+  ```elixir
+  config :my_app, Oban,
+    prefix: "auth",
+    repo: MyApp.Repo,
+    ...
+  ```
+
   In some cases, for example if your "auth" schema already exists and your database user in
   production doesn't have permissions to create a new schema, trying to create the schema from the
   migration will result in an error. In such situations, it may be useful to inhibit the creation

--- a/lib/phoenix_kit/migration.ex
+++ b/lib/phoenix_kit/migration.ex
@@ -140,6 +140,13 @@ defmodule PhoenixKit.Migration do
   it is interpolated into SQL, and anything else is rejected at the `up`/`down`
   entry points.
 
+  One requirement for *upgrading* an existing prefixed install: the migrating
+  role needs `CREATE` on the install's schema, because newer versions ensure a
+  schema-local `uuid_generate_v7()` there (older releases created it wherever
+  `search_path` pointed, typically `public`). If the schema is DBA-owned and
+  the role only has `USAGE`, have the DBA grant `CREATE` for the migration or
+  pre-create the function in the schema.
+
   ## Required Postgres extensions
 
   The migration chain needs three extensions: `citext` (case-insensitive

--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -1455,6 +1455,10 @@ defmodule PhoenixKit.Migrations.Postgres do
   """
   def heal_version_comment(reported_version, opts) do
     escaped_prefix = Map.get(opts, :escaped_prefix, opts[:prefix] || "public")
+    # Local guard (defense in depth) — current callers pre-validate, but
+    # this function interpolates the prefix into DDL and must not rely
+    # on every future caller doing so.
+    Helpers.validate_prefix!(escaped_prefix)
     prefix_str = if escaped_prefix != "public", do: "#{escaped_prefix}.", else: ""
 
     case get_repo_with_fallback() do

--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -1232,9 +1232,17 @@ defmodule PhoenixKit.Migrations.Postgres do
 
   use Ecto.Migration
 
+  alias PhoenixKit.Migrations.Postgres.Helpers
+
   @initial_version 1
   @current_version 142
   @default_prefix "public"
+
+  # First version whose SQL references uuid_generate_v7(). Chains that
+  # start at or above it never hit the V40/V56/V61/V63 creation sites,
+  # so the entry point has to guarantee the function exists in the
+  # install's schema before any newer version's DDL calls it.
+  @uuid_fn_version 40
 
   @doc false
   def initial_version, do: @initial_version
@@ -1252,6 +1260,7 @@ defmodule PhoenixKit.Migrations.Postgres do
         change(@initial_version..opts.version, :up, opts)
 
       initial < opts.version ->
+        if initial >= @uuid_fn_version, do: Helpers.ensure_uuid_v7_function(opts.prefix)
         change((initial + 1)..opts.version, :up, opts)
 
       true ->
@@ -1263,6 +1272,8 @@ defmodule PhoenixKit.Migrations.Postgres do
   def down(opts) do
     # For down operations, don't set a default version - let target_version logic handle it
     opts = Enum.into(opts, %{prefix: @default_prefix})
+
+    Helpers.validate_prefix!(opts.prefix)
 
     opts =
       opts
@@ -1596,6 +1607,8 @@ defmodule PhoenixKit.Migrations.Postgres do
 
   defp with_defaults(opts, version) do
     opts = Enum.into(opts, %{prefix: @default_prefix, version: version})
+
+    Helpers.validate_prefix!(opts.prefix)
 
     opts
     |> Map.put(:quoted_prefix, inspect(opts.prefix))

--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -1347,6 +1347,13 @@ defmodule PhoenixKit.Migrations.Postgres do
     # Add retry logic for better reliability
     retry_version_detection(opts, escaped_prefix, 3)
   rescue
+    # An invalid prefix must surface as the validation error, not be
+    # swallowed into 0 ("not installed") — that misleads the operator AND
+    # lets the unvalidated string reach interpolated SQL in callers'
+    # fallback paths.
+    e in ArgumentError ->
+      reraise e, __STACKTRACE__
+
     _ ->
       0
   end

--- a/lib/phoenix_kit/migrations/postgres/helpers.ex
+++ b/lib/phoenix_kit/migrations/postgres/helpers.ex
@@ -1,0 +1,229 @@
+defmodule PhoenixKit.Migrations.Postgres.Helpers do
+  @moduledoc """
+  Shared SQL helpers for the versioned Postgres migration chain.
+
+  Centralizes the prefix-sensitive patterns that individual version
+  modules used to hand-roll (and get subtly wrong in independent ways):
+
+    * `qualify_table/2` — schema-qualified table reference for raw SQL.
+      Index **names** must stay bare on `CREATE INDEX` (Postgres rejects
+      `CREATE INDEX schema.name`); only `DROP INDEX schema.name` accepts
+      a qualified name.
+    * `validate_prefix!/1` — rejects prefixes that can't be interpolated
+      into SQL safely. Called at the `up/down` entry points.
+    * `ensure_extension!/1` — privilege-aware replacement for a bare
+      `CREATE EXTENSION IF NOT EXISTS`. Postgres checks the CREATE
+      privilege *before* the IF-NOT-EXISTS short-circuit, so the bare
+      statement fails for low-privilege roles even when the extension is
+      already installed. This helper checks `pg_extension` first and
+      only attempts creation when the extension is genuinely missing.
+    * `ensure_uuid_v7_function/1` — creates `uuid_generate_v7()` inside
+      the install's schema (never wherever `search_path` happens to
+      point, which pollutes `public` and fails outright on PG15+ where
+      `public` isn't world-writable).
+
+  Functions without a `repo` argument run in `Ecto.Migration` context
+  (immediate existence checks via `repo().query/3`, DDL queued via
+  `execute/1`). The `repo`-taking variants are for runtime callers such
+  as `PhoenixKit.Migrations.UUIDRepair`.
+  """
+
+  @prefix_format ~r/^[a-z_][a-z0-9_]*$/
+
+  @required_extensions %{
+    "citext" => "case-insensitive email storage (V01)",
+    "pgcrypto" => "UUIDv7 generation via gen_random_bytes (V26/V40)",
+    "pg_trgm" => "trigram search on PDF page content (V111)"
+  }
+
+  @uuid_v7_function_body """
+  RETURNS uuid AS $$
+  DECLARE
+    unix_ts_ms bytea;
+    uuid_bytes bytea;
+  BEGIN
+    -- Get current timestamp in milliseconds
+    unix_ts_ms := substring(int8send(floor(extract(epoch FROM clock_timestamp()) * 1000)::bigint) FROM 3);
+
+    -- Build UUIDv7: 6 bytes timestamp + 2 bytes random (with version) + 8 bytes random (with variant)
+    uuid_bytes := unix_ts_ms || gen_random_bytes(10);
+
+    -- Set version 7 (0111xxxx in byte 7)
+    uuid_bytes := set_byte(uuid_bytes, 6, (get_byte(uuid_bytes, 6) & 15) | 112);
+
+    -- Set variant (10xxxxxx in byte 9)
+    uuid_bytes := set_byte(uuid_bytes, 8, (get_byte(uuid_bytes, 8) & 63) | 128);
+
+    RETURN encode(uuid_bytes, 'hex')::uuid;
+  END
+  $$ LANGUAGE plpgsql VOLATILE;
+  """
+
+  @doc """
+  Schema-qualified table reference for raw SQL interpolation.
+
+  `nil` and `"public"` both qualify explicitly as `public.` — an
+  explicit schema never depends on the connection's `search_path`.
+  """
+  @spec qualify_table(String.t() | atom(), String.t() | nil) :: String.t()
+  def qualify_table(table, nil), do: "public.#{table}"
+  def qualify_table(table, prefix), do: "#{prefix}.#{table}"
+
+  @doc """
+  Schema-qualified `uuid_generate_v7()` call for SQL interpolation.
+  """
+  @spec uuid_v7_call(String.t() | nil) :: String.t()
+  def uuid_v7_call(prefix), do: "#{schema(prefix)}.uuid_generate_v7()"
+
+  @doc """
+  Validates a schema prefix before it is interpolated into SQL.
+
+  The migration chain interpolates the prefix into hundreds of
+  statements, mostly unquoted, so only conventional lower-case
+  identifiers are supported: `#{inspect(@prefix_format.source)}`.
+  Raises `ArgumentError` for anything else (including uppercase or
+  dashed names, which only ever half-worked).
+  """
+  @spec validate_prefix!(term()) :: :ok
+  def validate_prefix!(prefix) when is_binary(prefix) do
+    if Regex.match?(@prefix_format, prefix) do
+      :ok
+    else
+      raise ArgumentError, """
+      invalid PhoenixKit schema prefix: #{inspect(prefix)}
+
+      The prefix is interpolated into SQL identifiers, so it must match
+      #{inspect(@prefix_format.source)} (lower-case letters, digits and
+      underscores, not starting with a digit) — e.g. "auth" or "my_app".
+      """
+    end
+  end
+
+  def validate_prefix!(prefix) do
+    raise ArgumentError,
+          "invalid PhoenixKit schema prefix: expected a string, got #{inspect(prefix)}"
+  end
+
+  @doc """
+  Ensures a Postgres extension is available, in migration context.
+
+  * already installed → no-op (skips the `CREATE EXTENSION` privilege
+    check entirely, so pre-provisioned low-privilege setups pass)
+  * missing + role can create → queues `CREATE EXTENSION IF NOT EXISTS`
+  * missing + role cannot create → raises an operator-facing error
+    listing the extensions to pre-create as a privileged role
+  """
+  @spec ensure_extension!(String.t()) :: :ok
+  def ensure_extension!(name) do
+    do_ensure_extension!(Ecto.Migration.repo(), name, &Ecto.Migration.execute/1)
+  end
+
+  @doc """
+  Runtime variant of `ensure_extension!/1` for callers outside migration
+  context (statements run immediately on `repo`).
+  """
+  @spec ensure_extension!(Ecto.Repo.t(), String.t()) :: :ok
+  def ensure_extension!(repo, name) do
+    do_ensure_extension!(repo, name, fn sql -> repo.query!(sql, [], log: false) end)
+  end
+
+  @doc """
+  Ensures `uuid_generate_v7()` exists in the install's schema, in
+  migration context.
+
+  Checks `pg_proc` first (so an existing function — possibly owned by a
+  different role — is never re-created) and queues a schema-qualified
+  `CREATE OR REPLACE FUNCTION` only when missing. The schema must exist
+  when this runs; V01 owns schema creation, so callers on the upgrade
+  path (installed version > 0) are always safe.
+  """
+  @spec ensure_uuid_v7_function(String.t() | nil) :: :ok
+  def ensure_uuid_v7_function(prefix) do
+    do_ensure_uuid_v7_function(Ecto.Migration.repo(), prefix, &Ecto.Migration.execute/1)
+  end
+
+  @doc """
+  Runtime variant of `ensure_uuid_v7_function/1` (statements run
+  immediately on `repo`).
+  """
+  @spec ensure_uuid_v7_function(Ecto.Repo.t(), String.t() | nil) :: :ok
+  def ensure_uuid_v7_function(repo, prefix) do
+    do_ensure_uuid_v7_function(repo, prefix, fn sql -> repo.query!(sql, [], log: false) end)
+  end
+
+  defp do_ensure_uuid_v7_function(repo, prefix, executor) do
+    unless uuid_v7_function_exists?(repo, prefix) do
+      executor.("""
+      CREATE OR REPLACE FUNCTION #{schema(prefix)}.uuid_generate_v7()
+      #{@uuid_v7_function_body}
+      """)
+    end
+
+    :ok
+  end
+
+  defp uuid_v7_function_exists?(repo, prefix) do
+    query = """
+    SELECT EXISTS (
+      SELECT FROM pg_proc p
+      JOIN pg_namespace n ON n.oid = p.pronamespace
+      WHERE p.proname = 'uuid_generate_v7'
+      AND n.nspname = $1
+    )
+    """
+
+    case repo.query(query, [schema(prefix)], log: false) do
+      {:ok, %{rows: [[true]]}} -> true
+      _ -> false
+    end
+  end
+
+  defp do_ensure_extension!(repo, name, executor) do
+    cond do
+      extension_exists?(repo, name) ->
+        :ok
+
+      can_create_extension?(repo) ->
+        executor.("CREATE EXTENSION IF NOT EXISTS #{name}")
+        :ok
+
+      true ->
+        raise """
+        PhoenixKit requires the Postgres extension '#{name}', which is not
+        installed, and the current database role cannot create it.
+
+        Pre-create the required extensions as a privileged role:
+
+        #{Enum.map_join(@required_extensions, "\n", fn {ext, why} -> "    CREATE EXTENSION IF NOT EXISTS #{ext};  -- #{why}" end)}
+
+        then re-run the migration.
+        """
+    end
+  end
+
+  defp extension_exists?(repo, name) do
+    case repo.query("SELECT 1 FROM pg_extension WHERE extname = $1", [name], log: false) do
+      {:ok, %{num_rows: rows}} -> rows > 0
+      _ -> false
+    end
+  end
+
+  # Trusted extensions (citext/pgcrypto/pg_trgm on PG13+) need CREATE on
+  # the current database; superusers can always create. When in doubt
+  # (query failure), report "can create" so the original CREATE EXTENSION
+  # path — and its native error message — is preserved.
+  defp can_create_extension?(repo) do
+    query = """
+    SELECT rolsuper OR has_database_privilege(current_database(), 'CREATE')
+    FROM pg_roles WHERE rolname = current_user
+    """
+
+    case repo.query(query, [], log: false) do
+      {:ok, %{rows: [[allowed]]}} -> allowed == true
+      _ -> true
+    end
+  end
+
+  defp schema(nil), do: "public"
+  defp schema(prefix), do: prefix
+end

--- a/lib/phoenix_kit/migrations/postgres/helpers.ex
+++ b/lib/phoenix_kit/migrations/postgres/helpers.ex
@@ -36,28 +36,35 @@ defmodule PhoenixKit.Migrations.Postgres.Helpers do
     "pg_trgm" => "trigram search on PDF page content (V111)"
   }
 
-  @uuid_v7_function_body """
-  RETURNS uuid AS $$
-  DECLARE
-    unix_ts_ms bytea;
-    uuid_bytes bytea;
-  BEGIN
-    -- Get current timestamp in milliseconds
-    unix_ts_ms := substring(int8send(floor(extract(epoch FROM clock_timestamp()) * 1000)::bigint) FROM 3);
+  # gen_random_bytes/1 comes from pgcrypto and is qualified with pgcrypto's
+  # actual installation schema at creation time — a plpgsql body resolves
+  # identifiers via the CALLER's search_path at execution, so an unqualified
+  # call would fail for roles whose search_path excludes pgcrypto's schema
+  # (defeating the point of a schema-qualified uuid_generate_v7()).
+  defp uuid_v7_function_body(pgcrypto_schema) do
+    """
+    RETURNS uuid AS $$
+    DECLARE
+      unix_ts_ms bytea;
+      uuid_bytes bytea;
+    BEGIN
+      -- Get current timestamp in milliseconds
+      unix_ts_ms := substring(int8send(floor(extract(epoch FROM clock_timestamp()) * 1000)::bigint) FROM 3);
 
-    -- Build UUIDv7: 6 bytes timestamp + 2 bytes random (with version) + 8 bytes random (with variant)
-    uuid_bytes := unix_ts_ms || gen_random_bytes(10);
+      -- Build UUIDv7: 6 bytes timestamp + 2 bytes random (with version) + 8 bytes random (with variant)
+      uuid_bytes := unix_ts_ms || #{pgcrypto_schema}.gen_random_bytes(10);
 
-    -- Set version 7 (0111xxxx in byte 7)
-    uuid_bytes := set_byte(uuid_bytes, 6, (get_byte(uuid_bytes, 6) & 15) | 112);
+      -- Set version 7 (0111xxxx in byte 7)
+      uuid_bytes := set_byte(uuid_bytes, 6, (get_byte(uuid_bytes, 6) & 15) | 112);
 
-    -- Set variant (10xxxxxx in byte 9)
-    uuid_bytes := set_byte(uuid_bytes, 8, (get_byte(uuid_bytes, 8) & 63) | 128);
+      -- Set variant (10xxxxxx in byte 9)
+      uuid_bytes := set_byte(uuid_bytes, 8, (get_byte(uuid_bytes, 8) & 63) | 128);
 
-    RETURN encode(uuid_bytes, 'hex')::uuid;
-  END
-  $$ LANGUAGE plpgsql VOLATILE;
-  """
+      RETURN encode(uuid_bytes, 'hex')::uuid;
+    END
+    $$ LANGUAGE plpgsql VOLATILE;
+    """
+  end
 
   @doc """
   Schema-qualified table reference for raw SQL interpolation.
@@ -155,7 +162,7 @@ defmodule PhoenixKit.Migrations.Postgres.Helpers do
     unless uuid_v7_function_exists?(repo, prefix) do
       executor.("""
       CREATE OR REPLACE FUNCTION #{schema(prefix)}.uuid_generate_v7()
-      #{@uuid_v7_function_body}
+      #{uuid_v7_function_body(pgcrypto_schema(repo))}
       """)
     end
 
@@ -168,6 +175,7 @@ defmodule PhoenixKit.Migrations.Postgres.Helpers do
       SELECT FROM pg_proc p
       JOIN pg_namespace n ON n.oid = p.pronamespace
       WHERE p.proname = 'uuid_generate_v7'
+      AND p.pronargs = 0
       AND n.nspname = $1
     )
     """
@@ -178,7 +186,30 @@ defmodule PhoenixKit.Migrations.Postgres.Helpers do
     end
   end
 
+  # Where pgcrypto actually lives. When the extension isn't visible yet
+  # (its CREATE EXTENSION may be queued but not flushed on a fresh
+  # chain), fall back to public — the default installation target. The
+  # plpgsql body is only resolved at first call, by which point the
+  # extension exists.
+  defp pgcrypto_schema(repo) do
+    query = """
+    SELECT n.nspname FROM pg_extension e
+    JOIN pg_namespace n ON n.oid = e.extnamespace
+    WHERE e.extname = 'pgcrypto'
+    """
+
+    case repo.query(query, [], log: false) do
+      {:ok, %{rows: [[schema]]}} when is_binary(schema) -> schema
+      _ -> "public"
+    end
+  end
+
   defp do_ensure_extension!(repo, name, executor) do
+    # The name is interpolated into DDL — keep it to known extensions.
+    unless Map.has_key?(@required_extensions, name) do
+      raise ArgumentError, "unknown Postgres extension for PhoenixKit: #{inspect(name)}"
+    end
+
     cond do
       extension_exists?(repo, name) ->
         :ok

--- a/lib/phoenix_kit/migrations/postgres/helpers.ex
+++ b/lib/phoenix_kit/migrations/postgres/helpers.ex
@@ -5,12 +5,15 @@ defmodule PhoenixKit.Migrations.Postgres.Helpers do
   Centralizes the prefix-sensitive patterns that individual version
   modules used to hand-roll (and get subtly wrong in independent ways):
 
-    * `qualify_table/2` — schema-qualified table reference for raw SQL.
-      Index **names** must stay bare on `CREATE INDEX` (Postgres rejects
-      `CREATE INDEX schema.name`); only `DROP INDEX schema.name` accepts
-      a qualified name.
+    * `qualify_table/2` — schema-qualified table reference for raw SQL
+      in NEW migration code (existing versions keep their local helpers;
+      migrating them is opportunistic). Index **names** must stay bare on
+      `CREATE INDEX` (Postgres rejects `CREATE INDEX schema.name`); only
+      `DROP INDEX schema.name` accepts a qualified name.
     * `validate_prefix!/1` — rejects prefixes that can't be interpolated
-      into SQL safely. Called at the `up/down` entry points.
+      into SQL safely. Called at the `up/down` entry points and by the
+      prefix-resolving tooling (`PrefixConfig.resolve_prefix/1`,
+      `Install.Common`, `UUIDRepair`).
     * `ensure_extension!/1` — privilege-aware replacement for a bare
       `CREATE EXTENSION IF NOT EXISTS`. Postgres checks the CREATE
       privilege *before* the IF-NOT-EXISTS short-circuit, so the bare
@@ -77,6 +80,12 @@ defmodule PhoenixKit.Migrations.Postgres.Helpers do
   def qualify_table(table, prefix), do: "#{prefix}.#{table}"
 
   @doc """
+  Whether the prefix denotes the default `public` schema (`nil` counts).
+  """
+  @spec public_prefix?(String.t() | nil) :: boolean()
+  def public_prefix?(prefix), do: prefix in [nil, "public"]
+
+  @doc """
   Schema-qualified `uuid_generate_v7()` call for SQL interpolation.
   """
   @spec uuid_v7_call(String.t() | nil) :: String.t()
@@ -122,7 +131,13 @@ defmodule PhoenixKit.Migrations.Postgres.Helpers do
   """
   @spec ensure_extension!(String.t()) :: :ok
   def ensure_extension!(name) do
-    do_ensure_extension!(Ecto.Migration.repo(), name, &Ecto.Migration.execute/1)
+    # Creation runs IMMEDIATELY (repo().query!) rather than queued via
+    # execute/1 — so a later ensure_uuid_v7_function/1 in the same version
+    # sees the extension in pg_extension and resolves pgcrypto's real
+    # schema instead of falling back to public. Also guarantees the
+    # citext type exists before any queued CREATE TABLE that uses it.
+    repo = Ecto.Migration.repo()
+    do_ensure_extension!(repo, name, fn sql -> repo.query!(sql, [], log: false) end)
   end
 
   @doc """
@@ -151,7 +166,7 @@ defmodule PhoenixKit.Migrations.Postgres.Helpers do
 
   @doc """
   Runtime variant of `ensure_uuid_v7_function/1` (statements run
-  immediately on `repo`).
+  immediately on `repo`; raises on database errors via `repo.query!/3`).
   """
   @spec ensure_uuid_v7_function(Ecto.Repo.t(), String.t() | nil) :: :ok
   def ensure_uuid_v7_function(repo, prefix) do
@@ -255,6 +270,5 @@ defmodule PhoenixKit.Migrations.Postgres.Helpers do
     end
   end
 
-  defp schema(nil), do: "public"
-  defp schema(prefix), do: prefix
+  defp schema(prefix), do: if(public_prefix?(prefix), do: "public", else: prefix)
 end

--- a/lib/phoenix_kit/migrations/postgres/v01.ex
+++ b/lib/phoenix_kit/migrations/postgres/v01.ex
@@ -3,14 +3,36 @@ defmodule PhoenixKit.Migrations.Postgres.V01 do
 
   use Ecto.Migration
 
+  alias PhoenixKit.Migrations.Postgres.Helpers
+
   def up(%{create_schema: create?, prefix: prefix} = opts) do
     %{quoted_prefix: quoted} = opts
 
-    # Only create schema if it's not 'public' and create_schema is true
-    if create? && prefix != "public", do: execute("CREATE SCHEMA IF NOT EXISTS #{quoted}")
+    # Only attempt schema creation when the schema is actually missing.
+    # Postgres checks the CREATE-on-database privilege BEFORE the
+    # IF-NOT-EXISTS short-circuit, so executing the statement against a
+    # pre-created schema fails for low-privilege roles that own the
+    # schema but not the database.
+    if prefix != "public" && !schema_exists?(prefix) do
+      if create? do
+        execute("CREATE SCHEMA IF NOT EXISTS #{quoted}")
+      else
+        raise """
+        PhoenixKit: schema #{inspect(prefix)} does not exist and the migration
+        was called with create_schema: false.
 
-    # Create citext extension if not exists
-    execute "CREATE EXTENSION IF NOT EXISTS citext"
+        Create it as a privileged role first:
+
+            CREATE SCHEMA #{prefix} AUTHORIZATION your_app_role;
+
+        or drop the create_schema: false option to let the migration create it.
+        """
+      end
+    end
+
+    # Create citext extension if not exists (skips the statement — and its
+    # privilege check — when the extension is already installed)
+    Helpers.ensure_extension!("citext")
 
     # Create version tracking table (phoenix_kit)
     create_if_not_exists table(:phoenix_kit, primary_key: false, prefix: prefix) do
@@ -133,6 +155,18 @@ defmodule PhoenixKit.Migrations.Postgres.V01 do
   # Helper function to build table name with prefix
   defp prefix_table_name(table_name, nil), do: table_name
   defp prefix_table_name(table_name, prefix), do: "#{prefix}.#{table_name}"
+
+  # Immediate check (repo().query/3 executes outside the migration
+  # command queue) — safe here because nothing queued before V01 could
+  # create the schema.
+  defp schema_exists?(prefix) do
+    query = "SELECT EXISTS (SELECT FROM information_schema.schemata WHERE schema_name = $1)"
+
+    case repo().query(query, [prefix], log: false) do
+      {:ok, %{rows: [[true]]}} -> true
+      _ -> false
+    end
+  end
 
   def down(%{prefix: prefix}) do
     # Drop tables in correct order (foreign key dependencies)

--- a/lib/phoenix_kit/migrations/postgres/v100.ex
+++ b/lib/phoenix_kit/migrations/postgres/v100.ex
@@ -26,7 +26,7 @@ defmodule PhoenixKit.Migrations.Postgres.V100 do
 
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_staff_departments (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       name VARCHAR(255) NOT NULL,
       description TEXT,
       inserted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
@@ -41,7 +41,7 @@ defmodule PhoenixKit.Migrations.Postgres.V100 do
 
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_staff_teams (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       department_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_staff_departments(uuid) ON DELETE CASCADE,
       name VARCHAR(255) NOT NULL,
       description TEXT,
@@ -62,7 +62,7 @@ defmodule PhoenixKit.Migrations.Postgres.V100 do
 
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_staff_people (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       user_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_users(uuid) ON DELETE CASCADE,
       primary_department_uuid UUID REFERENCES #{p}phoenix_kit_staff_departments(uuid) ON DELETE SET NULL,
       status VARCHAR(20) NOT NULL DEFAULT 'active',
@@ -103,7 +103,7 @@ defmodule PhoenixKit.Migrations.Postgres.V100 do
 
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_staff_team_memberships (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       team_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_staff_teams(uuid) ON DELETE CASCADE,
       staff_person_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_staff_people(uuid) ON DELETE CASCADE,
       inserted_at TIMESTAMPTZ NOT NULL DEFAULT NOW()

--- a/lib/phoenix_kit/migrations/postgres/v101.ex
+++ b/lib/phoenix_kit/migrations/postgres/v101.ex
@@ -30,7 +30,7 @@ defmodule PhoenixKit.Migrations.Postgres.V101 do
 
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_project_tasks (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       title VARCHAR(255) NOT NULL,
       description TEXT,
       estimated_duration INTEGER,
@@ -52,7 +52,7 @@ defmodule PhoenixKit.Migrations.Postgres.V101 do
 
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_projects (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       name VARCHAR(255) NOT NULL,
       description TEXT,
       status VARCHAR(20) NOT NULL DEFAULT 'active',
@@ -79,7 +79,7 @@ defmodule PhoenixKit.Migrations.Postgres.V101 do
 
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_project_assignments (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       project_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_projects(uuid) ON DELETE CASCADE,
       task_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_project_tasks(uuid) ON DELETE CASCADE,
       status VARCHAR(20) NOT NULL DEFAULT 'todo',
@@ -143,7 +143,7 @@ defmodule PhoenixKit.Migrations.Postgres.V101 do
 
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_project_dependencies (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       assignment_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_project_assignments(uuid) ON DELETE CASCADE,
       depends_on_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_project_assignments(uuid) ON DELETE CASCADE,
       inserted_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
@@ -164,7 +164,7 @@ defmodule PhoenixKit.Migrations.Postgres.V101 do
 
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_project_task_dependencies (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       task_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_project_tasks(uuid) ON DELETE CASCADE,
       depends_on_task_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_project_tasks(uuid) ON DELETE CASCADE,
       inserted_at TIMESTAMPTZ NOT NULL DEFAULT NOW()

--- a/lib/phoenix_kit/migrations/postgres/v102.ex
+++ b/lib/phoenix_kit/migrations/postgres/v102.ex
@@ -129,7 +129,7 @@ defmodule PhoenixKit.Migrations.Postgres.V102 do
     # ── Smart rules table ───────────────────────────────────────
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_cat_item_catalogue_rules (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       item_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_cat_items(uuid) ON DELETE CASCADE,
       referenced_catalogue_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_cat_catalogues(uuid) ON DELETE CASCADE,
       value DECIMAL(12, 4),

--- a/lib/phoenix_kit/migrations/postgres/v104.ex
+++ b/lib/phoenix_kit/migrations/postgres/v104.ex
@@ -35,7 +35,7 @@ defmodule PhoenixKit.Migrations.Postgres.V104 do
 
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_notifications (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       activity_uuid UUID NOT NULL
         REFERENCES #{p}phoenix_kit_activities(uuid) ON DELETE CASCADE,
       recipient_uuid UUID NOT NULL

--- a/lib/phoenix_kit/migrations/postgres/v105.ex
+++ b/lib/phoenix_kit/migrations/postgres/v105.ex
@@ -48,7 +48,7 @@ defmodule PhoenixKit.Migrations.Postgres.V105 do
 
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_crm_user_role_view (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       user_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_users(uuid) ON DELETE CASCADE,
       scope VARCHAR(100) NOT NULL,
       view_config JSONB NOT NULL DEFAULT '{}',

--- a/lib/phoenix_kit/migrations/postgres/v105.ex
+++ b/lib/phoenix_kit/migrations/postgres/v105.ex
@@ -20,7 +20,7 @@ defmodule PhoenixKit.Migrations.Postgres.V105 do
   ordering, active filters). One row per (user, scope) pair; scope values
   are strings like `"role:<uuid>"` or `"companies"`.
 
-  - `uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7()`
+  - `uuid UUID PRIMARY KEY DEFAULT <prefix>.uuid_generate_v7()`
   - `user_uuid UUID NOT NULL` — FK → `phoenix_kit_users(uuid)` ON DELETE CASCADE
   - `scope VARCHAR(100) NOT NULL` — e.g. `"role:<uuid>"`, `"companies"`
   - `view_config JSONB NOT NULL DEFAULT '{}'` — arbitrary UI preferences blob

--- a/lib/phoenix_kit/migrations/postgres/v111.ex
+++ b/lib/phoenix_kit/migrations/postgres/v111.ex
@@ -43,6 +43,8 @@ defmodule PhoenixKit.Migrations.Postgres.V111 do
 
   use Ecto.Migration
 
+  alias PhoenixKit.Migrations.Postgres.Helpers
+
   def up(opts) do
     prefix = Map.get(opts, :prefix, "public")
     p = prefix_str(prefix)
@@ -55,12 +57,12 @@ defmodule PhoenixKit.Migrations.Postgres.V111 do
     execute("DROP TABLE IF EXISTS #{p}phoenix_kit_cat_pdf_extractions CASCADE")
     execute("DROP TABLE IF EXISTS #{p}phoenix_kit_cat_pdf_page_contents CASCADE")
 
-    execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+    Helpers.ensure_extension!("pg_trgm")
 
     # ── per-upload row ─────────────────────────────────────────────────
 
     create table(:phoenix_kit_cat_pdfs, primary_key: false, prefix: prefix) do
-      add(:uuid, :uuid, primary_key: true, default: fragment("uuid_generate_v7()"))
+      add(:uuid, :uuid, primary_key: true, default: fragment("#{prefix}.uuid_generate_v7()"))
 
       add(
         :file_uuid,

--- a/lib/phoenix_kit/migrations/postgres/v113.ex
+++ b/lib/phoenix_kit/migrations/postgres/v113.ex
@@ -166,7 +166,7 @@ defmodule PhoenixKit.Migrations.Postgres.V113 do
                          ) do
       add(:uuid, :uuid,
         primary_key: true,
-        default: fragment("uuid_generate_v7()"),
+        default: fragment("#{prefix}.uuid_generate_v7()"),
         null: false
       )
 

--- a/lib/phoenix_kit/migrations/postgres/v115.ex
+++ b/lib/phoenix_kit/migrations/postgres/v115.ex
@@ -46,7 +46,7 @@ defmodule PhoenixKit.Migrations.Postgres.V115 do
                          ) do
       add(:uuid, :uuid,
         primary_key: true,
-        default: fragment("uuid_generate_v7()"),
+        default: fragment("#{prefix}.uuid_generate_v7()"),
         null: false
       )
 

--- a/lib/phoenix_kit/migrations/postgres/v117.ex
+++ b/lib/phoenix_kit/migrations/postgres/v117.ex
@@ -51,7 +51,7 @@ defmodule PhoenixKit.Migrations.Postgres.V117 do
                          ) do
       add(:uuid, :uuid,
         primary_key: true,
-        default: fragment("uuid_generate_v7()"),
+        default: fragment("#{prefix}.uuid_generate_v7()"),
         null: false
       )
 
@@ -100,7 +100,7 @@ defmodule PhoenixKit.Migrations.Postgres.V117 do
     # `:map` DSL can't express — use raw SQL for that column's default.
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_doc_template_presets (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7() NOT NULL,
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7() NOT NULL,
       name VARCHAR NOT NULL,
       description TEXT,
       category VARCHAR,

--- a/lib/phoenix_kit/migrations/postgres/v120.ex
+++ b/lib/phoenix_kit/migrations/postgres/v120.ex
@@ -36,7 +36,7 @@ defmodule PhoenixKit.Migrations.Postgres.V120 do
                            primary_key: false,
                            prefix: prefix
                          ) do
-      add(:uuid, :uuid, primary_key: true, default: fragment("uuid_generate_v7()"))
+      add(:uuid, :uuid, primary_key: true, default: fragment("#{prefix}.uuid_generate_v7()"))
       add(:name, :string, null: false)
       add(:description, :text)
       add(:position, :integer, null: false, default: 0)
@@ -53,7 +53,7 @@ defmodule PhoenixKit.Migrations.Postgres.V120 do
                            primary_key: false,
                            prefix: prefix
                          ) do
-      add(:uuid, :uuid, primary_key: true, default: fragment("uuid_generate_v7()"))
+      add(:uuid, :uuid, primary_key: true, default: fragment("#{prefix}.uuid_generate_v7()"))
       add(:name, :string, null: false)
       add(:description, :text)
       add(:position, :integer, null: false, default: 0)
@@ -147,7 +147,7 @@ defmodule PhoenixKit.Migrations.Postgres.V120 do
             WHEN 'technical' THEN 'Technical'
             ELSE upper(substr(rec.sample, 1, 1)) || substr(rec.sample, 2)
           END;
-          new_uuid := uuid_generate_v7();
+          new_uuid := #{prefix}.uuid_generate_v7();
           INSERT INTO #{p}phoenix_kit_doc_categories
             (uuid, name, position, status, data, inserted_at, updated_at)
           VALUES

--- a/lib/phoenix_kit/migrations/postgres/v122.ex
+++ b/lib/phoenix_kit/migrations/postgres/v122.ex
@@ -72,7 +72,7 @@ defmodule PhoenixKit.Migrations.Postgres.V122 do
                            primary_key: false,
                            prefix: prefix
                          ) do
-      add(:uuid, :uuid, primary_key: true, default: fragment("uuid_generate_v7()"))
+      add(:uuid, :uuid, primary_key: true, default: fragment("#{prefix}.uuid_generate_v7()"))
       add(:name, :string, null: false, size: 255)
       add(:description, :text)
       add(:public_notes, :text)
@@ -103,7 +103,7 @@ defmodule PhoenixKit.Migrations.Postgres.V122 do
                            primary_key: false,
                            prefix: prefix
                          ) do
-      add(:uuid, :uuid, primary_key: true, default: fragment("uuid_generate_v7()"))
+      add(:uuid, :uuid, primary_key: true, default: fragment("#{prefix}.uuid_generate_v7()"))
 
       add(
         :location_uuid,

--- a/lib/phoenix_kit/migrations/postgres/v123.ex
+++ b/lib/phoenix_kit/migrations/postgres/v123.ex
@@ -38,7 +38,7 @@ defmodule PhoenixKit.Migrations.Postgres.V123 do
                            primary_key: false,
                            prefix: prefix
                          ) do
-      add(:uuid, :uuid, primary_key: true, default: fragment("uuid_generate_v7()"))
+      add(:uuid, :uuid, primary_key: true, default: fragment("#{prefix}.uuid_generate_v7()"))
       add(:name, :string, null: false)
 
       add(

--- a/lib/phoenix_kit/migrations/postgres/v125.ex
+++ b/lib/phoenix_kit/migrations/postgres/v125.ex
@@ -119,7 +119,7 @@ defmodule PhoenixKit.Migrations.Postgres.V125 do
   defp create_project_statuses_table(p) do
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_project_statuses (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{p}uuid_generate_v7(),
       project_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_projects(uuid) ON DELETE CASCADE,
       label VARCHAR(255) NOT NULL,
       slug VARCHAR(255) NOT NULL,

--- a/lib/phoenix_kit/migrations/postgres/v133.ex
+++ b/lib/phoenix_kit/migrations/postgres/v133.ex
@@ -22,7 +22,7 @@ defmodule PhoenixKit.Migrations.Postgres.V133 do
 
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_dashboards (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       title VARCHAR(255) NOT NULL,
       slug VARCHAR(255) NOT NULL,
       owner_user_uuid UUID REFERENCES #{p}phoenix_kit_users(uuid) ON DELETE CASCADE,

--- a/lib/phoenix_kit/migrations/postgres/v135.ex
+++ b/lib/phoenix_kit/migrations/postgres/v135.ex
@@ -45,7 +45,7 @@ defmodule PhoenixKit.Migrations.Postgres.V135 do
     # 1. Skills entity (translatable, flat — no parent).
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_staff_skills (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       name VARCHAR(255) NOT NULL,
       description TEXT,
       translations JSONB NOT NULL DEFAULT '{}'::jsonb,
@@ -64,7 +64,7 @@ defmodule PhoenixKit.Migrations.Postgres.V135 do
     # 2. person ↔ skill join + nullable proficiency level.
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_staff_person_skills (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       staff_person_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_staff_people(uuid) ON DELETE CASCADE,
       skill_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_staff_skills(uuid) ON DELETE CASCADE,
       proficiency_levels JSONB NOT NULL DEFAULT '[]'::jsonb,

--- a/lib/phoenix_kit/migrations/postgres/v136.ex
+++ b/lib/phoenix_kit/migrations/postgres/v136.ex
@@ -48,7 +48,7 @@ defmodule PhoenixKit.Migrations.Postgres.V136 do
     # 1. Employment spans — a person's employment history.
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_staff_employments (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       staff_person_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_staff_people(uuid) ON DELETE CASCADE,
       employment_type VARCHAR(50),
       job_title VARCHAR(255),

--- a/lib/phoenix_kit/migrations/postgres/v138.ex
+++ b/lib/phoenix_kit/migrations/postgres/v138.ex
@@ -44,7 +44,7 @@ defmodule PhoenixKit.Migrations.Postgres.V138 do
     # ── Contacts ──────────────────────────────────────────────────────
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_crm_contacts (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       name VARCHAR(255),
       status VARCHAR(50) NOT NULL DEFAULT 'active',
       email VARCHAR(255),
@@ -72,7 +72,7 @@ defmodule PhoenixKit.Migrations.Postgres.V138 do
     # ── Companies ─────────────────────────────────────────────────────
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_crm_companies (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       name VARCHAR(255),
       status VARCHAR(50) NOT NULL DEFAULT 'active',
       website VARCHAR(255),
@@ -95,7 +95,7 @@ defmodule PhoenixKit.Migrations.Postgres.V138 do
     # ── Contact ↔ Company memberships ─────────────────────────────────
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_crm_company_memberships (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       contact_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_crm_contacts(uuid) ON DELETE CASCADE,
       company_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_crm_companies(uuid) ON DELETE CASCADE,
       role_in_company VARCHAR(255),
@@ -121,7 +121,7 @@ defmodule PhoenixKit.Migrations.Postgres.V138 do
     # ── Interactions ──────────────────────────────────────────────────
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_crm_interactions (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       contact_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_crm_contacts(uuid) ON DELETE CASCADE,
       interaction_type VARCHAR(50) NOT NULL DEFAULT 'note',
       occurred_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
@@ -145,7 +145,7 @@ defmodule PhoenixKit.Migrations.Postgres.V138 do
     # optional staff module stays optional.
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_crm_interaction_parties (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       interaction_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_crm_interactions(uuid) ON DELETE CASCADE,
       raw_name VARCHAR(255) NOT NULL,
       contact_uuid UUID REFERENCES #{p}phoenix_kit_crm_contacts(uuid) ON DELETE SET NULL,

--- a/lib/phoenix_kit/migrations/postgres/v140.ex
+++ b/lib/phoenix_kit/migrations/postgres/v140.ex
@@ -47,7 +47,7 @@ defmodule PhoenixKit.Migrations.Postgres.V140 do
     # 1. Stock — per (item, location) balance.
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_warehouse_stock (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{p}uuid_generate_v7(),
       item_uuid UUID NOT NULL,
       location_uuid UUID NOT NULL,
       quantity NUMERIC NOT NULL DEFAULT 0,
@@ -91,7 +91,7 @@ defmodule PhoenixKit.Migrations.Postgres.V140 do
 
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_warehouse_inventory_documents (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{p}uuid_generate_v7(),
       number BIGINT NOT NULL DEFAULT nextval('#{p}phoenix_kit_warehouse_inventory_documents_number_seq'),
       status VARCHAR(20) NOT NULL DEFAULT 'draft',
       track_value BOOLEAN NOT NULL DEFAULT false,
@@ -139,7 +139,7 @@ defmodule PhoenixKit.Migrations.Postgres.V140 do
 
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_warehouse_internal_orders (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{p}uuid_generate_v7(),
       number BIGINT NOT NULL DEFAULT nextval('#{p}phoenix_kit_warehouse_internal_orders_number_seq'),
       status VARCHAR(20) NOT NULL DEFAULT 'draft',
       location_uuid UUID NOT NULL,
@@ -229,7 +229,7 @@ defmodule PhoenixKit.Migrations.Postgres.V140 do
 
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_warehouse_supplier_orders (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{p}uuid_generate_v7(),
       number BIGINT NOT NULL DEFAULT nextval('#{p}phoenix_kit_warehouse_supplier_orders_number_seq'),
       status VARCHAR(20) NOT NULL DEFAULT 'draft',
       supplier_uuid UUID,
@@ -295,7 +295,7 @@ defmodule PhoenixKit.Migrations.Postgres.V140 do
 
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_warehouse_goods_receipts (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{p}uuid_generate_v7(),
       number BIGINT NOT NULL DEFAULT nextval('#{p}phoenix_kit_warehouse_goods_receipts_number_seq'),
       status VARCHAR(20) NOT NULL DEFAULT 'draft',
       supplier_order_uuid UUID REFERENCES #{p}phoenix_kit_warehouse_supplier_orders(uuid) ON DELETE SET NULL,
@@ -356,7 +356,7 @@ defmodule PhoenixKit.Migrations.Postgres.V140 do
 
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_warehouse_goods_issues (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{p}uuid_generate_v7(),
       number BIGINT NOT NULL DEFAULT nextval('#{p}phoenix_kit_warehouse_goods_issues_number_seq'),
       status VARCHAR(20) NOT NULL DEFAULT 'draft',
       internal_order_uuid UUID REFERENCES #{p}phoenix_kit_warehouse_internal_orders(uuid) ON DELETE SET NULL,

--- a/lib/phoenix_kit/migrations/postgres/v141.ex
+++ b/lib/phoenix_kit/migrations/postgres/v141.ex
@@ -53,7 +53,7 @@ defmodule PhoenixKit.Migrations.Postgres.V141 do
 
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_calendar_events (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       owner_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_users(uuid) ON DELETE CASCADE,
       title VARCHAR(255) NOT NULL,
       description TEXT,
@@ -127,7 +127,7 @@ defmodule PhoenixKit.Migrations.Postgres.V141 do
 
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_calendar_event_participants (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       event_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_calendar_events(uuid) ON DELETE CASCADE,
       kind VARCHAR(20) NOT NULL,
       target_uuid UUID,

--- a/lib/phoenix_kit/migrations/postgres/v26.ex
+++ b/lib/phoenix_kit/migrations/postgres/v26.ex
@@ -25,9 +25,12 @@ defmodule PhoenixKit.Migrations.Postgres.V26 do
 
   use Ecto.Migration
 
+  alias PhoenixKit.Migrations.Postgres.Helpers
+
   def up(%{prefix: prefix} = _opts) do
-    # Enable pgcrypto extension for digest function
-    execute "CREATE EXTENSION IF NOT EXISTS pgcrypto"
+    # Enable pgcrypto extension for digest function (skips the statement —
+    # and its privilege check — when the extension is already installed)
+    Helpers.ensure_extension!("pgcrypto")
 
     # Drop the unique index on checksum (from V24)
     drop_if_exists unique_index(:phoenix_kit_files, [:checksum], prefix: prefix)

--- a/lib/phoenix_kit/migrations/postgres/v27.ex
+++ b/lib/phoenix_kit/migrations/postgres/v27.ex
@@ -26,7 +26,7 @@ defmodule PhoenixKit.Migrations.Postgres.V27 do
   ## Queue Configuration
   After running this migration, configure Oban queues in config/config.exs:
 
-      config :phoenix_kit, Oban,
+      config :my_app, Oban,  # your host app's name, not :phoenix_kit
         repo: MyApp.Repo,
         queues: [
           default: 10,

--- a/lib/phoenix_kit/migrations/postgres/v27.ex
+++ b/lib/phoenix_kit/migrations/postgres/v27.ex
@@ -46,7 +46,14 @@ defmodule PhoenixKit.Migrations.Postgres.V27 do
   def up(%{prefix: prefix} = _opts) do
     # Run Oban migrations to create required tables
     # Uses latest Oban schema version automatically (forward-compatible)
-    Oban.Migration.up(prefix: prefix)
+    #
+    # create_schema: false is load-bearing: without it Oban's migrator
+    # defaults the flag to true for any non-public prefix and executes
+    # CREATE SCHEMA IF NOT EXISTS — which fails for low-privilege roles
+    # even when the schema exists (Postgres checks the CREATE privilege
+    # before the IF-NOT-EXISTS short-circuit). By V27 the schema always
+    # exists (V01 owns schema creation), so never ask Oban to create it.
+    Oban.Migration.up(prefix: prefix, create_schema: false)
 
     # Set version comment on phoenix_kit table for version tracking
     execute "COMMENT ON TABLE #{prefix_table_name("phoenix_kit", prefix)} IS '27'"

--- a/lib/phoenix_kit/migrations/postgres/v40.ex
+++ b/lib/phoenix_kit/migrations/postgres/v40.ex
@@ -31,8 +31,9 @@ defmodule PhoenixKit.Migrations.Postgres.V40 do
   - Sortable by creation time
   - Compatible with standard UUID format
 
-  A PostgreSQL function `uuid_generate_v7()` is created to generate UUIDv7
-  values at the database level.
+  A PostgreSQL function `uuid_generate_v7()` is created inside the
+  install's schema (`<prefix>.uuid_generate_v7()`) to generate UUIDv7
+  values at the database level; all call sites are schema-qualified.
 
   ## Tables Affected
 

--- a/lib/phoenix_kit/migrations/postgres/v40.ex
+++ b/lib/phoenix_kit/migrations/postgres/v40.ex
@@ -105,6 +105,8 @@ defmodule PhoenixKit.Migrations.Postgres.V40 do
   """
   use Ecto.Migration
 
+  alias PhoenixKit.Migrations.Postgres.Helpers
+
   @tables_to_migrate [
     # Core Auth (V01)
     :phoenix_kit_users,
@@ -178,34 +180,14 @@ defmodule PhoenixKit.Migrations.Postgres.V40 do
     # executes immediately and won't see unbuffered tables.
     flush()
 
-    # Step 1: Ensure pgcrypto extension exists
-    execute("CREATE EXTENSION IF NOT EXISTS pgcrypto")
+    # Step 1: Ensure pgcrypto extension exists (skips the statement — and
+    # its privilege check — when the extension is already installed)
+    Helpers.ensure_extension!("pgcrypto")
 
-    # Step 2: Create UUIDv7 generation function if it doesn't exist
-    # UUIDv7 format: timestamp (48 bits) + version (4 bits) + random (12 bits) + variant (2 bits) + random (62 bits)
-    execute("""
-    CREATE OR REPLACE FUNCTION uuid_generate_v7()
-    RETURNS uuid AS $$
-    DECLARE
-      unix_ts_ms bytea;
-      uuid_bytes bytea;
-    BEGIN
-      -- Get current timestamp in milliseconds
-      unix_ts_ms := substring(int8send(floor(extract(epoch FROM clock_timestamp()) * 1000)::bigint) FROM 3);
-
-      -- Build UUIDv7: 6 bytes timestamp + 2 bytes random (with version) + 8 bytes random (with variant)
-      uuid_bytes := unix_ts_ms || gen_random_bytes(10);
-
-      -- Set version 7 (0111xxxx in byte 7)
-      uuid_bytes := set_byte(uuid_bytes, 6, (get_byte(uuid_bytes, 6) & 15) | 112);
-
-      -- Set variant (10xxxxxx in byte 9)
-      uuid_bytes := set_byte(uuid_bytes, 8, (get_byte(uuid_bytes, 8) & 63) | 128);
-
-      RETURN encode(uuid_bytes, 'hex')::uuid;
-    END
-    $$ LANGUAGE plpgsql VOLATILE;
-    """)
+    # Step 2: Create UUIDv7 generation function inside the install's schema
+    # (never wherever search_path points — that pollutes public and fails
+    # on PG15+ where public isn't world-writable)
+    Helpers.ensure_uuid_v7_function(prefix)
 
     # Step 3: Process each table
     for table <- @tables_to_migrate do
@@ -244,18 +226,18 @@ defmodule PhoenixKit.Migrations.Postgres.V40 do
         # Ecto changesets will generate UUIDv7 in Elixir, which takes precedence.
         execute("""
         ALTER TABLE #{table_name}
-        ADD COLUMN uuid UUID DEFAULT uuid_generate_v7()
+        ADD COLUMN uuid UUID DEFAULT #{prefix}.uuid_generate_v7()
         """)
 
         # Step 2: Backfill existing records with UUIDv7
         # Use batched updates for large tables to avoid long locks
         if table in @large_tables do
-          backfill_uuids_batched(table_name)
+          backfill_uuids_batched(table_name, prefix)
         else
           # Small tables can be updated in one go
           execute("""
           UPDATE #{table_name}
-          SET uuid = uuid_generate_v7()
+          SET uuid = #{prefix}.uuid_generate_v7()
           WHERE uuid IS NULL
           """)
         end
@@ -281,7 +263,7 @@ defmodule PhoenixKit.Migrations.Postgres.V40 do
   end
 
   # Backfill UUIDs in batches to avoid long locks on large tables
-  defp backfill_uuids_batched(table_name) do
+  defp backfill_uuids_batched(table_name, prefix) do
     # Use a loop to update in batches
     # This is done via a DO block to handle it in a single migration step
     execute("""
@@ -292,7 +274,7 @@ defmodule PhoenixKit.Migrations.Postgres.V40 do
     BEGIN
       LOOP
         UPDATE #{table_name}
-        SET uuid = uuid_generate_v7()
+        SET uuid = #{prefix}.uuid_generate_v7()
         WHERE id IN (
           SELECT id FROM #{table_name}
           WHERE uuid IS NULL

--- a/lib/phoenix_kit/migrations/postgres/v56.ex
+++ b/lib/phoenix_kit/migrations/postgres/v56.ex
@@ -201,7 +201,7 @@ defmodule PhoenixKit.Migrations.Postgres.V56 do
     # Flush pending commands so repo().query() table checks see all tables
     flush()
 
-    # Ensure #{prefix}.uuid_generate_v7() function exists (created in V40, but be safe)
+    # Ensure <prefix>.uuid_generate_v7() function exists (created in V40, but be safe)
     Helpers.ensure_uuid_v7_function(prefix)
 
     # Fix 0: Add missing uuid columns (V43 consent_logs)
@@ -334,7 +334,7 @@ defmodule PhoenixKit.Migrations.Postgres.V56 do
     end
   end
 
-  # Fix 1: Set DEFAULT to #{prefix}.uuid_generate_v7()
+  # Fix 1: Set DEFAULT to <prefix>.uuid_generate_v7()
   defp fix_uuid_default(table, prefix, escaped_prefix) do
     table_name = prefix_table_name(Atom.to_string(table), prefix)
 

--- a/lib/phoenix_kit/migrations/postgres/v56.ex
+++ b/lib/phoenix_kit/migrations/postgres/v56.ex
@@ -88,6 +88,8 @@ defmodule PhoenixKit.Migrations.Postgres.V56 do
 
   use Ecto.Migration
 
+  alias PhoenixKit.Migrations.Postgres.Helpers
+
   alias PhoenixKit.Migrations.UUIDFKColumns
 
   # Tables missing the uuid column entirely (schema expects it, migration never created it)
@@ -199,22 +201,8 @@ defmodule PhoenixKit.Migrations.Postgres.V56 do
     # Flush pending commands so repo().query() table checks see all tables
     flush()
 
-    # Ensure uuid_generate_v7() function exists (created in V40, but be safe)
-    execute("""
-    CREATE OR REPLACE FUNCTION uuid_generate_v7()
-    RETURNS uuid AS $$
-    DECLARE
-      unix_ts_ms bytea;
-      uuid_bytes bytea;
-    BEGIN
-      unix_ts_ms := substring(int8send(floor(extract(epoch FROM clock_timestamp()) * 1000)::bigint) FROM 3);
-      uuid_bytes := unix_ts_ms || gen_random_bytes(10);
-      uuid_bytes := set_byte(uuid_bytes, 6, (get_byte(uuid_bytes, 6) & 15) | 112);
-      uuid_bytes := set_byte(uuid_bytes, 8, (get_byte(uuid_bytes, 8) & 63) | 128);
-      RETURN encode(uuid_bytes, 'hex')::uuid;
-    END
-    $$ LANGUAGE plpgsql VOLATILE;
-    """)
+    # Ensure #{prefix}.uuid_generate_v7() function exists (created in V40, but be safe)
+    Helpers.ensure_uuid_v7_function(prefix)
 
     # Fix 0: Add missing uuid columns (V43 consent_logs)
     for table <- @tables_missing_column do
@@ -334,26 +322,26 @@ defmodule PhoenixKit.Migrations.Postgres.V56 do
     if table_exists?(table, escaped_prefix) do
       execute("""
       ALTER TABLE #{table_name}
-      ADD COLUMN IF NOT EXISTS uuid UUID DEFAULT uuid_generate_v7()
+      ADD COLUMN IF NOT EXISTS uuid UUID DEFAULT #{prefix}.uuid_generate_v7()
       """)
 
       # Backfill existing rows
       execute("""
       UPDATE #{table_name}
-      SET uuid = uuid_generate_v7()
+      SET uuid = #{prefix}.uuid_generate_v7()
       WHERE uuid IS NULL
       """)
     end
   end
 
-  # Fix 1: Set DEFAULT to uuid_generate_v7()
+  # Fix 1: Set DEFAULT to #{prefix}.uuid_generate_v7()
   defp fix_uuid_default(table, prefix, escaped_prefix) do
     table_name = prefix_table_name(Atom.to_string(table), prefix)
 
     if table_exists?(table, escaped_prefix) and column_exists?(table, :uuid, escaped_prefix) do
       execute("""
       ALTER TABLE #{table_name}
-      ALTER COLUMN uuid SET DEFAULT uuid_generate_v7()
+      ALTER COLUMN uuid SET DEFAULT #{prefix}.uuid_generate_v7()
       """)
     end
   end
@@ -366,7 +354,7 @@ defmodule PhoenixKit.Migrations.Postgres.V56 do
       # Backfill any NULL uuid values with UUIDv7
       execute("""
       UPDATE #{table_name}
-      SET uuid = uuid_generate_v7()
+      SET uuid = #{prefix}.uuid_generate_v7()
       WHERE uuid IS NULL
       """)
 
@@ -398,7 +386,7 @@ defmodule PhoenixKit.Migrations.Postgres.V56 do
     if table_exists?(table, escaped_prefix) and column_exists?(table, :id, escaped_prefix) do
       execute("""
       ALTER TABLE #{table_name}
-      ALTER COLUMN id SET DEFAULT uuid_generate_v7()
+      ALTER COLUMN id SET DEFAULT #{prefix}.uuid_generate_v7()
       """)
     end
   end

--- a/lib/phoenix_kit/migrations/postgres/v59.ex
+++ b/lib/phoenix_kit/migrations/postgres/v59.ex
@@ -39,7 +39,7 @@ defmodule PhoenixKit.Migrations.Postgres.V59 do
 
     execute("""
     CREATE TABLE IF NOT EXISTS #{prefix_str}phoenix_kit_publishing_groups (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       name VARCHAR(255) NOT NULL,
       slug VARCHAR(255) NOT NULL,
       mode VARCHAR(20) NOT NULL DEFAULT 'timestamp',
@@ -61,7 +61,7 @@ defmodule PhoenixKit.Migrations.Postgres.V59 do
 
     execute("""
     CREATE TABLE IF NOT EXISTS #{prefix_str}phoenix_kit_publishing_posts (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       group_id UUID NOT NULL,
       slug VARCHAR(500) NOT NULL,
       status VARCHAR(20) NOT NULL DEFAULT 'draft',
@@ -148,7 +148,7 @@ defmodule PhoenixKit.Migrations.Postgres.V59 do
 
     execute("""
     CREATE TABLE IF NOT EXISTS #{prefix_str}phoenix_kit_publishing_versions (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       post_id UUID NOT NULL,
       version_number INTEGER NOT NULL,
       status VARCHAR(20) NOT NULL DEFAULT 'draft',
@@ -198,7 +198,7 @@ defmodule PhoenixKit.Migrations.Postgres.V59 do
 
     execute("""
     CREATE TABLE IF NOT EXISTS #{prefix_str}phoenix_kit_publishing_contents (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       version_id UUID NOT NULL,
       language VARCHAR(10) NOT NULL,
       title VARCHAR(500) NOT NULL,

--- a/lib/phoenix_kit/migrations/postgres/v59.ex
+++ b/lib/phoenix_kit/migrations/postgres/v59.ex
@@ -17,7 +17,7 @@ defmodule PhoenixKit.Migrations.Postgres.V59 do
 
   - JSONB `data` column on every table for extensibility without future migrations
   - Real columns for indexed/queried/FK fields (status, slug, language, dates)
-  - UUID v7 primary keys with `uuid_generate_v7()` default
+  - UUID v7 primary keys defaulting to the schema-qualified `<prefix>.uuid_generate_v7()`
   - Dual-write user FKs: `created_by_uuid` (UUID, FK) + `created_by_id` (bigint, no FK)
   - All timestamps use `timestamptz` (per V58 standardization)
   - One content row per language (mirrors filesystem one-file-per-language model)

--- a/lib/phoenix_kit/migrations/postgres/v61.ex
+++ b/lib/phoenix_kit/migrations/postgres/v61.ex
@@ -65,10 +65,10 @@ defmodule PhoenixKit.Migrations.Postgres.V61 do
     # Flush any pending commands from earlier versions
     flush()
 
-    # Ensure #{prefix}.uuid_generate_v7() exists (created in V40, but be safe)
+    # Ensure <prefix>.uuid_generate_v7() exists (created in V40, but be safe)
     Helpers.ensure_uuid_v7_function(prefix)
 
-    # Need to flush #{prefix}.uuid_generate_v7() creation before using it
+    # Need to flush <prefix>.uuid_generate_v7() creation before using it
     flush()
 
     # Add uuid column to each missing table

--- a/lib/phoenix_kit/migrations/postgres/v61.ex
+++ b/lib/phoenix_kit/migrations/postgres/v61.ex
@@ -48,6 +48,8 @@ defmodule PhoenixKit.Migrations.Postgres.V61 do
 
   use Ecto.Migration
 
+  alias PhoenixKit.Migrations.Postgres.Helpers
+
   @tables_missing_uuid [
     :phoenix_kit_admin_notes,
     :phoenix_kit_ai_requests,
@@ -63,24 +65,10 @@ defmodule PhoenixKit.Migrations.Postgres.V61 do
     # Flush any pending commands from earlier versions
     flush()
 
-    # Ensure uuid_generate_v7() exists (created in V40, but be safe)
-    execute("""
-    CREATE OR REPLACE FUNCTION uuid_generate_v7()
-    RETURNS uuid AS $$
-    DECLARE
-      unix_ts_ms bytea;
-      uuid_bytes bytea;
-    BEGIN
-      unix_ts_ms := substring(int8send(floor(extract(epoch FROM clock_timestamp()) * 1000)::bigint) FROM 3);
-      uuid_bytes := unix_ts_ms || gen_random_bytes(10);
-      uuid_bytes := set_byte(uuid_bytes, 6, (get_byte(uuid_bytes, 6) & 15) | 112);
-      uuid_bytes := set_byte(uuid_bytes, 8, (get_byte(uuid_bytes, 8) & 63) | 128);
-      RETURN encode(uuid_bytes, 'hex')::uuid;
-    END
-    $$ LANGUAGE plpgsql VOLATILE;
-    """)
+    # Ensure #{prefix}.uuid_generate_v7() exists (created in V40, but be safe)
+    Helpers.ensure_uuid_v7_function(prefix)
 
-    # Need to flush uuid_generate_v7() creation before using it
+    # Need to flush #{prefix}.uuid_generate_v7() creation before using it
     flush()
 
     # Add uuid column to each missing table
@@ -115,12 +103,12 @@ defmodule PhoenixKit.Migrations.Postgres.V61 do
       unless column_exists?(table, :uuid, escaped_prefix) do
         execute("""
         ALTER TABLE #{table_name}
-        ADD COLUMN uuid UUID DEFAULT uuid_generate_v7()
+        ADD COLUMN uuid UUID DEFAULT #{prefix}.uuid_generate_v7()
         """)
 
         execute("""
         UPDATE #{table_name}
-        SET uuid = uuid_generate_v7()
+        SET uuid = #{prefix}.uuid_generate_v7()
         WHERE uuid IS NULL
         """)
 

--- a/lib/phoenix_kit/migrations/postgres/v63.ex
+++ b/lib/phoenix_kit/migrations/postgres/v63.ex
@@ -45,10 +45,10 @@ defmodule PhoenixKit.Migrations.Postgres.V63 do
     # Flush any pending migration commands from earlier versions
     flush()
 
-    # Ensure #{prefix}.uuid_generate_v7() exists (created in V40, be defensive)
+    # Ensure <prefix>.uuid_generate_v7() exists (created in V40, be defensive)
     Helpers.ensure_uuid_v7_function(prefix)
 
-    # Flush so #{prefix}.uuid_generate_v7() is available for subsequent queries
+    # Flush so <prefix>.uuid_generate_v7() is available for subsequent queries
     flush()
 
     # 1. Add uuid column to ai_accounts (must come before account_uuid backfill)

--- a/lib/phoenix_kit/migrations/postgres/v63.ex
+++ b/lib/phoenix_kit/migrations/postgres/v63.ex
@@ -37,30 +37,18 @@ defmodule PhoenixKit.Migrations.Postgres.V63 do
 
   use Ecto.Migration
 
+  alias PhoenixKit.Migrations.Postgres.Helpers
+
   def up(%{prefix: prefix} = opts) do
     escaped_prefix = Map.get(opts, :escaped_prefix, prefix)
 
     # Flush any pending migration commands from earlier versions
     flush()
 
-    # Ensure uuid_generate_v7() exists (created in V40, be defensive)
-    execute("""
-    CREATE OR REPLACE FUNCTION uuid_generate_v7()
-    RETURNS uuid AS $$
-    DECLARE
-      unix_ts_ms bytea;
-      uuid_bytes bytea;
-    BEGIN
-      unix_ts_ms := substring(int8send(floor(extract(epoch FROM clock_timestamp()) * 1000)::bigint) FROM 3);
-      uuid_bytes := unix_ts_ms || gen_random_bytes(10);
-      uuid_bytes := set_byte(uuid_bytes, 6, (get_byte(uuid_bytes, 6) & 15) | 112);
-      uuid_bytes := set_byte(uuid_bytes, 8, (get_byte(uuid_bytes, 8) & 63) | 128);
-      RETURN encode(uuid_bytes, 'hex')::uuid;
-    END
-    $$ LANGUAGE plpgsql VOLATILE;
-    """)
+    # Ensure #{prefix}.uuid_generate_v7() exists (created in V40, be defensive)
+    Helpers.ensure_uuid_v7_function(prefix)
 
-    # Flush so uuid_generate_v7() is available for subsequent queries
+    # Flush so #{prefix}.uuid_generate_v7() is available for subsequent queries
     flush()
 
     # 1. Add uuid column to ai_accounts (must come before account_uuid backfill)
@@ -114,8 +102,11 @@ defmodule PhoenixKit.Migrations.Postgres.V63 do
          not column_exists?(table, :uuid, escaped_prefix) do
       table_name = prefix_table("phoenix_kit_ai_accounts", prefix)
 
-      execute("ALTER TABLE #{table_name} ADD COLUMN uuid UUID DEFAULT uuid_generate_v7()")
-      execute("UPDATE #{table_name} SET uuid = uuid_generate_v7() WHERE uuid IS NULL")
+      execute(
+        "ALTER TABLE #{table_name} ADD COLUMN uuid UUID DEFAULT #{prefix}.uuid_generate_v7()"
+      )
+
+      execute("UPDATE #{table_name} SET uuid = #{prefix}.uuid_generate_v7() WHERE uuid IS NULL")
 
       execute("""
       CREATE UNIQUE INDEX IF NOT EXISTS phoenix_kit_ai_accounts_uuid_idx

--- a/lib/phoenix_kit/migrations/postgres/v75.ex
+++ b/lib/phoenix_kit/migrations/postgres/v75.ex
@@ -6,7 +6,7 @@ defmodule PhoenixKit.Migrations.Postgres.V75 do
   DEFAULT was a `nextval()` sequence — that got dropped during the rename.
   This left 27 tables with no DEFAULT on `uuid`. Additionally, 4 tables
   (comments module + role_permissions) had `gen_random_uuid()` (UUIDv4) instead
-  of `uuid_generate_v7()` (UUIDv7).
+  of the schema-qualified `<prefix>.uuid_generate_v7()` (UUIDv7).
 
   While Ecto generates UUIDs in the app layer (`autogenerate: true`), a DB-level
   DEFAULT is important for:
@@ -15,8 +15,8 @@ defmodule PhoenixKit.Migrations.Postgres.V75 do
 
   ## Changes
 
-  1. **Set DEFAULT uuid_generate_v7()** on 27 tables missing it (Category A)
-  2. **Fix DEFAULT** on 4 tables using gen_random_uuid() → uuid_generate_v7()
+  1. **Set DEFAULT <prefix>.uuid_generate_v7()** on 27 tables missing it (Category A)
+  2. **Fix DEFAULT** on 4 tables using gen_random_uuid() → <prefix>.uuid_generate_v7()
   3. **Drop orphaned sequence** `phoenix_kit_id_seq` (CASCADE — also drops the DEFAULT
      on `phoenix_kit.id` meta table column that references it)
   """

--- a/lib/phoenix_kit/migrations/postgres/v75.ex
+++ b/lib/phoenix_kit/migrations/postgres/v75.ex
@@ -54,7 +54,7 @@ defmodule PhoenixKit.Migrations.Postgres.V75 do
     phoenix_kit_user_follows_history
   )
 
-  # Tables where uuid DEFAULT is gen_random_uuid() (wrong — should be #{prefix}.uuid_generate_v7())
+  # Tables where uuid DEFAULT is gen_random_uuid() (wrong — should be <prefix>.uuid_generate_v7())
   @wrong_default_tables ~w(
     phoenix_kit_comments
     phoenix_kit_comments_dislikes

--- a/lib/phoenix_kit/migrations/postgres/v75.ex
+++ b/lib/phoenix_kit/migrations/postgres/v75.ex
@@ -54,7 +54,7 @@ defmodule PhoenixKit.Migrations.Postgres.V75 do
     phoenix_kit_user_follows_history
   )
 
-  # Tables where uuid DEFAULT is gen_random_uuid() (wrong — should be uuid_generate_v7())
+  # Tables where uuid DEFAULT is gen_random_uuid() (wrong — should be #{prefix}.uuid_generate_v7())
   @wrong_default_tables ~w(
     phoenix_kit_comments
     phoenix_kit_comments_dislikes
@@ -71,7 +71,7 @@ defmodule PhoenixKit.Migrations.Postgres.V75 do
     for table <- @missing_default_tables do
       if table_exists?(table, escaped_prefix) do
         execute(
-          "ALTER TABLE #{prefix_table(table, prefix)} ALTER COLUMN uuid SET DEFAULT uuid_generate_v7()"
+          "ALTER TABLE #{prefix_table(table, prefix)} ALTER COLUMN uuid SET DEFAULT #{prefix}.uuid_generate_v7()"
         )
       end
     end
@@ -80,7 +80,7 @@ defmodule PhoenixKit.Migrations.Postgres.V75 do
     for table <- @wrong_default_tables do
       if table_exists?(table, escaped_prefix) do
         execute(
-          "ALTER TABLE #{prefix_table(table, prefix)} ALTER COLUMN uuid SET DEFAULT uuid_generate_v7()"
+          "ALTER TABLE #{prefix_table(table, prefix)} ALTER COLUMN uuid SET DEFAULT #{prefix}.uuid_generate_v7()"
         )
       end
     end

--- a/lib/phoenix_kit/migrations/postgres/v78.ex
+++ b/lib/phoenix_kit/migrations/postgres/v78.ex
@@ -125,10 +125,10 @@ defmodule PhoenixKit.Migrations.Postgres.V78 do
 
     execute("""
     ALTER TABLE #{full_table}
-    ADD COLUMN IF NOT EXISTS uuid UUID DEFAULT uuid_generate_v7()
+    ADD COLUMN IF NOT EXISTS uuid UUID DEFAULT #{prefix}.uuid_generate_v7()
     """)
 
-    execute("UPDATE #{full_table} SET uuid = uuid_generate_v7() WHERE uuid IS NULL")
+    execute("UPDATE #{full_table} SET uuid = #{prefix}.uuid_generate_v7() WHERE uuid IS NULL")
 
     execute("ALTER TABLE #{full_table} ALTER COLUMN uuid SET NOT NULL")
 

--- a/lib/phoenix_kit/migrations/postgres/v79.ex
+++ b/lib/phoenix_kit/migrations/postgres/v79.ex
@@ -22,7 +22,7 @@ defmodule PhoenixKit.Migrations.Postgres.V79 do
 
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_newsletters_lists (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       name VARCHAR(255) NOT NULL,
       slug VARCHAR(255) NOT NULL,
       description TEXT,
@@ -45,7 +45,7 @@ defmodule PhoenixKit.Migrations.Postgres.V79 do
 
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_newsletters_list_members (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       user_uuid UUID NOT NULL,
       list_uuid UUID NOT NULL,
       status VARCHAR(20) NOT NULL DEFAULT 'active',
@@ -78,7 +78,7 @@ defmodule PhoenixKit.Migrations.Postgres.V79 do
 
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_newsletters_broadcasts (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       subject VARCHAR(998) NOT NULL,
       markdown_body TEXT,
       html_body TEXT,
@@ -133,7 +133,7 @@ defmodule PhoenixKit.Migrations.Postgres.V79 do
 
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_newsletters_deliveries (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{prefix}.uuid_generate_v7(),
       broadcast_uuid UUID NOT NULL,
       user_uuid UUID NOT NULL,
       status VARCHAR(20) NOT NULL DEFAULT 'pending',

--- a/lib/phoenix_kit/migrations/postgres/v86.ex
+++ b/lib/phoenix_kit/migrations/postgres/v86.ex
@@ -19,7 +19,7 @@ defmodule PhoenixKit.Migrations.Postgres.V86 do
                            primary_key: false,
                            prefix: prefix
                          ) do
-      add(:uuid, :uuid, primary_key: true, default: fragment("uuid_generate_v7()"))
+      add(:uuid, :uuid, primary_key: true, default: fragment("#{prefix}.uuid_generate_v7()"))
       add(:name, :string, null: false, size: 255)
       add(:type, :string, null: false, default: "header", size: 20)
       add(:html, :text, default: "")
@@ -39,7 +39,7 @@ defmodule PhoenixKit.Migrations.Postgres.V86 do
                            primary_key: false,
                            prefix: prefix
                          ) do
-      add(:uuid, :uuid, primary_key: true, default: fragment("uuid_generate_v7()"))
+      add(:uuid, :uuid, primary_key: true, default: fragment("#{prefix}.uuid_generate_v7()"))
       add(:name, :string, null: false, size: 255)
       add(:slug, :string, size: 255)
       add(:description, :text)
@@ -87,7 +87,7 @@ defmodule PhoenixKit.Migrations.Postgres.V86 do
                            primary_key: false,
                            prefix: prefix
                          ) do
-      add(:uuid, :uuid, primary_key: true, default: fragment("uuid_generate_v7()"))
+      add(:uuid, :uuid, primary_key: true, default: fragment("#{prefix}.uuid_generate_v7()"))
       add(:name, :string, null: false, size: 255)
 
       add(

--- a/lib/phoenix_kit/migrations/postgres/v87.ex
+++ b/lib/phoenix_kit/migrations/postgres/v87.ex
@@ -22,7 +22,7 @@ defmodule PhoenixKit.Migrations.Postgres.V87 do
                            primary_key: false,
                            prefix: prefix
                          ) do
-      add(:uuid, :uuid, primary_key: true, default: fragment("uuid_generate_v7()"))
+      add(:uuid, :uuid, primary_key: true, default: fragment("#{prefix}.uuid_generate_v7()"))
       add(:name, :string, null: false, size: 255)
       add(:description, :text)
       add(:website, :string, size: 500)
@@ -42,7 +42,7 @@ defmodule PhoenixKit.Migrations.Postgres.V87 do
                            primary_key: false,
                            prefix: prefix
                          ) do
-      add(:uuid, :uuid, primary_key: true, default: fragment("uuid_generate_v7()"))
+      add(:uuid, :uuid, primary_key: true, default: fragment("#{prefix}.uuid_generate_v7()"))
       add(:name, :string, null: false, size: 255)
       add(:description, :text)
       add(:website, :string, size: 500)
@@ -61,7 +61,7 @@ defmodule PhoenixKit.Migrations.Postgres.V87 do
                            primary_key: false,
                            prefix: prefix
                          ) do
-      add(:uuid, :uuid, primary_key: true, default: fragment("uuid_generate_v7()"))
+      add(:uuid, :uuid, primary_key: true, default: fragment("#{prefix}.uuid_generate_v7()"))
 
       add(
         :manufacturer_uuid,
@@ -101,7 +101,7 @@ defmodule PhoenixKit.Migrations.Postgres.V87 do
                            primary_key: false,
                            prefix: prefix
                          ) do
-      add(:uuid, :uuid, primary_key: true, default: fragment("uuid_generate_v7()"))
+      add(:uuid, :uuid, primary_key: true, default: fragment("#{prefix}.uuid_generate_v7()"))
       add(:name, :string, null: false, size: 255)
       add(:description, :text)
       add(:status, :string, default: "active", size: 20)
@@ -117,7 +117,7 @@ defmodule PhoenixKit.Migrations.Postgres.V87 do
                            primary_key: false,
                            prefix: prefix
                          ) do
-      add(:uuid, :uuid, primary_key: true, default: fragment("uuid_generate_v7()"))
+      add(:uuid, :uuid, primary_key: true, default: fragment("#{prefix}.uuid_generate_v7()"))
       add(:name, :string, null: false, size: 255)
       add(:description, :text)
       add(:position, :integer, default: 0)
@@ -152,7 +152,7 @@ defmodule PhoenixKit.Migrations.Postgres.V87 do
                            primary_key: false,
                            prefix: prefix
                          ) do
-      add(:uuid, :uuid, primary_key: true, default: fragment("uuid_generate_v7()"))
+      add(:uuid, :uuid, primary_key: true, default: fragment("#{prefix}.uuid_generate_v7()"))
       add(:name, :string, null: false, size: 255)
       add(:description, :text)
       add(:sku, :string, size: 100)

--- a/lib/phoenix_kit/migrations/postgres/v90.ex
+++ b/lib/phoenix_kit/migrations/postgres/v90.ex
@@ -16,7 +16,7 @@ defmodule PhoenixKit.Migrations.Postgres.V90 do
                            primary_key: false,
                            prefix: prefix
                          ) do
-      add(:uuid, :uuid, primary_key: true, default: fragment("uuid_generate_v7()"))
+      add(:uuid, :uuid, primary_key: true, default: fragment("#{prefix}.uuid_generate_v7()"))
       add(:action, :string, null: false, size: 100)
       add(:module, :string, size: 50)
       add(:mode, :string, size: 20)

--- a/lib/phoenix_kit/migrations/postgres/v91.ex
+++ b/lib/phoenix_kit/migrations/postgres/v91.ex
@@ -20,7 +20,7 @@ defmodule PhoenixKit.Migrations.Postgres.V91 do
                            primary_key: false,
                            prefix: prefix
                          ) do
-      add(:uuid, :uuid, primary_key: true, default: fragment("uuid_generate_v7()"))
+      add(:uuid, :uuid, primary_key: true, default: fragment("#{prefix}.uuid_generate_v7()"))
       add(:name, :string, null: false, size: 255)
       add(:description, :text)
       add(:status, :string, default: "active", size: 20)
@@ -36,7 +36,7 @@ defmodule PhoenixKit.Migrations.Postgres.V91 do
                            primary_key: false,
                            prefix: prefix
                          ) do
-      add(:uuid, :uuid, primary_key: true, default: fragment("uuid_generate_v7()"))
+      add(:uuid, :uuid, primary_key: true, default: fragment("#{prefix}.uuid_generate_v7()"))
       add(:name, :string, null: false, size: 255)
       add(:description, :text)
       add(:public_notes, :text)
@@ -74,7 +74,7 @@ defmodule PhoenixKit.Migrations.Postgres.V91 do
                            primary_key: false,
                            prefix: prefix
                          ) do
-      add(:uuid, :uuid, primary_key: true, default: fragment("uuid_generate_v7()"))
+      add(:uuid, :uuid, primary_key: true, default: fragment("#{prefix}.uuid_generate_v7()"))
 
       add(
         :location_uuid,

--- a/lib/phoenix_kit/migrations/postgres/v92.ex
+++ b/lib/phoenix_kit/migrations/postgres/v92.ex
@@ -89,7 +89,7 @@ defmodule PhoenixKit.Migrations.Postgres.V92 do
           AND table_name = 'phoenix_kit_organization_invitations'
       ) THEN
         CREATE TABLE #{p}phoenix_kit_organization_invitations (
-          uuid UUID NOT NULL DEFAULT uuid_generate_v7() PRIMARY KEY,
+          uuid UUID NOT NULL DEFAULT #{prefix}.uuid_generate_v7() PRIMARY KEY,
           organization_uuid UUID NOT NULL
             REFERENCES #{p}phoenix_kit_users(uuid) ON DELETE CASCADE,
           email VARCHAR(160) NOT NULL,

--- a/lib/phoenix_kit/migrations/postgres/v95.ex
+++ b/lib/phoenix_kit/migrations/postgres/v95.ex
@@ -19,7 +19,7 @@ defmodule PhoenixKit.Migrations.Postgres.V95 do
                            primary_key: false,
                            prefix: prefix
                          ) do
-      add(:uuid, :uuid, primary_key: true, default: fragment("uuid_generate_v7()"))
+      add(:uuid, :uuid, primary_key: true, default: fragment("#{prefix}.uuid_generate_v7()"))
       add(:name, :string, null: false, size: 255)
       add(:color, :string, size: 20)
 
@@ -67,7 +67,7 @@ defmodule PhoenixKit.Migrations.Postgres.V95 do
                            primary_key: false,
                            prefix: prefix
                          ) do
-      add(:uuid, :uuid, primary_key: true, default: fragment("uuid_generate_v7()"))
+      add(:uuid, :uuid, primary_key: true, default: fragment("#{prefix}.uuid_generate_v7()"))
 
       add(
         :folder_uuid,

--- a/lib/phoenix_kit/migrations/uuid_fk_columns.ex
+++ b/lib/phoenix_kit/migrations/uuid_fk_columns.ex
@@ -668,7 +668,7 @@ defmodule PhoenixKit.Migrations.UUIDFKColumns do
       # (e.g. created_by references a deleted user with no CASCADE constraint)
       execute("""
       UPDATE #{table_name}
-      SET #{uuid_fk} = uuid_generate_v7()
+      SET #{uuid_fk} = #{prefix}.uuid_generate_v7()
       WHERE #{uuid_fk} IS NULL
       """)
 

--- a/lib/phoenix_kit/migrations/uuid_repair.ex
+++ b/lib/phoenix_kit/migrations/uuid_repair.ex
@@ -65,6 +65,7 @@ defmodule PhoenixKit.Migrations.UUIDRepair do
   """
   def maybe_repair(opts \\ []) do
     prefix = Keyword.get(opts, :prefix, "public")
+    Helpers.validate_prefix!(prefix)
 
     with {:ok, repo} <- get_repo(),
          {:ok, version} <- get_current_version(repo, prefix),
@@ -84,6 +85,7 @@ defmodule PhoenixKit.Migrations.UUIDRepair do
   """
   def needs_repair?(opts \\ []) do
     prefix = Keyword.get(opts, :prefix, "public")
+    Helpers.validate_prefix!(prefix)
 
     with {:ok, repo} <- get_repo(),
          {:ok, version} <- get_current_version(repo, prefix) do

--- a/lib/phoenix_kit/migrations/uuid_repair.ex
+++ b/lib/phoenix_kit/migrations/uuid_repair.ex
@@ -42,6 +42,8 @@ defmodule PhoenixKit.Migrations.UUIDRepair do
 
   require Logger
 
+  alias PhoenixKit.Migrations.Postgres.Helpers
+
   @tables_needing_repair [
     # Auth tables (V01) - CRITICAL for login/registration
     :phoenix_kit_users,
@@ -147,7 +149,7 @@ defmodule PhoenixKit.Migrations.UUIDRepair do
     ensure_pgcrypto(repo)
 
     # Ensure uuid_generate_v7() function exists (V40 creates it, but we run before V40)
-    ensure_uuid_generate_v7(repo)
+    ensure_uuid_generate_v7(repo, prefix)
 
     # Repair each table that needs it
     results =
@@ -167,27 +169,11 @@ defmodule PhoenixKit.Migrations.UUIDRepair do
   end
 
   defp ensure_pgcrypto(repo) do
-    repo.query("CREATE EXTENSION IF NOT EXISTS pgcrypto", [], log: false)
+    Helpers.ensure_extension!(repo, "pgcrypto")
   end
 
-  defp ensure_uuid_generate_v7(repo) do
-    query = """
-    CREATE OR REPLACE FUNCTION uuid_generate_v7()
-    RETURNS uuid AS $$
-    DECLARE
-      unix_ts_ms bytea;
-      uuid_bytes bytea;
-    BEGIN
-      unix_ts_ms := substring(int8send(floor(extract(epoch FROM clock_timestamp()) * 1000)::bigint) FROM 3);
-      uuid_bytes := unix_ts_ms || gen_random_bytes(10);
-      uuid_bytes := set_byte(uuid_bytes, 6, (get_byte(uuid_bytes, 6) & 15) | 112);
-      uuid_bytes := set_byte(uuid_bytes, 8, (get_byte(uuid_bytes, 8) & 63) | 128);
-      RETURN encode(uuid_bytes, 'hex')::uuid;
-    END
-    $$ LANGUAGE plpgsql VOLATILE;
-    """
-
-    repo.query(query, [], log: false)
+  defp ensure_uuid_generate_v7(repo, prefix) do
+    Helpers.ensure_uuid_v7_function(repo, prefix)
   end
 
   defp repair_table(repo, table, prefix) do
@@ -206,14 +192,16 @@ defmodule PhoenixKit.Migrations.UUIDRepair do
         # Need to add uuid column
         Logger.info("[PhoenixKit] Adding uuid column to #{table_name}...")
 
+        uuid_v7 = Helpers.uuid_v7_call(prefix)
+
         add_uuid_query = """
         ALTER TABLE #{table_name}
-        ADD COLUMN uuid UUID DEFAULT uuid_generate_v7()
+        ADD COLUMN uuid UUID DEFAULT #{uuid_v7}
         """
 
         backfill_query = """
         UPDATE #{table_name}
-        SET uuid = uuid_generate_v7()
+        SET uuid = #{uuid_v7}
         WHERE uuid IS NULL
         """
 

--- a/lib/phoenix_kit/notifications/notification.ex
+++ b/lib/phoenix_kit/notifications/notification.ex
@@ -15,6 +15,7 @@ defmodule PhoenixKit.Notifications.Notification do
   - `inserted_at`     — creation timestamp (no `updated_at`)
   """
   use Ecto.Schema
+  use PhoenixKit.SchemaPrefix
   import Ecto.Changeset
 
   @primary_key {:uuid, UUIDv7, autogenerate: true}

--- a/lib/phoenix_kit/scheduled_jobs/scheduled_job.ex
+++ b/lib/phoenix_kit/scheduled_jobs/scheduled_job.ex
@@ -23,6 +23,7 @@ defmodule PhoenixKit.ScheduledJobs.ScheduledJob do
   """
 
   use Ecto.Schema
+  use PhoenixKit.SchemaPrefix
   import Ecto.Changeset
 
   alias PhoenixKit.Utils.Date, as: UtilsDate

--- a/lib/phoenix_kit/schema_prefix.ex
+++ b/lib/phoenix_kit/schema_prefix.ex
@@ -1,0 +1,32 @@
+defmodule PhoenixKit.SchemaPrefix do
+  @moduledoc """
+  Applies the configured schema prefix to a PhoenixKit Ecto schema.
+
+  `use PhoenixKit.SchemaPrefix` sets `@schema_prefix` from
+
+      config :phoenix_kit, prefix: "myschema"
+
+  so every query, insert, preload, join, and bulk operation built on the
+  schema targets the named Postgres schema the migrations installed into
+  — without the host having to point the database role's `search_path`
+  at it. When no prefix is configured (the default `public` install),
+  `@schema_prefix` stays unset and behavior is unchanged.
+
+  This is **compile-time** configuration (read via
+  `Application.compile_env/2` while the host compiles phoenix_kit):
+  set it in `config/config.exs`, not `runtime.exs`. Mix tracks the value
+  and recompiles the schemas when it changes. That matches the nature of
+  the setting — an install's schema prefix is fixed at `mix
+  phoenix_kit.install --prefix ...` time and never changes at runtime.
+
+  Every table-backed schema in PhoenixKit must `use` this module right
+  after `use Ecto.Schema` (a conformance test enforces it). Embedded
+  schemas don't need it.
+  """
+
+  defmacro __using__(_opts) do
+    quote do
+      @schema_prefix Application.compile_env(:phoenix_kit, :prefix)
+    end
+  end
+end

--- a/lib/phoenix_kit/schema_prefix.ex
+++ b/lib/phoenix_kit/schema_prefix.ex
@@ -10,7 +10,8 @@ defmodule PhoenixKit.SchemaPrefix do
   schema targets the named Postgres schema the migrations installed into
   — without the host having to point the database role's `search_path`
   at it. When no prefix is configured (the default `public` install),
-  `@schema_prefix` stays unset and behavior is unchanged.
+  `@schema_prefix` compiles to `nil` — equivalent to unset — and
+  behavior is unchanged.
 
   This is **compile-time** configuration (read via
   `Application.compile_env/2` while the host compiles phoenix_kit):
@@ -18,6 +19,14 @@ defmodule PhoenixKit.SchemaPrefix do
   and recompiles the schemas when it changes. That matches the nature of
   the setting — an install's schema prefix is fixed at `mix
   phoenix_kit.install --prefix ...` time and never changes at runtime.
+
+  A stale build cannot silently target the wrong schema: Elixir records
+  `compile_env` values and validates them when the application boots
+  (`Config.Provider.validate_compile_env/1`), so phoenix_kit compiled
+  before the prefix was configured raises a clear "compiled with a
+  different value" error instead of quietly querying `public`. Any
+  `mix compile`/`phx.server`/`release` after the config change
+  recompiles the schemas automatically.
 
   Every table-backed schema in PhoenixKit must `use` this module right
   after `use Ecto.Schema` (a conformance test enforces it). Embedded

--- a/lib/phoenix_kit/settings/setting.ex
+++ b/lib/phoenix_kit/settings/setting.ex
@@ -47,6 +47,7 @@ defmodule PhoenixKit.Settings.Setting do
       |> Repo.update()
   """
   use Ecto.Schema
+  use PhoenixKit.SchemaPrefix
   import Ecto.Changeset
 
   alias PhoenixKit.Users.Role

--- a/lib/phoenix_kit/users/admin_note.ex
+++ b/lib/phoenix_kit/users/admin_note.ex
@@ -21,6 +21,7 @@ defmodule PhoenixKit.Users.AdminNote do
   - Notes show author information for accountability
   """
   use Ecto.Schema
+  use PhoenixKit.SchemaPrefix
   import Ecto.Changeset
 
   @type t :: %__MODULE__{

--- a/lib/phoenix_kit/users/auth/user.ex
+++ b/lib/phoenix_kit/users/auth/user.ex
@@ -21,6 +21,7 @@ defmodule PhoenixKit.Users.Auth.User do
   - Email confirmation workflow support
   """
   use Ecto.Schema
+  use PhoenixKit.SchemaPrefix
   import Ecto.Changeset
 
   alias PhoenixKit.Modules.Languages

--- a/lib/phoenix_kit/users/auth/user_token.ex
+++ b/lib/phoenix_kit/users/auth/user_token.ex
@@ -21,6 +21,7 @@ defmodule PhoenixKit.Users.Auth.UserToken do
   - Short-lived magic links (15 minutes) minimize security exposure
   """
   use Ecto.Schema
+  use PhoenixKit.SchemaPrefix
   import Ecto.Query
   alias PhoenixKit.Users.Auth.UserToken
   alias PhoenixKit.Utils.SessionFingerprint

--- a/lib/phoenix_kit/users/oauth_provider.ex
+++ b/lib/phoenix_kit/users/oauth_provider.ex
@@ -7,6 +7,7 @@ defmodule PhoenixKit.Users.OAuthProvider do
   """
 
   use Ecto.Schema
+  use PhoenixKit.SchemaPrefix
   import Ecto.Changeset
 
   alias PhoenixKit.Users.Auth.User

--- a/lib/phoenix_kit/users/organization_invitation.ex
+++ b/lib/phoenix_kit/users/organization_invitation.ex
@@ -6,6 +6,7 @@ defmodule PhoenixKit.Users.OrganizationInvitation do
   The raw token is never stored — only the SHA-256 hash, following the UserToken pattern.
   """
   use Ecto.Schema
+  use PhoenixKit.SchemaPrefix
   import Ecto.Changeset
 
   alias PhoenixKit.Users.Auth.User

--- a/lib/phoenix_kit/users/role.ex
+++ b/lib/phoenix_kit/users/role.ex
@@ -26,6 +26,7 @@ defmodule PhoenixKit.Users.Role do
   - Automatic assignment of Owner role to first user
   """
   use Ecto.Schema
+  use PhoenixKit.SchemaPrefix
   import Ecto.Changeset
 
   @type t :: %__MODULE__{

--- a/lib/phoenix_kit/users/role_assignment.ex
+++ b/lib/phoenix_kit/users/role_assignment.ex
@@ -20,6 +20,7 @@ defmodule PhoenixKit.Users.RoleAssignment do
   - Direct deletion for role removal
   """
   use Ecto.Schema
+  use PhoenixKit.SchemaPrefix
   import Ecto.Changeset
 
   alias PhoenixKit.Utils.Date, as: UtilsDate

--- a/lib/phoenix_kit/users/role_permission.ex
+++ b/lib/phoenix_kit/users/role_permission.ex
@@ -14,6 +14,7 @@ defmodule PhoenixKit.Users.RolePermission do
   """
 
   use Ecto.Schema
+  use PhoenixKit.SchemaPrefix
   import Ecto.Changeset
 
   alias PhoenixKit.Users.Permissions

--- a/lib/phoenix_kit_web/components/layout_wrapper.ex
+++ b/lib/phoenix_kit_web/components/layout_wrapper.ex
@@ -315,20 +315,6 @@ defmodule PhoenixKitWeb.Components.LayoutWrapper do
               <%= HTML.raw(ThemeConfig.custom_theme_css()) %>
             </style>
             <style>
-              /* daisyUI 5 reserves a scrollbar gutter while a modal/drawer is open
-                 (`:where(:root:has(.modal-open, …)) { scrollbar-gutter: stable }` in
-                 @layer base). On a page without a scrollbar the fixed backdrop can't
-                 cover that reserved strip, so classic-scrollbar users (Firefox, macOS
-                 "always show") see an uncovered gap at the window's right edge whenever
-                 a modal opens. UNLAYERED here, so it beats the layered zero-specificity
-                 original regardless of stylesheet order. Accepted trade-off: on pages
-                 that DO scroll, classic-scrollbar users see a ~15px reflow when a modal
-                 opens (scrollbar hides, nothing reserves its width) — less jarring than
-                 the mispainted strip, which host background overrides make common. */
-              :root:has(.modal-open, .modal[open], .modal:target, .modal-toggle:checked, .drawer:not(.drawer-open) > .drawer-toggle:checked) {
-                scrollbar-gutter: auto;
-              }
-
               /* Custom sidebar control for desktop - override lg:drawer-open grid layout when closed */
               @media (min-width: 1024px) {
                 /* Override the grid to collapse sidebar column when closed */

--- a/lib/phoenix_kit_web/components/layouts/root.html.heex
+++ b/lib/phoenix_kit_web/components/layouts/root.html.heex
@@ -47,18 +47,6 @@
       {assigns[:page_title]}
     </.live_title>
     <link phx-track-static rel="stylesheet" href={~p"/assets/app.css"} />
-    <%!-- daisyUI 5 reserves a scrollbar gutter while a modal/drawer is open
-    (`:where(:root:has(.modal-open, …)) { scrollbar-gutter: stable }` in
-    @layer base). On a page without a scrollbar the fixed backdrop can't cover
-    that reserved strip, so classic-scrollbar users (Firefox, macOS "always
-    show") see an uncovered gap at the window's right edge whenever a modal
-    opens. This UNLAYERED rule beats the layered zero-specificity original
-    regardless of stylesheet order. --%>
-    <style>
-      :root:has(.modal-open, .modal[open], .modal:target, .modal-toggle:checked, .drawer:not(.drawer-open) > .drawer-toggle:checked) {
-        scrollbar-gutter: auto;
-      }
-    </style>
     <script defer phx-track-static type="text/javascript" src={~p"/assets/app.js"}>
     </script>
     <%!-- PhoenixKit Cookie Consent Widget Setup --%>

--- a/priv/static/assets/phoenix_kit.js
+++ b/priv/static/assets/phoenix_kit.js
@@ -1798,11 +1798,6 @@ if (typeof window.Chart === "undefined") {
   //                    closeable.
   // ---------------------------------------------------------------------------
 
-  // Refcount of open PkDialog modals. Used to know when to restore the
-  // html's scrollbar-gutter (only when the LAST modal closes, since
-  // multiple <dialog> can be open simultaneously).
-  window._PkDialogOpenCount = window._PkDialogOpenCount || 0;
-
   // ---------------------------------------------------------------------------
   // PkCheckboxIndeterminate — applies the `indeterminate` property to a
   // checkbox based on `data-indeterminate="true"`. HTML has no attribute
@@ -2074,34 +2069,16 @@ if (typeof window.Chart === "undefined") {
     }
   }
 
+  // NOTE: no scrollbar-gutter games here. Old daisyUI (5.0.x) reserved a
+  // scrollbar gutter unconditionally while a modal was open, and this hook
+  // used to counter it with an inline `scrollbar-gutter: auto` override —
+  // which traded the phantom right-edge strip on non-scrolling pages for a
+  // ~15px content reflow on pages that DO scroll (classic-scrollbar users saw
+  // the scrollbar pop in/out around every modal). daisyUI >= 5.1 reserves the
+  // gutter only when the page really has a scrollbar (rootscrollgutter.css),
+  // which handles both page types correctly — PhoenixKit pins such a version
+  // (see PhoenixKit.Install.DaisyUI), so the override is gone. Don't re-add it.
   window.PhoenixKitHooks.PkDialog = {
-    _onOpened() {
-      // daisyUI 5 ships a `:where(:root:has(.modal[open])) { scrollbar-gutter: stable }`
-      // rule that prevents body layout jump when a modal opens but ALSO
-      // reduces the layout viewport by ~15px, leaving a strip on the right
-      // where the dialog/backdrop don't reach. Override per modal open so
-      // the dialog can cover the full visual viewport. Refcounted so
-      // concurrent modals don't fight each other.
-      if (window._PkDialogOpenCount === 0) {
-        const html = document.documentElement;
-        html.dataset.pkPrevScrollbarGutter = html.style.scrollbarGutter || "";
-        html.style.setProperty("scrollbar-gutter", "auto", "important");
-      }
-      window._PkDialogOpenCount += 1;
-    },
-    _onClosed() {
-      window._PkDialogOpenCount = Math.max(0, window._PkDialogOpenCount - 1);
-      if (window._PkDialogOpenCount === 0) {
-        const html = document.documentElement;
-        const prev = html.dataset.pkPrevScrollbarGutter;
-        if (prev) {
-          html.style.scrollbarGutter = prev;
-        } else {
-          html.style.removeProperty("scrollbar-gutter");
-        }
-        delete html.dataset.pkPrevScrollbarGutter;
-      }
-    },
     _isCloseable() {
       return this.el.dataset.closeable !== "false";
     },
@@ -2137,10 +2114,6 @@ if (typeof window.Chart === "undefined") {
         typeof this.el.showModal === "function"
       ) {
         this.el.showModal();
-        if (!this._opened) {
-          this._opened = true;
-          this._onOpened();
-        }
       } else if (wantOpen && isOpenForBrowser) {
         // Dialog is in the top layer but the `open` attribute may have
         // been stripped by Phoenix LV's DOM patch (the server template
@@ -2151,12 +2124,6 @@ if (typeof window.Chart === "undefined") {
         // the top layer. Restore the attribute so the dialog renders.
         if (!this.el.open) {
           this.el.setAttribute("open", "");
-        }
-        // Also track that the dialog is open (it may have been opened
-        // externally — e.g. BulkSelectScope — before this hook saw it).
-        if (!this._opened) {
-          this._opened = true;
-          this._onOpened();
         }
       } else if (!wantOpen && isOpenForBrowser) {
         // LV-driven close. If morphdom stripped the `open` attr after
@@ -2174,13 +2141,6 @@ if (typeof window.Chart === "undefined") {
     },
     mounted() {
       const self = this;
-      // `_opened` tracks whether we've incremented the global refcount,
-      // so the close event handler can decrement exactly once regardless
-      // of whether the close originated from Esc, backdrop, programmatic
-      // close, or destroyed(). Without this, a user-driven close would
-      // leave the gutter override sticky until `destroyed()` ran — and
-      // if LV didn't process the on_close event, that could be forever.
-      this._opened = false;
       this._closeFromLV = false;
 
       self._onCancel = function(e) {
@@ -2188,13 +2148,8 @@ if (typeof window.Chart === "undefined") {
       };
       // 'close' fires for every close path: Esc, our own el.close() in
       // destroyed(), backdrop click (via _onClick → el.close()), and
-      // form `method="dialog"` submits. This is the ONE place that
-      // decrements the refcount.
+      // form `method="dialog"` submits.
       self._onClose = function() {
-        if (self._opened) {
-          self._onClosed();
-          self._opened = false;
-        }
         if (!self._closeFromLV) self._pushClose();
         // Reset the LV-initiated flag now that the close event has
         // been fully processed. The next user-initiated close (Esc,
@@ -2224,10 +2179,6 @@ if (typeof window.Chart === "undefined") {
           typeof self.el.showModal === "function"
         ) {
           self.el.showModal();
-          if (!self._opened) {
-            self._opened = true;
-            self._onOpened();
-          }
         }
       };
       this.el.addEventListener("pk:dialog-show", self._onShowEvent);
@@ -2255,24 +2206,14 @@ if (typeof window.Chart === "undefined") {
       // LV is removing the element. Tell _onClose not to echo a close
       // event back (LV already initiated this).
       this._closeFromLV = true;
-      // Try the friendly path first (fires 'close' which decrements via
-      // _onClose). But if the element is already detached from the DOM
-      // when destroyed runs, close() may not fire 'close' on every UA —
-      // so always decrement defensively. _opened gates so we never
-      // double-decrement (whoever runs first wins).
-      //
-      // Use the same "is the browser holding this dialog open?"
-      // predicate as `_sync()` — `el.open` alone is unreliable when
-      // morphdom stripped the attribute earlier. Restore `open`
-      // first if needed so `close()` can release the top layer
-      // cleanly.
+      // Close the dialog so the browser releases it from the top layer.
+      // Use the same "is the browser holding this dialog open?" predicate
+      // as `_sync()` — `el.open` alone is unreliable when morphdom stripped
+      // the attribute earlier. Restore `open` first if needed so `close()`
+      // can release the top layer cleanly.
       if (isDialogOpenInBrowser(this.el)) {
         if (!this.el.open) this.el.setAttribute("open", "");
         this.el.close();
-      }
-      if (this._opened) {
-        this._onClosed();
-        this._opened = false;
       }
       if (this._onCancel) this.el.removeEventListener("cancel", this._onCancel);
       if (this._onClose) this.el.removeEventListener("close", this._onClose);

--- a/test/integration/prefix_migration_test.exs
+++ b/test/integration/prefix_migration_test.exs
@@ -162,5 +162,47 @@ defmodule PhoenixKit.Integration.PrefixMigrationTest do
       end)
 
     assert is_binary(uuid) and byte_size(uuid) == 36
+
+    # V40/V56-path pin: a LEGACY table's uuid default must also be bound to
+    # the prefixed function (the projects assert above covers the raw-SQL
+    # CREATE TABLE path; this covers the ALTER TABLE backfill path).
+    %{rows: [[users_default]]} =
+      Repo.query!(
+        """
+        SELECT column_default FROM information_schema.columns
+        WHERE table_schema = $1 AND table_name = 'phoenix_kit_users' AND column_name = 'uuid'
+        """,
+        [@schema]
+      )
+
+    assert users_default =~ "#{@schema}.uuid_generate_v7()"
+
+    # Upgrade-path pin: chains starting >= V40 skip the function-creation
+    # sites, so Postgres.up/1 must re-ensure the function at the prefix
+    # before running newer versions. Simulate: roll the marker back one
+    # version and move the function aside (rename, not drop — the column
+    # defaults are OID-bound to it), then re-run the migrator.
+    Repo.query!("ALTER FUNCTION #{@schema}.uuid_generate_v7() RENAME TO uuid_generate_v7_old")
+
+    previous_version = Postgres.current_version() - 1
+    Repo.query!("COMMENT ON TABLE #{@schema}.phoenix_kit IS '#{previous_version}'")
+
+    capture_io(fn ->
+      assert :ok = PhoenixKit.Migration.ensure_current(Repo, prefix: @schema, log: false)
+    end)
+
+    %{rows: [[fn_restored]]} =
+      Repo.query!(
+        """
+        SELECT EXISTS (
+          SELECT FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+          WHERE p.proname = 'uuid_generate_v7' AND n.nspname = $1
+        )
+        """,
+        [@schema]
+      )
+
+    assert fn_restored,
+           "Postgres.up did not re-ensure uuid_generate_v7 at the prefix on an upgrade chain"
   end
 end

--- a/test/integration/prefix_migration_test.exs
+++ b/test/integration/prefix_migration_test.exs
@@ -117,5 +117,36 @@ defmodule PhoenixKit.Integration.PrefixMigrationTest do
       )
 
     assert index_count > 500
+
+    # uuid_generate_v7() must live in the prefixed schema, not wherever
+    # search_path pointed (2026-07-12 field report: unqualified CREATE
+    # FUNCTION polluted public / failed on PG15+ low-privilege roles).
+    %{rows: [[fn_in_prefix]]} =
+      Repo.query!(
+        """
+        SELECT EXISTS (
+          SELECT FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+          WHERE p.proname = 'uuid_generate_v7' AND n.nspname = $1
+        )
+        """,
+        [@schema]
+      )
+
+    assert fn_in_prefix,
+           "uuid_generate_v7() was not created in the prefixed schema"
+
+    # And uuid DEFAULTs must be pinned to that schema-qualified function —
+    # an unqualified default would have resolved via search_path to
+    # public's copy, breaking installs where public has no function.
+    %{rows: [[default_expr]]} =
+      Repo.query!(
+        """
+        SELECT column_default FROM information_schema.columns
+        WHERE table_schema = $1 AND table_name = 'phoenix_kit_projects' AND column_name = 'uuid'
+        """,
+        [@schema]
+      )
+
+    assert default_expr =~ "#{@schema}.uuid_generate_v7()"
   end
 end

--- a/test/integration/prefix_migration_test.exs
+++ b/test/integration/prefix_migration_test.exs
@@ -148,5 +148,19 @@ defmodule PhoenixKit.Integration.PrefixMigrationTest do
       )
 
     assert default_expr =~ "#{@schema}.uuid_generate_v7()"
+
+    # The function must work with NO search_path at all — its body calls
+    # pgcrypto's gen_random_bytes/1, which a plpgsql body resolves via the
+    # CALLER's search_path unless qualified with pgcrypto's actual schema
+    # (2026-07 quorum finding: an unqualified body defeats the point of a
+    # schema-qualified function).
+    {:ok, uuid} =
+      Repo.transaction(fn ->
+        Repo.query!("SET LOCAL search_path TO ''")
+        %{rows: [[uuid]]} = Repo.query!("SELECT #{@schema}.uuid_generate_v7()::text")
+        uuid
+      end)
+
+    assert is_binary(uuid) and byte_size(uuid) == 36
   end
 end

--- a/test/mix/tasks/phoenix_kit_gen_migration_test.exs
+++ b/test/mix/tasks/phoenix_kit_gen_migration_test.exs
@@ -1,0 +1,40 @@
+defmodule Mix.Tasks.PhoenixKit.Gen.MigrationTest do
+  use ExUnit.Case, async: true
+
+  alias Mix.Tasks.PhoenixKit.Gen.Migration
+
+  # Regression (2026-07 quorum review): with no prior PhoenixKit migration
+  # in the project (from_version == 0), the generated migration IS the
+  # fresh install — a non-public schema may genuinely need creating, so
+  # create_schema must not be hardcoded to false.
+  test "fresh prefixed install (from_version 0) keeps schema creation" do
+    content =
+      Migration.migration_content("MyApp", "phoenix_kit_update_v0_to_v142", 0, 142, "auth")
+
+    assert content =~ ~s(prefix: "auth")
+    assert content =~ "create_schema: true"
+  end
+
+  test "prefixed upgrade never asks the chain to create the schema" do
+    content =
+      Migration.migration_content("MyApp", "phoenix_kit_update_v140_to_v142", 140, 142, "auth")
+
+    assert content =~ ~s(prefix: "auth")
+    assert content =~ "create_schema: false"
+  end
+
+  test "public installs never request schema creation" do
+    for from <- [0, 140] do
+      content =
+        Migration.migration_content(
+          "MyApp",
+          "phoenix_kit_update_v#{from}_to_v142",
+          from,
+          142,
+          "public"
+        )
+
+      assert content =~ "create_schema: false"
+    end
+  end
+end

--- a/test/phoenix_kit/install/common_unreachable_test.exs
+++ b/test/phoenix_kit/install/common_unreachable_test.exs
@@ -1,0 +1,30 @@
+defmodule PhoenixKit.Install.CommonUnreachableTest do
+  # async: false — mutates the :phoenix_kit repo config.
+  use ExUnit.Case, async: false
+
+  alias PhoenixKit.Install.Common
+
+  setup do
+    original = Application.get_env(:phoenix_kit, :repo)
+
+    on_exit(fn ->
+      case original do
+        nil -> Application.delete_env(:phoenix_kit, :repo)
+        value -> Application.put_env(:phoenix_kit, :repo, value)
+      end
+    end)
+
+    :ok
+  end
+
+  test "an unqueryable database reports {:unreachable, _}, never {:not_installed}" do
+    # Regression: with no version marker found, the old code fell through to
+    # {:not_installed} even when the DB couldn't be queried at all — and the
+    # update task drives migration generation off that answer. With no repo
+    # configured the install state is unknowable.
+    Application.delete_env(:phoenix_kit, :repo)
+
+    assert {:unreachable, :no_repo_configured} =
+             Common.check_installation_status("some_absent_prefix")
+  end
+end

--- a/test/phoenix_kit/install/daisyui_test.exs
+++ b/test/phoenix_kit/install/daisyui_test.exs
@@ -1,0 +1,63 @@
+defmodule PhoenixKit.Install.DaisyUITest do
+  use ExUnit.Case, async: true
+
+  alias PhoenixKit.Install.DaisyUI
+
+  describe "installed_version/1" do
+    @tag :tmp_dir
+    test "parses the version marker out of a plugin bundle", %{tmp_dir: tmp} do
+      path = Path.join(tmp, "daisyui.js")
+      File.write!(path, ~s|/** daisyUI */\nvar version = "5.0.35";\nmodule.exports = {};|)
+
+      assert DaisyUI.installed_version(path) == "5.0.35"
+    end
+
+    @tag :tmp_dir
+    test "returns nil when the file has no version marker", %{tmp_dir: tmp} do
+      path = Path.join(tmp, "daisyui.js")
+      File.write!(path, "module.exports = {};")
+
+      assert DaisyUI.installed_version(path) == nil
+    end
+
+    test "returns nil for a missing file" do
+      assert DaisyUI.installed_version("/nonexistent/daisyui.js") == nil
+    end
+  end
+
+  describe "outdated?/1" do
+    test "versions below the minimum are outdated" do
+      assert DaisyUI.outdated?("5.0.35")
+      assert DaisyUI.outdated?("5.1.0")
+    end
+
+    test "the minimum and above are not outdated" do
+      refute DaisyUI.outdated?(DaisyUI.minimum_version())
+      refute DaisyUI.outdated?("5.6.17")
+      # semver comparison, not string comparison
+      refute DaisyUI.outdated?("5.10.0")
+      refute DaisyUI.outdated?("6.0.0")
+    end
+
+    test "unparseable versions are not claimed outdated" do
+      refute DaisyUI.outdated?("not-a-version")
+    end
+  end
+
+  describe "minimum_version/0" do
+    test "is a valid semver string" do
+      assert {:ok, _} = Version.parse(DaisyUI.minimum_version())
+    end
+  end
+
+  describe "outdated_warning/1" do
+    test "names the installed and minimum versions and the upgrade path" do
+      warning = DaisyUI.outdated_warning("5.0.35")
+
+      assert warning =~ "5.0.35"
+      assert warning =~ DaisyUI.minimum_version()
+      assert warning =~ "assets/vendor"
+      assert warning =~ "daisyui.js"
+    end
+  end
+end

--- a/test/phoenix_kit/install/oban_config_test.exs
+++ b/test/phoenix_kit/install/oban_config_test.exs
@@ -1,0 +1,73 @@
+defmodule PhoenixKit.Install.ObanConfigTest do
+  use ExUnit.Case, async: true
+
+  alias PhoenixKit.Install.ObanConfig
+
+  describe "oban_block_missing_prefix?/1" do
+    test "true when the Oban block lacks prefix:" do
+      content = """
+      config :my_app, Oban,
+        repo: MyApp.Repo,
+        queues: [default: 10]
+
+      config :my_app, MyAppWeb.Endpoint, url: [host: "localhost"]
+      """
+
+      assert ObanConfig.oban_block_missing_prefix?(content)
+    end
+
+    test "false when the Oban block carries prefix:" do
+      content = """
+      config :my_app, Oban,
+        repo: MyApp.Repo,
+        prefix: "companyplexus",
+        queues: [default: 10]
+      """
+
+      refute ObanConfig.oban_block_missing_prefix?(content)
+    end
+
+    test "a phoenix_kit prefix entry OUTSIDE the Oban block does not satisfy the check" do
+      # Regression: a whole-file `prefix:` grep is satisfied by the
+      # config :phoenix_kit, prefix: line the installer itself writes,
+      # silencing the warning exactly when it's needed.
+      content = """
+      config :phoenix_kit, prefix: "companyplexus"
+
+      config :my_app, Oban,
+        repo: MyApp.Repo,
+        queues: [default: 10]
+      """
+
+      assert ObanConfig.oban_block_missing_prefix?(content)
+    end
+
+    test "computed prefix values count as configured" do
+      content = """
+      config :my_app, Oban,
+        repo: MyApp.Repo,
+        prefix: System.get_env("OBAN_PREFIX"),
+        queues: [default: 10]
+      """
+
+      refute ObanConfig.oban_block_missing_prefix?(content)
+    end
+
+    test "false when there is no Oban block at all" do
+      refute ObanConfig.oban_block_missing_prefix?("config :my_app, key: :value\n")
+    end
+
+    test "block detection stops at the next top-level config entry" do
+      # prefix: in a LATER unrelated block must not count for Oban
+      content = """
+      config :my_app, Oban,
+        repo: MyApp.Repo,
+        queues: [default: 10]
+
+      config :other_lib, prefix: "companyplexus"
+      """
+
+      assert ObanConfig.oban_block_missing_prefix?(content)
+    end
+  end
+end

--- a/test/phoenix_kit/install/prefix_config_test.exs
+++ b/test/phoenix_kit/install/prefix_config_test.exs
@@ -40,5 +40,24 @@ defmodule PhoenixKit.Install.PrefixConfigTest do
       Application.put_env(:phoenix_kit, :prefix, :auth)
       assert PrefixConfig.resolve_prefix([]) == "public"
     end
+
+    test "raises on an invalid explicit --prefix instead of passing it through" do
+      # Regression: --prefix "" / quoting-requiring values used to flow
+      # into tooling SQL and the generated migration, failing only at
+      # mix ecto.migrate time.
+      for bad <- ["", "My-App", "sp ace", "1abc"] do
+        assert_raise ArgumentError, ~r/invalid PhoenixKit schema prefix/, fn ->
+          PrefixConfig.resolve_prefix(prefix: bad)
+        end
+      end
+    end
+
+    test "raises on an invalid configured prefix" do
+      Application.put_env(:phoenix_kit, :prefix, "Bad-Prefix")
+
+      assert_raise ArgumentError, ~r/invalid PhoenixKit schema prefix/, fn ->
+        PrefixConfig.resolve_prefix([])
+      end
+    end
   end
 end

--- a/test/phoenix_kit/install/prefix_config_test.exs
+++ b/test/phoenix_kit/install/prefix_config_test.exs
@@ -1,0 +1,44 @@
+defmodule PhoenixKit.Install.PrefixConfigTest do
+  # async: false — mutates the :phoenix_kit application env.
+  use ExUnit.Case, async: false
+
+  alias PhoenixKit.Install.PrefixConfig
+
+  setup do
+    original = Application.get_env(:phoenix_kit, :prefix)
+
+    on_exit(fn ->
+      case original do
+        nil -> Application.delete_env(:phoenix_kit, :prefix)
+        value -> Application.put_env(:phoenix_kit, :prefix, value)
+      end
+    end)
+
+    :ok
+  end
+
+  describe "resolve_prefix/1" do
+    test "explicit --prefix option wins" do
+      Application.put_env(:phoenix_kit, :prefix, "from_config")
+      assert PrefixConfig.resolve_prefix(prefix: "from_flag") == "from_flag"
+    end
+
+    test "falls back to config :phoenix_kit, :prefix" do
+      Application.put_env(:phoenix_kit, :prefix, "companyplexus")
+      assert PrefixConfig.resolve_prefix([]) == "companyplexus"
+    end
+
+    test "defaults to public when neither is set" do
+      Application.delete_env(:phoenix_kit, :prefix)
+      assert PrefixConfig.resolve_prefix([]) == "public"
+    end
+
+    test "ignores blank or non-binary config values" do
+      Application.put_env(:phoenix_kit, :prefix, "")
+      assert PrefixConfig.resolve_prefix([]) == "public"
+
+      Application.put_env(:phoenix_kit, :prefix, :auth)
+      assert PrefixConfig.resolve_prefix([]) == "public"
+    end
+  end
+end

--- a/test/phoenix_kit/migrations/postgres_helpers_test.exs
+++ b/test/phoenix_kit/migrations/postgres_helpers_test.exs
@@ -1,0 +1,57 @@
+defmodule PhoenixKit.Migrations.Postgres.HelpersTest do
+  use ExUnit.Case, async: true
+
+  alias PhoenixKit.Migrations.Postgres.Helpers
+
+  describe "validate_prefix!/1" do
+    test "accepts conventional lower-case identifiers" do
+      assert :ok = Helpers.validate_prefix!("public")
+      assert :ok = Helpers.validate_prefix!("auth")
+      assert :ok = Helpers.validate_prefix!("companyplexus")
+      assert :ok = Helpers.validate_prefix!("my_app_2")
+      assert :ok = Helpers.validate_prefix!("_private")
+    end
+
+    test "rejects identifiers that need quoting" do
+      for bad <- ["MyApp", "my-app", "1schema", "sp ace", "we\"ird", ""] do
+        assert_raise ArgumentError, ~r/invalid PhoenixKit schema prefix/, fn ->
+          Helpers.validate_prefix!(bad)
+        end
+      end
+    end
+
+    test "rejects SQL-injection shaped prefixes" do
+      assert_raise ArgumentError, fn ->
+        Helpers.validate_prefix!("public; DROP TABLE phoenix_kit_users;--")
+      end
+    end
+
+    test "rejects non-binary values" do
+      assert_raise ArgumentError, ~r/expected a string/, fn ->
+        Helpers.validate_prefix!(nil)
+      end
+
+      assert_raise ArgumentError, ~r/expected a string/, fn ->
+        Helpers.validate_prefix!(:auth)
+      end
+    end
+  end
+
+  describe "qualify_table/2" do
+    test "qualifies with the prefix" do
+      assert Helpers.qualify_table("phoenix_kit_users", "auth") == "auth.phoenix_kit_users"
+    end
+
+    test "nil prefix qualifies explicitly as public" do
+      assert Helpers.qualify_table("phoenix_kit_users", nil) == "public.phoenix_kit_users"
+    end
+  end
+
+  describe "uuid_v7_call/1" do
+    test "always schema-qualifies the function call" do
+      assert Helpers.uuid_v7_call("auth") == "auth.uuid_generate_v7()"
+      assert Helpers.uuid_v7_call("public") == "public.uuid_generate_v7()"
+      assert Helpers.uuid_v7_call(nil) == "public.uuid_generate_v7()"
+    end
+  end
+end

--- a/test/phoenix_kit/migrations/prefix_validation_test.exs
+++ b/test/phoenix_kit/migrations/prefix_validation_test.exs
@@ -1,0 +1,77 @@
+defmodule PhoenixKit.Migrations.PrefixValidationTest do
+  use ExUnit.Case, async: true
+
+  alias PhoenixKit.Install.Common
+  alias PhoenixKit.Install.MigrationStrategy
+  alias PhoenixKit.Install.PrefixConfig
+  alias PhoenixKit.Migrations.Postgres
+  alias PhoenixKit.Migrations.Postgres.Helpers
+  alias PhoenixKit.Migrations.UUIDRepair
+
+  @moduledoc """
+  Pins the prefix-validation chokepoints added after the 2026-07 quorum
+  review: an invalid prefix must raise at every entry point — never be
+  swallowed into "not installed" or reach interpolated SQL. All of these
+  raise BEFORE any repo/migration-context use, so no DB is needed.
+  """
+
+  @bad "Bad-Prefix; DROP TABLE x;--"
+
+  test "Postgres.up/down reject an invalid prefix before touching the DB" do
+    assert_raise ArgumentError, ~r/invalid PhoenixKit schema prefix/, fn ->
+      Postgres.up(prefix: @bad)
+    end
+
+    assert_raise ArgumentError, ~r/invalid PhoenixKit schema prefix/, fn ->
+      Postgres.down(prefix: @bad)
+    end
+  end
+
+  test "migrated_version_runtime reraises the validation error instead of returning 0" do
+    assert_raise ArgumentError, ~r/invalid PhoenixKit schema prefix/, fn ->
+      Postgres.migrated_version_runtime(prefix: @bad)
+    end
+  end
+
+  test "Install.Common.check_installation_status rejects an invalid prefix" do
+    assert_raise ArgumentError, ~r/invalid PhoenixKit schema prefix/, fn ->
+      Common.check_installation_status(@bad)
+    end
+  end
+
+  test "UUIDRepair rejects an invalid prefix at both entry points" do
+    assert_raise ArgumentError, ~r/invalid PhoenixKit schema prefix/, fn ->
+      UUIDRepair.maybe_repair(prefix: @bad)
+    end
+
+    assert_raise ArgumentError, ~r/invalid PhoenixKit schema prefix/, fn ->
+      UUIDRepair.needs_repair?(prefix: @bad)
+    end
+  end
+
+  test "ensure_extension! rejects extension names outside the allowlist" do
+    # The name is interpolated into DDL; the guard runs before any repo use.
+    assert_raise ArgumentError, ~r/unknown Postgres extension/, fn ->
+      Helpers.ensure_extension!(:no_repo_needed, "bogus; DROP TABLE x;--")
+    end
+  end
+
+  test "migration_opts always emits create_schema explicitly for non-public prefixes" do
+    # Omitting the key would let the chain re-default it to true, silently
+    # discarding --create-schema=false.
+    assert MigrationStrategy.migration_opts("auth", true) ==
+             ~s([prefix: "auth", create_schema: true])
+
+    assert MigrationStrategy.migration_opts("auth", false) ==
+             ~s([prefix: "auth", create_schema: false])
+
+    assert MigrationStrategy.migration_opts("public", true) == "[]"
+    assert MigrationStrategy.migration_opts("public", false) == "[]"
+  end
+
+  test "add_prefix_configuration rejects an invalid prefix instead of persisting it" do
+    assert_raise ArgumentError, ~r/invalid PhoenixKit schema prefix/, fn ->
+      PrefixConfig.add_prefix_configuration(:igniter_unused, @bad)
+    end
+  end
+end

--- a/test/phoenix_kit/schema_prefix_test.exs
+++ b/test/phoenix_kit/schema_prefix_test.exs
@@ -1,0 +1,41 @@
+defmodule PhoenixKit.SchemaPrefixTest do
+  use ExUnit.Case, async: true
+
+  @moduledoc """
+  Guards the runtime half of named-schema (`--prefix`) support.
+
+  Every table-backed schema must `use PhoenixKit.SchemaPrefix` so its
+  queries target the schema the migrations installed into. A schema
+  missing it silently falls back to `search_path` resolution — invisible
+  on public installs, broken on prefixed ones.
+  """
+
+  test "every table-backed schema uses PhoenixKit.SchemaPrefix" do
+    offenders =
+      Path.wildcard("lib/**/*.ex")
+      |> Enum.filter(fn path ->
+        content = File.read!(path)
+
+        String.contains?(content, ~s[schema "phoenix_kit]) and
+          not String.contains?(content, "use PhoenixKit.SchemaPrefix")
+      end)
+
+    assert offenders == [],
+           "table-backed schemas missing `use PhoenixKit.SchemaPrefix` " <>
+             "(add it right after `use Ecto.Schema`): #{inspect(offenders)}"
+  end
+
+  # compile_env can't be read inside a function; the test build sets no
+  # prefix, so this must match what the schemas compiled against.
+  @compiled_prefix Application.compile_env(:phoenix_kit, :prefix)
+
+  test "schema prefix reflects the compiled :phoenix_kit, :prefix config" do
+    for schema <- [
+          PhoenixKit.Users.Auth.User,
+          PhoenixKit.Settings.Setting,
+          PhoenixKit.Modules.Storage.File
+        ] do
+      assert schema.__schema__(:prefix) == @compiled_prefix
+    end
+  end
+end


### PR DESCRIPTION
Supersedes #629 (closed before review to extend the batch). Follow-up to #628, driven by a field report from a hardened multi-schema install (schema pre-created by a DBA and owned by the app role, **no CREATE on the database**, PG 15+ non-writable `public`, PgBouncer). Every finding was reproduced against source before fixing, and the whole batch went through a multi-AI review (Codex / GLM / Kimi) plus a four-dimension quality sweep whose findings are also fixed here.

## Migration chain

- **`CREATE EXTENSION` / `CREATE SCHEMA` check the CREATE privilege *before* the IF-NOT-EXISTS short-circuit**, failing low-privilege roles even when the object exists. All five extension sites (V01 citext, V26/V40 pgcrypto, V111 pg_trgm, UUIDRepair) and V01's schema creation now check `pg_extension` / `information_schema.schemata` first and create only when genuinely missing; a missing extension the role cannot create raises an operator-facing message listing the three required extensions (documented in `PhoenixKit.Migration` for DBA pre-provisioning). Extension creation runs immediately (not queued) so same-version lookups see it.
- **V27 dropped the caller's `create_schema` flag at the Oban handoff** — Oban re-defaults it to true for non-public prefixes and executed the failing `CREATE SCHEMA` mid-chain (the report's "dies around v27–v31"). V27 now passes `create_schema: false`; by V27 the schema always exists.
- **`uuid_generate_v7()` was created unqualified** — it landed wherever `search_path` pointed (pollutes `public`; fails where `public` isn't writable). Now created inside the install's schema with **all ~89 call sites qualified**, and — per review — the function *body* qualifies pgcrypto's `gen_random_bytes` with the extension's actual schema (a plpgsql body resolves via the *caller's* search_path, which would have defeated the qualification). `Postgres.up/1` re-ensures the function at the prefix for upgrade chains starting ≥ V40. Existing installs keep their OID-pinned column defaults.
- **The prefix is validated (`[a-z_][a-z0-9_]*`) at every entry point** — `up`/`down`, the prefix-resolving tooling, `UUIDRepair`, `Install.Common` — and validation errors re-raise instead of being swallowed into "not installed". New shared `PhoenixKit.Migrations.Postgres.Helpers` centralizes these patterns.

## Tooling

- **`mix phoenix_kit.install --prefix X` persists `config :phoenix_kit, prefix: "X"`** (new `PhoenixKit.Install.PrefixConfig`); update/status/gen.migration resolve `--prefix` → config → `"public"`, so a prefixed install no longer reads as "Not installed".
- **`Install.Common` no longer fabricates `{:current_version, 1}`** from the mere existence of migration *files* — the bug that made `mix phoenix_kit.update` generate a from-scratch v01→v142 migration into the wrong schema. It now also distinguishes **`{:unreachable, reason}`** from `{:not_installed}` (a down DB must not read as an absent install); status renders "Unknown — database unreachable" and update refuses to generate migrations.
- Update-migration generators always emit `create_schema: false`; `gen.migration` keeps `create_schema: true` only for a genuinely fresh (from_version 0) prefixed project. `migration_opts` always emits the flag explicitly (omitting it silently discarded `--create-schema=false`).
- **Repo auto-detection halts (Igniter issue) when multiple Ecto repos are detected** and requires `--repo` — the field report's project got a migration-only repo silently wired into config.
- The generated Oban config carries `prefix:` (V27 puts `oban_jobs` inside the named schema); both install and update warn when a pre-existing Oban block lacks it (block-scoped check across config.exs + runtime.exs — a whole-file grep is defeated by the `config :phoenix_kit, prefix:` entry itself).

## Runtime schema prefix

Until now only migrations honored the prefix — runtime queries relied on the DB role's `search_path` (undocumented; the reporter's install depends on it). New `PhoenixKit.SchemaPrefix` sets `@schema_prefix` from `Application.compile_env(:phoenix_kit, :prefix)`; all 21 table-backed schemas use it, so every pathway (RepoHelper delegators, direct `repo()` calls, `update_all`/`insert_all`, Multi steps, preloads, joins) targets the named schema with zero call-site churn. Unset config compiles to nil — public installs are byte-for-byte unchanged. A conformance test blocks future schemas from skipping it. Compile-time by design; a stale build **fails loudly at boot** (`Config.Provider.validate_compile_env`) rather than silently querying `public` — documented, and the installer notice explains it for prefixed installs.

Disclosed limitation (documented in `PhoenixKit.Migration` + AGENTS.md): feature modules' own schemas need the same one-line adoption; until then prefixed installs running feature modules still need `search_path`.

## Verification

- `test/integration/prefix_migration_test.exs` extended to five pins: function lives in the prefixed schema; CREATE TABLE-path and ALTER TABLE-path uuid defaults bound to it; the function works under `SET LOCAL search_path TO ''`; upgrade chains starting ≥ V40 re-ensure the function.
- Field report's exact repro (low-priv role, no DB CREATE, pre-created schema): full v01→v142 chain, zero objects created in `public`. Fresh public install from a dropped DB also clean.
- Runtime e2e: test build recompiled with a prefix → `register_user` (user + token + owner role + activity) landed entirely in a scratch schema, `public` untouched.
- New unit suites: prefix validation chokepoints, `PrefixConfig.resolve_prefix`, Oban block-scoping, gen.migration content, SchemaPrefix conformance.
- `mix precommit` clean; full-suite failures identical to the pre-existing multi-session/sitemap set (verified by stash-rerun on the same base).

## daisyUI modal scrollbar-gutter (user-reported bug)

- **Fixes the reported "clicked cancel and a scroll bar showed up"** on the dashboards create modal: on pages that scroll, classic-scrollbar users (Windows/Linux, macOS "always show") saw content reflow ~15px and the scrollbar pop in/out around every modal open/close. Root cause: core's compensations for daisyUI 5.0.x's *unconditional* modal gutter reservation (the 1.7.179 counter-rules + PkDialog's inline override) defeat daisyUI ≥ 5.1's *conditional* reservation (`rootscrollgutter.css`), which handles both page types correctly on its own.
- **All compensations are removed** — both `:root:has(.modal-open, …) { scrollbar-gutter: auto }` rules (admin LayoutWrapper + `layouts/root.html.heex`) and PkDialog's inline override + `_PkDialogOpenCount` refcount machinery (~90 lines of JS). Do not re-add `scrollbar-gutter` overrides in layouts, PkDialog, or modules.
- **The vendored daisyUI stays host-owned** (`assets/vendor/daisyui.js`, scaffolded by phx.new) — a vendor-in-core auto-sync design was built, verified, and deliberately not adopted. Instead the new `PhoenixKit.Install.DaisyUI` declares a designed-for minimum (5.6.0; verified against 5.6.17/5.6.18) and warns when a host is behind: `phoenix_kit.install` (Igniter warning with curl upgrade steps), `phoenix_kit.update` (shell warning), `phoenix_kit.doctor` (new "daisyUI Version" check with pass / outdated / unversioned / missing states). Advisory only — nothing touches host files. Unit-tested.
- **Host impact:** a host on daisyUI < 5.1 gets daisyUI's stock old behavior — the gutter strip while a modal is open on non-scrolling pages (the pre-1.7.179 state) — plus the warning; the cure is updating the two `assets/vendor/` files, not core CSS. This knowingly re-trades the 1.7.179 counter-rule's fix for old-daisyUI hosts.
- Verified with native classic scrollbars: frame-by-frame layout capture shows zero reflow through the whole open → cancel cycle on a scrolling page, and no phantom strip (dialog covers the full viewport) on a viewport-locked page. Full investigation, options analysis, and measurement gotchas: `dev_docs/investigations/2026-07-12-daisyui-version-management-investigation.md`.

## Notes for the reviewer

- The two `DROP INDEX schema.name` sites the report warns about are deliberately untouched (qualified names are valid on DROP).
- Privilege-sensitive paths can't run under the suite's superuser connection — the manual repro recipe is documented in AGENTS.md.
- AGENTS.md refreshes ride along (prefix-hardening rules, the daisyUI version section, stale-doc cleanups).
