### PR TITLE
V143: consolidate manufacturing/warehouse module tables into core

### DIFF
--- a/dev_docs/pull_requests/2026/143-manufacturing-warehouse-tables-consolidation/CLAUDE_REVIEW.md
+++ b/dev_docs/pull_requests/2026/143-manufacturing-warehouse-tables-consolidation/CLAUDE_REVIEW.md
@@ -1,0 +1,181 @@
+# PR #632: V143 — consolidate manufacturing/warehouse module tables into core
+
+**Author**: @timujinne
+**Reviewer**: @claude (Sonnet 5)
+**Status**: 🔄 In Review (draft)
+**Commit**: `dcd497dd` (V143 migration), `ad7080a4` (dispatcher wiring)
+**Date**: 2026-07-13
+
+## Goal
+
+Move five tables — `phoenix_kit_machines`, `phoenix_kit_machine_type_assignments`,
+`phoenix_kit_machine_operations`, `phoenix_kit_warehouse_transfers` (+ its
+`number` sequence), `phoenix_kit_warehouse_min_stock` — out of the
+`phoenix_kit_manufacturing`/`phoenix_kit_warehouse` packages' own
+`migration_module/0` callbacks and into core's single numbered migration
+chain as `V143`, following the precedent already set by V140
+(`phoenix_kit_warehouse`'s other six tables, PR #624) and locations
+(V90/V122).
+
+## Verdict
+
+Clean. Every DDL statement was diffed by hand against its pre-consolidation
+source and matches byte-for-byte (modulo the deliberate, documented
+omissions below). No bugs found. One design decision worth recording
+explicitly because it looks like an oversight at a glance but isn't
+(index-naming inconsistency, see below).
+
+## Verification of claims
+
+### DDL fidelity vs. pre-consolidation sources
+
+- **`phoenix_kit_machines`** — `v143.ex:110-187` (columns, types, defaults,
+  both indexes) is an exact match for
+  `phoenix_kit_manufacturing`'s `machines.ex` V1 (identity columns +
+  `idx_machines_status`) and V2 (10 passport/soft-location `ADD COLUMN IF
+  NOT EXISTS` statements + `idx_machines_location`), confirmed by reading
+  the pre-removal source at commit `d202df9` in that repo. ✓
+- **`phoenix_kit_machine_type_assignments`** — table/index DDL
+  (`v143.ex:192-215`) matches the original except the `machine_type_uuid`
+  column drops its `REFERENCES #{p}phoenix_kit_machine_types (uuid) ON
+  DELETE CASCADE` clause (intentional — the target table is no longer
+  created here, see below) and gains the unconditional
+  `drop_fk_constraint/4` call for upgrade hosts. `phoenix_kit_machine_operations`
+  (`v143.ex:220-244`) is the same shape one column over
+  (`operation_uuid`). ✓
+- **`phoenix_kit_warehouse_transfers`/`min_stock`** — `v143.ex:277-359`
+  matches `phoenix_kit_warehouse`'s `v01.ex`/`v02.ex` (read from that
+  repo's history at commit `d6d8751^`, the last commit before their
+  removal) column-for-column, index-for-index. The only intentional
+  deletions are the `COMMENT ON TABLE ...phoenix_kit_warehouse_stock IS
+  '1'/'2'` lines — those tracked the *module's own* private version
+  counter on a table this migration doesn't own (`phoenix_kit_warehouse_stock`
+  is core's, created by V140); the plan correctly drops them since V143's
+  only version marker is `phoenix_kit`, core's own. ✓
+- **`fk_constraint_name/3` (`v143.ex:368-385`) / `drop_fk_constraint/4`
+  (`v143.ex:387-392`)** — diffed against `machines.ex:902-925` at the same
+  `d202df9` commit: identical, including the doc comment. Ported verbatim
+  as the plan directed, not reimplemented. `prefix_str/1` (`v143.ex:394-395`)
+  is **deliberately not** a verbatim port — the module's original
+  (`machines.ex:951-952`) returns `""` for `nil`/`"public"` (bare,
+  unqualified table names on the default schema); `v143.ex` instead
+  matches V138/V140/V142's own `prefix_str/1` (`"public"` → `"public."`,
+  always schema-qualified), per the plan's explicit style directive ("style
+  strictly like V140/V142, not like the module pattern"). Confirmed
+  identical to `v140.ex:414-415`, `v138.ex:202-203`, `v122.ex:219-220`. ✓
+
+### Mandatory review-fix checklist (from the wave-C plan header)
+
+- **#6 — eight indexes on `phoenix_kit_warehouse_transfers`.** Counted:
+  `number_index` (unique) + `status`, `inserted_at`, `deleted_at`,
+  `source_location_uuid`, `destination_location_uuid`, `shipped_at`,
+  `received_at` — 1 unique + 7 plain = 8, `received_at` included.
+  `v143.ex:304-341`. ✓
+- **#7 — FK drops before conditional legacy-table drops, `CASCADE` in the
+  dynamic `DROP TABLE`.** `up/1` (`v143.ex:55-77`) calls
+  `create_machine_type_assignments`/`create_machine_operations` (each
+  ending in `drop_fk_constraint`) *before* the three
+  `maybe_drop_if_empty` calls — and the code's own comment
+  (`v143.ex:63-68`) explains why the ordering matters. The dynamic
+  `EXECUTE 'DROP TABLE #{p}#{table} CASCADE'` (`v143.ex:265`) is present.
+  ✓
+- **#8 — `down/1` upgrade-host caveat in the moduledoc, not just the PR
+  body.** Present verbatim in `V143.down/1`'s own `@doc` (`v143.ex:79-93`).
+  ✓
+- **#9 — rollback terminology ("target exclusive").** Traced
+  `PhoenixKit.Migrations.Postgres.down/1` (`postgres.ex:1285-1307`):
+  `target_version = Map.get(opts, :version, 0)` and
+  `change(current_version..(target_version + 1)//-1, :down, opts)` — for
+  `version: 142`, that's `change(143..143, :down, opts)`, i.e. only V143's
+  `down/1` runs and 142 itself is never re-executed. Confirms "target
+  exclusive" is the accurate description used in this PR's body. ✓
+- **Dispatcher wiring (recon fact, not a numbered fix but load-bearing)**
+  — `Module.concat([__MODULE__, "V143"])`-style dispatch needs no separate
+  version registry; `postgres.ex`'s only required edits are
+  `@current_version 142 → 143` and the moduledoc version-list entry, both
+  present (`ad7080a4`). ✓
+- **`CHANGELOG.md` / `mix.exs` untouched.** `git diff
+  c989b1a2..core-v143-module-tables -- CHANGELOG.md mix.exs` is empty. ✓
+
+### Known bug classes checked and not present
+
+- **Schema-qualified index names** (the 2026-07-11 bug class fixed in PR
+  #628 — `CREATE INDEX <prefix>.<name> ON ...` is invalid; only the table
+  may be schema-qualified). Every `CREATE INDEX` in `v143.ex` qualifies
+  `ON #{p}<table>` and leaves the index name itself bare. ✓
+- **Constraint-existence guard not scoped to schema** (the PR #624 /
+  V140 bug — `pg_constraint.conname`/catalog lookups need to be
+  schema-scoped, since names aren't globally unique). `fk_constraint_name/3`
+  filters by `tc.table_schema = $1 AND tc.table_name = $2` and is a
+  parameterized query, not raw interpolation — correctly scoped, and
+  matches the pattern already fixed elsewhere in the repo. ✓
+- **Prefix escaping.** `v143.ex` interpolates `prefix`/`p` into raw SQL
+  without the dispatcher's `escaped_prefix`/`quoted_prefix` helpers.
+  Checked whether this is a regression: V138, V140, and V142 all do the
+  same (`escaped_prefix` is used only inside `postgres.ex`'s own
+  `migrated_version/1`/`version_checks/0`, never by an individual `V*.ex`
+  module) — consistent with established convention across the whole
+  migrations directory, not something V143 introduces. Not flagged.
+
+## Findings
+
+None. (See "Verified as correct" below for one item that could plausibly
+be *mis*-flagged as a bug on a shallow pass.)
+
+## Verified as correct (no action)
+
+- **Index-naming style differs between the two halves of this file, on
+  purpose.** The manufacturing tables use `idx_<table>_<col>` (e.g.
+  `idx_machines_status`); the warehouse tables use
+  `phoenix_kit_warehouse_<table>_<col>_index`. This looks like the kind
+  of inconsistency PR #610's review flagged as a NITPICK for the CRM
+  tables — but here it's load-bearing, not cosmetic: a real
+  `phoenix_kit_manufacturing` 0.2.0 host already has indexes named
+  `idx_machines_status` etc. from the module's own V1. If V143 used a
+  different name for the "same" index, `CREATE INDEX IF NOT EXISTS`
+  would not recognize the existing one as already present (index identity
+  is by name, not by definition) and an upgrade host would end up with
+  two functionally-identical indexes. Preserving each side's original
+  names is required for the `IF NOT EXISTS` idempotency claim to hold on
+  upgrade, not just continuity for its own sake.
+- **`create_machine_type_assignments`/`create_machine_operations` argument
+  order** (`p` then `prefix`) is consistent with every other private
+  helper in the file and with the ported originals — no accidental swap.
+- **Down-order is FK-safe**: `machine_operations`, `machine_type_assignments`,
+  `machines`, `warehouse_min_stock`, `warehouse_transfers` (+sequence) —
+  both join tables (children) drop before `machines` (parent); the two
+  warehouse tables have no FK relationship to the manufacturing ones or
+  to each other, so their relative order doesn't matter functionally.
+
+## Testing
+
+- [x] `mix format --check-formatted`
+- [x] `mix compile --warnings-as-errors`
+- [x] `mix test test/phoenix_kit/migration_test.exs` — 6 tests, 0 failures
+      (module-shape only, no DB required by design — see that file's own
+      moduledoc for why).
+- [ ] `mix test test/integration/prefix_migration_test.exs` — tagged
+      `:integration`, auto-excluded: no PostgreSQL reachable in this
+      environment (`pg_isready` refused on the default socket). This is
+      the test that runs the *entire* versioned chain, now 143 versions
+      deep, into a named schema — the closest thing to an automated
+      fresh-host rehearsal for this exact change. Left for CI / a
+      DB-backed environment; the orchestrator's separate live-Postgres
+      rehearsal (wave-C tasks C10/C11, against a real and a scratch
+      schema respectively) is the fuller manual complement to this gap.
+- No code changes were made by this review — the migration was correct on
+  first read.
+
+## Related
+
+- Migration: `lib/phoenix_kit/migrations/postgres/v143.ex`
+- Dispatcher: `lib/phoenix_kit/migrations/postgres.ex`
+- Pre-consolidation sources (for the byte-for-byte diff above):
+  `phoenix_kit_manufacturing@d202df9:lib/phoenix_kit_manufacturing/migrations/machines.ex`,
+  `phoenix_kit_warehouse@d6d8751^:lib/phoenix_kit_warehouse/migrations/postgres/{v01,v02}.ex`
+- Schema-qualified-index precedent: PR #628
+- Constraint-scoping precedent: PR #624 (`CLAUDE_REVIEW.md` in
+  `dev_docs/pull_requests/2026/624-warehouse-v140-tables/`)
+- Non-empty legacy-table manual migration runbook:
+  `phoenix_kit_manufacturing`'s `dev_docs/LEGACY_DATA_MIGRATION.md`
+  (companion PR)

--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -529,7 +529,29 @@ defmodule PhoenixKit.Migrations.Postgres do
   - Replaces unique index with partial index (slug-mode only, WHERE slug IS NOT NULL)
   - Adds unique index on `(group_uuid, post_date, post_time)` for timestamp-mode posts
 
-  ### V142 - Wider role-permission keys ⚡ LATEST
+  ### V143 - Manufacturing/Warehouse module tables consolidation ⚡ LATEST
+  - Consolidates 5 objects previously created by `phoenix_kit_manufacturing`'s
+    and `phoenix_kit_warehouse`'s own `migration_module/0` into core's
+    migration chain: `phoenix_kit_machines`, `phoenix_kit_machine_type_assignments`,
+    `phoenix_kit_machine_operations`, `phoenix_kit_warehouse_transfers`
+    (+ its `number` sequence), and `phoenix_kit_warehouse_min_stock`.
+  - `machine_type_uuid`/`operation_uuid` on the two join tables are soft
+    references (no FK) to the entities package. Upgrade path for hosts on
+    the published `phoenix_kit_manufacturing` 0.2.0 (module V1): the join
+    table already exists there with a *live* FK on `machine_type_uuid` —
+    this migration drops it unconditionally. Warehouse tables are
+    fresh-install-only DDL (`phoenix_kit_warehouse` 0.1.0 never published
+    migrations for them, so no upgrade case exists).
+  - The pre-V5 manufacturing directory tables (`phoenix_kit_machine_types`,
+    `phoenix_kit_operations`, `phoenix_kit_defect_reasons`) are not
+    re-created; each is dropped only if present and empty, left in place
+    with a database `NOTICE` when non-empty — see the PR body for the
+    manual data-migration note on such hosts.
+  - Rollback mirrors the five creates; see `V143.down/1`'s moduledoc for
+    the upgrade-host caveat (can't distinguish a pre-existing
+    `machine_type_assignments` table from one V143 created).
+
+  ### V142 - Wider role-permission keys
   - Widens `phoenix_kit_role_permissions.module_key` from `VARCHAR(50)` to
     `VARCHAR(120)` so fine-grained sub-permissions can be stored as composed
     dotted keys (`"calendar.view_others"` — base and sub parts are each
@@ -1235,7 +1257,7 @@ defmodule PhoenixKit.Migrations.Postgres do
   alias PhoenixKit.Migrations.Postgres.Helpers
 
   @initial_version 1
-  @current_version 142
+  @current_version 143
   @default_prefix "public"
 
   # First version whose SQL references uuid_generate_v7(). Chains that

--- a/lib/phoenix_kit/migrations/postgres/v143.ex
+++ b/lib/phoenix_kit/migrations/postgres/v143.ex
@@ -339,6 +339,11 @@ defmodule PhoenixKit.Migrations.Postgres.V143 do
     CREATE INDEX IF NOT EXISTS phoenix_kit_warehouse_transfers_received_at_index
     ON #{p}phoenix_kit_warehouse_transfers (received_at)
     """)
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS phoenix_kit_warehouse_transfers_source_refs_index
+    ON #{p}phoenix_kit_warehouse_transfers USING GIN (source_refs)
+    """)
   end
 
   defp create_warehouse_min_stock(p) do
@@ -356,6 +361,21 @@ defmodule PhoenixKit.Migrations.Postgres.V143 do
     CREATE UNIQUE INDEX IF NOT EXISTS phoenix_kit_warehouse_min_stock_item_uuid_index
     ON #{p}phoenix_kit_warehouse_min_stock (item_uuid)
     """)
+
+    execute("""
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'phoenix_kit_warehouse_min_stock_min_quantity_non_negative'
+        AND conrelid = '#{p}phoenix_kit_warehouse_min_stock'::regclass
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_warehouse_min_stock
+        ADD CONSTRAINT phoenix_kit_warehouse_min_stock_min_quantity_non_negative
+        CHECK (min_quantity >= 0);
+      END IF;
+    END $$;
+    """)
   end
 
   # ── FK-drop helpers, ported from PhoenixKitManufacturing.Migrations.Machines ──
@@ -364,6 +384,11 @@ defmodule PhoenixKit.Migrations.Postgres.V143 do
   # catalog rather than assuming a `..._fkey` naming convention. Returns
   # `nil` when no such constraint exists (fresh install, or already dropped
   # on a retry).
+  #
+  # Safe to call mid-migration: reads pre-V143 state via an immediate query;
+  # the V40/V61 flush trap does not apply because no preceding queued DDL in
+  # this migration creates the FK sought here — it pre-exists from module
+  # 0.2.0 installs.
   @spec fk_constraint_name(String.t(), String.t(), String.t()) :: String.t() | nil
   defp fk_constraint_name(prefix, table, column) do
     query = """
@@ -380,7 +405,8 @@ defmodule PhoenixKit.Migrations.Postgres.V143 do
 
     case PhoenixKit.RepoHelper.repo().query(query, [prefix || "public", table, column]) do
       {:ok, %{rows: [[name] | _]}} -> name
-      _ -> nil
+      {:ok, %{rows: []}} -> nil
+      {:error, reason} -> raise "FK lookup failed for #{table}.#{column}: #{inspect(reason)}"
     end
   end
 

--- a/lib/phoenix_kit/migrations/postgres/v143.ex
+++ b/lib/phoenix_kit/migrations/postgres/v143.ex
@@ -110,7 +110,7 @@ defmodule PhoenixKit.Migrations.Postgres.V143 do
   defp create_machines(p) do
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_machines (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{p}uuid_generate_v7(),
       name VARCHAR(255) NOT NULL,
       code VARCHAR(100),
       manufacturer VARCHAR(255),
@@ -192,7 +192,7 @@ defmodule PhoenixKit.Migrations.Postgres.V143 do
   defp create_machine_type_assignments(p, prefix) do
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_machine_type_assignments (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{p}uuid_generate_v7(),
       machine_uuid UUID NOT NULL
         REFERENCES #{p}phoenix_kit_machines (uuid) ON DELETE CASCADE,
       machine_type_uuid UUID NOT NULL,
@@ -220,7 +220,7 @@ defmodule PhoenixKit.Migrations.Postgres.V143 do
   defp create_machine_operations(p, prefix) do
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_machine_operations (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{p}uuid_generate_v7(),
       machine_uuid UUID NOT NULL
         REFERENCES #{p}phoenix_kit_machines (uuid) ON DELETE CASCADE,
       operation_uuid UUID NOT NULL,
@@ -279,7 +279,7 @@ defmodule PhoenixKit.Migrations.Postgres.V143 do
 
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_warehouse_transfers (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{p}uuid_generate_v7(),
       number BIGINT NOT NULL DEFAULT nextval('#{p}phoenix_kit_warehouse_transfers_number_seq'),
       status VARCHAR(20) NOT NULL DEFAULT 'draft',
       source_location_uuid UUID,
@@ -344,7 +344,7 @@ defmodule PhoenixKit.Migrations.Postgres.V143 do
   defp create_warehouse_min_stock(p) do
     execute("""
     CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_warehouse_min_stock (
-      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      uuid UUID PRIMARY KEY DEFAULT #{p}uuid_generate_v7(),
       item_uuid UUID NOT NULL,
       min_quantity NUMERIC NOT NULL DEFAULT 0,
       inserted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),

--- a/lib/phoenix_kit/migrations/postgres/v143.ex
+++ b/lib/phoenix_kit/migrations/postgres/v143.ex
@@ -1,0 +1,396 @@
+defmodule PhoenixKit.Migrations.Postgres.V143 do
+  @moduledoc """
+  V143: Manufacturing/Warehouse module tables consolidation.
+
+  Consolidates tables previously created by `phoenix_kit_manufacturing`'s
+  and `phoenix_kit_warehouse`'s own `migration_module/0` into core's
+  migration chain — see PR body for the manual-migration note on non-empty
+  legacy directory tables.
+
+  Five objects, each idempotent (safe to re-run):
+
+    * `phoenix_kit_machines` — machine reference-book records. V1 identity
+      columns (`name`, `code`, `manufacturer`, `serial_number`,
+      `description`, `location_note`, `status`, `data`, `metadata`) plus
+      the V2 passport/soft-location columns (`model`, `manufacture_year`,
+      `commissioned_on`, `warranty_until`, `to_last_on`,
+      `to_interval_days`, `to_next_on`, `notes`, `location_uuid`,
+      `space_uuid`), in their final (module V5-equivalent) shape.
+    * `phoenix_kit_machine_type_assignments` — machine<->machine_type join.
+      `machine_uuid` is a real FK to `phoenix_kit_machines`; `machine_type_uuid`
+      is a soft reference to `phoenix_kit_entity_data.uuid` (no FK) — machine
+      types now live in `phoenix_kit_entities`, a separate package this
+      migration doesn't own. On a host upgrading from the published
+      `phoenix_kit_manufacturing` 0.2.0 (module V1), this table already
+      exists with a *live* FK on `machine_type_uuid` (pointing at the
+      `phoenix_kit_machine_types` directory table below) — `CREATE TABLE IF
+      NOT EXISTS` is a no-op there, so the FK is dropped by a separate,
+      unconditional step.
+    * `phoenix_kit_machine_operations` — machine<->operation join, same
+      soft-reference shape on `operation_uuid`. Never published with a live
+      FK on any known external host (0.2.0 predates this table entirely),
+      but the drop is attempted unconditionally anyway, for symmetry with
+      `machine_type_uuid` above.
+    * `phoenix_kit_warehouse_transfers` (+ its `number` sequence) and
+      `phoenix_kit_warehouse_min_stock` — fresh-install-only DDL. The
+      published `phoenix_kit_warehouse` 0.1.0 shipped no migrations at all
+      (no `phoenix_kit_warehouse_transfers`/`min_stock` on any external
+      host), so there is no upgrade path to account for here, unlike the
+      manufacturing tables above.
+
+  `phoenix_kit_machine_types`, `phoenix_kit_operations`, and
+  `phoenix_kit_defect_reasons` — the pre-V5 manufacturing directory tables —
+  are **not** re-created by this migration; they are not one of the five
+  objects it owns. If a host still has one of them (realistic only on an
+  external `phoenix_kit_manufacturing` 0.2.0 install — our own dev database
+  has never had them, since the module's local migration already carried it
+  to V5), `up/1` drops it when empty and leaves it in place (with a
+  `RAISE NOTICE`) when it still holds rows, so real directory data is never
+  silently destroyed. See the core PR body for the manual data-migration
+  note on such hosts.
+  """
+
+  use Ecto.Migration
+
+  def up(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    create_machines(p)
+    create_machine_type_assignments(p, prefix)
+    create_machine_operations(p, prefix)
+
+    # FK drops above are unconditional and must run before these
+    # conditional legacy-table drops: a non-empty `phoenix_kit_machine_types`
+    # left in place still has to lose its inbound FK from
+    # `machine_type_assignments`, and `DROP TABLE ... CASCADE` below is a
+    # resilience net for a partially-applied prior run, not the primary
+    # mechanism for removing those FKs.
+    maybe_drop_if_empty(p, prefix, "phoenix_kit_machine_types")
+    maybe_drop_if_empty(p, prefix, "phoenix_kit_operations")
+    maybe_drop_if_empty(p, prefix, "phoenix_kit_defect_reasons")
+
+    create_warehouse_transfers(p)
+    create_warehouse_min_stock(p)
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '143'")
+  end
+
+  @doc """
+  Drops the five objects `up/1` owns, in FK-safe order (dependents before
+  the tables they reference), and restores the version marker to `142`.
+
+  **Upgrade-host caveat**: on a host that started from the published
+  `phoenix_kit_manufacturing` 0.2.0 (module V1), `phoenix_kit_machine_type_assignments`
+  pre-dates V143 — it was created by that module's own `migration_module/0`,
+  not by this migration. `down/1` cannot tell the two provenances apart, so
+  it drops that table unconditionally, which is a stricter rollback than
+  "undo only what V143 did" on such a host. Does **not** touch
+  `phoenix_kit_machine_types`, `phoenix_kit_operations`, or
+  `phoenix_kit_defect_reasons` — those are never owned by V143 (see
+  moduledoc), so rolling back leaves them exactly as `up/1` found them,
+  dropped-if-they-were-empty or still in place otherwise.
+  """
+  def down(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    execute("DROP TABLE IF EXISTS #{p}phoenix_kit_machine_operations")
+    execute("DROP TABLE IF EXISTS #{p}phoenix_kit_machine_type_assignments")
+    execute("DROP TABLE IF EXISTS #{p}phoenix_kit_machines")
+    execute("DROP TABLE IF EXISTS #{p}phoenix_kit_warehouse_min_stock")
+    execute("DROP TABLE IF EXISTS #{p}phoenix_kit_warehouse_transfers")
+    execute("DROP SEQUENCE IF EXISTS #{p}phoenix_kit_warehouse_transfers_number_seq")
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '142'")
+  end
+
+  # ── phoenix_kit_machines: V1 identity + V2 passport/soft-location ──
+
+  defp create_machines(p) do
+    execute("""
+    CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_machines (
+      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      name VARCHAR(255) NOT NULL,
+      code VARCHAR(100),
+      manufacturer VARCHAR(255),
+      serial_number VARCHAR(255),
+      description TEXT,
+      location_note VARCHAR(500),
+      status VARCHAR(20) NOT NULL DEFAULT 'active',
+      data JSONB NOT NULL DEFAULT '{}',
+      metadata JSONB NOT NULL DEFAULT '{}',
+      inserted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+    """)
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS idx_machines_status
+    ON #{p}phoenix_kit_machines (status)
+    """)
+
+    execute("""
+    ALTER TABLE #{p}phoenix_kit_machines
+    ADD COLUMN IF NOT EXISTS model VARCHAR(255)
+    """)
+
+    execute("""
+    ALTER TABLE #{p}phoenix_kit_machines
+    ADD COLUMN IF NOT EXISTS manufacture_year INTEGER
+    """)
+
+    execute("""
+    ALTER TABLE #{p}phoenix_kit_machines
+    ADD COLUMN IF NOT EXISTS commissioned_on DATE
+    """)
+
+    execute("""
+    ALTER TABLE #{p}phoenix_kit_machines
+    ADD COLUMN IF NOT EXISTS warranty_until DATE
+    """)
+
+    execute("""
+    ALTER TABLE #{p}phoenix_kit_machines
+    ADD COLUMN IF NOT EXISTS to_last_on DATE
+    """)
+
+    execute("""
+    ALTER TABLE #{p}phoenix_kit_machines
+    ADD COLUMN IF NOT EXISTS to_interval_days INTEGER
+    """)
+
+    execute("""
+    ALTER TABLE #{p}phoenix_kit_machines
+    ADD COLUMN IF NOT EXISTS to_next_on DATE
+    """)
+
+    execute("""
+    ALTER TABLE #{p}phoenix_kit_machines
+    ADD COLUMN IF NOT EXISTS notes TEXT
+    """)
+
+    execute("""
+    ALTER TABLE #{p}phoenix_kit_machines
+    ADD COLUMN IF NOT EXISTS location_uuid UUID
+    """)
+
+    execute("""
+    ALTER TABLE #{p}phoenix_kit_machines
+    ADD COLUMN IF NOT EXISTS space_uuid UUID
+    """)
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS idx_machines_location
+    ON #{p}phoenix_kit_machines (location_uuid)
+    """)
+  end
+
+  # ── phoenix_kit_machine_type_assignments: machine<->machine_type join ──
+  # machine_type_uuid is a soft reference (no FK) — see moduledoc.
+
+  defp create_machine_type_assignments(p, prefix) do
+    execute("""
+    CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_machine_type_assignments (
+      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      machine_uuid UUID NOT NULL
+        REFERENCES #{p}phoenix_kit_machines (uuid) ON DELETE CASCADE,
+      machine_type_uuid UUID NOT NULL,
+      inserted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+    """)
+
+    execute("""
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_machine_type_assignments_unique
+    ON #{p}phoenix_kit_machine_type_assignments (machine_uuid, machine_type_uuid)
+    """)
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS idx_machine_type_assignments_type
+    ON #{p}phoenix_kit_machine_type_assignments (machine_type_uuid)
+    """)
+
+    drop_fk_constraint(p, prefix, "phoenix_kit_machine_type_assignments", "machine_type_uuid")
+  end
+
+  # ── phoenix_kit_machine_operations: machine<->operation join ──
+  # operation_uuid is a soft reference (no FK) — see moduledoc.
+
+  defp create_machine_operations(p, prefix) do
+    execute("""
+    CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_machine_operations (
+      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      machine_uuid UUID NOT NULL
+        REFERENCES #{p}phoenix_kit_machines (uuid) ON DELETE CASCADE,
+      operation_uuid UUID NOT NULL,
+      time_norm_seconds INTEGER,
+      inserted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+    """)
+
+    execute("""
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_machine_operations_unique
+    ON #{p}phoenix_kit_machine_operations (machine_uuid, operation_uuid)
+    """)
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS idx_machine_operations_operation
+    ON #{p}phoenix_kit_machine_operations (operation_uuid)
+    """)
+
+    drop_fk_constraint(p, prefix, "phoenix_kit_machine_operations", "operation_uuid")
+  end
+
+  # ── legacy directory tables: conditional drop, never (re-)created ──
+  #
+  # Drops `table` only when it exists and is empty; a non-empty table is
+  # left in place with a RAISE NOTICE, since destroying real directory data
+  # without a chance to migrate it first is not acceptable. Plain PL/pgSQL
+  # can't run DDL directly, hence the dynamic EXECUTE. CASCADE on the DROP
+  # is a resilience net for a partially-applied prior run (e.g. a PgBouncer
+  # mid-batch drop that skipped one of the `drop_fk_constraint` calls
+  # above) — normally there is nothing left to cascade into, since those
+  # calls already run unconditionally before this.
+  defp maybe_drop_if_empty(p, prefix, table) do
+    execute("""
+    DO $$
+    BEGIN
+      IF EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_schema = '#{prefix}' AND table_name = '#{table}'
+      ) THEN
+        IF (SELECT COUNT(*) FROM #{p}#{table}) = 0 THEN
+          EXECUTE 'DROP TABLE #{p}#{table} CASCADE';
+        ELSE
+          RAISE NOTICE '#{table} is non-empty — left in place, see PR body for manual migration';
+        END IF;
+      END IF;
+    END $$;
+    """)
+  end
+
+  # ── phoenix_kit_warehouse_transfers + phoenix_kit_warehouse_min_stock ──
+  # Fresh-install-only DDL — see moduledoc.
+
+  defp create_warehouse_transfers(p) do
+    execute("CREATE SEQUENCE IF NOT EXISTS #{p}phoenix_kit_warehouse_transfers_number_seq")
+
+    execute("""
+    CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_warehouse_transfers (
+      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      number BIGINT NOT NULL DEFAULT nextval('#{p}phoenix_kit_warehouse_transfers_number_seq'),
+      status VARCHAR(20) NOT NULL DEFAULT 'draft',
+      source_location_uuid UUID,
+      destination_location_uuid UUID,
+      note TEXT,
+      storage_folder_uuid UUID,
+      lines JSONB NOT NULL DEFAULT '[]'::jsonb,
+      source_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+      created_by_uuid UUID,
+      performed_by_uuid UUID REFERENCES #{p}phoenix_kit_users(uuid) ON DELETE SET NULL,
+      shipped_at TIMESTAMPTZ,
+      received_at TIMESTAMPTZ,
+      cancelled_at TIMESTAMPTZ,
+      deleted_at TIMESTAMPTZ,
+      deleted_by_uuid UUID,
+      inserted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+    """)
+
+    execute("""
+    CREATE UNIQUE INDEX IF NOT EXISTS phoenix_kit_warehouse_transfers_number_index
+    ON #{p}phoenix_kit_warehouse_transfers (number)
+    """)
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS phoenix_kit_warehouse_transfers_status_index
+    ON #{p}phoenix_kit_warehouse_transfers (status)
+    """)
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS phoenix_kit_warehouse_transfers_inserted_at_index
+    ON #{p}phoenix_kit_warehouse_transfers (inserted_at)
+    """)
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS phoenix_kit_warehouse_transfers_deleted_at_index
+    ON #{p}phoenix_kit_warehouse_transfers (deleted_at)
+    """)
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS phoenix_kit_warehouse_transfers_source_location_uuid_index
+    ON #{p}phoenix_kit_warehouse_transfers (source_location_uuid)
+    """)
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS phoenix_kit_warehouse_transfers_destination_location_uuid_index
+    ON #{p}phoenix_kit_warehouse_transfers (destination_location_uuid)
+    """)
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS phoenix_kit_warehouse_transfers_shipped_at_index
+    ON #{p}phoenix_kit_warehouse_transfers (shipped_at)
+    """)
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS phoenix_kit_warehouse_transfers_received_at_index
+    ON #{p}phoenix_kit_warehouse_transfers (received_at)
+    """)
+  end
+
+  defp create_warehouse_min_stock(p) do
+    execute("""
+    CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_warehouse_min_stock (
+      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      item_uuid UUID NOT NULL,
+      min_quantity NUMERIC NOT NULL DEFAULT 0,
+      inserted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+    """)
+
+    execute("""
+    CREATE UNIQUE INDEX IF NOT EXISTS phoenix_kit_warehouse_min_stock_item_uuid_index
+    ON #{p}phoenix_kit_warehouse_min_stock (item_uuid)
+    """)
+  end
+
+  # ── FK-drop helpers, ported from PhoenixKitManufacturing.Migrations.Machines ──
+
+  # Discovers the live FK constraint name for `table.column` via the
+  # catalog rather than assuming a `..._fkey` naming convention. Returns
+  # `nil` when no such constraint exists (fresh install, or already dropped
+  # on a retry).
+  @spec fk_constraint_name(String.t(), String.t(), String.t()) :: String.t() | nil
+  defp fk_constraint_name(prefix, table, column) do
+    query = """
+    SELECT tc.constraint_name
+    FROM information_schema.table_constraints tc
+    JOIN information_schema.key_column_usage kcu
+      ON tc.constraint_name = kcu.constraint_name
+     AND tc.table_schema = kcu.table_schema
+    WHERE tc.constraint_type = 'FOREIGN KEY'
+      AND tc.table_schema = $1
+      AND tc.table_name = $2
+      AND kcu.column_name = $3
+    """
+
+    case PhoenixKit.RepoHelper.repo().query(query, [prefix || "public", table, column]) do
+      {:ok, %{rows: [[name] | _]}} -> name
+      _ -> nil
+    end
+  end
+
+  defp drop_fk_constraint(p, prefix, table, column) do
+    case fk_constraint_name(prefix, table, column) do
+      nil -> :ok
+      name -> execute("ALTER TABLE #{p}#{table} DROP CONSTRAINT IF EXISTS #{name}")
+    end
+  end
+
+  defp prefix_str("public"), do: "public."
+  defp prefix_str(prefix), do: "#{prefix}."
+end


### PR DESCRIPTION
## Summary

Adds `PhoenixKit.Migrations.Postgres.V143`, consolidating five tables previously created by the `phoenix_kit_manufacturing` and `phoenix_kit_warehouse` packages' own module-owned `migration_module/0` migrations into core's numbered chain:

- `phoenix_kit_machines`
- `phoenix_kit_machine_type_assignments`
- `phoenix_kit_machine_operations`
- `phoenix_kit_warehouse_transfers` (+ its `number` sequence)
- `phoenix_kit_warehouse_min_stock`

This PR only touches `phoenix_kit` core (`lib/phoenix_kit/migrations/postgres.ex`, `lib/phoenix_kit/migrations/postgres/v143.ex`) and has no dependency on any other open PR. Companion PRs in `phoenix_kit_manufacturing` and `phoenix_kit_warehouse` remove their now-redundant `migration_module/0` and switch to depending on core owning these tables — see "Depends on / blocks" below.

## Why here, not in the module packages

Both packages previously shipped their own `migration_module/0`, discovered and run by `mix phoenix_kit.update` on the host app. That worked, but split "does this host's schema match this module's expectations" across independently-versioned migration chains instead of one. This moves both packages onto the pattern already used for `phoenix_kit_locations` (V90/V122) and the standalone-warehouse-table precedent already in core (V140, PR #624) — one chain, one `@current_version`, one `mix phoenix_kit.update`.

## Scope per table

- **`phoenix_kit_machines`** — `CREATE TABLE IF NOT EXISTS` with the V1 identity columns plus the V2 passport/soft-location columns added via `ADD COLUMN IF NOT EXISTS` — i.e. the module's current (V5-equivalent) shape in one step. Idempotent against a V1-V5 host and a fresh host alike.
- **`phoenix_kit_machine_type_assignments`** / **`phoenix_kit_machine_operations`** — `machine_type_uuid`/`operation_uuid` are soft references (no FK): those directories now live in the separate, optional `phoenix_kit_entities` package, which this core migration correctly has no dependency on. **Upgrade path**: a host on the published `phoenix_kit_manufacturing` 0.2.0 (module schema V1) already has `machine_type_assignments` with a *live* FK on `machine_type_uuid`; this migration drops that FK unconditionally via a catalog lookup by table+column (not a guessed constraint name — see `fk_constraint_name/3`, ported verbatim from the module's own already-shipped code). `phoenix_kit_warehouse` 0.1.0 never published any migrations at all (verified against the published Hex tarball — no `migrations/` directory exists in it), so warehouse's two tables are fresh-install-only DDL, no upgrade branch needed or written.
- **Legacy directory tables** (`phoenix_kit_machine_types`, `phoenix_kit_operations`, `phoenix_kit_defect_reasons` — all pre-V5 module-owned) are **not** re-created; they aren't one of the five objects this migration owns. Each is dropped when it exists and is empty, and left in place (with a `RAISE NOTICE`) when it still holds rows, so no host's real directory data is silently destroyed. See "Non-empty legacy tables" below for hosts that hit that branch.

## What this PR does *not* do

- **Data conversion.** The module's own (never-published-to-Hex) local V5 used to *also* copy rows out of the three legacy directory tables into `phoenix_kit_entities` records and rewrite the join-table columns to point at them. V143 does not reproduce that step: a core schema migration has no business depending on the optional `phoenix_kit_entities` package, and silently converting someone's business data as a side effect of a schema migration is the wrong default. See "Non-empty legacy tables" below for the manual path.
- **`CHANGELOG.md`.** Left untouched, as usual — release notes are the maintainer's call. Note: `mix.exs` `@version` is already `1.7.189` (bumped upstream before this branch was rebased onto it), which is exactly the version the companion warehouse/manufacturing PRs pin (`>= 1.7.189`) — so only the CHANGELOG entry is pending, not a version bump. Suggested for the release notes: a warning that `down(version: 142)` on a host upgraded from `phoenix_kit_manufacturing` 0.2.0 drops the pre-existing `phoenix_kit_machine_type_assignments` table (documented caveat in the migration docstring).

## Non-empty legacy tables on upgrade hosts

Only relevant to a host that (a) installed `phoenix_kit_manufacturing` from the published `0.2.0` (module schema V1) *and* (b) has real rows in `phoenix_kit_machine_types` / `phoenix_kit_operations` / `phoenix_kit_defect_reasons` when it upgrades `phoenix_kit` core past V143. Fresh installs, and any host where those three tables are already empty or gone, need nothing further — V143 handles that case by itself.

Quick check after upgrading:

```sql
SELECT to_regclass('public.phoenix_kit_machine_types')  IS NOT NULL AS machine_types_left,
       to_regclass('public.phoenix_kit_operations')      IS NOT NULL AS operations_left,
       to_regclass('public.phoenix_kit_defect_reasons')  IS NOT NULL AS defect_reasons_left;
```

If any of those come back `true`, the conversion algorithm to finish by hand is:

1. Idempotently ensure three `phoenix_kit_entities` blueprint entities exist (`machine_type`, `operation`, `defect_reason`) via `get_entity_by_name/1` → `create_entity/2` (+ translations).
2. For every row in each legacy table, insert a `phoenix_kit_entity_data` record (title/description into the primary-language block of `data`; `machine_type`'s `field_template` into `metadata`), stamping `metadata["legacy_uuid"]` with the source row's uuid for idempotency.
3. `UPDATE phoenix_kit_machine_type_assignments SET machine_type_uuid = <new uuid> WHERE machine_type_uuid = <old uuid>` (and the `phoenix_kit_machine_operations.operation_uuid` equivalent) for every mapped pair — the FK constraints on these columns are already gone by this point (V143 drops them unconditionally in `up/1`), so there's nothing to drop yourself first.
4. `DROP TABLE` the three legacy tables once every row is confirmed migrated.

The exact, previously-shipped implementation of this algorithm (`migrate_legacy_directories_to_entities/2` and its private helpers, including the blueprint entity definitions and multilang reshaping) is preserved verbatim in `phoenix_kit_manufacturing`'s git history and walked step by step — with the exact commit to pull it from — in that repo's `dev_docs/LEGACY_DATA_MIGRATION.md` (added by its own companion PR removing `migration_module/0`).

## Rollback

`down/1` mirrors the five creates (drops in FK-safe order, restores the `phoenix_kit` table comment to `'142'`). One caveat, documented in `V143.down/1`'s own moduledoc: on a host that started from the published manufacturing 0.2.0, `phoenix_kit_machine_type_assignments` pre-dates V143 (created by that package's own old `migration_module/0`, not by this migration) — `down/1` can't distinguish the two provenances, so it drops that table unconditionally, which is a stricter rollback than "undo only what V143 did" on such a host. `down/1` never touches the three legacy directory tables in either direction — they're never owned by V143 regardless of whether `up/1` dropped them or left them in place.

Rolling back is `PhoenixKit.Migrations.down(prefix: "public", version: 142)` — the target version is exclusive of the down range (only V143's own `down/1` runs; V142 and below are untouched).

## Heads-up: unrelated dangling `v143.ex` on `feature/v143-crm-party-roles`

This fork also carries a stale, never-opened-as-a-PR branch `feature/v143-crm-party-roles` (`fb24bda0`, branched from `1.7.186`) with its own, unrelated `v143.ex` — a CRM party-roles migration (supplier/client roles on companies/contacts). It does not block this PR: `upstream/main` never merged it (`@current_version` is still `142` there, and no `v143.ex` exists on `upstream/main`, as of this PR), so there is no numbering collision today. If/when that CRM work is revived, it renumbers to V144+ — an intentional owner call, made so this consolidation didn't have to wait on an unopened, unrelated branch.

## Depends on / blocks

- No dependency on any other open PR.
- Companion PRs in `phoenix_kit_manufacturing` and `phoenix_kit_warehouse` remove their now-redundant `migration_module/0` and bump their `pk_dep(:phoenix_kit, ...)` pin to whatever patch version ships this V143 (placeholder in both `mix.exs` files until this is published — upstream `phoenix_kit` is at `1.7.189` as of this PR).

## Testing

- [x] `mix format`
- [x] `mix compile --warnings-as-errors`
- [x] `mix test test/phoenix_kit/migration_test.exs` — module-shape tests, no DB needed, 6/6 passing
- [ ] `mix test test/integration/prefix_migration_test.exs` — runs the full versioned chain (now including V143) into a named schema; not run in this environment (no reachable PostgreSQL). This is exactly the test that exercises V143 end to end once a DB-backed environment picks up this branch.
- Every DDL statement in `v143.ex` was diffed by hand against its pre-consolidation source (`phoenix_kit_manufacturing`'s module `machines.ex` V1/V2 shape, `phoenix_kit_warehouse`'s `v01.ex`/`v02.ex`) — see `CLAUDE_REVIEW.md` in this PR's doc folder for the full verification pass.

## Related

- Migration: `lib/phoenix_kit/migrations/postgres/v143.ex`
- Dispatcher: `lib/phoenix_kit/migrations/postgres.ex`
- Precedent: V140 (`phoenix_kit_warehouse`'s first core-owned tables, PR #624), V138/V122/V90 (locations — same core-owns-the-tables pattern)
- Review: `dev_docs/pull_requests/2026/143-manufacturing-warehouse-tables-consolidation/CLAUDE_REVIEW.md`

