### PR TITLE
Add V146 (catalogue primary_supplier_uuid) + fix V107 test flake

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,11 +105,21 @@ any new `execute`-built SQL can regress them:
   on `DROP INDEX`.
 - **Every existence check needs a schema anchor.** `information_schema.*`
   checks need `table_schema = '#{escaped_prefix}'`, `pg_indexes` needs
-  `schemaname`, and `pg_constraint` `conname` checks need
-  `AND conrelid = '#{p}table'::regclass` (V51's idiom). An unanchored
-  check sees `public`'s objects, so a prefixed install into a database
-  that also carries a public install silently skips creating the
-  prefixed object.
+  `schemaname`, and `pg_constraint` `conname` checks need a table anchor.
+  An unanchored check sees `public`'s objects, so a prefixed install into
+  a database that also carries a public install silently skips creating
+  the prefixed object.
+  ⚠️ For the `pg_constraint` anchor, prefer a name-based JOIN
+  (`JOIN pg_class t ON t.oid = c.conrelid JOIN pg_namespace n …
+  WHERE t.relname = '…' AND n.nspname = $1`) over V51's
+  `conrelid = '#{p}table'::regclass` idiom in IMMEDIATE checks
+  (`repo().query/3`): a regclass cast RAISES when the relation doesn't
+  exist yet — on a fresh chain the table's CREATE may still be queued —
+  and that aborts the whole migration transaction in a way a `rescue`
+  can't undo (every later statement dies with 25P02, surfacing at some
+  unrelated version). V146 hit exactly this; it now JOINs by name and
+  `flush()`es first. The regclass idiom is only safe after a `flush()`
+  guarantees the relation exists.
 - **Failures surface late.** Ecto queues `execute` calls; bad SQL queued
   by one version often blows up at a *later* version's `flush()`.
 

--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -529,7 +529,14 @@ defmodule PhoenixKit.Migrations.Postgres do
   - Replaces unique index with partial index (slug-mode only, WHERE slug IS NOT NULL)
   - Adds unique index on `(group_uuid, post_date, post_time)` for timestamp-mode posts
 
-  ### V145 - Newsletters Send Settings (send profiles) ⚡ LATEST
+  ### V146 - Catalogue item primary supplier ⚡ LATEST
+  - Adds nullable `primary_supplier_uuid` FK (`ON DELETE SET NULL`) +
+    partial index to `phoenix_kit_cat_items` — an item's default
+    supplier, independent of manufacturer (generic/unbranded materials;
+    tie-break when a manufacturer has several suppliers). Backs the
+    `phoenix_kit_catalogue` feature from its commit 2e47cdf.
+
+  ### V145 - Newsletters Send Settings (send profiles)
   - Adds `phoenix_kit_newsletters_send_profiles`: named send configurations
     referencing a core Integrations connection (`integration_uuid`, no FK)
     plus per-account send parameters (from-name/email, reply-to, signature,
@@ -1275,7 +1282,7 @@ defmodule PhoenixKit.Migrations.Postgres do
   alias PhoenixKit.Migrations.Postgres.Helpers
 
   @initial_version 1
-  @current_version 145
+  @current_version 146
   @default_prefix "public"
 
   # First version whose SQL references uuid_generate_v7(). Chains that

--- a/lib/phoenix_kit/migrations/postgres/v146.ex
+++ b/lib/phoenix_kit/migrations/postgres/v146.ex
@@ -1,0 +1,102 @@
+defmodule PhoenixKit.Migrations.Postgres.V146 do
+  @moduledoc """
+  V146: `primary_supplier_uuid` on catalogue items.
+
+  Backs `phoenix_kit_catalogue`'s per-item default supplier (upstream
+  catalogue commit 2e47cdf): lets an item specify a supplier directly,
+  independent of manufacturer — needed for generic/unbranded materials
+  that have no brand to resolve a supplier through, and to break ties
+  when a manufacturer has more than one linked supplier.
+
+  - Nullable `primary_supplier_uuid` FK → `phoenix_kit_cat_suppliers(uuid)`
+    with `ON DELETE SET NULL` — the pointer is an optional default; the
+    item must survive its supplier (mirrors `category_uuid`'s nilify
+    semantics, deliberately NOT `manufacturer_uuid`'s delete_all).
+  - Partial index on `(primary_supplier_uuid) WHERE NOT NULL` for the
+    "items defaulting to this supplier" reverse lookup.
+
+  Idempotent + prefix-safe: bare index name on CREATE, all existence
+  checks schema-anchored, FK constraint checked via `pg_constraint`
+  anchored to the prefixed table (the V51 idiom).
+  """
+
+  use Ecto.Migration
+
+  def up(%{prefix: prefix} = opts) do
+    escaped_prefix = Map.get(opts, :escaped_prefix, prefix)
+    p = prefix_str(prefix)
+
+    # Flush queued commands so the immediate pg_constraint check below sees
+    # phoenix_kit_cat_items — on a fresh chain V87's CREATE TABLE is still
+    # queued at this point, and an immediate query touching a missing
+    # relation would abort the whole migration transaction.
+    flush()
+
+    execute("""
+    ALTER TABLE #{p}phoenix_kit_cat_items
+    ADD COLUMN IF NOT EXISTS primary_supplier_uuid UUID
+    """)
+
+    unless constraint_exists?(escaped_prefix, p) do
+      execute("""
+      ALTER TABLE #{p}phoenix_kit_cat_items
+      ADD CONSTRAINT phoenix_kit_cat_items_primary_supplier_uuid_fkey
+      FOREIGN KEY (primary_supplier_uuid)
+      REFERENCES #{p}phoenix_kit_cat_suppliers(uuid)
+      ON DELETE SET NULL
+      """)
+    end
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS phoenix_kit_cat_items_primary_supplier_uuid_index
+    ON #{p}phoenix_kit_cat_items (primary_supplier_uuid)
+    WHERE primary_supplier_uuid IS NOT NULL
+    """)
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '146'")
+  end
+
+  def down(%{prefix: prefix} = _opts) do
+    p = prefix_str(prefix)
+
+    execute("DROP INDEX IF EXISTS #{p}phoenix_kit_cat_items_primary_supplier_uuid_index")
+
+    execute("""
+    ALTER TABLE #{p}phoenix_kit_cat_items
+    DROP CONSTRAINT IF EXISTS phoenix_kit_cat_items_primary_supplier_uuid_fkey
+    """)
+
+    execute("""
+    ALTER TABLE #{p}phoenix_kit_cat_items
+    DROP COLUMN IF EXISTS primary_supplier_uuid
+    """)
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '145'")
+  end
+
+  # Immediate check; anchored to the prefixed table so a public install's
+  # constraint can't satisfy the check for a prefixed one. Deliberately a
+  # name-based JOIN rather than the `'table'::regclass` idiom: a regclass
+  # cast RAISES when the relation doesn't exist yet, which aborts the whole
+  # migration transaction (and a rescue can't unpoison it).
+  defp constraint_exists?(escaped_prefix, _p) do
+    query = """
+    SELECT EXISTS (
+      SELECT FROM pg_constraint c
+      JOIN pg_class t ON t.oid = c.conrelid
+      JOIN pg_namespace n ON n.oid = t.relnamespace
+      WHERE c.conname = 'phoenix_kit_cat_items_primary_supplier_uuid_fkey'
+      AND t.relname = 'phoenix_kit_cat_items'
+      AND n.nspname = $1
+    )
+    """
+
+    case repo().query(query, [escaped_prefix], log: false) do
+      {:ok, %{rows: [[true]]}} -> true
+      _ -> false
+    end
+  end
+
+  defp prefix_str("public"), do: "public."
+  defp prefix_str(prefix), do: "#{prefix}."
+end

--- a/test/phoenix_kit/migrations/v107_test.exs
+++ b/test/phoenix_kit/migrations/v107_test.exs
@@ -208,7 +208,7 @@ defmodule PhoenixKit.Migrations.Postgres.V107Test do
           "api_key" => "sk-first"
         })
 
-      _second =
+      second =
         insert_integration!("openrouter:second", %{
           "provider" => "openrouter",
           "name" => "second",
@@ -219,9 +219,13 @@ defmodule PhoenixKit.Migrations.Postgres.V107Test do
 
       run_backfill!()
 
-      # UUIDv7 is time-ordered, so `first` (inserted first → smaller uuid)
-      # wins under `uuid ASC`.
-      assert endpoint_integration_uuid(endpoint_uuid) == first
+      # The winner is whichever row got the SMALLER uuid — usually the
+      # first inserted (UUIDv7 is time-ordered), but two inserts within
+      # the same millisecond fall back to random bits and insertion
+      # order no longer implies uuid order. Asserting min/2 instead of
+      # "first" removes the same-millisecond flake seen in full-suite
+      # runs.
+      assert endpoint_integration_uuid(endpoint_uuid) == min(first, second)
     end
   end
 

--- a/test/phoenix_kit/migrations/v145_test.exs
+++ b/test/phoenix_kit/migrations/v145_test.exs
@@ -145,11 +145,14 @@ defmodule PhoenixKit.Migrations.Postgres.V145Test do
   end
 
   describe "version marker" do
-    test "phoenix_kit table comment reflects V145" do
+    test "phoenix_kit table comment is at or past V145" do
       %{rows: [[comment]]} =
         Repo.query!("SELECT obj_description('phoenix_kit'::regclass, 'pg_class')")
 
-      assert comment == "145"
+      # >= rather than ==: pinning the exact latest version breaks this
+      # test every time a NEWER migration ships (V146 did exactly that).
+      # What V145 owns is "the chain reached at least me".
+      assert String.to_integer(comment) >= 145
     end
   end
 end


### PR DESCRIPTION
Two commits:

**V146 — `primary_supplier_uuid` on `phoenix_kit_cat_items`.** phoenix_kit_catalogue's per-item default-supplier feature (its commit 2e47cdf) shipped the schema/UI half, but the column's core migration never landed — the module's suite failed 339 tests on `undefined_column`. Nullable FK → `phoenix_kit_cat_suppliers(uuid)` with `ON DELETE SET NULL` (an optional pointer; the item survives its supplier — mirrors `category_uuid`'s nilify, not `manufacturer_uuid`'s delete_all) + a partial reverse-lookup index. Prefix-safe per the 2026-07 rules, with one new lesson baked in: the `pg_constraint` existence check is a name-based JOIN, **not** the `'table'::regclass` idiom — a regclass cast raises when the relation doesn't exist yet (on a fresh chain V87's CREATE TABLE is still queued when V146's immediate check runs) and poisons the whole migration transaction in a way a rescue can't undo; a `flush()` at the top materializes the queue first. Verified: full prefixed-chain integration test green; catalogue's suite goes 1260/0 against this core (from 339 failures).

**V107 flake fix.** The uuid-ASC tiebreak test asserted 'first inserted wins' — same-millisecond UUIDv7s fall back to random bits, so insertion order doesn't imply uuid order; it failed intermittently in full-suite runs only. Now asserts `min(first, second)`, which is the actual contract. Also V145's marker test now asserts `>= 145` instead of pinning the exact latest version (V146 broke it; any future version would too).

Full suite failures unchanged at the known multi-session/sitemap set.