### PR TITLE
V148: phoenix_kit_crm_party_roles table (unblocks phoenix_kit_crm #10)

### DIFF
--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -529,7 +529,15 @@ defmodule PhoenixKit.Migrations.Postgres do
   - Replaces unique index with partial index (slug-mode only, WHERE slug IS NOT NULL)
   - Adds unique index on `(group_uuid, post_date, post_time)` for timestamp-mode posts
 
-  ### V147 - Known-device geo-location ⚡ LATEST
+  ### V148 - CRM party roles (suppliers, clients) ⚡ LATEST
+  - Adds `phoenix_kit_crm_party_roles` for the `phoenix_kit_crm` module:
+    polymorphic role edge marking a CRM company or contact as `supplier`,
+    `client`, or other commercial role. One party can hold several roles;
+    `valid_from`/`valid_to` lifecycle, `is_active` filter, role-scoped
+    `metadata`. No FK on `roleable_uuid`; unique on
+    `(roleable_type, roleable_uuid, role)`.
+
+  ### V147 - Known-device geo-location
   - Adds nullable `location` (`City, Country`) to
     `phoenix_kit_user_known_devices`. Resolved once at new-device time by
     `PhoenixKit.Users.LoginAlerts` and stored so the user's Active Sessions
@@ -1288,7 +1296,7 @@ defmodule PhoenixKit.Migrations.Postgres do
   alias PhoenixKit.Migrations.Postgres.Helpers
 
   @initial_version 1
-  @current_version 147
+  @current_version 148
   @default_prefix "public"
 
   # First version whose SQL references uuid_generate_v7(). Chains that

--- a/lib/phoenix_kit/migrations/postgres/v148.ex
+++ b/lib/phoenix_kit/migrations/postgres/v148.ex
@@ -1,0 +1,104 @@
+defmodule PhoenixKit.Migrations.Postgres.V148 do
+  @moduledoc """
+  V148: CRM v2 — party roles (suppliers, clients).
+
+  One table for the `phoenix_kit_crm` plugin's commercial party typing: a
+  polymorphic role edge that marks an existing CRM company **or** contact as
+  a `supplier`, `client`, or other commercial counterparty role. This is the
+  Odoo `supplier_rank`/`customer_rank` / SAP Business-Partner-roles property
+  expressed as rows: one party can hold several roles simultaneously (a
+  company that is both supplier and client has two rows).
+
+  ## phoenix_kit_crm_party_roles
+  `roleable_type` + `roleable_uuid` point at `phoenix_kit_crm_companies` or
+  `phoenix_kit_crm_contacts` (sole-trader suppliers are contacts). The pair
+  carries **no FK** — a single FK cannot express the polymorphic target;
+  integrity lives in the CRM changesets, mirroring the `staff_person_uuid`
+  soft-ref precedent in V138's `interaction_parties`.
+
+  `role` is a free string (initial vocabulary: supplier/client/partner) so
+  the set can grow without a migration; the CRM module validates allowed
+  values. `valid_from`/`valid_to` give roles a lifecycle ("former supplier")
+  without deleting history; `is_active` is the quick filter. `metadata`
+  absorbs role-scoped commercial attributes (payment terms, tax id, account
+  number, default currency) until they stabilize into typed columns.
+
+  Design doc: `phoenix_kit_crm` `dev_docs/design/crm_v2_parties_suppliers_clients.md`.
+
+  All operations are idempotent.
+  """
+
+  use Ecto.Migration
+
+  def up(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    execute("""
+    CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_crm_party_roles (
+      uuid UUID PRIMARY KEY DEFAULT uuid_generate_v7(),
+      roleable_type VARCHAR(20) NOT NULL,
+      roleable_uuid UUID NOT NULL,
+      role VARCHAR(30) NOT NULL,
+      is_active BOOLEAN NOT NULL DEFAULT TRUE,
+      valid_from DATE,
+      valid_to DATE,
+      metadata JSONB NOT NULL DEFAULT '{}',
+      inserted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+    """)
+
+    # Guarded CHECK: roleable_type is a closed set (the polymorphic targets
+    # are CRM-owned tables; adding a third target is a migration anyway).
+    execute("""
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'phoenix_kit_crm_party_roles_roleable_type_check'
+        AND conrelid = '#{p}phoenix_kit_crm_party_roles'::regclass
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_crm_party_roles
+        ADD CONSTRAINT phoenix_kit_crm_party_roles_roleable_type_check
+        CHECK (roleable_type IN ('company', 'contact'));
+      END IF;
+    END $$;
+    """)
+
+    execute("""
+    CREATE UNIQUE INDEX IF NOT EXISTS phoenix_kit_crm_party_roles_uniq
+    ON #{p}phoenix_kit_crm_party_roles (roleable_type, roleable_uuid, role)
+    """)
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS phoenix_kit_crm_party_roles_role_active_idx
+    ON #{p}phoenix_kit_crm_party_roles (role, is_active)
+    """)
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS phoenix_kit_crm_party_roles_roleable_idx
+    ON #{p}phoenix_kit_crm_party_roles (roleable_type, roleable_uuid)
+    """)
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '148'")
+  end
+
+  @doc """
+  Rolls V148 back by dropping the party-roles table.
+
+  **Lossy rollback:** all supplier/client role assignments are lost. The
+  underlying companies/contacts (V138) are untouched.
+  """
+  def down(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    execute("DROP TABLE IF EXISTS #{p}phoenix_kit_crm_party_roles CASCADE")
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '147'")
+  end
+
+  defp prefix_str("public"), do: "public."
+  defp prefix_str(prefix), do: "#{prefix}."
+end


### PR DESCRIPTION
Adds the core migration that creates `phoenix_kit_crm_party_roles` — the table backing phoenix_kit_crm's supplier/client party roles merged in phoenix_kit_crm#10. That PR's post-merge review flagged this as the one release-blocking gap: without the migration, the feature crashes at runtime.

Polymorphic role edge marking a CRM company or contact as supplier/client/partner (one party can hold several roles). No FK on `roleable_uuid` (polymorphic company-or-contact target), mirroring V138's `interaction_parties.staff_person_uuid` soft-ref; unique on `(roleable_type, roleable_uuid, role)`. Idempotent up/down.

Rebased onto current `main` (V147). Full migration-chain integration test passes (V03→V148).