### PR TITLE
Fix sanitizer XSS + sidebar flip; harden phoenix_kit.doctor (prefix, child-order, schema-drift)

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -39,6 +39,13 @@
   # Ecto.Multi opaque type false positives (code works correctly)
   ~r/lib\/phoenix_kit\/users\/auth\.ex:.*call_without_opaque/,
 
+  # QrLogin.location_for/1 uses the textbook Task.Supervisor.async_nolink +
+  # `Task.yield(task, t) || Task.shutdown(task, :brutal_kill)` idiom. Dialyzer
+  # widens the opaque Task.t()'s :pid/:ref fields and flags Task.yield's 1st
+  # arg — a false positive (same class as the auth.ex entry above); the code
+  # is correct and well-covered.
+  ~r/lib\/phoenix_kit\/users\/qr_login\.ex:.*call_without_opaque/,
+
   # Connections module (extracted to phoenix_kit_user_connections) — conditional calls via Code.ensure_loaded?
   {"lib/phoenix_kit_web/live/users/user_details.ex", :unknown_function},
 

--- a/lib/mix/tasks/phoenix_kit.doctor.ex
+++ b/lib/mix/tasks/phoenix_kit.doctor.ex
@@ -31,12 +31,14 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
    11. **Orphaned Connections** — Idle-in-transaction or stuck connections
    12. **Oban Configuration** — Queues and plugins that consume pool connections
    13. **Supervisor Children** — What's running (update_mode vs full)?
-   14. **Update Mode** — Is update_mode active?
-   15. **daisyUI Version** — Is the host's vendored daisyUI recent enough?
+   14. **Child Start Order** — Does the Repo start before PhoenixKit/Oban in application.ex?
+   15. **Update Mode** — Is update_mode active?
+   16. **daisyUI Version** — Is the host's vendored daisyUI recent enough?
   """
 
   use Mix.Task
 
+  alias PhoenixKit.Install.ChildOrder
   alias PhoenixKit.Migrations.Postgres
 
   @shortdoc "Diagnoses PhoenixKit installation, migration, and runtime issues"
@@ -72,6 +74,7 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
       run_check("Orphaned Connections", fn -> check_orphaned_connections() end),
       run_check("Oban Configuration", fn -> check_oban_config() end),
       run_check("PhoenixKit Supervisor", fn -> check_supervisor_state() end),
+      run_check("Child Start Order", fn -> check_child_order() end),
       run_check("Update Mode", fn -> check_update_mode() end),
       run_check("daisyUI Version", fn -> check_daisyui() end)
     ]
@@ -605,6 +608,45 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
     end
   end
 
+  # Reads the host application.ex and verifies the Repo starts BEFORE
+  # PhoenixKit.Supervisor and Oban — a child listed before the Repo crashes the
+  # app at boot (PhoenixKit reads Settings from the DB; Oban needs the pool).
+  # The runtime supervisor check above can't catch this (by the time doctor
+  # runs, everything has already started), so we read the source order.
+  defp check_child_order do
+    repo = get_repo!()
+
+    case host_application_source() do
+      {:ok, path, source} ->
+        where = Path.relative_to_cwd(path)
+
+        case ChildOrder.check(source, repo) do
+          {:ok, detail} ->
+            {:pass, "#{detail} (#{where})"}
+
+          {:misordered, mods} ->
+            names = Enum.map_join(mods, ", ", &inspect/1)
+
+            {:fail,
+             "#{names} start BEFORE #{inspect(repo)} in #{where}. PhoenixKit.Supervisor " <>
+               "reads Settings from the database and Oban needs the connection pool, so both " <>
+               "must be listed AFTER your Repo. Move #{inspect(repo)} above them in the " <>
+               "children list to fix the boot crash."}
+
+          :no_repo_in_children ->
+            {:warn,
+             "Couldn't find #{inspect(repo)} in the children list of #{where} — verify " <>
+               "PhoenixKit.Supervisor and Oban are started after your Repo."}
+
+          :no_children ->
+            {:warn, "Couldn't locate a children list in #{where} to verify start order."}
+        end
+
+      :error ->
+        {:warn, "Couldn't locate your application.ex to verify child start order."}
+    end
+  end
+
   defp check_update_mode do
     update_mode = Application.get_env(:phoenix_kit, :update_mode, false)
 
@@ -624,6 +666,40 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
       [repo | _] -> repo
       [] -> raise "No :ecto_repos configured for :#{app}"
     end
+  end
+
+  # Locate the host's application.ex — first via the compiled application
+  # module's source path, then the conventional lib/<app>/application.ex.
+  defp host_application_source do
+    app = Mix.Project.config()[:app]
+
+    candidates =
+      [
+        case Application.spec(app, :mod) do
+          {mod, _args} -> module_source(mod)
+          _ -> nil
+        end,
+        Path.join(["lib", "#{app}", "application.ex"])
+      ]
+      |> Enum.reject(&is_nil/1)
+
+    Enum.find_value(candidates, :error, fn path ->
+      case File.read(path) do
+        {:ok, source} -> {:ok, path, source}
+        _ -> nil
+      end
+    end)
+  end
+
+  defp module_source(mod) do
+    with {:module, _} <- Code.ensure_loaded(mod),
+         source when not is_nil(source) <- mod.module_info(:compile)[:source] do
+      to_string(source)
+    else
+      _ -> nil
+    end
+  rescue
+    _ -> nil
   end
 
   defp cap_repo_pool_size(pool_size) do

--- a/lib/mix/tasks/phoenix_kit.doctor.ex
+++ b/lib/mix/tasks/phoenix_kit.doctor.ex
@@ -14,7 +14,10 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
 
   ## Options
 
-    * `--prefix` - Database schema prefix (default: "public")
+    * `--prefix` - Database schema prefix. When omitted, resolves from
+      `config :phoenix_kit, :prefix`, then `"public"` — the same resolution
+      `mix phoenix_kit.update` / `--status` use, so a prefixed install is
+      diagnosed against the schema it actually lives in.
 
   ## Checks Performed
 
@@ -39,6 +42,7 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
   use Mix.Task
 
   alias PhoenixKit.Install.ChildOrder
+  alias PhoenixKit.Install.PrefixConfig
   alias PhoenixKit.Migrations.Postgres
 
   @shortdoc "Diagnoses PhoenixKit installation, migration, and runtime issues"
@@ -50,10 +54,21 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
   def run(argv) do
     {opts, _argv, _errors} = OptionParser.parse(argv, switches: @switches, aliases: @aliases)
 
-    prefix = opts[:prefix] || "public"
-
     # Start app with minimal footprint (same approach as phoenix_kit.update)
     Mix.Task.run("app.config")
+
+    # Resolve the prefix AFTER app.config loads config, so a configured
+    # non-public prefix is honored — same resolution the updater/status use
+    # (--prefix flag → config :phoenix_kit, :prefix → "public"). Reading
+    # opts[:prefix] || "public" here queries the version marker at public and
+    # reports a prefixed install as "not installed".
+    prefix = PrefixConfig.resolve_prefix(opts)
+
+    # Snapshot the host's Oban config BEFORE cap_repo_pool_size/1 zeroes its
+    # queues/plugins (it does that to conserve connections in update_mode) —
+    # otherwise the Oban Configuration check reports "0 queues, 0 plugins".
+    oban_config = Application.get_env(Mix.Project.config()[:app], Oban)
+
     cap_repo_pool_size(2)
     Application.put_env(:phoenix_kit, :update_mode, true)
     Mix.Task.run("app.start")
@@ -72,7 +87,7 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
       run_check("Orphaned FK References", fn -> check_orphaned_fk_refs(prefix) end),
       run_check("Lock Conflicts", fn -> check_lock_conflicts() end),
       run_check("Orphaned Connections", fn -> check_orphaned_connections() end),
-      run_check("Oban Configuration", fn -> check_oban_config() end),
+      run_check("Oban Configuration", fn -> check_oban_config(oban_config) end),
       run_check("PhoenixKit Supervisor", fn -> check_supervisor_state() end),
       run_check("Child Start Order", fn -> check_child_order() end),
       run_check("Update Mode", fn -> check_update_mode() end),
@@ -580,21 +595,19 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
     end
   end
 
-  defp check_oban_config do
-    app = Mix.Project.config()[:app]
+  # Reports the Oban config snapshotted in run/1 BEFORE cap_repo_pool_size/1
+  # zeroed its queues/plugins — reading it live here would always show 0/0.
+  defp check_oban_config(nil), do: {:pass, "Oban not configured"}
 
-    case Application.get_env(app, Oban) do
-      nil ->
-        {:pass, "Oban not configured"}
+  defp check_oban_config(config) when is_list(config) do
+    queues = Keyword.get(config, :queues, [])
+    plugins = Keyword.get(config, :plugins, [])
 
-      config ->
-        queues = Keyword.get(config, :queues, [])
-        plugins = Keyword.get(config, :plugins, [])
-
-        {:pass,
-         "#{length(queues)} queues, #{length(plugins)} plugins. Each active queue uses 1 pool connection."}
-    end
+    {:pass,
+     "#{length(queues)} queues, #{length(plugins)} plugins. Each active queue uses 1 pool connection."}
   end
+
+  defp check_oban_config(_other), do: {:pass, "Oban configured (non-keyword config)"}
 
   defp check_supervisor_state do
     case Process.whereis(PhoenixKit.Supervisor) do

--- a/lib/mix/tasks/phoenix_kit.doctor.ex
+++ b/lib/mix/tasks/phoenix_kit.doctor.ex
@@ -26,17 +26,18 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
     3. **Pool Configuration** — Pool size, checkout timeout, queue settings
     4. **PgBouncer Detection** — Is PgBouncer between app and PostgreSQL?
     5. **Migration State** — PhoenixKit version (COMMENT), schema_migrations alignment
-    6. **Pending Migrations** — Migration files not yet recorded in schema_migrations
-    7. **UUID Column Types** — Detects varchar uuid columns that crash Ecto on startup
-    8. **NULL UUIDs in FK Sources** — Detects NULL uuids that cause infinite backfill loops
-    9. **Orphaned FK References** — Detects orphaned rows that block FK constraint creation
-   10. **Lock Conflicts** — Any blocked or long-running queries?
-   11. **Orphaned Connections** — Idle-in-transaction or stuck connections
-   12. **Oban Configuration** — Queues and plugins that consume pool connections
-   13. **Supervisor Children** — What's running (update_mode vs full)?
-   14. **Child Start Order** — Does the Repo start before PhoenixKit/Oban in application.ex?
-   15. **Update Mode** — Is update_mode active?
-   16. **daisyUI Version** — Is the host's vendored daisyUI recent enough?
+    6. **Schema Drift** — Columns a migration should have added but the DB lacks
+    7. **Pending Migrations** — Migration files not yet recorded in schema_migrations
+    8. **UUID Column Types** — Detects varchar uuid columns that crash Ecto on startup
+    9. **NULL UUIDs in FK Sources** — Detects NULL uuids that cause infinite backfill loops
+   10. **Orphaned FK References** — Detects orphaned rows that block FK constraint creation
+   11. **Lock Conflicts** — Any blocked or long-running queries?
+   12. **Orphaned Connections** — Idle-in-transaction or stuck connections
+   13. **Oban Configuration** — Queues and plugins that consume pool connections
+   14. **Supervisor Children** — What's running (update_mode vs full)?
+   15. **Child Start Order** — Does the Repo start before PhoenixKit/Oban in application.ex?
+   16. **Update Mode** — Is update_mode active?
+   17. **daisyUI Version** — Is the host's vendored daisyUI recent enough?
   """
 
   use Mix.Task
@@ -81,6 +82,7 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
       run_check("Pool Configuration", fn -> check_pool_config() end),
       run_check("PgBouncer Detection", fn -> check_pgbouncer() end),
       run_check("Migration State", fn -> check_migration_state(prefix) end),
+      run_check("Schema Drift", fn -> check_schema_drift(prefix) end),
       run_check("Pending Migrations", fn -> check_pending_migrations() end),
       run_check("UUID Column Types", fn -> check_uuid_column_types(prefix) end),
       run_check("NULL UUIDs in FK Sources", fn -> check_null_uuids(prefix) end),
@@ -243,6 +245,71 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
         {:warn, "DB version > code version.\n       #{info}"}
     end
   end
+
+  # Columns a given migration version adds. If the version marker claims that
+  # version (or higher) but the column is missing at the prefix, the install
+  # drifted — the marker is ahead of the actual schema (e.g. a version renumber
+  # that crossed an upgrade, or an earlier prefix-confused migration run). A
+  # query that selects the column then crashes at runtime, and re-running the
+  # migrator is a no-op because the marker already covers that version.
+  @expected_columns [
+    {150, "phoenix_kit_users_tokens", "browser"},
+    {150, "phoenix_kit_users_tokens", "os"}
+  ]
+
+  defp check_schema_drift(prefix) do
+    repo = get_repo!()
+    escaped_prefix = String.replace(prefix, "'", "\\'")
+    marker = get_comment_version(repo, escaped_prefix)
+
+    if marker == 0 do
+      {:pass, "PhoenixKit not installed at prefix #{inspect(prefix)} — nothing to check."}
+    else
+      missing =
+        @expected_columns
+        |> Enum.filter(fn {min_version, _t, _c} -> marker >= min_version end)
+        |> Enum.reject(fn {_v, table, column} ->
+          column_exists?(repo, escaped_prefix, table, column)
+        end)
+
+      report_schema_drift(missing, marker, prefix)
+    end
+  end
+
+  defp report_schema_drift([], marker, _prefix),
+    do: {:pass, "Columns expected at V#{marker} are present."}
+
+  defp report_schema_drift(missing, marker, prefix) do
+    names = Enum.map_join(missing, ", ", fn {v, t, c} -> "#{t}.#{c} (V#{v})" end)
+    lowest = missing |> Enum.map(fn {v, _t, _c} -> v end) |> Enum.min()
+    p = if prefix == "public", do: "public.", else: "#{prefix}."
+
+    {:fail,
+     "Marker says V#{marker} but these columns are missing: #{names}. The install drifted " <>
+       "(marker ahead of schema). Roll the marker back one version and re-run the migrator — " <>
+       "the column adds are idempotent (add_if_not_exists), so this is safe:\n" <>
+       "       COMMENT ON TABLE #{p}phoenix_kit IS '#{lowest - 1}';\n" <>
+       "       mix phoenix_kit.update#{prefix_flag(prefix)}"}
+  end
+
+  defp column_exists?(repo, escaped_prefix, table, column) do
+    query = """
+    SELECT EXISTS (
+      SELECT FROM information_schema.columns
+      WHERE table_schema = '#{escaped_prefix}'
+      AND table_name = '#{table}'
+      AND column_name = '#{column}'
+    )
+    """
+
+    case repo.query(query, [], log: false) do
+      {:ok, %{rows: [[true]]}} -> true
+      _ -> false
+    end
+  end
+
+  defp prefix_flag("public"), do: ""
+  defp prefix_flag(prefix), do: " --prefix=#{prefix}"
 
   defp check_pending_migrations do
     repo = get_repo!()

--- a/lib/phoenix_kit/install/child_order.ex
+++ b/lib/phoenix_kit/install/child_order.ex
@@ -1,0 +1,153 @@
+defmodule PhoenixKit.Install.ChildOrder do
+  @moduledoc """
+  Reads a host application's `application.ex` and checks that the Ecto Repo
+  starts BEFORE `PhoenixKit.Supervisor` and `Oban` in the supervision
+  `children` list.
+
+  `PhoenixKit.Supervisor` reads Settings / OAuth configuration from the
+  database as it boots, and Oban opens a connection pool against the same
+  Repo — so both MUST appear after the Repo in the children list. A
+  mis-ordered list crashes the app at startup (typically an Oban crash-loop:
+  the pool has no database to reach yet).
+
+  `mix phoenix_kit.install` positions its child after the detected Repo, but a
+  hand-edited `application.ex` — or an Igniter anchor miss that prepends the
+  child instead of inserting it after the Repo — can regress the order. This
+  module is the deterministic safety net: `mix phoenix_kit.doctor` runs
+  `check/2` against the host's source so both fresh and existing installs are
+  caught, independent of how the children ended up ordered.
+
+  Everything here is a pure function over source text — no application boot,
+  no database — so it is unit-testable in isolation.
+  """
+
+  # Children that depend on the Repo already being started.
+  @repo_dependents [PhoenixKit.Supervisor, Oban]
+
+  @typedoc "A module extracted from a child spec, or `nil` when unrecognized."
+  @type child :: module() | nil
+
+  @doc """
+  Checks the child ordering in `source` relative to `repo_module`.
+
+  Returns:
+
+    * `{:ok, detail}` — the Repo precedes every Repo-dependent child that is
+      present (or none are present); `detail` is a human-readable summary.
+    * `{:misordered, [module]}` — the listed Repo-dependent modules appear
+      *before* the Repo. This is the crash case.
+    * `:no_repo_in_children` — `repo_module` wasn't found in the children list,
+      so ordering can't be judged (verify manually).
+    * `:no_children` — no `children` list could be located in the source.
+  """
+  @spec check(String.t(), module()) ::
+          {:ok, String.t()} | {:misordered, [module()]} | :no_repo_in_children | :no_children
+  def check(source, repo_module) when is_binary(source) and is_atom(repo_module) do
+    case ordered_children(source) do
+      {:ok, mods} ->
+        case Enum.find_index(mods, &(&1 == repo_module)) do
+          nil ->
+            :no_repo_in_children
+
+          repo_index ->
+            offenders = Enum.filter(@repo_dependents, &before?(mods, &1, repo_index))
+
+            if offenders == [] do
+              {:ok, describe(mods, repo_module, repo_index)}
+            else
+              {:misordered, offenders}
+            end
+        end
+
+      :error ->
+        :no_children
+    end
+  end
+
+  @doc """
+  Extracts the ordered list of head modules from the host's `children` list.
+
+  Each element is the module heading a child spec (`MyApp.Repo`,
+  `{Oban, opts}` → `Oban`, `{Phoenix.PubSub, ...}` → `Phoenix.PubSub`), or
+  `nil` for a spec whose module can't be read cheaply (e.g. a `%{}` map spec).
+  Returns `:error` if no children list can be found.
+  """
+  @spec ordered_children(String.t()) :: {:ok, [child()]} | :error
+  def ordered_children(source) when is_binary(source) do
+    with {:ok, ast} <- Code.string_to_quoted(source),
+         [list | _] <- children_lists(ast) do
+      {:ok, Enum.map(list, &child_head_module/1)}
+    else
+      _ -> :error
+    end
+  end
+
+  # ── Locating the children list ──────────────────────────────────────
+
+  # Collects every candidate children list in document order, from the two
+  # shapes the Phoenix generator and hand-written apps use:
+  #   children = [ ... ]
+  #   Supervisor.start_link([ ... ], opts)
+  defp children_lists(ast) do
+    {_ast, acc} = Macro.prewalk(ast, [], fn node, acc -> {node, collect_list(node, acc)} end)
+    acc |> Enum.reverse() |> Enum.map(fn {_pos, list} -> list end)
+  end
+
+  # `children = [ ... ]`
+  defp collect_list({:=, meta, [{:children, _, ctx}, list]}, acc)
+       when is_atom(ctx) and is_list(list),
+       do: [{meta[:line] || 0, list} | acc]
+
+  # `Supervisor.start_link([ ... ], opts)`
+  defp collect_list(
+         {{:., _, [{:__aliases__, _, [:Supervisor]}, :start_link]}, meta, [list | _]},
+         acc
+       )
+       when is_list(list),
+       do: [{meta[:line] || 0, list} | acc]
+
+  defp collect_list(_node, acc), do: acc
+
+  # ── Reading a child spec's head module ──────────────────────────────
+
+  # Bare module: `MyApp.Repo`
+  defp child_head_module({:__aliases__, _, parts}), do: safe_concat(parts)
+
+  # 3+-element tuple literal: `{Mod, a, b}` — module heads it.
+  defp child_head_module({:{}, _, [first | _]}), do: child_head_module(first)
+
+  # 2-element tuple literal: `{Oban, opts}` / `{Phoenix.PubSub, name: ...}`.
+  # (Alias/call/`{:{}}` nodes are all 3-tuples, so only genuine 2-tuples reach
+  # here.)
+  defp child_head_module({first, _second}), do: child_head_module(first)
+
+  defp child_head_module(_other), do: nil
+
+  defp safe_concat(parts) do
+    if Enum.all?(parts, &is_atom/1), do: Module.concat(parts), else: nil
+  end
+
+  # ── Helpers ─────────────────────────────────────────────────────────
+
+  defp before?(mods, module, repo_index) do
+    case Enum.find_index(mods, &(&1 == module)) do
+      nil -> false
+      index -> index < repo_index
+    end
+  end
+
+  defp describe(mods, repo_module, repo_index) do
+    present =
+      @repo_dependents
+      |> Enum.filter(&(&1 in mods))
+      |> Enum.map(&inspect/1)
+
+    dependents =
+      case present do
+        [] -> "no Repo-dependent children in the list"
+        names -> "before #{Enum.join(names, ", ")}"
+      end
+
+    "#{inspect(repo_module)} (position #{repo_index}) starts #{dependents}"
+  end
+end

--- a/lib/phoenix_kit/utils/html_sanitizer.ex
+++ b/lib/phoenix_kit/utils/html_sanitizer.ex
@@ -129,10 +129,83 @@ defmodule PhoenixKit.Utils.HtmlSanitizer do
     end)
   end
 
+  # Schemes a link/media URL may use; anything else (or an unlisted scheme) is
+  # dropped. Relative/fragment/query URLs (no scheme) are allowed.
+  @allowed_schemes ~w(http https mailto tel)
+  @dangerous_scheme ~r/^(?:javascript|vbscript|data|file|blob):/
+  @scheme ~r/^[a-z][a-z0-9+.\-]*:/i
+
+  # A few named entities whose decoded form matters for scheme detection
+  # (a browser decodes `javascript&colon;alert(1)` before dispatching).
+  @named_entities %{
+    "tab" => "\t",
+    "newline" => "\n",
+    "colon" => ":",
+    "sol" => "/",
+    "lpar" => "(",
+    "rpar" => ")",
+    "num" => "#"
+  }
+
+  # Sanitize `href`/`src` URLs with an ALLOWLIST over a normalized value, not a
+  # scheme blacklist. MDEx renders raw HTML (`unsafe: true`) and the browser
+  # decodes entities + ignores whitespace/control chars in the scheme, so a
+  # blacklist is trivially bypassed (`jav&#x61;script:`, `java&Tab;script:`,
+  # `java\tscript:`). We decode entities and strip those chars BEFORE checking,
+  # and only ever REMOVE an attribute — never rewrite the visible URL — so the
+  # transform is fail-safe even if decoding is imperfect.
   defp sanitize_urls(html) do
-    # Remove dangerous href and src attributes
     html
-    |> then(&Regex.replace(~r/href\s*=\s*["']\s*(javascript|vbscript|data):[^"']*["']/i, &1, ""))
-    |> then(&Regex.replace(~r/src\s*=\s*["']\s*(javascript|vbscript|data):[^"']*["']/i, &1, ""))
+    |> scrub_url_attr("href")
+    |> scrub_url_attr("src")
   end
+
+  defp scrub_url_attr(html, attr) do
+    regex = ~r/\s#{attr}\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))/i
+
+    Regex.replace(regex, html, fn full, dquoted, squoted, unquoted ->
+      value = dquoted <> squoted <> unquoted
+      if safe_url?(value), do: full, else: ""
+    end)
+  end
+
+  defp safe_url?(value) do
+    normalized =
+      value
+      |> decode_entities()
+      # Browsers ignore ASCII control chars + whitespace when parsing a scheme.
+      |> String.replace(~r/[\x00-\x20\x7f]/u, "")
+      |> String.downcase()
+
+    cond do
+      Regex.match?(@dangerous_scheme, normalized) -> false
+      not Regex.match?(@scheme, normalized) -> true
+      Regex.match?(~r/^(?:#{Enum.join(@allowed_schemes, "|")}):/, normalized) -> true
+      true -> false
+    end
+  end
+
+  defp decode_entities(str) do
+    str
+    |> replace_entities(~r/&#x([0-9a-f]+);?/i, &String.to_integer(&1, 16))
+    |> replace_entities(~r/&#([0-9]+);?/, &String.to_integer/1)
+    |> then(
+      &Regex.replace(~r/&([a-z]+);/i, &1, fn whole, name ->
+        Map.get(@named_entities, String.downcase(name), whole)
+      end)
+    )
+  end
+
+  defp replace_entities(str, regex, to_codepoint) do
+    Regex.replace(regex, str, fn _whole, digits -> codepoint(to_codepoint.(digits)) end)
+  end
+
+  defp codepoint(n) when is_integer(n) and n in 0..0x10FFFF do
+    <<n::utf8>>
+  rescue
+    # Surrogate/invalid code points can't be encoded — treat as removed.
+    _ -> ""
+  end
+
+  defp codepoint(_), do: ""
 end

--- a/lib/phoenix_kit_web/components/layout_wrapper.ex
+++ b/lib/phoenix_kit_web/components/layout_wrapper.ex
@@ -323,7 +323,10 @@ defmodule PhoenixKitWeb.Components.LayoutWrapper do
                   transition: grid-template-columns 300ms ease-in-out;
                 }
                 #admin-drawer.sidebar-closed .drawer-side {
-                  transform: translateX(-16rem); /* -256px (w-64) */
+                  /* -100%, not -16rem: the drawer-side is wider than the w-64 aside
+                     when its scrollbar gutter is reserved — a fixed offset would
+                     leave the gutter strip peeking out when closed. */
+                  transform: translateX(-100%);
                   transition: transform 300ms ease-in-out;
                   overflow: hidden;
                 }
@@ -447,8 +450,14 @@ defmodule PhoenixKitWeb.Components.LayoutWrapper do
                 </div>
               </div>
 
-              <%!-- Desktop/Mobile Sidebar --%>
-              <div class="drawer-side">
+              <%!-- Desktop/Mobile Sidebar. lg:[scrollbar-gutter:stable]: the sidebar is
+                   its own scroll container (the menu outgrows the viewport), and the
+                   drawer grid auto-sizes this column — without a reserved gutter its
+                   width flips ±15px (classic scrollbars) when a modal's page scroll
+                   lock changes ambient scroll state, shifting the whole content pane.
+                   Scoped to lg (the drawer-open column mode); the mobile overlay
+                   drawer needs no gutter. --%>
+              <div class="drawer-side lg:[scrollbar-gutter:stable]">
                 <label for="admin-mobile-menu" class="drawer-overlay lg:hidden"></label>
                 <aside class="min-h-full w-64 bg-base-100 shadow-lg border-r border-base-300 flex flex-col pt-16">
                   <%!-- Navigation (fills available space) --%>

--- a/test/phoenix_kit/install/child_order_test.exs
+++ b/test/phoenix_kit/install/child_order_test.exs
@@ -1,0 +1,173 @@
+defmodule PhoenixKit.Install.ChildOrderTest do
+  @moduledoc """
+  Unit coverage for `ChildOrder` — the doctor safety net that catches a
+  host `application.ex` whose supervision `children` list starts
+  `PhoenixKit.Supervisor` or `Oban` before the Ecto Repo. That order crashes
+  the app at boot (PhoenixKit reads Settings from the DB; Oban needs the pool),
+  and it can slip in via a hand edit or an Igniter anchor miss that prepends.
+  """
+  use ExUnit.Case, async: true
+
+  alias PhoenixKit.Install.ChildOrder
+
+  defp app(children_lines) do
+    """
+    defmodule MyApp.Application do
+      use Application
+
+      def start(_type, _args) do
+        children = [
+    #{children_lines}
+        ]
+
+        opts = [strategy: :one_for_one, name: MyApp.Supervisor]
+        Supervisor.start_link(children, opts)
+      end
+    end
+    """
+  end
+
+  describe "check/2 — correct order" do
+    test "passes when the Repo precedes PhoenixKit.Supervisor and Oban" do
+      source =
+        app("""
+              MyApp.Repo,
+              {Phoenix.PubSub, name: MyApp.PubSub},
+              PhoenixKit.Supervisor,
+              {Oban, Application.fetch_env!(:my_app, Oban)},
+              MyAppWeb.Endpoint
+        """)
+
+      assert {:ok, detail} = ChildOrder.check(source, MyApp.Repo)
+      assert detail =~ "MyApp.Repo"
+      assert detail =~ "PhoenixKit.Supervisor"
+      assert detail =~ "Oban"
+    end
+
+    test "passes when no Repo-dependent children are present" do
+      source =
+        app("""
+              MyApp.Repo,
+              MyAppWeb.Endpoint
+        """)
+
+      assert {:ok, _detail} = ChildOrder.check(source, MyApp.Repo)
+    end
+
+    test "passes when the Repo is written as a 2-tuple child spec" do
+      source =
+        app("""
+              {MyApp.Repo, []},
+              PhoenixKit.Supervisor,
+              MyAppWeb.Endpoint
+        """)
+
+      assert {:ok, _detail} = ChildOrder.check(source, MyApp.Repo)
+    end
+  end
+
+  describe "check/2 — misordered (the boot-crash cases)" do
+    test "flags PhoenixKit.Supervisor listed before the Repo" do
+      source =
+        app("""
+              PhoenixKit.Supervisor,
+              MyApp.Repo,
+              MyAppWeb.Endpoint
+        """)
+
+      assert {:misordered, [PhoenixKit.Supervisor]} = ChildOrder.check(source, MyApp.Repo)
+    end
+
+    test "flags Oban (as a {Oban, opts} tuple) listed before the Repo" do
+      source =
+        app("""
+              {Oban, queues: [default: 10]},
+              MyApp.Repo,
+              MyAppWeb.Endpoint
+        """)
+
+      assert {:misordered, [Oban]} = ChildOrder.check(source, MyApp.Repo)
+    end
+
+    test "flags both PhoenixKit.Supervisor and Oban when both precede the Repo" do
+      source =
+        app("""
+              PhoenixKit.Supervisor,
+              {Oban, []},
+              MyApp.Repo,
+              MyAppWeb.Endpoint
+        """)
+
+      assert {:misordered, offenders} = ChildOrder.check(source, MyApp.Repo)
+      assert Enum.sort(offenders) == Enum.sort([PhoenixKit.Supervisor, Oban])
+    end
+  end
+
+  describe "check/2 — indeterminate inputs" do
+    test "returns :no_repo_in_children when the Repo isn't in the list" do
+      source =
+        app("""
+              {Phoenix.PubSub, name: MyApp.PubSub},
+              PhoenixKit.Supervisor,
+              MyAppWeb.Endpoint
+        """)
+
+      assert :no_repo_in_children = ChildOrder.check(source, MyApp.Repo)
+    end
+
+    test "returns :no_children when no children list can be located" do
+      source = """
+      defmodule MyApp.Application do
+        use Application
+        def start(_type, _args), do: :ignore
+      end
+      """
+
+      assert :no_children = ChildOrder.check(source, MyApp.Repo)
+    end
+  end
+
+  describe "ordered_children/1" do
+    test "reads head modules in list order, including tuple specs" do
+      source =
+        app("""
+              MyApp.Repo,
+              {Phoenix.PubSub, name: MyApp.PubSub},
+              {Oban, []},
+              MyAppWeb.Endpoint
+        """)
+
+      assert {:ok, [MyApp.Repo, Phoenix.PubSub, Oban, MyAppWeb.Endpoint]} =
+               ChildOrder.ordered_children(source)
+    end
+
+    test "reads the inline Supervisor.start_link([...]) shape" do
+      source = """
+      defmodule MyApp.Application do
+        use Application
+        def start(_type, _args) do
+          Supervisor.start_link(
+            [MyApp.Repo, PhoenixKit.Supervisor, MyAppWeb.Endpoint],
+            strategy: :one_for_one
+          )
+        end
+      end
+      """
+
+      assert {:ok, [MyApp.Repo, PhoenixKit.Supervisor, MyAppWeb.Endpoint]} =
+               ChildOrder.ordered_children(source)
+    end
+
+    test "yields nil for a map child spec but keeps positions" do
+      source =
+        app("""
+              MyApp.Repo,
+              %{id: MyWorker, start: {MyWorker, :start_link, []}},
+              PhoenixKit.Supervisor
+        """)
+
+      assert {:ok, [MyApp.Repo, nil, PhoenixKit.Supervisor]} =
+               ChildOrder.ordered_children(source)
+    end
+  end
+end

--- a/test/phoenix_kit/utils/html_sanitizer_test.exs
+++ b/test/phoenix_kit/utils/html_sanitizer_test.exs
@@ -1,0 +1,75 @@
+defmodule PhoenixKit.Utils.HtmlSanitizerTest do
+  use ExUnit.Case, async: true
+
+  alias PhoenixKit.Utils.HtmlSanitizer
+
+  describe "sanitize/1 strips dangerous content" do
+    test "literal dangerous schemes are removed" do
+      for scheme <- ~w(javascript vbscript data file blob) do
+        html = ~s(<a href="#{scheme}:alert1">x</a>)
+        refute HtmlSanitizer.sanitize(html) =~ "#{scheme}:"
+      end
+    end
+
+    test "entity-encoded scheme bypass is closed (the reported XSS)" do
+      # A browser decodes the attribute before dispatching, so a blacklist over
+      # the raw text misses these — normalize (decode + strip) then allowlist.
+      vectors = [
+        ~s(<a href="jav&#x61;script:alert1">x</a>),
+        ~s(<a href="jav&#97;script:alert1">x</a>),
+        ~s(<a href="java&Tab;script:alert1">x</a>),
+        ~s(<a href="java&NewLine;script:alert1">x</a>),
+        ~s(<a href="javascript&colon;alert1">x</a>)
+      ]
+
+      for html <- vectors do
+        clean = HtmlSanitizer.sanitize(html)
+        refute clean =~ ~r/href/i, "leaked a dangerous href: #{clean}"
+      end
+    end
+
+    test "whitespace/control-char obfuscation in the scheme is closed" do
+      clean = HtmlSanitizer.sanitize("<a href=\"java\tscript:alert1\">x</a>")
+      refute clean =~ ~r/href/i
+    end
+
+    test "unquoted dangerous href is removed" do
+      refute HtmlSanitizer.sanitize("<a href=javascript:alert1>x</a>") =~ "javascript"
+    end
+  end
+
+  describe "sanitize/1 keeps safe URLs" do
+    test "allowed schemes and relative URLs survive intact" do
+      for url <- [
+            "https://example.com/page?q=1",
+            "http://example.com",
+            "mailto:me@example.com",
+            "tel:+123456789",
+            "/relative/path",
+            "#fragment",
+            "?just=query"
+          ] do
+        html = ~s(<a href="#{url}">link</a>)
+        assert HtmlSanitizer.sanitize(html) =~ ~s(href="#{url}")
+      end
+    end
+
+    test "safe img src survives; a data: src is dropped" do
+      assert HtmlSanitizer.sanitize(~s(<img src="/img/a.png">)) =~ ~s(src="/img/a.png")
+      refute HtmlSanitizer.sanitize(~s(<img src="data:image/png;base64,AAAA">)) =~ "data:"
+    end
+
+    test "a href value that merely contains 'javascript' as text is not itself a scheme" do
+      # e.g. a link TO a page about javascript — path, not scheme.
+      html = ~s(<a href="/articles/javascript-guide">JS guide</a>)
+      assert HtmlSanitizer.sanitize(html) =~ ~s(href="/articles/javascript-guide")
+    end
+  end
+
+  describe "sanitize/1 non-URL vectors (unchanged behaviour)" do
+    test "script/style/event handlers still stripped" do
+      assert HtmlSanitizer.sanitize("<p>Hi</p><script>x</script>") == "<p>Hi</p>"
+      assert HtmlSanitizer.sanitize("<p onclick=\"x()\">Hi</p>") == "<p>Hi</p>"
+    end
+  end
+end


### PR DESCRIPTION
Six fixes across two themes: a security/CSS pair, and a `mix phoenix_kit.doctor` + prefix-safety hardening batch surfaced by a real `--prefix` (named-schema) install.

## 1. HTML sanitizer URL bypass (security)

`HtmlSanitizer.sanitize_urls/1` blacklisted only literal `javascript:` / `vbscript:` / `data:` schemes, but `<.markdown>` renders raw HTML (`unsafe: true`) and the browser decodes entities + ignores whitespace/control chars in a scheme — so `jav&#x61;script:`, `java&Tab;script:`, and `java<tab>script:` all slipped through as stored XSS in any markdown sink (the dashboards note widget among them).

Replaced the blacklist with an **allowlist over a normalized value**: decode HTML entities, strip control/whitespace chars, then keep only `http` / `https` / `mailto` / `tel` (and relative/fragment) URLs. The transform only ever *removes* an attribute — never rewrites the visible URL — so it stays fail-safe. No new dependency. Covered by `test/phoenix_kit/utils/html_sanitizer_test.exs` (every reported bypass vector).

## 2. Admin sidebar width flip around modal scroll locks (CSS)

The admin `.drawer-side` is its own scroll container inside the drawer grid's auto-sized column. Chromium resolves that column ~15px narrower on pages where the root scrolls, and a daisyUI modal's page scroll-lock re-resolves it wider mid-session — shifting the whole content pane sideways on every modal open/cancel on long admin pages, then latching until the next load.

Reserve the sidebar's scrollbar gutter (`lg:[scrollbar-gutter:stable]` — the mobile overlay drawer needs none) so the column width is state-independent, and switch the collapsed transform to `-100%` so the now-wider element still hides fully. This targets the sidebar column's own width — distinct from the modal-body gutter compensations removed in `39e93eb6` (which daisyUI ≥5.1 handles).

## 3. Installer child start order — new `phoenix_kit.doctor` check

Field report: on a prefixed install the supervision children were ordered with `PhoenixKit.Supervisor` / `Oban` *before* the app's Repo in `application.ex`, so PhoenixKit (which reads Settings from the DB at boot) and Oban (which needs the pool) started before the database — an Oban crash-loop at boot.

The installer already positions its child `after: [repo], before: [endpoint]`; the prepend happens inside Igniter's insertion fallback when its anchor doesn't match, which isn't reliably fixable from phoenix_kit. So the deterministic fix is **detection**: a new **Child Start Order** doctor check reads the host `application.ex`, extracts the ordered supervision children via a pure `PhoenixKit.Install.ChildOrder` analyzer (handles bare aliases, `{Mod, opts}` tuples, and the inline `Supervisor.start_link([...])` shape), and FAILs when `PhoenixKit.Supervisor` or `Oban` precede the Repo — catching both fresh and existing bad installs. Unit-tested in `test/phoenix_kit/install/child_order_test.exs`.

## 4. `phoenix_kit.doctor` prefix-blindness + Oban `0/0` report

On a prefixed install (`config :phoenix_kit, prefix: "…"`), doctor resolved the schema as `opts[:prefix] || "public"`, so the Migration State check read the version marker at `public`, found nothing, and reported "not installed / V0" — while `phoenix_kit.update --status`, run seconds apart, resolved the prefix and reported the truth.

Routed doctor's prefix resolution through the same `PrefixConfig.resolve_prefix/1` the updater/status use (`--prefix` → `config :phoenix_kit, :prefix` → `"public"`, after `app.config` loads config), so the fix flows to every prefix-consuming check (migration state, uuid types, null uuids, orphaned FKs). Also fixed the Oban Configuration check reporting `0 queues, 0 plugins`: doctor's own pool-capping zeroes Oban queues/plugins in the app env before any check runs — now snapshots the config *before* capping and reports from the snapshot.

## 5. `phoenix_kit.doctor` schema-drift check

The same prefixed install crashed at runtime with `column phoenix_kit_users_tokens.browser does not exist` while its version marker read V150 — the migration that adds `browser`/`os`. The migration is correct and idempotent (`add_if_not_exists` → native, prefix-safe `ADD COLUMN IF NOT EXISTS`); the install had drifted so the marker sat *ahead* of the actual schema (a residue of the V149→V150 renumber crossing earlier prefix-confused upgrades), and re-running the migrator is a no-op once the marker covers V150 — so the crash has no self-service recovery, and the existing `heal_version_comment` only heals the marker *up*, never this direction.

New **Schema Drift** doctor check: for a small `{version, table, column}` table, when the marker claims that version (or higher) but the column is missing at the resolved prefix, FAIL with the surgical repair — roll the marker back one version and re-run the migrator (idempotent). A marker *below* the expected version reads as pending-migration, not drift (no false positive).

## 6. Dialyzer: qr_login Task-opaque false positive

`QrLogin.location_for/1` uses the textbook `Task.Supervisor.async_nolink` + `Task.yield(task, t) || Task.shutdown(task, :brutal_kill)` bounded-async idiom, but dialyzer widens the opaque `Task.t()`'s `:pid`/`:ref` fields and flags `Task.yield`'s first argument (`call_without_opaque`). Added a scoped `.dialyzer_ignore.exs` regex mirroring the existing `auth.ex` entry for the same class rather than distorting correct runtime code. `mix dialyzer` now passes.

## Testing

- `mix format`, `mix compile --warnings-as-errors`, `mix credo --strict` clean; **`mix dialyzer` passes** (the qr_login false positive is the only change to the ignore set).
- New unit tests green: `html_sanitizer_test.exs` (bypass vectors), `child_order_test.exs` (11 cases); doctor's prefix resolution is covered by the existing `prefix_config_test.exs` (flag → config → public, including a non-public fixture).
- The prefix + schema-drift behavior was validated against a real `--prefix` field install and reproduced/verified against the local parent database.
