### PR TITLE
Component polish: search-picker on-focus, nav_tabs pulse, multilang auto switch-handler

### DIFF
--- a/lib/phoenix_kit_web/components/core/nav_tabs.ex
+++ b/lib/phoenix_kit_web/components/core/nav_tabs.ex
@@ -69,12 +69,18 @@ defmodule PhoenixKitWeb.Components.Core.NavTabs do
             </span>
           </.link>
         <% else %>
+          <%!-- While the switch round-trips, LiveView tags the clicked tab
+               with phx-click-loading — pulse it so a switch whose content
+               needs server work still gives instant feedback. --%>
           <button
             type="button"
             role="tab"
             phx-click={@on_change}
             phx-value-tab={tab.id}
-            class={["tab gap-2", tab.id == @active_tab && "tab-active"]}
+            class={[
+              "tab gap-2 [&.phx-click-loading]:animate-pulse",
+              tab.id == @active_tab && "tab-active"
+            ]}
           >
             <.icon :if={Map.has_key?(tab, :icon)} name={tab.icon} class="w-4 h-4" />
             {tab.label}

--- a/lib/phoenix_kit_web/components/core/search_picker.ex
+++ b/lib/phoenix_kit_web/components/core/search_picker.ex
@@ -74,6 +74,14 @@ defmodule PhoenixKitWeb.Components.Core.SearchPicker do
     The selector must actually match an element or every push is dropped
     with a console error.
   - `mode` — `"multi"` (default) or `"single"` (see moduledoc)
+  - `search_on_focus` — when `true`, clicking/focusing the EMPTY input
+    already opens the dropdown in browse mode (the hook searches with an
+    empty query, so the server should answer it with a first page — the
+    workspace picker rule: offer options before any typing). Off by
+    default; without it the dropdown only opens while typing, which also
+    means a multi-mode picker won't reopen after a pick clears the input.
+    (Previously only reachable as a raw `data-search-on-focus` rest attr —
+    still honored for existing call sites.)
   - `direction` — `"down"` (default) or `"up"`. Use `"up"` when the input
     sits near the BOTTOM of a scrollable container (e.g. the last field
     of a modal): a downward dropdown there extends the container's
@@ -90,6 +98,7 @@ defmodule PhoenixKitWeb.Components.Core.SearchPicker do
   attr :dropdown_id, :string, required: true
   attr :target, :any, default: nil
   attr :mode, :string, default: "multi", values: ["multi", "single"]
+  attr :search_on_focus, :boolean, default: false
   attr :direction, :string, default: "down", values: ["down", "up"]
   attr :name, :string, default: nil
   attr :value, :string, default: nil
@@ -121,6 +130,7 @@ defmodule PhoenixKitWeb.Components.Core.SearchPicker do
         data-target={@target}
         data-dropdown={@dropdown_id}
         data-mode={@mode}
+        data-search-on-focus={@search_on_focus || nil}
         data-search-event={@search_event}
         data-results-event={@results_event}
         data-pick-event={@pick_event}

--- a/lib/phoenix_kit_web/components/multilang_form.ex
+++ b/lib/phoenix_kit_web/components/multilang_form.ex
@@ -29,9 +29,9 @@ defmodule PhoenixKitWeb.Components.MultilangForm do
 
   ### Events
 
-      def handle_event("switch_language", %{"lang" => lang_code}, socket) do
-        {:noreply, handle_switch_language(socket, lang_code)}
-      end
+  `mount_multilang/2` auto-handles the `"switch_language"` event, so you do
+  NOT need a `handle_event("switch_language", …)` clause — you only wire your
+  own form events:
 
       def handle_event("validate", %{"record" => params}, socket) do
         params = merge_translatable_params(params, socket, ["name", "description"],
@@ -39,6 +39,18 @@ defmodule PhoenixKitWeb.Components.MultilangForm do
         changeset = MySchema.changeset(socket.assigns.record, params)
         {:noreply, assign(socket, :changeset, changeset)}
       end
+
+  ## Storage caveat — the helper OWNS the `data` column
+
+  `merge_translatable_params/4` (and `put_language_data/3`) store translations
+  by RESTRUCTURING the schema's `data` JSONB into a multilang shape
+  (`%{"_primary_language" => "en", "en" => %{…}, "et" => %{…}}`). On a schema
+  whose `data` column already holds unrelated keys (e.g. per-record settings),
+  this MOVES those keys into the primary-language sub-map and every top-level
+  reader breaks. In that case do NOT point `merge_translatable_params` at
+  `data`: keep translations in an isolated sub-key and use `translatable_field`
+  in its settings-translations mode (`secondary_name` + `lang_data_key`) with
+  your own small merge. See the `translatable_field` docs.
 
   ### Template — whole-form translation
 
@@ -105,10 +117,25 @@ defmodule PhoenixKitWeb.Components.MultilangForm do
   Adds: `:multilang_enabled`, `:primary_language`, `:current_lang`,
   `:language_tabs`, `:show_multilang_tabs`, `:switching_lang` (no-op
   compat assign — kept because consumer templates pass it through to
-  the wrapper). Also attaches an internal `:handle_info` hook that
-  receives the debounced language-switch timer message.
+  the wrapper).
+
+  Also attaches two internal LiveView hooks so consumers don't have to
+  wire the language-switching protocol by hand:
+
+    * a `:handle_info` hook for the debounced language-switch timer, and
+    * a `:handle_event` hook for the `"switch_language"` event that
+      `<.multilang_tabs>` pushes — it calls `handle_switch_language/2`
+      and halts, so **you no longer need to add**
+      `def handle_event("switch_language", …)` yourself. Forgetting that
+      clause used to crash the LiveView on the first tab click.
+
+  ## Options
+
+    * `:auto_switch_language` — when `false`, skips the `"switch_language"`
+      event hook so you can handle the event yourself (e.g. to switch
+      language immediately without the debounce). Default `true`.
   """
-  def mount_multilang(socket) do
+  def mount_multilang(socket, opts \\ []) do
     multilang_enabled = multilang_enabled?()
     primary_language = if multilang_enabled, do: safe_primary_language(), else: nil
 
@@ -126,21 +153,27 @@ defmodule PhoenixKitWeb.Components.MultilangForm do
       # The wrapper no longer reads it — visibility is client-side JS.
       switching_lang: false
     )
-    |> attach_multilang_hook()
+    |> attach_multilang_hooks(opts)
   end
 
-  # Attaches a `:handle_info` hook that intercepts the internal
-  # `{:__multilang_apply_lang__, lang}` message. The hook lives on the
-  # consumer's socket but is invisible to them — no `handle_info/2`
-  # clause needed. Returning `{:halt, socket}` prevents the message
-  # from reaching the consumer's own handle_info (and suppresses the
-  # "unhandled message" warning). Other messages pass through with
-  # `{:cont, socket}`.
-  #
-  # `attach_hook/4` is idempotent-by-name within a process — re-running
-  # `mount_multilang/1` (e.g. across reconnects) with the same hook id
-  # simply replaces the prior callback, so we don't need a guard.
-  defp attach_multilang_hook(socket) do
+  # Attaches the internal hooks. Both are idempotent-by-name within a
+  # process — re-running `mount_multilang/2` (e.g. across reconnects) with
+  # the same hook ids simply replaces the prior callbacks, so no guard is
+  # needed. `attach_hook/4` only works on LiveView sockets (not
+  # LiveComponents), so each attach is guarded — a LiveComponent consumer
+  # would need to wire the handlers itself.
+  defp attach_multilang_hooks(socket, opts) do
+    socket = attach_apply_lang_hook(socket)
+
+    if Keyword.get(opts, :auto_switch_language, true),
+      do: attach_switch_language_hook(socket),
+      else: socket
+  end
+
+  # Intercepts the debounced `{:__multilang_apply_lang__, lang}` message so
+  # the consumer needs no `handle_info/2` clause. Other messages pass
+  # through with `{:cont, socket}`.
+  defp attach_apply_lang_hook(socket) do
     Phoenix.LiveView.attach_hook(
       socket,
       :__phoenix_kit_multilang_apply_lang__,
@@ -154,10 +187,27 @@ defmodule PhoenixKitWeb.Components.MultilangForm do
       end
     )
   rescue
-    # `attach_hook/4` only works on LiveView sockets, not LiveComponent
-    # sockets. Multilang consumers are all `Phoenix.LiveView` today, but
-    # if someone wires it into a component in the future, fall back
-    # silently — they'll need to add the `handle_info` themselves.
+    ArgumentError -> socket
+  end
+
+  # Intercepts the `"switch_language"` event that `<.multilang_tabs>`
+  # pushes, so the consumer needs no `handle_event/3` clause. Halting stops
+  # propagation to the consumer's own callbacks; every other event passes
+  # through with `{:cont, socket}`.
+  defp attach_switch_language_hook(socket) do
+    Phoenix.LiveView.attach_hook(
+      socket,
+      :__phoenix_kit_multilang_switch_language__,
+      :handle_event,
+      fn
+        "switch_language", %{"lang" => lang_code}, socket ->
+          {:halt, handle_switch_language(socket, lang_code)}
+
+        _event, _params, socket ->
+          {:cont, socket}
+      end
+    )
+  rescue
     ArgumentError -> socket
   end
 


### PR DESCRIPTION
Small component-polish / DX commits.

The first two came out of the projects calendar work (BeamLabEU/phoenix_kit_projects#30 uses both, but degrades gracefully without them); the third came out of the publishing group-name translation work.

## `search_on_focus` attr on the search picker

The SearchPicker hook has always honored `data-search-on-focus` (open the dropdown in browse mode when the empty input is focused/clicked — offer options before any typing), but the component never exposed it: consumers had to know the raw data attribute and pass it through the global rest. It is now a documented boolean attr rendering that same attribute; the raw form keeps working for existing call sites.

## nav_tabs in-flight pulse

Tab buttons that push an event now pulse (`phx-click-loading` → `animate-pulse`) while the switch is round-tripping, so a click on a slower tab is visibly acknowledged instead of appearing dead. Navigation-style tabs are unaffected.

## MultilangForm auto-handles the `"switch_language"` event

`mount_multilang/2` now attaches a `:handle_event` hook (mirroring its existing debounced `:handle_info` hook) that calls `handle_switch_language/2` and halts — so consumers no longer need their own `def handle_event("switch_language", …)` clause. Forgetting that clause previously crashed the LiveView on the first language-tab click, a silent footgun since `mount_multilang` already wired the *other* half of the switching protocol (the `handle_info` timer) automatically.

- Existing consumers' manual clauses keep working (the hook halts first; the clause becomes harmless dead code).
- Opt out with `mount_multilang(socket, auto_switch_language: false)` when a form switches language immediately, without the debounce (catalogue's import screen does this).
- Also documents a storage footgun: `merge_translatable_params/4` / `put_language_data/3` take over the schema's `data` JSONB (restructuring it into a per-language shape), so schemas whose `data` already holds unrelated keys must not point the helper at `data` — use `translatable_field`'s settings-translations mode instead.

## Testing

- `mix test test/phoenix_kit_web/components/core/search_picker_test.exs` — 6 tests, 0 failures (rebased onto current main, full compile clean with `--warnings-as-errors`).
- Browser-verified through the projects module: browse-on-focus lists people via the documented attr, and the project List/Timeline/Calendar tab switches pulse while loading.
- MultilangForm change: compiles clean (`--warnings-as-errors`); language-tab switching verified in-app via the publishing group-name edit form (tabs switch without any per-consumer `switch_language` handler). All existing multilang consumers across the workspace delegate to `handle_switch_language/2`, so the auto-hook is behaviour-preserving for them; the one immediate-switch consumer (catalogue import) opts out.
