### PR TITLE
Persist media rotation for any user, not just admins

### DIFF
--- a/lib/phoenix_kit_web/components/media_browser.html.heex
+++ b/lib/phoenix_kit_web/components/media_browser.html.heex
@@ -2396,6 +2396,10 @@
         <%!-- + variant count so a processing-completion refresh (see    --%>
         <%!-- refresh_processed_file/2) remounts with the real canvas    --%>
         <%!-- instead of the 1000x1000 placeholder.                      --%>
+        <%!-- persist_rotation is unconditional: rotation is the file's   --%>
+        <%!-- shared orientation, so anyone who can open the viewer and   --%>
+        <%!-- rotate saves it for everyone (not admin-only). The Details  --%>
+        <%!-- link stays admin-only — it targets the admin detail page.   --%>
         <.live_component
           module={PhoenixKitWeb.Components.MediaCanvasViewer}
           id={"media-canvas-viewer-#{f.file_uuid}-#{f.width || 0}x#{f.height || 0}-#{map_size(f.urls)}"}
@@ -2404,7 +2408,7 @@
           parent_id={@id}
           has_prev={has_prev}
           has_next={has_next}
-          persist_rotation={@admin}
+          persist_rotation={true}
           details_path={if @admin, do: Routes.path("/admin/media/#{f.file_uuid}")}
         />
       </div>

--- a/lib/phoenix_kit_web/components/media_canvas_viewer.ex
+++ b/lib/phoenix_kit_web/components/media_canvas_viewer.ex
@@ -153,9 +153,12 @@ defmodule PhoenixKitWeb.Components.MediaCanvasViewer do
       |> assign(:has_prev, assigns[:has_prev] || false)
       |> assign(:has_next, assigns[:has_next] || false)
       |> assign(:viewer_only, assigns[:viewer_only] || false)
-      # Opt-in: only admin-context hosts persist a rotation back to the shared
-      # file row (see handle_event "fresco:rotate"). Public hosts still seed
-      # `initial_rotation` below so everyone sees the saved orientation.
+      # Opt-in: hosts that pass `persist_rotation` write a rotation back to the
+      # shared file row (see handle_event "fresco:rotate") — the media browser
+      # popup and the detail page do, so any user who can open and rotate a file
+      # saves its orientation for everyone. Hosts that don't opt in (the gallery
+      # lightbox) still seed `initial_rotation` below so the saved orientation
+      # shows; they just don't write.
       |> assign(:persist_rotation, assigns[:persist_rotation] || false)
       |> assign(:details_path, assigns[:details_path])
 
@@ -305,8 +308,9 @@ defmodule PhoenixKitWeb.Components.MediaCanvasViewer do
   # Fresco's opt-in server bridge: fires on every rotation change when the
   # canvas is mounted with `persist_rotation`. The rotation lives on the shared
   # file row (`metadata["rotation"]`) — it's the image's saved orientation for
-  # every viewer, not a per-user preference — so only persist when the host
-  # opted in (admin contexts). Seeds `initial_rotation` on the next open.
+  # every viewer, not a per-user preference — so it persists whenever the host
+  # opted in (the browser popup and detail page, for any user). Seeds
+  # `initial_rotation` on the next open.
   @impl true
   def handle_event("fresco:rotate", %{"rotation" => rotation}, socket) do
     file = socket.assigns[:file]

--- a/test/integration/phoenix_kit_web/components/media_browser_test.exs
+++ b/test/integration/phoenix_kit_web/components/media_browser_test.exs
@@ -343,10 +343,12 @@ defmodule PhoenixKitWeb.Components.MediaBrowserTest do
   end
 
   # ---------------------------------------------------------------------------
-  # Rotation persistence — admin popup opts in via persist_rotation={@admin}
+  # Rotation persistence — the popup opts in unconditionally (any user who can
+  # open and rotate a file saves its shared orientation). Exercised via the
+  # admin route since that's the only in-suite MediaBrowser host.
   # ---------------------------------------------------------------------------
 
-  describe "rotation persistence in the admin popup" do
+  describe "rotation persistence in the popup" do
     test "fresco:rotate persists to file metadata and seeds the next open",
          %{conn: conn} do
       {user, _token} = create_admin_user()

--- a/test/phoenix_kit_web/components/multilang_form_test.exs
+++ b/test/phoenix_kit_web/components/multilang_form_test.exs
@@ -5,6 +5,8 @@ defmodule PhoenixKitWeb.Components.MultilangFormTest do
   import Phoenix.Component, only: [sigil_H: 2]
   import PhoenixKitWeb.Components.MultilangForm
 
+  alias Phoenix.LiveView.Lifecycle
+
   # ── Test helpers ─────────────────────────────────────────────
 
   defp html(assigns) do
@@ -826,14 +828,14 @@ defmodule PhoenixKitWeb.Components.MultilangFormTest do
 
   describe "mount_multilang/2 auto-switch-language hook" do
     defp bare_socket do
-      %Phoenix.LiveView.Socket{private: %{lifecycle: %Phoenix.LiveView.Lifecycle{}}}
+      %Phoenix.LiveView.Socket{private: %{lifecycle: %Lifecycle{}}}
     end
 
     test "intercepts and halts the switch_language event" do
       socket = mount_multilang(bare_socket())
 
       assert {:halt, %Phoenix.LiveView.Socket{}} =
-               Phoenix.LiveView.Lifecycle.handle_event(
+               Lifecycle.handle_event(
                  "switch_language",
                  %{"lang" => "en"},
                  socket
@@ -844,14 +846,14 @@ defmodule PhoenixKitWeb.Components.MultilangFormTest do
       socket = mount_multilang(bare_socket())
 
       assert {:cont, ^socket} =
-               Phoenix.LiveView.Lifecycle.handle_event("some_other_event", %{}, socket)
+               Lifecycle.handle_event("some_other_event", %{}, socket)
     end
 
     test "auto_switch_language: false skips the hook — event passes through" do
       socket = mount_multilang(bare_socket(), auto_switch_language: false)
 
       assert {:cont, ^socket} =
-               Phoenix.LiveView.Lifecycle.handle_event(
+               Lifecycle.handle_event(
                  "switch_language",
                  %{"lang" => "en"},
                  socket


### PR DESCRIPTION
## Summary
- **Rotation is the file's shared orientation** (`metadata["rotation"]`) — every viewer sees it — so gating the *write* on admin context was arbitrary. A non-admin who could open and rotate a file in an embedded browser saw the turn but it never stuck. The media browser popup now passes `persist_rotation` unconditionally (the detail page already did). The **Details** link stays admin-only; it targets the admin page.
- Layering note: Fresco already owns the mechanism (the `persist_rotation` attr + `fresco:rotate` bridge, shipped in fresco 0.9.0). This change is purely phoenix_kit's *policy* on top of it — who may persist, and to where (the file's DB row). Nothing to push into Fresco.

## Also
- **Alias `Phoenix.LiveView.Lifecycle` in `multilang_form_test.exs`** — `credo --strict` flagged three fully-qualified calls (nested-module-alias) that came in with #643 and had turned `mix precommit` red on `main`. Unrelated to the rotation change; folded in to get precommit green.

## Test plan
- `mix precommit` green (was red before the credo fix — a pre-existing #643 issue, confirmed on the base commit).
- Existing rotation-persistence integration test still passes (exercised via the admin route, the only in-suite MediaBrowser host). The non-admin path can't be reached in-suite since `/admin/media` is admin-gated; the change is a one-attribute gate removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MsjUy1HnuJnCSrqdbnANYL