### PR TITLE
V152: deliveries addressability CHECK + friendly incomplete-credentials flash

### DIFF
--- a/lib/phoenix_kit/migrations/postgres/v152.ex
+++ b/lib/phoenix_kit/migrations/postgres/v152.ex
@@ -104,6 +104,14 @@ defmodule PhoenixKit.Migrations.Postgres.V152 do
   make the documented rollback-and-reapply dance (see the warning above)
   fail on exactly the data this section exists to create. Only the new
   columns are dropped.
+
+  A dropped `user_uuid` `NOT NULL` alone would let a delivery row be
+  addressable by neither identifier at all — `phoenix_kit_newsletters_deliveries_recipient_check`
+  (`CHECK (user_uuid IS NOT NULL OR recipient_email IS NOT NULL)`) closes
+  that gap; `down/1` drops it along with the columns. The Ecto-layer
+  `Broadcaster` insert path already guards the same invariant before this
+  constraint existed — this is a cheap, redundant DB-level backstop, not
+  a replacement for it.
   """
 
   use Ecto.Migration
@@ -311,7 +319,7 @@ defmodule PhoenixKit.Migrations.Postgres.V152 do
 
   # ── Section: broadcasts can source recipients from a CRM list ──
 
-  defp up_broadcast_crm_source(_opts, _prefix, p) do
+  defp up_broadcast_crm_source(opts, prefix, p) do
     Helpers.ensure_extension!("citext")
 
     # A crm_list broadcast has no newsletters list of its own.
@@ -351,11 +359,41 @@ defmodule PhoenixKit.Migrations.Postgres.V152 do
     ALTER TABLE #{p}phoenix_kit_newsletters_deliveries
     ADD COLUMN IF NOT EXISTS recipient_email CITEXT
     """)
+
+    # Cheap integrity guard: with both NOT NULLs dropped above, a delivery
+    # row addressable by neither a core User nor a snapshotted email is
+    # unreachable by any send path — Postgres has no
+    # `ADD CONSTRAINT IF NOT EXISTS`, so guard on the constraint name (same
+    # pattern used elsewhere in this migration chain, e.g. V125's
+    # `add_status_entity_uuid_fk/2`). Deliberately no CHECK on `source_type`
+    # here — this repo's convention keeps enum-shaped columns Ecto-only
+    # (see `broadcasts.status`), not DB CHECK-constrained.
+    escaped_prefix = Map.get(opts, :escaped_prefix, prefix)
+
+    execute("""
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT FROM information_schema.table_constraints
+        WHERE table_schema = '#{escaped_prefix}'
+          AND table_name = 'phoenix_kit_newsletters_deliveries'
+          AND constraint_name = 'phoenix_kit_newsletters_deliveries_recipient_check'
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_newsletters_deliveries
+          ADD CONSTRAINT phoenix_kit_newsletters_deliveries_recipient_check
+          CHECK (user_uuid IS NOT NULL OR recipient_email IS NOT NULL);
+      END IF;
+    END $$;
+    """)
   end
 
   defp down_broadcast_crm_source(_opts, _prefix, p) do
     # Deliberately does NOT restore the NOT NULLs — see the module doc's
     # "Section: broadcasts can source recipients from a CRM list" note.
+    execute(
+      "ALTER TABLE #{p}phoenix_kit_newsletters_deliveries DROP CONSTRAINT IF EXISTS phoenix_kit_newsletters_deliveries_recipient_check"
+    )
+
     execute("DROP INDEX IF EXISTS #{p}idx_newsletters_broadcasts_crm_list")
 
     execute(

--- a/lib/phoenix_kit_web/live/settings/email_sending.ex
+++ b/lib/phoenix_kit_web/live/settings/email_sending.ex
@@ -131,6 +131,17 @@ defmodule PhoenixKitWeb.Live.Settings.EmailSending do
            gettext("Test email sent to %{recipient}", recipient: recipient)
          )}
 
+      {:error, {:incomplete_credentials, missing_fields}} ->
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           gettext(
+             "Could not send test email: the send integration is missing required field(s): %{fields}",
+             fields: Enum.map_join(missing_fields, ", ", &to_string/1)
+           )
+         )}
+
       {:error, reason} ->
         {:noreply,
          put_flash(

--- a/test/integration/phoenix_kit_web/live/settings/email_sending_test.exs
+++ b/test/integration/phoenix_kit_web/live/settings/email_sending_test.exs
@@ -178,5 +178,41 @@ defmodule PhoenixKitWeb.Live.Settings.EmailSendingTest do
 
       assert html =~ "Enter a recipient email address"
     end
+
+    test "a default integration with a since-blanked required field shows a safe, readable flash (security)",
+         %{conn: conn} do
+      # Same exploit chain as PhoenixKit.MailerTest's
+      # deliver_via_integration/3 test: a "connected" status is sticky, so
+      # blanking a required field afterward does not un-connect the
+      # integration. This proves the resulting flash names only the
+      # missing field, never the still-present secret.
+      {:ok, %{uuid: uuid}} = Integrations.add_connection("smtp", "flaky relay")
+      secret = "very-real-password-#{System.unique_integer([:positive])}"
+
+      {:ok, _} =
+        Integrations.save_setup(uuid, %{
+          "host" => "smtp.example.com",
+          "port" => "587",
+          "username" => "user",
+          "password" => secret
+        })
+
+      :ok = Integrations.record_validation(uuid, :ok)
+      {:ok, _} = Settings.update_setting("default_email_integration_uuid", uuid)
+
+      # Blank the host after the fact — status stays "connected".
+      {:ok, _} = Integrations.save_setup(uuid, %{"host" => ""})
+      assert Integrations.connected?(uuid)
+
+      {:ok, view, _html} = live(conn, @path)
+
+      html =
+        view
+        |> element("form[phx-submit=\"send_test_email\"]")
+        |> render_submit(%{"recipient" => "ops@example.com"})
+
+      assert html =~ "missing required field(s): host"
+      refute html =~ secret
+    end
   end
 end

--- a/test/phoenix_kit/migrations/v152_test.exs
+++ b/test/phoenix_kit/migrations/v152_test.exs
@@ -17,6 +17,7 @@ defmodule PhoenixKit.Migrations.Postgres.V152Test do
   use PhoenixKit.DataCase, async: false
 
   alias PhoenixKit.Test.Repo
+  alias PhoenixKit.Users.Auth.User
 
   defp column(table, column) do
     %{rows: rows} =
@@ -580,6 +581,63 @@ defmodule PhoenixKit.Migrations.Postgres.V152Test do
 
       assert column_udt_name("phoenix_kit_newsletters_deliveries", "recipient_email") ==
                "citext"
+    end
+
+    defp insert_broadcast! do
+      %{rows: [[uuid]]} =
+        Repo.query!("""
+        INSERT INTO phoenix_kit_newsletters_broadcasts (subject)
+        VALUES ('V152 CHECK constraint test')
+        RETURNING uuid
+        """)
+
+      uuid
+    end
+
+    test "a row with neither user_uuid nor recipient_email is rejected" do
+      broadcast_uuid = insert_broadcast!()
+
+      assert {:error, %Postgrex.Error{postgres: %{code: :check_violation}}} =
+               Repo.query(
+                 """
+                 INSERT INTO phoenix_kit_newsletters_deliveries (broadcast_uuid, user_uuid, recipient_email)
+                 VALUES ($1, NULL, NULL)
+                 """,
+                 [broadcast_uuid]
+               )
+    end
+
+    test "a row with only recipient_email set is accepted (crm_list delivery)" do
+      broadcast_uuid = insert_broadcast!()
+
+      assert {:ok, %{num_rows: 1}} =
+               Repo.query(
+                 """
+                 INSERT INTO phoenix_kit_newsletters_deliveries (broadcast_uuid, user_uuid, recipient_email)
+                 VALUES ($1, NULL, 'crm-contact@example.com')
+                 """,
+                 [broadcast_uuid]
+               )
+    end
+
+    test "a row with only user_uuid set is accepted (newsletters_list delivery, unchanged behavior)" do
+      broadcast_uuid = insert_broadcast!()
+
+      user =
+        %User{}
+        |> User.guest_user_changeset(%{
+          email: "v152-check-test-#{System.unique_integer([:positive])}@example.com"
+        })
+        |> Repo.insert!()
+
+      assert {:ok, %{num_rows: 1}} =
+               Repo.query(
+                 """
+                 INSERT INTO phoenix_kit_newsletters_deliveries (broadcast_uuid, user_uuid, recipient_email)
+                 VALUES ($1, $2, NULL)
+                 """,
+                 [broadcast_uuid, Ecto.UUID.dump!(user.uuid)]
+               )
     end
   end
 


### PR DESCRIPTION
Follow-up to the post-merge credential-leak fix (82f2ffc8) that closed the [MAJOR] finding from the #647 review — two small pieces from that review round hadn't landed with it:

1. **Deliveries addressability CHECK.** `phoenix_kit_newsletters_deliveries` gains `CHECK (user_uuid IS NOT NULL OR recipient_email IS NOT NULL)` in V152's broadcast section — with both columns now nullable, a both-NULL row is unaddressable. Idempotently guarded via `information_schema.table_constraints` (the V125 pattern; Postgres has no `ADD CONSTRAINT IF NOT EXISTS`), dropped first in `down/1`. The newsletters Broadcaster already filters such rows before `insert_all`, so this is a pure DB backstop; V152Test covers both-null rejected / either-side-alone accepted.

2. **Friendly flash for incomplete credentials.** The Email Sending test-send handler now renders a specific message for `{:error, {:incomplete_credentials, fields}}` (field names only) instead of the generic `inspect(reason)` fallback, plus a LiveView test walking the full chain (validated connection → required field blanked → still `connected?` → flash names the missing field, and the secret never appears in the rendered HTML).

Databases already stamped '152' need the constraint applied manually (`ALTER TABLE ... ADD CONSTRAINT phoenix_kit_newsletters_deliveries_recipient_check CHECK (user_uuid IS NOT NULL OR recipient_email IS NOT NULL)`) — same accumulator caveat as documented in the migration's moduledoc.

Verification: V152 fresh-chain + targeted suites (migration, mailer, Email Sending LiveView) — 69 tests, 0 failures; credo --strict clean on touched files.