### PR TITLE
Add V154 OG migration + admin list-UI, breadcrumb and sidebar enhancements

### DIFF
--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -529,7 +529,15 @@ defmodule PhoenixKit.Migrations.Postgres do
   - Replaces unique index with partial index (slug-mode only, WHERE slug IS NOT NULL)
   - Adds unique index on `(group_uuid, post_date, post_time)` for timestamp-mode posts
 
-  ### V153 - Folder header size defaults to small ⚡ LATEST
+  ### V154 - OpenGraph templates + assignments (`phoenix_kit_og`) ⚡ LATEST
+  - Adds `phoenix_kit_og_templates` (reusable OG canvas designs; JSONB
+    `canvas` element list) and `phoenix_kit_og_assignments` (binds a
+    template to a `module_key × scope_type × scope_uuid` scope with a JSONB
+    `slot_mapping`). Uniqueness via a partial-index pair (NULL `scope_uuid`
+    is the module-wide default tier); `template_uuid` cascades on delete.
+    Powers the `phoenix_kit_og` plugin.
+
+  ### V153 - Folder header size defaults to small
   - Flips `phoenix_kit_media_folders.header_size` column default from
     'medium' (V134) to 'small', and backfills existing 'medium' rows to
     'small' ('medium' was the old default, so it reads as untouched;
@@ -1329,7 +1337,7 @@ defmodule PhoenixKit.Migrations.Postgres do
   alias PhoenixKit.Migrations.Postgres.Helpers
 
   @initial_version 1
-  @current_version 153
+  @current_version 154
   @default_prefix "public"
 
   # First version whose SQL references uuid_generate_v7(). Chains that

--- a/lib/phoenix_kit/migrations/postgres/v154.ex
+++ b/lib/phoenix_kit/migrations/postgres/v154.ex
@@ -1,0 +1,111 @@
+defmodule PhoenixKit.Migrations.Postgres.V154 do
+  @moduledoc """
+  V154: OpenGraph templates + hierarchical assignments
+  (`phoenix_kit_og` plugin).
+
+  ## phoenix_kit_og_templates
+
+  Reusable OG canvas designs. `canvas` is JSONB so the structure can
+  grow new element types without a schema change. `preview_image_uuid`
+  is an optional pointer to a rendered cached preview.
+
+  ## phoenix_kit_og_assignments
+
+  Binds a template to a scope inside a consumer module's hierarchy. The
+  `(module_key, scope_type, scope_uuid)` triple is unique — enforced via
+  a partial-index pair because PostgreSQL treats `NULL` as distinct:
+
+  - one row per `(module, scope_type)` when `scope_uuid IS NULL` (the
+    module-wide default tier)
+  - one row per `(module, scope_type, scope_uuid)` when not null
+
+  `template_uuid` cascades on delete: removing a template wipes every
+  assignment that pointed at it.
+
+  All operations are idempotent.
+  """
+
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+
+  def up(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    execute("""
+    CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_og_templates (
+      uuid UUID PRIMARY KEY DEFAULT #{p}uuid_generate_v7(),
+      name VARCHAR(255) NOT NULL,
+      description VARCHAR(1024),
+      canvas JSONB NOT NULL DEFAULT '{}',
+      preview_image_uuid UUID,
+      inserted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      CONSTRAINT phoenix_kit_og_templates_name_uniq UNIQUE (name)
+    )
+    """)
+
+    execute("""
+    CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_og_assignments (
+      uuid UUID PRIMARY KEY DEFAULT #{p}uuid_generate_v7(),
+      module_key VARCHAR(64) NOT NULL,
+      scope_type VARCHAR(32) NOT NULL,
+      scope_uuid UUID,
+      template_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_og_templates(uuid) ON DELETE CASCADE,
+      slot_mapping JSONB NOT NULL DEFAULT '{}',
+      inserted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+    """)
+
+    # If the assignments table already exists (from an earlier run that
+    # shipped without slot_mapping), backfill the column so an in-place
+    # re-migrate doesn't leave the schema out of sync with the code.
+    execute("""
+    ALTER TABLE #{p}phoenix_kit_og_assignments
+    ADD COLUMN IF NOT EXISTS slot_mapping JSONB NOT NULL DEFAULT '{}'
+    """)
+
+    # Partial-index pair gives us "one row per (module, scope_type, scope_uuid)"
+    # while still allowing exactly one (module, scope_type) row when scope_uuid
+    # IS NULL (the module-wide default tier).
+    execute("""
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_og_assignments_unique_scoped
+    ON #{p}phoenix_kit_og_assignments (module_key, scope_type, scope_uuid)
+    WHERE scope_uuid IS NOT NULL
+    """)
+
+    execute("""
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_og_assignments_unique_default
+    ON #{p}phoenix_kit_og_assignments (module_key, scope_type)
+    WHERE scope_uuid IS NULL
+    """)
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS idx_og_assignments_template
+    ON #{p}phoenix_kit_og_assignments (template_uuid)
+    """)
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '154'")
+  end
+
+  @doc """
+  Rolls V154 back by dropping the two OG tables.
+
+  **Lossy rollback:** all templates and assignments are lost. Back up
+  before rolling back in production.
+  """
+  def down(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    execute("DROP TABLE IF EXISTS #{p}phoenix_kit_og_assignments CASCADE")
+    execute("DROP TABLE IF EXISTS #{p}phoenix_kit_og_templates CASCADE")
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '153'")
+  end
+
+  defp prefix_str("public"), do: "public."
+  defp prefix_str(prefix), do: "#{prefix}."
+end

--- a/lib/phoenix_kit_web/components/core/bulk_select.ex
+++ b/lib/phoenix_kit_web/components/core/bulk_select.ex
@@ -177,6 +177,10 @@ defmodule PhoenixKitWeb.Components.Core.BulkSelect do
     doc:
       "Content rendered on the left of the toolbar before the action buttons. Common use: tuck a sort selector in here so the toolbar reads as one widget."
 
+  slot :trailing,
+    doc:
+      "Content rendered at the far right of the toolbar, after the contextual Reorder/Delete/Clear buttons. Common use: a view-mode switcher that should sit visually apart from the filter/sort controls on the left."
+
   def bulk_actions_toolbar(assigns) do
     assigns =
       assigns
@@ -236,6 +240,8 @@ defmodule PhoenixKitWeb.Components.Core.BulkSelect do
         >
           {@clear_label}
         </button>
+
+        {render_slot(@trailing)}
       </div>
     </div>
     """

--- a/lib/phoenix_kit_web/components/core/table_default.ex
+++ b/lib/phoenix_kit_web/components/core/table_default.ex
@@ -816,6 +816,12 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
   attr :debounce, :integer, default: 300
   attr :name, :string, default: "search"
   attr :target, :any, default: nil
+
+  attr :loading_indicator, :boolean,
+    default: true,
+    doc:
+      "Show a spinner while the change event is in flight (LiveView's `phx-change-loading` on the input). Pass false when results appear instantly anyway — e.g. a client-side filter (TableLocalSearch) — where a spinner would be noise."
+
   attr :class, :any, default: ""
 
   def search_toolbar(assigns) do
@@ -841,6 +847,14 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
         phx-target={@target}
         class="input input-sm flex-1 min-w-0"
       />
+      <%!-- Sibling selector: the input (the element LiveView stamps
+           `phx-change-loading` on while the debounced query is in
+           flight) precedes this span, so `.phx-change-loading ~ &`
+           shows the spinner exactly for the round-trip window. --%>
+      <span
+        :if={@loading_indicator}
+        class="hidden [.phx-change-loading~&]:inline-block loading loading-spinner loading-xs shrink-0 text-base-content/50"
+      ></span>
     </form>
     """
   end

--- a/lib/phoenix_kit_web/components/dashboard/tab_item.ex
+++ b/lib/phoenix_kit_web/components/dashboard/tab_item.ex
@@ -95,6 +95,7 @@ defmodule PhoenixKitWeb.Components.Dashboard.TabItem do
         class={@tab_class}
         style={@tab_style}
         title={Tab.localized_tooltip(@tab)}
+        aria-current={@active && "page"}
         data-tab-id={@tab.id}
         data-parent-id={@tab.parent}
       >
@@ -116,6 +117,7 @@ defmodule PhoenixKitWeb.Components.Dashboard.TabItem do
         class={@tab_class}
         style={@tab_style}
         title={Tab.localized_tooltip(@tab)}
+        aria-current={@active && "page"}
         data-tab-id={@tab.id}
         data-parent-id={@tab.parent}
       >

--- a/lib/phoenix_kit_web/components/layout_wrapper.ex
+++ b/lib/phoenix_kit_web/components/layout_wrapper.ex
@@ -475,7 +475,17 @@ defmodule PhoenixKitWeb.Components.LayoutWrapper do
                    lock changes ambient scroll state, shifting the whole content pane.
                    Scoped to lg (the drawer-open column mode); the mobile overlay
                    drawer needs no gutter. --%>
-              <div class="drawer-side lg:[scrollbar-gutter:stable]">
+              <%!-- id + hook: AdminSidebarScroll keeps the menu's scroll
+                   position across navigations (a live redirect replaces
+                   this whole container; cross-live_session navigation is
+                   a full reload). The hook restores pre-paint; the save
+                   side lives in phoenix_kit.js as document-level
+                   listeners so no per-element cleanup is needed. --%>
+              <div
+                id="pk-admin-sidebar"
+                phx-hook="AdminSidebarScroll"
+                class="drawer-side lg:[scrollbar-gutter:stable]"
+              >
                 <label for="admin-mobile-menu" class="drawer-overlay lg:hidden"></label>
                 <aside class="min-h-full w-64 bg-base-100 shadow-lg border-r border-base-300 flex flex-col pt-16">
                   <%!-- Navigation (fills available space) --%>

--- a/lib/phoenix_kit_web/components/layout_wrapper.ex
+++ b/lib/phoenix_kit_web/components/layout_wrapper.ex
@@ -93,6 +93,11 @@ defmodule PhoenixKitWeb.Components.LayoutWrapper do
     doc:
       "Prefixed path (via `PhoenixKit.Utils.Routes.path/1`) the `page_section` crumb links to. Renders as plain text when omitted."
 
+  attr :page_action, :map,
+    default: nil,
+    doc:
+      "Optional compact action button rendered right after the breadcrumb title: `%{icon: \"hero-plus\", label: \"New template\", navigate: path}`. Lets a page keep its primary create action without spending an in-content header row. `label` becomes the tooltip/aria-label; `icon` defaults to hero-plus."
+
   attr :current_path, :string, default: nil
   attr :inner_content, :string, default: nil
   attr :project_title, :string, default: nil
@@ -285,6 +290,7 @@ defmodule PhoenixKitWeb.Components.LayoutWrapper do
               page_subtitle: assigns[:page_subtitle],
               page_section: assigns[:page_section],
               page_section_path: assigns[:page_section_path],
+              page_action: assigns[:page_action],
               phoenix_kit_current_scope: assigns[:phoenix_kit_current_scope],
               project_title: assigns[:project_title] || PhoenixKit.Settings.get_project_title(),
               current_locale: assigns[:current_locale],
@@ -403,6 +409,18 @@ defmodule PhoenixKitWeb.Components.LayoutWrapper do
                       >
                         {@page_subtitle}
                       </span>
+                      <.link
+                        :if={@page_action}
+                        navigate={@page_action[:navigate]}
+                        class="btn btn-xs btn-primary btn-circle shrink-0"
+                        title={@page_action[:label]}
+                        aria-label={@page_action[:label]}
+                      >
+                        <PhoenixKitWeb.Components.Core.Icon.icon
+                          name={@page_action[:icon] || "hero-plus"}
+                          class="w-4 h-4"
+                        />
+                      </.link>
                     </span>
                   </div>
                 </div>

--- a/lib/phoenix_kit_web/components/layouts/admin.html.heex
+++ b/lib/phoenix_kit_web/components/layouts/admin.html.heex
@@ -17,6 +17,7 @@
   page_subtitle={assigns[:page_subtitle]}
   page_section={assigns[:page_section]}
   page_section_path={assigns[:page_section_path]}
+  page_action={assigns[:page_action]}
   from_layout={true}
 >
   {@inner_content}

--- a/priv/static/assets/phoenix_kit.js
+++ b/priv/static/assets/phoenix_kit.js
@@ -2154,6 +2154,121 @@ if (typeof window.Chart === "undefined") {
     }
   };
 
+  // ---------------------------------------------------------------------------
+  // AdminSidebarScroll — keep the admin menu's scroll position across
+  // navigations.
+  // ---------------------------------------------------------------------------
+  //
+  // Every sidebar navigation rebuilds the sidebar DOM: a live redirect
+  // replaces the whole main container, and cross-live_session navigation
+  // (each feature module has its own session) is a full page reload. Both
+  // reset the menu's scrollTop to 0 — on short screens most of the menu
+  // lives below the fold, so the user loses their place on every click.
+  //
+  // Design (per the sidebar-scroll design review):
+  //   * scroll position is client/viewport state — it is saved to
+  //     sessionStorage (per-tab) and restored, never sent to the server;
+  //   * SAVE: one document-level capture listener (scroll doesn't bubble,
+  //     but it does capture), rAF-throttled, plus flushes on
+  //     phx:page-loading-start and pagehide so the final position right
+  //     before a navigation is never lost. Document/window listeners
+  //     survive live redirects, so there is nothing to re-bind or clean up.
+  //   * RESTORE: the AdminSidebarScroll hook's mounted() — which re-fires
+  //     on every live redirect because the container is replaced — runs
+  //     synchronously with the DOM patch, before paint (no flash at 0).
+  //     Full page loads restore at DOMContentLoaded, before the LiveView
+  //     socket connects.
+  //   * CORRECTION: when nothing is saved (fresh tab, deep link) or the
+  //     restored offset leaves the current page's [aria-current="page"]
+  //     link off-screen (menu shape changed: permissions, locale, module
+  //     set), center the active link instead. Direct scrollTop math, not
+  //     scrollIntoView — the latter can scroll ancestor containers too.
+  (function () {
+    const EL_ID = "pk-admin-sidebar";
+    const KEY = "phoenix_kit:admin:sidebar:scroll";
+
+    function readSaved() {
+      try {
+        const v = sessionStorage.getItem(KEY);
+        if (v == null) return null;
+        const n = parseInt(v, 10);
+        return isNaN(n) ? null : n;
+      } catch (_e) {
+        return null;
+      }
+    }
+
+    function save(el) {
+      try {
+        sessionStorage.setItem(KEY, String(Math.round(el.scrollTop)));
+      } catch (_e) {
+        // Storage unavailable (private browsing etc.) — degrade to the
+        // active-item fallback on the next load.
+      }
+    }
+
+    function restore(el) {
+      const max = Math.max(0, el.scrollHeight - el.clientHeight);
+      const saved = readSaved();
+      if (saved != null) {
+        el.scrollTop = Math.min(saved, max);
+      }
+
+      const active = el.querySelector('[aria-current="page"]');
+      if (!active) return;
+      const er = el.getBoundingClientRect();
+      const ar = active.getBoundingClientRect();
+      const visible = ar.top >= er.top && ar.bottom <= er.bottom;
+      if (saved == null || !visible) {
+        const target = el.scrollTop + (ar.top - er.top) - (el.clientHeight - ar.height) / 2;
+        el.scrollTop = Math.min(Math.max(0, target), max);
+      }
+    }
+
+    // Save side — bound once per full page load, element-independent.
+    let saveQueued = false;
+    document.addEventListener(
+      "scroll",
+      function (e) {
+        const el = e.target;
+        if (!el || el.id !== EL_ID || saveQueued) return;
+        saveQueued = true;
+        requestAnimationFrame(function () {
+          saveQueued = false;
+          const live = document.getElementById(EL_ID);
+          if (live) save(live);
+        });
+      },
+      { capture: true, passive: true }
+    );
+
+    function flush() {
+      const el = document.getElementById(EL_ID);
+      if (el) save(el);
+    }
+    window.addEventListener("phx:page-loading-start", flush);
+    window.addEventListener("pagehide", flush);
+
+    // Restore on full page loads (before the socket connects).
+    function early() {
+      const el = document.getElementById(EL_ID);
+      if (el) restore(el);
+    }
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", early);
+    } else {
+      early();
+    }
+
+    // Restore on live redirects (mounted re-fires on the fresh container,
+    // pre-paint). Idempotent with the early restore on full loads.
+    window.PhoenixKitHooks.AdminSidebarScroll = {
+      mounted() {
+        restore(this.el);
+      }
+    };
+  })();
+
   // NOTE: no scrollbar-gutter games here. Old daisyUI (5.0.x) reserved a
   // scrollbar gutter unconditionally while a modal was open, and this hook
   // used to counter it with an inline `scrollbar-gutter: auto` override —

--- a/priv/static/assets/phoenix_kit.js
+++ b/priv/static/assets/phoenix_kit.js
@@ -2095,6 +2095,65 @@ if (typeof window.Chart === "undefined") {
     }
   }
 
+  // ---------------------------------------------------------------------------
+  // TableLocalSearch Hook
+  // ---------------------------------------------------------------------------
+  //
+  // Client-instant narrowing for list tables that use <.search_toolbar>:
+  // while the debounced server round-trip is in flight, rows are hidden
+  // locally so the filter feels immediate. The server response stays
+  // authoritative — its patch replaces the row set, and `updated()`
+  // re-applies the live query so the two never fight.
+  //
+  // Attach to an element wrapping BOTH the search input and the rows:
+  //
+  //   <div id="..." phx-hook="TableLocalSearch"
+  //        data-local-search-enabled={to_string(@all_rows_loaded?)}>
+  //     <.search_toolbar ... />
+  //     ...rows carrying a lowercase data-search="haystack" attribute...
+  //     <p data-local-search-empty class="hidden">No matches</p>
+  //   </div>
+  //
+  // When `data-local-search-enabled` != "true" (the row set is incomplete
+  // because server pagination is in play), the hook does nothing — hiding
+  // only the loaded rows would falsely report "no matches" for rows that
+  // live beyond the current page. The server search covers that case.
+  window.PhoenixKitHooks.TableLocalSearch = {
+    mounted() {
+      this._onInput = (e) => {
+        const input = this._input();
+        if (!input || e.target !== input) return;
+        this._apply();
+      };
+      this.el.addEventListener("input", this._onInput);
+    },
+    updated() {
+      // A server patch landed (authoritative row set) — re-apply the
+      // current query so re-added rows don't flash unfiltered, and so
+      // client-added `hidden` classes get reconciled with server truth.
+      this._apply();
+    },
+    destroyed() {
+      this.el.removeEventListener("input", this._onInput);
+    },
+    _input() {
+      return this.el.querySelector('input[name="search"]');
+    },
+    _apply() {
+      if (this.el.dataset.localSearchEnabled !== "true") return;
+      const input = this._input();
+      const q = ((input && input.value) || "").trim().toLowerCase();
+      let visible = 0;
+      this.el.querySelectorAll("[data-search]").forEach((row) => {
+        const match = q === "" || (row.dataset.search || "").includes(q);
+        row.classList.toggle("hidden", !match);
+        if (match) visible += 1;
+      });
+      const empty = this.el.querySelector("[data-local-search-empty]");
+      if (empty) empty.classList.toggle("hidden", !(q !== "" && visible === 0));
+    }
+  };
+
   // NOTE: no scrollbar-gutter games here. Old daisyUI (5.0.x) reserved a
   // scrollbar gutter unconditionally while a modal was open, and this hook
   // used to counter it with an inline `scrollbar-gutter: auto` override —

--- a/test/phoenix_kit_web/components/dashboard/tab_item_test.exs
+++ b/test/phoenix_kit_web/components/dashboard/tab_item_test.exs
@@ -43,6 +43,22 @@ defmodule PhoenixKitWeb.Components.Dashboard.TabItemTest do
       assert html =~ "Home"
     end
 
+    test "active tab carries aria-current=page; inactive does not" do
+      # The AdminSidebarScroll JS (phoenix_kit.js) locates the current
+      # page's link via [aria-current="page"] to center it when no saved
+      # scroll position exists — and it's the accessible marker anyway.
+      tab = Tab.new!(id: :home, label: "Home", path: "/home", icon: "hero-home")
+
+      active_html =
+        render_component(&TabItem.tab_item/1, tab: tab, active: true, locale: nil)
+
+      inactive_html =
+        render_component(&TabItem.tab_item/1, tab: tab, active: false, locale: nil)
+
+      assert active_html =~ ~s(aria-current="page")
+      refute inactive_html =~ "aria-current"
+    end
+
     test "renders translated label when gettext_backend is set and locale is ru" do
       Gettext.put_locale(@backend, "ru")
 


### PR DESCRIPTION
## What

Adds core migration **V154**, creating the two tables the `phoenix_kit_og` plugin needs:

- `phoenix_kit_og_templates` — reusable OG canvas designs (`canvas` JSONB, optional `preview_image_uuid`)
- `phoenix_kit_og_assignments` — binds a template to a `module_key × scope_type × scope_uuid` scope via a JSONB `slot_mapping`

Uniqueness is a partial-unique-index pair, so a NULL `scope_uuid` (module-wide default tier) and per-scope assignments don't collide; `template_uuid` cascades on delete. Bumps `@current_version` → 154 and adds the `### V154` moduledoc block.

> **Renumbered on rebase (V152 → V154).** This branch was authored against V152, but `upstream/main` has since claimed **V152** (Newsletters/CRM send-profile restructuring) and **V153** (folder header default). The OG migration was rebased onto current main and renumbered to **V154** — the next free slot. The chain is contiguous `1..154` with no gaps. The migration file (`postgres/v154.ex`), `@current_version`, the moduledoc block, and the up/down version markers (`'154'` / `'153'`) were all updated to match.

## Notes

- Idempotent (`CREATE TABLE/INDEX IF NOT EXISTS`, `ADD COLUMN IF NOT EXISTS`).
- Prefix-safe: `uuid_generate_v7()` calls are schema-qualified, matching V148/V149.
- `CHANGELOG.md` + `mix.exs` version bump intentionally left out for the maintainer to add at review.

## Verification

- `mix format --check-formatted` ✓
- `mix compile --warnings-as-errors` ✓
- `mix credo --strict` ✓ (no issues, whole tree)
- `prefix_migration_test.exs` (the full-chain scratch-schema oracle) ✓ — applies `V153→V154` cleanly, both OG tables created, marker → `154`.
- Full suite: **42 failures, identical to clean `upstream/main`** (verified by running the same suite on `3813638f` after a DB reset — the rebase introduces zero new failures; the 42 are pre-existing owner-role-protected / flash-not-fetched harness issues unrelated to this branch).

---

## Also in this PR: admin list-UI & chrome enhancements (6 commits)

The components/JS work that backs the `phoenix_kit_projects` list-page overhaul, all reusable by any module. Rebased onto current main; two of the original commits (a `search_toolbar` form fix and a `page_section` forward) were dropped as redundant — `upstream/main` already carries equivalents.

### Components (`core/`)

- **`search_toolbar`**: added an in-flight **loading spinner** driven by `phx-change-loading` (sibling selector, pure CSS) with a `loading_indicator` opt-out for client-instant contexts.
- **`bulk_actions_toolbar`**: new `:trailing` slot — far-right toolbar content (e.g. a view-mode switcher) rendered after the contextual Reorder/Delete/Clear buttons.

### Admin layout / breadcrumb

- **`page_action`**: pages can declare `%{icon, label, navigate}` and get a compact action button in the header breadcrumb next to the page title — lets list pages drop their in-content header row entirely. Forwarded through `layouts/admin.html.heex` alongside the existing `page_section` / `page_section_path` crumbs.
- Active sidebar tabs now carry **`aria-current="page"`** (accessibility + a stable client-side marker).

### JS (`priv/static/assets/phoenix_kit.js`)

- **`TableLocalSearch`** hook: client-instant row narrowing for search_toolbar tables — hides rows by a lowercase `data-search` haystack during the debounce window while the server result stays authoritative; inert when the row set is incomplete (`data-local-search-enabled`).
- **`AdminSidebarScroll`**: the admin menu keeps its scroll position across every navigation (live redirects rebuild the main container; cross-live_session navigation is a full reload). sessionStorage save with `phx:page-loading-start`/`pagehide` flushes; pre-paint restore via the hook on live redirects and `DOMContentLoaded` on full loads; falls back to centering the `[aria-current="page"]` link.

### Verification

- `mix precommit` ✓ (format, compile --warnings-as-errors, credo --strict)
- Component tests: `table_default_test.exs` — includes pins for the spinner opt-out and `aria-current`.
- Browser-verified in the parent app across the Projects/Tasks/Templates admin pages at desktop + phone widths.
