### PR TITLE
Add a cheap timezone-label accessor that never queries roles

### DIFF
--- a/lib/modules/maintenance/settings.ex
+++ b/lib/modules/maintenance/settings.ex
@@ -37,7 +37,7 @@ defmodule PhoenixKitWeb.Live.Modules.Maintenance.Settings do
 
     # Get the system timezone offset for display and conversion
     tz_offset = Settings.get_setting_cached("time_zone", "0")
-    tz_label = Settings.get_timezone_label(tz_offset, Settings.get_setting_options())
+    tz_label = Settings.get_timezone_label(tz_offset)
 
     # Format datetimes for datetime-local inputs (converted to system timezone)
     scheduled_start_str = format_datetime_for_input(config.scheduled_start, tz_offset)

--- a/lib/phoenix_kit/settings/settings.ex
+++ b/lib/phoenix_kit/settings/settings.ex
@@ -1003,52 +1003,97 @@ defmodule PhoenixKit.Settings do
         {"Saturday", "6"},
         {"Sunday", "7"}
       ],
-      "time_zone" => [
-        {"UTC-12 (Baker Island)", "-12"},
-        {"UTC-11 (Pago Pago, Niue)", "-11"},
-        {"UTC-10 (Honolulu, Tahiti)", "-10"},
-        {"UTC-9 (Anchorage, Juneau)", "-9"},
-        {"UTC-8 (Los Angeles, Vancouver, Seattle)", "-8"},
-        {"UTC-7 (Denver, Phoenix, Calgary)", "-7"},
-        {"UTC-6 (Chicago, Mexico City, Guatemala)", "-6"},
-        {"UTC-5 (New York, Toronto, Bogotá, Lima)", "-5"},
-        {"UTC-4 (Halifax, Caracas, Santiago)", "-4"},
-        {"UTC-3 (Buenos Aires, São Paulo, Montevideo)", "-3"},
-        {"UTC-2 (South Georgia)", "-2"},
-        {"UTC-1 (Azores, Cape Verde)", "-1"},
-        {"UTC+0 (London, Dublin, Lisbon, Accra)", "0"},
-        {"UTC+1 (Paris, Berlin, Rome, Madrid, Lagos)", "1"},
-        {"UTC+2 (Kyiv, Athens, Helsinki, Cairo, Johannesburg)", "2"},
-        {"UTC+3 (Istanbul, Riyadh, Nairobi, Baghdad, Moscow)", "3"},
-        {"UTC+4 (Dubai, Baku, Tbilisi)", "4"},
-        {"UTC+5 (Karachi, Tashkent, Yekaterinburg)", "5"},
-        {"UTC+5:30 (Mumbai, Delhi, Kolkata, Colombo)", "5.5"},
-        {"UTC+6 (Dhaka, Almaty, Bishkek)", "6"},
-        {"UTC+7 (Bangkok, Jakarta, Ho Chi Minh City)", "7"},
-        {"UTC+8 (Beijing, Singapore, Hong Kong, Perth)", "8"},
-        {"UTC+9 (Tokyo, Seoul, Pyongyang)", "9"},
-        {"UTC+9:30 (Adelaide, Darwin)", "9.5"},
-        {"UTC+10 (Sydney, Melbourne, Brisbane)", "10"},
-        {"UTC+11 (Honiara, Noumea)", "11"},
-        {"UTC+12 (Auckland, Fiji, Wellington)", "12"},
-        {"UTC+13 (Nuku'alofa, Apia)", "13"},
-        {"UTC+14 (Kiritimati)", "14"}
-      ],
+      "time_zone" => timezone_options(),
       "date_format" => UtilsDate.get_date_format_options(),
       "time_format" => UtilsDate.get_time_format_options()
     }
   end
 
   @doc """
-  Gets the display label for a timezone value.
+  The static timezone offset options, as {label, value} tuples.
+
+  This is the single source for the `"time_zone"` entry in
+  `get_setting_options/0` and for `get_timezone_label/1` — callers that
+  only need the timezone list (not the whole options map, which also
+  queries roles via `get_role_options/0`) should use this directly
+  instead of duplicating the list or paying for `get_setting_options/0`.
+
+  ## Examples
+
+      iex> {"UTC+0 (London, Dublin, Lisbon, Accra)", "0"} in PhoenixKit.Settings.timezone_options()
+      true
+  """
+  @spec timezone_options() :: [{String.t(), String.t()}]
+  def timezone_options do
+    [
+      {"UTC-12 (Baker Island)", "-12"},
+      {"UTC-11 (Pago Pago, Niue)", "-11"},
+      {"UTC-10 (Honolulu, Tahiti)", "-10"},
+      {"UTC-9 (Anchorage, Juneau)", "-9"},
+      {"UTC-8 (Los Angeles, Vancouver, Seattle)", "-8"},
+      {"UTC-7 (Denver, Phoenix, Calgary)", "-7"},
+      {"UTC-6 (Chicago, Mexico City, Guatemala)", "-6"},
+      {"UTC-5 (New York, Toronto, Bogotá, Lima)", "-5"},
+      {"UTC-4 (Halifax, Caracas, Santiago)", "-4"},
+      {"UTC-3 (Buenos Aires, São Paulo, Montevideo)", "-3"},
+      {"UTC-2 (South Georgia)", "-2"},
+      {"UTC-1 (Azores, Cape Verde)", "-1"},
+      {"UTC+0 (London, Dublin, Lisbon, Accra)", "0"},
+      {"UTC+1 (Paris, Berlin, Rome, Madrid, Lagos)", "1"},
+      {"UTC+2 (Kyiv, Athens, Helsinki, Cairo, Johannesburg)", "2"},
+      {"UTC+3 (Istanbul, Riyadh, Nairobi, Baghdad, Moscow)", "3"},
+      {"UTC+4 (Dubai, Baku, Tbilisi)", "4"},
+      {"UTC+5 (Karachi, Tashkent, Yekaterinburg)", "5"},
+      {"UTC+5:30 (Mumbai, Delhi, Kolkata, Colombo)", "5.5"},
+      {"UTC+6 (Dhaka, Almaty, Bishkek)", "6"},
+      {"UTC+7 (Bangkok, Jakarta, Ho Chi Minh City)", "7"},
+      {"UTC+8 (Beijing, Singapore, Hong Kong, Perth)", "8"},
+      {"UTC+9 (Tokyo, Seoul, Pyongyang)", "9"},
+      {"UTC+9:30 (Adelaide, Darwin)", "9.5"},
+      {"UTC+10 (Sydney, Melbourne, Brisbane)", "10"},
+      {"UTC+11 (Honiara, Noumea)", "11"},
+      {"UTC+12 (Auckland, Fiji, Wellington)", "12"},
+      {"UTC+13 (Nuku'alofa, Apia)", "13"},
+      {"UTC+14 (Kiritimati)", "14"}
+    ]
+  end
+
+  @doc """
+  Gets the display label for a timezone value — the cheap path.
+
+  Resolves against `timezone_options/0` only. Unlike `get_timezone_label/2`,
+  this never builds the full `get_setting_options/0` map, so it never
+  queries roles (`get_role_options/0` → `Roles.list_roles/0`). Prefer this
+  whenever only the timezone label is needed — most callers.
+
+  ## Examples
+
+      iex> PhoenixKit.Settings.get_timezone_label("0")
+      "UTC+0 (London, Dublin, Lisbon, Accra)"
+  """
+  @spec get_timezone_label(String.t()) :: String.t()
+  def get_timezone_label(value) do
+    resolve_timezone_label(value, timezone_options())
+  end
+
+  @doc """
+  Gets the display label for a timezone value from an already-built
+  `get_setting_options/0` map. Kept for callers that already have the
+  full options map on hand (e.g. rendering several dropdowns on the same
+  page) — for everyone else, `get_timezone_label/1` is cheaper.
 
   ## Examples
 
       iex> PhoenixKit.Settings.get_timezone_label("0", get_setting_options())
       "UTC+0 (GMT/London)"
   """
+  @spec get_timezone_label(String.t(), map()) :: String.t()
   def get_timezone_label(value, setting_options) do
-    case Enum.find(setting_options["time_zone"], fn {_label, val} -> val == value end) do
+    resolve_timezone_label(value, setting_options["time_zone"] || timezone_options())
+  end
+
+  defp resolve_timezone_label(value, options) do
+    case Enum.find(options, fn {_label, val} -> val == value end) do
       {label, _value} -> label
       nil -> "UTC#{if value != "0", do: value, else: ""}"
     end

--- a/lib/phoenix_kit/settings/settings.ex
+++ b/lib/phoenix_kit/settings/settings.ex
@@ -980,12 +980,9 @@ defmodule PhoenixKit.Settings do
 
   ## Examples
 
-      iex> PhoenixKit.Settings.get_setting_options()
-      %{
-        "time_zone" => [{"UTC-12", "-12"}, {"UTC+0 (GMT)", "0"}, {"UTC+8", "8"}],
-        "date_format" => [{"YYYY-MM-DD", "Y-m-d"}, {"MM/DD/YYYY", "m/d/Y"}],
-        "time_format" => [{"24 Hour (15:30)", "H:i"}, {"12 Hour (3:30 PM)", "h:i A"}]
-      }
+      iex> options = PhoenixKit.Settings.get_setting_options()
+      iex> {"UTC+0 (London, Dublin, Lisbon, Accra)", "0"} in options["time_zone"]
+      true
   """
   def get_setting_options do
     %{
@@ -1084,8 +1081,8 @@ defmodule PhoenixKit.Settings do
 
   ## Examples
 
-      iex> PhoenixKit.Settings.get_timezone_label("0", get_setting_options())
-      "UTC+0 (GMT/London)"
+      iex> PhoenixKit.Settings.get_timezone_label("0", PhoenixKit.Settings.get_setting_options())
+      "UTC+0 (London, Dublin, Lisbon, Accra)"
   """
   @spec get_timezone_label(String.t(), map()) :: String.t()
   def get_timezone_label(value, setting_options) do

--- a/lib/phoenix_kit_web/live/components/user_settings.ex
+++ b/lib/phoenix_kit_web/live/components/user_settings.ex
@@ -143,8 +143,7 @@ defmodule PhoenixKitWeb.Live.Components.UserSettings do
       |> assign_new(:password_form, fn -> to_form(Auth.change_user_password(user)) end)
       |> assign_new(:profile_form, fn -> to_form(Auth.change_user_profile(user)) end)
       |> assign_new(:timezone_options, fn ->
-        setting_options = Settings.get_setting_options()
-        [{"Use System Default", nil} | setting_options["time_zone"]]
+        [{"Use System Default", nil} | Settings.timezone_options()]
       end)
       |> assign_new(:browser_timezone_name, fn -> nil end)
       |> assign_new(:browser_timezone_offset, fn -> nil end)

--- a/lib/phoenix_kit_web/live/settings/authorization.ex
+++ b/lib/phoenix_kit_web/live/settings/authorization.ex
@@ -17,7 +17,6 @@ defmodule PhoenixKitWeb.Live.Settings.Authorization do
   def mount(_params, _session, socket) do
     current_settings = Settings.list_all_settings()
     defaults = Settings.get_defaults()
-    setting_options = Settings.get_setting_options()
 
     merged_settings = Map.merge(defaults, current_settings)
     changeset = Settings.change_settings(merged_settings)
@@ -27,7 +26,6 @@ defmodule PhoenixKitWeb.Live.Settings.Authorization do
       |> assign(:page_title, "Authorization Settings")
       |> assign(:settings, merged_settings)
       |> assign(:saved_settings, merged_settings)
-      |> assign(:setting_options, setting_options)
       |> assign(:changeset, changeset)
       |> assign(:saving, false)
       |> assign(

--- a/lib/phoenix_kit_web/users/user_form.ex
+++ b/lib/phoenix_kit_web/users/user_form.ex
@@ -47,9 +47,11 @@ defmodule PhoenixKitWeb.Users.UserForm do
     # Load default role for new user creation
     default_role = Settings.get_setting("new_user_default_role", "User")
 
-    # Load timezone options
-    setting_options = Settings.get_setting_options()
-    timezone_options = [{"Use System Default", nil} | setting_options["time_zone"]]
+    # Load timezone options — timezone_options/0 directly, not
+    # get_setting_options/0: this form already loads all_roles above for
+    # its own role-management UI, so building the whole options map here
+    # too would query roles a second time for nothing.
+    timezone_options = [{"Use System Default", nil} | Settings.timezone_options()]
 
     # Organization accounts
     org_accounts_enabled =

--- a/test/phoenix_kit/settings/timezone_label_test.exs
+++ b/test/phoenix_kit/settings/timezone_label_test.exs
@@ -1,0 +1,119 @@
+defmodule PhoenixKit.Settings.TimezoneLabelTest do
+  use PhoenixKit.DataCase, async: true
+
+  alias PhoenixKit.Settings
+
+  describe "timezone_options/0" do
+    test "is a non-empty list of {label, value} tuples covering the known offsets" do
+      options = Settings.timezone_options()
+
+      assert [_ | _] = options
+
+      assert Enum.all?(
+               options,
+               &match?({label, value} when is_binary(label) and is_binary(value), &1)
+             )
+
+      assert {"UTC+0 (London, Dublin, Lisbon, Accra)", "0"} in options
+      assert {"UTC-5 (New York, Toronto, Bogotá, Lima)", "-5"} in options
+      assert {"UTC+5:30 (Mumbai, Delhi, Kolkata, Colombo)", "5.5"} in options
+    end
+
+    test "is the same list get_setting_options/0 uses for \"time_zone\"" do
+      assert Settings.timezone_options() == Settings.get_setting_options()["time_zone"]
+    end
+  end
+
+  describe "get_timezone_label/1 (cheap path)" do
+    test "resolves a positive offset" do
+      assert Settings.get_timezone_label("8") == "UTC+8 (Beijing, Singapore, Hong Kong, Perth)"
+    end
+
+    test "resolves a negative offset" do
+      assert Settings.get_timezone_label("-5") == "UTC-5 (New York, Toronto, Bogotá, Lima)"
+    end
+
+    test "resolves the zero offset" do
+      assert Settings.get_timezone_label("0") == "UTC+0 (London, Dublin, Lisbon, Accra)"
+    end
+
+    test "resolves a half-hour offset" do
+      assert Settings.get_timezone_label("5.5") ==
+               "UTC+5:30 (Mumbai, Delhi, Kolkata, Colombo)"
+    end
+
+    test "falls back to a bare UTC label for a value not in the list" do
+      assert Settings.get_timezone_label("99") == "UTC99"
+      assert Settings.get_timezone_label("-3.25") == "UTC-3.25"
+    end
+
+    test "agrees with the existing get_timezone_label/2 for every listed offset" do
+      full_options = Settings.get_setting_options()
+
+      for {_label, value} <- Settings.timezone_options() do
+        assert Settings.get_timezone_label(value) ==
+                 Settings.get_timezone_label(value, full_options)
+      end
+    end
+
+    # This is the actual point of the change: get_timezone_label/2 needs
+    # the whole get_setting_options/0 map, which builds "new_user_default_role"
+    # via get_role_options/0 → Roles.list_roles/0 — a real query, paid on
+    # every call site that only wanted the timezone label (mount/3 of
+    # PhoenixKitWeb.Live.Modules.Maintenance.Settings, among others).
+    # get_timezone_label/1 must never touch the database at all.
+    test "never issues a repo query — proves it doesn't build the full options map" do
+      query_count = count_repo_queries(fn -> Settings.get_timezone_label("3") end)
+
+      assert query_count == 0
+    end
+  end
+
+  describe "get_timezone_label/2 (backward-compatible path)" do
+    test "still resolves against a real get_setting_options/0 map" do
+      assert Settings.get_timezone_label("0", Settings.get_setting_options()) ==
+               "UTC+0 (London, Dublin, Lisbon, Accra)"
+    end
+
+    test "falls back to timezone_options/0 if the given map has no \"time_zone\" key" do
+      assert Settings.get_timezone_label("0", %{}) == "UTC+0 (London, Dublin, Lisbon, Accra)"
+    end
+
+    test "falls back to a bare UTC label for an unknown value" do
+      assert Settings.get_timezone_label("42", Settings.get_setting_options()) == "UTC42"
+    end
+  end
+
+  # Counts Ecto query telemetry events fired on this process while running
+  # `fun` — proves get_timezone_label/1 resolves purely in-memory. Mirrors
+  # the pattern already used in phoenix_kit_crm's import_test.exs.
+  #
+  # :telemetry.attach is process-global, not scoped to the caller — under
+  # async: true, other tests' concurrently-running queries fire the same
+  # event and would inflate the count. Telemetry handlers run synchronously
+  # in whichever process executes :telemetry.execute (i.e. whichever
+  # process issued the query), so filtering on self() inside the handler
+  # isolates counts to queries issued by this test's own process.
+  defp count_repo_queries(fun) do
+    handler_id = "count-repo-queries-#{inspect(self())}-#{System.unique_integer()}"
+    counter = :counters.new(1, [])
+    test_pid = self()
+
+    :telemetry.attach(
+      handler_id,
+      [:phoenix_kit, :test, :repo, :query],
+      fn _event, _measurements, _metadata, _config ->
+        if self() == test_pid, do: :counters.add(counter, 1, 1)
+      end,
+      nil
+    )
+
+    try do
+      fun.()
+    after
+      :telemetry.detach(handler_id)
+    end
+
+    :counters.get(counter, 1)
+  end
+end

--- a/test/phoenix_kit/settings/timezone_label_test.exs
+++ b/test/phoenix_kit/settings/timezone_label_test.exs
@@ -94,6 +94,12 @@ defmodule PhoenixKit.Settings.TimezoneLabelTest do
   # in whichever process executes :telemetry.execute (i.e. whichever
   # process issued the query), so filtering on self() inside the handler
   # isolates counts to queries issued by this test's own process.
+  #
+  # The event name below is not the conventional [otp_app, :repo, :query]
+  # — Ecto derives its telemetry prefix from the REPO MODULE's own name
+  # (Module.split/1, underscored), not the OTP app. This suite's repo is
+  # PhoenixKit.Test.Repo, so the prefix is [:phoenix_kit, :test, :repo],
+  # and the query event is that prefix with :query appended.
   defp count_repo_queries(fun) do
     handler_id = "count-repo-queries-#{inspect(self())}-#{System.unique_integer()}"
     counter = :counters.new(1, [])


### PR DESCRIPTION
## Summary

`Settings.get_timezone_label/2` requires the full `get_setting_options/0` map as its second argument, and that map's `"new_user_default_role"` entry queries `Roles.list_roles/0` — so every caller that only wanted a timezone label paid for a role query it never uses. `phoenix_kit_newsletters` worked around this by keeping its own 28-entry copy of the timezone list, a drift risk (core adds a zone, the copy silently falls behind).

- Extract the static timezone list into `timezone_options/0` (public) — the single source `get_setting_options/0`'s `"time_zone"` entry and the new accessor both read from.
- Add `get_timezone_label/1`: resolves against `timezone_options/0` only, no role query, no full options map. This is what most callers actually need.
- `get_timezone_label/2` stays for callers that already have a full `setting_options` map on hand; it now falls back to `timezone_options/0` if the map has no `"time_zone"` key, and shares the same resolution logic as the 1-arity form.

## Other cheap wins found in the same area

Per review request, I checked every other call site that builds the whole `get_setting_options/0` map:

- **`Maintenance.Settings.mount/3`** — the flagged call site. Migrated to `get_timezone_label/1`.
- **`user_settings.ex`'s (component) lazy `:timezone_options` assign** — only ever read `setting_options["time_zone"]`. Migrated to `Settings.timezone_options/0` directly.
- **`UserForm.mount/3`** — same pattern, and it also had a **redundant second `Roles.list_roles/0` call**: it already loads `all_roles` separately (line 45) for its own role-management UI, so building the full options map on top of that queried roles twice. Migrated to `Settings.timezone_options/0`.
- **`Settings.Authorization.mount/3`** — computed and assigned `setting_options` every mount, but neither the module nor its template ever reads it. Removed the fetch and the assign entirely (dead code, not a timezone-specific fix, but the same class of "building the whole map for nothing").

## Tests

`test/phoenix_kit/settings/timezone_label_test.exs` (new):
- `timezone_options/0` is non-empty, and is the exact list `get_setting_options/0`'s `"time_zone"` entry uses.
- `get_timezone_label/1` resolves positive/negative/zero/half-hour offsets, and falls back to a bare `"UTC#{value}"` label for values not in the list.
- `get_timezone_label/1` and `/2` agree for every listed offset (round-trip check).
- `get_timezone_label/2` still works against a real `get_setting_options/0` map, and falls back to `timezone_options/0` if given a map with no `"time_zone"` key.
- **The actual point of the change**: `get_timezone_label/1` issues **zero** repo queries, proven via a `:telemetry`-based query counter attached to `[:phoenix_kit, :test, :repo, :query]` (same pattern already used in `phoenix_kit_crm`'s `import_test.exs`, ported here since core doesn't have an existing helper for this).

## Verification

- `MIX_ENV=test mix compile --warnings-as-errors` — clean.
- `mix format --check-formatted` — clean.
- `mix credo --strict` — clean (0 issues, checked against the touched files directly and the full 697-file sweep via the repo's pre-commit hook).
- `mix dialyzer` (via the pre-commit hook) — 0 unignored errors.
- `PGHOST=postgres PGPASSWORD=yourrandompassword MIX_ENV=test mix test test/phoenix_kit/settings/` — **13 tests, 0 failures** (12 new + the existing `setting_test.exs`).
- Did not run the full suite (tracked upstream regression, ~42 pre-existing failures unrelated to this change per issue #652) — scoped to the settings test directory and the touched files' own compile/credo/dialyzer instead.

CHANGELOG.md and the version in `mix.exs` are untouched per project convention.
