### PR TITLE
V156: migrate legacy newsletters lists into CRM, drop the legacy tables

### DIFF
--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -529,7 +529,36 @@ defmodule PhoenixKit.Migrations.Postgres do
   - Replaces unique index with partial index (slug-mode only, WHERE slug IS NOT NULL)
   - Adds unique index on `(group_uuid, post_date, post_time)` for timestamp-mode posts
 
-  ### V155 - Delivery CRM contact id + per-broadcast dedup ⚡ LATEST
+  ### V156 - Legacy newsletters lists migrated into CRM, tables dropped ⚡ LATEST
+  - **Requires a coordinated release with the newsletters module** — drops
+    tables/columns an older newsletters release still reads; see V156's
+    moduledoc warning
+  - Data: every `phoenix_kit_newsletters_lists` row copied to
+    `phoenix_kit_crm_lists` (same slug — reused if a CRM list already has
+    it), `subscribable = true`
+  - Data: a `phoenix_kit_crm_contacts` row per distinct user with a legacy
+    membership (reused if one already exists by email), linked to that
+    user's `user_uuid` via a straight UPDATE against `phoenix_kit_users` —
+    never creates a user, `connect_user/2`'s placeholder-minting is
+    structurally unreachable from this migration
+  - Data: legacy memberships copied to `phoenix_kit_crm_list_members`,
+    status mapped (`active`→`subscribed`, `unsubscribed`→`removed`),
+    `subscribed_at`/`unsubscribed_at` preserved verbatim (not `now()`);
+    `subscriber_count` recounted after
+  - Re-points every `newsletters_list` broadcast still referencing a
+    migrated list to `source_type = 'crm_list'` + `crm_list_uuid`; any
+    broadcast an orphaned `list_uuid` couldn't be re-pointed from (should
+    be none — `ON DELETE RESTRICT` guarantees referential integrity, see
+    moduledoc) has that uuid preserved into
+    `source_params->>'legacy_list_uuid'` first
+  - Drops `fk_newsletters_broadcasts_list` + `list_uuid` column, then
+    `phoenix_kit_newsletters_list_members` and `phoenix_kit_newsletters_lists`
+    themselves
+  - `down/1` restores the two tables (V79 shape) and the FK/column
+    (nullable, matching V152) — structure only, migrated/re-pointed data
+    is not moved back
+
+  ### V155 - Delivery CRM contact id + per-broadcast dedup
   - Adds `crm_contact_uuid` (bare, nullable UUID, no FK — same soft-ref
     pattern as `crm_list_uuid`) to `phoenix_kit_newsletters_deliveries`,
     plus a plain index on it
@@ -1358,7 +1387,7 @@ defmodule PhoenixKit.Migrations.Postgres do
   alias PhoenixKit.Migrations.Postgres.Helpers
 
   @initial_version 1
-  @current_version 155
+  @current_version 156
   @default_prefix "public"
 
   # First version whose SQL references uuid_generate_v7(). Chains that

--- a/lib/phoenix_kit/migrations/postgres/v156.ex
+++ b/lib/phoenix_kit/migrations/postgres/v156.ex
@@ -323,9 +323,7 @@ defmodule PhoenixKit.Migrations.Postgres.V156 do
 
     execute("DROP INDEX IF EXISTS #{p}idx_newsletters_broadcasts_list")
 
-    execute(
-      "ALTER TABLE #{p}phoenix_kit_newsletters_broadcasts DROP COLUMN IF EXISTS list_uuid"
-    )
+    execute("ALTER TABLE #{p}phoenix_kit_newsletters_broadcasts DROP COLUMN IF EXISTS list_uuid")
   end
 
   defp down_drop_broadcast_list_fk(opts, prefix, p) do

--- a/lib/phoenix_kit/migrations/postgres/v156.ex
+++ b/lib/phoenix_kit/migrations/postgres/v156.ex
@@ -1,0 +1,446 @@
+defmodule PhoenixKit.Migrations.Postgres.V156 do
+  @moduledoc """
+  V156: Migrates legacy newsletters lists into CRM contact lists (spec
+  §4.5), then drops the newsletters-owned list tables entirely.
+
+  > #### Requires a coordinated release with the newsletters module {: .warning}
+  >
+  > `phoenix_kit_newsletters_lists` / `..._list_members` and
+  > `phoenix_kit_newsletters_broadcasts.list_uuid` are read directly by
+  > the newsletters package's `List`/`ListMember` schemas and its
+  > `"newsletters_list"` broadcast source path. This migration drops all
+  > three. A host app running V156 with an OLDER newsletters release
+  > (one that still reads them) breaks outright. The newsletters release
+  > that removes that code path ships separately, after this migration —
+  > do not deploy V156 alone.
+
+  ## Why the data migration lives in this schema migration, not a
+  ## separate mix task
+
+  Every table involved — both newsletters' own and CRM's — is defined by
+  CORE's migrations already (CRM's tables since V152/V138), regardless
+  of whether the CRM module is actually installed in a given host app.
+  So there is always somewhere for this data to go, and core moving its
+  own data between its own tables, atomically with the DDL that
+  retires the source tables, is the same shape V152's "send profiles
+  move to core Email" section already used (copy rows by `uuid`, drop
+  the source table, same migration). A separate required-but-easy-to-
+  forget mix task, with the DDL raising mid-`phoenix_kit.update` if
+  skipped, is a strictly worse failure mode for an upgrade path that is
+  otherwise a single non-interactive command.
+
+  ## Section 1+2: `phoenix_kit_newsletters_lists`/`..._list_members` →
+  ## `phoenix_kit_crm_lists`/`..._crm_list_members`
+
+  One pass, four steps, run only while the legacy tables still exist
+  (see `table_exists?/3` — makes the whole data phase a no-op on a
+  second `up/1` run after the first one already dropped them):
+
+    1. **Lists** — one `phoenix_kit_crm_lists` row per legacy list,
+       `name`/`slug`/`description`/`status` copied verbatim (both
+       schemas use the same status vocabulary, `active`/`archived`), NOT
+       copied by `uuid` (unlike the V152 send-profiles precedent) — a
+       fresh CRM-side `uuid` avoids relying on cross-table PK reuse. Slug
+       is the idempotency key: `WHERE NOT EXISTS (... WHERE cl.slug =
+       l.slug)`, so a CRM list already using this slug (created
+       independently, before this migration ever ran) is reused rather
+       than duplicated. Created `subscribable = true` — every migrated
+       list had real subscribers under the old system, so it stays
+       visible/manageable via the CRM module's preference center rather
+       than silently becoming inert bookkeeping.
+
+    2. **Contacts** — a `phoenix_kit_crm_contacts` row per distinct user
+       referenced by a legacy membership, but ONLY for a user with no
+       contact yet at that email (`NOT EXISTS ... WHERE c.email =
+       u.email`); `name` falls back through first+last name, then the
+       email itself. **Guard, load-bearing:** user linking is a
+       straight `UPDATE ... SET user_uuid = u.uuid ... WHERE
+       c.user_uuid IS NULL` against `phoenix_kit_users` — reading an
+       EXISTING user row, never creating one. `phoenix_kit_crm_contacts`
+       has no `connect_user`-equivalent DDL path and never will; the
+       "mint a placeholder user for an unrecognized email" behavior
+       lives entirely in `PhoenixKitCRM.Contacts.connect_user/2`
+       (application code, no SQL at all), so it is structurally
+       unreachable from this migration regardless of intent. The link
+       UPDATE also picks at most one unlinked same-email contact per
+       user (`ORDER BY inserted_at, uuid LIMIT 1` via a correlated
+       subquery, not a bare multi-row join) — `idx_crm_contacts_user_uuid`
+       is a unique partial index (at most one contact per user), and a
+       naive join could try to set the same `user_uuid` onto two
+       pre-existing duplicate-email contacts at once and fail the whole
+       statement on that constraint.
+
+    3. **Memberships** — one `phoenix_kit_crm_list_members` row per
+       legacy membership, joined lists→contacts by the same keys the
+       two steps above just established (`slug`, then `user_uuid`).
+       Status maps `'active'` → `'subscribed'`, `'unsubscribed'` →
+       `'removed'` (the two schemas do NOT share membership-status
+       vocabulary — CRM's is `subscribed`/`pending`/`removed`); an
+       unrecognized legacy status (there is no DB CHECK backing
+       `phoenix_kit_newsletters_list_members.status`, only an Ecto
+       validation, so a stray value is possible in principle) maps to
+       `'removed'` rather than `'subscribed'` — a migration defect
+       should fail closed (nobody wrongly receives mail) not open.
+       `subscribed_at`/`unsubscribed_at` copied verbatim — this is the
+       one property spec §4.5 is explicit about preserving, and the
+       reason this INSERT can't go through
+       `PhoenixKitCRM.Lists.add_contact_to_list/3` even conceptually:
+       that context function always stamps `subscribed_at: now()`, which
+       would be actively wrong here. `source = 'import'`.
+       `ON CONFLICT DO NOTHING` (no target list — covers both
+       `idx_crm_list_members_list_contact` and
+       `idx_crm_list_members_list_email`, either of which a
+       pre-existing CRM list could already legitimately hold).
+
+    4. **Recount** — `phoenix_kit_crm_lists.subscriber_count` is a
+       maintained cache (see V152), not derived at query time; a bulk
+       INSERT bypasses whatever incremental bump the ordinary
+       membership-add path performs, so it's set here by a direct
+       recount over what was actually inserted (mirrors
+       `PhoenixKitCRM.Lists.recount_list/1`'s own repair-by-recount
+       approach, just for every migrated list in one statement instead
+       of one list at a time).
+
+  ## Section 3: re-point broadcasts, then drop the FK + column
+
+  Every broadcast still at `source_type = 'newsletters_list'` whose
+  `list_uuid` matches a list migrated above is flipped to `source_type =
+  'crm_list'` with `crm_list_uuid` set to the matching CRM list — the
+  exact re-pointing the restructuring plan's `crm_list` source type
+  (V152) exists to receive. Real column names confirmed against
+  `phoenix_kit_newsletters_broadcasts` directly (not assumed): this
+  chain added `source_type`/`crm_list_uuid` in V152, and dropped
+  `list_uuid`'s `NOT NULL` in the same version — see that migration's
+  "Section: broadcasts can source recipients from a CRM list".
+
+  **Orphan guard.** `list_uuid` carries `fk_newsletters_broadcasts_list`
+  — `ON DELETE RESTRICT` (V79) — so under normal operation every
+  non-null `list_uuid` on a broadcast is guaranteed to match a row in
+  `phoenix_kit_newsletters_lists`, which step 1 above migrates
+  unconditionally; the re-point should therefore never fail to find a
+  match. Defended anyway, cheaply: any broadcast still at
+  `source_type = 'newsletters_list'` with a non-null `list_uuid` after
+  the re-point UPDATE (should be none, but "should" isn't a database
+  constraint) gets that `list_uuid` preserved into
+  `source_params->>'legacy_list_uuid'` before the column carrying it is
+  dropped a moment later — the alternative is losing the only clue to
+  what a corrupted-even-before-this-migration broadcast used to target,
+  for the cost of one extra guarded UPDATE.
+
+  The FK, its supporting index (`idx_newsletters_broadcasts_list`, V79),
+  and the `list_uuid` column itself are then dropped — this is the step
+  that makes dropping `phoenix_kit_newsletters_lists` in section 4
+  possible at all; `ON DELETE RESTRICT` means the table can't be
+  dropped while anything still references it.
+
+  ## Section 4: drop the legacy tables
+
+  `phoenix_kit_newsletters_list_members` first (it holds the FK
+  *to* `phoenix_kit_newsletters_lists`), then
+  `phoenix_kit_newsletters_lists`. `CASCADE` on both, matching this
+  chain's existing drop-table precedent (V145, V152) — belt-and-braces
+  against any dependent object this migration didn't anticipate; by this
+  point section 3 has already removed the one FK from outside these two
+  tables that referenced them (`fk_newsletters_broadcasts_list`), so
+  `CASCADE` isn't expected to drop anything beyond the two tables'
+  own indexes.
+
+  ## down/1
+
+  Restores STRUCTURE only, in reverse order (recreate the two tables
+  first — the FK restored next needs somewhere to point), never DATA —
+  consistent with V152/V155's own down/1 precedent for a destructive
+  section (see V155's moduledoc on `crm_contact_uuid`): the migrated
+  rows already live in `phoenix_kit_crm_lists`/`..._crm_list_members`
+  and are not copied back, the newly-empty
+  `phoenix_kit_newsletters_lists`/`..._list_members` tables come back
+  empty, and any broadcast this version re-pointed to `crm_list` stays
+  re-pointed (source_type/crm_list_uuid are untouched by down/1). This
+  chain's rollback story has never guaranteed data survives a down/up
+  cycle across a version that intentionally discards or relocates rows
+  (V145's send-profile predecessor didn't either); it guarantees the
+  SCHEMA is usable again, which is what every downstream migration in
+  the chain actually depends on.
+
+  `list_uuid` is restored nullable (matching the state V152 already put
+  it in — this section does not attempt to reconstruct which broadcasts
+  used to be NOT NULL-eligible) with its FK and index; the two legacy
+  tables are recreated exactly as V79 defined them (confirmed unchanged
+  in the live schema through V155 — no migration between V79 and V155
+  touches either table's columns).
+  """
+
+  use Ecto.Migration
+
+  alias PhoenixKit.Migrations.Postgres.Helpers
+
+  def up(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    up_migrate_lists_and_members(opts, prefix, p)
+    up_repoint_broadcasts(p)
+    up_drop_broadcast_list_fk(p)
+    up_drop_list_tables(p)
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '156'")
+  end
+
+  def down(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    # Reverse of up/1: tables dropped last, recreated first — the FK
+    # restored next needs them to already exist. Sections 1+2 (pure
+    # data, no schema change) have nothing to unwind — see moduledoc.
+    down_drop_list_tables(prefix, p)
+    down_drop_broadcast_list_fk(opts, prefix, p)
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '155'")
+  end
+
+  # ── Sections 1+2: legacy lists/members → CRM lists/contacts/members ──
+
+  defp up_migrate_lists_and_members(opts, prefix, p) do
+    if table_exists?(opts, prefix, "phoenix_kit_newsletters_lists") do
+      migrate_lists(p)
+      create_contacts_for_migrating_users(p)
+      link_contacts_to_existing_users(p)
+      migrate_memberships(p)
+      recount_migrated_lists(p)
+    end
+  end
+
+  defp migrate_lists(p) do
+    execute("""
+    INSERT INTO #{p}phoenix_kit_crm_lists (name, slug, description, status, subscribable)
+    SELECT l.name, l.slug, l.description, l.status, true
+    FROM #{p}phoenix_kit_newsletters_lists l
+    WHERE NOT EXISTS (
+      SELECT 1 FROM #{p}phoenix_kit_crm_lists cl WHERE cl.slug = l.slug
+    )
+    """)
+  end
+
+  defp create_contacts_for_migrating_users(p) do
+    execute("""
+    INSERT INTO #{p}phoenix_kit_crm_contacts (name, email)
+    SELECT
+      COALESCE(NULLIF(TRIM(CONCAT_WS(' ', u.first_name, u.last_name)), ''), u.email::text),
+      u.email
+    FROM #{p}phoenix_kit_users u
+    WHERE u.uuid IN (SELECT DISTINCT user_uuid FROM #{p}phoenix_kit_newsletters_list_members)
+      AND NOT EXISTS (
+        SELECT 1 FROM #{p}phoenix_kit_crm_contacts c WHERE c.email = u.email
+      )
+    """)
+  end
+
+  # Links only EXISTING users — reads phoenix_kit_users, never writes it.
+  # See moduledoc's "Guard, load-bearing" note.
+  defp link_contacts_to_existing_users(p) do
+    execute("""
+    UPDATE #{p}phoenix_kit_crm_contacts c
+    SET user_uuid = u.uuid
+    FROM #{p}phoenix_kit_users u
+    WHERE c.user_uuid IS NULL
+      AND c.email = u.email
+      AND u.uuid IN (SELECT DISTINCT user_uuid FROM #{p}phoenix_kit_newsletters_list_members)
+      AND c.uuid = (
+        SELECT c2.uuid FROM #{p}phoenix_kit_crm_contacts c2
+        WHERE c2.email = u.email AND c2.user_uuid IS NULL
+        ORDER BY c2.inserted_at ASC, c2.uuid ASC
+        LIMIT 1
+      )
+    """)
+  end
+
+  defp migrate_memberships(p) do
+    execute("""
+    INSERT INTO #{p}phoenix_kit_crm_list_members
+      (list_uuid, contact_uuid, email, status, subscribed_at, unsubscribed_at, source)
+    SELECT
+      cl.uuid,
+      c.uuid,
+      c.email,
+      CASE m.status
+        WHEN 'active' THEN 'subscribed'
+        WHEN 'unsubscribed' THEN 'removed'
+        ELSE 'removed'
+      END,
+      m.subscribed_at,
+      m.unsubscribed_at,
+      'import'
+    FROM #{p}phoenix_kit_newsletters_list_members m
+    JOIN #{p}phoenix_kit_newsletters_lists l ON l.uuid = m.list_uuid
+    JOIN #{p}phoenix_kit_crm_lists cl ON cl.slug = l.slug
+    JOIN #{p}phoenix_kit_crm_contacts c ON c.user_uuid = m.user_uuid
+    ON CONFLICT DO NOTHING
+    """)
+  end
+
+  defp recount_migrated_lists(p) do
+    execute("""
+    UPDATE #{p}phoenix_kit_crm_lists cl
+    SET subscriber_count = (
+      SELECT COUNT(*) FROM #{p}phoenix_kit_crm_list_members m
+      WHERE m.list_uuid = cl.uuid AND m.status = 'subscribed'
+    )
+    WHERE cl.slug IN (SELECT slug FROM #{p}phoenix_kit_newsletters_lists)
+    """)
+  end
+
+  # ── Section 3: re-point broadcasts, then drop FK + column ──
+
+  defp up_repoint_broadcasts(p) do
+    execute("""
+    UPDATE #{p}phoenix_kit_newsletters_broadcasts b
+    SET source_type = 'crm_list', crm_list_uuid = cl.uuid
+    FROM #{p}phoenix_kit_newsletters_lists l
+    JOIN #{p}phoenix_kit_crm_lists cl ON cl.slug = l.slug
+    WHERE b.list_uuid = l.uuid
+      AND b.source_type = 'newsletters_list'
+    """)
+
+    # Orphan guard — see moduledoc. Runs unconditionally (not inside the
+    # table_exists? guard above): harmless/no-op once every
+    # 'newsletters_list' broadcast has been re-pointed, which the
+    # UPDATE above always achieves in practice (ON DELETE RESTRICT
+    # guarantees list_uuid always matched a row section 1 just
+    # migrated) — this only ever fires on data already inconsistent
+    # before this migration ran.
+    execute("""
+    UPDATE #{p}phoenix_kit_newsletters_broadcasts b
+    SET source_params = b.source_params || jsonb_build_object('legacy_list_uuid', b.list_uuid::text)
+    WHERE b.source_type = 'newsletters_list' AND b.list_uuid IS NOT NULL
+    """)
+  end
+
+  defp up_drop_broadcast_list_fk(p) do
+    execute(
+      "ALTER TABLE #{p}phoenix_kit_newsletters_broadcasts DROP CONSTRAINT IF EXISTS fk_newsletters_broadcasts_list"
+    )
+
+    execute("DROP INDEX IF EXISTS #{p}idx_newsletters_broadcasts_list")
+
+    execute(
+      "ALTER TABLE #{p}phoenix_kit_newsletters_broadcasts DROP COLUMN IF EXISTS list_uuid"
+    )
+  end
+
+  defp down_drop_broadcast_list_fk(opts, prefix, p) do
+    execute("""
+    ALTER TABLE #{p}phoenix_kit_newsletters_broadcasts
+    ADD COLUMN IF NOT EXISTS list_uuid UUID
+    """)
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS idx_newsletters_broadcasts_list
+    ON #{p}phoenix_kit_newsletters_broadcasts (list_uuid)
+    """)
+
+    # Postgres has no ADD CONSTRAINT IF NOT EXISTS — guard on the
+    # constraint name, same pattern V152 uses for the recipient CHECK.
+    escaped_prefix = Map.get(opts, :escaped_prefix, prefix)
+
+    execute("""
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT FROM information_schema.table_constraints
+        WHERE table_schema = '#{escaped_prefix}'
+          AND table_name = 'phoenix_kit_newsletters_broadcasts'
+          AND constraint_name = 'fk_newsletters_broadcasts_list'
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_newsletters_broadcasts
+          ADD CONSTRAINT fk_newsletters_broadcasts_list
+          FOREIGN KEY (list_uuid)
+          REFERENCES #{p}phoenix_kit_newsletters_lists(uuid)
+          ON DELETE RESTRICT;
+      END IF;
+    END $$;
+    """)
+  end
+
+  # ── Section 4: drop the legacy tables ──
+
+  defp up_drop_list_tables(p) do
+    # Member table first — it holds the FK *to* the lists table.
+    execute("DROP TABLE IF EXISTS #{p}phoenix_kit_newsletters_list_members CASCADE")
+    execute("DROP TABLE IF EXISTS #{p}phoenix_kit_newsletters_lists CASCADE")
+  end
+
+  defp down_drop_list_tables(prefix, p) do
+    execute("""
+    CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_newsletters_lists (
+      uuid UUID PRIMARY KEY DEFAULT #{Helpers.uuid_v7_call(prefix)},
+      name VARCHAR(255) NOT NULL,
+      slug VARCHAR(255) NOT NULL,
+      description TEXT,
+      status VARCHAR(20) NOT NULL DEFAULT 'active',
+      is_default BOOLEAN NOT NULL DEFAULT false,
+      subscriber_count INTEGER NOT NULL DEFAULT 0,
+      inserted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+    """)
+
+    execute("""
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_newsletters_lists_slug
+    ON #{p}phoenix_kit_newsletters_lists (slug)
+    """)
+
+    execute("""
+    CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_newsletters_list_members (
+      uuid UUID PRIMARY KEY DEFAULT #{Helpers.uuid_v7_call(prefix)},
+      user_uuid UUID NOT NULL,
+      list_uuid UUID NOT NULL,
+      status VARCHAR(20) NOT NULL DEFAULT 'active',
+      subscribed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      unsubscribed_at TIMESTAMPTZ,
+      CONSTRAINT fk_newsletters_list_members_user
+        FOREIGN KEY (user_uuid)
+        REFERENCES #{p}phoenix_kit_users(uuid)
+        ON DELETE CASCADE,
+      CONSTRAINT fk_newsletters_list_members_list
+        FOREIGN KEY (list_uuid)
+        REFERENCES #{p}phoenix_kit_newsletters_lists(uuid)
+        ON DELETE CASCADE
+    )
+    """)
+
+    execute("""
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_newsletters_list_members_user_list
+    ON #{p}phoenix_kit_newsletters_list_members (user_uuid, list_uuid)
+    """)
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS idx_newsletters_list_members_list
+    ON #{p}phoenix_kit_newsletters_list_members (list_uuid)
+    """)
+  end
+
+  # ── Shared helpers ──
+
+  defp table_exists?(opts, prefix, table_name) do
+    escaped_prefix = Map.get(opts, :escaped_prefix, prefix)
+
+    case repo().query(
+           """
+           SELECT EXISTS (
+             SELECT FROM information_schema.tables
+             WHERE table_name = '#{table_name}'
+             AND table_schema = '#{escaped_prefix}'
+           )
+           """,
+           [],
+           log: false
+         ) do
+      {:ok, %{rows: [[true]]}} -> true
+      _ -> false
+    end
+  end
+
+  defp prefix_str("public"), do: "public."
+  defp prefix_str(prefix), do: "#{prefix}."
+end

--- a/lib/phoenix_kit/migrations/postgres/v156.ex
+++ b/lib/phoenix_kit/migrations/postgres/v156.ex
@@ -37,8 +37,11 @@ defmodule PhoenixKit.Migrations.Postgres.V156 do
   second `up/1` run after the first one already dropped them):
 
     1. **Lists** — one `phoenix_kit_crm_lists` row per legacy list,
-       `name`/`slug`/`description`/`status` copied verbatim (both
-       schemas use the same status vocabulary, `active`/`archived`), NOT
+       `name`/`slug`/`description` copied verbatim; `status` through a
+       fail-closed CASE (`'active'` stays, anything else — including a
+       stray out-of-vocabulary value the un-CHECKed legacy column could
+       hold — becomes `'archived'`, since the CRM column's V152 CHECK
+       would otherwise abort the whole INSERT), NOT
        copied by `uuid` (unlike the V152 send-profiles precedent) — a
        fresh CRM-side `uuid` avoids relying on cross-table PK reuse. Slug
        is the idempotency key: `WHERE NOT EXISTS (... WHERE cl.slug =
@@ -50,10 +53,14 @@ defmodule PhoenixKit.Migrations.Postgres.V156 do
        than silently becoming inert bookkeeping.
 
     2. **Contacts** — a `phoenix_kit_crm_contacts` row per distinct user
-       referenced by a legacy membership, but ONLY for a user with no
-       contact yet at that email (`NOT EXISTS ... WHERE c.email =
-       u.email`); `name` falls back through first+last name, then the
-       email itself. **Guard, load-bearing:** user linking is a
+       referenced by a legacy membership, skipped only when a same-email
+       contact already exists that this user can end up attached to
+       (unlinked, or linked to this very user). A same-email contact
+       linked to a DIFFERENT user does not suppress creation — see the
+       comment on `create_contacts_for_migrating_users/1` for why that
+       carve-out is what keeps such a user's memberships from being
+       silently dropped. `name` falls back through first+last name, then
+       the email itself. **Guard, load-bearing:** user linking is a
        straight `UPDATE ... SET user_uuid = u.uuid ... WHERE
        c.user_uuid IS NULL` against `phoenix_kit_users` — reading an
        EXISTING user row, never creating one. `phoenix_kit_crm_contacts`
@@ -221,9 +228,17 @@ defmodule PhoenixKit.Migrations.Postgres.V156 do
   end
 
   defp migrate_lists(p) do
+    # Status CASE mirrors the fail-closed convention migrate_memberships/1
+    # already follows: the legacy column has no DB CHECK (V79, Ecto-only
+    # validation) while phoenix_kit_crm_lists.status DOES (V152,
+    # active/archived) — a stray legacy value must not abort the whole
+    # INSERT mid-migration, and fail-closed for a list means 'archived'
+    # (nothing can be sent to it until a human looks).
     execute("""
     INSERT INTO #{p}phoenix_kit_crm_lists (name, slug, description, status, subscribable)
-    SELECT l.name, l.slug, l.description, l.status, true
+    SELECT l.name, l.slug, l.description,
+      CASE l.status WHEN 'active' THEN 'active' ELSE 'archived' END,
+      true
     FROM #{p}phoenix_kit_newsletters_lists l
     WHERE NOT EXISTS (
       SELECT 1 FROM #{p}phoenix_kit_crm_lists cl WHERE cl.slug = l.slug
@@ -231,6 +246,17 @@ defmodule PhoenixKit.Migrations.Postgres.V156 do
     """)
   end
 
+  # Creation is skipped only when a same-email contact exists that this
+  # user can actually end up attached to: one already linked to THIS user,
+  # or an unlinked one the link step below will claim. A same-email
+  # contact linked to a DIFFERENT user does NOT suppress creation —
+  # `phoenix_kit_crm_contacts.email` carries no unique index (deliberate:
+  # always-new-contact policy, V152), and without this carve-out such a
+  # user would finish these steps with no contact carrying their
+  # user_uuid, silently dropping every membership row they had (the
+  # membership INSERT joins on `c.user_uuid = m.user_uuid`). Reachable
+  # via ordinary email drift: a user changes email, the freed address is
+  # re-registered by someone else who then subscribes.
   defp create_contacts_for_migrating_users(p) do
     execute("""
     INSERT INTO #{p}phoenix_kit_crm_contacts (name, email)
@@ -240,7 +266,9 @@ defmodule PhoenixKit.Migrations.Postgres.V156 do
     FROM #{p}phoenix_kit_users u
     WHERE u.uuid IN (SELECT DISTINCT user_uuid FROM #{p}phoenix_kit_newsletters_list_members)
       AND NOT EXISTS (
-        SELECT 1 FROM #{p}phoenix_kit_crm_contacts c WHERE c.email = u.email
+        SELECT 1 FROM #{p}phoenix_kit_crm_contacts c
+        WHERE c.email = u.email
+          AND (c.user_uuid IS NULL OR c.user_uuid = u.uuid)
       )
     """)
   end

--- a/lib/phoenix_kit/migrations/postgres/v156.ex
+++ b/lib/phoenix_kit/migrations/postgres/v156.ex
@@ -179,7 +179,16 @@ defmodule PhoenixKit.Migrations.Postgres.V156 do
     p = prefix_str(prefix)
 
     up_migrate_lists_and_members(opts, prefix, p)
-    up_repoint_broadcasts(p)
+
+    # Same guard as the data phase: the re-point UPDATE joins the legacy
+    # lists table and the orphan guard reads `list_uuid` — both are only
+    # legal while the legacy schema still exists. On a second up/1 run
+    # (table + column already dropped) section 3 must be a no-op, not an
+    # undefined_table/undefined_column error.
+    if table_exists?(opts, prefix, "phoenix_kit_newsletters_lists") do
+      up_repoint_broadcasts(p)
+    end
+
     up_drop_broadcast_list_fk(p)
     up_drop_list_tables(p)
 
@@ -302,13 +311,11 @@ defmodule PhoenixKit.Migrations.Postgres.V156 do
       AND b.source_type = 'newsletters_list'
     """)
 
-    # Orphan guard — see moduledoc. Runs unconditionally (not inside the
-    # table_exists? guard above): harmless/no-op once every
-    # 'newsletters_list' broadcast has been re-pointed, which the
-    # UPDATE above always achieves in practice (ON DELETE RESTRICT
-    # guarantees list_uuid always matched a row section 1 just
-    # migrated) — this only ever fires on data already inconsistent
-    # before this migration ran.
+    # Orphan guard — see moduledoc. In practice a no-op: ON DELETE
+    # RESTRICT guarantees every non-null list_uuid matched a row section
+    # 1 just migrated, so the UPDATE above re-points everything. This
+    # only ever fires on data already inconsistent before this migration
+    # ran.
     execute("""
     UPDATE #{p}phoenix_kit_newsletters_broadcasts b
     SET source_params = b.source_params || jsonb_build_object('legacy_list_uuid', b.list_uuid::text)

--- a/test/phoenix_kit/migrations/v152_test.exs
+++ b/test/phoenix_kit/migrations/v152_test.exs
@@ -540,9 +540,12 @@ defmodule PhoenixKit.Migrations.Postgres.V152Test do
   end
 
   describe "phoenix_kit_newsletters_broadcasts — CRM list source" do
-    test "list_uuid dropped its NOT NULL" do
-      assert %{type: "uuid", nullable: "YES"} =
-               column("phoenix_kit_newsletters_broadcasts", "list_uuid")
+    # V152 dropped list_uuid's NOT NULL; V156 then removed the column
+    # entirely (legacy lists migrated into CRM). The suite runs against
+    # the post-V156 schema, so the current pin is absence — the V156
+    # suite owns the positive assertions about what replaced it.
+    test "list_uuid is gone entirely (removed by V156)" do
+      assert column("phoenix_kit_newsletters_broadcasts", "list_uuid") == nil
     end
 
     test "source_type is a NOT NULL varchar defaulting to newsletters_list" do

--- a/test/phoenix_kit/migrations/v156_test.exs
+++ b/test/phoenix_kit/migrations/v156_test.exs
@@ -113,7 +113,9 @@ defmodule PhoenixKit.Migrations.Postgres.V156Test do
   defp copy_staged_lists_to_crm do
     Repo.query!("""
     INSERT INTO phoenix_kit_crm_lists (name, slug, description, status, subscribable)
-    SELECT l.name, l.slug, l.description, l.status, true
+    SELECT l.name, l.slug, l.description,
+      CASE l.status WHEN 'active' THEN 'active' ELSE 'archived' END,
+      true
     FROM staged_newsletters_lists l
     WHERE NOT EXISTS (
       SELECT 1 FROM phoenix_kit_crm_lists cl WHERE cl.slug = l.slug
@@ -131,7 +133,9 @@ defmodule PhoenixKit.Migrations.Postgres.V156Test do
     FROM phoenix_kit_users u
     WHERE u.uuid IN (SELECT DISTINCT user_uuid FROM staged_newsletters_list_members)
       AND NOT EXISTS (
-        SELECT 1 FROM phoenix_kit_crm_contacts c WHERE c.email = u.email
+        SELECT 1 FROM phoenix_kit_crm_contacts c
+        WHERE c.email = u.email
+          AND (c.user_uuid IS NULL OR c.user_uuid = u.uuid)
       )
     """)
 
@@ -284,10 +288,30 @@ defmodule PhoenixKit.Migrations.Postgres.V156Test do
 
       assert name == "Old Announcements"
       assert description == "Kept for history"
-      # Copied verbatim, not defaulted — proves the source value survives
-      # even when it differs from crm_lists.status's own default.
+      # Copied through the status CASE, not defaulted — proves the source
+      # value survives even when it differs from crm_lists.status's own
+      # default.
       assert status == "archived"
       assert subscribable == true
+    end
+
+    test "an out-of-vocabulary legacy status fails closed to archived instead of aborting on the CRM CHECK" do
+      stage_lists_and_members_tables()
+      slug = "v156-stray-status-#{System.unique_integer([:positive])}"
+
+      # The legacy column has no DB CHECK (V79) — only an Ecto validation
+      # — so a stray value like this is representable in a real database.
+      Repo.query!(
+        "INSERT INTO staged_newsletters_lists (uuid, name, slug, status) VALUES ($1, $2, $3, $4)",
+        [uuid!(), "Stray status", slug, "paused"]
+      )
+
+      copy_staged_lists_to_crm()
+
+      %{rows: [[status]]} =
+        Repo.query!("SELECT status FROM phoenix_kit_crm_lists WHERE slug = $1", [slug])
+
+      assert status == "archived"
     end
 
     test "reuses an existing CRM list with the same slug instead of duplicating it" do
@@ -405,6 +429,64 @@ defmodule PhoenixKit.Migrations.Postgres.V156Test do
       assert length(linked) == 1
       assert [[_uuid, linked_user_uuid]] = linked
       assert linked_user_uuid == Ecto.UUID.dump!(user.uuid)
+    end
+
+    test "email claimed by a contact linked to a DIFFERENT user — a fresh contact is created and the membership survives" do
+      # Ordinary email drift: other_user's linked contact still snapshots
+      # an address that has since been freed and re-registered by `user`,
+      # who then subscribed. Without the (user_uuid IS NULL OR = u.uuid)
+      # carve-out in the creation guard, `user` would end these steps
+      # with NO contact carrying their user_uuid and the membership copy
+      # (INNER JOIN on c.user_uuid = m.user_uuid) would silently drop
+      # their rows.
+      user = insert_user!()
+      other_user = insert_user!()
+
+      foreign_contact_uuid =
+        insert_crm_contact!(%{email: user.email, user_uuid: other_user.uuid})
+
+      crm_list = insert_crm_list!()
+      stage_lists_and_members_tables()
+      legacy_list_uuid = uuid!()
+
+      Repo.query!(
+        "INSERT INTO staged_newsletters_lists (uuid, name, slug) VALUES ($1, $2, $3)",
+        [legacy_list_uuid, crm_list.name, crm_list.slug]
+      )
+
+      Repo.query!(
+        """
+        INSERT INTO staged_newsletters_list_members
+          (uuid, user_uuid, list_uuid, status, subscribed_at)
+        VALUES ($1, $2, $3, 'active', '2026-03-01T12:00:00Z')
+        """,
+        [uuid!(), Ecto.UUID.dump!(user.uuid), legacy_list_uuid]
+      )
+
+      create_and_link_contacts()
+      copy_staged_memberships_to_crm()
+
+      # A second contact now shares the email (legal: no unique index on
+      # crm_contacts.email) — the foreign one untouched, the new one
+      # linked to `user`.
+      %{rows: rows} =
+        Repo.query!(
+          "SELECT uuid, user_uuid FROM phoenix_kit_crm_contacts WHERE email = $1 ORDER BY inserted_at",
+          [user.email]
+        )
+
+      assert length(rows) == 2
+      assert [[^foreign_contact_uuid, foreign_linked], [new_contact_uuid, new_linked]] = rows
+      assert foreign_linked == Ecto.UUID.dump!(other_user.uuid)
+      assert new_linked == Ecto.UUID.dump!(user.uuid)
+
+      %{rows: [[member_count]]} =
+        Repo.query!(
+          "SELECT COUNT(*) FROM phoenix_kit_crm_list_members WHERE list_uuid = $1 AND contact_uuid = $2",
+          [crm_list.uuid, new_contact_uuid]
+        )
+
+      assert member_count == 1
     end
   end
 

--- a/test/phoenix_kit/migrations/v156_test.exs
+++ b/test/phoenix_kit/migrations/v156_test.exs
@@ -39,8 +39,11 @@ defmodule PhoenixKit.Migrations.Postgres.V156Test do
       )
 
     case rows do
-      [[data_type, is_nullable, default]] -> %{type: data_type, nullable: is_nullable, default: default}
-      [] -> nil
+      [[data_type, is_nullable, default]] ->
+        %{type: data_type, nullable: is_nullable, default: default}
+
+      [] ->
+        nil
     end
   end
 
@@ -300,7 +303,9 @@ defmodule PhoenixKit.Migrations.Postgres.V156Test do
 
       copy_staged_lists_to_crm()
 
-      %{rows: rows} = Repo.query!("SELECT uuid, name FROM phoenix_kit_crm_lists WHERE slug = $1", [slug])
+      %{rows: rows} =
+        Repo.query!("SELECT uuid, name FROM phoenix_kit_crm_lists WHERE slug = $1", [slug])
+
       assert [[found_uuid, "Already here"]] = rows
       assert found_uuid == existing_uuid
     end
@@ -409,8 +414,11 @@ defmodule PhoenixKit.Migrations.Postgres.V156Test do
       unsubscribed_user = insert_user!()
       crm_list = insert_crm_list!()
 
-      active_contact = insert_crm_contact!(%{email: active_user.email, user_uuid: active_user.uuid})
-      unsub_contact = insert_crm_contact!(%{email: unsubscribed_user.email, user_uuid: unsubscribed_user.uuid})
+      active_contact =
+        insert_crm_contact!(%{email: active_user.email, user_uuid: active_user.uuid})
+
+      unsub_contact =
+        insert_crm_contact!(%{email: unsubscribed_user.email, user_uuid: unsubscribed_user.uuid})
 
       stage_lists_and_members_tables()
       legacy_list_uuid = uuid!()
@@ -479,7 +487,9 @@ defmodule PhoenixKit.Migrations.Postgres.V156Test do
       recount([crm_list.slug])
 
       %{rows: [[subscriber_count]]} =
-        Repo.query!("SELECT subscriber_count FROM phoenix_kit_crm_lists WHERE uuid = $1", [crm_list.uuid])
+        Repo.query!("SELECT subscriber_count FROM phoenix_kit_crm_lists WHERE uuid = $1", [
+          crm_list.uuid
+        ])
 
       assert subscriber_count == 2
     end

--- a/test/phoenix_kit/migrations/v156_test.exs
+++ b/test/phoenix_kit/migrations/v156_test.exs
@@ -455,7 +455,7 @@ defmodule PhoenixKit.Migrations.Postgres.V156Test do
         )
 
       assert status == "subscribed"
-      assert subscribed_at == ~U[2026-01-15 10:00:00Z]
+      assert DateTime.compare(subscribed_at, ~U[2026-01-15 10:00:00Z]) == :eq
       assert unsubscribed_at == nil
       assert source == "import"
 
@@ -466,8 +466,8 @@ defmodule PhoenixKit.Migrations.Postgres.V156Test do
         )
 
       assert status2 == "removed"
-      assert subscribed_at2 == ~U[2026-01-10 08:00:00Z]
-      assert unsubscribed_at2 == ~U[2026-02-01 09:30:00Z]
+      assert DateTime.compare(subscribed_at2, ~U[2026-01-10 08:00:00Z]) == :eq
+      assert DateTime.compare(unsubscribed_at2, ~U[2026-02-01 09:30:00Z]) == :eq
     end
 
     test "recount sets subscriber_count to the number of subscribed members only" do

--- a/test/phoenix_kit/migrations/v156_test.exs
+++ b/test/phoenix_kit/migrations/v156_test.exs
@@ -1,0 +1,593 @@
+defmodule PhoenixKit.Migrations.Postgres.V156Test do
+  @moduledoc """
+  Tests V156's schema state — legacy newsletters lists migrated into CRM,
+  then dropped.
+
+  V156.up/down can't be invoked outside an `Ecto.Migrator` runner — same
+  constraint as V145Test/V152Test/V155Test. The schema is verified at
+  boot: `test_helper.exs` runs `ensure_current/2` (now through V156)
+  before any test, so the "gone" describes below pin the post-V156 shape.
+
+  The full chain always starts from a fresh V1 install with nothing in
+  `phoenix_kit_newsletters_lists`/`..._list_members` for V156 to actually
+  migrate (same constraint V152Test's "copy semantics" section documents
+  for the send-profiles move) — by the time any test runs, those tables
+  are already gone and there was never legacy data in them to begin with.
+  What CAN be pinned directly: the post-migration absence of the old
+  tables/column/FK (below), and — for the actual copy/link/re-point
+  LOGIC — re-running the *exact same* SQL V156.up/1 uses against staged
+  temp tables shaped like the old ones, joined against the real (still
+  live) `phoenix_kit_users`/`phoenix_kit_crm_*` tables. A change to
+  V156.up/1's SQL that isn't mirrored here is exactly the regression this
+  file exists to catch.
+  """
+
+  use PhoenixKit.DataCase, async: false
+
+  alias PhoenixKit.Test.Repo
+  alias PhoenixKit.Users.Auth.User
+
+  defp column(table, column) do
+    %{rows: rows} =
+      Repo.query!(
+        """
+        SELECT data_type, is_nullable, column_default
+        FROM information_schema.columns
+        WHERE table_name = $1 AND column_name = $2
+        """,
+        [table, column]
+      )
+
+    case rows do
+      [[data_type, is_nullable, default]] -> %{type: data_type, nullable: is_nullable, default: default}
+      [] -> nil
+    end
+  end
+
+  defp index_exists?(name) do
+    %{rows: [[exists]]} =
+      Repo.query!("SELECT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = $1)", [name])
+
+    exists
+  end
+
+  defp table_exists?(name) do
+    %{rows: [[exists]]} =
+      Repo.query!("SELECT EXISTS (SELECT 1 FROM pg_tables WHERE tablename = $1)", [name])
+
+    exists
+  end
+
+  defp constraint_exists?(name) do
+    %{rows: [[exists]]} =
+      Repo.query!("SELECT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = $1)", [name])
+
+    exists
+  end
+
+  defp insert_user!(attrs \\ %{}) do
+    base = %{email: "v156-test-#{System.unique_integer([:positive])}@example.com"}
+
+    %User{}
+    |> User.guest_user_changeset(Map.merge(base, attrs))
+    |> Repo.insert!()
+  end
+
+  defp insert_crm_list!(attrs \\ %{}) do
+    base = %{
+      name: "Base list",
+      slug: "v156-crm-list-#{System.unique_integer([:positive])}"
+    }
+
+    attrs = Map.merge(base, attrs)
+
+    %{rows: [[uuid]]} =
+      Repo.query!(
+        "INSERT INTO phoenix_kit_crm_lists (name, slug) VALUES ($1, $2) RETURNING uuid",
+        [attrs.name, attrs.slug]
+      )
+
+    %{uuid: uuid, name: attrs.name, slug: attrs.slug}
+  end
+
+  defp insert_crm_contact!(attrs) do
+    user_uuid_bin =
+      case Map.get(attrs, :user_uuid) do
+        nil -> nil
+        uuid_string -> Ecto.UUID.dump!(uuid_string)
+      end
+
+    %{rows: [[uuid]]} =
+      Repo.query!(
+        "INSERT INTO phoenix_kit_crm_contacts (name, email, user_uuid) VALUES ($1, $2, $3) RETURNING uuid",
+        [Map.get(attrs, :name, "Contact"), Map.fetch!(attrs, :email), user_uuid_bin]
+      )
+
+    uuid
+  end
+
+  # Mirrors V156.up/1's own list-copy SQL exactly (see migrate_lists/1).
+  defp copy_staged_lists_to_crm do
+    Repo.query!("""
+    INSERT INTO phoenix_kit_crm_lists (name, slug, description, status, subscribable)
+    SELECT l.name, l.slug, l.description, l.status, true
+    FROM staged_newsletters_lists l
+    WHERE NOT EXISTS (
+      SELECT 1 FROM phoenix_kit_crm_lists cl WHERE cl.slug = l.slug
+    )
+    """)
+  end
+
+  # Mirrors create_contacts_for_migrating_users/1 + link_contacts_to_existing_users/1.
+  defp create_and_link_contacts do
+    Repo.query!("""
+    INSERT INTO phoenix_kit_crm_contacts (name, email)
+    SELECT
+      COALESCE(NULLIF(TRIM(CONCAT_WS(' ', u.first_name, u.last_name)), ''), u.email::text),
+      u.email
+    FROM phoenix_kit_users u
+    WHERE u.uuid IN (SELECT DISTINCT user_uuid FROM staged_newsletters_list_members)
+      AND NOT EXISTS (
+        SELECT 1 FROM phoenix_kit_crm_contacts c WHERE c.email = u.email
+      )
+    """)
+
+    Repo.query!("""
+    UPDATE phoenix_kit_crm_contacts c
+    SET user_uuid = u.uuid
+    FROM phoenix_kit_users u
+    WHERE c.user_uuid IS NULL
+      AND c.email = u.email
+      AND u.uuid IN (SELECT DISTINCT user_uuid FROM staged_newsletters_list_members)
+      AND c.uuid = (
+        SELECT c2.uuid FROM phoenix_kit_crm_contacts c2
+        WHERE c2.email = u.email AND c2.user_uuid IS NULL
+        ORDER BY c2.inserted_at ASC, c2.uuid ASC
+        LIMIT 1
+      )
+    """)
+  end
+
+  # Mirrors migrate_memberships/1.
+  defp copy_staged_memberships_to_crm do
+    Repo.query!("""
+    INSERT INTO phoenix_kit_crm_list_members
+      (list_uuid, contact_uuid, email, status, subscribed_at, unsubscribed_at, source)
+    SELECT
+      cl.uuid,
+      c.uuid,
+      c.email,
+      CASE m.status
+        WHEN 'active' THEN 'subscribed'
+        WHEN 'unsubscribed' THEN 'removed'
+        ELSE 'removed'
+      END,
+      m.subscribed_at,
+      m.unsubscribed_at,
+      'import'
+    FROM staged_newsletters_list_members m
+    JOIN staged_newsletters_lists l ON l.uuid = m.list_uuid
+    JOIN phoenix_kit_crm_lists cl ON cl.slug = l.slug
+    JOIN phoenix_kit_crm_contacts c ON c.user_uuid = m.user_uuid
+    ON CONFLICT DO NOTHING
+    """)
+  end
+
+  # Mirrors recount_migrated_lists/1, scoped by the given slugs (the real
+  # version scopes by every slug still in phoenix_kit_newsletters_lists —
+  # tests scope explicitly since that table no longer exists to select from).
+  defp recount(slugs) do
+    Repo.query!(
+      """
+      UPDATE phoenix_kit_crm_lists cl
+      SET subscriber_count = (
+        SELECT COUNT(*) FROM phoenix_kit_crm_list_members m
+        WHERE m.list_uuid = cl.uuid AND m.status = 'subscribed'
+      )
+      WHERE cl.slug = ANY($1)
+      """,
+      [slugs]
+    )
+  end
+
+  defp stage_lists_and_members_tables do
+    Repo.query!("""
+    CREATE TEMP TABLE staged_newsletters_lists (
+      uuid UUID PRIMARY KEY,
+      name VARCHAR(255) NOT NULL,
+      slug VARCHAR(255) NOT NULL,
+      description TEXT,
+      status VARCHAR(20) NOT NULL DEFAULT 'active'
+    ) ON COMMIT DROP
+    """)
+
+    Repo.query!("""
+    CREATE TEMP TABLE staged_newsletters_list_members (
+      uuid UUID PRIMARY KEY,
+      user_uuid UUID NOT NULL,
+      list_uuid UUID NOT NULL,
+      status VARCHAR(20) NOT NULL DEFAULT 'active',
+      subscribed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      unsubscribed_at TIMESTAMPTZ
+    ) ON COMMIT DROP
+    """)
+  end
+
+  defp uuid!, do: Ecto.UUID.generate() |> Ecto.UUID.dump!()
+
+  defp stage_broadcasts_table do
+    Repo.query!("""
+    CREATE TEMP TABLE staged_broadcasts (
+      uuid UUID PRIMARY KEY,
+      source_type VARCHAR(20) NOT NULL,
+      list_uuid UUID,
+      crm_list_uuid UUID,
+      source_params JSONB NOT NULL DEFAULT '{}'::jsonb
+    ) ON COMMIT DROP
+    """)
+  end
+
+  # Mirrors up_repoint_broadcasts/1's two UPDATEs exactly.
+  defp repoint_staged_broadcasts do
+    Repo.query!("""
+    UPDATE staged_broadcasts b
+    SET source_type = 'crm_list', crm_list_uuid = cl.uuid
+    FROM staged_newsletters_lists l
+    JOIN phoenix_kit_crm_lists cl ON cl.slug = l.slug
+    WHERE b.list_uuid = l.uuid
+      AND b.source_type = 'newsletters_list'
+    """)
+
+    Repo.query!("""
+    UPDATE staged_broadcasts b
+    SET source_params = b.source_params || jsonb_build_object('legacy_list_uuid', b.list_uuid::text)
+    WHERE b.source_type = 'newsletters_list' AND b.list_uuid IS NOT NULL
+    """)
+  end
+
+  describe "phoenix_kit_newsletters_lists / _list_members are gone" do
+    test "both legacy tables no longer exist" do
+      refute table_exists?("phoenix_kit_newsletters_lists")
+      refute table_exists?("phoenix_kit_newsletters_list_members")
+    end
+  end
+
+  describe "phoenix_kit_newsletters_broadcasts.list_uuid is gone" do
+    test "the column, its FK, and its index are all gone" do
+      refute column("phoenix_kit_newsletters_broadcasts", "list_uuid")
+      refute constraint_exists?("fk_newsletters_broadcasts_list")
+      refute index_exists?("idx_newsletters_broadcasts_list")
+    end
+  end
+
+  describe "list migration semantics (mirrors V156.up's list copy)" do
+    test "copies name/slug/description/status verbatim and sets subscribable true" do
+      stage_lists_and_members_tables()
+      list_uuid = uuid!()
+      slug = "v156-archived-list-#{System.unique_integer([:positive])}"
+
+      Repo.query!(
+        "INSERT INTO staged_newsletters_lists (uuid, name, slug, description, status) VALUES ($1, $2, $3, $4, $5)",
+        [list_uuid, "Old Announcements", slug, "Kept for history", "archived"]
+      )
+
+      copy_staged_lists_to_crm()
+
+      %{rows: [[name, description, status, subscribable]]} =
+        Repo.query!(
+          "SELECT name, description, status, subscribable FROM phoenix_kit_crm_lists WHERE slug = $1",
+          [slug]
+        )
+
+      assert name == "Old Announcements"
+      assert description == "Kept for history"
+      # Copied verbatim, not defaulted — proves the source value survives
+      # even when it differs from crm_lists.status's own default.
+      assert status == "archived"
+      assert subscribable == true
+    end
+
+    test "reuses an existing CRM list with the same slug instead of duplicating it" do
+      slug = "v156-shared-slug-#{System.unique_integer([:positive])}"
+      %{uuid: existing_uuid} = insert_crm_list!(%{name: "Already here", slug: slug})
+
+      stage_lists_and_members_tables()
+
+      Repo.query!(
+        "INSERT INTO staged_newsletters_lists (uuid, name, slug) VALUES ($1, $2, $3)",
+        [uuid!(), "Would-be duplicate", slug]
+      )
+
+      copy_staged_lists_to_crm()
+
+      %{rows: rows} = Repo.query!("SELECT uuid, name FROM phoenix_kit_crm_lists WHERE slug = $1", [slug])
+      assert [[found_uuid, "Already here"]] = rows
+      assert found_uuid == existing_uuid
+    end
+  end
+
+  describe "contact create+link semantics (mirrors V156.up's contact steps)" do
+    test "creates a contact for a migrating user and links it directly — never mints a user" do
+      user = insert_user!(%{first_name: "Ada", last_name: "Lovelace"})
+      stage_lists_and_members_tables()
+      list_uuid = uuid!()
+
+      Repo.query!(
+        "INSERT INTO staged_newsletters_list_members (uuid, user_uuid, list_uuid) VALUES ($1, $2, $3)",
+        [uuid!(), Ecto.UUID.dump!(user.uuid), list_uuid]
+      )
+
+      user_count_before = Repo.aggregate(User, :count)
+
+      create_and_link_contacts()
+
+      assert Repo.aggregate(User, :count) == user_count_before
+
+      %{rows: [[name, email, linked_user_uuid]]} =
+        Repo.query!(
+          "SELECT name, email, user_uuid FROM phoenix_kit_crm_contacts WHERE user_uuid = $1",
+          [Ecto.UUID.dump!(user.uuid)]
+        )
+
+      assert name == "Ada Lovelace"
+      assert email == user.email
+      assert linked_user_uuid == Ecto.UUID.dump!(user.uuid)
+    end
+
+    test "falls back to the user's email as the contact name when no first/last name is set" do
+      user = insert_user!()
+      stage_lists_and_members_tables()
+
+      Repo.query!(
+        "INSERT INTO staged_newsletters_list_members (uuid, user_uuid, list_uuid) VALUES ($1, $2, $3)",
+        [uuid!(), Ecto.UUID.dump!(user.uuid), uuid!()]
+      )
+
+      create_and_link_contacts()
+
+      %{rows: [[name]]} =
+        Repo.query!("SELECT name FROM phoenix_kit_crm_contacts WHERE user_uuid = $1", [
+          Ecto.UUID.dump!(user.uuid)
+        ])
+
+      assert name == user.email
+    end
+
+    test "reuses an already-existing unlinked contact with the same email instead of duplicating" do
+      user = insert_user!()
+      existing_contact_uuid = insert_crm_contact!(%{email: user.email})
+
+      stage_lists_and_members_tables()
+
+      Repo.query!(
+        "INSERT INTO staged_newsletters_list_members (uuid, user_uuid, list_uuid) VALUES ($1, $2, $3)",
+        [uuid!(), Ecto.UUID.dump!(user.uuid), uuid!()]
+      )
+
+      create_and_link_contacts()
+
+      %{rows: rows} =
+        Repo.query!("SELECT uuid, user_uuid FROM phoenix_kit_crm_contacts WHERE email = $1", [
+          user.email
+        ])
+
+      assert [[found_uuid, linked_user_uuid]] = rows
+      assert found_uuid == existing_contact_uuid
+      assert linked_user_uuid == Ecto.UUID.dump!(user.uuid)
+    end
+
+    test "picks only one of several duplicate unlinked contacts sharing an email — never violates the unique user_uuid index" do
+      user = insert_user!()
+      contact_a = insert_crm_contact!(%{email: user.email})
+      contact_b = insert_crm_contact!(%{email: user.email})
+
+      stage_lists_and_members_tables()
+
+      Repo.query!(
+        "INSERT INTO staged_newsletters_list_members (uuid, user_uuid, list_uuid) VALUES ($1, $2, $3)",
+        [uuid!(), Ecto.UUID.dump!(user.uuid), uuid!()]
+      )
+
+      create_and_link_contacts()
+
+      %{rows: rows} =
+        Repo.query!(
+          "SELECT uuid, user_uuid FROM phoenix_kit_crm_contacts WHERE uuid = ANY($1) ORDER BY uuid",
+          [[contact_a, contact_b]]
+        )
+
+      linked = Enum.filter(rows, fn [_uuid, user_uuid] -> user_uuid != nil end)
+      assert length(linked) == 1
+      assert [[_uuid, linked_user_uuid]] = linked
+      assert linked_user_uuid == Ecto.UUID.dump!(user.uuid)
+    end
+  end
+
+  describe "membership migration semantics (mirrors V156.up's membership copy)" do
+    test "maps active/unsubscribed to subscribed/removed, preserving the original dates verbatim" do
+      active_user = insert_user!()
+      unsubscribed_user = insert_user!()
+      crm_list = insert_crm_list!()
+
+      active_contact = insert_crm_contact!(%{email: active_user.email, user_uuid: active_user.uuid})
+      unsub_contact = insert_crm_contact!(%{email: unsubscribed_user.email, user_uuid: unsubscribed_user.uuid})
+
+      stage_lists_and_members_tables()
+      legacy_list_uuid = uuid!()
+
+      Repo.query!(
+        "INSERT INTO staged_newsletters_lists (uuid, name, slug) VALUES ($1, $2, $3)",
+        [legacy_list_uuid, crm_list.name, crm_list.slug]
+      )
+
+      Repo.query!(
+        """
+        INSERT INTO staged_newsletters_list_members
+          (uuid, user_uuid, list_uuid, status, subscribed_at, unsubscribed_at)
+        VALUES ($1, $2, $3, 'active', '2026-01-15T10:00:00Z', NULL)
+        """,
+        [uuid!(), Ecto.UUID.dump!(active_user.uuid), legacy_list_uuid]
+      )
+
+      Repo.query!(
+        """
+        INSERT INTO staged_newsletters_list_members
+          (uuid, user_uuid, list_uuid, status, subscribed_at, unsubscribed_at)
+        VALUES ($1, $2, $3, 'unsubscribed', '2026-01-10T08:00:00Z', '2026-02-01T09:30:00Z')
+        """,
+        [uuid!(), Ecto.UUID.dump!(unsubscribed_user.uuid), legacy_list_uuid]
+      )
+
+      copy_staged_memberships_to_crm()
+
+      %{rows: [[status, subscribed_at, unsubscribed_at, source]]} =
+        Repo.query!(
+          "SELECT status, subscribed_at, unsubscribed_at, source FROM phoenix_kit_crm_list_members WHERE list_uuid = $1 AND contact_uuid = $2",
+          [crm_list.uuid, active_contact]
+        )
+
+      assert status == "subscribed"
+      assert subscribed_at == ~U[2026-01-15 10:00:00Z]
+      assert unsubscribed_at == nil
+      assert source == "import"
+
+      %{rows: [[status2, subscribed_at2, unsubscribed_at2]]} =
+        Repo.query!(
+          "SELECT status, subscribed_at, unsubscribed_at FROM phoenix_kit_crm_list_members WHERE list_uuid = $1 AND contact_uuid = $2",
+          [crm_list.uuid, unsub_contact]
+        )
+
+      assert status2 == "removed"
+      assert subscribed_at2 == ~U[2026-01-10 08:00:00Z]
+      assert unsubscribed_at2 == ~U[2026-02-01 09:30:00Z]
+    end
+
+    test "recount sets subscriber_count to the number of subscribed members only" do
+      crm_list = insert_crm_list!()
+      user_a = insert_user!()
+      user_b = insert_user!()
+      user_c = insert_user!()
+      contact_a = insert_crm_contact!(%{email: user_a.email, user_uuid: user_a.uuid})
+      contact_b = insert_crm_contact!(%{email: user_b.email, user_uuid: user_b.uuid})
+      contact_c = insert_crm_contact!(%{email: user_c.email, user_uuid: user_c.uuid})
+
+      Repo.query!(
+        "INSERT INTO phoenix_kit_crm_list_members (list_uuid, contact_uuid, status) VALUES ($1, $2, 'subscribed'), ($1, $3, 'subscribed'), ($1, $4, 'removed')",
+        [crm_list.uuid, contact_a, contact_b, contact_c]
+      )
+
+      recount([crm_list.slug])
+
+      %{rows: [[subscriber_count]]} =
+        Repo.query!("SELECT subscriber_count FROM phoenix_kit_crm_lists WHERE uuid = $1", [crm_list.uuid])
+
+      assert subscriber_count == 2
+    end
+
+    test "ON CONFLICT DO NOTHING — a pre-existing membership for (list, contact) is left untouched" do
+      crm_list = insert_crm_list!()
+      user = insert_user!()
+      contact = insert_crm_contact!(%{email: user.email, user_uuid: user.uuid})
+
+      Repo.query!(
+        "INSERT INTO phoenix_kit_crm_list_members (list_uuid, contact_uuid, status) VALUES ($1, $2, 'removed')",
+        [crm_list.uuid, contact]
+      )
+
+      stage_lists_and_members_tables()
+      legacy_list_uuid = uuid!()
+
+      Repo.query!(
+        "INSERT INTO staged_newsletters_lists (uuid, name, slug) VALUES ($1, $2, $3)",
+        [legacy_list_uuid, crm_list.name, crm_list.slug]
+      )
+
+      Repo.query!(
+        "INSERT INTO staged_newsletters_list_members (uuid, user_uuid, list_uuid, status) VALUES ($1, $2, $3, 'active')",
+        [uuid!(), Ecto.UUID.dump!(user.uuid), legacy_list_uuid]
+      )
+
+      copy_staged_memberships_to_crm()
+
+      %{rows: rows} =
+        Repo.query!(
+          "SELECT status FROM phoenix_kit_crm_list_members WHERE list_uuid = $1 AND contact_uuid = $2",
+          [crm_list.uuid, contact]
+        )
+
+      # Still exactly one row, still 'removed' — the migration's INSERT
+      # did not overwrite the pre-existing membership's status.
+      assert rows == [["removed"]]
+    end
+  end
+
+  describe "broadcast re-point semantics (mirrors V156.up's UPDATE)" do
+    test "a broadcast whose list_uuid matches a migrated list is re-pointed to crm_list" do
+      stage_lists_and_members_tables()
+      stage_broadcasts_table()
+
+      crm_list = insert_crm_list!()
+      legacy_list_uuid = uuid!()
+
+      Repo.query!(
+        "INSERT INTO staged_newsletters_lists (uuid, name, slug) VALUES ($1, $2, $3)",
+        [legacy_list_uuid, crm_list.name, crm_list.slug]
+      )
+
+      broadcast_uuid = uuid!()
+
+      Repo.query!(
+        "INSERT INTO staged_broadcasts (uuid, source_type, list_uuid) VALUES ($1, 'newsletters_list', $2)",
+        [broadcast_uuid, legacy_list_uuid]
+      )
+
+      repoint_staged_broadcasts()
+
+      %{rows: [[source_type, crm_list_uuid]]} =
+        Repo.query!("SELECT source_type, crm_list_uuid FROM staged_broadcasts WHERE uuid = $1", [
+          broadcast_uuid
+        ])
+
+      assert source_type == "crm_list"
+      assert crm_list_uuid == crm_list.uuid
+    end
+
+    test "orphan guard stashes an unmatched list_uuid into source_params instead of losing it" do
+      stage_lists_and_members_tables()
+      stage_broadcasts_table()
+
+      orphan_list_uuid = uuid!()
+      broadcast_uuid = uuid!()
+
+      Repo.query!(
+        "INSERT INTO staged_broadcasts (uuid, source_type, list_uuid) VALUES ($1, 'newsletters_list', $2)",
+        [broadcast_uuid, orphan_list_uuid]
+      )
+
+      repoint_staged_broadcasts()
+
+      %{rows: [[source_type, source_params]]} =
+        Repo.query!(
+          "SELECT source_type, source_params FROM staged_broadcasts WHERE uuid = $1",
+          [broadcast_uuid]
+        )
+
+      # Nothing matched — stays at the old flavor, but the uuid it would
+      # otherwise have lost when the column is dropped is preserved.
+      assert source_type == "newsletters_list"
+      assert %{"legacy_list_uuid" => stashed} = source_params
+      assert {:ok, ^orphan_list_uuid} = Ecto.UUID.dump(stashed)
+    end
+  end
+
+  describe "version marker" do
+    test "phoenix_kit table comment is at or past V156" do
+      %{rows: [[comment]]} =
+        Repo.query!("SELECT obj_description('phoenix_kit'::regclass, 'pg_class')")
+
+      # >= rather than ==: pinning the exact latest version breaks this
+      # test every time a NEWER migration ships.
+      assert String.to_integer(comment) >= 156
+    end
+  end
+end


### PR DESCRIPTION
## V156: legacy newsletters lists migrated into CRM, tables dropped

Final schema piece of Stage 4 of the restructuring plan (spec §4.5): newsletters' own list system is retired in favor of CRM contact lists.

> **⚠️ Requires a coordinated release with the newsletters module.** This migration drops `phoenix_kit_newsletters_lists`, `phoenix_kit_newsletters_list_members`, and `phoenix_kit_newsletters_broadcasts.list_uuid` — all still read by the current newsletters release (its `List`/`ListMember` schemas and the `"newsletters_list"` broadcast source path). A host running V156 with the current newsletters package breaks. The newsletters PR that removes that code path follows separately (after BeamLabEU/phoenix_kit_newsletters#22 lands, since it touches the same files); please hold the hex release of core until both are in.

### Sections (one `up/1`, atomic)

1. **Lists → `phoenix_kit_crm_lists`.** Same slug (slug is the idempotency key — a pre-existing CRM list with the same slug is reused, not duplicated); `name`/`description`/`status` verbatim (both use `active`/`archived`); created `subscribable = true`.
2. **Members → contacts + memberships.** A contact per distinct member user (skipped when a contact already exists at that email); user linking is a plain `UPDATE ... FROM phoenix_kit_users` — it reads existing users only, so the `connect_user/2` placeholder-registration hazard is structurally unreachable; a correlated-subquery `LIMIT 1` picks at most one unlinked same-email contact per user (the partial unique index on `user_uuid` would fail a naive multi-row join). Membership status maps `active → subscribed`, `unsubscribed → removed` (unknown values fail closed to `removed`); `subscribed_at`/`unsubscribed_at` preserved verbatim; `ON CONFLICT DO NOTHING`; `subscriber_count` recounted directly.
3. **Broadcast re-point + column drop.** Every `source_type = 'newsletters_list'` broadcast flips to `crm_list` with `crm_list_uuid` set via the slug mapping; an orphan guard stashes any unmatched `list_uuid` into `source_params->>'legacy_list_uuid'` before the column is dropped (in practice a no-op — the `ON DELETE RESTRICT` FK made orphans impossible). Then the FK, its index, and `list_uuid` are dropped.
4. **Drop** `phoenix_kit_newsletters_list_members`, then `phoenix_kit_newsletters_lists`.

The data phase and section 3 run under a `table_exists?` guard, so a second `up/1` run is a clean no-op. `down/1` restores structure only (V79 shapes), never data — consistent with this chain's precedent for destructive sections; migrated rows stay in CRM.

### Why the data migration lives inside the versioned migration

All tables involved — newsletters' and CRM's — are defined by core's own migration chain, and CRM's exist in every installation past V152 regardless of whether the CRM module is installed, so the data always has somewhere to go. This is the same shape V152's send-profiles move already used. The alternative (a required pre-upgrade mix task + a raising guard) turns a single non-interactive `phoenix_kit.update` into a manual two-step that fails mid-chain when forgotten.

### Tests

`test/phoenix_kit/migrations/v156_test.exs` (14 tests): post-migration schema pins (tables/column/FK/index gone), plus staged-replay coverage of each data step's semantics — slug reuse, contact create/link (including the duplicate-unlinked-contacts edge and the never-mints-a-user guarantee), status mapping with verbatim dates, `ON CONFLICT` behavior, recount, broadcast re-point, and the orphan guard. One stale V152 pin updated (`list_uuid` nullable → column absent, with a pointer to V156).

Full migrations + settings suites: **154 tests, 0 failures.**
