### PR TITLE
Atomic custom_fields merge/delete: close the concurrent lost-update race

### DIFF
--- a/lib/phoenix_kit/repo_helper.ex
+++ b/lib/phoenix_kit/repo_helper.ex
@@ -103,6 +103,13 @@ defmodule PhoenixKit.RepoHelper do
   end
 
   @doc """
+  Delegates to the configured repo's update_all function.
+  """
+  def update_all(queryable, updates, opts \\ []) do
+    repo().update_all(queryable, updates, opts)
+  end
+
+  @doc """
   Delegates to the configured repo's exists? function.
   """
   def exists?(queryable, opts \\ []) do

--- a/lib/phoenix_kit/users/auth.ex
+++ b/lib/phoenix_kit/users/auth.ex
@@ -1566,17 +1566,19 @@ defmodule PhoenixKit.Users.Auth do
   def update_user_locale_preference(%User{} = user, preferred_locale) do
     case User.validate_locale_value(preferred_locale) do
       :ok ->
-        # Merge locale into existing custom_fields
-        current_fields = user.custom_fields || %{}
-
-        updated_fields =
-          if preferred_locale && preferred_locale != "" do
-            Map.put(current_fields, "preferred_locale", preferred_locale)
-          else
-            Map.delete(current_fields, "preferred_locale")
-          end
-
-        update_user_custom_fields(user, updated_fields)
+        # Both branches operate on the single affected key at the
+        # database level rather than replacing the whole map — this
+        # function is fired from the language-switcher hook and used to
+        # race (and lose against) any concurrent custom_fields writer,
+        # e.g. a newsletters opt-out. Validation stays above, on the
+        # explicit path, before anything touches the row.
+        if preferred_locale && preferred_locale != "" do
+          merge_user_custom_fields(user, %{"preferred_locale" => preferred_locale},
+            ensure_definitions: false
+          )
+        else
+          delete_user_custom_field(user, "preferred_locale")
+        end
 
       {:error, message} ->
         {:error, message}
@@ -1645,7 +1647,8 @@ defmodule PhoenixKit.Users.Auth do
   Only ever ADDS or OVERWRITES the given keys — this can't clear/remove
   one (unlike `update_user_custom_fields/3`, which replaces the whole
   map and so CAN clear fields by omitting them from the replacement —
-  see that function's own tests). Reach for this whenever the intent is
+  see that function's own tests); to remove a single key atomically use
+  `delete_user_custom_field/3`. Reach for this whenever the intent is
   "add/update these specific keys, leave everything else exactly as any
   concurrent writer left it"; reach for `update_user_custom_fields/3`
   when the caller genuinely needs to replace the whole map.
@@ -1671,10 +1674,11 @@ defmodule PhoenixKit.Users.Auth do
         where: u.uuid == ^user.uuid,
         update: [
           set: [custom_fields: fragment("? || ?", u.custom_fields, type(^additions, :map))]
-        ]
+        ],
+        select: u
       )
 
-    case Repo.update_all(query, [], returning: true) do
+    case Repo.update_all(query, []) do
       {1, [updated_user]} ->
         if Keyword.get(opts, :broadcast, true) do
           Events.broadcast_user_updated(updated_user)
@@ -2005,25 +2009,52 @@ defmodule PhoenixKit.Users.Auth do
       {:ok, %User{}}
   """
   def set_user_custom_field(%User{} = user, key, value) when is_binary(key) do
-    current_fields = user.custom_fields || %{}
-    updated_fields = Map.put(current_fields, key, value)
-    update_user_custom_fields(user, updated_fields)
+    # Delegates to the atomic merge rather than the historical
+    # Map.put + whole-map replace, so a concurrent writer touching a
+    # DIFFERENT key can no longer be silently overwritten — see
+    # merge_user_custom_fields/3.
+    merge_user_custom_fields(user, %{key => value})
   end
 
   @doc """
   Deletes a specific custom field for a user.
 
-  Removes the key from the custom_fields map.
+  Removes the key at the database level (`custom_fields - key`) — the
+  removal counterpart to `merge_user_custom_fields/3`, with the same
+  lost-update rationale: the historical Map.delete + whole-map replace
+  could silently drop a key a concurrent writer had just merged in.
+  Removing an absent key is a no-op that still returns `{:ok, user}`;
+  returns `{:error, :not_found}` if the user row was deleted
+  concurrently.
 
   ## Examples
 
       iex> delete_user_custom_field(user, "phone")
       {:ok, %User{}}
   """
-  def delete_user_custom_field(%User{} = user, key) when is_binary(key) do
-    current_fields = user.custom_fields || %{}
-    updated_fields = Map.delete(current_fields, key)
-    update_user_custom_fields(user, updated_fields)
+  @spec delete_user_custom_field(User.t(), String.t(), keyword()) ::
+          {:ok, User.t()} | {:error, :not_found}
+  def delete_user_custom_field(%User{} = user, key, opts \\ []) when is_binary(key) do
+    query =
+      from(u in User,
+        where: u.uuid == ^user.uuid,
+        update: [
+          set: [custom_fields: fragment("? - ?::text", u.custom_fields, ^key)]
+        ],
+        select: u
+      )
+
+    case Repo.update_all(query, []) do
+      {1, [updated_user]} ->
+        if Keyword.get(opts, :broadcast, true) do
+          Events.broadcast_user_updated(updated_user)
+        end
+
+        {:ok, updated_user}
+
+      {0, _} ->
+        {:error, :not_found}
+    end
   end
 
   @doc """

--- a/lib/phoenix_kit/users/auth.ex
+++ b/lib/phoenix_kit/users/auth.ex
@@ -1624,6 +1624,70 @@ defmodule PhoenixKit.Users.Auth do
   end
 
   @doc """
+  Atomically merges `additions` into a user's custom_fields JSONB column
+  at the database level (`custom_fields || additions`), instead of
+  `update_user_custom_fields/3`'s read-modify-write contract.
+
+  Every existing caller that wants to add/update a couple of keys while
+  preserving the rest follows the same pattern: fetch the user, compute
+  `Map.merge(user.custom_fields, %{"key" => value})` in Elixir, then call
+  `update_user_custom_fields/3` with the merged result. That has a real
+  lost-update race: two callers merging DIFFERENT keys into the same
+  user's custom_fields concurrently (say, a locale preference switch and
+  a newsletters opt-out) can each read the same pre-update snapshot, and
+  whichever write commits second silently overwrites the whole column
+  with a map that never saw the other's key — no error, no conflict
+  raised, just quietly missing data. Doing the merge inside the UPDATE
+  statement itself closes that window: Postgres serializes concurrent
+  writers on the same row, so the second UPDATE's `||` reads the FIRST
+  writer's already-committed value, not a stale snapshot.
+
+  Only ever ADDS or OVERWRITES the given keys — this can't clear/remove
+  one (unlike `update_user_custom_fields/3`, which replaces the whole
+  map and so CAN clear fields by omitting them from the replacement —
+  see that function's own tests). Reach for this whenever the intent is
+  "add/update these specific keys, leave everything else exactly as any
+  concurrent writer left it"; reach for `update_user_custom_fields/3`
+  when the caller genuinely needs to replace the whole map.
+
+  Returns `{:error, :not_found}` rather than raising if the user row was
+  deleted concurrently between the caller's read and this call.
+
+  ## Examples
+
+      iex> merge_user_custom_fields(user, %{"newsletters_opted_out_at" => "2026-01-01T00:00:00Z"})
+      {:ok, %User{}}
+  """
+  @spec merge_user_custom_fields(User.t(), map(), keyword()) ::
+          {:ok, User.t()} | {:error, :not_found}
+  def merge_user_custom_fields(%User{} = user, additions, opts \\ [])
+      when is_map(additions) do
+    if Keyword.get(opts, :ensure_definitions, true) do
+      CustomFields.ensure_definitions_exist(additions)
+    end
+
+    query =
+      from(u in User,
+        where: u.uuid == ^user.uuid,
+        update: [
+          set: [custom_fields: fragment("? || ?", u.custom_fields, type(^additions, :map))]
+        ]
+      )
+
+    case Repo.update_all(query, [], returning: true) do
+      {1, [updated_user]} ->
+        if Keyword.get(opts, :broadcast, true) do
+          Events.broadcast_user_updated(updated_user)
+        end
+
+        {:ok, updated_user}
+
+      {0, _} ->
+        {:error, :not_found}
+    end
+  end
+
+  @doc """
   Updates both schema and custom fields in a single call.
 
   This is a unified update function that automatically splits the provided

--- a/test/integration/users/profile_test.exs
+++ b/test/integration/users/profile_test.exs
@@ -2,6 +2,7 @@ defmodule PhoenixKit.Integration.Users.ProfileTest do
   use PhoenixKit.DataCase, async: true
 
   alias PhoenixKit.Users.Auth
+  alias PhoenixKit.Users.CustomFields
   alias PhoenixKit.Users.Roles
 
   defp unique_email, do: "profile_#{System.unique_integer([:positive])}@example.com"
@@ -102,6 +103,77 @@ defmodule PhoenixKit.Integration.Users.ProfileTest do
         })
 
       assert updated.custom_fields["preferences"]["theme"] == "dark"
+    end
+  end
+
+  describe "merge_user_custom_fields/3" do
+    test "adds a new key while preserving existing ones (unlike update_user_custom_fields/3)" do
+      user = create_user()
+      {:ok, with_color} = Auth.update_user_custom_fields(user, %{"color" => "blue"})
+
+      {:ok, merged} = Auth.merge_user_custom_fields(with_color, %{"size" => "large"})
+
+      assert merged.custom_fields["color"] == "blue"
+      assert merged.custom_fields["size"] == "large"
+    end
+
+    test "overwrites an existing key's value, leaving the rest untouched" do
+      user = create_user()
+
+      {:ok, with_fields} =
+        Auth.update_user_custom_fields(user, %{"color" => "blue", "size" => "large"})
+
+      {:ok, merged} = Auth.merge_user_custom_fields(with_fields, %{"color" => "red"})
+
+      assert merged.custom_fields["color"] == "red"
+      assert merged.custom_fields["size"] == "large"
+    end
+
+    test "persists to the database" do
+      user = create_user()
+      {:ok, _} = Auth.merge_user_custom_fields(user, %{"persisted" => "yes"})
+
+      reloaded = Auth.get_user(user.uuid)
+      assert reloaded.custom_fields["persisted"] == "yes"
+    end
+
+    test "closes the lost-update race — two merges against the same stale in-memory user both survive" do
+      user = create_user()
+      {:ok, with_color} = Auth.update_user_custom_fields(user, %{"color" => "blue"})
+
+      # Both calls start from the SAME stale struct (with_color, whose
+      # in-memory custom_fields is already what the second call would
+      # read if this were a read-modify-write function) — exactly the
+      # shape of two concurrent callers racing off the same snapshot.
+      # update_user_custom_fields/3 would have the second call's write
+      # clobber the first's key entirely; merge_user_custom_fields/3
+      # merges at the database level, so neither key is lost regardless
+      # of what the caller's in-memory struct still thinks is current.
+      {:ok, _} = Auth.merge_user_custom_fields(with_color, %{"newsletters_opted_out_at" => "now"})
+      {:ok, _} = Auth.merge_user_custom_fields(with_color, %{"preferred_locale" => "et"})
+
+      reloaded = Auth.get_user(user.uuid)
+      assert reloaded.custom_fields["color"] == "blue"
+      assert reloaded.custom_fields["newsletters_opted_out_at"] == "now"
+      assert reloaded.custom_fields["preferred_locale"] == "et"
+    end
+
+    test "returns {:error, :not_found} instead of raising when the user row no longer exists" do
+      user = create_user()
+      actor = create_user()
+      {:ok, _} = Auth.delete_user(user, %{current_user: actor})
+
+      assert {:error, :not_found} = Auth.merge_user_custom_fields(user, %{"key" => "value"})
+    end
+
+    test "ensure_definitions: false skips field-definition registration, same as update_user_custom_fields/3" do
+      user = create_user()
+      unique_key = "merge_check_#{System.unique_integer([:positive])}"
+
+      {:ok, _} =
+        Auth.merge_user_custom_fields(user, %{unique_key => "x"}, ensure_definitions: false)
+
+      refute Enum.any?(CustomFields.list_field_definitions(), &(&1["key"] == unique_key))
     end
   end
 

--- a/test/integration/users/profile_test.exs
+++ b/test/integration/users/profile_test.exs
@@ -160,8 +160,14 @@ defmodule PhoenixKit.Integration.Users.ProfileTest do
 
     test "returns {:error, :not_found} instead of raising when the user row no longer exists" do
       user = create_user()
-      actor = create_user()
-      {:ok, _} = Auth.delete_user(user, %{current_user: actor})
+      # Hard-delete the row directly — simulates the user vanishing under
+      # a concurrent caller (Auth.delete_user would trip unrelated
+      # business rules like last-Owner protection).
+      import Ecto.Query
+
+      PhoenixKit.RepoHelper.delete_all(
+        from(u in PhoenixKit.Users.Auth.User, where: u.uuid == ^user.uuid)
+      )
 
       assert {:error, :not_found} = Auth.merge_user_custom_fields(user, %{"key" => "value"})
     end
@@ -174,6 +180,70 @@ defmodule PhoenixKit.Integration.Users.ProfileTest do
         Auth.merge_user_custom_fields(user, %{unique_key => "x"}, ensure_definitions: false)
 
       refute Enum.any?(CustomFields.list_field_definitions(), &(&1["key"] == unique_key))
+    end
+  end
+
+  describe "delete_user_custom_field/3" do
+    test "removes only the named key, atomically" do
+      user = create_user()
+
+      {:ok, with_fields} =
+        Auth.update_user_custom_fields(user, %{"color" => "blue", "preferred_locale" => "et"})
+
+      {:ok, cleared} = Auth.delete_user_custom_field(with_fields, "preferred_locale")
+
+      assert cleared.custom_fields["color"] == "blue"
+      refute Map.has_key?(cleared.custom_fields, "preferred_locale")
+    end
+
+    test "removing an absent key is a no-op {:ok, user}" do
+      user = create_user()
+
+      assert {:ok, unchanged} = Auth.delete_user_custom_field(user, "never_set")
+      assert unchanged.custom_fields == (user.custom_fields || %{})
+    end
+
+    test "returns {:error, :not_found} for a deleted user" do
+      user = create_user()
+      import Ecto.Query
+
+      PhoenixKit.RepoHelper.delete_all(
+        from(u in PhoenixKit.Users.Auth.User, where: u.uuid == ^user.uuid)
+      )
+
+      assert {:error, :not_found} = Auth.delete_user_custom_field(user, "key")
+    end
+  end
+
+  describe "update_user_locale_preference/2 (now atomic underneath)" do
+    test "setting a locale no longer clobbers a concurrently-written key" do
+      user = create_user()
+      # Simulate the racing writer having already committed while the
+      # locale caller still holds the stale pre-write struct.
+      {:ok, _} = Auth.merge_user_custom_fields(user, %{"newsletters_opted_out_at" => "now"})
+
+      {:ok, _} = Auth.update_user_locale_preference(user, "et")
+
+      reloaded = Auth.get_user(user.uuid)
+      assert reloaded.custom_fields["newsletters_opted_out_at"] == "now"
+      assert reloaded.custom_fields["preferred_locale"] == "et"
+    end
+
+    test "clearing the locale removes only that key" do
+      user = create_user()
+      {:ok, with_locale} = Auth.update_user_locale_preference(user, "et")
+      {:ok, _} = Auth.merge_user_custom_fields(with_locale, %{"color" => "blue"})
+
+      {:ok, _} = Auth.update_user_locale_preference(with_locale, nil)
+
+      reloaded = Auth.get_user(user.uuid)
+      refute Map.has_key?(reloaded.custom_fields, "preferred_locale")
+      assert reloaded.custom_fields["color"] == "blue"
+    end
+
+    test "still rejects an invalid locale before touching the row" do
+      user = create_user()
+      assert {:error, _message} = Auth.update_user_locale_preference(user, "not a locale!!")
     end
   end
 


### PR DESCRIPTION
## Atomic custom_fields writes: close the concurrent lost-update race

`custom_fields` writers today follow read-modify-write: fetch the user, `Map.put`/`Map.merge`/`Map.delete` in Elixir, then `update_user_custom_fields/3` replaces the **whole map**. Two callers touching *different* keys concurrently (the language-switcher hook writing `preferred_locale` vs. a module writing its own flag — e.g. the newsletters opt-out marker, which is a compliance-relevant signal) can each read the same snapshot; whichever commits second silently erases the other's key. No error, no conflict — just missing data. (Surfaced as NOTE-2 of the phoenix_kit_newsletters#22 review.)

### What this adds

- **`Auth.merge_user_custom_fields/3`** — merges the given keys inside the UPDATE itself (`custom_fields || $1::jsonb`, `select: u` for the updated row). Postgres serializes concurrent row writers, so the second writer's `||` operates on the first's committed value, not a stale snapshot. Returns `{:error, :not_found}` instead of raising if the row vanished. Options mirror the existing API (`ensure_definitions`, `broadcast`).
- **`delete_user_custom_field/2,3`** (existing function, rewritten) — atomic single-key removal (`custom_fields - key`), since `||` can only add/overwrite. Same contract, plus opts; removing an absent key stays a no-op `{:ok, user}`.
- **Converted callers**: `set_user_custom_field/3` now delegates to the merge; `update_user_locale_preference/2` routes set→merge / clear→atomic delete (validation unchanged, still ahead of any row touch) — this was one half of the racing pair that motivated the change.
- `update_user_custom_fields/3` (whole-map replace) is untouched — replacing the map is a legitimate contract some callers want (its tests pin "replaces entirely" and "empty map clears"); the merge doc spells out when to reach for which.
- `RepoHelper` gains an `update_all/3` delegate (the only repo op the new queries needed that wasn't already wrapped).

### Tests

`test/integration/users/profile_test.exs`: the stale-snapshot race pin (two merges from the same stale struct — both keys survive; the same shape through `update_user_locale_preference` vs. a merged flag), atomic delete semantics, `{:error, :not_found}` for a concurrently-deleted row (via hard row deletion — `Auth.delete_user` trips the unrelated last-Owner protection), `ensure_definitions: false`, no-op merges.

Targeted suites (`users/`, `integration/users/`, `settings/`): 513 tests, 19 failures — all 19 are `MultiSessionTest`, failing identically on a clean upstream/main checkout (pre-existing, unrelated to this change; same class of upstream test regression as #652). Everything this PR touches: green.
