### PR TITLE
Move admin_page_header's back affordance inline beside the title

### DIFF
--- a/lib/phoenix_kit_web/components/core/admin_page_header.ex
+++ b/lib/phoenix_kit_web/components/core/admin_page_header.ex
@@ -27,9 +27,11 @@ defmodule PhoenixKitWeb.Components.Core.AdminPageHeader do
     resolved (e.g. via `Routes.path/1` / `PhoenixKit.Utils.Routes.path/1`) — this
     renders a plain `<.link navigate>`, it does NOT re-apply the PhoenixKit URL
     prefix the way `<.pk_link>` would. When set, renders a compact ghost
-    back-affordance (arrow icon, optionally labeled) above the title.
-  - `back_label` - Optional text shown next to the back arrow. When omitted the
-    button is icon-only (still gets an accessible label).
+    back-affordance inline beside the title, aligned to its first line (never
+    on its own row — an icon-only circle by default).
+  - `back_label` - Optional text shown next to the back arrow (from the `sm`
+    breakpoint up; phones stay icon-only). When omitted the button is a
+    circular icon-only chip (still gets an accessible label + title tooltip).
   - `back_click` - Deprecated, no-op. Retained so existing callers compile.
 
   ## Slots
@@ -85,17 +87,21 @@ defmodule PhoenixKitWeb.Components.Core.AdminPageHeader do
   def admin_page_header(assigns) do
     ~H"""
     <header class={@class || "mb-3 sm:mb-6"}>
-      <.link
-        :if={@back}
-        navigate={@back}
-        class="btn btn-ghost btn-sm -ml-2 mb-1 gap-1"
-        aria-label={@back_label || gettext("Back")}
-      >
-        <.icon name="hero-arrow-left" class="w-4 h-4" />
-        <span :if={@back_label}>{@back_label}</span>
-      </.link>
       <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-        <div class="flex items-center gap-3 min-w-0">
+        <div class="flex items-start gap-2 min-w-0">
+          <.link
+            :if={@back}
+            navigate={@back}
+            class={[
+              "btn btn-ghost btn-sm shrink-0 -ml-2 mt-0.5 lg:mt-1",
+              (@back_label && "gap-1") || "btn-circle"
+            ]}
+            aria-label={@back_label || gettext("Back")}
+            title={@back_label || gettext("Back")}
+          >
+            <.icon name="hero-arrow-left" class="w-4 h-4" />
+            <span :if={@back_label} class="hidden sm:inline">{@back_label}</span>
+          </.link>
           <div class="min-w-0">
             <%= if @title do %>
               <h1 class="text-xl sm:text-2xl lg:text-3xl font-bold text-base-content break-words">

--- a/test/phoenix_kit_web/components/core/admin_page_header_test.exs
+++ b/test/phoenix_kit_web/components/core/admin_page_header_test.exs
@@ -50,6 +50,37 @@ defmodule PhoenixKitWeb.Components.Core.AdminPageHeaderTest do
       assert result =~ ~s(aria-label="Back")
     end
 
+    test "icon-only back renders as an inline circle chip, not a standalone row" do
+      assigns = %{}
+
+      result =
+        rendered_to_string(~H"""
+        <.admin_page_header back="/admin/x" title="Send Profiles" />
+        """)
+
+      # The chip lives inside the title cluster (items-start) as a circle…
+      assert result =~ "btn-circle"
+      assert result =~ "items-start"
+      # …and the back link precedes the h1 within the same flex row: the link
+      # must open AFTER the title-row wrapper div, never before it (the old
+      # anatomy rendered it as a standalone row above).
+      {link_pos, _} = :binary.match(result, "hero-arrow-left")
+      {row_pos, _} = :binary.match(result, "sm:justify-between")
+      assert row_pos < link_pos
+    end
+
+    test "back_label switches the chip off circle mode and hides the label on phones" do
+      assigns = %{}
+
+      result =
+        rendered_to_string(~H"""
+        <.admin_page_header back="/admin/x" back_label="Email Sending" title="Send Profiles" />
+        """)
+
+      refute result =~ "btn-circle"
+      assert result =~ "hidden sm:inline"
+    end
+
     test "no back attr → no back link rendered" do
       assigns = %{}
 


### PR DESCRIPTION
## Summary

The shared `admin_page_header` component rendered its `back` link as a bare arrow ghost button **on its own row above the title** — on every admin page of every module that passes `back`, the arrow read as an orphaned/broken control (raised on publishing's group page, but the anatomy came from here).

The back link now renders **inline inside the title cluster**: a circular icon-only ghost chip aligned to the title's first line (`items-start` + a small top offset so multi-line title+subtitle blocks keep first-line alignment). When `back_label` is passed, the chip widens and shows the label from the `sm` breakpoint up (phones stay icon-only). `aria-label` + a `title` tooltip cover discoverability in both modes.

```
before                             after
[<-]                               (<-) Date123          [actions…]
Date123               [actions…]        subtitle
subtitle
```

No caller API change — `back` / `back_label` / `back_click` (deprecated no-op) keep their contracts, so all existing call sites (core's integration form + user details, publishing's index/edit/new/group pages, other modules) pick up the fix with zero edits. Saves a full row of vertical space above every list.

## Background

A 5-AI design panel (Gemini/Vibe/Grok/Codex/ZAI) brainstormed the header layout and unanimously picked this inline-chip anatomy as the component-level fix, with the breadcrumb-offload direction (page_section, as in the projects module) as the longer-term evolution for list/show pages — this change is complementary to that, since rich in-content headers (edit forms, detail pages) keep using the component either way.

## Testing

- `mix precommit` clean.
- `admin_page_header_test.exs`: 7 tests, 0 failures — existing pins (href, icon, aria-label, label text, no-back) unchanged; two new pins: icon-only mode renders an inline `btn-circle` inside the title row (position-asserted against the old standalone-row anatomy), and `back_label` switches off circle mode with the label `hidden sm:inline`.
- Browser-verified through `phoenix_kit_parent` on publishing's group page (rich inner_block + actions) and edit-group page (title-attr variant): chip renders 28×28 beside the first title line, actions stay right-aligned, header height drops ~30px.