### PR TITLE
Move admin_page_header's back affordance inline beside the title

### DIFF
--- a/lib/phoenix_kit_web/components/core/admin_page_header.ex
+++ b/lib/phoenix_kit_web/components/core/admin_page_header.ex
@@ -27,9 +27,11 @@ defmodule PhoenixKitWeb.Components.Core.AdminPageHeader do
     resolved (e.g. via `Routes.path/1` / `PhoenixKit.Utils.Routes.path/1`) — this
     renders a plain `<.link navigate>`, it does NOT re-apply the PhoenixKit URL
     prefix the way `<.pk_link>` would. When set, renders a compact ghost
-    back-affordance (arrow icon, optionally labeled) above the title.
-  - `back_label` - Optional text shown next to the back arrow. When omitted the
-    button is icon-only (still gets an accessible label).
+    back-affordance inline beside the title, aligned to its first line (never
+    on its own row — an icon-only circle by default).
+  - `back_label` - Optional text shown next to the back arrow (from the `sm`
+    breakpoint up; phones stay icon-only). When omitted the button is a
+    circular icon-only chip (still gets an accessible label + title tooltip).
   - `back_click` - Deprecated, no-op. Retained so existing callers compile.
 
   ## Slots
@@ -83,19 +85,41 @@ defmodule PhoenixKitWeb.Components.Core.AdminPageHeader do
   slot :actions
 
   def admin_page_header(assigns) do
+    # A blank back_label behaves as absent — "" is truthy in Elixir and would
+    # otherwise pick labeled mode with an empty aria-label/tooltip.
+    assigns =
+      case assigns.back_label do
+        "" -> assign(assigns, :back_label, nil)
+        _ -> assigns
+      end
+
     ~H"""
     <header class={@class || "mb-3 sm:mb-6"}>
-      <.link
-        :if={@back}
-        navigate={@back}
-        class="btn btn-ghost btn-sm -ml-2 mb-1 gap-1"
-        aria-label={@back_label || gettext("Back")}
-      >
-        <.icon name="hero-arrow-left" class="w-4 h-4" />
-        <span :if={@back_label}>{@back_label}</span>
-      </.link>
       <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-        <div class="flex items-center gap-3 min-w-0">
+        <%!-- gap-x-2, NOT gap-2: core's legacy shipped app.css carries an
+          unlayered mobile rule (`.flex.gap-2 > .btn { width: 100% }` at
+          ≤768px) that would stretch the back chip full-width — layered
+          Tailwind utilities cannot override it, so keep the class off the
+          selector's reach. The :actions div's gap-2 stays: its buttons rely
+          on that stretch. --%>
+        <div class="flex items-start gap-x-2 min-w-0">
+          <.link
+            :if={@back}
+            navigate={@back}
+            class={
+              [
+                "btn btn-ghost btn-sm shrink-0 -ml-2 mt-0.5 lg:mt-1",
+                # Icon-only renders as a circle; a labeled chip keeps the circle
+                # on phones too, where the label span is hidden anyway.
+                (@back_label && "max-sm:btn-circle gap-1") || "btn-circle"
+              ]
+            }
+            aria-label={@back_label || gettext("Back")}
+            title={@back_label || gettext("Back")}
+          >
+            <.icon name="hero-arrow-left" class="w-4 h-4" />
+            <span :if={@back_label} class="hidden sm:inline">{@back_label}</span>
+          </.link>
           <div class="min-w-0">
             <%= if @title do %>
               <h1 class="text-xl sm:text-2xl lg:text-3xl font-bold text-base-content break-words">

--- a/test/phoenix_kit_web/components/core/admin_page_header_test.exs
+++ b/test/phoenix_kit_web/components/core/admin_page_header_test.exs
@@ -50,6 +50,81 @@ defmodule PhoenixKitWeb.Components.Core.AdminPageHeaderTest do
       assert result =~ ~s(aria-label="Back")
     end
 
+    test "icon-only back renders as an inline circle chip, not a standalone row" do
+      assigns = %{}
+
+      result =
+        rendered_to_string(~H"""
+        <.admin_page_header back="/admin/x" title="Send Profiles" />
+        """)
+
+      # The chip lives inside the title cluster (items-start) as a circle —
+      # the plain circle, not the labeled variant's phone-only one.
+      assert result =~ "btn-circle"
+      refute result =~ "max-sm:btn-circle"
+      assert result =~ "items-start"
+      # The tooltip must survive refactors — it's the icon-only mode's only
+      # visible hint.
+      assert result =~ ~s(title="Back")
+      # gap-x-2, never gap-2: the legacy shipped app.css mobile rule
+      # `.flex.gap-2 > .btn { width: 100% }` would stretch the chip full-width
+      # on phones (unlayered — utilities can't override it).
+      assert result =~ "gap-x-2"
+      refute result =~ ~s(class="flex items-start gap-2 min-w-0")
+      # …and the back link precedes the h1 within the same flex row: the link
+      # must open AFTER the title-row wrapper div, never before it (the old
+      # anatomy rendered it as a standalone row above).
+      {link_pos, _} = :binary.match(result, "hero-arrow-left")
+      {row_pos, _} = :binary.match(result, "sm:justify-between")
+      assert row_pos < link_pos
+    end
+
+    test "back_label switches the chip off circle mode and hides the label on phones" do
+      assigns = %{}
+
+      result =
+        rendered_to_string(~H"""
+        <.admin_page_header back="/admin/x" back_label="Email Sending" title="Send Profiles" />
+        """)
+
+      # Labeled: not a circle from `sm` up, but still a circle on phones
+      # (where the label span is hidden and only the icon shows).
+      refute result =~ ~s( btn-circle)
+      assert result =~ "max-sm:btn-circle"
+      assert result =~ "hidden sm:inline"
+    end
+
+    test "a blank back_label behaves as absent (icon-only circle, real aria-label)" do
+      assigns = %{}
+
+      result =
+        rendered_to_string(~H"""
+        <.admin_page_header back="/admin/x" back_label="" title="Send Profiles" />
+        """)
+
+      # "" is truthy in Elixir — without normalization this would pick labeled
+      # mode with an empty aria-label/tooltip.
+      assert result =~ "btn-circle"
+      refute result =~ "max-sm:btn-circle"
+      assert result =~ ~s(aria-label="Back")
+    end
+
+    test "back composes with inner_block titles (the rich-markup call sites)" do
+      assigns = %{}
+
+      result =
+        rendered_to_string(~H"""
+        <.admin_page_header back="/admin/x">
+          <h1 class="text-xl font-bold">Invoice #123</h1>
+          <p class="text-sm">Created 2 days ago</p>
+        </.admin_page_header>
+        """)
+
+      assert result =~ "btn-circle"
+      assert result =~ "Invoice #123"
+      assert result =~ "Created 2 days ago"
+    end
+
     test "no back attr → no back link rendered" do
       assigns = %{}
 


### PR DESCRIPTION
## Summary

The shared `admin_page_header` component rendered its `back` link as a bare arrow ghost button **on its own row above the title** — on every admin page of every module that passes `back`, the arrow read as an orphaned/broken control.

The back link now renders **inline inside the title cluster**: a circular icon-only ghost chip aligned to the title's first line. With `back_label`, the chip widens to show the label from the `sm` breakpoint up (phones stay a circle — the label span is hidden there). `aria-label` + a `title` tooltip cover discoverability in both modes, and a blank `back_label` normalizes to absent so it can't produce an empty aria-label.

```
before                             after
[<-]                               (<-) Date123          [actions…]
Date123               [actions…]        subtitle
subtitle
```

No caller API change — `back` / `back_label` / `back_click` (deprecated no-op) keep their contracts, so all existing call sites (~30 swept across core + modules) pick up the fix with zero edits, and every page saves a full row of vertical space.

## The subtle bit: `gap-x-2`, not `gap-2`

The legacy shipped `app.css` carries an **unlayered** mobile rule — `.flex.gap-2 > .btn { width: 100% }` at ≤768px — that would stretch the chip full-width on phones and squeeze the title out. Layered Tailwind utilities cannot override an unlayered rule, so the title cluster deliberately uses `gap-x-2` to stay off the selector's reach (the `:actions` div keeps `gap-2` — its buttons rely on that stretch). Pinned by a test comment + assertion so it can't be "simplified" back.

## Review

Designed and reviewed with a multi-AI panel (two rounds: a 5-AI layout brainstorm picked this anatomy unanimously; a 5-AI adversarial review of the diff found the legacy-CSS mobile regression — fixed above — and drove the test hardening below). Browser-verified at desktop and at 700px (inside the legacy media query): 28×28 circle beside the title.

## Testing

`mix precommit` clean. Component suite: **9 tests, 0 failures** — existing pins plus: inline-circle anatomy (position-asserted against the old standalone-row), labeled-mode phone/desktop split (`max-sm:btn-circle` / `hidden sm:inline`), tooltip presence, blank-label normalization, `gap-x-2` regression pin, and `back` composing with `inner_block` titles (the rich-markup call sites).

Supersedes #658 (same change, pre-review; closed while iterating).