### PR TITLE
V158: broadcast attachments column (accumulator)

### DIFF
--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -529,7 +529,16 @@ defmodule PhoenixKit.Migrations.Postgres do
   - Replaces unique index with partial index (slug-mode only, WHERE slug IS NOT NULL)
   - Adds unique index on `(group_uuid, post_date, post_time)` for timestamp-mode posts
 
-  ### V157 - Image annotation kind ⚡ LATEST
+  ### V158 - Broadcast attachments (accumulator) ⚡ LATEST
+  - Adds `attachments JSONB NOT NULL DEFAULT '[]'` to
+    `phoenix_kit_newsletters_broadcasts` — an ordered list of Storage
+    file uuids attached to every email of the broadcast; soft references
+    (no FK) per this table's `crm_list_uuid` precedent, with a
+    `jsonb_typeof = 'array'` CHECK as the DB-level shape backstop
+  - Unreleased — per the one-open-migration rule, further DDL lands here
+    as new sections until this ships
+
+  ### V157 - Image annotation kind
   - Widens `phoenix_kit_annotations_kind_check` to allow `'image'`
   - Pairs with the schema's `@kinds` (also widened) so Etcher's `:image`
     tool — exposed in the media viewer's toolbar by PR #660 — can
@@ -1393,7 +1402,7 @@ defmodule PhoenixKit.Migrations.Postgres do
   alias PhoenixKit.Migrations.Postgres.Helpers
 
   @initial_version 1
-  @current_version 157
+  @current_version 158
   @default_prefix "public"
 
   # First version whose SQL references uuid_generate_v7(). Chains that

--- a/lib/phoenix_kit/migrations/postgres/v158.ex
+++ b/lib/phoenix_kit/migrations/postgres/v158.ex
@@ -1,0 +1,75 @@
+defmodule PhoenixKit.Migrations.Postgres.V158 do
+  @moduledoc """
+  V158: broadcast attachments (accumulator).
+
+  Per the one-open-migration rule this file is the accumulator for the
+  restructuring work until it ships in a release; later sections append
+  here rather than opening V159.
+
+  ## Section: `phoenix_kit_newsletters_broadcasts.attachments`
+
+  A JSONB array of Storage file uuids (`phoenix_kit_files.uuid`) to be
+  attached to every email of the broadcast. Deliberately a bare uuid
+  list, not an FK'd join table:
+
+  - The soft-reference pattern matches this table's existing
+    `crm_list_uuid`/`source_params` precedent — newsletters rows never
+    hold FKs into other modules' tables, so a file deleted from Media
+    later degrades to "skipped at send time" (the worker resolves each
+    uuid via Storage and skips misses) rather than blocking the delete
+    with a RESTRICT nobody can see the reason for.
+  - Order matters to the sender (attachments appear in the email in list
+    order), which a join table would need an extra column to preserve;
+    a JSONB array carries it for free.
+
+  The application-side writer (broadcast editor + `Broadcast` changeset,
+  newsletters package) validates entries are uuids and caps the count;
+  the column itself only guarantees "a JSON array" via the CHECK — the
+  DB-level backstop that a stray writer can't store an object/scalar
+  here and crash every reader.
+
+  All operations idempotent.
+  """
+
+  use Ecto.Migration
+
+  def up(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    execute("""
+    ALTER TABLE #{p}phoenix_kit_newsletters_broadcasts
+      ADD COLUMN IF NOT EXISTS attachments JSONB NOT NULL DEFAULT '[]'
+    """)
+
+    execute(
+      "ALTER TABLE #{p}phoenix_kit_newsletters_broadcasts DROP CONSTRAINT IF EXISTS phoenix_kit_newsletters_broadcasts_attachments_is_array"
+    )
+
+    execute("""
+    ALTER TABLE #{p}phoenix_kit_newsletters_broadcasts
+      ADD CONSTRAINT phoenix_kit_newsletters_broadcasts_attachments_is_array
+      CHECK (jsonb_typeof(attachments) = 'array')
+    """)
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '158'")
+  end
+
+  def down(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    execute(
+      "ALTER TABLE #{p}phoenix_kit_newsletters_broadcasts DROP CONSTRAINT IF EXISTS phoenix_kit_newsletters_broadcasts_attachments_is_array"
+    )
+
+    execute(
+      "ALTER TABLE #{p}phoenix_kit_newsletters_broadcasts DROP COLUMN IF EXISTS attachments"
+    )
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '157'")
+  end
+
+  defp prefix_str("public"), do: "public."
+  defp prefix_str(prefix), do: "#{prefix}."
+end

--- a/lib/phoenix_kit/migrations/postgres/v158.ex
+++ b/lib/phoenix_kit/migrations/postgres/v158.ex
@@ -39,7 +39,7 @@ defmodule PhoenixKit.Migrations.Postgres.V158 do
 
     execute("""
     ALTER TABLE #{p}phoenix_kit_newsletters_broadcasts
-      ADD COLUMN IF NOT EXISTS attachments JSONB NOT NULL DEFAULT '[]'
+      ADD COLUMN IF NOT EXISTS attachments JSONB NOT NULL DEFAULT '[]'::jsonb
     """)
 
     execute(

--- a/test/phoenix_kit/migrations/v158_test.exs
+++ b/test/phoenix_kit/migrations/v158_test.exs
@@ -1,0 +1,72 @@
+defmodule PhoenixKit.Migrations.Postgres.V158Test do
+  @moduledoc """
+  Pins the post-V158 schema shape — the suite's `ensure_current/2` runs
+  the full chain (now through V158) before any test, same approach as
+  `v155_test.exs`/`v156_test.exs`.
+  """
+
+  use PhoenixKit.DataCase, async: false
+
+  alias PhoenixKit.RepoHelper, as: Repo
+
+  defp column(table, name) do
+    %{rows: rows} =
+      Repo.query!(
+        """
+        SELECT data_type, is_nullable, column_default
+        FROM information_schema.columns
+        WHERE table_name = $1 AND column_name = $2
+        """,
+        [table, name]
+      )
+
+    case rows do
+      [[data_type, is_nullable, default]] ->
+        %{type: data_type, nullable: is_nullable, default: default}
+
+      [] ->
+        nil
+    end
+  end
+
+  describe "phoenix_kit_newsletters_broadcasts.attachments" do
+    test "jsonb, NOT NULL, defaults to an empty array" do
+      assert %{type: "jsonb", nullable: "NO", default: default} =
+               column("phoenix_kit_newsletters_broadcasts", "attachments")
+
+      assert default =~ "'[]'::jsonb"
+    end
+
+    test "the CHECK rejects a non-array value" do
+      assert_raise Postgrex.Error, ~r/attachments_is_array/, fn ->
+        Repo.query!("""
+        INSERT INTO phoenix_kit_newsletters_broadcasts (subject, attachments)
+        VALUES ('V158 shape check', '{"not": "an array"}'::jsonb)
+        """)
+      end
+    end
+
+    test "an array of uuids inserts cleanly and round-trips in order" do
+      %{rows: [[attachments]]} =
+        Repo.query!("""
+        INSERT INTO phoenix_kit_newsletters_broadcasts (subject, attachments)
+        VALUES ('V158 roundtrip', '["019f0000-0000-7000-8000-000000000001", "019f0000-0000-7000-8000-000000000002"]'::jsonb)
+        RETURNING attachments
+        """)
+
+      assert attachments == [
+               "019f0000-0000-7000-8000-000000000001",
+               "019f0000-0000-7000-8000-000000000002"
+             ]
+    end
+  end
+
+  describe "version marker" do
+    test "phoenix_kit table comment is at or past V158" do
+      %{rows: [[comment]]} =
+        Repo.query!("SELECT obj_description('phoenix_kit'::regclass, 'pg_class')")
+
+      assert String.to_integer(comment) >= 158
+    end
+  end
+end


### PR DESCRIPTION
## V158 — new accumulator (V157 shipped in 1.7.210)

One section for now: `attachments JSONB NOT NULL DEFAULT '[]'` on `phoenix_kit_newsletters_broadcasts` — an **ordered** list of Storage file uuids to attach to every email of a broadcast.

- Soft references (no FK into `phoenix_kit_files`), per this table's `crm_list_uuid`/`source_params` precedent: a file later deleted from Media degrades to skipped-at-send (the worker resolves each uuid and skips misses) instead of a RESTRICT nobody can trace.
- A JSONB array (not a join table) because order matters to the sender and the array carries it for free; `jsonb_typeof = 'array'` CHECK as the DB-level shape backstop. Count/uuid validation lives in the newsletters changeset (companion PR to follow there — editor picker via the core MediaSelector + Swoosh attachments in the DeliveryWorker).

Tests: shape pins (type/NOT NULL/default), CHECK rejection of a non-array, ordered round-trip. Migrations + settings suites: **160 tests, 0 failures.**