### PR TITLE
Installer/doctor: ship Oban.Plugins.Lifeline to host apps

### DIFF
--- a/lib/mix/tasks/phoenix_kit.doctor.ex
+++ b/lib/mix/tasks/phoenix_kit.doctor.ex
@@ -670,11 +670,29 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
     queues = Keyword.get(config, :queues, [])
     plugins = Keyword.get(config, :plugins, [])
 
-    {:pass,
-     "#{length(queues)} queues, #{length(plugins)} plugins. Each active queue uses 1 pool connection."}
+    base =
+      "#{length(queues)} queues, #{length(plugins)} plugins. Each active queue uses 1 pool connection."
+
+    if lifeline_plugin_configured?(plugins) do
+      {:pass, base}
+    else
+      {:warn,
+       base <>
+         " Oban.Plugins.Lifeline is not configured — a job orphaned in :executing by a hard " <>
+         "crash (kill -9, OOM, node failure) is never rescued back to :available. Run " <>
+         "mix phoenix_kit.update to add {Oban.Plugins.Lifeline, rescue_after: :timer.minutes(30)}."}
+    end
   end
 
   defp check_oban_config(_other), do: {:pass, "Oban configured (non-keyword config)"}
+
+  defp lifeline_plugin_configured?(plugins) do
+    Enum.any?(plugins, fn
+      Oban.Plugins.Lifeline -> true
+      {Oban.Plugins.Lifeline, _opts} -> true
+      _ -> false
+    end)
+  end
 
   defp check_supervisor_state do
     case Process.whereis(PhoenixKit.Supervisor) do

--- a/lib/phoenix_kit/install/oban_config.ex
+++ b/lib/phoenix_kit/install/oban_config.ex
@@ -20,6 +20,7 @@ defmodule PhoenixKit.Install.ObanConfig do
   @dialyzer {:nowarn_function, ensure_catalogue_pdf_queue: 2}
   @dialyzer {:nowarn_function, ensure_cron_plugin: 2}
   @dialyzer {:nowarn_function, ensure_pruner_max_age: 2}
+  @dialyzer {:nowarn_function, ensure_lifeline_plugin: 2}
   @dialyzer {:nowarn_function, add_cron_plugin_to_plugins: 2}
 
   alias Igniter.Libs.Phoenix
@@ -211,6 +212,10 @@ defmodule PhoenixKit.Install.ObanConfig do
       plugins: [
         # Pruner: delete completed/discarded jobs after 30 days
         {Oban.Plugins.Pruner, max_age: 60 * 60 * 24 * 30},
+        # Lifeline: rescue jobs orphaned in :executing by a hard crash
+        # (BEAM kill -9, OOM, node failure) back to :available so they
+        # run again — without it, an orphaned job sits stuck forever.
+        {Oban.Plugins.Lifeline, rescue_after: :timer.minutes(30)},
         {Oban.Plugins.Cron,
          crontab: [
            {"* * * * *", PhoenixKit.ScheduledJobs.Workers.ProcessScheduledJobsWorker},
@@ -266,10 +271,11 @@ defmodule PhoenixKit.Install.ObanConfig do
       |> ensure_catalogue_pdf_queue(app_name)
       |> ensure_cron_plugin(app_name)
       |> ensure_pruner_max_age(app_name)
+      |> ensure_lifeline_plugin(app_name)
 
     if updated_content == content do
       Mix.shell().info(
-        "✅ Oban configuration already up-to-date (queues, cron plugin, and pruner max_age present)"
+        "✅ Oban configuration already up-to-date (queues, cron plugin, pruner max_age, and Lifeline present)"
       )
     else
       Mix.shell().info("✅ Updated Oban configuration (queues, cron plugin, pruner retention)")
@@ -534,6 +540,68 @@ defmodule PhoenixKit.Install.ObanConfig do
           Mix.shell().info("  ℹ️  Pruner configuration not found or already has options")
           content
         end
+      end
+    end
+  end
+
+  @doc """
+  Ensure the Lifeline plugin exists in an existing `config :app, Oban`
+  block's `plugins:` list, adding it if missing.
+
+  Rescues a job orphaned in `:executing` by a hard crash (BEAM `kill -9`,
+  OOM, node failure) back to `:available` so it runs again — without it,
+  an orphaned job sits stuck in `:executing` forever. That's more than a
+  stalled retry: for a unique worker whose unique `states:` includes
+  `:executing` (a self-scheduling chain deduping against its own
+  in-flight run is a common pattern — see `phoenix_kit_emails`' pollers),
+  an orphan permanently blocks every future insert for that worker too,
+  not just the one crashed job.
+
+  Public (not `defp`, unlike the sibling `ensure_*_queue/2` helpers)
+  specifically so this can be unit-tested directly against plain content
+  strings, the same way `oban_block_missing_prefix?/1` is — no live
+  Igniter/Mix context needed.
+  """
+  @spec ensure_lifeline_plugin(String.t(), atom() | String.t()) :: String.t()
+  def ensure_lifeline_plugin(content, app_name) do
+    if Regex.match?(~r/Oban\.Plugins\.Lifeline/, content) do
+      Mix.shell().info("  ℹ️  Lifeline plugin already configured")
+      content
+    else
+      Mix.shell().info("  ➕ Adding Oban.Plugins.Lifeline to Oban configuration...")
+
+      case Regex.run(
+             ~r/(^[ \t]+plugins:\s*\[\n)(.*?)(\n[ \t]+\])/ms,
+             content,
+             capture: :all
+           ) do
+        [full_match, plugins_open, plugins_content, plugins_close] ->
+          Mix.shell().info("  ✓ Found plugins block, adding Lifeline plugin")
+
+          trimmed_content = String.trim(plugins_content)
+          has_trailing_comma = String.ends_with?(trimmed_content, ",")
+
+          lifeline_plugin =
+            if has_trailing_comma do
+              "\n    {Oban.Plugins.Lifeline, rescue_after: :timer.minutes(30)}"
+            else
+              ",\n    {Oban.Plugins.Lifeline, rescue_after: :timer.minutes(30)}"
+            end
+
+          updated_plugins = plugins_open <> plugins_content <> lifeline_plugin <> plugins_close
+
+          String.replace(content, full_match, updated_plugins, global: false)
+
+        nil ->
+          Mix.shell().error(
+            "  ⚠️  Could not parse plugins block for :#{app_name} - skipping Lifeline plugin update"
+          )
+
+          Mix.shell().error(
+            "     Please manually add: {Oban.Plugins.Lifeline, rescue_after: :timer.minutes(30)}"
+          )
+
+          content
       end
     end
   end
@@ -861,6 +929,8 @@ defmodule PhoenixKit.Install.ObanConfig do
         plugins: [
           # Pruner: delete completed/discarded jobs after 30 days
           {Oban.Plugins.Pruner, max_age: 60 * 60 * 24 * 30},
+          # Lifeline: rescue jobs orphaned in :executing by a hard crash
+          {Oban.Plugins.Lifeline, rescue_after: :timer.minutes(30)},
           {Oban.Plugins.Cron,
            crontab: [
              {"* * * * *", PhoenixKit.ScheduledJobs.Workers.ProcessScheduledJobsWorker},

--- a/lib/phoenix_kit/install/oban_config.ex
+++ b/lib/phoenix_kit/install/oban_config.ex
@@ -278,7 +278,9 @@ defmodule PhoenixKit.Install.ObanConfig do
         "✅ Oban configuration already up-to-date (queues, cron plugin, pruner max_age, and Lifeline present)"
       )
     else
-      Mix.shell().info("✅ Updated Oban configuration (queues, cron plugin, pruner retention)")
+      Mix.shell().info(
+        "✅ Updated Oban configuration (queues, cron plugin, pruner retention, Lifeline)"
+      )
     end
 
     Rewrite.Source.update(source, :content, updated_content)
@@ -570,22 +572,36 @@ defmodule PhoenixKit.Install.ObanConfig do
     else
       Mix.shell().info("  ➕ Adding Oban.Plugins.Lifeline to Oban configuration...")
 
+      # The closing `]` is matched at the SAME indentation as the
+      # `plugins:` keyword itself (backreference `\\2`). A lazy `.*?` up
+      # to the first `]` would instead stop inside a nested list — the
+      # generated config's own Cron plugin carries `crontab: [...]`, and
+      # inserting there corrupts the file (review finding on this very
+      # function). Nested lists are always indented deeper, so anchoring
+      # the close to the keyword's indentation skips them.
       case Regex.run(
-             ~r/(^[ \t]+plugins:\s*\[\n)(.*?)(\n[ \t]+\])/ms,
+             ~r/(^([ \t]+)plugins:\s*\[\n)(.*?)(\n\2\])/ms,
              content,
              capture: :all
            ) do
-        [full_match, plugins_open, plugins_content, plugins_close] ->
+        [full_match, plugins_open, indent, plugins_content, plugins_close] ->
           Mix.shell().info("  ✓ Found plugins block, adding Lifeline plugin")
 
           trimmed_content = String.trim(plugins_content)
           has_trailing_comma = String.ends_with?(trimmed_content, ",")
 
+          # Entry indentation inferred from the block's own: keyword
+          # indent + 2, matching how the generated template nests entries.
+          entry_indent = indent <> "  "
+
+          lifeline_entry =
+            entry_indent <> "{Oban.Plugins.Lifeline, rescue_after: :timer.minutes(30)}"
+
           lifeline_plugin =
             if has_trailing_comma do
-              "\n    {Oban.Plugins.Lifeline, rescue_after: :timer.minutes(30)}"
+              "\n" <> lifeline_entry
             else
-              ",\n    {Oban.Plugins.Lifeline, rescue_after: :timer.minutes(30)}"
+              ",\n" <> lifeline_entry
             end
 
           updated_plugins = plugins_open <> plugins_content <> lifeline_plugin <> plugins_close

--- a/test/phoenix_kit/install/oban_config_test.exs
+++ b/test/phoenix_kit/install/oban_config_test.exs
@@ -161,6 +161,53 @@ defmodule PhoenixKit.Install.ObanConfigTest do
       assert ObanConfig.ensure_lifeline_plugin(content, "my_app") == content
     end
 
+    test "closes at the plugins-block bracket, not the Cron crontab's nested one" do
+      # The real generated config always carries a Cron plugin with a
+      # nested `crontab: [...]` list. A lazy match to the FIRST `]` used
+      # to insert Lifeline INSIDE that list, corrupting the config
+      # (review finding). The close is anchored to the `plugins:`
+      # keyword's own indentation, which nested lists never share.
+      content = """
+      config :my_app, Oban,
+        repo: MyApp.Repo,
+        plugins: [
+          {Oban.Plugins.Pruner, max_age: 60 * 60 * 24 * 30},
+          {Oban.Plugins.Cron,
+           crontab: [
+             {"* * * * *", PhoenixKit.ScheduledJobs.Workers.ProcessScheduledJobsWorker}
+           ]}
+        ]
+      """
+
+      updated = ObanConfig.ensure_lifeline_plugin(content, "my_app")
+
+      assert updated =~ "Oban.Plugins.Lifeline"
+
+      # Lifeline landed as a SIBLING of Cron (after its closing `]}`),
+      # not inside the crontab list.
+      assert updated =~ ~r/\]\}[,]?\n\s+\{Oban\.Plugins\.Lifeline/
+
+      refute updated =~ ~r/crontab: \[[^\]]*Lifeline/s
+
+      # Still parseable Elixir.
+      assert {:ok, _} = Code.string_to_quoted(updated)
+    end
+
+    test "inserted entry inherits the block's own indentation" do
+      content = """
+      config :my_app, Oban,
+          plugins: [
+            {Oban.Plugins.Pruner, max_age: 60}
+          ]
+      """
+
+      updated = ObanConfig.ensure_lifeline_plugin(content, "my_app")
+
+      # plugins: at 4 spaces -> entries at 6.
+      assert updated =~ "\n      {Oban.Plugins.Lifeline"
+      assert {:ok, _} = Code.string_to_quoted(updated)
+    end
+
     test "leaves content unchanged when no plugins: block can be found" do
       content = """
       config :my_app, Oban,

--- a/test/phoenix_kit/install/oban_config_test.exs
+++ b/test/phoenix_kit/install/oban_config_test.exs
@@ -100,4 +100,75 @@ defmodule PhoenixKit.Install.ObanConfigTest do
       assert ObanConfig.oban_block_missing_prefix?(content)
     end
   end
+
+  describe "ensure_lifeline_plugin/2" do
+    test "adds the Lifeline plugin when the plugins list has a trailing comma" do
+      content = """
+      config :my_app, Oban,
+        repo: MyApp.Repo,
+        queues: [default: 10],
+        plugins: [
+          {Oban.Plugins.Pruner, max_age: 60 * 60 * 24 * 30},
+        ]
+      """
+
+      updated = ObanConfig.ensure_lifeline_plugin(content, "my_app")
+
+      assert updated =~ "{Oban.Plugins.Lifeline, rescue_after: :timer.minutes(30)}"
+      # Still valid-looking: the plugin was inserted inside the same block.
+      assert updated =~ ~r/plugins:\s*\[.*Oban\.Plugins\.Lifeline.*\]/s
+    end
+
+    test "adds the Lifeline plugin when the plugins list has no trailing comma" do
+      content = """
+      config :my_app, Oban,
+        repo: MyApp.Repo,
+        queues: [default: 10],
+        plugins: [
+          {Oban.Plugins.Pruner, max_age: 60 * 60 * 24 * 30}
+        ]
+      """
+
+      updated = ObanConfig.ensure_lifeline_plugin(content, "my_app")
+
+      assert updated =~ "{Oban.Plugins.Lifeline, rescue_after: :timer.minutes(30)}"
+    end
+
+    test "is a no-op when the Lifeline plugin is already present" do
+      content = """
+      config :my_app, Oban,
+        repo: MyApp.Repo,
+        queues: [default: 10],
+        plugins: [
+          {Oban.Plugins.Pruner, max_age: 60 * 60 * 24 * 30},
+          {Oban.Plugins.Lifeline, rescue_after: :timer.minutes(30)}
+        ]
+      """
+
+      assert ObanConfig.ensure_lifeline_plugin(content, "my_app") == content
+    end
+
+    test "a bare (no-opts) Oban.Plugins.Lifeline entry also counts as already present" do
+      content = """
+      config :my_app, Oban,
+        repo: MyApp.Repo,
+        queues: [default: 10],
+        plugins: [
+          Oban.Plugins.Lifeline
+        ]
+      """
+
+      assert ObanConfig.ensure_lifeline_plugin(content, "my_app") == content
+    end
+
+    test "leaves content unchanged when no plugins: block can be found" do
+      content = """
+      config :my_app, Oban,
+        repo: MyApp.Repo,
+        queues: [default: 10]
+      """
+
+      assert ObanConfig.ensure_lifeline_plugin(content, "my_app") == content
+    end
+  end
 end


### PR DESCRIPTION
Companion to BeamLabEU/phoenix_kit_emails#21 (pollers moving to Oban unique jobs) — but valuable standalone.

## Problem

The installer-generated host Oban config has Pruner and Cron but **no Lifeline**: a job orphaned in `:executing` by a hard crash (BEAM `kill -9`, OOM, node failure, deploy restart) is never rescued — it sits stuck forever. Observed live: 10 zombie `SQSPollingJob` rows accumulated in a dev database from server restarts. With unique self-scheduling workers (the emails pollers after #21) the stakes rise: if a worker's unique `states` ever includes `:executing`, one orphan permanently blocks every future insert for that worker.

## Changes

- **Template** (`Install.ObanConfig`): generated `plugins:` now includes `{Oban.Plugins.Lifeline, rescue_after: :timer.minutes(30)}`, with a comment.
- **Upgrade path**: a new `ensure_lifeline_plugin/2` mirrors the existing `ensure_pruner_max_age/2` — `phoenix_kit.update` adds the plugin to existing host configs that lack it (regex-append into the `plugins:` block; graceful skip + manual instruction when the block can't be parsed).
- **`phoenix_kit.doctor`**: warns when a keyword Oban config has no Lifeline entry, with the exact snippet to add.

No migrations involved — Lifeline is a runtime plugin over the existing `oban_jobs` table.

## Tests

New `ensure_lifeline_plugin` cases in `oban_config_test.exs` (adds when missing — both trailing-comma shapes; no-ops when present in tuple or bare-module form). Installer suites green; the 4 `common_test.exs` failures ("no source found for mix.exs") reproduce identically on clean upstream/main — a pre-existing Rewrite/Igniter regression unrelated to this change.