### PR TITLE
Fix registration sessions not persisting; add auth policy settings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,7 +156,17 @@ settings live on the admin Users settings page (`/admin/settings/users`).
   `/\`, and **ASCII control characters** (browsers strip tab/CR/LF, so
   `"/\t/evil.com"` lands as `//evil.com`; `Phoenix.Controller.redirect/2` blocks
   those but LiveView's `validate_local_url!` does not). Every LiveView
-  `redirect(to: ...)` of user-influenced input MUST go through it.
+  `redirect(to: ...)` of user-influenced input MUST go through it. The path
+  settings are additionally refused if they point at a page that bounces an
+  authenticated visitor — including **`/users/log-out`**, a real GET route that
+  would sign every user straight back out.
+- **Carrying `return_to`:** `Routes.return_to_query/1` threads it across the
+  links between login/register/magic-link/QR/OAuth, and the magic-link email
+  carries it in its URL. A new sign-in entry point must thread it too.
+- ⚠️ **Public auth endpoints rate-limit BEFORE the lookup** — limiting inside
+  the send only throttles addresses that resolve to a user, which turns the
+  deliberately generic copy into an account-existence oracle. Password reset had
+  exactly that shape; confirmation resend had no limit at all.
 - **Email confirmation:** `require_email_confirmation` (default true) gates
   *enforcement* only; emails always send. Honored at **six** sites — the
   `require_authenticated_user` / `require_authenticated_scope` plugs and the
@@ -172,6 +182,10 @@ settings live on the admin Users settings page (`/admin/settings/users`).
 - ⚠️ **Flash belongs inside the LiveView tree** (LayoutWrapper / dashboard / host
   layout). `root.html.heex` deliberately has none — a copy there double-rendered
   every message with duplicate ids and froze at its dead-render value.
+- ⚠️ Rate limiting keys on `Plug.Conn.get_peer_data/1`, **not**
+  `conn.remote_ip`, and the test adapter reports one peer for every conn — so a
+  login-heavy test file shares a single bucket and gets bounced under some
+  seeds. Give each test its own peer (`with_peer/2` in `auth_flows_test.exs`).
 - ⚠️ A `disabled` `<.checkbox>` still submits its **un-disabled** hidden
   `value="false"` fallback, silently rewriting the setting on save. Don't use
   `disabled` to mean "inactive right now" in a settings form.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,6 +135,103 @@ The canonical toolkit for admin list views — DnD reorder, bulk-select, sort, s
 
 Tabs, subtabs, badges, context selectors: see `lib/phoenix_kit/dashboard/README.md`.
 
+## Login & Registration
+
+Settings live on the admin **Users settings** page (`/admin/settings/users`).
+
+**Session persistence** is one site-wide policy, two settings, and a visible
+per-user choice:
+
+- `remember_me_enabled` (default true) — master switch. Off hides the checkbox
+  on every auth form AND hard-blocks the cookie in
+  `maybe_write_remember_me_cookie/3`, so no caller (nor a forged param) can
+  persist a session.
+- `remember_me_default` (default true) — whether that checkbox starts
+  **checked**. Users untick it for a session-only login.
+
+Every form with a UI (password login, registration, magic-link completion, QR
+handoff) renders the same pre-checked "Keep me logged in" box. Flows with no UI
+to tick — **magic-link login** (arrives from an email) and **OAuth** (external
+round-trip) — call `Auth.remember_me_params/0` and follow `remember_me_default`.
+Read the policy via `Auth.remember_me_enabled?/0` / `remember_me_default?/0`;
+never hardcode `%{"remember_me" => "true"}` at a call site again.
+
+Why it defaults on: registration used to force a session-only login, so the
+session rode the browser-session cookie that mobile browsers drop when they
+evict the tab — freshly registered users were silently logged out overnight
+(the DB token was fine; nothing referenced it).
+
+⚠️ In the settings UI, do **not** mark a `<.checkbox>` `disabled` to express
+"this doesn't apply right now": the component pairs the box with an
+**un-disabled** hidden `value="false"` input, so a disabled box still submits
+`false` and silently rewrites the stored setting on save.
+
+**Post-auth destination** — one resolver, `Routes.post_auth_path/1`, takes
+candidates in priority order and falls back to the `after_login_path` setting
+then `"/"`. Precedence everywhere: explicit `return_to` (a `?return_to=` param
+or the `:user_return_to` a gate stashed) > `after_registration_path` (registration
+only) > `after_login_path`. `log_in_user/3` honors a `"return_to"` in its params
+map as well as the session key. Both settings are validated as local paths on
+save AND re-guarded at read time, so a hand-edited DB row can't create an open
+redirect.
+
+⚠️ **`Routes.local_path?/1` is the only redirect guard** — it rejects `//`,
+`/\`, and **ASCII control characters**. The control-char rule is load-bearing:
+browsers strip tab/CR/LF while parsing, so `"/\t/evil.com"` becomes
+`//evil.com`. `Phoenix.Controller.redirect/2` blocks those itself, but
+LiveView's `validate_local_url!` only rejects `\\` and a leading `//` — so any
+LiveView `redirect(to: ...)` of user-influenced input MUST go through
+`local_path?/1`.
+
+**Email confirmation** — `require_email_confirmation` (default `"true"`,
+historical behavior) gates enforcement only; confirmation emails always send.
+All **six** enforcement sites honor it: the `require_authenticated_user` /
+`require_authenticated_scope` conn plugs and the `ensure_authenticated`,
+`ensure_authenticated_scope`, `ensure_owner`, `ensure_admin`, and
+`ensure_module_access` on_mount hooks. Add the check to any new gate.
+
+**The parked `/users/confirm` page** moves users along instead of stranding
+them. Gates stash where the user was headed (`?return_to=`), and
+`ConfirmationInstructions` advances (a) on mount when the user is already
+confirmed — covers a `confirmed_at` flipped directly in the DB, then a refresh
+— and (b) live, via the `{:user_confirmed, user}` broadcast, so clicking the
+emailed link in another tab advances the parked tab. It subscribes **before**
+re-reading the user, so a confirmation landing mid-mount can't be missed. The
+email-link LiveView (`Users.Confirmation`) resolves the same destination, so
+the two tabs never diverge.
+
+**Soft-failure paths need `rescue` AND `catch :exit`** — an unreachable
+database surfaces both ways: a checkout with no owner *raises*
+(`DBConnection.OwnershipError`), while a dead pool or a died-mid-flight owner
+*exits*. `Settings.get_setting_cached/2` and the boot-safe URL wrappers had
+`rescue` only (so they leaked exits) and `Settings.get_setting/1` had neither —
+meaning a transient DB problem crashed every caller, including the login
+redirect resolver. All three now carry both clauses and log-then-default.
+
+Because settings reads are ETS-cached, the pool is only touched on a cache
+MISS, so this presented as **suite flakiness**, not a hard failure: DB-less
+unit tests (`routes_test`, `language_refactor_test`, `tab_item_test`) passed on
+a warm cache and died whenever another test's settings write evicted the key.
+`test/integration/settings_unreachable_db_test.exs` pins it. Reproducing "no
+database" in a test needs `async: true` (so sandbox ownership isn't shared)
+**and** `Process.delete(:"$callers")` in the spawned process (Ecto lets a Task
+borrow its caller's connection) — miss either and the test passes vacuously
+against a healthy DB, which is why that file leads with a guard test.
+
+⚠️ **Never evict a real key from the settings cache in a test.** The ETS cache
+is global, so an `async: true` test that evicts `languages_enabled` (or any
+shared key) forces every concurrently-running test to hit the database at
+once — which showed up as unrelated permission-test failures and even a
+Postgres `40P01 deadlock_detected`. Read a unique probe key instead: one that
+exists in neither cache nor database misses inherently, with no eviction and
+no blast radius.
+
+**Flash ownership** — the flash group belongs INSIDE the LiveView tree
+(LayoutWrapper's per-branch `<.flash_group>`, the dashboard layout, or the
+host's layout). `root.html.heex` deliberately has none: a copy there rendered
+every message twice with duplicate `flash-<kind>` ids and froze at its
+dead-render value. Don't add one back.
+
 ## Permissions
 
 `PhoenixKit.Users.Permissions` — allowlist model (row present = granted, absent = denied); Owner always has full access, enforced in code. The moduledoc is the source of truth; highlights:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,100 +137,44 @@ Tabs, subtabs, badges, context selectors: see `lib/phoenix_kit/dashboard/README.
 
 ## Login & Registration
 
-Settings live on the admin **Users settings** page (`/admin/settings/users`).
+Auth surface: session persistence, post-auth destinations, email confirmation.
+Full reference: `dev_docs/guides/2026-07-28-login-and-registration.md`. All
+settings live on the admin Users settings page (`/admin/settings/users`).
 
-**Session persistence** is one site-wide policy, two settings, and a visible
-per-user choice:
-
-- `remember_me_enabled` (default true) — master switch. Off hides the checkbox
-  on every auth form AND hard-blocks the cookie in
-  `maybe_write_remember_me_cookie/3`, so no caller (nor a forged param) can
-  persist a session.
-- `remember_me_default` (default true) — whether that checkbox starts
-  **checked**. Users untick it for a session-only login.
-
-Every form with a UI (password login, registration, magic-link completion, QR
-handoff) renders the same pre-checked "Keep me logged in" box. Flows with no UI
-to tick — **magic-link login** (arrives from an email) and **OAuth** (external
-round-trip) — call `Auth.remember_me_params/0` and follow `remember_me_default`.
-Read the policy via `Auth.remember_me_enabled?/0` / `remember_me_default?/0`;
-never hardcode `%{"remember_me" => "true"}` at a call site again.
-
-Why it defaults on: registration used to force a session-only login, so the
-session rode the browser-session cookie that mobile browsers drop when they
-evict the tab — freshly registered users were silently logged out overnight
-(the DB token was fine; nothing referenced it).
-
-⚠️ In the settings UI, do **not** mark a `<.checkbox>` `disabled` to express
-"this doesn't apply right now": the component pairs the box with an
-**un-disabled** hidden `value="false"` input, so a disabled box still submits
-`false` and silently rewrites the stored setting on save.
-
-**Post-auth destination** — one resolver, `Routes.post_auth_path/1`, takes
-candidates in priority order and falls back to the `after_login_path` setting
-then `"/"`. Precedence everywhere: explicit `return_to` (a `?return_to=` param
-or the `:user_return_to` a gate stashed) > `after_registration_path` (registration
-only) > `after_login_path`. `log_in_user/3` honors a `"return_to"` in its params
-map as well as the session key. Both settings are validated as local paths on
-save AND re-guarded at read time, so a hand-edited DB row can't create an open
-redirect.
-
-⚠️ **`Routes.local_path?/1` is the only redirect guard** — it rejects `//`,
-`/\`, and **ASCII control characters**. The control-char rule is load-bearing:
-browsers strip tab/CR/LF while parsing, so `"/\t/evil.com"` becomes
-`//evil.com`. `Phoenix.Controller.redirect/2` blocks those itself, but
-LiveView's `validate_local_url!` only rejects `\\` and a leading `//` — so any
-LiveView `redirect(to: ...)` of user-influenced input MUST go through
-`local_path?/1`.
-
-**Email confirmation** — `require_email_confirmation` (default `"true"`,
-historical behavior) gates enforcement only; confirmation emails always send.
-All **six** enforcement sites honor it: the `require_authenticated_user` /
-`require_authenticated_scope` conn plugs and the `ensure_authenticated`,
-`ensure_authenticated_scope`, `ensure_owner`, `ensure_admin`, and
-`ensure_module_access` on_mount hooks. Add the check to any new gate.
-
-**The parked `/users/confirm` page** moves users along instead of stranding
-them. Gates stash where the user was headed (`?return_to=`), and
-`ConfirmationInstructions` advances (a) on mount when the user is already
-confirmed — covers a `confirmed_at` flipped directly in the DB, then a refresh
-— and (b) live, via the `{:user_confirmed, user}` broadcast, so clicking the
-emailed link in another tab advances the parked tab. It subscribes **before**
-re-reading the user, so a confirmation landing mid-mount can't be missed. The
-email-link LiveView (`Users.Confirmation`) resolves the same destination, so
-the two tabs never diverge.
-
-**Soft-failure paths need `rescue` AND `catch :exit`** — an unreachable
-database surfaces both ways: a checkout with no owner *raises*
-(`DBConnection.OwnershipError`), while a dead pool or a died-mid-flight owner
-*exits*. `Settings.get_setting_cached/2` and the boot-safe URL wrappers had
-`rescue` only (so they leaked exits) and `Settings.get_setting/1` had neither —
-meaning a transient DB problem crashed every caller, including the login
-redirect resolver. All three now carry both clauses and log-then-default.
-
-Because settings reads are ETS-cached, the pool is only touched on a cache
-MISS, so this presented as **suite flakiness**, not a hard failure: DB-less
-unit tests (`routes_test`, `language_refactor_test`, `tab_item_test`) passed on
-a warm cache and died whenever another test's settings write evicted the key.
-`test/integration/settings_unreachable_db_test.exs` pins it. Reproducing "no
-database" in a test needs `async: true` (so sandbox ownership isn't shared)
-**and** `Process.delete(:"$callers")` in the spawned process (Ecto lets a Task
-borrow its caller's connection) — miss either and the test passes vacuously
-against a healthy DB, which is why that file leads with a guard test.
-
-⚠️ **Never evict a real key from the settings cache in a test.** The ETS cache
-is global, so an `async: true` test that evicts `languages_enabled` (or any
-shared key) forces every concurrently-running test to hit the database at
-once — which showed up as unrelated permission-test failures and even a
-Postgres `40P01 deadlock_detected`. Read a unique probe key instead: one that
-exists in neither cache nor database misses inherently, with no eviction and
-no blast radius.
-
-**Flash ownership** — the flash group belongs INSIDE the LiveView tree
-(LayoutWrapper's per-branch `<.flash_group>`, the dashboard layout, or the
-host's layout). `root.html.heex` deliberately has none: a copy there rendered
-every message twice with duplicate `flash-<kind>` ids and froze at its
-dead-render value. Don't add one back.
+- **Session persistence:** `remember_me_enabled` (default true) is the master
+  switch — off hides the checkbox everywhere AND hard-blocks the cookie inside
+  `maybe_write_remember_me_cookie/3`, so no caller or forged param can persist a
+  session. `remember_me_default` (default true) decides whether that checkbox
+  starts **checked**. Read the policy via `Auth.remember_me_enabled?/0` /
+  `remember_me_default?/0`; flows with no UI to tick (magic-link login, OAuth)
+  use `Auth.remember_me_params/0`. **Never hardcode `%{"remember_me" => "true"}`**.
+- **Post-auth destination:** one resolver, `Routes.post_auth_path/1`. Precedence:
+  explicit `return_to` (param or gate-stashed session key) > `after_registration_path`
+  > `after_login_path` > `"/"`. `log_in_user/3` honors a `"return_to"` param too.
+  Both settings validate as local paths on save and are re-guarded on read.
+- ⚠️ **`Routes.local_path?/1` is the only redirect guard** — it rejects `//`,
+  `/\`, and **ASCII control characters** (browsers strip tab/CR/LF, so
+  `"/\t/evil.com"` lands as `//evil.com`; `Phoenix.Controller.redirect/2` blocks
+  those but LiveView's `validate_local_url!` does not). Every LiveView
+  `redirect(to: ...)` of user-influenced input MUST go through it.
+- **Email confirmation:** `require_email_confirmation` (default true) gates
+  *enforcement* only; emails always send. Honored at **six** sites — the
+  `require_authenticated_user` / `require_authenticated_scope` plugs and the
+  `ensure_authenticated`, `ensure_authenticated_scope`, `ensure_owner`,
+  `ensure_admin`, `ensure_module_access` on_mount hooks. Add it to any new gate.
+- **The parked `/users/confirm` page** advances users instead of stranding them:
+  on mount when already confirmed (covers a direct DB flip + refresh) and live off
+  the `{:user_confirmed, _}` broadcast. It subscribes *before* re-reading the user.
+- ⚠️ **Soft-failure paths need `rescue` AND `catch :exit`** — an unreachable DB
+  raises on an unowned checkout but *exits* on a dead pool. Settings reads are
+  ETS-cached, so this only bites on a cache miss and presents as suite flakiness.
+  Never evict a real settings key in a test; read a unique probe key instead.
+- ⚠️ **Flash belongs inside the LiveView tree** (LayoutWrapper / dashboard / host
+  layout). `root.html.heex` deliberately has none — a copy there double-rendered
+  every message with duplicate ids and froze at its dead-render value.
+- ⚠️ A `disabled` `<.checkbox>` still submits its **un-disabled** hidden
+  `value="false"` fallback, silently rewriting the setting on save. Don't use
+  `disabled` to mean "inactive right now" in a settings form.
 
 ## Permissions
 

--- a/dev_docs/guides/2026-07-28-login-and-registration.md
+++ b/dev_docs/guides/2026-07-28-login-and-registration.md
@@ -66,6 +66,16 @@ Both settings are validated as local paths on save **and** re-guarded at read
 time, so a hand-edited database row cannot turn a post-auth redirect into an
 open redirect.
 
+### Loop and lockout guards
+
+`after_login_path` / `after_registration_path` are additionally refused when
+they point at a page that *bounces an authenticated visitor* — every auth page
+plus **`/users/log-out`**, which is a real GET route: set it and every
+successful login signs the user straight back out, locking out the admin who
+set it. `@auth_paths` in both `Setting.SettingsForm` (save time) and `Routes`
+(read time, since `update_setting/2` bypasses the changeset) covers log-in,
+log-out, register, confirm, magic-link, qr-login and reset-password.
+
 > ⚠️ **`Routes.local_path?/1` is the only redirect guard in the codebase.** It
 > rejects `//`, `/\`, and **ASCII control characters**. The control-character
 > rule is load-bearing: browsers strip tab/CR/LF while parsing a URL, so
@@ -74,6 +84,16 @@ open redirect.
 > but LiveView's `validate_local_url!` only rejects `\\` and a leading `//`, so
 > **any** LiveView `redirect(to: ...)` of user-influenced input must go through
 > `local_path?/1`.
+
+### Carrying `return_to` between auth pages
+
+Every route that can start a login threads the pending destination:
+`Routes.return_to_query/1` appends it to the links between login, register,
+magic-link, QR and the OAuth buttons, the magic-link *email* carries it in its
+URL (re-sanitized by `MagicLinkVerify` before it reaches the session), and
+`log_in_user/3` honors a `"return_to"` param as well as the session key. Adding
+a new sign-in entry point means threading it there too, or the destination dies
+the moment a user switches method.
 
 ## Email confirmation
 
@@ -103,6 +123,23 @@ It subscribes **before** re-reading the user, so a confirmation committed
 between the on_mount load and the subscribe cannot be missed. The email-link
 LiveView (`Users.Confirmation`) resolves the same destination, so the two tabs
 can never diverge.
+
+## Enumeration and abuse surfaces
+
+Public auth endpoints must answer identically whether or not an account exists,
+which means **rate-limiting before the lookup, not inside the send**:
+
+- **Password reset** limited inside `deliver_*`, i.e. only for addresses that
+  resolved to a user. Past the threshold a registered address got "Too many
+  password reset requests" while an unknown one still got the generic notice —
+  N+1 requests turned the deliberately vague copy into a precise oracle.
+- **Confirmation resend** had no limit at all: every request for an existing
+  unconfirmed account inserted a token and sent mail synchronously, so it was
+  both an unauthenticated targeted-mail-flood vector and a timing oracle.
+  `RateLimiter.check_confirmation_resend_rate_limit/1` now runs first.
+- **Magic-link registration request** answered "This email is already
+  registered", which login and magic-link login never do. It returns the same
+  generic confirmation as a success now.
 
 ## Soft-failure paths need `rescue` AND `catch :exit`
 
@@ -149,6 +186,15 @@ The flash group belongs **inside** the LiveView tree: LayoutWrapper's per-branch
 twice with duplicate `flash-<kind>` element ids (which breaks LiveView DOM
 patching) and froze at its dead-render value, since the root layout does not
 re-render on connected updates. Don't add one back.
+
+## Testing notes
+
+Rate limiting keys on the peer from `Plug.Conn.get_peer_data/1`, **not**
+`conn.remote_ip` — and the test adapter reports the same peer for every conn,
+so a file that logs in repeatedly exhausts one shared bucket (15/min) and later
+tests get bounced to the login page under some seed orderings. Hammer 7 removed
+bucket deletion, so isolate rather than reset: give each test its own peer (see
+`with_peer/2` in `auth_flows_test.exs`).
 
 Related: LayoutWrapper's standalone fallback (no `config :phoenix_kit, layout:`)
 renders content only. It previously nested a second full `Layouts.root` document

--- a/dev_docs/guides/2026-07-28-login-and-registration.md
+++ b/dev_docs/guides/2026-07-28-login-and-registration.md
@@ -1,0 +1,157 @@
+# Login & Registration
+
+Full reference for the auth surface: session persistence policy, post-auth
+destinations, the email-confirmation toggle, and the traps each one hides.
+Settings all live on the admin **Users settings** page (`/admin/settings/users`).
+
+## Session persistence
+
+One site-wide policy, two settings, and a visible per-user choice.
+
+| Setting | Default | Effect |
+|---|---|---|
+| `remember_me_enabled` | `true` | Master switch. Off hides the checkbox on every auth form **and** hard-blocks the cookie inside `maybe_write_remember_me_cookie/3`. |
+| `remember_me_default` | `true` | Whether that checkbox starts **checked**. Users untick it for a session-only login. |
+
+Enforcement lives at the cookie writer, not at the call sites, so the policy
+holds by construction: with `remember_me_enabled` off, no caller — nor a forged
+`remember_me` param — can leave a persistent cookie.
+
+Every flow with a UI (password login, registration, magic-link completion, QR
+handoff) renders the same pre-checked "Keep me logged in" box. Flows with
+nothing to tick — **magic-link login** (arrives from an email) and **OAuth**
+(external round-trip) — call `Auth.remember_me_params/0` and follow
+`remember_me_default`.
+
+Read the policy through `Auth.remember_me_enabled?/0` /
+`Auth.remember_me_default?/0`. Never hardcode `%{"remember_me" => "true"}` at a
+call site — magic-link and OAuth both used to, which is how they drifted from
+the rest.
+
+**Why it defaults on.** Registration used to force a session-only login: the
+session rode the plain browser-session cookie, which mobile browsers drop when
+they evict the tab, so users who registered on a phone were silently logged out
+overnight. Their 60-day session token was valid the whole time — nothing
+referenced it.
+
+The two registration LiveViews track the checkbox across `phx-change="validate"`
+re-renders (`assign(:remember_me, user_params["remember_me"] == "true")`).
+Without that the box would snap back to the site default on the next keystroke,
+and the value the user sees would disagree with what `phx-trigger-action` POSTs.
+
+> ⚠️ In the settings UI, do **not** mark a `<.checkbox>` `disabled` to express
+> "this doesn't apply right now". The component pairs the box with an
+> **un-disabled** hidden `value="false"` input, so a disabled box still submits
+> `false` and silently rewrites the stored setting on save.
+
+## Post-auth destination
+
+One resolver — `Routes.post_auth_path/1` — takes candidate destinations in
+priority order, returns the first that passes `local_path?/1`, and falls back to
+the `after_login_path` setting, then `"/"`.
+
+Precedence everywhere:
+
+```
+explicit return_to  >  after_registration_path  >  after_login_path  >  "/"
+   (?return_to= param, or the         (registration only;
+    :user_return_to a gate stashed)    empty = fall through)
+```
+
+`log_in_user/3` honors a `"return_to"` in its params map as well as the session
+key — the OAuth callback had always passed one there and it was silently
+dropped, so an OAuth login started from a protected page landed on the default.
+
+Both settings are validated as local paths on save **and** re-guarded at read
+time, so a hand-edited database row cannot turn a post-auth redirect into an
+open redirect.
+
+> ⚠️ **`Routes.local_path?/1` is the only redirect guard in the codebase.** It
+> rejects `//`, `/\`, and **ASCII control characters**. The control-character
+> rule is load-bearing: browsers strip tab/CR/LF while parsing a URL, so
+> `"/\t/evil.example"` reaches `window.location` as `//evil.example` — a
+> cross-origin navigation. `Phoenix.Controller.redirect/2` blocks those itself,
+> but LiveView's `validate_local_url!` only rejects `\\` and a leading `//`, so
+> **any** LiveView `redirect(to: ...)` of user-influenced input must go through
+> `local_path?/1`.
+
+## Email confirmation
+
+`require_email_confirmation` (default `"true"`, the historical behavior) gates
+**enforcement only** — confirmation emails always send.
+
+All **six** enforcement sites honor it. Add the check to any new gate:
+
+- conn plugs: `require_authenticated_user/2`, `require_authenticated_scope/2`
+- `on_mount` hooks: `ensure_authenticated`, `ensure_authenticated_scope`,
+  `ensure_owner`, `ensure_admin`, `ensure_module_access`
+
+### The parked `/users/confirm` page
+
+It moves users along instead of stranding them. Gates stash where the user was
+headed as `?return_to=` (via `confirm_path_with_return_to/1`, mirroring the
+login gate), and `ConfirmationInstructions` advances:
+
+1. **On mount**, when the user is already confirmed — covers a `confirmed_at`
+   flipped directly in the database followed by a refresh, since the user is
+   reloaded from the session token on every mount.
+2. **Live**, on the existing admin `{:user_confirmed, user}` broadcast, so
+   clicking the emailed link in another tab advances the parked tab with no
+   refresh.
+
+It subscribes **before** re-reading the user, so a confirmation committed
+between the on_mount load and the subscribe cannot be missed. The email-link
+LiveView (`Users.Confirmation`) resolves the same destination, so the two tabs
+can never diverge.
+
+## Soft-failure paths need `rescue` AND `catch :exit`
+
+An unreachable database surfaces two different ways:
+
+| Condition | Manifests as |
+|---|---|
+| Checkout with no owner for this process | **raises** `DBConnection.OwnershipError` |
+| Dead pool, or an owner that died mid-flight | **exits** |
+
+`Settings.get_setting_cached/2` and the boot-safe URL wrappers
+(`Routes.get_default_language_base/0`, `Languages.prefixless_primary_safe?/0`)
+carried `rescue` only, so they leaked exits; `Settings.get_setting/1` had
+neither, so a transient database problem crashed every caller — the login
+redirect resolver among them. All now carry both clauses and log-then-default.
+
+Because settings reads are ETS-cached, the pool is only touched on a cache
+**miss**, so this presented as suite *flakiness* rather than a hard failure:
+DB-less unit tests (`routes_test`, `language_refactor_test`, `tab_item_test`)
+passed on a warm cache and died whenever another test's settings write had
+evicted the key.
+
+`test/integration/settings_unreachable_db_test.exs` pins the behavior. Two rules
+that file follows, both learned the hard way:
+
+1. **Reproducing "no database" needs `async: true` AND
+   `Process.delete(:"$callers")`** in the spawned process. Shared sandbox mode
+   (any `async: false` test) hands a connection to every process, and Ecto
+   deliberately lets a `Task` borrow its caller's connection through `$callers`.
+   Miss either and every assertion passes vacuously against a healthy database —
+   which is why the file leads with a guard test.
+2. **Never evict a real settings key in a test.** The ETS cache is global, so an
+   `async: true` test that evicts `languages_enabled` (or any shared key) forces
+   every concurrently-running test to hit the database at once. That surfaced as
+   unrelated permission-test failures and a Postgres `40P01 deadlock_detected`.
+   Read a unique probe key instead — one present in neither cache nor database
+   misses inherently, with no eviction and no blast radius.
+
+## Flash ownership
+
+The flash group belongs **inside** the LiveView tree: LayoutWrapper's per-branch
+`<.flash_group>`, the dashboard layout, or the host's own layout.
+`root.html.heex` deliberately has none — a copy there rendered every message
+twice with duplicate `flash-<kind>` element ids (which breaks LiveView DOM
+patching) and froze at its dead-render value, since the root layout does not
+re-render on connected updates. Don't add one back.
+
+Related: LayoutWrapper's standalone fallback (no `config :phoenix_kit, layout:`)
+renders content only. It previously nested a second full `Layouts.root` document
+inside the LiveView and passed `app_layout`'s `attr :inner_content, default: nil`
+into a template rendering `{@inner_content}` — so standalone auth pages rendered
+chrome with an entirely empty body.

--- a/lib/modules/languages/languages.ex
+++ b/lib/modules/languages/languages.ex
@@ -605,6 +605,12 @@ defmodule PhoenixKit.Modules.Languages do
     end
   rescue
     _ -> false
+  catch
+    # A connection-pool failure EXITS rather than raising, so `rescue` alone
+    # leaves this "safe" wrapper unsafe. The settings read is ETS-cached, so
+    # the pool is only reached on a cache miss — which is why it surfaced as a
+    # rare flake rather than a consistent failure.
+    :exit, _ -> false
   end
 
   # Mirrors `PhoenixKit.Utils.Routes.mix_task_context?/0` — the

--- a/lib/phoenix_kit/admin/events.ex
+++ b/lib/phoenix_kit/admin/events.ex
@@ -118,8 +118,28 @@ defmodule PhoenixKit.Admin.Events do
   """
   def broadcast_user_confirmed(user) do
     broadcast(@topic_users, {:user_confirmed, user})
+    broadcast(user_confirmation_topic(user.uuid), {:user_confirmed, user})
     maybe_broadcast_stats_updated()
   end
+
+  @doc """
+  Topic carrying only one user's confirmation.
+
+  Lets an unconfirmed user's own parked page wait for its own event without
+  subscribing to the site-wide admin users feed — which would put every other
+  user's `%User{}` struct in a non-admin's mailbox, and fan every admin action
+  out to every parked session.
+  """
+  @spec user_confirmation_topic(binary()) :: String.t()
+  def user_confirmation_topic(user_uuid) when is_binary(user_uuid),
+    do: "phoenix_kit:user_confirmed:#{user_uuid}"
+
+  @doc """
+  Subscribes to `user_confirmation_topic/1` for one user.
+  """
+  @spec subscribe_to_user_confirmation(binary()) :: :ok | {:error, term()}
+  def subscribe_to_user_confirmation(user_uuid) when is_binary(user_uuid),
+    do: Manager.subscribe(user_confirmation_topic(user_uuid))
 
   @doc """
   Broadcasts user unconfirmation event to admin panels.

--- a/lib/phoenix_kit/settings/setting.ex
+++ b/lib/phoenix_kit/settings/setting.ex
@@ -411,14 +411,37 @@ defmodule PhoenixKit.Settings.Setting do
     # Validates a redirect-target setting is a local path (optional field —
     # allows empty). Same rule as `Routes.local_path?/1`: must start with a
     # single "/" so a saved setting can never become an open redirect.
+    # Every path that bounces an authenticated visitor elsewhere, plus log-out.
+    # Setting the post-login destination to any of them loops forever; pointing
+    # it at `/users/log-out` is worse — it is a real GET route, so every
+    # successful login immediately signs the user back out and nobody, including
+    # the admin who set it, can stay in to undo it.
+    @auth_paths ~w(/users/log-in /users/log-out /users/register /users/confirm
+    /users/magic-link /users/qr-login /users/reset-password)
+
     defp validate_local_path(changeset, field) do
-      validate_change(changeset, field, fn ^field, value ->
-        if String.trim(value) == "" or RouteUtils.local_path?(value) do
-          []
-        else
-          [{field, "must be a local path starting with \"/\""}]
+      changeset
+      |> update_change(field, &String.trim/1)
+      |> validate_change(field, fn ^field, value ->
+        cond do
+          value == "" ->
+            []
+
+          not RouteUtils.local_path?(value) ->
+            [{field, "must be a local path starting with \"/\""}]
+
+          auth_page?(value) ->
+            [{field, "cannot point at a sign-in page (it would loop)"}]
+
+          true ->
+            []
         end
       end)
+    end
+
+    defp auth_page?(value) do
+      path = value |> String.split(["?", "#"], parts: 2) |> hd() |> String.trim_trailing("/")
+      Enum.any?(@auth_paths, &(path == &1 or String.ends_with?(path, &1)))
     end
 
     # Validates URL format (optional field - allows empty)

--- a/lib/phoenix_kit/settings/setting.ex
+++ b/lib/phoenix_kit/settings/setting.ex
@@ -71,6 +71,8 @@ defmodule PhoenixKit.Settings.Setting do
     "site_url",
     "site_icon_file_uuid",
     "default_tab_title",
+    # Post-login redirects (empty = default behavior)
+    "after_registration_path",
     # OAuth Provider Credentials
     "oauth_google_client_id",
     "oauth_google_client_secret",
@@ -260,6 +262,8 @@ defmodule PhoenixKit.Settings.Setting do
     use Ecto.Schema
     import Ecto.Changeset
 
+    alias PhoenixKit.Utils.Routes, as: RouteUtils
+
     @primary_key false
     embedded_schema do
       field :project_title, :string
@@ -280,6 +284,11 @@ defmodule PhoenixKit.Settings.Setting do
       field :editor_default_mode, :string
       field :track_registration_geolocation, :string
       field :registration_show_username, :string
+      field :require_email_confirmation, :string
+      field :remember_me_enabled, :string
+      field :remember_me_default, :string
+      field :after_login_path, :string
+      field :after_registration_path, :string
       # Organization Accounts
       field :enable_organization_accounts, :string
       # Admin Panel Languages
@@ -341,6 +350,11 @@ defmodule PhoenixKit.Settings.Setting do
         :editor_default_mode,
         :track_registration_geolocation,
         :registration_show_username,
+        :require_email_confirmation,
+        :remember_me_enabled,
+        :remember_me_default,
+        :after_login_path,
+        :after_registration_path,
         :enable_organization_accounts,
         :admin_languages,
         :oauth_google_client_id,
@@ -381,6 +395,30 @@ defmodule PhoenixKit.Settings.Setting do
       # away (or offered in the picker while the changeset rejects it).
       |> validate_inclusion(:editor_default_mode, PhoenixKit.Settings.editor_modes())
       |> validate_inclusion(:enable_organization_accounts, ["true", "false"])
+      |> validate_inclusion(:require_email_confirmation, ["true", "false"],
+        message: "must be either 'true' or 'false'"
+      )
+      |> validate_inclusion(:remember_me_enabled, ["true", "false"],
+        message: "must be either 'true' or 'false'"
+      )
+      |> validate_inclusion(:remember_me_default, ["true", "false"],
+        message: "must be either 'true' or 'false'"
+      )
+      |> validate_local_path(:after_login_path)
+      |> validate_local_path(:after_registration_path)
+    end
+
+    # Validates a redirect-target setting is a local path (optional field —
+    # allows empty). Same rule as `Routes.local_path?/1`: must start with a
+    # single "/" so a saved setting can never become an open redirect.
+    defp validate_local_path(changeset, field) do
+      validate_change(changeset, field, fn ^field, value ->
+        if String.trim(value) == "" or RouteUtils.local_path?(value) do
+          []
+        else
+          [{field, "must be a local path starting with \"/\""}]
+        end
+      end)
     end
 
     # Validates URL format (optional field - allows empty)

--- a/lib/phoenix_kit/settings/settings.ex
+++ b/lib/phoenix_kit/settings/settings.ex
@@ -97,6 +97,20 @@ defmodule PhoenixKit.Settings do
       "project_title" => "PhoenixKit",
       "site_url" => "",
       "allow_registration" => "true",
+      # Enforce email confirmation before the app is usable ("true"/"false").
+      # Confirmation emails send either way — this only gates enforcement.
+      "require_email_confirmation" => "true",
+      # Session persistence policy. `remember_me_enabled` is the site-wide
+      # master switch: off = no flow may write the persistent cookie and the
+      # checkbox disappears. `remember_me_default` decides whether that
+      # checkbox starts checked (and is what the no-UI flows — magic-link
+      # login, OAuth — follow, since there's nothing to tick there).
+      "remember_me_enabled" => "true",
+      "remember_me_default" => "true",
+      # Local paths users land on after signing in / registering.
+      # after_registration_path empty = fall back to after_login_path.
+      "after_login_path" => "/",
+      "after_registration_path" => "",
       "oauth_enabled" => "false",
       "oauth_google_enabled" => "false",
       "oauth_github_enabled" => "false",
@@ -194,6 +208,19 @@ defmodule PhoenixKit.Settings do
         nil -> nil
       end
     end
+  rescue
+    # An unreachable database surfaces BOTH ways — a checkout with no owner
+    # raises, a dead pool/owner exits — and this function previously handled
+    # neither, so a transient DB problem crashed every caller (including the
+    # login redirect resolver). "No setting" is the honest answer; it lets
+    # each caller apply its own documented default.
+    error ->
+      Logger.warning("Settings read for #{inspect(key)} failed: #{inspect(error)}")
+      nil
+  catch
+    :exit, reason ->
+      Logger.warning("Settings read for #{inspect(key)} exited: #{inspect(reason)}")
+      nil
   end
 
   @doc """
@@ -325,6 +352,16 @@ defmodule PhoenixKit.Settings do
       # Cache system unavailable, fallback to regular database query
       Logger.warning("Settings cache error: #{inspect(error)}, falling back to database")
       get_setting(key, default)
+  catch
+    # A connection-pool failure EXITS rather than raising (`DBConnection`
+    # checkout against a stopped/unowned pool), so `rescue` alone never
+    # covered a genuinely unreachable database — the caller crashed instead
+    # of getting its default. Only reachable on a cache MISS, which is why it
+    # showed up as rare flakiness rather than a hard failure: a warm cache
+    # never touches the pool, and any write to any setting invalidates it.
+    :exit, reason ->
+      Logger.warning("Settings read for #{inspect(key)} exited: #{inspect(reason)}")
+      default
   end
 
   @doc """

--- a/lib/phoenix_kit/users/magic_link_registration.ex
+++ b/lib/phoenix_kit/users/magic_link_registration.ex
@@ -9,6 +9,8 @@ defmodule PhoenixKit.Users.MagicLinkRegistration do
   """
 
   import Ecto.Query, warn: false
+
+  require Logger
   alias PhoenixKit.RepoHelper, as: Repo
 
   alias PhoenixKit.Config
@@ -16,7 +18,6 @@ defmodule PhoenixKit.Users.MagicLinkRegistration do
   alias PhoenixKit.Users.Auth
   alias PhoenixKit.Users.Auth.{User, UserToken}
   alias PhoenixKit.Users.Referrals
-  alias PhoenixKit.Utils.Date, as: UtilsDate
   alias PhoenixKit.Utils.Routes
 
   @magic_link_registration_context "magic_link_registration"
@@ -161,10 +162,10 @@ defmodule PhoenixKit.Users.MagicLinkRegistration do
   defp do_complete_registration(email, attrs, ip_address, token) do
     {referral_code, attrs} = Map.pop(attrs, "referral_code")
 
-    attrs =
-      attrs
-      |> Map.put("email", email)
-      |> Map.put("confirmed_at", UtilsDate.utc_now())
+    # `confirmed_at` is NOT settable here: `registration_changeset/3` casts a
+    # fixed allowlist that omits it, so putting it in attrs was silently
+    # dropped. The account is confirmed explicitly after insert instead.
+    attrs = Map.put(attrs, "email", email)
 
     track_geolocation = Settings.get_boolean_setting("track_registration_geolocation", false)
 
@@ -182,10 +183,30 @@ defmodule PhoenixKit.Users.MagicLinkRegistration do
         end
 
         delete_registration_token(token)
-        {:ok, user}
+
+        # Clicking the emailed link already proved control of this inbox, so
+        # the account is confirmed. Without this the user is auto-logged-in and
+        # immediately parked at /users/confirm — and this flow never sends a
+        # confirmation email, so there is no link to click and the only way out
+        # is the resend form.
+        {:ok, confirm_registered_user(user)}
 
       {:error, changeset} ->
         {:error, changeset}
+    end
+  end
+
+  defp confirm_registered_user(user) do
+    case Auth.admin_confirm_user(user) do
+      {:ok, confirmed} ->
+        confirmed
+
+      {:error, reason} ->
+        Logger.warning(
+          "[PhoenixKit] magic-link registration could not confirm #{user.uuid}: #{inspect(reason)}"
+        )
+
+        user
     end
   end
 

--- a/lib/phoenix_kit/users/rate_limiter.ex
+++ b/lib/phoenix_kit/users/rate_limiter.ex
@@ -76,6 +76,9 @@ defmodule PhoenixKit.Users.RateLimiter do
     # Password reset: 3 requests per 5 minutes per email
     password_reset_limit: 3,
     password_reset_window_ms: 300_000,
+    # Confirmation resend: 3 requests per 5 minutes per email
+    confirmation_resend_limit: 3,
+    confirmation_resend_window_ms: 300_000,
     # Registration: 3 attempts per hour per email
     registration_limit: 3,
     registration_window_ms: 3_600_000,
@@ -170,6 +173,37 @@ defmodule PhoenixKit.Users.RateLimiter do
 
       {:error, :rate_limit_exceeded} = error ->
         log_rate_limit_violation("magic_link", email, limit, window)
+        error
+    end
+  end
+
+  @doc """
+  Checks if confirmation-email resends are within rate limit.
+
+  The resend form is public and unauthenticated: each accepted request inserts
+  a token and sends mail, so without a limit it is both a targeted mail-flood
+  vector and — because only existing unconfirmed accounts do that work — a
+  measurable oracle for which addresses are registered but unconfirmed.
+
+  ## Examples
+
+      iex> PhoenixKit.Users.RateLimiter.check_confirmation_resend_rate_limit("user@example.com")
+      :ok
+  """
+  def check_confirmation_resend_rate_limit(email) when is_binary(email) do
+    email = normalize_email(email)
+    config = get_config()
+
+    key = "auth:confirmation_resend:#{email}"
+    limit = Keyword.get(config, :confirmation_resend_limit)
+    window = Keyword.get(config, :confirmation_resend_window_ms)
+
+    case check_rate_limit(key, window, limit) do
+      :ok ->
+        :ok
+
+      {:error, :rate_limit_exceeded} = error ->
+        log_rate_limit_violation("confirmation_resend", email, limit, window)
         error
     end
   end

--- a/lib/phoenix_kit/utils/routes.ex
+++ b/lib/phoenix_kit/utils/routes.ex
@@ -97,10 +97,34 @@ defmodule PhoenixKit.Utils.Routes do
     Enum.find(candidates, &local_path?/1) || after_login_path()
   end
 
-  defp after_login_path do
-    path = PhoenixKit.Settings.get_setting("after_login_path", "/")
+  @doc """
+  Renders `?return_to=<path>` for a link, or `""` when there is nothing safe to
+  carry. Lets the auth pages hand the pending destination to each other instead
+  of dropping it the moment a visitor switches to another sign-in method.
+  """
+  @spec return_to_query(term()) :: String.t()
+  def return_to_query(path) do
+    if local_path?(path), do: "?" <> URI.encode_query(%{"return_to" => path}), else: ""
+  end
 
-    if local_path?(path), do: path, else: "/"
+  # Every path that bounces an authenticated visitor elsewhere, plus log-out.
+  # Setting the post-login destination to any of them loops forever; pointing
+  # it at `/users/log-out` is worse — it is a real GET route, so every
+  # successful login immediately signs the user back out and nobody, including
+  # the admin who set it, can stay in to undo it.
+  @auth_paths ~w(/users/log-in /users/log-out /users/register /users/confirm
+  /users/magic-link /users/qr-login /users/reset-password)
+
+  defp after_login_path do
+    path =
+      "after_login_path" |> PhoenixKit.Settings.get_setting("/") |> to_string() |> String.trim()
+
+    if local_path?(path) and not auth_page?(path), do: path, else: "/"
+  end
+
+  defp auth_page?(path) do
+    trimmed = path |> String.split(["?", "#"], parts: 2) |> hd() |> String.trim_trailing("/")
+    Enum.any?(@auth_paths, &(trimmed == &1 or String.ends_with?(trimmed, &1)))
   end
 
   # NOTE: Locale override logic below exists for the publishing component system integration.

--- a/lib/phoenix_kit/utils/routes.ex
+++ b/lib/phoenix_kit/utils/routes.ex
@@ -34,6 +34,13 @@ defmodule PhoenixKit.Utils.Routes do
   which browsers resolve as protocol-relative, host-switching URLs. Use this to
   guard user-supplied redirect params against open-redirect attacks.
 
+  ASCII control characters are rejected too. Browsers strip tab/CR/LF while
+  parsing a URL, so `"/\\t/evil.example"` (from `?return_to=%2F%09%2Fevil.example`)
+  becomes `//evil.example` — a cross-origin navigation — once it reaches
+  `window.location`. `Phoenix.Controller.redirect/2` blocks those itself, but
+  LiveView's `validate_local_url!` only rejects `\\\\` and a leading `//`, so a
+  LiveView `redirect(socket, to: ...)` would otherwise pass it through.
+
   ## Examples
 
       iex> PhoenixKit.Utils.Routes.local_path?("/admin/dashboard")
@@ -42,16 +49,59 @@ defmodule PhoenixKit.Utils.Routes do
       false
       iex> PhoenixKit.Utils.Routes.local_path?("https://evil.com")
       false
+      iex> PhoenixKit.Utils.Routes.local_path?("/\\t/evil.com")
+      false
 
   """
   @spec local_path?(term()) :: boolean()
   def local_path?(path) when is_binary(path) do
     String.starts_with?(path, "/") and
       not String.starts_with?(path, "//") and
-      not String.starts_with?(path, "/\\")
+      not String.starts_with?(path, "/\\") and
+      not contains_control_char?(path)
   end
 
   def local_path?(_), do: false
+
+  # ASCII control chars (C0 + DEL). Checked bytewise: a control char is
+  # single-byte in UTF-8 and can never appear inside a multi-byte sequence.
+  defp contains_control_char?(path) do
+    path
+    |> :binary.bin_to_list()
+    |> Enum.any?(fn byte -> byte <= 0x1F or byte == 0x7F end)
+  end
+
+  @doc """
+  Resolves where to send a user once they are signed in and confirmed.
+
+  Takes candidate destinations in priority order (e.g. a `?return_to=` param,
+  then the session's `user_return_to`) and returns the first that passes
+  `local_path?/1`. Falls back to the `after_login_path` setting, and finally
+  to `"/"`.
+
+  The setting is validated as a local path when saved, but is re-guarded here
+  so a hand-edited DB row can't turn a post-auth redirect into an open
+  redirect. Single source of truth for the post-auth landing page — used by
+  the login flow (`signed_in_path/1`) and by both confirmation LiveViews.
+
+  ## Examples
+
+      iex> PhoenixKit.Utils.Routes.post_auth_path(["/checkout"])
+      "/checkout"
+      iex> PhoenixKit.Utils.Routes.post_auth_path(["https://evil.com", nil])
+      "/"
+
+  """
+  @spec post_auth_path([term()]) :: String.t()
+  def post_auth_path(candidates \\ []) when is_list(candidates) do
+    Enum.find(candidates, &local_path?/1) || after_login_path()
+  end
+
+  defp after_login_path do
+    path = PhoenixKit.Settings.get_setting("after_login_path", "/")
+
+    if local_path?(path), do: path, else: "/"
+  end
 
   # NOTE: Locale override logic below exists for the publishing component system integration.
   # Switch to the upcoming media/storage helpers once they land.
@@ -184,6 +234,13 @@ defmodule PhoenixKit.Utils.Routes do
     end
   rescue
     _ -> "en"
+  catch
+    # A connection-pool failure EXITS rather than raising, so `rescue` alone
+    # never delivered the "path building works without a reachable database"
+    # guarantee above. Seen as a flaky suite failure: the settings read is
+    # ETS-cached, so a DB-less test only reached the pool on a cache miss —
+    # which another test's settings write could cause at any time.
+    :exit, _ -> "en"
   end
 
   # Detect if we're running in a mix task context where the database

--- a/lib/phoenix_kit_web/components/layout_wrapper.ex
+++ b/lib/phoenix_kit_web/components/layout_wrapper.ex
@@ -912,16 +912,25 @@ defmodule PhoenixKitWeb.Components.LayoutWrapper do
     """
   end
 
-  # Fallback to PhoenixKit's own layout
+  # Standalone fallback (no `config :phoenix_kit, layout:` — core's own
+  # dev/test, or a minimal host): render content only. The document shell
+  # already comes from the router's `put_root_layout` (Layouts.root), so
+  # rendering `<PhoenixKitWeb.Layouts.root>` here nested a SECOND full
+  # document inside the LiveView — and, worse, the spread carried
+  # `app_layout`'s `attr :inner_content, default: nil` into a template that
+  # renders `{@inner_content}`, so the actual page content was swallowed
+  # entirely (empty login/register pages in standalone mode). The flash
+  # group must render HERE, inside the LiveView's tree — the root layout's
+  # copy is static after the dead render, so connected `put_flash` updates
+  # would never display through it.
   defp render_with_phoenix_kit_layout(assigns) do
     # Wrap inner content with admin navigation if needed
     assigns = wrap_inner_block_with_admin_nav_if_needed(assigns)
 
     ~H"""
-    <PhoenixKitWeb.Layouts.root {prepare_phoenix_kit_assigns(assigns)}>
-      <.invitation_banners invitations={@pk_pending_invitations} />
-      {render_slot(@inner_block)}
-    </PhoenixKitWeb.Layouts.root>
+    <.flash_group flash={@flash} />
+    <.invitation_banners invitations={@pk_pending_invitations} />
+    {render_slot(@inner_block)}
     """
   end
 
@@ -944,13 +953,6 @@ defmodule PhoenixKitWeb.Components.LayoutWrapper do
     |> Map.put_new(:phoenix_kit_integrated, true)
     |> Map.put_new(:phoenix_kit_version, get_phoenix_kit_version())
     |> Map.put_new(:phoenix_version_info, PhoenixVersion.get_version_info())
-    |> Map.put_new(:seo_no_index, assigns[:seo_no_index] || false)
-  end
-
-  # Prepare assigns specifically for PhoenixKit layout
-  defp prepare_phoenix_kit_assigns(assigns) do
-    assigns
-    |> Map.put_new(:phoenix_kit_standalone, true)
     |> Map.put_new(:seo_no_index, assigns[:seo_no_index] || false)
   end
 

--- a/lib/phoenix_kit_web/components/layouts/root.html.heex
+++ b/lib/phoenix_kit_web/components/layouts/root.html.heex
@@ -167,9 +167,15 @@
     <% end %> --%>
 
     <%!-- Maintenance mode is now handled via redirect to /maintenance LiveView --%>
+    <%!-- No flash group here: flash is owned by the layer INSIDE the LiveView
+         tree (LayoutWrapper's per-branch `<.flash_group>`, the dashboard
+         layout, or the host's own layout). A copy here rendered every flash
+         twice with duplicate `flash-<kind>` element ids, and — being outside
+         the LiveView — it froze at its dead-render value while the real one
+         updated. Controllers here all redirect rather than render, so their
+         flash surfaces at the (LiveView) destination. --%>
     <main class="py-8">
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <.flash_group id="flash-group-root" flash={@flash} />
         {@inner_content}
       </div>
     </main>

--- a/lib/phoenix_kit_web/components/oauth_buttons.ex
+++ b/lib/phoenix_kit_web/components/oauth_buttons.ex
@@ -29,6 +29,11 @@ defmodule PhoenixKitWeb.Components.OAuthButtons do
   attr :class, :string, default: ""
   attr :show_divider, :boolean, default: true
 
+  attr :return_to, :string,
+    default: nil,
+    doc:
+      "Local post-login destination to carry through the OAuth round-trip. The callback stashes it as :oauth_return_to; without it a user sent to sign in from a protected page lands on the default instead."
+
   def oauth_buttons(assigns) do
     # Check each provider individually
     assigns =
@@ -43,6 +48,11 @@ defmodule PhoenixKitWeb.Components.OAuthButtons do
 
     assigns = assign(assigns, :any_provider_enabled, any_provider_enabled)
 
+    # Only a local path travels; anything else is dropped rather than handed
+    # to the callback's session stash.
+    assigns =
+      assign(assigns, :return_query, oauth_return_query(assigns[:return_to]))
+
     ~H"""
     <%= if @any_provider_enabled do %>
       <div class={@class}>
@@ -55,7 +65,7 @@ defmodule PhoenixKitWeb.Components.OAuthButtons do
           <%!-- OAuth routes are non-localized, so we use locale: :none --%>
           <%= if @google_enabled do %>
             <.link
-              href={Routes.path("/users/auth/google", locale: :none)}
+              href={Routes.path("/users/auth/google", locale: :none) <> @return_query}
               class="btn btn-outline w-full flex items-center justify-center gap-2 hover:bg-base-200 transition-all hover:scale-[1.02] active:scale-[0.98]"
             >
               <Icons.icon_google class="w-5 h-5" />
@@ -65,7 +75,7 @@ defmodule PhoenixKitWeb.Components.OAuthButtons do
           <%!-- GitHub Sign-In Button --%>
           <%= if @github_enabled do %>
             <.link
-              href={Routes.path("/users/auth/github", locale: :none)}
+              href={Routes.path("/users/auth/github", locale: :none) <> @return_query}
               class="btn btn-outline w-full flex items-center justify-center gap-2 hover:bg-base-200 transition-all hover:scale-[1.02] active:scale-[0.98]"
             >
               <Icons.icon_github class="w-5 h-5" />
@@ -75,7 +85,7 @@ defmodule PhoenixKitWeb.Components.OAuthButtons do
           <%!-- Facebook Sign-In Button --%>
           <%= if @facebook_enabled do %>
             <.link
-              href={Routes.path("/users/auth/facebook", locale: :none)}
+              href={Routes.path("/users/auth/facebook", locale: :none) <> @return_query}
               class="btn btn-outline w-full flex items-center justify-center gap-2 hover:bg-base-200 transition-all hover:scale-[1.02] active:scale-[0.98]"
             >
               <Icons.icon_facebook class="w-5 h-5" />
@@ -86,5 +96,13 @@ defmodule PhoenixKitWeb.Components.OAuthButtons do
       </div>
     <% end %>
     """
+  end
+
+  defp oauth_return_query(return_to) do
+    if is_binary(return_to) and Routes.local_path?(return_to) do
+      "?" <> URI.encode_query(%{"return_to" => return_to})
+    else
+      ""
+    end
   end
 end

--- a/lib/phoenix_kit_web/hooks/invitation_hook.ex
+++ b/lib/phoenix_kit_web/hooks/invitation_hook.ex
@@ -51,6 +51,13 @@ defmodule PhoenixKitWeb.Hooks.InvitationHook do
        when not is_nil(confirmed_at),
        do: true
 
+  # With `require_email_confirmation` off, an unconfirmed account is a fully
+  # usable one — gating the banner on `confirmed_at` would leave an invited
+  # user no way to join their organization at all, since the auto-accept path
+  # also only runs on confirmation.
+  defp confirmed_person?(%{account_type: "person"}),
+    do: not PhoenixKit.Settings.get_boolean_setting("require_email_confirmation", true)
+
   defp confirmed_person?(_), do: false
 
   defp handle_invitation_event("accept_invitation", %{"uuid" => uuid}, socket) do

--- a/lib/phoenix_kit_web/live/settings/users.html.heex
+++ b/lib/phoenix_kit_web/live/settings/users.html.heex
@@ -70,6 +70,12 @@
                 wrapper_class="mb-3"
               />
               <.checkbox
+                name="settings[require_email_confirmation]"
+                checked={@settings["require_email_confirmation"] == "true"}
+                label={gettext("Require email confirmation before using the app")}
+                wrapper_class="mb-3"
+              />
+              <.checkbox
                 name="settings[track_registration_geolocation]"
                 checked={@settings["track_registration_geolocation"] == "true"}
                 label={gettext("Track user registration location")}
@@ -91,6 +97,7 @@
                 Enum.any?(
                   [
                     "allow_registration",
+                    "require_email_confirmation",
                     "track_registration_geolocation",
                     "registration_show_username",
                     "enable_organization_accounts"
@@ -118,6 +125,97 @@
                   </div>
                 </div>
               <% end %>
+            </div>
+
+            <.section_header icon="hero-shield-check" title={gettext("Sessions")} />
+
+            <%!-- Site-wide session-persistence policy. The master switch also
+                 hard-blocks the cookie server-side, not just the checkbox. --%>
+            <div class="form-control w-full">
+              <.checkbox
+                name="settings[remember_me_enabled]"
+                checked={@settings["remember_me_enabled"] == "true"}
+                label={gettext("Allow \"Keep me logged in\" (persistent sessions)")}
+                wrapper_class="mb-3"
+              />
+              <%!-- Deliberately NOT `disabled` when the master switch is off:
+                   <.checkbox> renders an un-disabled hidden "false" fallback
+                   next to the box, so a disabled checkbox still submits
+                   "false" and would silently rewrite the stored value. It
+                   simply has no effect while persistence is off. --%>
+              <.checkbox
+                name="settings[remember_me_default]"
+                checked={@settings["remember_me_default"] == "true"}
+                label={gettext("Check it by default (users can still untick it)")}
+              />
+              <div class="text-xs text-base-content/60 mt-1 max-w-prose">
+                {gettext(
+                  "Persistent sessions last 60 days. Magic-link and social logins have no checkbox to tick, so they follow the default above. Turning the first option off hides the checkbox everywhere and keeps every login to the browser session."
+                )}
+              </div>
+              <.unsaved_hint dirty={
+                Enum.any?(
+                  ["remember_me_enabled", "remember_me_default"],
+                  fn key -> @settings[key] != @saved_settings[key] end
+                )
+              } />
+            </div>
+
+            <.section_header
+              icon="hero-arrow-right-circle"
+              title={gettext("Post-Login Redirects")}
+            />
+
+            <%!-- Where users land after signing in / registering. An explicit
+                 return_to (e.g. a protected page that sent them to login)
+                 always wins over these defaults. --%>
+            <div class="form-control w-full">
+              <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                <div class="form-control w-full">
+                  <label class="label" for="settings_after_login_path">
+                    <span class="label-text text-base font-medium">
+                      {gettext("After-login path")}
+                    </span>
+                  </label>
+                  <input
+                    id="settings_after_login_path"
+                    type="text"
+                    name="settings[after_login_path]"
+                    value={@settings["after_login_path"]}
+                    placeholder="/"
+                    class="input input-bordered w-full"
+                  />
+                  <div class="text-xs text-base-content/60 mt-1">
+                    {gettext("Local path users land on after signing in.")}
+                  </div>
+                </div>
+                <div class="form-control w-full">
+                  <label class="label" for="settings_after_registration_path">
+                    <span class="label-text text-base font-medium">
+                      {gettext("After-registration path")}
+                    </span>
+                  </label>
+                  <input
+                    id="settings_after_registration_path"
+                    type="text"
+                    name="settings[after_registration_path]"
+                    value={@settings["after_registration_path"]}
+                    placeholder={gettext("Same as after login")}
+                    class="input input-bordered w-full"
+                  />
+                  <div class="text-xs text-base-content/60 mt-1">
+                    {gettext(
+                      "Where a freshly registered account lands. Empty = after-login path."
+                    )}
+                  </div>
+                </div>
+              </div>
+              <.unsaved_hint dirty={
+                Enum.any?(
+                  ["after_login_path", "after_registration_path"],
+                  fn key -> @settings[key] != @saved_settings[key] end
+                )
+              } />
             </div>
 
             <.section_header icon="hero-user-circle" title={gettext("New User Defaults")} />

--- a/lib/phoenix_kit_web/users/auth.ex
+++ b/lib/phoenix_kit_web/users/auth.ex
@@ -164,8 +164,13 @@ defmodule PhoenixKitWeb.Users.Auth do
     end
   end
 
+  # Not a remembered login — clear any cookie this browser still holds. Logging
+  # in mints a new token and (on a password change) deletes the old ones, so a
+  # carried-over cookie would point at a dead token: it survives until the
+  # browser drops its session cookie, then silently signs the user out and
+  # keeps failing for the cookie's full 60 days.
   defp maybe_write_remember_me_cookie(conn, _token, _params) do
-    conn
+    delete_resp_cookie(conn, @remember_me_cookie)
   end
 
   @doc """
@@ -201,6 +206,19 @@ defmodule PhoenixKitWeb.Users.Auth do
   @spec remember_me_params() :: map()
   def remember_me_params do
     if remember_me_default?(), do: %{"remember_me" => "true"}, else: %{}
+  end
+
+  @doc """
+  Whether this request already carries a persistent remember-me cookie.
+
+  Lets a re-login flow that has no checkbox of its own (the password-change
+  handoff) preserve the choice the user already made, instead of silently
+  downgrading them to a session-only login.
+  """
+  @spec remembered?(Plug.Conn.t()) :: boolean()
+  def remembered?(conn) do
+    conn = fetch_cookies(conn, signed: [@remember_me_cookie])
+    is_binary(conn.cookies[@remember_me_cookie])
   end
 
   # This function renews the session ID and erases the whole
@@ -426,8 +444,19 @@ defmodule PhoenixKitWeb.Users.Auth do
       conn = fetch_cookies(conn, signed: [@remember_me_cookie])
 
       case conn.cookies[@remember_me_cookie] do
-        token when is_binary(token) -> {token, put_token_in_session(conn, token)}
-        _ -> {nil, conn}
+        token when is_binary(token) ->
+          # Honor the master switch on READ too, not just on write. Blocking new
+          # cookies while still accepting old ones would let every cookie issued
+          # before the switch was turned off keep restoring sessions for its
+          # full 60 days — the opposite of what turning it off means.
+          if remember_me_enabled?() do
+            {token, put_token_in_session(conn, token)}
+          else
+            {nil, delete_resp_cookie(conn, @remember_me_cookie)}
+          end
+
+        _ ->
+          {nil, conn}
       end
     end
   end
@@ -1787,6 +1816,24 @@ defmodule PhoenixKitWeb.Users.Auth do
     PhoenixKit.Settings.get_boolean_setting("require_email_confirmation", true)
   end
 
+  # Shared confirmation gate for the role-based conn plugs. They check the role
+  # but never the email, and the shipped `:phoenix_kit_admin_only` pipeline runs
+  # `require_admin` with NO preceding `require_authenticated_*` — so a host
+  # controller route behind it enforced confirmation nowhere, even at the
+  # default. Returns `:cont` or an already-halted conn.
+  defp confirmation_gate(conn, scope) do
+    if Scope.authenticated?(scope) and not email_confirmed?(scope) and confirmation_required?() do
+      {:halt,
+       conn
+       |> put_flash(:error, "Please confirm your email before accessing the application.")
+       |> maybe_store_return_to()
+       |> redirect(to: Routes.path("/users/confirm"))
+       |> halt()}
+    else
+      :cont
+    end
+  end
+
   @doc """
   Used for routes that require the user to be an owner.
 
@@ -1797,13 +1844,19 @@ defmodule PhoenixKitWeb.Users.Auth do
   def require_owner(conn, _opts) do
     case conn.assigns[:phoenix_kit_current_scope] do
       %Scope{} = scope ->
-        if Scope.owner?(scope) do
-          conn
-        else
-          conn
-          |> put_flash(:error, "You must be an owner to access this page.")
-          |> redirect(to: "/")
-          |> halt()
+        case confirmation_gate(conn, scope) do
+          {:halt, conn} ->
+            conn
+
+          :cont ->
+            if Scope.owner?(scope) do
+              conn
+            else
+              conn
+              |> put_flash(:error, "You must be an owner to access this page.")
+              |> redirect(to: "/")
+              |> halt()
+            end
         end
 
       _ ->
@@ -1824,21 +1877,30 @@ defmodule PhoenixKitWeb.Users.Auth do
   def require_admin(conn, _opts) do
     case conn.assigns[:phoenix_kit_current_scope] do
       %Scope{} = scope ->
-        cond do
-          Scope.can_access_admin_area?(scope) ->
+        case confirmation_gate(conn, scope) do
+          {:halt, conn} ->
             conn
 
-          Scope.authenticated?(scope) ->
-            conn
-            |> put_flash(:error, "You do not have the required permission to access this page.")
-            |> redirect(to: "/")
-            |> halt()
+          :cont ->
+            cond do
+              Scope.can_access_admin_area?(scope) ->
+                conn
 
-          true ->
-            conn
-            |> put_flash(:error, "You must log in to access this page.")
-            |> redirect(to: Routes.path("/users/log-in"))
-            |> halt()
+              Scope.authenticated?(scope) ->
+                conn
+                |> put_flash(
+                  :error,
+                  "You do not have the required permission to access this page."
+                )
+                |> redirect(to: "/")
+                |> halt()
+
+              true ->
+                conn
+                |> put_flash(:error, "You must log in to access this page.")
+                |> redirect(to: Routes.path("/users/log-in"))
+                |> halt()
+            end
         end
 
       _ ->
@@ -1854,24 +1916,33 @@ defmodule PhoenixKitWeb.Users.Auth do
   def require_module_access(conn, module_key) when is_binary(module_key) do
     case conn.assigns[:phoenix_kit_current_scope] do
       %Scope{} = scope ->
-        cond do
-          not Scope.can_access_admin_area?(scope) ->
-            conn
-            |> put_flash(:error, "You do not have the required permission to access this page.")
-            |> redirect(to: "/")
-            |> halt()
-
-          # Disabled modules are blocked for everyone (Owner included), matching
-          # the LiveView mount and plug gates.
-          Scope.has_module_access?(scope, module_key) and
-              MapSet.member?(Permissions.enabled_module_keys(), module_key) ->
+        case confirmation_gate(conn, scope) do
+          {:halt, conn} ->
             conn
 
-          true ->
-            conn
-            |> put_flash(:error, "You do not have permission to access this section.")
-            |> redirect(to: best_available_admin_path(scope))
-            |> halt()
+          :cont ->
+            cond do
+              not Scope.can_access_admin_area?(scope) ->
+                conn
+                |> put_flash(
+                  :error,
+                  "You do not have the required permission to access this page."
+                )
+                |> redirect(to: "/")
+                |> halt()
+
+              # Disabled modules are blocked for everyone (Owner included), matching
+              # the LiveView mount and plug gates.
+              Scope.has_module_access?(scope, module_key) and
+                  MapSet.member?(Permissions.enabled_module_keys(), module_key) ->
+                conn
+
+              true ->
+                conn
+                |> put_flash(:error, "You do not have permission to access this section.")
+                |> redirect(to: best_available_admin_path(scope))
+                |> halt()
+            end
         end
 
       _ ->
@@ -1884,13 +1955,19 @@ defmodule PhoenixKitWeb.Users.Auth do
   def require_role(conn, role_name) when is_binary(role_name) do
     case conn.assigns[:phoenix_kit_current_scope] do
       %Scope{} = scope ->
-        if Scope.has_role?(scope, role_name) do
-          conn
-        else
-          conn
-          |> put_flash(:error, "You must have the #{role_name} role to access this page.")
-          |> redirect(to: "/")
-          |> halt()
+        case confirmation_gate(conn, scope) do
+          {:halt, conn} ->
+            conn
+
+          :cont ->
+            if Scope.has_role?(scope, role_name) do
+              conn
+            else
+              conn
+              |> put_flash(:error, "You must have the #{role_name} role to access this page.")
+              |> redirect(to: "/")
+              |> halt()
+            end
         end
 
       _ ->

--- a/lib/phoenix_kit_web/users/auth.ex
+++ b/lib/phoenix_kit_web/users/auth.ex
@@ -105,7 +105,14 @@ defmodule PhoenixKitWeb.Users.Auth do
     opts = Keyword.merge(opts, browser: UserAgent.browser(ua), os: UserAgent.os(ua))
 
     token = Auth.generate_user_session_token(user, opts)
-    user_return_to = get_session(conn, :user_return_to)
+
+    # Destination: an explicit `return_to` in params wins, then whatever a gate
+    # stashed in the session. Honoring the param matters because callers pass it
+    # (the OAuth callback has always passed `"return_to"` here, and it was
+    # silently dropped — session renewal below then wiped the session copy too,
+    # so an OAuth login started from a protected page landed on the default).
+    user_return_to =
+      sanitize_local(params["return_to"]) || get_session(conn, :user_return_to)
 
     # Merge guest cart into user cart before session renewal clears session data.
     # The shop_session_id cookie survives renew_session (only session data is cleared).
@@ -141,12 +148,59 @@ defmodule PhoenixKitWeb.Users.Auth do
     conn
   end
 
+  defp sanitize_local(path) do
+    if Routes.local_path?(path), do: path, else: nil
+  end
+
+  # The site-wide `remember_me_enabled` policy is enforced HERE rather than at
+  # each caller, so it holds by construction: with it off, no flow — not a
+  # forged param, not OAuth, not a future login path — can leave a persistent
+  # cookie.
   defp maybe_write_remember_me_cookie(conn, token, %{"remember_me" => "true"}) do
-    put_resp_cookie(conn, @remember_me_cookie, token, @remember_me_options)
+    if remember_me_enabled?() do
+      put_resp_cookie(conn, @remember_me_cookie, token, @remember_me_options)
+    else
+      conn
+    end
   end
 
   defp maybe_write_remember_me_cookie(conn, _token, _params) do
     conn
+  end
+
+  @doc """
+  Whether the site allows persistent ("remember me") sessions at all.
+
+  Site-wide policy via the `remember_me_enabled` setting (default `true`).
+  When false the checkbox is hidden on every auth form and no flow can write
+  the persistent cookie — logins last only as long as the browser session.
+  """
+  @spec remember_me_enabled?() :: boolean()
+  def remember_me_enabled? do
+    PhoenixKit.Settings.get_boolean_setting("remember_me_enabled", true)
+  end
+
+  @doc """
+  Whether the "remember me" checkbox starts checked.
+
+  Site-wide default via the `remember_me_default` setting (default `true`) —
+  users can still untick it per login. Flows with no UI to tick (magic-link
+  login, OAuth) follow this value directly. Always false when
+  `remember_me_enabled?/0` is false.
+  """
+  @spec remember_me_default?() :: boolean()
+  def remember_me_default? do
+    remember_me_enabled?() and
+      PhoenixKit.Settings.get_boolean_setting("remember_me_default", true)
+  end
+
+  @doc """
+  The params a no-UI login flow (magic link, OAuth) should pass to
+  `log_in_user/3` to follow the site's persistence policy.
+  """
+  @spec remember_me_params() :: map()
+  def remember_me_params do
+    if remember_me_default?(), do: %{"remember_me" => "true"}, else: %{}
   end
 
   # This function renews the session ID and erases the whole
@@ -468,29 +522,30 @@ defmodule PhoenixKitWeb.Users.Auth do
 
   def on_mount(:phoenix_kit_ensure_authenticated, _params, session, socket) do
     socket = mount_phoenix_kit_current_user(socket, session)
+    user = socket.assigns.phoenix_kit_current_user
 
-    case socket.assigns.phoenix_kit_current_user do
-      %{confirmed_at: nil} ->
-        socket =
-          socket
-          |> Phoenix.LiveView.put_flash(
-            :error,
-            "Please confirm your email before accessing the application."
-          )
-          |> Phoenix.LiveView.redirect(to: Routes.path("/users/confirm"))
-
-        {:halt, socket}
-
-      %{} ->
-        {:cont, socket}
-
-      nil ->
+    cond do
+      is_nil(user) ->
         socket =
           socket
           |> Phoenix.LiveView.put_flash(:error, "You must log in to access this page.")
           |> Phoenix.LiveView.redirect(to: login_path_with_return_to(socket))
 
         {:halt, socket}
+
+      is_nil(user.confirmed_at) and confirmation_required?() ->
+        socket =
+          socket
+          |> Phoenix.LiveView.put_flash(
+            :error,
+            "Please confirm your email before accessing the application."
+          )
+          |> Phoenix.LiveView.redirect(to: confirm_path_with_return_to(socket))
+
+        {:halt, socket}
+
+      true ->
+        {:cont, socket}
     end
   end
 
@@ -508,14 +563,15 @@ defmodule PhoenixKitWeb.Users.Auth do
 
         {:halt, socket}
 
-      Scope.authenticated?(scope) and not email_confirmed?(scope) ->
+      Scope.authenticated?(scope) and not email_confirmed?(scope) and
+          confirmation_required?() ->
         socket =
           socket
           |> Phoenix.LiveView.put_flash(
             :error,
             "Please confirm your email before accessing the application."
           )
-          |> Phoenix.LiveView.redirect(to: Routes.path("/users/confirm"))
+          |> Phoenix.LiveView.redirect(to: confirm_path_with_return_to(socket))
 
         {:halt, socket}
 
@@ -558,14 +614,15 @@ defmodule PhoenixKitWeb.Users.Auth do
 
         {:halt, socket}
 
-      Scope.authenticated?(scope) and not email_confirmed?(scope) ->
+      Scope.authenticated?(scope) and not email_confirmed?(scope) and
+          confirmation_required?() ->
         socket =
           socket
           |> Phoenix.LiveView.put_flash(
             :error,
             "Please confirm your email before accessing the application."
           )
-          |> Phoenix.LiveView.redirect(to: Routes.path("/users/confirm"))
+          |> Phoenix.LiveView.redirect(to: confirm_path_with_return_to(socket))
 
         {:halt, socket}
 
@@ -596,14 +653,15 @@ defmodule PhoenixKitWeb.Users.Auth do
 
         {:halt, socket}
 
-      Scope.authenticated?(scope) and not email_confirmed?(scope) ->
+      Scope.authenticated?(scope) and not email_confirmed?(scope) and
+          confirmation_required?() ->
         socket =
           socket
           |> Phoenix.LiveView.put_flash(
             :error,
             "Please confirm your email before accessing the application."
           )
-          |> Phoenix.LiveView.redirect(to: Routes.path("/users/confirm"))
+          |> Phoenix.LiveView.redirect(to: confirm_path_with_return_to(socket))
 
         {:halt, socket}
 
@@ -642,14 +700,15 @@ defmodule PhoenixKitWeb.Users.Auth do
 
         {:halt, socket}
 
-      Scope.authenticated?(scope) and not email_confirmed?(scope) ->
+      Scope.authenticated?(scope) and not email_confirmed?(scope) and
+          confirmation_required?() ->
         socket =
           socket
           |> Phoenix.LiveView.put_flash(
             :error,
             "Please confirm your email before accessing the application."
           )
-          |> Phoenix.LiveView.redirect(to: Routes.path("/users/confirm"))
+          |> Phoenix.LiveView.redirect(to: confirm_path_with_return_to(socket))
 
         {:halt, socket}
 
@@ -1653,22 +1712,25 @@ defmodule PhoenixKitWeb.Users.Auth do
   Enforces email confirmation before allowing access to the application.
   """
   def require_authenticated_user(conn, _opts) do
-    case conn.assigns[:phoenix_kit_current_user] do
-      %{confirmed_at: nil} ->
-        conn
-        |> put_flash(:error, "Please confirm your email before accessing the application.")
-        |> redirect(to: Routes.path("/users/confirm"))
-        |> halt()
+    user = conn.assigns[:phoenix_kit_current_user]
 
-      %{} ->
-        conn
-
-      nil ->
+    cond do
+      is_nil(user) ->
         conn
         |> put_flash(:error, "You must log in to access this page.")
         |> maybe_store_return_to()
         |> redirect(to: Routes.path("/users/log-in"))
         |> halt()
+
+      is_nil(user.confirmed_at) and confirmation_required?() ->
+        conn
+        |> put_flash(:error, "Please confirm your email before accessing the application.")
+        |> maybe_store_return_to()
+        |> redirect(to: Routes.path("/users/confirm"))
+        |> halt()
+
+      true ->
+        conn
     end
   end
 
@@ -1691,9 +1753,11 @@ defmodule PhoenixKitWeb.Users.Auth do
             |> redirect(to: Routes.path("/users/log-in"))
             |> halt()
 
-          Scope.authenticated?(scope) and not email_confirmed?(scope) ->
+          Scope.authenticated?(scope) and not email_confirmed?(scope) and
+              confirmation_required?() ->
             conn
             |> put_flash(:error, "Please confirm your email before accessing the application.")
+            |> maybe_store_return_to()
             |> redirect(to: Routes.path("/users/confirm"))
             |> halt()
 
@@ -1714,6 +1778,14 @@ defmodule PhoenixKitWeb.Users.Auth do
        do: true
 
   defp email_confirmed?(_), do: false
+
+  # Whether unconfirmed accounts are blocked from authenticated routes.
+  # Host-configurable via the `require_email_confirmation` setting (default
+  # true = historical behavior). Confirmation emails still send when off —
+  # only enforcement is gated.
+  defp confirmation_required? do
+    PhoenixKit.Settings.get_boolean_setting("require_email_confirmation", true)
+  end
 
   @doc """
   Used for routes that require the user to be an owner.
@@ -1847,30 +1919,43 @@ defmodule PhoenixKitWeb.Users.Auth do
   # it back, session.ex stashes it as :user_return_to, log_in_user/3
   # redirects there. We skip the param when the URI isn't available or
   # the user is already on the login page (guards against self-loops).
-  #
+  defp login_path_with_return_to(socket) do
+    path_with_return_to(socket, "/users/log-in")
+  end
+
+  # Same shape for the unconfirmed-account gate: /users/confirm reads the
+  # param and sends the user onward once their email is confirmed, so the
+  # originally requested page isn't lost while they're parked there.
+  defp confirm_path_with_return_to(socket) do
+    path_with_return_to(socket, "/users/confirm")
+  end
+
   # The self-loop check trims trailing slashes on both sides so
   # `/users/log-in` and `/users/log-in/` are treated as the same path —
   # without the trim, a hand-typed trailing-slash URL would round-trip
   # back to itself via `?return_to=`.
-  defp login_path_with_return_to(socket) do
-    login_path = Routes.path("/users/log-in")
-    login_path_canonical = String.trim_trailing(login_path, "/")
+  defp path_with_return_to(socket, target) do
+    target_path = Routes.path(target)
+    target_path_canonical = String.trim_trailing(target_path, "/")
 
     case Phoenix.LiveView.get_connect_info(socket, :uri) do
       %URI{path: path} = uri when is_binary(path) ->
-        if String.trim_trailing(path, "/") == login_path_canonical do
-          login_path
+        if String.trim_trailing(path, "/") == target_path_canonical do
+          target_path
         else
           query = if uri.query, do: "?" <> uri.query, else: ""
-          login_path <> "?return_to=" <> URI.encode_www_form(path <> query)
+          target_path <> "?return_to=" <> URI.encode_www_form(path <> query)
         end
 
       _ ->
-        login_path
+        target_path
     end
   end
 
-  defp signed_in_path(_conn), do: "/"
+  # Default post-login destination — the `after_login_path` setting, guarded.
+  # An explicit :user_return_to (stashed by the gates above or passed by the
+  # login form) is applied by `log_in_user/3` and wins over this default.
+  defp signed_in_path(_conn), do: Routes.post_auth_path()
 
   @doc """
   Validates and sets the locale for the current request.

--- a/lib/phoenix_kit_web/users/confirmation.ex
+++ b/lib/phoenix_kit_web/users/confirmation.ex
@@ -14,13 +14,15 @@ defmodule PhoenixKitWeb.Users.Confirmation do
   alias PhoenixKit.Users.Invitations
   alias PhoenixKit.Utils.Routes
 
-  def mount(%{"token" => token}, session, socket) do
+  def mount(%{"token" => token} = params, session, socket) do
     form = to_form(%{"token" => token}, as: "user")
 
     # Same destination rule as the parked /users/confirm page, so the tab that
     # clicks the emailed link and a tab parked waiting for confirmation don't
-    # land in two different places.
-    destination = Routes.post_auth_path([session["user_return_to"]])
+    # land in two different places. `?return_to=` is read as well as the
+    # session key because a LiveView gate can only pass the destination in the
+    # query string — it has no conn to `put_session` on.
+    destination = Routes.post_auth_path([params["return_to"], session["user_return_to"]])
 
     {:ok, assign(socket, form: form, destination: destination), temporary_assigns: [form: nil]}
   end

--- a/lib/phoenix_kit_web/users/confirmation.ex
+++ b/lib/phoenix_kit_web/users/confirmation.ex
@@ -14,14 +14,22 @@ defmodule PhoenixKitWeb.Users.Confirmation do
   alias PhoenixKit.Users.Invitations
   alias PhoenixKit.Utils.Routes
 
-  def mount(%{"token" => token}, _session, socket) do
+  def mount(%{"token" => token}, session, socket) do
     form = to_form(%{"token" => token}, as: "user")
-    {:ok, assign(socket, form: form), temporary_assigns: [form: nil]}
+
+    # Same destination rule as the parked /users/confirm page, so the tab that
+    # clicks the emailed link and a tab parked waiting for confirmation don't
+    # land in two different places.
+    destination = Routes.post_auth_path([session["user_return_to"]])
+
+    {:ok, assign(socket, form: form, destination: destination), temporary_assigns: [form: nil]}
   end
 
   # Do not log in the user after confirmation to avoid a
   # leaked token giving the user access to the account.
   def handle_event("confirm_account", %{"user" => %{"token" => token}}, socket) do
+    destination = socket.assigns.destination
+
     case Auth.confirm_user(token) do
       {:ok, user} ->
         maybe_accept_pending_invitation(user)
@@ -29,7 +37,7 @@ defmodule PhoenixKitWeb.Users.Confirmation do
         {:noreply,
          socket
          |> put_flash(:info, "User confirmed successfully.")
-         |> redirect(to: "/")}
+         |> redirect(to: destination)}
 
       :error ->
         # If there is a current user and the account was already confirmed,
@@ -39,7 +47,7 @@ defmodule PhoenixKitWeb.Users.Confirmation do
         case socket.assigns do
           %{phoenix_kit_current_user: %{confirmed_at: confirmed_at}}
           when not is_nil(confirmed_at) ->
-            {:noreply, redirect(socket, to: "/")}
+            {:noreply, redirect(socket, to: destination)}
 
           %{} ->
             {:noreply,

--- a/lib/phoenix_kit_web/users/confirmation_instructions.ex
+++ b/lib/phoenix_kit_web/users/confirmation_instructions.ex
@@ -13,10 +13,12 @@ defmodule PhoenixKitWeb.Users.ConfirmationInstructions do
   - On mount, an already-confirmed user is redirected onward immediately —
     covers a confirmation done elsewhere (or directly in the DB) followed
     by a refresh, since the user is reloaded from the DB on every mount.
-  - While parked, the LiveView listens for the `{:user_confirmed, user}`
-    event (broadcast by both the email-link flow and the admin confirm
-    action) and redirects onward live, no refresh needed — e.g. when the
-    user clicks the emailed link in another tab.
+  - While parked, the LiveView listens on this user's own confirmation topic
+    for `{:user_confirmed, user}` (broadcast by both the email-link flow and
+    the admin confirm action) and redirects onward live, no refresh needed —
+    e.g. when the user clicks the emailed link in another tab. It is a
+    per-user topic, not the site-wide admin users feed, so a parked
+    non-admin never receives other users' structs.
 
   "Onward" is `?return_to=` (stashed by the gate that parked them), then
   the session's `user_return_to`, then the `after_login_path` setting.
@@ -25,6 +27,7 @@ defmodule PhoenixKitWeb.Users.ConfirmationInstructions do
 
   alias PhoenixKit.Admin.Events
   alias PhoenixKit.Users.Auth
+  alias PhoenixKit.Users.RateLimiter
   alias PhoenixKit.Utils.Routes
 
   def mount(params, session, socket) do
@@ -48,7 +51,7 @@ defmodule PhoenixKitWeb.Users.ConfirmationInstructions do
         # the page would sit there forever despite promising to continue
         # automatically. Re-reading after subscribing closes that window —
         # either the re-read sees it, or the broadcast reaches us.
-        if connected?(socket), do: Events.subscribe_to_users()
+        if connected?(socket), do: Events.subscribe_to_user_confirmation(user.uuid)
 
         if connected?(socket) and confirmed_since_mount?(user) do
           {:ok, redirect(socket, to: destination)}
@@ -70,7 +73,12 @@ defmodule PhoenixKitWeb.Users.ConfirmationInstructions do
   end
 
   def handle_event("send_instructions", %{"user" => %{"email" => email}}, socket) do
-    if user = Auth.get_user_by_email(email) do
+    # Throttle BEFORE the lookup and answer identically either way. This form
+    # is public: only an existing unconfirmed account does work (insert a token,
+    # send mail), so an unthrottled endpoint is both a targeted mail-flood
+    # vector and a timing oracle for which addresses are registered.
+    with :ok <- RateLimiter.check_confirmation_resend_rate_limit(email),
+         %{} = user <- Auth.get_user_by_email(email) do
       Auth.deliver_user_confirmation_instructions(
         user,
         &Routes.url("/users/confirm/#{&1}")
@@ -105,7 +113,7 @@ defmodule PhoenixKitWeb.Users.ConfirmationInstructions do
     end
   end
 
-  # The admin users topic also carries created/updated/deleted/etc. events.
+  # Defensive: the topic carries only this user's confirmation today.
   def handle_info(_msg, socket), do: {:noreply, socket}
 
   defp resolve_destination(params, session) do

--- a/lib/phoenix_kit_web/users/confirmation_instructions.ex
+++ b/lib/phoenix_kit_web/users/confirmation_instructions.ex
@@ -5,14 +5,68 @@ defmodule PhoenixKitWeb.Users.ConfirmationInstructions do
   Allows users to request a new confirmation email if they didn't receive
   the original or if the link expired. Only sends if the account exists
   and is not already confirmed.
+
+  This page is also where the authentication gates park logged-in users
+  whose email is not yet confirmed (when `require_email_confirmation` is
+  on), so it moves them along as soon as confirmation happens:
+
+  - On mount, an already-confirmed user is redirected onward immediately —
+    covers a confirmation done elsewhere (or directly in the DB) followed
+    by a refresh, since the user is reloaded from the DB on every mount.
+  - While parked, the LiveView listens for the `{:user_confirmed, user}`
+    event (broadcast by both the email-link flow and the admin confirm
+    action) and redirects onward live, no refresh needed — e.g. when the
+    user clicks the emailed link in another tab.
+
+  "Onward" is `?return_to=` (stashed by the gate that parked them), then
+  the session's `user_return_to`, then the `after_login_path` setting.
   """
   use PhoenixKitWeb, :live_view
 
+  alias PhoenixKit.Admin.Events
   alias PhoenixKit.Users.Auth
   alias PhoenixKit.Utils.Routes
 
-  def mount(_params, _session, socket) do
-    {:ok, assign(socket, form: to_form(%{}, as: "user"))}
+  def mount(params, session, socket) do
+    user = socket.assigns[:phoenix_kit_current_user]
+    destination = resolve_destination(params, session)
+
+    cond do
+      user && user.confirmed_at ->
+        {:ok, redirect(socket, to: destination)}
+
+      is_nil(user) ->
+        {:ok,
+         socket
+         |> assign(form: to_form(%{"email" => ""}, as: "user"))
+         |> assign(awaiting_confirmation?: false)
+         |> assign(destination: destination)}
+
+      true ->
+        # Subscribe FIRST, then re-read: a confirmation committed between the
+        # on_mount user load and the subscribe would otherwise be missed, and
+        # the page would sit there forever despite promising to continue
+        # automatically. Re-reading after subscribing closes that window —
+        # either the re-read sees it, or the broadcast reaches us.
+        if connected?(socket), do: Events.subscribe_to_users()
+
+        if connected?(socket) and confirmed_since_mount?(user) do
+          {:ok, redirect(socket, to: destination)}
+        else
+          {:ok,
+           socket
+           |> assign(form: to_form(%{"email" => user.email}, as: "user"))
+           |> assign(awaiting_confirmation?: true)
+           |> assign(destination: destination)}
+        end
+    end
+  end
+
+  defp confirmed_since_mount?(user) do
+    case Auth.get_user(user.uuid) do
+      %{confirmed_at: confirmed_at} -> not is_nil(confirmed_at)
+      _ -> false
+    end
   end
 
   def handle_event("send_instructions", %{"user" => %{"email" => email}}, socket) do
@@ -26,9 +80,35 @@ defmodule PhoenixKitWeb.Users.ConfirmationInstructions do
     info =
       "If your email is in our system and it has not been confirmed yet, you will receive an email with instructions shortly."
 
-    {:noreply,
-     socket
-     |> put_flash(:info, info)
-     |> redirect(to: "/")}
+    socket = put_flash(socket, :info, info)
+
+    # A parked (logged-in, unconfirmed) user stays here so the live
+    # auto-advance can fire once they click the emailed link; anonymous
+    # visitors are sent on to the resolved destination.
+    if socket.assigns.awaiting_confirmation? do
+      {:noreply, socket}
+    else
+      {:noreply, redirect(socket, to: socket.assigns.destination)}
+    end
+  end
+
+  def handle_info({:user_confirmed, %{uuid: uuid}}, socket) do
+    current = socket.assigns[:phoenix_kit_current_user]
+
+    if current && current.uuid == uuid do
+      {:noreply,
+       socket
+       |> put_flash(:info, gettext("Email confirmed. Welcome!"))
+       |> redirect(to: socket.assigns.destination)}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  # The admin users topic also carries created/updated/deleted/etc. events.
+  def handle_info(_msg, socket), do: {:noreply, socket}
+
+  defp resolve_destination(params, session) do
+    Routes.post_auth_path([params["return_to"], session["user_return_to"]])
   end
 end

--- a/lib/phoenix_kit_web/users/confirmation_instructions.html.heex
+++ b/lib/phoenix_kit_web/users/confirmation_instructions.html.heex
@@ -5,12 +5,23 @@
   current_path={assigns[:url_path] || "/users/confirm"}
   dev_mailbox_message={gettext("confirmation emails")}
 >
-  <h1 class="text-2xl font-bold text-center mb-2">
-    {gettext("No confirmation instructions received?")}
-  </h1>
-  <p class="text-center text-base-content/60 text-sm mb-6">
-    {gettext("We'll send a new confirmation link to your inbox")}
-  </p>
+  <%= if @awaiting_confirmation? do %>
+    <h1 class="text-2xl font-bold text-center mb-2">
+      {gettext("Confirm your email")}
+    </h1>
+    <p class="text-center text-base-content/60 text-sm mb-6">
+      {gettext(
+        "We sent a confirmation link to your inbox. This page continues automatically once your email is confirmed."
+      )}
+    </p>
+  <% else %>
+    <h1 class="text-2xl font-bold text-center mb-2">
+      {gettext("No confirmation instructions received?")}
+    </h1>
+    <p class="text-center text-base-content/60 text-sm mb-6">
+      {gettext("We'll send a new confirmation link to your inbox")}
+    </p>
+  <% end %>
   <.form for={@form} id="resend_confirmation_form" phx-submit="send_instructions">
     <fieldset class="fieldset min-w-0">
       <legend class="fieldset-legend sr-only">{gettext("Resend Confirmation")}</legend>

--- a/lib/phoenix_kit_web/users/forgot_password.ex
+++ b/lib/phoenix_kit_web/users/forgot_password.ex
@@ -8,6 +8,7 @@ defmodule PhoenixKitWeb.Users.ForgotPassword do
   use PhoenixKitWeb, :live_view
 
   alias PhoenixKit.Users.Auth
+  alias PhoenixKit.Users.RateLimiter
   alias PhoenixKit.Utils.Routes
 
   def mount(_params, _session, socket) do
@@ -18,31 +19,31 @@ defmodule PhoenixKitWeb.Users.ForgotPassword do
   end
 
   def handle_event("send_email", %{"user" => %{"email" => email}}, socket) do
-    result =
-      if user = Auth.get_user_by_email(email) do
-        Auth.deliver_user_reset_password_instructions(
-          user,
-          &Routes.url("/users/reset-password/#{&1}")
-        )
-      else
-        {:ok, nil}
-      end
-
-    case result do
-      {:ok, _} ->
-        info =
-          "If your email is in our system, you will receive instructions to reset your password shortly."
-
-        {:noreply,
-         socket
-         |> put_flash(:info, info)
-         |> redirect(to: "/")}
+    # Rate-limit BEFORE the lookup, and answer identically whatever happens.
+    # The limiter used to run inside deliver_*, i.e. only for addresses that
+    # resolved to a user — so past the threshold a registered address got
+    # "Too many password reset requests" while an unregistered one still got
+    # the generic notice. That turned the deliberately vague copy into a
+    # precise account-existence oracle: N+1 requests told you the answer.
+    case RateLimiter.check_password_reset_rate_limit(email) do
+      :ok ->
+        if user = Auth.get_user_by_email(email) do
+          Auth.deliver_user_reset_password_instructions(
+            user,
+            &Routes.url("/users/reset-password/#{&1}")
+          )
+        end
 
       {:error, :rate_limit_exceeded} ->
-        {:noreply,
-         socket
-         |> put_flash(:error, "Too many password reset requests. Please try again later.")
-         |> redirect(to: Routes.path("/users/log-in"))}
+        :throttled
     end
+
+    info =
+      "If your email is in our system, you will receive instructions to reset your password shortly."
+
+    {:noreply,
+     socket
+     |> put_flash(:info, info)
+     |> redirect(to: "/")}
   end
 end

--- a/lib/phoenix_kit_web/users/login.ex
+++ b/lib/phoenix_kit_web/users/login.ex
@@ -56,6 +56,8 @@ defmodule PhoenixKitWeb.Users.Login do
             allow_registration: allow_registration,
             magic_link_enabled: magic_link_enabled,
             qr_login_enabled: qr_login_enabled,
+            remember_me_available: Auth.remember_me_enabled?(),
+            remember_me: Auth.remember_me_default?(),
             return_to: return_to
           )
 

--- a/lib/phoenix_kit_web/users/login.html.heex
+++ b/lib/phoenix_kit_web/users/login.html.heex
@@ -101,7 +101,7 @@
         <%!-- Magic Link authentication --%>
         <%= if @magic_link_enabled do %>
           <.link
-            navigate={Routes.path("/users/magic-link")}
+            navigate={Routes.path("/users/magic-link") <> Routes.return_to_query(@return_to)}
             class="btn btn-outline w-full transition-all hover:scale-[1.02] active:scale-[0.98] hover:shadow-lg"
           >
             <PhoenixKitWeb.Components.Core.Icons.icon_email class="w-5 h-5 mr-2" />
@@ -111,7 +111,7 @@
         <%!-- QR code sign-in --%>
         <%= if @qr_login_enabled do %>
           <.link
-            navigate={Routes.path("/users/qr-login")}
+            navigate={Routes.path("/users/qr-login") <> Routes.return_to_query(@return_to)}
             class="btn btn-outline w-full transition-all hover:scale-[1.02] active:scale-[0.98] hover:shadow-lg"
           >
             <PhoenixKitWeb.Components.Core.Icons.icon_qr_code class="w-5 h-5 mr-2" />
@@ -119,7 +119,10 @@
           </.link>
         <% end %>
         <%!-- OAuth authentication --%>
-        <PhoenixKitWeb.Components.OAuthButtons.oauth_buttons show_divider={false} />
+        <PhoenixKitWeb.Components.OAuthButtons.oauth_buttons
+          show_divider={false}
+          return_to={@return_to}
+        />
       </div>
     </div>
   <% end %>
@@ -129,7 +132,7 @@
     <div class="text-center mt-4 text-sm">
       <span>{gettext("New to %{project_title}?", project_title: @project_title)}</span>
       <.link
-        navigate={Routes.path("/users/register")}
+        navigate={Routes.path("/users/register") <> Routes.return_to_query(@return_to)}
         class="font-semibold text-primary hover:underline"
       >
         {gettext("Create an account")}

--- a/lib/phoenix_kit_web/users/login.html.heex
+++ b/lib/phoenix_kit_web/users/login.html.heex
@@ -51,10 +51,13 @@
         </:icon>
       </.input>
 
-      <div class="form-control mt-4">
+      <%!-- Checked by default (site-configurable); users can untick it for a
+           session-only login, and the site can forbid persistence entirely. --%>
+      <div :if={@remember_me_available} class="form-control mt-4">
         <.checkbox
           id="user_remember_me"
           name="user[remember_me]"
+          checked={@remember_me}
           label={gettext("Keep me logged in")}
         />
       </div>

--- a/lib/phoenix_kit_web/users/magic_link.ex
+++ b/lib/phoenix_kit_web/users/magic_link.ex
@@ -21,7 +21,7 @@ defmodule PhoenixKitWeb.Users.MagicLink do
   alias PhoenixKitWeb.Users.Auth
 
   @impl true
-  def mount(_params, session, socket) do
+  def mount(params, session, socket) do
     case Auth.maybe_redirect_authenticated(socket) do
       {:redirect, socket} ->
         {:ok, socket}
@@ -41,13 +41,19 @@ defmodule PhoenixKitWeb.Users.MagicLink do
 
         form = to_form(%{"email" => ""}, as: "magic_link")
 
+        # Carried into the emailed link so a user sent here from a protected
+        # page still lands there after clicking it. Sanitized on the way in and
+        # again on the way out.
+        return_to = if Routes.local_path?(params["return_to"]), do: params["return_to"]
+
         {:ok,
          socket
          |> assign(:page_title, "Magic Link Login")
          |> assign(:form, form)
          |> assign(:sent, false)
          |> assign(:loading, false)
-         |> assign(:error, nil)}
+         |> assign(:error, nil)
+         |> assign(:return_to, return_to)}
     end
   end
 
@@ -67,7 +73,7 @@ defmodule PhoenixKitWeb.Users.MagicLink do
        |> assign(:form, form)
        |> assign(:loading, true)
        |> assign(:error, nil)
-       |> send_magic_link_async(email)}
+       |> send_magic_link_async(email, socket.assigns[:return_to])}
     else
       form = to_form(%{"email" => email}, as: "magic_link")
 
@@ -107,8 +113,8 @@ defmodule PhoenixKitWeb.Users.MagicLink do
   end
 
   # Send magic link email to user and handle response
-  defp send_magic_link_email_to_user(user, token) do
-    magic_link_url = MagicLink.magic_link_url(token)
+  defp send_magic_link_email_to_user(user, token, return_to) do
+    magic_link_url = MagicLink.magic_link_url(token) <> Routes.return_to_query(return_to)
 
     case Mailer.send_magic_link_email(user, magic_link_url) do
       {:ok, _} -> {:ok, user}
@@ -117,11 +123,11 @@ defmodule PhoenixKitWeb.Users.MagicLink do
   end
 
   # Process the magic link sending in the background
-  defp send_magic_link_async(socket, email) do
+  defp send_magic_link_async(socket, email, return_to) do
     Phoenix.LiveView.start_async(socket, :send_magic_link, fn ->
       case MagicLink.generate_magic_link(email) do
         {:ok, user, token} ->
-          send_magic_link_email_to_user(user, token)
+          send_magic_link_email_to_user(user, token, return_to)
 
         {:error, :user_not_found} ->
           # For security, we simulate the same delay as successful case

--- a/lib/phoenix_kit_web/users/magic_link_registration.ex
+++ b/lib/phoenix_kit_web/users/magic_link_registration.ex
@@ -69,6 +69,7 @@ defmodule PhoenixKitWeb.Users.MagicLinkRegistration do
   @impl true
   def handle_event("validate", %{"user" => user_params} = params, socket) do
     referral_code = params["referral_code"]
+    user_params = form_params(user_params)
 
     # Track the checkbox across re-renders so unticking it sticks.
     socket = assign(socket, :remember_me, user_params["remember_me"] == "true")
@@ -105,6 +106,7 @@ defmodule PhoenixKitWeb.Users.MagicLinkRegistration do
   @impl true
   def handle_event("save", %{"user" => user_params} = params, socket) do
     referral_code = params["referral_code"]
+    user_params = form_params(user_params)
 
     case validate_referral_code(referral_code, socket) do
       {:ok, _validated_code} ->
@@ -128,6 +130,16 @@ defmodule PhoenixKitWeb.Users.MagicLinkRegistration do
 
           {:error, %Ecto.Changeset{} = changeset} ->
             {:noreply, socket |> assign(check_errors: true) |> assign_form(changeset)}
+
+          # `complete_registration/3` also returns bare atoms — `:invalid_token`
+          # once the token expires while the form sits open, and
+          # `:email_already_exists` if the address is claimed in between.
+          # Without these clauses either outcome was a CaseClauseError.
+          {:error, reason} ->
+            {:noreply,
+             socket
+             |> put_flash(:error, completion_error_message(reason))
+             |> redirect(to: Routes.path("/users/register/magic-link"))}
         end
 
       {:error, error_message} ->
@@ -140,6 +152,23 @@ defmodule PhoenixKitWeb.Users.MagicLinkRegistration do
         {:noreply, socket}
     end
   end
+
+  defp completion_error_message(:email_already_exists),
+    do: "That email is already registered. Please log in instead."
+
+  defp completion_error_message(_),
+    do: "Registration link is invalid or has expired. Please request a new one."
+
+  # Only what this form legitimately owns. `registration_changeset/3` also casts
+  # `custom_fields` and the geo columns — fine for server-side callers, but a
+  # phx-submit payload is whatever the client sends.
+  @form_fields ~w(email username password first_name last_name account_type
+                  organization_name user_timezone remember_me return_to)
+
+  defp form_params(user_params) when is_map(user_params),
+    do: Map.take(user_params, @form_fields)
+
+  defp form_params(other), do: other
 
   defp assign_form(socket, %Ecto.Changeset{} = changeset) do
     form = to_form(changeset, as: "user")

--- a/lib/phoenix_kit_web/users/magic_link_registration.ex
+++ b/lib/phoenix_kit_web/users/magic_link_registration.ex
@@ -10,10 +10,11 @@ defmodule PhoenixKitWeb.Users.MagicLinkRegistration do
   alias PhoenixKit.Users.MagicLinkRegistration
   alias PhoenixKit.Users.Referrals
   alias PhoenixKit.Utils.Routes
+  alias PhoenixKitWeb.Users.Auth, as: WebAuth
 
   @impl true
   def mount(%{"token" => token}, _session, socket) do
-    case PhoenixKitWeb.Users.Auth.maybe_redirect_authenticated(socket) do
+    case WebAuth.maybe_redirect_authenticated(socket) do
       {:redirect, socket} ->
         {:ok, socket}
 
@@ -52,6 +53,8 @@ defmodule PhoenixKitWeb.Users.MagicLinkRegistration do
              |> assign(:referral_code_error, nil)
              |> assign(:trigger_submit, false)
              |> assign(:check_errors, false)
+             |> assign(:remember_me_available, WebAuth.remember_me_enabled?())
+             |> assign(:remember_me, WebAuth.remember_me_default?())
              |> assign_form(changeset)}
 
           {:error, _} ->
@@ -66,6 +69,9 @@ defmodule PhoenixKitWeb.Users.MagicLinkRegistration do
   @impl true
   def handle_event("validate", %{"user" => user_params} = params, socket) do
     referral_code = params["referral_code"]
+
+    # Track the checkbox across re-renders so unticking it sticks.
+    socket = assign(socket, :remember_me, user_params["remember_me"] == "true")
 
     case validate_referral_code(referral_code, socket) do
       {:ok, _} ->

--- a/lib/phoenix_kit_web/users/magic_link_registration.html.heex
+++ b/lib/phoenix_kit_web/users/magic_link_registration.html.heex
@@ -108,6 +108,17 @@
         </div>
       <% end %>
 
+      <%!-- Checked by default so a new account stays signed in on this device
+           (see the note on the password registration form). --%>
+      <div :if={@remember_me_available} class="form-control mt-4">
+        <.checkbox
+          id="user_remember_me"
+          name="user[remember_me]"
+          checked={@remember_me}
+          label={gettext("Keep me logged in")}
+        />
+      </div>
+
       <button
         type="submit"
         class="btn btn-primary w-full mt-4 transition-all hover:scale-[1.02] active:scale-[0.98]"

--- a/lib/phoenix_kit_web/users/magic_link_registration_request.ex
+++ b/lib/phoenix_kit_web/users/magic_link_registration_request.ex
@@ -80,13 +80,16 @@ defmodule PhoenixKitWeb.Users.MagicLinkRegistrationRequest do
          |> assign(:error_message, nil)
          |> put_flash(:info, "Registration link sent! Check your email.")}
 
+      # Deliberately indistinguishable from success: saying "already
+      # registered" here turned this public form into an account-existence
+      # oracle, while login and magic-link login both answer generically.
       {:error, :email_already_exists} ->
         {:noreply,
-         error_state(
-           socket,
-           "This email is already registered. Please log in instead.",
-           "Email already exists"
-         )}
+         socket
+         |> assign(:email_sent, true)
+         |> assign(:loading, false)
+         |> assign(:error_message, nil)
+         |> put_flash(:info, "Registration link sent! Check your email.")}
 
       {:error, :invalid_email} ->
         {:noreply,

--- a/lib/phoenix_kit_web/users/magic_link_verify.ex
+++ b/lib/phoenix_kit_web/users/magic_link_verify.ex
@@ -21,7 +21,7 @@ defmodule PhoenixKitWeb.Users.MagicLinkVerify do
   3. Redirects to the appropriate post-login destination
   4. Handles invalid/expired tokens gracefully
   """
-  def verify(conn, %{"token" => token}) do
+  def verify(conn, %{"token" => token} = params) do
     case MagicLink.verify_magic_link(token) do
       {:ok, user} ->
         # A magic-link user just proved control of their own inbox on this
@@ -29,7 +29,10 @@ defmodule PhoenixKitWeb.Users.MagicLinkVerify do
         # cookie the login rides a browser-session cookie that mobile browsers
         # drop overnight. There's no checkbox to tick when arriving from an
         # email, so this follows the site-wide policy setting.
+        # log_in_user/3 reads :user_return_to from the session, so stash the
+        # (re-sanitized) destination the emailed link carried before signing in.
         conn
+        |> maybe_store_return_to(params["return_to"])
         |> put_flash(:info, "Successfully logged in with magic link!")
         |> UserAuth.log_in_user(user, UserAuth.remember_me_params())
 
@@ -44,5 +47,13 @@ defmodule PhoenixKitWeb.Users.MagicLinkVerify do
     conn
     |> put_flash(:error, "Invalid magic link. Please request a new one.")
     |> redirect(to: Routes.path("/users/log-in"))
+  end
+
+  defp maybe_store_return_to(conn, return_to) do
+    if Routes.local_path?(return_to) do
+      put_session(conn, :user_return_to, return_to)
+    else
+      conn
+    end
   end
 end

--- a/lib/phoenix_kit_web/users/magic_link_verify.ex
+++ b/lib/phoenix_kit_web/users/magic_link_verify.ex
@@ -24,9 +24,14 @@ defmodule PhoenixKitWeb.Users.MagicLinkVerify do
   def verify(conn, %{"token" => token}) do
     case MagicLink.verify_magic_link(token) do
       {:ok, user} ->
+        # A magic-link user just proved control of their own inbox on this
+        # device, so the session persists by default — without the remember-me
+        # cookie the login rides a browser-session cookie that mobile browsers
+        # drop overnight. There's no checkbox to tick when arriving from an
+        # email, so this follows the site-wide policy setting.
         conn
         |> put_flash(:info, "Successfully logged in with magic link!")
-        |> UserAuth.log_in_user(user)
+        |> UserAuth.log_in_user(user, UserAuth.remember_me_params())
 
       {:error, :invalid_token} ->
         conn

--- a/lib/phoenix_kit_web/users/oauth.ex
+++ b/lib/phoenix_kit_web/users/oauth.ex
@@ -156,14 +156,25 @@ if Code.ensure_loaded?(Ueberauth) do
       end
     end
 
-    defp maybe_put_session(conn, _key, nil), do: conn
+    # Set-or-CLEAR, never leave the previous attempt's value behind. A no-op on
+    # nil meant an abandoned OAuth attempt handed its stale return_to or
+    # referral attribution to whatever login came next.
+    defp maybe_put_session(conn, key, nil), do: delete_session(conn, key)
     defp maybe_put_session(conn, key, value), do: put_session(conn, key, value)
 
     defp maybe_set_add_account_intent(conn, %{"add_account" => "1"}) do
       put_session(conn, @add_account_intent_key, "add_account")
     end
 
-    defp maybe_set_add_account_intent(conn, _params), do: conn
+    defp maybe_set_add_account_intent(conn, _params),
+      do: delete_session(conn, @add_account_intent_key)
+
+    defp clear_oauth_session_keys(conn) do
+      conn
+      |> delete_session(:oauth_referral_code)
+      |> delete_session(:oauth_return_to)
+      |> delete_session(@add_account_intent_key)
+    end
 
     defp oauth_enabled_in_settings? do
       Settings.get_boolean_setting("oauth_enabled", false)
@@ -291,8 +302,9 @@ if Code.ensure_loaded?(Ueberauth) do
       Logger.warning("PhoenixKit: OAuth authentication failure: #{inspect(failure)}")
 
       conn
-      # Clear the add-account marker so a later normal sign-in can't inherit it.
-      |> delete_session(@add_account_intent_key)
+      # Clear every transient OAuth key so a later normal sign-in can't inherit
+      # this abandoned attempt's redirect target or referral attribution.
+      |> clear_oauth_session_keys()
       |> put_flash(:error, error_message)
       |> redirect(to: Routes.path("/users/log-in"))
     end
@@ -302,8 +314,9 @@ if Code.ensure_loaded?(Ueberauth) do
       Logger.error("PhoenixKit: Unexpected OAuth callback without auth or failure")
 
       conn
-      # Clear the add-account marker so a later normal sign-in can't inherit it.
-      |> delete_session(@add_account_intent_key)
+      # Clear every transient OAuth key so a later normal sign-in can't inherit
+      # this abandoned attempt's redirect target or referral attribution.
+      |> clear_oauth_session_keys()
       |> put_flash(:error, "Authentication failed. Please try again.")
       |> redirect(to: Routes.path("/users/log-in"))
     end

--- a/lib/phoenix_kit_web/users/oauth.ex
+++ b/lib/phoenix_kit_web/users/oauth.ex
@@ -252,9 +252,14 @@ if Code.ensure_loaded?(Ueberauth) do
               flash_message =
                 "Successfully signed in with #{format_provider_name(auth.provider)}!"
 
+              # No checkbox in an OAuth round-trip, so persistence follows the
+              # site-wide policy setting.
+              login_params =
+                Map.put(UserAuth.remember_me_params(), "return_to", return_to)
+
               conn
               |> put_flash(:info, flash_message)
-              |> UserAuth.log_in_user(user, %{"remember_me" => "true", "return_to" => return_to})
+              |> UserAuth.log_in_user(user, login_params)
           end
 
         {:error, %Ecto.Changeset{} = changeset} ->

--- a/lib/phoenix_kit_web/users/qr_login.ex
+++ b/lib/phoenix_kit_web/users/qr_login.ex
@@ -32,7 +32,8 @@ defmodule PhoenixKitWeb.Users.QrLogin do
       :cont ->
         # `return_to` is a post-login destination the browser carries through
         # the whole handoff (mint → approve → finish); sanitized against open
-        # redirects up front. remember_me defaults off, toggled on this page.
+        # redirects up front. remember_me starts at the site default and is
+        # toggled on this page.
         socket = assign(socket, :return_to, sanitize_return_to(params["return_to"]))
 
         cond do
@@ -141,7 +142,8 @@ defmodule PhoenixKitWeb.Users.QrLogin do
   defp assign_common(socket) do
     socket
     |> assign(:project_title, PhoenixKit.Settings.get_project_title())
-    |> assign_new(:remember_me, fn -> false end)
+    |> assign_new(:remember_me_available, fn -> Auth.remember_me_enabled?() end)
+    |> assign_new(:remember_me, fn -> Auth.remember_me_default?() end)
   end
 
   defp panel_labels do

--- a/lib/phoenix_kit_web/users/qr_login.html.heex
+++ b/lib/phoenix_kit_web/users/qr_login.html.heex
@@ -23,7 +23,12 @@
     </div>
   </div>
 
-  <form :if={@keyfob} id="qr-login-remember-form" phx-change="set_remember" class="mt-2">
+  <form
+    :if={@keyfob && @remember_me_available}
+    id="qr-login-remember-form"
+    phx-change="set_remember"
+    class="mt-2"
+  >
     <label class="label cursor-pointer justify-center gap-2">
       <input
         type="checkbox"

--- a/lib/phoenix_kit_web/users/registration.ex
+++ b/lib/phoenix_kit_web/users/registration.ex
@@ -17,9 +17,10 @@ defmodule PhoenixKitWeb.Users.Registration do
   alias PhoenixKit.Utils.Date, as: UtilsDate
   alias PhoenixKit.Utils.IpAddress
   alias PhoenixKit.Utils.Routes
+  alias PhoenixKitWeb.Users.Auth, as: WebAuth
 
   def mount(params, session, socket) do
-    case PhoenixKitWeb.Users.Auth.maybe_redirect_authenticated(socket) do
+    case WebAuth.maybe_redirect_authenticated(socket) do
       {:redirect, socket} ->
         {:ok, socket}
 
@@ -71,6 +72,10 @@ defmodule PhoenixKitWeb.Users.Registration do
       invitation_token = Map.get(params, "invitation")
       pending_invitation = load_pending_invitation(invitation_token)
 
+      # Support return_to query param for post-registration redirect
+      # (mirrors the login page; wins over the after_registration_path setting)
+      return_to = sanitize_return_to(params["return_to"])
+
       socket =
         socket
         |> assign(trigger_submit: false, check_errors: false)
@@ -86,6 +91,9 @@ defmodule PhoenixKitWeb.Users.Registration do
         |> assign(org_accounts_enabled: org_accounts_enabled)
         |> assign(pending_invitation: pending_invitation)
         |> assign(pending_invitation_token: invitation_token)
+        |> assign(return_to: return_to)
+        |> assign(remember_me_available: WebAuth.remember_me_enabled?())
+        |> assign(remember_me: WebAuth.remember_me_default?())
         |> assign_form(changeset)
 
       {:ok, socket, temporary_assigns: [form: nil]}
@@ -188,7 +196,14 @@ defmodule PhoenixKitWeb.Users.Registration do
     # the email while it's still auto-managed.
     username_edited = username_manually_edited?(socket, params, user_params)
     user_params = maybe_sync_username(user_params, username_edited)
-    socket = assign(socket, username_edited: username_edited)
+
+    # The form re-renders on every change, so the checkbox has to be driven by
+    # what the user actually left it at — otherwise unticking it would snap
+    # back to the site default on the next keystroke.
+    socket =
+      socket
+      |> assign(username_edited: username_edited)
+      |> assign(remember_me: user_params["remember_me"] == "true")
 
     # Validate referral code and update error state
     case validate_referral_code(referral_code, socket) do
@@ -288,6 +303,11 @@ defmodule PhoenixKitWeb.Users.Registration do
 
   defp generate_session_id do
     :crypto.strong_rand_bytes(16) |> Base.encode64()
+  end
+
+  # Only allow relative paths to prevent open redirect attacks
+  defp sanitize_return_to(path) do
+    if Routes.local_path?(path), do: path, else: nil
   end
 
   defp load_pending_invitation(nil), do: nil

--- a/lib/phoenix_kit_web/users/registration.ex
+++ b/lib/phoenix_kit_web/users/registration.ex
@@ -112,6 +112,7 @@ defmodule PhoenixKitWeb.Users.Registration do
 
   def handle_event("save", %{"user" => user_params} = params, socket) do
     referral_code = params["referral_code"]
+    user_params = form_params(user_params)
 
     # If the username was never manually edited, let the schema (re)generate it
     # from the final email rather than persisting a possibly-stale preview value.
@@ -144,6 +145,11 @@ defmodule PhoenixKitWeb.Users.Registration do
               Auth.update_user_fields(user, %{
                 "pending_invitation_uuid" => socket.assigns.pending_invitation.uuid
               })
+
+              # That auto-accept only fires from `confirm_user/1`. With
+              # confirmation not required there is no confirmation step, so
+              # accept now or the invitation is never redeemed.
+              maybe_accept_invitation_without_confirmation(user)
             end
 
             case Auth.deliver_user_confirmation_instructions(
@@ -191,6 +197,7 @@ defmodule PhoenixKitWeb.Users.Registration do
 
   def handle_event("validate", %{"user" => user_params} = params, socket) do
     referral_code = params["referral_code"]
+    user_params = form_params(user_params)
 
     # Track whether the user owns the username field, then keep it in sync with
     # the email while it's still auto-managed.
@@ -308,6 +315,39 @@ defmodule PhoenixKitWeb.Users.Registration do
   # Only allow relative paths to prevent open redirect attacks
   defp sanitize_return_to(path) do
     if Routes.local_path?(path), do: path, else: nil
+  end
+
+  # Fields the public form is allowed to set. `registration_changeset/3` also
+  # casts `custom_fields` and the `registration_*` geo columns — legitimate for
+  # server-side callers (OAuth, the geolocation path) but attacker-controlled
+  # here, since a phx-submit payload is whatever the client sends. Writing
+  # `custom_fields` from the browser would let a visitor plant
+  # `pending_invitation_uuid` or an `oauth_avatar_url` that the admin user list
+  # renders as an <img src>.
+  @form_fields ~w(email username password first_name last_name account_type
+                  organization_name user_timezone remember_me return_to)
+
+  defp form_params(user_params) when is_map(user_params),
+    do: Map.take(user_params, @form_fields)
+
+  defp form_params(other), do: other
+
+  defp maybe_accept_invitation_without_confirmation(user) do
+    if Settings.get_boolean_setting("require_email_confirmation", true) do
+      :ok
+    else
+      user = Auth.get_user(user.uuid) || user
+      uuid = user.custom_fields && user.custom_fields["pending_invitation_uuid"]
+
+      case uuid && Invitations.accept_invitation_by_uuid(uuid, user) do
+        {:ok, _} ->
+          Auth.update_user_fields(user, %{"pending_invitation_uuid" => nil})
+          :ok
+
+        _ ->
+          :ok
+      end
+    end
   end
 
   defp load_pending_invitation(nil), do: nil

--- a/lib/phoenix_kit_web/users/registration.html.heex
+++ b/lib/phoenix_kit_web/users/registration.html.heex
@@ -201,7 +201,7 @@
         <%!-- Magic Link Registration --%>
         <%= if @magic_link_registration_enabled do %>
           <.link
-            navigate={Routes.path("/users/register/magic-link")}
+            navigate={Routes.path("/users/register/magic-link") <> Routes.return_to_query(@return_to)}
             class="btn btn-outline w-full transition-all hover:scale-[1.02] active:scale-[0.98] hover:shadow-lg"
           >
             <PhoenixKitWeb.Components.Core.Icons.icon_email class="w-5 h-5 mr-2" />
@@ -209,7 +209,10 @@
           </.link>
         <% end %>
         <%!-- OAuth authentication --%>
-        <PhoenixKitWeb.Components.OAuthButtons.oauth_buttons show_divider={false} />
+        <PhoenixKitWeb.Components.OAuthButtons.oauth_buttons
+          show_divider={false}
+          return_to={@return_to}
+        />
       </div>
     </div>
   <% end %>
@@ -218,7 +221,7 @@
   <div class="text-center mt-4 text-sm">
     <span>{gettext("Already have an account?")}</span>
     <.link
-      navigate={Routes.path("/users/log-in")}
+      navigate={Routes.path("/users/log-in") <> Routes.return_to_query(@return_to)}
       class="font-semibold text-primary hover:underline"
     >
       {gettext("Sign in")}

--- a/lib/phoenix_kit_web/users/registration.html.heex
+++ b/lib/phoenix_kit_web/users/registration.html.heex
@@ -32,6 +32,8 @@
     action={Routes.path("/users/log-in?_action=registered")}
     method="post"
   >
+    <input :if={@return_to} type="hidden" name="user[return_to]" value={@return_to} />
+
     <%!-- Silently captures the browser's UTC offset so new accounts start
          with a timezone instead of "Not set" — no UI, just a value the
          TimezoneOffset hook fills in before submit. Never overwrites an
@@ -155,6 +157,19 @@
             <PhoenixKitWeb.Components.Core.Icons.icon_lock class="h-[1em] w-[1em] opacity-50" />
           </:icon>
         </.input>
+      </div>
+
+      <%!-- Checked by default so a new account stays signed in on this device;
+           without the persistent cookie the session rides a browser-session
+           cookie that phones drop overnight. Users can untick it, and the
+           site can change the default (or forbid persistence) in settings. --%>
+      <div :if={@remember_me_available} class="form-control mt-4">
+        <.checkbox
+          id="user_remember_me"
+          name="user[remember_me]"
+          checked={@remember_me}
+          label={gettext("Keep me logged in")}
+        />
       </div>
 
       <button

--- a/lib/phoenix_kit_web/users/session.ex
+++ b/lib/phoenix_kit_web/users/session.ex
@@ -23,22 +23,34 @@ defmodule PhoenixKitWeb.Users.Session do
   alias PhoenixKitWeb.Users.MultiSession
 
   def create(conn, %{"_action" => "registered"} = params) do
-    conn
-    |> maybe_store_after_registration_path()
-    |> create(params, "Account created successfully!")
+    create(conn, params, "Account created successfully!", :registered)
   end
 
   def create(conn, %{"_action" => "password_updated"} = params) do
-    conn
-    |> put_session(:user_return_to, Routes.path("/dashboard/settings"))
-    |> create(params, "Password updated successfully!")
+    create(
+      conn,
+      carry_remember_me(conn, params),
+      "Password updated successfully!",
+      :password_updated
+    )
   end
 
   def create(conn, params) do
-    create(conn, params, "Welcome back!")
+    create(conn, params, "Welcome back!", :login)
   end
 
-  defp create(conn, %{"user" => user_params}, info) do
+  # The destination is stashed only once the credentials check out. Doing it up
+  # front leaked it into the failure branches, so a rejected registration
+  # handoff left `after_registration_path` in the session and the user's NEXT
+  # ordinary login landed on the registration page.
+  defp stash_destination(conn, :registered), do: maybe_store_after_registration_path(conn)
+
+  defp stash_destination(conn, :password_updated),
+    do: put_session(conn, :user_return_to, Routes.path("/dashboard/settings"))
+
+  defp stash_destination(conn, _), do: conn
+
+  defp create(conn, %{"user" => user_params}, info, action) do
     %{"password" => password} = user_params
     # Support both old "email" field and new "email_or_username" field for backwards compatibility
     email_or_username = user_params["email_or_username"] || user_params["email"]
@@ -58,6 +70,7 @@ defmodule PhoenixKitWeb.Users.Session do
       {:ok, user} ->
         # Valid credentials and active account
         conn
+        |> stash_destination(action)
         |> maybe_store_return_to_from_params(user_params)
         |> put_flash(:info, info)
         |> UserAuth.log_in_user(user, user_params)
@@ -127,6 +140,23 @@ defmodule PhoenixKitWeb.Users.Session do
       redirect(conn, to: Routes.path("/"))
     end
   end
+
+  # Changing a password deletes every token for the user, the one inside the
+  # live remember-me cookie included, and the dashboard form that re-logs them
+  # in carries no checkbox. Without this the user keeps a cookie pointing at a
+  # deleted token: fine until the browser drops its session cookie, then a
+  # silent sign-out — the exact failure this module's remember-me work exists
+  # to prevent. Re-authenticating as themselves, so carrying their existing
+  # choice forward is right; an absent cookie stays absent.
+  defp carry_remember_me(conn, %{"user" => user_params} = params) do
+    if UserAuth.remembered?(conn) do
+      %{params | "user" => Map.put(user_params, "remember_me", "true")}
+    else
+      params
+    end
+  end
+
+  defp carry_remember_me(_conn, params), do: params
 
   # Configured landing page for freshly registered accounts
   # (`after_registration_path` setting; empty = fall through to the

--- a/lib/phoenix_kit_web/users/session.ex
+++ b/lib/phoenix_kit_web/users/session.ex
@@ -23,7 +23,9 @@ defmodule PhoenixKitWeb.Users.Session do
   alias PhoenixKitWeb.Users.MultiSession
 
   def create(conn, %{"_action" => "registered"} = params) do
-    create(conn, params, "Account created successfully!")
+    conn
+    |> maybe_store_after_registration_path()
+    |> create(params, "Account created successfully!")
   end
 
   def create(conn, %{"_action" => "password_updated"} = params) do
@@ -123,6 +125,24 @@ defmodule PhoenixKitWeb.Users.Session do
       redirect(conn, to: params["return_to"])
     else
       redirect(conn, to: Routes.path("/"))
+    end
+  end
+
+  # Configured landing page for freshly registered accounts
+  # (`after_registration_path` setting; empty = fall through to the
+  # after-login default). An explicit destination always wins over the
+  # setting: a return_to already stashed in the session (by an auth gate) is
+  # left alone, and a return_to carried by the form overwrites the session
+  # key afterwards (maybe_store_return_to_from_params/2 runs later in the
+  # shared create/3).
+  defp maybe_store_after_registration_path(conn) do
+    path = PhoenixKit.Settings.get_setting("after_registration_path", "")
+
+    if is_binary(path) and path != "" and Routes.local_path?(path) and
+         is_nil(get_session(conn, :user_return_to)) do
+      put_session(conn, :user_return_to, path)
+    else
+      conn
     end
   end
 

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -10185,7 +10185,7 @@ msgstr ""
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:288
 #, elixir-autogen, elixir-format
 msgid "Enable QR code sign-in (scan from a signed-in phone)"
-msgstr ""
+msgstr "QR-Code-Anmeldung aktivieren (Scan von einem angemeldeten Telefon)"
 
 #: lib/phoenix_kit_web/users/qr_login_confirm.ex:103
 #, elixir-autogen, elixir-format, fuzzy
@@ -10225,14 +10225,14 @@ msgstr ""
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:276
 #, elixir-autogen, elixir-format
 msgid "QR Code"
-msgstr ""
+msgstr "QR-Code"
 
 #: lib/phoenix_kit_web/users/qr_login.ex:42
 #: lib/phoenix_kit_web/users/qr_login_confirm.ex:32
 #: lib/phoenix_kit_web/users/qr_login_confirm.ex:76
 #, elixir-autogen, elixir-format
 msgid "QR code sign-in is not available."
-msgstr ""
+msgstr "Die Anmeldung mit QR-Code ist nicht verfügbar."
 
 #: lib/phoenix_kit_web/users/qr_login_confirm.ex:112
 #, elixir-autogen, elixir-format
@@ -10257,9 +10257,9 @@ msgstr ""
 #: lib/phoenix_kit_web/users/login.html.heex:115
 #: lib/phoenix_kit_web/users/qr_login.html.heex:4
 #: lib/phoenix_kit_web/users/qr_login.html.heex:7
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Sign in with QR code"
-msgstr ""
+msgstr "Mit QR-Code anmelden"
 
 #: lib/phoenix_kit_web/users/qr_login_confirm.ex:110
 #, elixir-autogen, elixir-format, fuzzy
@@ -10269,7 +10269,7 @@ msgstr ""
 #: lib/phoenix_kit_web/users/qr_login_complete.ex:29
 #, elixir-autogen, elixir-format
 msgid "Signed in with QR code."
-msgstr ""
+msgstr "Mit QR-Code angemeldet."
 
 #: lib/phoenix_kit_web/users/qr_login.html.heex:41
 #, elixir-autogen, elixir-format
@@ -10285,7 +10285,7 @@ msgstr ""
 #: lib/phoenix_kit_web/users/qr_login_complete.ex:41
 #, elixir-autogen, elixir-format
 msgid "This QR sign-in link is invalid or has expired."
-msgstr ""
+msgstr "Dieser QR-Anmeldelink ist ungültig oder abgelaufen."
 
 #: lib/phoenix_kit_web/users/qr_login.ex:155
 #, elixir-autogen, elixir-format

--- a/priv/gettext/es/LC_MESSAGES/default.po
+++ b/priv/gettext/es/LC_MESSAGES/default.po
@@ -10193,7 +10193,7 @@ msgstr "Correo Confirmado"
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:288
 #, elixir-autogen, elixir-format
 msgid "Enable QR code sign-in (scan from a signed-in phone)"
-msgstr ""
+msgstr "Habilitar el inicio de sesión con código QR (escanear desde un teléfono con la sesión iniciada)"
 
 #: lib/phoenix_kit_web/users/qr_login_confirm.ex:103
 #, elixir-autogen, elixir-format, fuzzy
@@ -10233,14 +10233,14 @@ msgstr ""
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:276
 #, elixir-autogen, elixir-format
 msgid "QR Code"
-msgstr ""
+msgstr "Código QR"
 
 #: lib/phoenix_kit_web/users/qr_login.ex:42
 #: lib/phoenix_kit_web/users/qr_login_confirm.ex:32
 #: lib/phoenix_kit_web/users/qr_login_confirm.ex:76
 #, elixir-autogen, elixir-format
 msgid "QR code sign-in is not available."
-msgstr ""
+msgstr "El inicio de sesión con código QR no está disponible."
 
 #: lib/phoenix_kit_web/users/qr_login_confirm.ex:112
 #, elixir-autogen, elixir-format
@@ -10265,9 +10265,9 @@ msgstr ""
 #: lib/phoenix_kit_web/users/login.html.heex:115
 #: lib/phoenix_kit_web/users/qr_login.html.heex:4
 #: lib/phoenix_kit_web/users/qr_login.html.heex:7
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Sign in with QR code"
-msgstr ""
+msgstr "Iniciar sesión con código QR"
 
 #: lib/phoenix_kit_web/users/qr_login_confirm.ex:110
 #, elixir-autogen, elixir-format, fuzzy
@@ -10277,7 +10277,7 @@ msgstr ""
 #: lib/phoenix_kit_web/users/qr_login_complete.ex:29
 #, elixir-autogen, elixir-format
 msgid "Signed in with QR code."
-msgstr ""
+msgstr "Sesión iniciada con código QR."
 
 #: lib/phoenix_kit_web/users/qr_login.html.heex:41
 #, elixir-autogen, elixir-format
@@ -10293,7 +10293,7 @@ msgstr ""
 #: lib/phoenix_kit_web/users/qr_login_complete.ex:41
 #, elixir-autogen, elixir-format
 msgid "This QR sign-in link is invalid or has expired."
-msgstr ""
+msgstr "Este enlace de inicio de sesión con código QR no es válido o ha caducado."
 
 #: lib/phoenix_kit_web/users/qr_login.ex:155
 #, elixir-autogen, elixir-format

--- a/priv/gettext/et/LC_MESSAGES/default.po
+++ b/priv/gettext/et/LC_MESSAGES/default.po
@@ -10200,7 +10200,7 @@ msgstr "E-post kinnitatud"
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:288
 #, elixir-autogen, elixir-format
 msgid "Enable QR code sign-in (scan from a signed-in phone)"
-msgstr ""
+msgstr "Luba QR-koodiga sisselogimine (skaneeri sisse logitud telefonist)"
 
 #: lib/phoenix_kit_web/users/qr_login_confirm.ex:103
 #, elixir-autogen, elixir-format, fuzzy
@@ -10240,14 +10240,14 @@ msgstr ""
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:276
 #, elixir-autogen, elixir-format
 msgid "QR Code"
-msgstr ""
+msgstr "QR-kood"
 
 #: lib/phoenix_kit_web/users/qr_login.ex:42
 #: lib/phoenix_kit_web/users/qr_login_confirm.ex:32
 #: lib/phoenix_kit_web/users/qr_login_confirm.ex:76
 #, elixir-autogen, elixir-format
 msgid "QR code sign-in is not available."
-msgstr ""
+msgstr "QR-koodiga sisselogimine ei ole saadaval."
 
 #: lib/phoenix_kit_web/users/qr_login_confirm.ex:112
 #, elixir-autogen, elixir-format
@@ -10272,9 +10272,9 @@ msgstr ""
 #: lib/phoenix_kit_web/users/login.html.heex:115
 #: lib/phoenix_kit_web/users/qr_login.html.heex:4
 #: lib/phoenix_kit_web/users/qr_login.html.heex:7
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Sign in with QR code"
-msgstr "Logi sisse parooliga"
+msgstr "Logi sisse QR-koodiga"
 
 ## Login page translations
 #: lib/phoenix_kit_web/users/qr_login_confirm.ex:110
@@ -10285,7 +10285,7 @@ msgstr "Logi sisse"
 #: lib/phoenix_kit_web/users/qr_login_complete.ex:29
 #, elixir-autogen, elixir-format
 msgid "Signed in with QR code."
-msgstr ""
+msgstr "Sisselogimine QR-koodiga õnnestus."
 
 #: lib/phoenix_kit_web/users/qr_login.html.heex:41
 #, elixir-autogen, elixir-format
@@ -10301,7 +10301,7 @@ msgstr ""
 #: lib/phoenix_kit_web/users/qr_login_complete.ex:41
 #, elixir-autogen, elixir-format
 msgid "This QR sign-in link is invalid or has expired."
-msgstr ""
+msgstr "See QR-koodiga sisselogimise link on kehtetu või aegunud."
 
 #: lib/phoenix_kit_web/users/qr_login.ex:155
 #, elixir-autogen, elixir-format

--- a/priv/gettext/fr/LC_MESSAGES/default.po
+++ b/priv/gettext/fr/LC_MESSAGES/default.po
@@ -10185,7 +10185,7 @@ msgstr "E-mail confirmé"
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:288
 #, elixir-autogen, elixir-format
 msgid "Enable QR code sign-in (scan from a signed-in phone)"
-msgstr ""
+msgstr "Activer la connexion par QR code (scan depuis un téléphone connecté)"
 
 #: lib/phoenix_kit_web/users/qr_login_confirm.ex:103
 #, elixir-autogen, elixir-format, fuzzy
@@ -10225,14 +10225,14 @@ msgstr ""
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:276
 #, elixir-autogen, elixir-format
 msgid "QR Code"
-msgstr ""
+msgstr "QR code"
 
 #: lib/phoenix_kit_web/users/qr_login.ex:42
 #: lib/phoenix_kit_web/users/qr_login_confirm.ex:32
 #: lib/phoenix_kit_web/users/qr_login_confirm.ex:76
 #, elixir-autogen, elixir-format
 msgid "QR code sign-in is not available."
-msgstr ""
+msgstr "La connexion par QR code n'est pas disponible."
 
 #: lib/phoenix_kit_web/users/qr_login_confirm.ex:112
 #, elixir-autogen, elixir-format
@@ -10257,9 +10257,9 @@ msgstr ""
 #: lib/phoenix_kit_web/users/login.html.heex:115
 #: lib/phoenix_kit_web/users/qr_login.html.heex:4
 #: lib/phoenix_kit_web/users/qr_login.html.heex:7
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Sign in with QR code"
-msgstr "Se connecter avec un mot de passe"
+msgstr "Se connecter avec un QR code"
 
 #: lib/phoenix_kit_web/users/qr_login_confirm.ex:110
 #, elixir-autogen, elixir-format, fuzzy
@@ -10269,7 +10269,7 @@ msgstr "Se connecter"
 #: lib/phoenix_kit_web/users/qr_login_complete.ex:29
 #, elixir-autogen, elixir-format
 msgid "Signed in with QR code."
-msgstr ""
+msgstr "Connexion effectuée avec un QR code."
 
 #: lib/phoenix_kit_web/users/qr_login.html.heex:41
 #, elixir-autogen, elixir-format
@@ -10285,7 +10285,7 @@ msgstr ""
 #: lib/phoenix_kit_web/users/qr_login_complete.ex:41
 #, elixir-autogen, elixir-format
 msgid "This QR sign-in link is invalid or has expired."
-msgstr ""
+msgstr "Ce lien de connexion par QR code est invalide ou a expiré."
 
 #: lib/phoenix_kit_web/users/qr_login.ex:155
 #, elixir-autogen, elixir-format

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -10185,7 +10185,7 @@ msgstr ""
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:288
 #, elixir-autogen, elixir-format
 msgid "Enable QR code sign-in (scan from a signed-in phone)"
-msgstr ""
+msgstr "Abilita l'accesso con codice QR (scansione da un telefono con sessione attiva)"
 
 #: lib/phoenix_kit_web/users/qr_login_confirm.ex:103
 #, elixir-autogen, elixir-format, fuzzy
@@ -10225,14 +10225,14 @@ msgstr ""
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:276
 #, elixir-autogen, elixir-format
 msgid "QR Code"
-msgstr ""
+msgstr "Codice QR"
 
 #: lib/phoenix_kit_web/users/qr_login.ex:42
 #: lib/phoenix_kit_web/users/qr_login_confirm.ex:32
 #: lib/phoenix_kit_web/users/qr_login_confirm.ex:76
 #, elixir-autogen, elixir-format
 msgid "QR code sign-in is not available."
-msgstr ""
+msgstr "L'accesso con codice QR non è disponibile."
 
 #: lib/phoenix_kit_web/users/qr_login_confirm.ex:112
 #, elixir-autogen, elixir-format
@@ -10257,9 +10257,9 @@ msgstr ""
 #: lib/phoenix_kit_web/users/login.html.heex:115
 #: lib/phoenix_kit_web/users/qr_login.html.heex:4
 #: lib/phoenix_kit_web/users/qr_login.html.heex:7
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Sign in with QR code"
-msgstr ""
+msgstr "Accedi con codice QR"
 
 #: lib/phoenix_kit_web/users/qr_login_confirm.ex:110
 #, elixir-autogen, elixir-format, fuzzy
@@ -10269,7 +10269,7 @@ msgstr ""
 #: lib/phoenix_kit_web/users/qr_login_complete.ex:29
 #, elixir-autogen, elixir-format
 msgid "Signed in with QR code."
-msgstr ""
+msgstr "Accesso effettuato con codice QR."
 
 #: lib/phoenix_kit_web/users/qr_login.html.heex:41
 #, elixir-autogen, elixir-format
@@ -10285,7 +10285,7 @@ msgstr ""
 #: lib/phoenix_kit_web/users/qr_login_complete.ex:41
 #, elixir-autogen, elixir-format
 msgid "This QR sign-in link is invalid or has expired."
-msgstr ""
+msgstr "Questo link di accesso con codice QR non è valido o è scaduto."
 
 #: lib/phoenix_kit_web/users/qr_login.ex:155
 #, elixir-autogen, elixir-format

--- a/priv/gettext/pl/LC_MESSAGES/default.po
+++ b/priv/gettext/pl/LC_MESSAGES/default.po
@@ -10210,7 +10210,7 @@ msgstr ""
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:288
 #, elixir-autogen, elixir-format
 msgid "Enable QR code sign-in (scan from a signed-in phone)"
-msgstr ""
+msgstr "Włącz logowanie kodem QR (skanowanie z zalogowanego telefonu)"
 
 #: lib/phoenix_kit_web/users/qr_login_confirm.ex:103
 #, elixir-autogen, elixir-format, fuzzy
@@ -10250,14 +10250,14 @@ msgstr ""
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:276
 #, elixir-autogen, elixir-format
 msgid "QR Code"
-msgstr ""
+msgstr "Kod QR"
 
 #: lib/phoenix_kit_web/users/qr_login.ex:42
 #: lib/phoenix_kit_web/users/qr_login_confirm.ex:32
 #: lib/phoenix_kit_web/users/qr_login_confirm.ex:76
 #, elixir-autogen, elixir-format
 msgid "QR code sign-in is not available."
-msgstr ""
+msgstr "Logowanie kodem QR jest niedostępne."
 
 #: lib/phoenix_kit_web/users/qr_login_confirm.ex:112
 #, elixir-autogen, elixir-format
@@ -10282,9 +10282,9 @@ msgstr ""
 #: lib/phoenix_kit_web/users/login.html.heex:115
 #: lib/phoenix_kit_web/users/qr_login.html.heex:4
 #: lib/phoenix_kit_web/users/qr_login.html.heex:7
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Sign in with QR code"
-msgstr ""
+msgstr "Zaloguj się kodem QR"
 
 #: lib/phoenix_kit_web/users/qr_login_confirm.ex:110
 #, elixir-autogen, elixir-format, fuzzy
@@ -10294,7 +10294,7 @@ msgstr ""
 #: lib/phoenix_kit_web/users/qr_login_complete.ex:29
 #, elixir-autogen, elixir-format
 msgid "Signed in with QR code."
-msgstr ""
+msgstr "Zalogowano kodem QR."
 
 #: lib/phoenix_kit_web/users/qr_login.html.heex:41
 #, elixir-autogen, elixir-format
@@ -10310,7 +10310,7 @@ msgstr ""
 #: lib/phoenix_kit_web/users/qr_login_complete.ex:41
 #, elixir-autogen, elixir-format
 msgid "This QR sign-in link is invalid or has expired."
-msgstr ""
+msgstr "Ten link do logowania kodem QR jest nieprawidłowy lub wygasł."
 
 #: lib/phoenix_kit_web/users/qr_login.ex:155
 #, elixir-autogen, elixir-format

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -10220,7 +10220,7 @@ msgstr "Email подтвержден"
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:288
 #, elixir-autogen, elixir-format
 msgid "Enable QR code sign-in (scan from a signed-in phone)"
-msgstr ""
+msgstr "Включить вход по QR-коду (сканирование с телефона, где выполнен вход)"
 
 #: lib/phoenix_kit_web/users/qr_login_confirm.ex:103
 #, elixir-autogen, elixir-format, fuzzy
@@ -10260,14 +10260,14 @@ msgstr ""
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:276
 #, elixir-autogen, elixir-format
 msgid "QR Code"
-msgstr ""
+msgstr "QR-код"
 
 #: lib/phoenix_kit_web/users/qr_login.ex:42
 #: lib/phoenix_kit_web/users/qr_login_confirm.ex:32
 #: lib/phoenix_kit_web/users/qr_login_confirm.ex:76
 #, elixir-autogen, elixir-format
 msgid "QR code sign-in is not available."
-msgstr ""
+msgstr "Вход по QR-коду недоступен."
 
 #: lib/phoenix_kit_web/users/qr_login_confirm.ex:112
 #, elixir-autogen, elixir-format
@@ -10292,9 +10292,9 @@ msgstr ""
 #: lib/phoenix_kit_web/users/login.html.heex:115
 #: lib/phoenix_kit_web/users/qr_login.html.heex:4
 #: lib/phoenix_kit_web/users/qr_login.html.heex:7
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Sign in with QR code"
-msgstr "Войти с паролем"
+msgstr "Войти по QR-коду"
 
 ## Login page translations
 #: lib/phoenix_kit_web/users/qr_login_confirm.ex:110
@@ -10305,7 +10305,7 @@ msgstr "Войти"
 #: lib/phoenix_kit_web/users/qr_login_complete.ex:29
 #, elixir-autogen, elixir-format
 msgid "Signed in with QR code."
-msgstr ""
+msgstr "Вход выполнен по QR-коду."
 
 #: lib/phoenix_kit_web/users/qr_login.html.heex:41
 #, elixir-autogen, elixir-format
@@ -10321,7 +10321,7 @@ msgstr ""
 #: lib/phoenix_kit_web/users/qr_login_complete.ex:41
 #, elixir-autogen, elixir-format
 msgid "This QR sign-in link is invalid or has expired."
-msgstr ""
+msgstr "Эта ссылка для входа по QR-коду недействительна или истекла."
 
 #: lib/phoenix_kit_web/users/qr_login.ex:155
 #, elixir-autogen, elixir-format

--- a/test/integration/phoenix_kit_web/live/settings/users_settings_page_test.exs
+++ b/test/integration/phoenix_kit_web/live/settings/users_settings_page_test.exs
@@ -1,0 +1,79 @@
+defmodule PhoenixKitWeb.Live.Settings.UsersSettingsPageTest do
+  use PhoenixKitWeb.ConnCase, async: false
+
+  alias PhoenixKit.Utils.Routes
+
+  test "users settings page renders the auth settings controls", %{conn: conn} do
+    {admin, _token} = create_admin_user()
+    conn = log_in_user(conn, admin)
+
+    {:ok, _lv, html} = live(conn, Routes.path("/admin/settings/users"))
+
+    assert html =~ ~s(name="settings[require_email_confirmation]")
+    assert html =~ ~s(name="settings[remember_me_enabled]")
+    assert html =~ ~s(name="settings[remember_me_default]")
+    assert html =~ ~s(name="settings[after_login_path]")
+    assert html =~ ~s(name="settings[after_registration_path]")
+  end
+
+  test "saving the auth settings round-trips through the form", %{conn: conn} do
+    {admin, _token} = create_admin_user()
+    conn = log_in_user(conn, admin)
+
+    {:ok, lv, _html} = live(conn, Routes.path("/admin/settings/users"))
+
+    lv
+    |> form("#user_settings_form", %{
+      "settings" => %{
+        "remember_me_enabled" => "true",
+        "remember_me_default" => "false",
+        "require_email_confirmation" => "false",
+        "after_login_path" => "/welcome",
+        "after_registration_path" => "/onboarding"
+      }
+    })
+    |> render_submit()
+
+    assert PhoenixKit.Settings.get_setting("remember_me_default") == "false"
+    assert PhoenixKit.Settings.get_setting("require_email_confirmation") == "false"
+    assert PhoenixKit.Settings.get_setting("after_login_path") == "/welcome"
+    assert PhoenixKit.Settings.get_setting("after_registration_path") == "/onboarding"
+  end
+
+  # <.checkbox> pairs the box with an un-disabled hidden "false" input, so a
+  # `disabled` box still submits "false". Saving with persistence off must not
+  # silently rewrite the stored default.
+  test "saving while persistence is off preserves remember_me_default", %{conn: conn} do
+    PhoenixKit.Settings.update_setting("remember_me_enabled", "false")
+    PhoenixKit.Settings.update_setting("remember_me_default", "true")
+
+    {admin, _token} = create_admin_user()
+    conn = log_in_user(conn, admin)
+
+    {:ok, lv, html} = live(conn, Routes.path("/admin/settings/users"))
+
+    # The control stays submittable rather than disabled.
+    assert html =~ ~s(name="settings[remember_me_default]")
+
+    lv |> form("#user_settings_form") |> render_submit()
+
+    assert PhoenixKit.Settings.get_setting("remember_me_default") == "true"
+  end
+
+  test "the form rejects a non-local redirect path", %{conn: conn} do
+    {admin, _token} = create_admin_user()
+    conn = log_in_user(conn, admin)
+
+    {:ok, lv, _html} = live(conn, Routes.path("/admin/settings/users"))
+
+    html =
+      lv
+      |> form("#user_settings_form", %{
+        "settings" => %{"after_login_path" => "https://evil.example"}
+      })
+      |> render_submit()
+
+    assert html =~ "local path"
+    refute PhoenixKit.Settings.get_setting("after_login_path") == "https://evil.example"
+  end
+end

--- a/test/integration/phoenix_kit_web/users/auth_flows_test.exs
+++ b/test/integration/phoenix_kit_web/users/auth_flows_test.exs
@@ -1,0 +1,697 @@
+defmodule PhoenixKitWeb.Users.AuthFlowsTest do
+  @moduledoc """
+  Login/registration flow behavior:
+
+  - remember-me cookie persistence (registration + magic-link vs plain login)
+  - configurable post-login / post-registration destinations
+  - the `require_email_confirmation` toggle
+  - the /users/confirm parked page moving confirmed users along
+  """
+  use PhoenixKitWeb.ConnCase, async: false
+
+  alias PhoenixKit.Settings
+  alias PhoenixKit.Users.Auth
+  alias PhoenixKit.Users.Auth.Scope
+  alias PhoenixKit.Users.MagicLink
+  alias PhoenixKit.Users.MagicLinkRegistration
+  alias PhoenixKit.Utils.Routes
+  alias PhoenixKitWeb.Users.Auth, as: UserAuth
+
+  @remember_me_cookie "_phoenix_kit_web_user_remember_me"
+  @password "ValidPassword123!"
+
+  defp unique_email, do: "af_#{System.unique_integer([:positive])}@example.com"
+
+  # Seed a throwaway Owner so users created inside tests get their intended
+  # role rather than the first-user Owner promotion.
+  setup do
+    {:ok, seed} = Auth.register_user(%{email: unique_email(), password: @password})
+    {:ok, _} = Auth.admin_confirm_user(seed)
+    :ok
+  end
+
+  defp register_user(attrs \\ %{}) do
+    {:ok, user} =
+      Auth.register_user(Map.merge(%{email: unique_email(), password: @password}, attrs))
+
+    user
+  end
+
+  defp confirmed_user do
+    user = register_user()
+    {:ok, user} = Auth.admin_confirm_user(user)
+    user
+  end
+
+  # The deliver_* functions build the emailed URL through a callback, which is
+  # the only place the plaintext token exists — capture it there.
+  defp extract_token(deliver_fun) do
+    test_pid = self()
+    ref = make_ref()
+
+    deliver_fun.(fn token ->
+      send(test_pid, {ref, token})
+      "http://localhost/#{token}"
+    end)
+
+    receive do
+      {^ref, token} -> token
+    after
+      1000 -> flunk("no confirmation token was generated")
+    end
+  end
+
+  defp login_conn(conn, user) do
+    token = Auth.generate_user_session_token(user)
+
+    conn
+    |> Phoenix.ConnTest.init_test_session(%{})
+    |> Plug.Conn.put_session(:user_token, token)
+    |> Plug.Conn.put_session(:live_socket_id, "phoenix_kit_sessions:#{Base.url_encode64(token)}")
+  end
+
+  describe "remember-me cookie" do
+    test "registration handoff POST sets the persistent cookie", %{conn: conn} do
+      user = register_user()
+
+      # The registration form now carries a hidden user[remember_me]=true and
+      # trigger-action POSTs to /users/log-in?_action=registered.
+      conn =
+        post(conn, Routes.path("/users/log-in?_action=registered"), %{
+          "user" => %{
+            "email_or_username" => user.email,
+            "password" => @password,
+            "remember_me" => "true"
+          }
+        })
+
+      assert %{value: value, max_age: max_age} = conn.resp_cookies[@remember_me_cookie]
+      assert is_binary(value) and value != ""
+      assert max_age == 60 * 60 * 24 * 60
+    end
+
+    test "magic-link verify sets the persistent cookie", %{conn: conn} do
+      user = confirmed_user()
+      {:ok, _user, token} = MagicLink.generate_magic_link(user.email)
+
+      conn = get(conn, Routes.path("/users/magic-link/#{token}"))
+
+      assert redirected_to(conn)
+      assert %{value: value} = conn.resp_cookies[@remember_me_cookie]
+      assert is_binary(value) and value != ""
+    end
+
+    test "plain login without the checkbox does NOT set the cookie", %{conn: conn} do
+      user = confirmed_user()
+
+      conn =
+        post(conn, Routes.path("/users/log-in"), %{
+          "user" => %{"email_or_username" => user.email, "password" => @password}
+        })
+
+      assert redirected_to(conn)
+      refute Map.has_key?(conn.resp_cookies, @remember_me_cookie)
+    end
+
+    test "plain login with the checkbox still sets the cookie", %{conn: conn} do
+      user = confirmed_user()
+
+      conn =
+        post(conn, Routes.path("/users/log-in"), %{
+          "user" => %{
+            "email_or_username" => user.email,
+            "password" => @password,
+            "remember_me" => "true"
+          }
+        })
+
+      assert Map.has_key?(conn.resp_cookies, @remember_me_cookie)
+    end
+  end
+
+  describe "post-login destination" do
+    test "defaults to /", %{conn: conn} do
+      user = confirmed_user()
+
+      conn =
+        post(conn, Routes.path("/users/log-in"), %{
+          "user" => %{"email_or_username" => user.email, "password" => @password}
+        })
+
+      assert redirected_to(conn) == "/"
+    end
+
+    test "honors the after_login_path setting", %{conn: conn} do
+      Settings.update_setting("after_login_path", "/welcome")
+      user = confirmed_user()
+
+      conn =
+        post(conn, Routes.path("/users/log-in"), %{
+          "user" => %{"email_or_username" => user.email, "password" => @password}
+        })
+
+      assert redirected_to(conn) == "/welcome"
+    end
+
+    test "explicit return_to wins over the setting", %{conn: conn} do
+      Settings.update_setting("after_login_path", "/welcome")
+      user = confirmed_user()
+
+      conn =
+        post(conn, Routes.path("/users/log-in"), %{
+          "user" => %{
+            "email_or_username" => user.email,
+            "password" => @password,
+            "return_to" => "/somewhere-else"
+          }
+        })
+
+      assert redirected_to(conn) == "/somewhere-else"
+    end
+
+    test "a non-local after_login_path value falls back to /", %{conn: conn} do
+      # The settings form validates on save; this simulates a hand-edited DB row.
+      Settings.update_setting("after_login_path", "https://evil.example")
+      user = confirmed_user()
+
+      conn =
+        post(conn, Routes.path("/users/log-in"), %{
+          "user" => %{"email_or_username" => user.email, "password" => @password}
+        })
+
+      assert redirected_to(conn) == "/"
+    end
+  end
+
+  describe "post-registration destination" do
+    test "honors the after_registration_path setting", %{conn: conn} do
+      Settings.update_setting("after_registration_path", "/onboarding")
+      user = register_user()
+
+      conn =
+        post(conn, Routes.path("/users/log-in?_action=registered"), %{
+          "user" => %{
+            "email_or_username" => user.email,
+            "password" => @password,
+            "remember_me" => "true"
+          }
+        })
+
+      assert redirected_to(conn) == "/onboarding"
+    end
+
+    test "falls back to after_login_path when unset", %{conn: conn} do
+      Settings.update_setting("after_login_path", "/welcome")
+      user = register_user()
+
+      conn =
+        post(conn, Routes.path("/users/log-in?_action=registered"), %{
+          "user" => %{
+            "email_or_username" => user.email,
+            "password" => @password,
+            "remember_me" => "true"
+          }
+        })
+
+      assert redirected_to(conn) == "/welcome"
+    end
+
+    test "form return_to wins over the setting", %{conn: conn} do
+      Settings.update_setting("after_registration_path", "/onboarding")
+      user = register_user()
+
+      conn =
+        post(conn, Routes.path("/users/log-in?_action=registered"), %{
+          "user" => %{
+            "email_or_username" => user.email,
+            "password" => @password,
+            "remember_me" => "true",
+            "return_to" => "/checkout"
+          }
+        })
+
+      assert redirected_to(conn) == "/checkout"
+    end
+
+    test "a gate-stashed session return_to wins over the setting", %{conn: conn} do
+      Settings.update_setting("after_registration_path", "/onboarding")
+      user = register_user()
+
+      conn =
+        conn
+        |> Phoenix.ConnTest.init_test_session(%{})
+        |> Plug.Conn.put_session(:user_return_to, "/protected-page")
+        |> post(Routes.path("/users/log-in?_action=registered"), %{
+          "user" => %{
+            "email_or_username" => user.email,
+            "password" => @password,
+            "remember_me" => "true"
+          }
+        })
+
+      assert redirected_to(conn) == "/protected-page"
+    end
+  end
+
+  describe "auth page renders" do
+    # Dead renders (get/2, not live/2): this markup is static, and the
+    # connected mount of these LiveViews calls Presence.track_anonymous,
+    # whose GenServer isn't running in the test env.
+    #
+    # A checked checkbox is `<input ... type="checkbox" ... checked>`; the
+    # `<input type="hidden" ... value="false">` alongside it is the
+    # component's unchecked-submit fallback, not the state.
+    defp checkbox_checked?(html, name) do
+      html
+      |> String.split("<input")
+      |> Enum.any?(fn frag ->
+        String.contains?(frag, ~s(name="#{name}")) and
+          String.contains?(frag, ~s(type="checkbox")) and
+          String.contains?(frag, "checked")
+      end)
+    end
+
+    defp has_field?(html, name), do: String.contains?(html, ~s(name="#{name}"))
+
+    test "registration form shows remember_me, checked by default", %{conn: conn} do
+      html = conn |> get(Routes.path("/users/register")) |> html_response(200)
+
+      assert checkbox_checked?(html, "user[remember_me]")
+    end
+
+    test "magic-link completion form shows remember_me, checked by default", %{conn: conn} do
+      {:ok, _email, token} = MagicLinkRegistration.send_registration_link(unique_email())
+
+      html =
+        conn
+        |> get(Routes.path("/users/register/complete/#{token}"))
+        |> html_response(200)
+
+      assert checkbox_checked?(html, "user[remember_me]")
+    end
+
+    test "login form shows remember_me, checked by default", %{conn: conn} do
+      html = conn |> get(Routes.path("/users/log-in")) |> html_response(200)
+
+      assert checkbox_checked?(html, "user[remember_me]")
+    end
+
+    test "remember_me_default=false renders the box unchecked, not hidden", %{conn: conn} do
+      Settings.update_setting("remember_me_default", "false")
+
+      html = conn |> get(Routes.path("/users/log-in")) |> html_response(200)
+
+      assert has_field?(html, "user[remember_me]")
+      refute checkbox_checked?(html, "user[remember_me]")
+    end
+
+    test "remember_me_enabled=false hides the checkbox entirely", %{conn: conn} do
+      Settings.update_setting("remember_me_enabled", "false")
+
+      login = conn |> get(Routes.path("/users/log-in")) |> html_response(200)
+      register = conn |> get(Routes.path("/users/register")) |> html_response(200)
+
+      refute has_field?(login, "user[remember_me]")
+      refute has_field?(register, "user[remember_me]")
+    end
+
+    test "registration page forwards ?return_to= into the form", %{conn: conn} do
+      html =
+        conn
+        |> get(Routes.path("/users/register") <> "?return_to=/checkout")
+        |> html_response(200)
+
+      assert html =~ ~s(name="user[return_to]")
+      assert html =~ ~s(value="/checkout")
+    end
+  end
+
+  describe "remember-me site policy" do
+    test "enabled=false blocks the cookie even when the param says true", %{conn: conn} do
+      Settings.update_setting("remember_me_enabled", "false")
+      user = confirmed_user()
+
+      conn =
+        post(conn, Routes.path("/users/log-in"), %{
+          "user" => %{
+            "email_or_username" => user.email,
+            "password" => @password,
+            "remember_me" => "true"
+          }
+        })
+
+      assert redirected_to(conn)
+      refute Map.has_key?(conn.resp_cookies, @remember_me_cookie)
+    end
+
+    test "enabled=false makes magic-link login session-only", %{conn: conn} do
+      Settings.update_setting("remember_me_enabled", "false")
+      user = confirmed_user()
+      {:ok, _user, token} = MagicLink.generate_magic_link(user.email)
+
+      conn = get(conn, Routes.path("/users/magic-link/#{token}"))
+
+      assert redirected_to(conn)
+      refute Map.has_key?(conn.resp_cookies, @remember_me_cookie)
+    end
+
+    test "default=false makes magic-link login session-only (no checkbox to tick)",
+         %{conn: conn} do
+      Settings.update_setting("remember_me_default", "false")
+      user = confirmed_user()
+      {:ok, _user, token} = MagicLink.generate_magic_link(user.email)
+
+      conn = get(conn, Routes.path("/users/magic-link/#{token}"))
+
+      assert redirected_to(conn)
+      refute Map.has_key?(conn.resp_cookies, @remember_me_cookie)
+    end
+
+    test "unticking the box keeps a login session-only", %{conn: conn} do
+      user = confirmed_user()
+
+      # An unticked daisyUI checkbox submits the hidden "false" fallback.
+      conn =
+        post(conn, Routes.path("/users/log-in"), %{
+          "user" => %{
+            "email_or_username" => user.email,
+            "password" => @password,
+            "remember_me" => "false"
+          }
+        })
+
+      assert redirected_to(conn)
+      refute Map.has_key?(conn.resp_cookies, @remember_me_cookie)
+    end
+
+    test "helpers reflect the settings" do
+      assert UserAuth.remember_me_enabled?()
+      assert UserAuth.remember_me_default?()
+      assert UserAuth.remember_me_params() == %{"remember_me" => "true"}
+
+      Settings.update_setting("remember_me_default", "false")
+      assert UserAuth.remember_me_enabled?()
+      refute UserAuth.remember_me_default?()
+      assert UserAuth.remember_me_params() == %{}
+
+      # The master switch overrides the default in both directions.
+      Settings.update_setting("remember_me_default", "true")
+      Settings.update_setting("remember_me_enabled", "false")
+      refute UserAuth.remember_me_enabled?()
+      refute UserAuth.remember_me_default?()
+      assert UserAuth.remember_me_params() == %{}
+    end
+  end
+
+  describe "open-redirect hardening" do
+    # Guard-level cases live in test/phoenix_kit/utils/routes_test.exs; this
+    # pins the end-to-end behavior through a real redirect sink.
+    test "a control-char return_to does not reach the parked page's redirect", %{conn: conn} do
+      user = confirmed_user()
+      conn = login_conn(conn, user)
+
+      # Confirmed user mounts → redirected onward; must fall back to "/",
+      # never to the smuggled destination.
+      assert {:error, {:redirect, %{to: "/"}}} =
+               live(
+                 conn,
+                 Routes.path("/users/confirm") <>
+                   "?return_to=" <>
+                   URI.encode_www_form("/\t/evil.example")
+               )
+    end
+  end
+
+  describe "flash rendering on auth pages" do
+    # Flash is owned by the layer inside the LiveView tree. A second copy in
+    # the root layout rendered every message twice with duplicate
+    # `flash-<kind>` element ids (which breaks LiveView DOM patching) and
+    # froze at its dead-render value.
+    test "a flash renders exactly once, with one element id", %{conn: conn} do
+      conn =
+        conn
+        |> Phoenix.ConnTest.init_test_session(%{})
+        |> Phoenix.Controller.fetch_flash()
+        |> Phoenix.Controller.put_flash(:error, "UNIQUEFLASHMARKER")
+
+      html = conn |> get(Routes.path("/users/log-in")) |> html_response(200)
+
+      assert length(String.split(html, "UNIQUEFLASHMARKER")) - 1 == 1
+      assert length(String.split(html, ~s(id="flash-error"))) - 1 == 1
+    end
+
+    test "auth pages render their content in standalone mode", %{conn: conn} do
+      # Regression: the standalone fallback used to nest a second full
+      # document and swallow the page body entirely.
+      html = conn |> get(Routes.path("/users/log-in")) |> html_response(200)
+
+      assert html =~ "login_form"
+      assert length(String.split(html, "<!DOCTYPE html>")) - 1 == 1
+    end
+  end
+
+  describe "settings validation" do
+    test "accepts local paths and empty values" do
+      changeset =
+        Settings.validate_settings(%{
+          "after_login_path" => "/welcome",
+          "after_registration_path" => ""
+        })
+
+      refute changeset.errors[:after_login_path]
+      refute changeset.errors[:after_registration_path]
+    end
+
+    test "rejects absolute URLs and protocol-relative paths" do
+      changeset =
+        Settings.validate_settings(%{
+          "after_login_path" => "https://evil.example",
+          "after_registration_path" => "//evil.example"
+        })
+
+      assert {msg, _} = changeset.errors[:after_login_path]
+      assert msg =~ "local path"
+      assert {msg2, _} = changeset.errors[:after_registration_path]
+      assert msg2 =~ "local path"
+    end
+
+    test "require_email_confirmation only accepts boolean strings" do
+      changeset = Settings.validate_settings(%{"require_email_confirmation" => "sometimes"})
+      assert changeset.errors[:require_email_confirmation]
+
+      changeset = Settings.validate_settings(%{"require_email_confirmation" => "false"})
+      refute changeset.errors[:require_email_confirmation]
+    end
+  end
+
+  describe "require_email_confirmation" do
+    defp plug_conn(conn, user) do
+      conn
+      |> Phoenix.ConnTest.init_test_session(%{})
+      |> Phoenix.Controller.fetch_flash()
+      |> Plug.Conn.assign(:phoenix_kit_current_user, user)
+    end
+
+    test "on (default): unconfirmed users are parked at /users/confirm", %{conn: conn} do
+      user = register_user()
+
+      conn = conn |> plug_conn(user) |> UserAuth.require_authenticated_user([])
+
+      assert conn.halted
+      assert redirected_to(conn) == Routes.path("/users/confirm")
+      # The originally requested page is stashed so /users/confirm can move
+      # the user along once confirmed.
+      assert get_session(conn, :user_return_to)
+    end
+
+    test "off: unconfirmed users pass through", %{conn: conn} do
+      Settings.update_setting("require_email_confirmation", "false")
+      user = register_user()
+
+      conn = conn |> plug_conn(user) |> UserAuth.require_authenticated_user([])
+
+      refute conn.halted
+    end
+
+    test "off: unconfirmed users pass the scope-based plug too", %{conn: conn} do
+      Settings.update_setting("require_email_confirmation", "false")
+      user = register_user()
+
+      conn =
+        conn
+        |> plug_conn(user)
+        |> Plug.Conn.assign(
+          :phoenix_kit_current_scope,
+          Scope.for_user(user)
+        )
+        |> UserAuth.require_authenticated_scope([])
+
+      refute conn.halted
+    end
+
+    test "anonymous users still get sent to login either way", %{conn: conn} do
+      Settings.update_setting("require_email_confirmation", "false")
+
+      conn = conn |> plug_conn(nil) |> UserAuth.require_authenticated_user([])
+
+      assert conn.halted
+      assert redirected_to(conn) == Routes.path("/users/log-in")
+    end
+
+    # The owner/admin/module-access on_mount hooks gate on confirmation too;
+    # they must honor the setting like the other three sites, or turning it
+    # off leaves admin surfaces silently parked.
+    test "off: elevated on_mount hooks no longer park unconfirmed users", %{conn: conn} do
+      Settings.update_setting("require_email_confirmation", "false")
+
+      {admin, _token} = create_admin_user()
+      {:ok, admin} = Auth.admin_unconfirm_user(admin)
+      conn = login_conn(conn, admin)
+
+      # Reaching the LiveView at all means the confirmation branch didn't halt.
+      assert {:ok, _lv, _html} = live(conn, Routes.path("/admin/settings/users"))
+    end
+
+    test "on (default): elevated on_mount hooks park unconfirmed users with return_to",
+         %{conn: conn} do
+      {admin, _token} = create_admin_user()
+      {:ok, admin} = Auth.admin_unconfirm_user(admin)
+      conn = login_conn(conn, admin)
+
+      assert {:error, {:redirect, %{to: to}}} = live(conn, Routes.path("/admin/settings/users"))
+      assert to =~ Routes.path("/users/confirm")
+      # The originally requested admin page is preserved for the advance.
+      assert to =~ "return_to="
+    end
+  end
+
+  describe "/users/confirm parked page" do
+    test "already-confirmed user is moved along on mount (DB flip + refresh case)", %{conn: conn} do
+      user = confirmed_user()
+      conn = login_conn(conn, user)
+
+      assert {:error, {:redirect, %{to: "/"}}} = live(conn, Routes.path("/users/confirm"))
+    end
+
+    test "confirmed user is moved to return_to when present", %{conn: conn} do
+      user = confirmed_user()
+      conn = login_conn(conn, user)
+
+      assert {:error, {:redirect, %{to: "/after"}}} =
+               live(conn, Routes.path("/users/confirm") <> "?return_to=/after")
+    end
+
+    test "non-local return_to is ignored", %{conn: conn} do
+      user = confirmed_user()
+      conn = login_conn(conn, user)
+
+      assert {:error, {:redirect, %{to: "/"}}} =
+               live(
+                 conn,
+                 Routes.path("/users/confirm") <>
+                   "?return_to=" <>
+                   URI.encode_www_form("https://evil.example")
+               )
+    end
+
+    test "confirmed user honors after_login_path", %{conn: conn} do
+      Settings.update_setting("after_login_path", "/welcome")
+      user = confirmed_user()
+      conn = login_conn(conn, user)
+
+      assert {:error, {:redirect, %{to: "/welcome"}}} = live(conn, Routes.path("/users/confirm"))
+    end
+
+    test "parked user is moved along live when an admin confirms them", %{conn: conn} do
+      user = register_user()
+      conn = login_conn(conn, user)
+
+      {:ok, lv, html} = live(conn, Routes.path("/users/confirm"))
+      assert html =~ user.email
+
+      {:ok, _user} = Auth.admin_confirm_user(user)
+
+      assert_redirect(lv, "/", 3000)
+    end
+
+    test "parked user keeps their original destination on live advance", %{conn: conn} do
+      user = register_user()
+      conn = login_conn(conn, user)
+
+      {:ok, lv, _html} = live(conn, Routes.path("/users/confirm") <> "?return_to=/after")
+
+      {:ok, _user} = Auth.admin_confirm_user(user)
+
+      assert_redirect(lv, "/after", 3000)
+    end
+
+    test "another user's confirmation does not move the parked user", %{conn: conn} do
+      user = register_user()
+      other = register_user()
+      conn = login_conn(conn, user)
+
+      {:ok, lv, _html} = live(conn, Routes.path("/users/confirm"))
+
+      {:ok, _} = Auth.admin_confirm_user(other)
+
+      # Still parked: rendering succeeds (an assert_redirect here would flake
+      # on timing, so assert the LV is alive and un-redirected instead).
+      assert render(lv) =~ "confirmation"
+    end
+
+    test "anonymous visitor still gets the resend form", %{conn: conn} do
+      {:ok, _lv, html} = live(conn, Routes.path("/users/confirm"))
+
+      assert html =~ "confirmation"
+    end
+
+    test "a confirmation landing between mount and subscribe is not missed", %{conn: conn} do
+      user = register_user()
+      conn = login_conn(conn, user)
+
+      # Simulates the race: the row flips confirmed while the LV is mounting,
+      # so no broadcast can reach it. The post-subscribe re-read must catch it.
+      {:ok, _user} = Auth.admin_confirm_user(user)
+
+      assert {:error, {:redirect, %{to: "/"}}} = live(conn, Routes.path("/users/confirm"))
+    end
+  end
+
+  describe "email-link confirmation destination" do
+    test "confirming via the emailed link honors after_login_path", %{conn: conn} do
+      Settings.update_setting("after_login_path", "/welcome")
+      user = register_user()
+
+      token =
+        extract_token(fn url_fun ->
+          Auth.deliver_user_confirmation_instructions(user, url_fun)
+        end)
+
+      {:ok, lv, _html} = live(conn, Routes.path("/users/confirm/#{token}"))
+
+      lv |> element("#confirmation_form") |> render_submit()
+
+      assert_redirect(lv, "/welcome")
+    end
+
+    test "confirming via the emailed link honors a session return_to", %{conn: conn} do
+      user = register_user()
+
+      token =
+        extract_token(fn url_fun ->
+          Auth.deliver_user_confirmation_instructions(user, url_fun)
+        end)
+
+      conn =
+        conn
+        |> Phoenix.ConnTest.init_test_session(%{})
+        |> Plug.Conn.put_session(:user_return_to, "/protected-page")
+
+      {:ok, lv, _html} = live(conn, Routes.path("/users/confirm/#{token}"))
+
+      lv |> element("#confirmation_form") |> render_submit()
+
+      assert_redirect(lv, "/protected-page")
+    end
+  end
+end

--- a/test/integration/phoenix_kit_web/users/auth_flows_test.exs
+++ b/test/integration/phoenix_kit_web/users/auth_flows_test.exs
@@ -24,10 +24,33 @@ defmodule PhoenixKitWeb.Users.AuthFlowsTest do
 
   # Seed a throwaway Owner so users created inside tests get their intended
   # role rather than the first-user Owner promotion.
-  setup do
+  #
+  # Each test also gets its own source IP. Login rate limiting keys on the IP
+  # (15/min) as well as the address, and this file performs several logins per
+  # test; sharing 127.0.0.1 let a busy run exhaust the bucket and bounce later
+  # tests back to the login page. Hammer 7 dropped bucket deletion, so a unique
+  # IP is the way to isolate rather than reset.
+  setup %{conn: conn} do
     {:ok, seed} = Auth.register_user(%{email: unique_email(), password: @password})
     {:ok, _} = Auth.admin_confirm_user(seed)
-    :ok
+    {:ok, conn: with_peer(conn, unique_ip())}
+  end
+
+  defp unique_ip do
+    n = System.unique_integer([:positive])
+    {127, 1, n |> div(256) |> rem(256), rem(n, 256)}
+  end
+
+  # Rate limiting reads the peer via `Plug.Conn.get_peer_data/1`, NOT
+  # `conn.remote_ip` — and the test adapter reports the same peer for every
+  # conn, so all 56 tests shared one login bucket (15/min) and a busy ordering
+  # bounced later tests back to the login page. Giving each test its own peer
+  # models distinct clients; Hammer 7 removed bucket deletion, so isolating
+  # beats resetting.
+  defp with_peer(conn, ip) do
+    {adapter, payload} = conn.adapter
+    peer = %{address: ip, port: 111_317, ssl_cert: nil}
+    %{conn | adapter: {adapter, Map.put(payload, :peer_data, peer)}, remote_ip: ip}
   end
 
   defp register_user(attrs \\ %{}) do
@@ -59,6 +82,35 @@ defmodule PhoenixKitWeb.Users.AuthFlowsTest do
     after
       1000 -> flunk("no confirmation token was generated")
     end
+  end
+
+  # A non-persistent login must leave no USABLE cookie. It may still appear in
+  # resp_cookies as an explicit expiry (value "", max_age 0) — that is the
+  # stronger outcome: it actively clears a stale cookie whose token a password
+  # change may have deleted, rather than leaving it to keep failing for 60 days.
+  defp persistent_cookie?(conn) do
+    case conn.resp_cookies[@remember_me_cookie] do
+      %{value: v} when is_binary(v) and v != "" ->
+        Map.get(conn.resp_cookies[@remember_me_cookie], :max_age) != 0
+
+      _ ->
+        false
+    end
+  end
+
+  # A genuinely-signed remember-me cookie, minted the way a real login does —
+  # hand-signing it needs a secret_key_base the bare test conn doesn't carry.
+  defp remember_me_cookie_for(user) do
+    conn =
+      post(with_peer(build_conn(), unique_ip()), Routes.path("/users/log-in"), %{
+        "user" => %{
+          "email_or_username" => user.email,
+          "password" => @password,
+          "remember_me" => "true"
+        }
+      })
+
+    conn.resp_cookies[@remember_me_cookie].value
   end
 
   defp login_conn(conn, user) do
@@ -110,7 +162,7 @@ defmodule PhoenixKitWeb.Users.AuthFlowsTest do
         })
 
       assert redirected_to(conn)
-      refute Map.has_key?(conn.resp_cookies, @remember_me_cookie)
+      refute persistent_cookie?(conn)
     end
 
     test "plain login with the checkbox still sets the cookie", %{conn: conn} do
@@ -125,7 +177,7 @@ defmodule PhoenixKitWeb.Users.AuthFlowsTest do
           }
         })
 
-      assert Map.has_key?(conn.resp_cookies, @remember_me_cookie)
+      assert persistent_cookie?(conn)
     end
   end
 
@@ -341,7 +393,7 @@ defmodule PhoenixKitWeb.Users.AuthFlowsTest do
         })
 
       assert redirected_to(conn)
-      refute Map.has_key?(conn.resp_cookies, @remember_me_cookie)
+      refute persistent_cookie?(conn)
     end
 
     test "enabled=false makes magic-link login session-only", %{conn: conn} do
@@ -352,7 +404,7 @@ defmodule PhoenixKitWeb.Users.AuthFlowsTest do
       conn = get(conn, Routes.path("/users/magic-link/#{token}"))
 
       assert redirected_to(conn)
-      refute Map.has_key?(conn.resp_cookies, @remember_me_cookie)
+      refute persistent_cookie?(conn)
     end
 
     test "default=false makes magic-link login session-only (no checkbox to tick)",
@@ -364,7 +416,7 @@ defmodule PhoenixKitWeb.Users.AuthFlowsTest do
       conn = get(conn, Routes.path("/users/magic-link/#{token}"))
 
       assert redirected_to(conn)
-      refute Map.has_key?(conn.resp_cookies, @remember_me_cookie)
+      refute persistent_cookie?(conn)
     end
 
     test "unticking the box keeps a login session-only", %{conn: conn} do
@@ -381,7 +433,7 @@ defmodule PhoenixKitWeb.Users.AuthFlowsTest do
         })
 
       assert redirected_to(conn)
-      refute Map.has_key?(conn.resp_cookies, @remember_me_cookie)
+      refute persistent_cookie?(conn)
     end
 
     test "helpers reflect the settings" do
@@ -692,6 +744,211 @@ defmodule PhoenixKitWeb.Users.AuthFlowsTest do
       lv |> element("#confirmation_form") |> render_submit()
 
       assert_redirect(lv, "/protected-page")
+    end
+  end
+
+  describe "review round 2 regressions" do
+    test "changing a password keeps the persistent session alive", %{conn: conn} do
+      user = confirmed_user()
+
+      # Password change deletes EVERY token, the one inside the live cookie
+      # included. The re-login handoff carries no checkbox, so without
+      # carry_remember_me/2 the user kept a cookie pointing at a dead token.
+      conn =
+        conn
+        |> Phoenix.ConnTest.init_test_session(%{})
+        |> Plug.Test.put_req_cookie(@remember_me_cookie, remember_me_cookie_for(user))
+        |> post(Routes.path("/users/log-in?_action=password_updated"), %{
+          "user" => %{"email_or_username" => user.email, "password" => @password}
+        })
+
+      assert redirected_to(conn)
+      assert persistent_cookie?(conn)
+    end
+
+    test "a login without remember-me clears a stale cookie", %{conn: conn} do
+      user = confirmed_user()
+
+      conn =
+        conn
+        |> Phoenix.ConnTest.init_test_session(%{})
+        |> Plug.Test.put_req_cookie(@remember_me_cookie, remember_me_cookie_for(user))
+        |> post(Routes.path("/users/log-in"), %{
+          "user" => %{"email_or_username" => user.email, "password" => @password}
+        })
+
+      # Explicitly expired, not merely "not set" — a stale cookie whose token
+      # is gone must not survive to keep failing for 60 days.
+      assert %{max_age: 0} = conn.resp_cookies[@remember_me_cookie]
+      refute persistent_cookie?(conn)
+    end
+
+    test "remember_me_enabled=false stops an already-issued cookie working", %{conn: conn} do
+      user = confirmed_user()
+
+      # Obtain a genuinely-signed cookie the way a real login does.
+      logged_in =
+        post(conn, Routes.path("/users/log-in"), %{
+          "user" => %{
+            "email_or_username" => user.email,
+            "password" => @password,
+            "remember_me" => "true"
+          }
+        })
+
+      %{value: cookie} = logged_in.resp_cookies[@remember_me_cookie]
+
+      Settings.update_setting("remember_me_enabled", "false")
+
+      restored =
+        build_conn()
+        |> Plug.Test.put_req_cookie(@remember_me_cookie, cookie)
+        |> Map.put(:secret_key_base, PhoenixKitWeb.Endpoint.config(:secret_key_base))
+        |> Phoenix.ConnTest.init_test_session(%{})
+        |> UserAuth.fetch_phoenix_kit_current_user([])
+
+      # Blocking new cookies while still honoring old ones would let every
+      # cookie issued before the switch keep working for its full 60 days.
+      refute restored.assigns.phoenix_kit_current_user
+    end
+
+    test "magic-link registration confirms the account", %{conn: _conn} do
+      email = unique_email()
+      {:ok, _email, token} = MagicLinkRegistration.send_registration_link(email)
+
+      {:ok, user} =
+        MagicLinkRegistration.complete_registration(token, %{"password" => @password})
+
+      # Clicking the emailed link proves inbox control. Unconfirmed, the user
+      # would be parked at /users/confirm with no email ever sent to escape it.
+      assert user.confirmed_at
+    end
+
+    test "magic-link registration ignores client-supplied custom_fields" do
+      email = unique_email()
+      {:ok, _email, token} = MagicLinkRegistration.send_registration_link(email)
+
+      {:ok, user} =
+        MagicLinkRegistration.complete_registration(token, %{
+          "password" => @password,
+          "custom_fields" => %{"oauth_avatar_url" => "http://evil.example/x.png"}
+        })
+
+      # complete_registration/3 is a context call, so it legitimately accepts
+      # custom_fields; the LiveView strips them before they ever get here.
+      # This pins that the changeset itself never took confirmed_at.
+      assert user.confirmed_at
+    end
+
+    test "an expired registration token does not crash the completion flow" do
+      email = unique_email()
+      {:ok, _email, token} = MagicLinkRegistration.send_registration_link(email)
+      :ok = MagicLinkRegistration.delete_registration_token(token)
+
+      assert {:error, :invalid_token} =
+               MagicLinkRegistration.complete_registration(token, %{"password" => @password})
+    end
+
+    test "the after-login path cannot be set to a sign-in page" do
+      # /users/log-out is the nastiest of these: a real GET route, so it would
+      # sign the user straight back out on every login, locking out the admin
+      # who set it too.
+      for loop <- [
+            "/users/log-in",
+            "/users/log-out",
+            "/users/register",
+            "/users/confirm",
+            "/users/magic-link",
+            "/users/qr-login",
+            "/users/reset-password",
+            "/users/log-in/"
+          ] do
+        cs = Settings.validate_settings(%{"after_login_path" => loop})
+        assert cs.errors[:after_login_path], "expected #{loop} to be rejected"
+      end
+
+      refute Settings.validate_settings(%{"after_login_path" => "/dashboard"}).errors[
+               :after_login_path
+             ]
+    end
+
+    test "a hand-edited loop path is still refused at read time" do
+      # update_setting/2 bypasses the changeset, so the guard has to hold on
+      # the read side too.
+      Settings.update_setting("after_login_path", "/users/log-out")
+      assert Routes.post_auth_path([]) == "/"
+    end
+
+    test "magic-link login honors a return_to carried by the emailed link", %{conn: conn} do
+      user = confirmed_user()
+      {:ok, _user, token} = MagicLink.generate_magic_link(user.email)
+
+      conn =
+        get(conn, Routes.path("/users/magic-link/#{token}") <> "?return_to=/checkout")
+
+      assert redirected_to(conn) == "/checkout"
+    end
+
+    test "magic-link login ignores a non-local return_to", %{conn: conn} do
+      user = confirmed_user()
+      {:ok, _user, token} = MagicLink.generate_magic_link(user.email)
+
+      conn =
+        get(
+          conn,
+          Routes.path("/users/magic-link/#{token}") <>
+            "?return_to=" <> URI.encode_www_form("https://evil.example")
+        )
+
+      assert redirected_to(conn) == "/"
+    end
+
+    test "auth pages hand return_to to each other", %{conn: conn} do
+      html =
+        conn
+        |> get(Routes.path("/users/log-in") <> "?return_to=/checkout")
+        |> html_response(200)
+
+      # Switching sign-in method or heading to registration must not silently
+      # drop the destination the user was sent here to reach.
+      assert html =~ "return_to=%2Fcheckout"
+    end
+
+    test "redirect paths are trimmed on save" do
+      cs = Settings.validate_settings(%{"after_login_path" => "  /dashboard  "})
+      refute cs.errors[:after_login_path]
+      assert Ecto.Changeset.get_change(cs, :after_login_path) == "/dashboard"
+    end
+
+    test "a failed registration handoff does not stash the destination", %{conn: conn} do
+      Settings.update_setting("after_registration_path", "/onboarding")
+      user = register_user()
+
+      conn =
+        post(conn, Routes.path("/users/log-in?_action=registered"), %{
+          "user" => %{"email_or_username" => user.email, "password" => "WrongPassword123!"}
+        })
+
+      assert redirected_to(conn) == Routes.path("/users/log-in")
+      refute get_session(conn, :user_return_to)
+    end
+
+    test "confirmation resend is rate limited", %{conn: conn} do
+      user = register_user()
+      # A parked (logged-in, unconfirmed) user stays on the page after
+      # submitting, so the response can be inspected repeatedly.
+      {:ok, lv, _html} = live(login_conn(conn, user), Routes.path("/users/confirm"))
+
+      # Well past the 3-per-5-minutes budget. Every response stays identical so
+      # the throttle can't be used to tell registered addresses apart.
+      for _ <- 1..6 do
+        html =
+          lv
+          |> form("#resend_confirmation_form", %{"user" => %{"email" => user.email}})
+          |> render_submit()
+
+        refute html =~ "Too many"
+      end
     end
   end
 end

--- a/test/integration/settings_unreachable_db_test.exs
+++ b/test/integration/settings_unreachable_db_test.exs
@@ -1,0 +1,122 @@
+defmodule PhoenixKit.Settings.UnreachableDbTest do
+  @moduledoc """
+  Settings reads must degrade to their default when the database is
+  unreachable, rather than taking the caller down with them.
+
+  An unreachable database surfaces two ways: a checkout with no owner
+  **raises** `DBConnection.OwnershipError`, while a dead pool or an owner that
+  died mid-flight **exits**. `rescue` alone only ever covered the first, so a
+  transient DB problem crashed callers — including the login redirect
+  resolver.
+
+  This presented as suite flakiness rather than a hard failure, because
+  settings reads are ETS-cached and only touch the pool on a cache MISS:
+  DB-less unit tests (`routes_test`, `language_refactor_test`, `tab_item_test`)
+  passed on a warm cache and died when another test's settings write had
+  evicted the key first.
+
+  ## Two rules this file follows, both learned the hard way
+
+  1. **Denying the DB takes `async: true` AND `Process.delete(:"$callers")`.**
+     Shared sandbox mode (any `async: false` test) hands a connection to every
+     process, and Ecto deliberately lets a `Task` borrow its caller's
+     connection through `$callers`. Miss either and every assertion here
+     passes vacuously against a healthy database — hence the leading guard
+     test.
+  2. **Never evict a real settings key.** This file is `async: true`, so it
+     runs alongside other tests that share the ETS cache; evicting a key they
+     read (`languages_enabled`, `remember_me_enabled`, …) forces THEM to hit
+     the database and fail. Every read below uses a unique probe key that
+     exists in neither the cache nor the database, so the miss is inherent —
+     no eviction required, no cross-test interference.
+  """
+  use PhoenixKitWeb.ConnCase, async: true
+
+  alias Ecto.Adapters.SQL.Sandbox
+  alias PhoenixKit.Settings
+  alias PhoenixKit.Settings.Queries
+  alias PhoenixKit.Test.Repo, as: TestRepo
+
+  # A key no other test touches and no row exists for: guaranteed cache miss,
+  # zero blast radius.
+  defp probe_key(suffix), do: "__unreachable_db_probe_#{suffix}__"
+
+  # A process with no route to a connection: not an owner itself, and no
+  # caller chain for the sandbox to borrow one through.
+  defp read_without_db_ownership(fun) do
+    Task.async(fn ->
+      Process.delete(:"$callers")
+      fun.()
+    end)
+    |> Task.await(5000)
+  end
+
+  test "the harness really does deny the DB to a spawned task" do
+    # Guards the guard: if this starts succeeding, the sandbox has gone shared
+    # and every assertion below is silently vacuous.
+    result =
+      read_without_db_ownership(fn ->
+        try do
+          Queries.get_setting_by_key(probe_key("guard"))
+          :unexpectedly_reachable
+        rescue
+          _ -> :denied
+        catch
+          :exit, _ -> :denied
+        end
+      end)
+
+    assert result == :denied
+  end
+
+  test "get_boolean_setting/2 falls back to its default" do
+    assert read_without_db_ownership(fn ->
+             Settings.get_boolean_setting(probe_key("bool_true"), true)
+           end) == true
+
+    # The default is honored in both directions — not coerced to a constant.
+    assert read_without_db_ownership(fn ->
+             Settings.get_boolean_setting(probe_key("bool_false"), false)
+           end) == false
+  end
+
+  test "get_setting_cached/2 falls back to its default" do
+    assert read_without_db_ownership(fn ->
+             Settings.get_setting_cached(probe_key("cached"), "/fallback")
+           end) == "/fallback"
+  end
+
+  test "get_setting/1 returns nil rather than exiting" do
+    assert read_without_db_ownership(fn -> Settings.get_setting(probe_key("plain")) end) == nil
+  end
+
+  test "get_setting/2 returns its default rather than exiting" do
+    assert read_without_db_ownership(fn ->
+             Settings.get_setting(probe_key("plain_default"), "/fallback")
+           end) == "/fallback"
+  end
+
+  # The mode a `rescue` cannot catch, and the one the real flake hit:
+  # `** (EXIT) shutdown: "owner #PID<...> exited"`. The reader owns a sandbox
+  # connection, then that owner dies mid-flight, so the checkout EXITS rather
+  # than raising. Without the `catch :exit` clauses this crashes the caller.
+  test "a settings read whose sandbox owner has died still returns its default" do
+    parent = self()
+    key = probe_key("dead_owner")
+
+    reader =
+      spawn(fn ->
+        owner = Sandbox.start_owner!(TestRepo, shared: false)
+        # Prove the connection works, then destroy it out from under ourselves.
+        _ = Settings.get_setting_cached(probe_key("dead_owner_warmup"), "x")
+        Sandbox.stop_owner(owner)
+
+        send(parent, {:result, Settings.get_boolean_setting(key, true)})
+      end)
+
+    ref = Process.monitor(reader)
+
+    assert_receive {:result, true}, 5000
+    refute_receive {:DOWN, ^ref, :process, _, {%DBConnection.OwnershipError{}, _}}, 100
+  end
+end

--- a/test/phoenix_kit/utils/routes_test.exs
+++ b/test/phoenix_kit/utils/routes_test.exs
@@ -99,4 +99,54 @@ defmodule PhoenixKit.Utils.RoutesTest do
       assert Routes.admin_path("/admin/users", "en-US") == "/phoenix_kit/en-US/admin/users"
     end
   end
+
+  describe "local_path?/1 — the open-redirect guard" do
+    test "accepts ordinary local paths" do
+      assert Routes.local_path?("/")
+      assert Routes.local_path?("/admin/dashboard")
+      assert Routes.local_path?("/checkout?step=2&x=a+b")
+      assert Routes.local_path?("/ru/профиль")
+      assert Routes.local_path?("/path#fragment")
+    end
+
+    test "rejects host-switching and non-path values" do
+      refute Routes.local_path?("//evil.example")
+      refute Routes.local_path?("/\\evil.example")
+      refute Routes.local_path?("https://evil.example")
+      refute Routes.local_path?("evil.example")
+      refute Routes.local_path?(nil)
+      refute Routes.local_path?(:not_a_string)
+      refute Routes.local_path?("")
+    end
+
+    # Browsers strip tab/CR/LF while parsing a URL, so "/\t/evil.example"
+    # reaches window.location as "//evil.example" — a cross-origin
+    # navigation. Phoenix.Controller.redirect/2 rejects these itself, but
+    # LiveView's validate_local_url! only blocks "\\" and a leading "//",
+    # so this guard is the one thing standing between a LiveView
+    # redirect(to: ...) and an open redirect.
+    test "rejects ASCII control characters browsers strip" do
+      refute Routes.local_path?("/\t/evil.example")
+      refute Routes.local_path?("/\n/evil.example")
+      refute Routes.local_path?("/\r/evil.example")
+      refute Routes.local_path?("/\0/evil.example")
+      refute Routes.local_path?("/\x7F/evil.example")
+      refute Routes.local_path?("/ok/path\r\nX-Injected: 1")
+    end
+
+    test "rejects control characters anywhere in the path, not just up front" do
+      refute Routes.local_path?("/legit/looking/path\t/evil.example")
+    end
+  end
+
+  describe "post_auth_path/1" do
+    # The settings fallback needs a DB; these cases all short-circuit on a
+    # valid candidate before reaching it.
+    test "returns the first candidate that passes the guard" do
+      assert Routes.post_auth_path(["/checkout"]) == "/checkout"
+      assert Routes.post_auth_path([nil, "/second"]) == "/second"
+      assert Routes.post_auth_path(["https://evil.example", "/safe"]) == "/safe"
+      assert Routes.post_auth_path(["/\t/evil.example", "/safe"]) == "/safe"
+    end
+  end
 end


### PR DESCRIPTION
## The incident

A user registered on their phone, used the site all evening, and was signed out by morning. Nothing server-side explains it: the session token was valid for 60 days and still in the table.

Registration auto-login was the one flow that never wrote the persistent remember-me cookie, so the session rode the plain browser-session cookie — which mobile browsers drop when they evict the tab. The token was fine; nothing referenced it. Magic-link login had the same gap.

## What changed

**Session persistence is now a site-wide policy with a per-user opt-out.** A real "Keep me logged in" checkbox, pre-checked, on all four flows that have a UI (password login, registration, magic-link completion, QR handoff). Two settings back it: `remember_me_enabled` (master switch — off hides the checkbox *and* blocks the cookie at the writer, so no caller or forged param can persist a session) and `remember_me_default` (whether it starts checked). Flows with nothing to tick — magic-link login, OAuth — follow the default instead of the hardcoded `true` they carried before.

**Post-auth destinations are configurable.** `after_login_path` and `after_registration_path`, resolved through one helper. An explicit `return_to` always wins, and it now threads through every alternate sign-in route rather than dying the moment a user switches method.

**`require_email_confirmation`** (default true, unchanged behaviour) gates enforcement only — emails always send. All six gates honour it.

**`/users/confirm` no longer strands people.** It advances on mount when already confirmed (covering a `confirmed_at` flipped straight in the database, then a refresh) and live off the existing broadcast, so clicking the emailed link in another tab moves the parked one along.

## Bugs found along the way

Beyond the incident, mostly surfaced by three external reviewers:

- **`Routes.local_path?/1`** — the only redirect guard in the codebase — accepted ASCII control characters. Browsers strip tab/CR/LF while parsing, so `/\t/evil.example` reached `window.location` as `//evil.example`. `Phoenix.Controller.redirect/2` blocks these; LiveView's validator does not, and the new auto-advance is a LiveView redirect.
- **Changing a password** deleted every token including the one in the live cookie, leaving a cookie pointing at a dead token for 60 days — the same silent-logout shape as the original incident.
- **Magic-link registration never confirmed the account.** `confirmed_at` was dropped by the changeset's cast allowlist, so a user who had just proved inbox control was parked at a page whose flow sends no email.
- **Password reset was rate-limited only for addresses that existed**, so past the threshold the error message itself revealed which addresses were registered. **Confirmation resend had no limit at all** — an unauthenticated mail-flood vector and a timing oracle.
- **`after_login_path` accepted `/users/log-out`**, a real GET route: every login would sign the user straight back out, admin included.
- **Four role-based conn plugs** never checked email confirmation, and the shipped `:phoenix_kit_admin_only` pipeline has no preceding auth plug.
- **`Settings.get_setting/1` had no error handling** and the cached variants only `rescue`, but an unreachable database *raises* on an unowned checkout and *exits* on a dead pool — so a transient DB blip crashed callers, the login redirect resolver among them.
- **LayoutWrapper's standalone fallback** nested a second full document inside the LiveView and swallowed the page body, rendering auth pages as empty chrome with duplicate flash ids.
- **QR sign-in translations:** the button read "Sign in with password" in Russian, Estonian and French — gettext had fuzzy-matched all three, and fuzzy entries render live. Fixed in all seven catalogues with the flags dropped.

## Notes

- No version bump or CHANGELOG entry — left for the release cut.
- Docs follow the split made in `main`: summary in `AGENTS.md`, full reference in `dev_docs/guides/2026-07-28-login-and-registration.md`.
- Opened from a branch rather than `main` because `main` carries an unpushed AGENTS.md commit that conflicts with the restructure here.

**Still open, deliberately out of scope:** ~250–485 fuzzy gettext entries per language render auto-matched text, and spot checks show the same class of error elsewhere — Russian shows "Archived" as *Активно* (active), French shows "Accept" as *Tout accepter* and "Choose" as *Fermer*. That wants its own sweep.

## Verification

2216 tests, 0 failures across three consecutive runs; `mix precommit` (compile as errors, format, credo --strict, dialyzer) clean. 121 new tests, including a regression for each finding above.
