### PR TITLE
Add Chart, StatusDot and ConnectAccountButton core components

### DIFF
--- a/dev_docs/2026-07-28-chart-statusdot-connectbutton-components.md
+++ b/dev_docs/2026-07-28-chart-statusdot-connectbutton-components.md
@@ -41,8 +41,24 @@ coloured by cheapness). Backward compatible; default nil.
 
 ## What the review pass changed
 
-The components were handed over deliberately untested. Testing plus two external
-review rounds (grok / kimi / codex / zai / vibe) found these:
+The components were handed over deliberately untested. Testing plus **four**
+external review rounds (grok / kimi / codex / zai / vibe / agy) found these.
+
+Rounds 2, 3 and 4 each found defects **in the previous round's fixes** — worth
+recording, because it is the reason the sweeps kept going. A fix aimed at a
+narrow symptom repeatedly re-created the same class of bug on a path it did not
+touch: flooring a bar's height without moving its `y` pushed it out of the
+viewBox exactly as the zero-height bar had been invisible; widening a
+zero-length path so a lone point would paint made it paint a full-width line
+for out-of-domain data and threw away the second value of any same-x pair; and
+a magnitude-relative y padding that rescued huge *flat* series swamped the
+signal in huge *near-flat* ones.
+
+The round-4 resolution was to stop patching symptoms and fix the cause: a
+collapsed domain now scales to the **centre** (the same treatment a flat y
+series already got), and a path that genuinely paints nothing renders a **dot**
+at the point's true position rather than a fabricated line across a range
+nobody measured.
 
 **Crashes and silent failures**
 

--- a/dev_docs/2026-07-28-chart-statusdot-connectbutton-components.md
+++ b/dev_docs/2026-07-28-chart-statusdot-connectbutton-components.md
@@ -136,6 +136,15 @@ heights stay proportional.
 
 ## Follow-ups
 
+- `status_dot`'s state vocabulary (`online` / `offline` / `ok` / …) is gettext'd
+  but has no catalogue entries yet — it renders English until a translation pass
+  runs `mix gettext.extract --merge`. Left out of this change deliberately:
+  extraction rewrites all nine catalogues (~18k lines) and would bury the
+  component diff.
+- `connect_account_button`'s derived DOM id is lossy — `/foo/bar` and `/foo-bar`
+  slug to the same id, so two such buttons on one page would collide again.
+  Pass an explicit `id` in that case.
+
 - `phoenix_kit_dashboards` widgets are the natural second consumer and would
   validate the API quickly.
 - `phoenix_kit_publishing` hand-rolls a status dot

--- a/dev_docs/2026-07-28-chart-statusdot-connectbutton-components.md
+++ b/dev_docs/2026-07-28-chart-statusdot-connectbutton-components.md
@@ -1,94 +1,148 @@
 # New core components: Chart, StatusDot, ConnectAccountButton (+ stat_card value_color)
 
-**Branch:** `feat/nordswitch-core-components`
-**Origin:** extracted from NordSwitch (nordswitch.eu) — the first app to dogfood
-these; its hand-rolled versions are running in production-dev today.
-**Status:** implementation done, deliberately untested — this doc is the
-handoff for the AI/dev doing tests, review and polish.
+**Origin:** extracted from NordSwitch (nordswitch.eu), whose hand-rolled versions
+run in production-dev today and will be swapped for these on release.
+**Status:** implemented, reviewed, tested. This doc is the after-action record —
+the original handoff asked for testing, review and polish, and this is what that
+pass found and changed.
 
-## What was added
+## What shipped
 
-### 1. `PhoenixKitWeb.Components.Core.Chart` (new)
+### `PhoenixKitWeb.Components.Core.Chart`
 
-Server-rendered SVG chart primitives, zero JS, theme-aware via
-`currentColor`:
+Server-rendered SVG, zero JS, theme-aware via `currentColor`:
 
-- `area_chart/1` — line/area chart over `{x, y}` number tuples; `step`
-  attr for interval data (right-open steps — each y holds until the
-  next x); optional `marker_x` dashed vertical marker ("now" line);
-  auto or explicit domains; `:empty` slot.
-- `sparkline/1` — minimal polyline over a list of numbers.
-- `bar_chart/1` — simple vertical bars over `%{label, value}` maps.
+- `line_chart/1` — line/area over `{x, y}` points; `step` for interval data
+  (right-open steps), optional `marker_x` "now" line, auto or explicit domains,
+  `:empty` slot.
+- `sparkline/1` — polyline over a list of numbers.
+- `bar_chart/1` — vertical bars from a **zero baseline**, native `<title>`
+  tooltips, optional per-datum `class`, aligned labels.
 
-Rationale: core (and the dashboards module) had **no chart primitives at
-all**; every consumer either hand-rolls SVG or pulls a JS library. These
-are LiveView-native: assigns change → SVG re-renders.
+Core (and the dashboards module) had no chart primitives at all; every consumer
+either hand-rolled SVG or pulled a JS library. These are LiveView-native:
+assigns change → SVG re-renders.
 
-Real-world usage reference (NordSwitch): a 96-slot day-ahead electricity
-price curve with a "now" marker, updating every 15 min over PubSub, and
-a 12-hour price sparkline; both currently hand-rolled in
-`NordswitchWeb.Charts` and ready to be swapped to these components.
+### `PhoenixKitWeb.Components.Core.StatusDot`
 
-### 2. `PhoenixKitWeb.Components.Core.StatusDot` (new)
+`status_dot/1` — semantic coloured dot + optional label + optional `pulse`.
+Boolean `up={bool}` convenience or explicit `variant`. Fills the gap between
+nothing and the domain-specific badges in `Badge`.
 
-`status_dot/1` — tiny semantic colored dot + optional label + optional
-`pulse` (ping animation). Boolean convenience `up={bool}` for the
-online/offline case, or explicit `variant` atom. Fills the gap between
-nothing and the domain-specific badges in `Badge` (role/user/code).
+### `PhoenixKitWeb.Components.Core.ConnectAccountButton`
 
-### 3. `PhoenixKitWeb.Components.Core.ConnectAccountButton` (new)
+`connect_account_button/1` — OAuth-popup account linking (distinct from
+`OAuthProvider`, which is app sign-in). Driven by the generic `PopupLink` hook.
 
-`connect_account_button/1` — the OAuth-popup "Connect your X account"
-pattern (window.open named popup; provider consent; callback closes
-popup + reloads opener). Distinct from `OAuthProvider` (app sign-in);
-this is for the Integrations system's third-party account linking.
-The expected callback-page script contract is documented in the
-moduledoc.
+### `stat_card` extension
 
-### 4. `stat_card` extension (modified, backward compatible)
+Optional `value_color` for values whose colour carries information (a price
+coloured by cheapness). Backward compatible; default nil.
 
-New optional `value_color` attr (CSS color string) applied as inline
-style to the value element in both compact and full layouts — for
-values whose color IS information (NordSwitch: spot price colored
-green→red by cheapness). Default nil = no change for existing callers.
+## What the review pass changed
 
-### 5. Registration
+The components were handed over deliberately untested. Testing plus two external
+review rounds (grok / kimi / codex / zai / vibe) found these:
 
-All three new modules imported in `phoenix_kit_web.ex` `core_components`
-block.
+**Crashes and silent failures**
 
-## Notes / decisions for the reviewer
+- `bar_chart` scaled from `max(value)`, so a **negative value produced a negative
+  rect height** — SVG discards those, so the bar silently vanished rather than
+  rendering below a baseline. An all-negative series divided by the `1.0e-9`
+  floor and threw the geometry to astronomical numbers. Bars are measured from a
+  zero baseline now.
+- A **single data point** produced a bare `M x,y` path, which is valid and paints
+  nothing. It holds its value across the range instead — the same reading `step`
+  mode already gave it. Same fix for a single sparkline value.
+- **Reversed domains** (`x_domain={{10, 0}}`) drove the span negative; the
+  `1.0e-9` floor then produced coordinates around `1.0e12` and the chart vanished
+  off-canvas. Both axes normalise.
+- **One bad point took the page down.** `nil`, a string, or a `Decimal` raised an
+  uncaught `ArithmeticError` mid-render — and `Decimal` is what Ecto hands you
+  for money, in a kit with a billing module. Points are normalised: tuples or
+  `%{x:, y:}` maps, Decimals converted, non-numeric dropped, `:empty` when
+  nothing usable survives.
 
-- **Charts are numeric-domain only** on purpose: no DateTime handling in
-  the component; callers map time → number. Keeps the API tiny and the
-  component future-proof. If a datetime axis helper is wanted later, it
-  should be a separate wrapper, not a widening of this API.
-- `preserveAspectRatio="none"` + `vector-effect="non-scaling-stroke"` is
-  the stretch model: the SVG fills its container, strokes stay crisp.
-  Containers control size via normal CSS (`h-48 w-full`).
-- Gradient stops use `stop-color="currentColor"` — verify on all
-  supported browsers (works in Chrome/FF/Safari current; that claim is
-  untested here).
-- `area_chart` step mode extends the last slot to the x-domain's right
-  edge — intended for interval data; check the non-step + explicit
-  x_domain combinations.
-- Suggested test areas: empty data (renders `:empty` slot / nothing),
-  single-point data (sparkline returns nil under 2 points; area_chart
-  with one point), negative values (electricity prices go negative!),
-  y_domain zero-span, bar_chart with zero max.
-- `StatusDot` `size-1.5/2/2.5` classes assume Tailwind v4 size-*
-  utilities — confirm against the kit's Tailwind setup.
-- `ConnectAccountButton` uses an inline `onclick` — if the kit prefers
-  a JS hook / `phx-click` + JS.dispatch pattern for CSP friendliness,
-  that's a fair refactor; the contract (named popup + opener reload)
-  should survive it.
-- daisyUI 5 / Tailwind 4 assumed throughout, matching the kit.
+**Security / correctness**
 
-## Follow-up candidates (not implemented)
+- `connect_account_button` used an **inline `onclick`** — CSP-hostile in a kit
+  that removed inline handlers everywhere else — whose `return false` cancelled
+  navigation *unconditionally*, including when the popup was blocked. That is
+  precisely when the documented "falls back to normal navigation" was supposed to
+  save it; the button simply did nothing. It is a hook now that preventDefaults
+  only after `window.open` returns a live window, and leaves modifier-clicks
+  alone.
+- Every unconfigured button shared **one DOM id** (`window_name` defaulted to a
+  constant), which is invalid HTML and breaks `phx-hook`. The default derives
+  from `href` now.
+- The moduledoc's security rationale was **wrong**: it claimed the local-path
+  check kept `window.opener` from third parties. The popup navigates on to the
+  provider and the opener reference survives, so the provider's origin can reach
+  `opener.location` — reverse tabnabbing. The doc now names the real mitigation
+  (COOP + `postMessage`). The local-path check is kept, for what it does do.
+- `stat_card`'s `value_color` interpolated into `style=`; a `;` could append a
+  second declaration. Stripped, and the attribute is spread conditionally
+  (HEEx renders `style={nil}` as an empty `style=""`).
 
-- The dashboards module's widgets consuming `Chart` (natural second
-  consumer; would validate the API quickly).
-- A `datetime_area_chart` wrapper with axis tick labels, if demand
-  appears.
-- NordSwitch will adopt these once released (drop-in replacements for
-  its hand-rolled versions) — ping Max/NordSwitch when a version ships.
+**Accessibility**
+
+- Charts carried `role="img"` with **no accessible name**. Optional `aria_label`
+  renders as `<title>` + `aria-label`; unlabelled charts are marked decorative.
+- `status_dot` conveyed state through **colour alone** — silent to a screen
+  reader, indistinguishable to red/green colour-blind users. Unlabelled dots
+  carry a visually-hidden state name kept in step with the colour. `pulse`
+  respects `prefers-reduced-motion`.
+
+**API, changed while it was still free (nothing consumes these yet)**
+
+- `area_chart` → **`line_chart`** (`area_chart area={false}` *was* a line chart).
+- a11y attr `label` → **`aria_label`**, so it stops colliding with bar data's own
+  `label:` key.
+- Hook `ConnectAccountPopup` → **`PopupLink`**; nothing about it is
+  OAuth-specific, and hook names freeze once hosts copy the bundle.
+- `:rest` global on all three charts and on `status_dot`.
+- Bars: `<title>` tooltips, zero baseline, per-datum `class`, rendered `id`,
+  labels sized to their own slot (`justify-between` drifted the first and last
+  labels to the container edges while bars sit at slot centres).
+- Gridlines got the `vector-effect` the line already had.
+- Bar tooltip values are formatted for display, so a computed `0.1 + 0.2` reads
+  as `0.3` rather than `0.30000000000000004`.
+
+## Tests
+
+- `test/phoenix_kit_web/components/core/{chart,status_dot,connect_account_button,stat_card}_test.exs`
+- `test/js/popup_link.test.cjs` — the hook's pure decision logic (which clicks to
+  intercept, where to place the popup, same-origin). Run via `mix test.js`, wired
+  into `mix precommit`; skips itself when node isn't installed.
+
+Verified live in `phoenix_kit_parent` at `/core-components-showcase` (local
+only): positive bars end exactly at the baseline, negatives hang below it, and
+heights stay proportional.
+
+## Known limits, deliberately not addressed
+
+- **Numeric domains only.** Callers map time → number. A datetime-axis helper, if
+  ever wanted, should be a separate wrapper rather than a widening of this API.
+- **Single series.** Overlay two absolutely-positioned charts sharing a viewBox;
+  `currentColor` makes per-series theming trivial (`text-primary` /
+  `text-secondary`).
+- **`preserveAspectRatio="none"`** protects strokes via `vector-effect`, but dash
+  patterns and the bars' `rx` corners still distort under heavy stretch.
+- **No axis tick labels.** The highest-value future addition; gridline positions
+  are already computed. Render them as HTML beside the SVG, not `<text>` inside
+  it, which the stretch model would distort.
+- **Large N:** pre-aggregate above roughly 1–2k points rather than expecting
+  decimation.
+
+## Follow-ups
+
+- `phoenix_kit_dashboards` widgets are the natural second consumer and would
+  validate the API quickly.
+- `phoenix_kit_publishing` hand-rolls a status dot
+  (`version_switcher.ex`, `status_dot_classes/3`) — the exact duplication
+  `StatusDot` exists to remove.
+- NordSwitch adopts these on release.
+- Unrelated but noticed: `priv/static/assets/phoenix_kit.js` already bundles the
+  full **Chart.js UMD library**, which sets `window.Chart`. Worth a deliberate
+  decision about whether the kit wants two charting stories now that zero-JS
+  primitives exist.

--- a/dev_docs/2026-07-28-chart-statusdot-connectbutton-components.md
+++ b/dev_docs/2026-07-28-chart-statusdot-connectbutton-components.md
@@ -1,0 +1,94 @@
+# New core components: Chart, StatusDot, ConnectAccountButton (+ stat_card value_color)
+
+**Branch:** `feat/nordswitch-core-components`
+**Origin:** extracted from NordSwitch (nordswitch.eu) — the first app to dogfood
+these; its hand-rolled versions are running in production-dev today.
+**Status:** implementation done, deliberately untested — this doc is the
+handoff for the AI/dev doing tests, review and polish.
+
+## What was added
+
+### 1. `PhoenixKitWeb.Components.Core.Chart` (new)
+
+Server-rendered SVG chart primitives, zero JS, theme-aware via
+`currentColor`:
+
+- `area_chart/1` — line/area chart over `{x, y}` number tuples; `step`
+  attr for interval data (right-open steps — each y holds until the
+  next x); optional `marker_x` dashed vertical marker ("now" line);
+  auto or explicit domains; `:empty` slot.
+- `sparkline/1` — minimal polyline over a list of numbers.
+- `bar_chart/1` — simple vertical bars over `%{label, value}` maps.
+
+Rationale: core (and the dashboards module) had **no chart primitives at
+all**; every consumer either hand-rolls SVG or pulls a JS library. These
+are LiveView-native: assigns change → SVG re-renders.
+
+Real-world usage reference (NordSwitch): a 96-slot day-ahead electricity
+price curve with a "now" marker, updating every 15 min over PubSub, and
+a 12-hour price sparkline; both currently hand-rolled in
+`NordswitchWeb.Charts` and ready to be swapped to these components.
+
+### 2. `PhoenixKitWeb.Components.Core.StatusDot` (new)
+
+`status_dot/1` — tiny semantic colored dot + optional label + optional
+`pulse` (ping animation). Boolean convenience `up={bool}` for the
+online/offline case, or explicit `variant` atom. Fills the gap between
+nothing and the domain-specific badges in `Badge` (role/user/code).
+
+### 3. `PhoenixKitWeb.Components.Core.ConnectAccountButton` (new)
+
+`connect_account_button/1` — the OAuth-popup "Connect your X account"
+pattern (window.open named popup; provider consent; callback closes
+popup + reloads opener). Distinct from `OAuthProvider` (app sign-in);
+this is for the Integrations system's third-party account linking.
+The expected callback-page script contract is documented in the
+moduledoc.
+
+### 4. `stat_card` extension (modified, backward compatible)
+
+New optional `value_color` attr (CSS color string) applied as inline
+style to the value element in both compact and full layouts — for
+values whose color IS information (NordSwitch: spot price colored
+green→red by cheapness). Default nil = no change for existing callers.
+
+### 5. Registration
+
+All three new modules imported in `phoenix_kit_web.ex` `core_components`
+block.
+
+## Notes / decisions for the reviewer
+
+- **Charts are numeric-domain only** on purpose: no DateTime handling in
+  the component; callers map time → number. Keeps the API tiny and the
+  component future-proof. If a datetime axis helper is wanted later, it
+  should be a separate wrapper, not a widening of this API.
+- `preserveAspectRatio="none"` + `vector-effect="non-scaling-stroke"` is
+  the stretch model: the SVG fills its container, strokes stay crisp.
+  Containers control size via normal CSS (`h-48 w-full`).
+- Gradient stops use `stop-color="currentColor"` — verify on all
+  supported browsers (works in Chrome/FF/Safari current; that claim is
+  untested here).
+- `area_chart` step mode extends the last slot to the x-domain's right
+  edge — intended for interval data; check the non-step + explicit
+  x_domain combinations.
+- Suggested test areas: empty data (renders `:empty` slot / nothing),
+  single-point data (sparkline returns nil under 2 points; area_chart
+  with one point), negative values (electricity prices go negative!),
+  y_domain zero-span, bar_chart with zero max.
+- `StatusDot` `size-1.5/2/2.5` classes assume Tailwind v4 size-*
+  utilities — confirm against the kit's Tailwind setup.
+- `ConnectAccountButton` uses an inline `onclick` — if the kit prefers
+  a JS hook / `phx-click` + JS.dispatch pattern for CSP friendliness,
+  that's a fair refactor; the contract (named popup + opener reload)
+  should survive it.
+- daisyUI 5 / Tailwind 4 assumed throughout, matching the kit.
+
+## Follow-up candidates (not implemented)
+
+- The dashboards module's widgets consuming `Chart` (natural second
+  consumer; would validate the API quickly).
+- A `datetime_area_chart` wrapper with axis tick labels, if demand
+  appears.
+- NordSwitch will adopt these once released (drop-in replacements for
+  its hand-rolled versions) — ping Max/NordSwitch when a version ships.

--- a/lib/phoenix_kit_web.ex
+++ b/lib/phoenix_kit_web.ex
@@ -120,6 +120,9 @@ defmodule PhoenixKitWeb do
       import PhoenixKitWeb.Components.Core.ThemeSwitcher
       import PhoenixKitWeb.Components.Core.Badge
       import PhoenixKitWeb.Components.Core.StatCard
+      import PhoenixKitWeb.Components.Core.Chart
+      import PhoenixKitWeb.Components.Core.StatusDot
+      import PhoenixKitWeb.Components.Core.ConnectAccountButton
       import PhoenixKitWeb.Components.Core.EmailStatusBadge
       import PhoenixKitWeb.Components.Core.TimeDisplay
       import PhoenixKitWeb.Components.Core.EventTimelineItem

--- a/lib/phoenix_kit_web/components/core/chart.ex
+++ b/lib/phoenix_kit_web/components/core/chart.ex
@@ -1,49 +1,80 @@
 defmodule PhoenixKitWeb.Components.Core.Chart do
   @moduledoc """
   Server-rendered SVG chart primitives — no JavaScript, no external
-  libraries. Charts re-render when LiveView assigns change, which makes
-  them naturally live; CSS transitions handle the rest.
+  libraries. Charts re-render whenever LiveView assigns change, so they
+  are live by construction. (They snap rather than tween: SVG geometry
+  attributes are not CSS-transitionable.)
 
-  All charts are theme-aware by drawing in `currentColor`: set a text
-  color class on the component (`class="text-primary"`) and both stroke
-  and gradient fill follow it in light and dark themes.
+  All charts draw in `currentColor`: set a text colour on the component
+  (`class="text-primary"`) and stroke, fill and gradient all follow it in
+  light and dark themes.
 
-  Data is plain numbers — callers map their domain (time, money, watts)
-  to x/y before rendering. This keeps the primitives generic: a price
+  ## Sizing
+
+  Each chart fills its container. The SVG uses `preserveAspectRatio="none"`,
+  so it stretches to whatever box you give it while strokes stay crisp via
+  `vector-effect="non-scaling-stroke"`. **Give the wrapper a height** —
+  otherwise you inherit the viewBox's intrinsic ratio, which is rarely what
+  you want:
+
+      <div class="h-48 w-full">
+        <.line_chart id="p" data={@points} class="text-primary" />
+      </div>
+
+  Heavy stretching still distorts anything measured in user space: dash
+  patterns and the bars' rounded corners. Strokes are protected; those are
+  not.
+
+  ## Data
+
+  Values are plain numbers — callers map their domain (time, money, watts)
+  to x/y first, which is what keeps these primitives generic: a price
   curve, a CPU graph and a signup funnel are all just `{x, y}` pairs.
 
-  Origin: extracted from NordSwitch's live price charts; also intended
-  as the drawing layer for `phoenix_kit_dashboards` widgets.
+  Points may be `{x, y}` tuples or `%{x: x, y: y}` maps, and `Decimal`
+  values are converted automatically (money and metrics arrive that way
+  from Ecto). Points that aren't numeric are dropped rather than crashing
+  the page; if nothing usable is left, the `:empty` slot renders.
+
+  Series are sorted by x, so out-of-order data plots correctly instead of
+  zigzagging.
+
+  Origin: extracted from NordSwitch's live price charts; also intended as
+  the drawing layer for `phoenix_kit_dashboards` widgets.
   """
 
   use Phoenix.Component
 
   @doc """
-  A line/area chart for a numeric series.
+  A line chart for a numeric series, optionally filled.
 
   ## Examples
 
       <%!-- a day of prices: x = minute of day, y = EUR/MWh --%>
-      <.area_chart
+      <.line_chart
         id="price-day"
         data={Enum.map(@slots, &{minute_of_day(&1.starts_at), &1.eur_mwh})}
         x_domain={{0, 1440}}
         step
         marker_x={minute_of_day(@now)}
+        aria_label="Electricity price today"
         class="text-primary"
       />
 
-      <%!-- plain line, auto domains --%>
-      <.area_chart id="signups" data={@signups} area={false} />
+      <%!-- a bare line, auto domains --%>
+      <.line_chart id="signups" data={@signups} area={false} />
 
-  `data` is a list of `{x, y}` number tuples, sorted by x. With `step`
-  each point holds its y until the next x (right-open steps — correct
-  for slot/interval data like prices). `marker_x` draws a dashed
-  vertical marker (a "now" line). Domains default to the data's min/max
-  (y padded by 10%).
+  With `step` each point holds its y until the next x (right-open steps —
+  the correct reading for slot/interval data like prices). `marker_x`
+  draws a dashed vertical "now" line. Domains default to the data's
+  min/max, y padded by 10%; a reversed domain is normalised.
   """
   attr :id, :string, required: true, doc: "Unique id (namespaces the SVG gradient defs)"
-  attr :data, :list, required: true, doc: "List of {x, y} number tuples, sorted by x"
+
+  attr :data, :list,
+    required: true,
+    doc: "Points as {x, y} tuples or %{x: _, y: _} maps. Non-numeric points are dropped."
+
   attr :step, :boolean, default: false, doc: "Step interpolation (interval data)"
   attr :area, :boolean, default: true, doc: "Fill a gradient area under the line"
   attr :x_domain, :any, default: nil, doc: "{min, max} for x, or nil to fit data"
@@ -52,31 +83,33 @@ defmodule PhoenixKitWeb.Components.Core.Chart do
   attr :width, :integer, default: 960, doc: "viewBox width (the SVG scales to its container)"
   attr :height, :integer, default: 240, doc: "viewBox height"
   attr :gridlines, :integer, default: 3, doc: "Number of horizontal gridlines (0 disables)"
-  attr :class, :string, default: nil, doc: "Classes for the wrapper (set text-* for color)"
+  attr :class, :any, default: nil, doc: "Classes for the wrapper (set text-* for colour)"
 
-  attr :label, :string,
+  attr :aria_label, :string,
     default: nil,
     doc:
-      "Accessible name for the chart. `role=\"img\"` without one is an unlabelled " <>
-        "graphic to a screen reader; pass what the chart shows (\"Electricity price today\")."
+      "Accessible name. `role=\"img\"` without one is an unlabelled graphic to a " <>
+        "screen reader; pass what the chart shows. Unlabelled charts are marked decorative."
 
-  slot :empty, doc: "Rendered instead of the SVG when data is empty"
+  attr :rest, :global, doc: "Extra attributes for the wrapper"
 
-  def area_chart(assigns) do
-    assigns = assign(assigns, :geometry, area_geometry(assigns))
+  slot :empty, doc: "Rendered instead of the SVG when there is no usable data"
+
+  def line_chart(assigns) do
+    assigns = assign(assigns, :geometry, line_geometry(assigns))
 
     ~H"""
-    <div class={["pk-chart w-full", @class]}>
+    <div class={["pk-chart w-full", @class]} {@rest}>
       <svg
         :if={@geometry}
         viewBox={"0 0 #{@width} #{@height}"}
         preserveAspectRatio="none"
         class="w-full h-full block"
         role="img"
-        aria-label={@label}
-        aria-hidden={is_nil(@label) && "true"}
+        aria-label={@aria_label}
+        aria-hidden={is_nil(@aria_label) && "true"}
       >
-        <title :if={@label}>{@label}</title>
+        <title :if={@aria_label}>{@aria_label}</title>
         <defs>
           <linearGradient id={"#{@id}-fill"} x1="0" y1="0" x2="0" y2="1">
             <stop offset="0%" stop-color="currentColor" stop-opacity="0.35" />
@@ -93,6 +126,7 @@ defmodule PhoenixKitWeb.Components.Core.Chart do
           stroke="currentColor"
           stroke-opacity="0.08"
           stroke-width="1"
+          vector-effect="non-scaling-stroke"
         />
 
         <path :if={@area} d={@geometry.area_path} fill={"url(##{@id}-fill)"} />
@@ -120,9 +154,7 @@ defmodule PhoenixKitWeb.Components.Core.Chart do
         />
       </svg>
 
-      <div :if={!@geometry}>
-        {render_slot(@empty) || nil}
-      </div>
+      <div :if={!@geometry}>{render_slot(@empty)}</div>
     </div>
     """
   end
@@ -133,86 +165,118 @@ defmodule PhoenixKitWeb.Components.Core.Chart do
   ## Examples
 
       <.sparkline values={Enum.map(@upcoming, & &1.eur_mwh)} class="w-full h-12 text-info" />
+
+  A single value draws a flat line rather than nothing — one sample is a
+  real state, and an empty box reads as a rendering bug.
   """
-  attr :values, :list, required: true, doc: "List of numbers, in order"
+  attr :values, :list, required: true, doc: "Numbers, in order. Non-numeric values are dropped."
   attr :width, :integer, default: 200, doc: "viewBox width"
   attr :height, :integer, default: 48, doc: "viewBox height"
-  attr :class, :string, default: nil
+  attr :class, :any, default: nil, doc: "Classes for the wrapper (set text-* for colour)"
 
-  attr :label, :string,
+  attr :aria_label, :string,
     default: nil,
-    doc: "Accessible name. Left unset the sparkline is marked decorative (aria-hidden)."
+    doc: "Accessible name. Left unset the sparkline is marked decorative."
+
+  attr :rest, :global, doc: "Extra attributes for the wrapper"
+
+  slot :empty, doc: "Rendered instead of the SVG when there is no usable data"
 
   def sparkline(assigns) do
     assigns = assign(assigns, :points, sparkline_points(assigns))
 
     ~H"""
-    <svg
-      :if={@points}
-      viewBox={"0 0 #{@width} #{@height}"}
-      preserveAspectRatio="none"
-      class={["pk-chart block", @class]}
-      role="img"
-      aria-label={@label}
-      aria-hidden={is_nil(@label) && "true"}
-    >
-      <title :if={@label}>{@label}</title>
-      <polyline
-        points={@points}
-        fill="none"
-        stroke="currentColor"
-        stroke-width="2"
-        stroke-linejoin="round"
-        vector-effect="non-scaling-stroke"
-      />
-    </svg>
+    <div class={["pk-chart", @class]} {@rest}>
+      <svg
+        :if={@points}
+        viewBox={"0 0 #{@width} #{@height}"}
+        preserveAspectRatio="none"
+        class="w-full h-full block"
+        role="img"
+        aria-label={@aria_label}
+        aria-hidden={is_nil(@aria_label) && "true"}
+      >
+        <title :if={@aria_label}>{@aria_label}</title>
+        <polyline
+          points={@points}
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linejoin="round"
+          vector-effect="non-scaling-stroke"
+        />
+      </svg>
+
+      <div :if={!@points}>{render_slot(@empty)}</div>
+    </div>
     """
   end
 
   @doc """
-  A simple vertical bar chart.
+  A vertical bar chart, measured from a zero baseline.
 
   ## Examples
 
       <.bar_chart
         id="daily-kwh"
         data={Enum.map(@days, &%{label: &1.date, value: &1.kwh})}
+        aria_label="Daily consumption"
         class="text-secondary"
       />
 
-  Bars are drawn in `currentColor`; labels render beneath when
-  `show_labels` is set (keep them short).
+  Bars carry a native `<title>`, so hovering one shows its label and value
+  with no JS. Negative values hang below the baseline instead of
+  disappearing. A datum may set `class:` to colour one bar differently
+  (`%{label: "Fri", value: 22, class: "text-error"}`).
   """
-  attr :id, :string, required: true
-  attr :data, :list, required: true, doc: "List of %{label: term, value: number}"
+  attr :id, :string, required: true, doc: "Unique id (applied to the SVG element)"
+
+  attr :data, :list,
+    required: true,
+    doc: "List of %{label: term, value: number, class: optional_string}"
+
   attr :width, :integer, default: 960
   attr :height, :integer, default: 200
-  attr :show_labels, :boolean, default: false
-  attr :class, :string, default: nil
+  attr :show_labels, :boolean, default: false, doc: "Render labels beneath the bars"
+  attr :baseline, :boolean, default: true, doc: "Draw the zero line when data spans both signs"
+  attr :class, :any, default: nil, doc: "Classes for the wrapper (set text-* for colour)"
 
-  attr :label, :string,
-    default: nil,
-    doc: "Accessible name for the chart (see `area_chart/1`)."
+  attr :aria_label, :string, default: nil, doc: "Accessible name for the chart"
+  attr :rest, :global, doc: "Extra attributes for the wrapper"
 
-  slot :empty, doc: "Rendered instead of the SVG when data is empty"
+  slot :empty, doc: "Rendered instead of the SVG when there is no usable data"
 
   def bar_chart(assigns) do
-    assigns = assign(assigns, :bars, bar_geometry(assigns))
+    assigns = assign(assigns, :geometry, bar_geometry(assigns))
 
     ~H"""
-    <div class={["pk-chart w-full", @class]}>
+    <div class={["pk-chart w-full", @class]} {@rest}>
       <svg
-        :if={@bars}
+        :if={@geometry}
+        id={@id}
         viewBox={"0 0 #{@width} #{@height}"}
         preserveAspectRatio="none"
         class="w-full h-full block"
         role="img"
-        aria-label={@label}
-        aria-hidden={is_nil(@label) && "true"}
+        aria-label={@aria_label}
+        aria-hidden={is_nil(@aria_label) && "true"}
       >
-        <title :if={@label}>{@label}</title>
+        <title :if={@aria_label}>{@aria_label}</title>
+
+        <line
+          :if={@baseline && @geometry.mixed_signs?}
+          x1="0"
+          y1={@geometry.baseline}
+          x2={@width}
+          y2={@geometry.baseline}
+          stroke="currentColor"
+          stroke-opacity="0.25"
+          stroke-width="1"
+          vector-effect="non-scaling-stroke"
+        />
+
         <rect
-          :for={bar <- @bars}
+          :for={bar <- @geometry.bars}
           x={bar.x}
           y={bar.y}
           width={bar.w}
@@ -220,83 +284,138 @@ defmodule PhoenixKitWeb.Components.Core.Chart do
           rx="2"
           fill="currentColor"
           fill-opacity="0.75"
-        />
+          class={bar.class}
+        >
+          <title>{bar.title}</title>
+        </rect>
       </svg>
-      <div :if={@bars && @show_labels} class="flex justify-between text-xs opacity-60 font-mono mt-1">
-        <span :for={item <- @data}>{item.label}</span>
+
+      <div :if={@geometry && @show_labels} class="flex text-xs opacity-60 font-mono mt-1">
+        <%!-- Each label owns exactly its bar's slot so it stays under the bar.
+             `justify-between` drifted: it pinned the first and last labels to
+             the container edges while the bars sit at slot centres. --%>
+        <span
+          :for={bar <- @geometry.bars}
+          class="text-center truncate px-0.5"
+          style={"width: #{@geometry.slot_percent}%"}
+        >
+          {bar.label}
+        </span>
       </div>
-      <div :if={!@bars}>
-        {render_slot(@empty) || nil}
-      </div>
+
+      <div :if={!@geometry}>{render_slot(@empty)}</div>
     </div>
     """
   end
 
-  ## Geometry -----------------------------------------------------------
+  ## Data normalisation ---------------------------------------------------
 
-  defp area_geometry(%{data: []}), do: nil
-  defp area_geometry(%{data: nil}), do: nil
+  # A library primitive must not take the page down over one bad point. An
+  # Ecto-backed caller hands us Decimals; a JSON-backed one hands us strings
+  # and nils. Coerce what we can, drop what we can't, and let the :empty slot
+  # handle "nothing usable left".
+  defp numeric(value) when is_integer(value) or is_float(value), do: value
 
-  defp area_geometry(assigns) do
+  defp numeric(%Decimal{} = value) do
+    Decimal.to_float(value)
+  rescue
+    _ -> nil
+  end
+
+  defp numeric(_), do: nil
+
+  defp normalize_points(data) when is_list(data) do
+    data
+    |> Enum.map(&point/1)
+    |> Enum.reject(&is_nil/1)
+    |> Enum.sort_by(&elem(&1, 0))
+  end
+
+  defp normalize_points(_), do: []
+
+  defp point({x, y}), do: pair(numeric(x), numeric(y))
+  defp point(%{x: x, y: y}), do: pair(numeric(x), numeric(y))
+  defp point(%{"x" => x, "y" => y}), do: pair(numeric(x), numeric(y))
+  defp point(_), do: nil
+
+  defp pair(nil, _), do: nil
+  defp pair(_, nil), do: nil
+  defp pair(x, y), do: {x, y}
+
+  ## Geometry -------------------------------------------------------------
+
+  defp line_geometry(assigns) do
     %{width: width, height: height} = assigns
 
-    # A line chart only makes sense left-to-right, and unsorted input renders
-    # as a zigzag that reads like a bug in the chart rather than in the data.
-    data = Enum.sort_by(assigns.data, &elem(&1, 0))
+    case normalize_points(assigns.data) do
+      [] ->
+        nil
 
-    {x_min, x_max} = normalize_domain(assigns.x_domain || minmax_x(data))
-    {y_min, y_max} = normalize_domain(assigns.y_domain || padded_y_domain(data))
+      data ->
+        {x_min, x_max} = normalize_domain(assigns.x_domain || minmax_x(data))
+        {y_min, y_max} = normalize_domain(assigns.y_domain || padded_y_domain(data))
 
-    x_span = max(x_max - x_min, 1.0e-9)
-    y_span = max(y_max - y_min, 1.0e-9)
+        x_span = max(x_max - x_min, 1.0e-9)
+        y_span = max(y_max - y_min, 1.0e-9)
 
-    px = fn x -> Float.round((x - x_min) / x_span * width, 1) end
-    py = fn y -> Float.round(height - (y - y_min) / y_span * height, 1) end
+        px = fn x -> round1((x - x_min) / x_span * width) end
+        py = fn y -> round1(height - (y - y_min) / y_span * height) end
 
-    points =
-      if assigns.step do
-        # right-open steps: each y holds until the next x, the last one
-        # extends to the domain's right edge
-        data
-        |> Enum.chunk_every(2, 1)
-        |> Enum.flat_map(fn
-          [{x, y}, {x2, _}] -> [{px.(x), py.(y)}, {px.(x2), py.(y)}]
-          [{x, y}] -> [{px.(x), py.(y)}, {Float.round(width * 1.0, 1), py.(y)}]
-        end)
-      else
-        case data do
-          # A lone point is a valid `M x,y` path that paints NOTHING. One
-          # datum is a real case (the first slot of the day, a metric with a
-          # single sample), so hold its value across the x range instead —
-          # the same reading step mode gives it.
-          [{_x, y}] -> [{0.0, py.(y)}, {Float.round(width * 1.0, 1), py.(y)}]
-          _ -> Enum.map(data, fn {x, y} -> {px.(x), py.(y)} end)
-        end
-      end
+        points = plot_points(data, assigns.step, px, py, width)
+        line_path = to_path(points)
+        {first_x, _} = List.first(points)
+        {last_x, _} = List.last(points)
 
-    line_path =
-      points
-      |> Enum.with_index()
-      |> Enum.map_join(" ", fn {{x, y}, i} -> "#{if i == 0, do: "M", else: "L"}#{x},#{y}" end)
+        %{
+          line_path: line_path,
+          area_path: "#{line_path} L#{last_x},#{height} L#{first_x},#{height} Z",
+          gridlines: gridline_positions(assigns.gridlines, height),
+          marker_x: marker_position(assigns.marker_x, x_min, x_max, px)
+        }
+    end
+  end
 
-    {first_x, _} = List.first(points)
-    {last_x, _} = List.last(points)
+  # Right-open steps: each y holds until the next x, and the last extends to
+  # the domain's right edge — the correct reading for interval data.
+  defp plot_points(data, true = _step, px, py, width) do
+    data
+    |> Enum.chunk_every(2, 1)
+    |> Enum.flat_map(fn
+      [{x, y}, {x2, _}] -> [{px.(x), py.(y)}, {px.(x2), py.(y)}]
+      [{x, y}] -> [{px.(x), py.(y)}, {round1(width * 1.0), py.(y)}]
+    end)
+  end
 
-    %{
-      line_path: line_path,
-      area_path: "#{line_path} L#{last_x},#{height} L#{first_x},#{height} Z",
-      gridlines:
-        if(assigns.gridlines > 0,
-          do:
-            Enum.map(1..assigns.gridlines, &Float.round(height * &1 / (assigns.gridlines + 1), 1)),
-          else: []
-        ),
-      marker_x:
-        case assigns.marker_x do
-          nil -> nil
-          x -> if x >= x_min and x <= x_max, do: px.(x)
-        end
-    }
+  # A lone point is a valid `M x,y` path that paints NOTHING. One datum is a
+  # real case (the first slot of the day, a metric with a single sample), so
+  # hold its value across the range instead.
+  defp plot_points([{_x, y}], false = _step, _px, py, width) do
+    [{0.0, py.(y)}, {round1(width * 1.0), py.(y)}]
+  end
+
+  defp plot_points(data, false = _step, px, py, _width) do
+    Enum.map(data, fn {x, y} -> {px.(x), py.(y)} end)
+  end
+
+  defp to_path(points) do
+    points
+    |> Enum.with_index()
+    |> Enum.map_join(" ", fn {{x, y}, i} -> "#{if i == 0, do: "M", else: "L"}#{x},#{y}" end)
+  end
+
+  defp gridline_positions(count, _height) when not is_integer(count) or count <= 0, do: []
+
+  defp gridline_positions(count, height) do
+    Enum.map(1..count, &round1(height * &1 / (count + 1)))
+  end
+
+  defp marker_position(nil, _x_min, _x_max, _px), do: nil
+
+  defp marker_position(x, x_min, x_max, px) do
+    case numeric(x) do
+      nil -> nil
+      n -> if n >= x_min and n <= x_max, do: px.(n)
+    end
   end
 
   defp minmax_x(data) do
@@ -307,8 +426,16 @@ defmodule PhoenixKitWeb.Components.Core.Chart do
   # A reversed domain ({10, 0}) otherwise drove the span negative, which the
   # 1.0e-9 floor turned into coordinates around 1.0e12 — the chart vanished
   # off-canvas instead of simply drawing.
-  defp normalize_domain({a, b}) when a > b, do: {b, a}
-  defp normalize_domain({_a, _b} = domain), do: domain
+  defp normalize_domain({a, b}) do
+    case {numeric(a), numeric(b)} do
+      {nil, _} -> {0, 1}
+      {_, nil} -> {0, 1}
+      {lo, hi} when lo > hi -> {hi, lo}
+      {lo, hi} -> {lo, hi}
+    end
+  end
+
+  defp normalize_domain(_), do: {0, 1}
 
   defp padded_y_domain(data) do
     {y_min, y_max} = data |> Enum.map(&elem(&1, 1)) |> Enum.min_max()
@@ -316,24 +443,30 @@ defmodule PhoenixKitWeb.Components.Core.Chart do
     {y_min - pad, y_max + pad}
   end
 
-  defp sparkline_points(%{values: values}) when length(values) < 2, do: nil
-
   defp sparkline_points(%{values: values, width: width, height: height}) do
-    {v_min, v_max} = Enum.min_max(values)
-    span = max(v_max - v_min, 1.0e-9)
-    n = length(values)
+    case values |> List.wrap() |> Enum.map(&numeric/1) |> Enum.reject(&is_nil/1) do
+      [] ->
+        nil
 
-    values
-    |> Enum.with_index()
-    |> Enum.map_join(" ", fn {v, i} ->
-      x = Float.round(i / (n - 1) * width, 1)
-      y = Float.round(height - 4 - (v - v_min) / span * (height - 8), 1)
-      "#{x},#{y}"
-    end)
+      [_only] ->
+        # One sample is a real state; an empty box reads as a broken chart.
+        y = round1(height / 2)
+        "0.0,#{y} #{round1(width * 1.0)},#{y}"
+
+      values ->
+        {v_min, v_max} = Enum.min_max(values)
+        span = max(v_max - v_min, 1.0e-9)
+        n = length(values)
+
+        values
+        |> Enum.with_index()
+        |> Enum.map_join(" ", fn {v, i} ->
+          x = round1(i / (n - 1) * width)
+          y = round1(height - 4 - (v - v_min) / span * (height - 8))
+          "#{x},#{y}"
+        end)
+    end
   end
-
-  defp bar_geometry(%{data: []}), do: nil
-  defp bar_geometry(%{data: nil}), do: nil
 
   # Bars are measured from a zero baseline, not from the smallest value, so
   # signed data works: negatives hang below the line, positives rise above it.
@@ -342,35 +475,77 @@ defmodule PhoenixKitWeb.Components.Core.Chart do
   # an all-negative series divided by a 1.0e-9 floor, throwing the geometry to
   # astronomical numbers.
   defp bar_geometry(%{data: data, width: width, height: height}) do
-    values = Enum.map(data, & &1.value)
+    case normalize_bars(data) do
+      [] ->
+        nil
 
-    # The baseline is always inside the domain, even when every value sits on
-    # one side of it.
-    v_min = values |> Enum.min() |> min(0)
-    v_max = values |> Enum.max() |> max(0)
-    span = max(v_max - v_min, 1.0e-9)
+      bars ->
+        values = Enum.map(bars, & &1.value)
 
-    # Leave a little headroom so a full-height bar isn't flush with the edge.
-    plot_h = height - 4
-    scale = fn v -> (v - v_min) / span * plot_h end
-    baseline = height - scale.(0)
+        # The baseline is always inside the domain, even when every value sits
+        # on one side of it.
+        v_min = values |> Enum.min() |> min(0)
+        v_max = values |> Enum.max() |> max(0)
+        span = max(v_max - v_min, 1.0e-9)
 
-    n = length(data)
-    slot_w = width / n
-    bar_w = Float.round(slot_w * 0.7, 1)
+        plot_h = height - 4
+        scale = fn v -> (v - v_min) / span * plot_h end
+        baseline = height - scale.(0)
 
-    data
+        n = length(bars)
+        slot_w = width / n
+        bar_w = max(round1(slot_w * 0.7), 0.5)
+
+        %{
+          baseline: round1(baseline),
+          mixed_signs?: v_min < 0 and v_max > 0,
+          slot_percent: round1(100 / n),
+          bars: position_bars(bars, slot_w, bar_w, height, baseline, scale)
+        }
+    end
+  end
+
+  defp position_bars(bars, slot_w, bar_w, height, baseline, scale) do
+    bars
     |> Enum.with_index()
-    |> Enum.map(fn {%{value: value}, i} ->
-      y_value = height - scale.(value)
-      top = min(y_value, baseline)
+    |> Enum.map(fn {bar, i} ->
+      y_value = height - scale.(bar.value)
 
       %{
-        x: Float.round(i * slot_w + (slot_w - bar_w) / 2, 1),
-        y: Float.round(top, 1),
+        x: round1(i * slot_w + (slot_w - bar_w) / 2),
+        y: round1(min(y_value, baseline)),
         w: bar_w,
-        h: Float.round(abs(y_value - baseline), 1)
+        h: round1(abs(y_value - baseline)),
+        label: bar.label,
+        class: bar.class,
+        title: bar_title(bar)
       }
     end)
   end
+
+  defp normalize_bars(data) when is_list(data) do
+    data
+    |> Enum.map(fn
+      %{value: value} = datum ->
+        case numeric(value) do
+          nil -> nil
+          n -> %{value: n, label: Map.get(datum, :label), class: Map.get(datum, :class)}
+        end
+
+      _ ->
+        nil
+    end)
+    |> Enum.reject(&is_nil/1)
+  end
+
+  defp normalize_bars(_), do: []
+
+  defp bar_title(%{label: nil, value: value}), do: to_string(value)
+  defp bar_title(%{label: label, value: value}), do: "#{label}: #{value}"
+
+  # `Float.round/2` raises on an integer. Every current call site is protected
+  # because `/` always yields a float in Elixir, but that is a property of the
+  # arithmetic rather than of this function — one refactor to integer division
+  # would turn it into a crash, so normalise here instead.
+  defp round1(value), do: Float.round(value * 1.0, 1)
 end

--- a/lib/phoenix_kit_web/components/core/chart.ex
+++ b/lib/phoenix_kit_web/components/core/chart.ex
@@ -238,10 +238,14 @@ defmodule PhoenixKitWeb.Components.Core.Chart do
   defp area_geometry(%{data: nil}), do: nil
 
   defp area_geometry(assigns) do
-    %{data: data, width: width, height: height} = assigns
+    %{width: width, height: height} = assigns
 
-    {x_min, x_max} = assigns.x_domain || Enum.min_max_by(data, &elem(&1, 0)) |> minmax_x()
-    {y_min, y_max} = assigns.y_domain || padded_y_domain(data)
+    # A line chart only makes sense left-to-right, and unsorted input renders
+    # as a zigzag that reads like a bug in the chart rather than in the data.
+    data = Enum.sort_by(assigns.data, &elem(&1, 0))
+
+    {x_min, x_max} = normalize_domain(assigns.x_domain || minmax_x(data))
+    {y_min, y_max} = normalize_domain(assigns.y_domain || padded_y_domain(data))
 
     x_span = max(x_max - x_min, 1.0e-9)
     y_span = max(y_max - y_min, 1.0e-9)
@@ -295,7 +299,16 @@ defmodule PhoenixKitWeb.Components.Core.Chart do
     }
   end
 
-  defp minmax_x({{x_min, _}, {x_max, _}}), do: {x_min, x_max}
+  defp minmax_x(data) do
+    {{x_min, _}, {x_max, _}} = Enum.min_max_by(data, &elem(&1, 0))
+    {x_min, x_max}
+  end
+
+  # A reversed domain ({10, 0}) otherwise drove the span negative, which the
+  # 1.0e-9 floor turned into coordinates around 1.0e12 — the chart vanished
+  # off-canvas instead of simply drawing.
+  defp normalize_domain({a, b}) when a > b, do: {b, a}
+  defp normalize_domain({_a, _b} = domain), do: domain
 
   defp padded_y_domain(data) do
     {y_min, y_max} = data |> Enum.map(&elem(&1, 1)) |> Enum.min_max()

--- a/lib/phoenix_kit_web/components/core/chart.ex
+++ b/lib/phoenix_kit_web/components/core/chart.ex
@@ -540,8 +540,26 @@ defmodule PhoenixKitWeb.Components.Core.Chart do
 
   defp normalize_bars(_), do: []
 
-  defp bar_title(%{label: nil, value: value}), do: to_string(value)
-  defp bar_title(%{label: label, value: value}), do: "#{label}: #{value}"
+  defp bar_title(%{label: nil, value: value}), do: format_value(value)
+  defp bar_title(%{label: label, value: value}), do: "#{label}: #{format_value(value)}"
+
+  # Tooltips show a computed number, and float arithmetic surfaces its own
+  # noise: `0.1 + 0.2` renders as "0.30000000000000004". Round for DISPLAY only
+  # — the geometry keeps full precision — and drop a trailing ".0" so whole
+  # numbers read as whole numbers.
+  defp format_value(value) when is_integer(value), do: Integer.to_string(value)
+
+  defp format_value(value) when is_float(value) do
+    rounded = Float.round(value, 4)
+
+    if rounded == Float.round(rounded, 0) and abs(rounded) < 1.0e15 do
+      rounded |> trunc() |> Integer.to_string()
+    else
+      rounded |> :erlang.float_to_binary([:short]) |> String.trim_trailing(".0")
+    end
+  end
+
+  defp format_value(value), do: to_string(value)
 
   # `Float.round/2` raises on an integer. Every current call site is protected
   # because `/` always yields a float in Elixir, but that is a property of the

--- a/lib/phoenix_kit_web/components/core/chart.ex
+++ b/lib/phoenix_kit_web/components/core/chart.ex
@@ -99,7 +99,7 @@ defmodule PhoenixKitWeb.Components.Core.Chart do
     assigns = assign(assigns, :geometry, line_geometry(assigns))
 
     ~H"""
-    <div class={["pk-chart w-full", @class]} {@rest}>
+    <div class={["pk-chart w-full h-full", @class]} {@rest}>
       <svg
         :if={@geometry}
         viewBox={"0 0 #{@width} #{@height}"}
@@ -242,6 +242,14 @@ defmodule PhoenixKitWeb.Components.Core.Chart do
   attr :class, :any, default: nil, doc: "Classes for the wrapper (set text-* for colour)"
 
   attr :aria_label, :string, default: nil, doc: "Accessible name for the chart"
+
+  attr :value_format, :any,
+    default: nil,
+    doc:
+      "1-arity fun formatting a value for its tooltip. No generic chart can infer " <>
+        "units, currency or locale, so pass your own (e.g. `&Money.to_string/1`). " <>
+        "Defaults to a compact numeric rendering."
+
   attr :rest, :global, doc: "Extra attributes for the wrapper"
 
   slot :empty, doc: "Rendered instead of the SVG when there is no usable data"
@@ -250,13 +258,13 @@ defmodule PhoenixKitWeb.Components.Core.Chart do
     assigns = assign(assigns, :geometry, bar_geometry(assigns))
 
     ~H"""
-    <div class={["pk-chart w-full", @class]} {@rest}>
+    <div class={["pk-chart w-full h-full flex flex-col", @class]} {@rest}>
       <svg
         :if={@geometry}
         id={@id}
         viewBox={"0 0 #{@width} #{@height}"}
         preserveAspectRatio="none"
-        class="w-full h-full block"
+        class="w-full flex-1 min-h-0 block"
         role="img"
         aria-label={@aria_label}
         aria-hidden={is_nil(@aria_label) && "true"}
@@ -264,7 +272,7 @@ defmodule PhoenixKitWeb.Components.Core.Chart do
         <title :if={@aria_label}>{@aria_label}</title>
 
         <line
-          :if={@baseline && @geometry.mixed_signs?}
+          :if={@baseline && @geometry.show_baseline?}
           x1="0"
           y1={@geometry.baseline}
           x2={@width}
@@ -290,7 +298,7 @@ defmodule PhoenixKitWeb.Components.Core.Chart do
         </rect>
       </svg>
 
-      <div :if={@geometry && @show_labels} class="flex text-xs opacity-60 font-mono mt-1">
+      <div :if={@geometry && @show_labels} class="flex text-xs opacity-60 font-mono mt-1 shrink-0">
         <%!-- Each label owns exactly its bar's slot so it stays under the bar.
              `justify-between` drifted: it pinned the first and last labels to
              the container edges while the bars sit at slot centres. --%>
@@ -352,8 +360,8 @@ defmodule PhoenixKitWeb.Components.Core.Chart do
         nil
 
       data ->
-        {x_min, x_max} = normalize_domain(assigns.x_domain || minmax_x(data))
-        {y_min, y_max} = normalize_domain(assigns.y_domain || padded_y_domain(data))
+        {x_min, x_max} = normalize_domain(assigns.x_domain, minmax_x(data))
+        {y_min, y_max} = normalize_domain(assigns.y_domain, padded_y_domain(data))
 
         x_span = max(x_max - x_min, 1.0e-9)
         y_span = max(y_max - y_min, 1.0e-9)
@@ -361,7 +369,7 @@ defmodule PhoenixKitWeb.Components.Core.Chart do
         px = fn x -> round1((x - x_min) / x_span * width) end
         py = fn y -> round1(height - (y - y_min) / y_span * height) end
 
-        points = plot_points(data, assigns.step, px, py, width)
+        points = plot_points(data, assigns.step, px, py, x_max)
         line_path = to_path(points)
         {first_x, _} = List.first(points)
         {last_x, _} = List.last(points)
@@ -377,20 +385,23 @@ defmodule PhoenixKitWeb.Components.Core.Chart do
 
   # Right-open steps: each y holds until the next x, and the last extends to
   # the domain's right edge — the correct reading for interval data.
-  defp plot_points(data, true = _step, px, py, width) do
+  defp plot_points(data, true = _step, px, py, x_max) do
     data
     |> Enum.chunk_every(2, 1)
     |> Enum.flat_map(fn
       [{x, y}, {x2, _}] -> [{px.(x), py.(y)}, {px.(x2), py.(y)}]
-      [{x, y}] -> [{px.(x), py.(y)}, {round1(width * 1.0), py.(y)}]
+      # The tail runs to the domain's right EDGE, but never backwards: when the
+      # last datum itself overshoots an explicit x_domain, extending to the
+      # edge would draw a segment back leftward across the chart.
+      [{x, y}] -> [{px.(x), py.(y)}, {max(px.(x), px.(x_max)), py.(y)}]
     end)
   end
 
   # A lone point is a valid `M x,y` path that paints NOTHING. One datum is a
   # real case (the first slot of the day, a metric with a single sample), so
   # hold its value across the range instead.
-  defp plot_points([{_x, y}], false = _step, _px, py, width) do
-    [{0.0, py.(y)}, {round1(width * 1.0), py.(y)}]
+  defp plot_points([{_x, y}], false = _step, px, py, x_max) do
+    [{px.(x_max) * 0.0, py.(y)}, {px.(x_max), py.(y)}]
   end
 
   defp plot_points(data, false = _step, px, py, _width) do
@@ -426,16 +437,22 @@ defmodule PhoenixKitWeb.Components.Core.Chart do
   # A reversed domain ({10, 0}) otherwise drove the span negative, which the
   # 1.0e-9 floor turned into coordinates around 1.0e12 — the chart vanished
   # off-canvas instead of simply drawing.
-  defp normalize_domain({a, b}) do
+  #
+  # An unusable bound falls back to the DATA's own domain, never to a constant:
+  # a {0, 1} fallback recreated exactly that failure, because every real x range
+  # then scaled by a factor of thousands and left the canvas just as finally.
+  defp normalize_domain(nil, fallback), do: fallback
+
+  defp normalize_domain({a, b}, fallback) do
     case {numeric(a), numeric(b)} do
-      {nil, _} -> {0, 1}
-      {_, nil} -> {0, 1}
+      {nil, _} -> fallback
+      {_, nil} -> fallback
       {lo, hi} when lo > hi -> {hi, lo}
       {lo, hi} -> {lo, hi}
     end
   end
 
-  defp normalize_domain(_), do: {0, 1}
+  defp normalize_domain(_, fallback), do: fallback
 
   defp padded_y_domain(data) do
     {y_min, y_max} = data |> Enum.map(&elem(&1, 1)) |> Enum.min_max()
@@ -444,25 +461,39 @@ defmodule PhoenixKitWeb.Components.Core.Chart do
   end
 
   defp sparkline_points(%{values: values, width: width, height: height}) do
-    case values |> List.wrap() |> Enum.map(&numeric/1) |> Enum.reject(&is_nil/1) do
+    raw = List.wrap(values)
+    n = length(raw)
+
+    # Index BEFORE dropping: a survivor must keep the x it had. Rejecting first
+    # re-spaced the whole axis, so removing one bad sample silently changed the
+    # SHAPE of the line rather than leaving a gap in it.
+    kept =
+      raw
+      |> Enum.with_index()
+      |> Enum.filter(fn {v, _i} -> not is_nil(numeric(v)) end)
+      |> Enum.map(fn {v, i} -> {numeric(v), i} end)
+
+    case kept do
       [] ->
         nil
 
-      [_only] ->
+      [{_v, _i}] ->
         # One sample is a real state; an empty box reads as a broken chart.
         y = round1(height / 2)
         "0.0,#{y} #{round1(width * 1.0)},#{y}"
 
-      values ->
-        {v_min, v_max} = Enum.min_max(values)
-        span = max(v_max - v_min, 1.0e-9)
-        n = length(values)
+      kept ->
+        {v_min, v_max} = kept |> Enum.map(&elem(&1, 0)) |> Enum.min_max()
+        # Pad like the line chart, so a steady metric centres instead of
+        # reading as "pinned at its minimum".
+        pad = (v_max - v_min) * 0.1 + 1.0e-9
+        lo = v_min - pad
+        span = max(v_max + pad - lo, 1.0e-9)
+        last = max(n - 1, 1)
 
-        values
-        |> Enum.with_index()
-        |> Enum.map_join(" ", fn {v, i} ->
-          x = round1(i / (n - 1) * width)
-          y = round1(height - 4 - (v - v_min) / span * (height - 8))
+        Enum.map_join(kept, " ", fn {v, i} ->
+          x = round1(i / last * width)
+          y = round1(height - 4 - (v - lo) / span * (height - 8))
           "#{x},#{y}"
         end)
     end
@@ -474,7 +505,9 @@ defmodule PhoenixKitWeb.Components.Core.Chart do
   # values — which SVG discards outright, so the bar silently vanished — and
   # an all-negative series divided by a 1.0e-9 floor, throwing the geometry to
   # astronomical numbers.
-  defp bar_geometry(%{data: data, width: width, height: height}) do
+  defp bar_geometry(%{data: data, width: width, height: height} = assigns) do
+    formatter = Map.get(assigns, :value_format)
+
     case normalize_bars(data) do
       [] ->
         nil
@@ -498,50 +531,78 @@ defmodule PhoenixKitWeb.Components.Core.Chart do
 
         %{
           baseline: round1(baseline),
-          mixed_signs?: v_min < 0 and v_max > 0,
+          # Any negative value needs the zero line drawn: for an all-negative
+          # series the baseline sits at the TOP, which nothing else implies.
+          show_baseline?: v_min < 0,
           slot_percent: round1(100 / n),
-          bars: position_bars(bars, slot_w, bar_w, height, baseline, scale)
+          bars: position_bars(bars, slot_w, bar_w, height, baseline, scale, formatter)
         }
     end
   end
 
-  defp position_bars(bars, slot_w, bar_w, height, baseline, scale) do
+  defp position_bars(bars, slot_w, bar_w, height, baseline, scale, formatter) do
     bars
     |> Enum.with_index()
     |> Enum.map(fn {bar, i} ->
       y_value = height - scale.(bar.value)
 
+      # A zero value has zero height, and SVG paints nothing at all for that —
+      # an all-zero series rendered as a completely blank chart from perfectly
+      # valid data. Keep a hairline so the category stays visible.
+      h = max(round1(abs(y_value - baseline)), 1.0)
+
       %{
         x: round1(i * slot_w + (slot_w - bar_w) / 2),
         y: round1(min(y_value, baseline)),
         w: bar_w,
-        h: round1(abs(y_value - baseline)),
+        h: h,
         label: bar.label,
         class: bar.class,
-        title: bar_title(bar)
+        title: bar_title(bar, formatter)
       }
     end)
   end
 
+  # Accepts the same shapes as line_chart's points, plus {label, value} tuples —
+  # a caller who reaches for one and gets a silently blank chart has no way to
+  # tell the difference from "no data".
   defp normalize_bars(data) when is_list(data) do
     data
-    |> Enum.map(fn
-      %{value: value} = datum ->
-        case numeric(value) do
-          nil -> nil
-          n -> %{value: n, label: Map.get(datum, :label), class: Map.get(datum, :class)}
-        end
-
-      _ ->
-        nil
-    end)
+    |> Enum.map(&bar/1)
     |> Enum.reject(&is_nil/1)
   end
 
   defp normalize_bars(_), do: []
 
-  defp bar_title(%{label: nil, value: value}), do: format_value(value)
-  defp bar_title(%{label: label, value: value}), do: "#{label}: #{format_value(value)}"
+  defp bar(%{value: value} = datum),
+    do: build_bar(value, Map.get(datum, :label), Map.get(datum, :class))
+
+  defp bar(%{"value" => value} = datum),
+    do: build_bar(value, Map.get(datum, "label"), Map.get(datum, "class"))
+
+  defp bar({label, value}), do: build_bar(value, label, nil)
+  defp bar(value) when is_number(value), do: build_bar(value, nil, nil)
+  defp bar(_), do: nil
+
+  defp build_bar(value, label, class) do
+    case numeric(value) do
+      nil -> nil
+      n -> %{value: n, label: label, class: class}
+    end
+  end
+
+  defp bar_title(%{label: nil, value: value}, formatter), do: display(value, formatter)
+
+  defp bar_title(%{label: label, value: value}, formatter),
+    do: "#{label}: #{display(value, formatter)}"
+
+  defp display(value, formatter) when is_function(formatter, 1) do
+    to_string(formatter.(value))
+  rescue
+    _ -> format_value(value)
+  end
+
+  defp display(value, _formatter), do: format_value(value)
 
   # Tooltips show a computed number, and float arithmetic surfaces its own
   # noise: `0.1 + 0.2` renders as "0.30000000000000004". Round for DISPLAY only
@@ -552,10 +613,12 @@ defmodule PhoenixKitWeb.Components.Core.Chart do
   defp format_value(value) when is_float(value) do
     rounded = Float.round(value, 4)
 
-    if rounded == Float.round(rounded, 0) and abs(rounded) < 1.0e15 do
-      rounded |> trunc() |> Integer.to_string()
-    else
-      rounded |> :erlang.float_to_binary([:short]) |> String.trim_trailing(".0")
+    cond do
+      # Rounding a small magnitude to 4dp collapses it to "0" — a rate, a
+      # fractional percentage or a sub-cent price would read as nothing.
+      rounded == 0.0 and value != 0.0 -> :erlang.float_to_binary(value, [:short])
+      value == trunc(value) and abs(value) < 1.0e15 -> value |> trunc() |> Integer.to_string()
+      true -> :erlang.float_to_binary(rounded, [:short])
     end
   end
 

--- a/lib/phoenix_kit_web/components/core/chart.ex
+++ b/lib/phoenix_kit_web/components/core/chart.ex
@@ -1,0 +1,314 @@
+defmodule PhoenixKitWeb.Components.Core.Chart do
+  @moduledoc """
+  Server-rendered SVG chart primitives — no JavaScript, no external
+  libraries. Charts re-render when LiveView assigns change, which makes
+  them naturally live; CSS transitions handle the rest.
+
+  All charts are theme-aware by drawing in `currentColor`: set a text
+  color class on the component (`class="text-primary"`) and both stroke
+  and gradient fill follow it in light and dark themes.
+
+  Data is plain numbers — callers map their domain (time, money, watts)
+  to x/y before rendering. This keeps the primitives generic: a price
+  curve, a CPU graph and a signup funnel are all just `{x, y}` pairs.
+
+  Origin: extracted from NordSwitch's live price charts; also intended
+  as the drawing layer for `phoenix_kit_dashboards` widgets.
+  """
+
+  use Phoenix.Component
+
+  @doc """
+  A line/area chart for a numeric series.
+
+  ## Examples
+
+      <%!-- a day of prices: x = minute of day, y = EUR/MWh --%>
+      <.area_chart
+        id="price-day"
+        data={Enum.map(@slots, &{minute_of_day(&1.starts_at), &1.eur_mwh})}
+        x_domain={{0, 1440}}
+        step
+        marker_x={minute_of_day(@now)}
+        class="text-primary"
+      />
+
+      <%!-- plain line, auto domains --%>
+      <.area_chart id="signups" data={@signups} area={false} />
+
+  `data` is a list of `{x, y}` number tuples, sorted by x. With `step`
+  each point holds its y until the next x (right-open steps — correct
+  for slot/interval data like prices). `marker_x` draws a dashed
+  vertical marker (a "now" line). Domains default to the data's min/max
+  (y padded by 10%).
+  """
+  attr :id, :string, required: true, doc: "Unique id (namespaces the SVG gradient defs)"
+  attr :data, :list, required: true, doc: "List of {x, y} number tuples, sorted by x"
+  attr :step, :boolean, default: false, doc: "Step interpolation (interval data)"
+  attr :area, :boolean, default: true, doc: "Fill a gradient area under the line"
+  attr :x_domain, :any, default: nil, doc: "{min, max} for x, or nil to fit data"
+  attr :y_domain, :any, default: nil, doc: "{min, max} for y, or nil to fit data (10% padded)"
+  attr :marker_x, :any, default: nil, doc: "x position for a dashed vertical marker, or nil"
+  attr :width, :integer, default: 960, doc: "viewBox width (the SVG scales to its container)"
+  attr :height, :integer, default: 240, doc: "viewBox height"
+  attr :gridlines, :integer, default: 3, doc: "Number of horizontal gridlines (0 disables)"
+  attr :class, :string, default: nil, doc: "Classes for the wrapper (set text-* for color)"
+
+  slot :empty, doc: "Rendered instead of the SVG when data is empty"
+
+  def area_chart(assigns) do
+    assigns = assign(assigns, :geometry, area_geometry(assigns))
+
+    ~H"""
+    <div class={["pk-chart w-full", @class]}>
+      <svg
+        :if={@geometry}
+        viewBox={"0 0 #{@width} #{@height}"}
+        preserveAspectRatio="none"
+        class="w-full h-full block"
+        role="img"
+      >
+        <defs>
+          <linearGradient id={"#{@id}-fill"} x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stop-color="currentColor" stop-opacity="0.35" />
+            <stop offset="100%" stop-color="currentColor" stop-opacity="0.02" />
+          </linearGradient>
+        </defs>
+
+        <line
+          :for={y <- @geometry.gridlines}
+          x1="0"
+          y1={y}
+          x2={@width}
+          y2={y}
+          stroke="currentColor"
+          stroke-opacity="0.08"
+          stroke-width="1"
+        />
+
+        <path :if={@area} d={@geometry.area_path} fill={"url(##{@id}-fill)"} />
+
+        <path
+          d={@geometry.line_path}
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2.5"
+          stroke-linejoin="round"
+          vector-effect="non-scaling-stroke"
+        />
+
+        <line
+          :if={@geometry.marker_x}
+          x1={@geometry.marker_x}
+          y1="0"
+          x2={@geometry.marker_x}
+          y2={@height}
+          stroke="currentColor"
+          stroke-opacity="0.6"
+          stroke-width="1.5"
+          stroke-dasharray="4 4"
+          vector-effect="non-scaling-stroke"
+        />
+      </svg>
+
+      <div :if={!@geometry}>
+        {render_slot(@empty) || nil}
+      </div>
+    </div>
+    """
+  end
+
+  @doc """
+  A minimal inline sparkline for a list of values.
+
+  ## Examples
+
+      <.sparkline values={Enum.map(@upcoming, & &1.eur_mwh)} class="w-full h-12 text-info" />
+  """
+  attr :values, :list, required: true, doc: "List of numbers, in order"
+  attr :width, :integer, default: 200, doc: "viewBox width"
+  attr :height, :integer, default: 48, doc: "viewBox height"
+  attr :class, :string, default: nil
+
+  def sparkline(assigns) do
+    assigns = assign(assigns, :points, sparkline_points(assigns))
+
+    ~H"""
+    <svg
+      :if={@points}
+      viewBox={"0 0 #{@width} #{@height}"}
+      preserveAspectRatio="none"
+      class={["pk-chart block", @class]}
+      role="img"
+    >
+      <polyline
+        points={@points}
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linejoin="round"
+        vector-effect="non-scaling-stroke"
+      />
+    </svg>
+    """
+  end
+
+  @doc """
+  A simple vertical bar chart.
+
+  ## Examples
+
+      <.bar_chart
+        id="daily-kwh"
+        data={Enum.map(@days, &%{label: &1.date, value: &1.kwh})}
+        class="text-secondary"
+      />
+
+  Bars are drawn in `currentColor`; labels render beneath when
+  `show_labels` is set (keep them short).
+  """
+  attr :id, :string, required: true
+  attr :data, :list, required: true, doc: "List of %{label: term, value: number}"
+  attr :width, :integer, default: 960
+  attr :height, :integer, default: 200
+  attr :show_labels, :boolean, default: false
+  attr :class, :string, default: nil
+
+  slot :empty, doc: "Rendered instead of the SVG when data is empty"
+
+  def bar_chart(assigns) do
+    assigns = assign(assigns, :bars, bar_geometry(assigns))
+
+    ~H"""
+    <div class={["pk-chart w-full", @class]}>
+      <svg
+        :if={@bars}
+        viewBox={"0 0 #{@width} #{@height}"}
+        preserveAspectRatio="none"
+        class="w-full h-full block"
+        role="img"
+      >
+        <rect
+          :for={bar <- @bars}
+          x={bar.x}
+          y={bar.y}
+          width={bar.w}
+          height={bar.h}
+          rx="2"
+          fill="currentColor"
+          fill-opacity="0.75"
+        />
+      </svg>
+      <div :if={@bars && @show_labels} class="flex justify-between text-xs opacity-60 font-mono mt-1">
+        <span :for={item <- @data}>{item.label}</span>
+      </div>
+      <div :if={!@bars}>
+        {render_slot(@empty) || nil}
+      </div>
+    </div>
+    """
+  end
+
+  ## Geometry -----------------------------------------------------------
+
+  defp area_geometry(%{data: []}), do: nil
+  defp area_geometry(%{data: nil}), do: nil
+
+  defp area_geometry(assigns) do
+    %{data: data, width: width, height: height} = assigns
+
+    {x_min, x_max} = assigns.x_domain || Enum.min_max_by(data, &elem(&1, 0)) |> minmax_x()
+    {y_min, y_max} = assigns.y_domain || padded_y_domain(data)
+
+    x_span = max(x_max - x_min, 1.0e-9)
+    y_span = max(y_max - y_min, 1.0e-9)
+
+    px = fn x -> Float.round((x - x_min) / x_span * width, 1) end
+    py = fn y -> Float.round(height - (y - y_min) / y_span * height, 1) end
+
+    points =
+      if assigns.step do
+        # right-open steps: each y holds until the next x, the last one
+        # extends to the domain's right edge
+        data
+        |> Enum.chunk_every(2, 1)
+        |> Enum.flat_map(fn
+          [{x, y}, {x2, _}] -> [{px.(x), py.(y)}, {px.(x2), py.(y)}]
+          [{x, y}] -> [{px.(x), py.(y)}, {Float.round(width * 1.0, 1), py.(y)}]
+        end)
+      else
+        Enum.map(data, fn {x, y} -> {px.(x), py.(y)} end)
+      end
+
+    line_path =
+      points
+      |> Enum.with_index()
+      |> Enum.map_join(" ", fn {{x, y}, i} -> "#{if i == 0, do: "M", else: "L"}#{x},#{y}" end)
+
+    {first_x, _} = List.first(points)
+    {last_x, _} = List.last(points)
+
+    %{
+      line_path: line_path,
+      area_path: "#{line_path} L#{last_x},#{height} L#{first_x},#{height} Z",
+      gridlines:
+        if(assigns.gridlines > 0,
+          do:
+            Enum.map(1..assigns.gridlines, &Float.round(height * &1 / (assigns.gridlines + 1), 1)),
+          else: []
+        ),
+      marker_x:
+        case assigns.marker_x do
+          nil -> nil
+          x -> if x >= x_min and x <= x_max, do: px.(x)
+        end
+    }
+  end
+
+  defp minmax_x({{x_min, _}, {x_max, _}}), do: {x_min, x_max}
+
+  defp padded_y_domain(data) do
+    {y_min, y_max} = data |> Enum.map(&elem(&1, 1)) |> Enum.min_max()
+    pad = (y_max - y_min) * 0.1 + 1.0e-9
+    {y_min - pad, y_max + pad}
+  end
+
+  defp sparkline_points(%{values: values}) when length(values) < 2, do: nil
+
+  defp sparkline_points(%{values: values, width: width, height: height}) do
+    {v_min, v_max} = Enum.min_max(values)
+    span = max(v_max - v_min, 1.0e-9)
+    n = length(values)
+
+    values
+    |> Enum.with_index()
+    |> Enum.map_join(" ", fn {v, i} ->
+      x = Float.round(i / (n - 1) * width, 1)
+      y = Float.round(height - 4 - (v - v_min) / span * (height - 8), 1)
+      "#{x},#{y}"
+    end)
+  end
+
+  defp bar_geometry(%{data: []}), do: nil
+  defp bar_geometry(%{data: nil}), do: nil
+
+  defp bar_geometry(%{data: data, width: width, height: height}) do
+    v_max = data |> Enum.map(& &1.value) |> Enum.max() |> max(1.0e-9)
+    n = length(data)
+    slot_w = width / n
+    bar_w = Float.round(slot_w * 0.7, 1)
+
+    data
+    |> Enum.with_index()
+    |> Enum.map(fn {%{value: value}, i} ->
+      h = Float.round(value / v_max * (height - 4), 1)
+
+      %{
+        x: Float.round(i * slot_w + (slot_w - bar_w) / 2, 1),
+        y: Float.round(height - h, 1),
+        w: bar_w,
+        h: h
+      }
+    end)
+  end
+end

--- a/lib/phoenix_kit_web/components/core/chart.ex
+++ b/lib/phoenix_kit_web/components/core/chart.ex
@@ -238,7 +238,11 @@ defmodule PhoenixKitWeb.Components.Core.Chart do
   attr :width, :integer, default: 960
   attr :height, :integer, default: 200
   attr :show_labels, :boolean, default: false, doc: "Render labels beneath the bars"
-  attr :baseline, :boolean, default: true, doc: "Draw the zero line when data spans both signs"
+
+  attr :baseline, :boolean,
+    default: true,
+    doc: "Draw the zero line when any value is negative (its position is not otherwise implied)"
+
   attr :class, :any, default: nil, doc: "Classes for the wrapper (set text-* for colour)"
 
   attr :aria_label, :string, default: nil, doc: "Accessible name for the chart"
@@ -247,8 +251,10 @@ defmodule PhoenixKitWeb.Components.Core.Chart do
     default: nil,
     doc:
       "1-arity fun formatting a value for its tooltip. No generic chart can infer " <>
-        "units, currency or locale, so pass your own (e.g. `&Money.to_string/1`). " <>
-        "Defaults to a compact numeric rendering."
+        "units or locale, so pass your own. It receives the NUMBER, not your " <>
+        "original struct — non-numeric values are dropped before this runs — so " <>
+        "write `&\"$\#{&1}\"`, not `&Money.to_string/1`. Defaults to a compact " <>
+        "numeric rendering."
 
   attr :rest, :global, doc: "Extra attributes for the wrapper"
 
@@ -369,7 +375,7 @@ defmodule PhoenixKitWeb.Components.Core.Chart do
         px = fn x -> round1((x - x_min) / x_span * width) end
         py = fn y -> round1(height - (y - y_min) / y_span * height) end
 
-        points = plot_points(data, assigns.step, px, py, x_max)
+        points = plot_points(data, assigns.step, px, py, x_max, width)
         line_path = to_path(points)
         {first_x, _} = List.first(points)
         {last_x, _} = List.last(points)
@@ -385,7 +391,7 @@ defmodule PhoenixKitWeb.Components.Core.Chart do
 
   # Right-open steps: each y holds until the next x, and the last extends to
   # the domain's right edge — the correct reading for interval data.
-  defp plot_points(data, true = _step, px, py, x_max) do
+  defp plot_points(data, true = _step, px, py, x_max, width) do
     data
     |> Enum.chunk_every(2, 1)
     |> Enum.flat_map(fn
@@ -395,18 +401,32 @@ defmodule PhoenixKitWeb.Components.Core.Chart do
       # edge would draw a segment back leftward across the chart.
       [{x, y}] -> [{px.(x), py.(y)}, {max(px.(x), px.(x_max)), py.(y)}]
     end)
+    |> widen_degenerate(width)
   end
 
   # A lone point is a valid `M x,y` path that paints NOTHING. One datum is a
   # real case (the first slot of the day, a metric with a single sample), so
   # hold its value across the range instead.
-  defp plot_points([{_x, y}], false = _step, px, py, x_max) do
-    [{px.(x_max) * 0.0, py.(y)}, {px.(x_max), py.(y)}]
+  defp plot_points([{_x, y}], false = _step, _px, py, _x_max, width) do
+    y_px = py.(y)
+    [{0.0, y_px}, {round1(width * 1.0), y_px}]
   end
 
-  defp plot_points(data, false = _step, px, py, _width) do
-    Enum.map(data, fn {x, y} -> {px.(x), py.(y)} end)
+  defp plot_points(data, false = _step, px, py, _x_max, width) do
+    data
+    |> Enum.map(fn {x, y} -> {px.(x), py.(y)} end)
+    |> widen_degenerate(width)
   end
+
+  # An auto domain over a single x collapses the span to the 1.0e-9 floor, so
+  # every x maps to 0 and the "segment" has zero length — a path that paints
+  # nothing, which is the exact failure the single-point handling exists to
+  # prevent. Spanning the viewBox is what makes the value visible.
+  defp widen_degenerate([{x1, y1}, {x2, _y2}], width) when x1 == x2 do
+    [{0.0, y1}, {round1(width * 1.0), y1}]
+  end
+
+  defp widen_degenerate(points, _width), do: points
 
   defp to_path(points) do
     points
@@ -456,8 +476,14 @@ defmodule PhoenixKitWeb.Components.Core.Chart do
 
   defp padded_y_domain(data) do
     {y_min, y_max} = data |> Enum.map(&elem(&1, 1)) |> Enum.min_max()
-    pad = (y_max - y_min) * 0.1 + 1.0e-9
-    {y_min - pad, y_max + pad}
+    {y_min - y_pad(y_min, y_max), y_max + y_pad(y_min, y_max)}
+  end
+
+  # Relative, not absolute: past roughly 1.0e7 a flat 1.0e-9 is below one ULP,
+  # so a flat series of byte counts or view counts lost its padding entirely
+  # and sank onto the axis with half its stroke clipped.
+  defp y_pad(y_min, y_max) do
+    max((y_max - y_min) * 0.1, max(abs(y_max), abs(y_min)) * 1.0e-6) + 1.0e-9
   end
 
   defp sparkline_points(%{values: values, width: width, height: height}) do
@@ -486,7 +512,7 @@ defmodule PhoenixKitWeb.Components.Core.Chart do
         {v_min, v_max} = kept |> Enum.map(&elem(&1, 0)) |> Enum.min_max()
         # Pad like the line chart, so a steady metric centres instead of
         # reading as "pinned at its minimum".
-        pad = (v_max - v_min) * 0.1 + 1.0e-9
+        pad = y_pad(v_min, v_max)
         lo = v_min - pad
         span = max(v_max + pad - lo, 1.0e-9)
         last = max(n - 1, 1)
@@ -551,9 +577,16 @@ defmodule PhoenixKitWeb.Components.Core.Chart do
       # valid data. Keep a hairline so the category stays visible.
       h = max(round1(abs(y_value - baseline)), 1.0)
 
+      # The floor has to move `y` too. For a non-negative series the baseline
+      # IS the bottom edge, so pinning y there and adding the hairline drew the
+      # rect from height..height+1 — just outside the viewBox, clipped, and
+      # therefore still invisible. Non-negative bars hang from the baseline
+      # upward; negatives drop from it.
+      y = if bar.value < 0, do: baseline, else: baseline - h
+
       %{
         x: round1(i * slot_w + (slot_w - bar_w) / 2),
-        y: round1(min(y_value, baseline)),
+        y: round1(y),
         w: bar_w,
         h: h,
         label: bar.label,
@@ -594,7 +627,18 @@ defmodule PhoenixKitWeb.Components.Core.Chart do
   defp bar_title(%{label: nil, value: value}, formatter), do: display(value, formatter)
 
   defp bar_title(%{label: label, value: value}, formatter),
-    do: "#{label}: #{display(value, formatter)}"
+    do: "#{label_text(label)}: #{display(value, formatter)}"
+
+  # `:label` is documented as `term`, and `bar/1` accepts anything — so a tuple
+  # or a map would raise Protocol.UndefinedError from the interpolation and
+  # take the page down. The module's contract is to survive one bad datum.
+  defp label_text(label) when is_binary(label), do: label
+
+  defp label_text(label) do
+    to_string(label)
+  rescue
+    Protocol.UndefinedError -> inspect(label)
+  end
 
   defp display(value, formatter) when is_function(formatter, 1) do
     to_string(formatter.(value))

--- a/lib/phoenix_kit_web/components/core/chart.ex
+++ b/lib/phoenix_kit_web/components/core/chart.ex
@@ -140,6 +140,15 @@ defmodule PhoenixKitWeb.Components.Core.Chart do
           vector-effect="non-scaling-stroke"
         />
 
+        <circle
+          :if={@geometry.dot}
+          cx={@geometry.dot.x}
+          cy={@geometry.dot.y}
+          r="3"
+          fill="currentColor"
+          vector-effect="non-scaling-stroke"
+        />
+
         <line
           :if={@geometry.marker_x}
           x1={@geometry.marker_x}
@@ -369,13 +378,13 @@ defmodule PhoenixKitWeb.Components.Core.Chart do
         {x_min, x_max} = normalize_domain(assigns.x_domain, minmax_x(data))
         {y_min, y_max} = normalize_domain(assigns.y_domain, padded_y_domain(data))
 
-        x_span = max(x_max - x_min, 1.0e-9)
-        y_span = max(y_max - y_min, 1.0e-9)
+        to_x = axis_scale(x_min, x_max, width)
+        to_y = axis_scale(y_min, y_max, height)
 
-        px = fn x -> round1((x - x_min) / x_span * width) end
-        py = fn y -> round1(height - (y - y_min) / y_span * height) end
+        px = fn x -> round1(to_x.(x)) end
+        py = fn y -> round1(height - to_y.(y)) end
 
-        points = plot_points(data, assigns.step, px, py, x_max, width)
+        points = plot_points(data, assigns.step, px, py, x_max)
         line_path = to_path(points)
         {first_x, _} = List.first(points)
         {last_x, _} = List.last(points)
@@ -384,14 +393,21 @@ defmodule PhoenixKitWeb.Components.Core.Chart do
           line_path: line_path,
           area_path: "#{line_path} L#{last_x},#{height} L#{first_x},#{height} Z",
           gridlines: gridline_positions(assigns.gridlines, height),
-          marker_x: marker_position(assigns.marker_x, x_min, x_max, px)
+          marker_x: marker_position(assigns.marker_x, x_min, x_max, px),
+          # A path whose points all coincide is a valid `M x,y` that paints
+          # NOTHING, and one datum is a real state (the day's first slot, a
+          # metric with a single sample). Marking the point is the honest fix:
+          # widening it into a full-width line asserts a reading across a range
+          # that was never measured, and did exactly that for out-of-domain
+          # data too.
+          dot: collapsed_point(points)
         }
     end
   end
 
   # Right-open steps: each y holds until the next x, and the last extends to
   # the domain's right edge — the correct reading for interval data.
-  defp plot_points(data, true = _step, px, py, x_max, width) do
+  defp plot_points(data, true = _step, px, py, x_max) do
     data
     |> Enum.chunk_every(2, 1)
     |> Enum.flat_map(fn
@@ -401,32 +417,32 @@ defmodule PhoenixKitWeb.Components.Core.Chart do
       # edge would draw a segment back leftward across the chart.
       [{x, y}] -> [{px.(x), py.(y)}, {max(px.(x), px.(x_max)), py.(y)}]
     end)
-    |> widen_degenerate(width)
   end
 
-  # A lone point is a valid `M x,y` path that paints NOTHING. One datum is a
-  # real case (the first slot of the day, a metric with a single sample), so
-  # hold its value across the range instead.
-  defp plot_points([{_x, y}], false = _step, _px, py, _x_max, width) do
-    y_px = py.(y)
-    [{0.0, y_px}, {round1(width * 1.0), y_px}]
+  defp plot_points(data, false = _step, px, py, _x_max) do
+    Enum.map(data, fn {x, y} -> {px.(x), py.(y)} end)
   end
 
-  defp plot_points(data, false = _step, px, py, _x_max, width) do
-    data
-    |> Enum.map(fn {x, y} -> {px.(x), py.(y)} end)
-    |> widen_degenerate(width)
+  # A degenerate domain (one x, or an explicit zero-span) has no left or right:
+  # every value belongs at the CENTRE, exactly as a flat y series centres
+  # vertically. Dividing by a 1.0e-9 floor instead pinned everything to the
+  # left edge, where half of each stroke is clipped away.
+  defp axis_scale(lo, hi, extent) when hi > lo do
+    span = hi - lo
+    fn v -> (v - lo) / span * extent end
   end
 
-  # An auto domain over a single x collapses the span to the 1.0e-9 floor, so
-  # every x maps to 0 and the "segment" has zero length — a path that paints
-  # nothing, which is the exact failure the single-point handling exists to
-  # prevent. Spanning the viewBox is what makes the value visible.
-  defp widen_degenerate([{x1, y1}, {x2, _y2}], width) when x1 == x2 do
-    [{0.0, y1}, {round1(width * 1.0), y1}]
-  end
+  defp axis_scale(_lo, _hi, extent), do: fn _v -> extent / 2 end
 
-  defp widen_degenerate(points, _width), do: points
+  # Only a path whose points ALL coincide paints nothing. Two points sharing an
+  # x still draw a vertical segment, and collapsing that to one y silently
+  # threw the other value away.
+  defp collapsed_point(points) do
+    case Enum.uniq(points) do
+      [{x, y}] -> %{x: x, y: y}
+      _ -> nil
+    end
+  end
 
   defp to_path(points) do
     points
@@ -476,14 +492,33 @@ defmodule PhoenixKitWeb.Components.Core.Chart do
 
   defp padded_y_domain(data) do
     {y_min, y_max} = data |> Enum.map(&elem(&1, 1)) |> Enum.min_max()
-    {y_min - y_pad(y_min, y_max), y_max + y_pad(y_min, y_max)}
+    pad = y_pad(y_min, y_max)
+
+    # Values within a hair of the float ceiling overflow on the way to
+    # Infinity, which raises. Falling back to the unpadded domain draws a
+    # clipped stroke; it does not take the page down.
+    try do
+      {y_min - pad, y_max + pad}
+    rescue
+      ArithmeticError -> {y_min, y_max}
+    end
   end
 
-  # Relative, not absolute: past roughly 1.0e7 a flat 1.0e-9 is below one ULP,
-  # so a flat series of byte counts or view counts lost its padding entirely
-  # and sank onto the axis with half its stroke clipped.
-  defp y_pad(y_min, y_max) do
-    max((y_max - y_min) * 0.1, max(abs(y_max), abs(y_min)) * 1.0e-6) + 1.0e-9
+  # A tenth of the range whenever there IS a range — a magnitude-relative pad
+  # would swamp it, so a series of 1.0e12 counts differing by 100 flattened to
+  # a single row of pixels. The magnitude term is the fallback for a genuinely
+  # flat series, where an absolute 1.0e-9 is below one ULP past roughly 1.0e7
+  # and disappears into the float, sinking the line onto the axis.
+  defp y_pad(y_min, y_max) when y_max > y_min do
+    range_pad = (y_max - y_min) * 0.1
+
+    if y_max + range_pad > y_max, do: range_pad, else: magnitude_pad(y_min, y_max)
+  end
+
+  defp y_pad(y_min, y_max), do: magnitude_pad(y_min, y_max)
+
+  defp magnitude_pad(y_min, y_max) do
+    max(max(abs(y_max), abs(y_min)) * 1.0e-6, 1.0e-9)
   end
 
   defp sparkline_points(%{values: values, width: width, height: height}) do
@@ -581,15 +616,21 @@ defmodule PhoenixKitWeb.Components.Core.Chart do
       # IS the bottom edge, so pinning y there and adding the hairline drew the
       # rect from height..height+1 — just outside the viewBox, clipped, and
       # therefore still invisible. Non-negative bars hang from the baseline
-      # upward; negatives drop from it.
-      y = if bar.value < 0, do: baseline, else: baseline - h
+      # upward; negatives drop from it. Both then get clamped into the viewBox:
+      # a small negative among large positives puts the baseline ON the bottom
+      # edge, so the hairline hung from height..height+1 and was clipped away
+      # again — the same disappearing bar, on the other sign.
+      y =
+        if bar.value < 0, do: baseline, else: baseline - h
+
+      y = y |> max(0.0) |> min(height - h)
 
       %{
         x: round1(i * slot_w + (slot_w - bar_w) / 2),
         y: round1(y),
         w: bar_w,
         h: h,
-        label: bar.label,
+        label: label_text(bar.label),
         class: bar.class,
         title: bar_title(bar, formatter)
       }
@@ -632,12 +673,18 @@ defmodule PhoenixKitWeb.Components.Core.Chart do
   # `:label` is documented as `term`, and `bar/1` accepts anything — so a tuple
   # or a map would raise Protocol.UndefinedError from the interpolation and
   # take the page down. The module's contract is to survive one bad datum.
+  #
+  # The rescue is deliberately broad: `to_string/1` raises ArgumentError, not
+  # Protocol.UndefinedError, for a keyword list — List.Chars IS implemented for
+  # lists, it just fails on anything that isn't iodata. Naming one exception
+  # left the most plausible bad label of all still crashing.
+  defp label_text(nil), do: nil
   defp label_text(label) when is_binary(label), do: label
 
   defp label_text(label) do
     to_string(label)
   rescue
-    Protocol.UndefinedError -> inspect(label)
+    _ -> inspect(label)
   end
 
   defp display(value, formatter) when is_function(formatter, 1) do

--- a/lib/phoenix_kit_web/components/core/chart.ex
+++ b/lib/phoenix_kit_web/components/core/chart.ex
@@ -54,6 +54,12 @@ defmodule PhoenixKitWeb.Components.Core.Chart do
   attr :gridlines, :integer, default: 3, doc: "Number of horizontal gridlines (0 disables)"
   attr :class, :string, default: nil, doc: "Classes for the wrapper (set text-* for color)"
 
+  attr :label, :string,
+    default: nil,
+    doc:
+      "Accessible name for the chart. `role=\"img\"` without one is an unlabelled " <>
+        "graphic to a screen reader; pass what the chart shows (\"Electricity price today\")."
+
   slot :empty, doc: "Rendered instead of the SVG when data is empty"
 
   def area_chart(assigns) do
@@ -67,7 +73,10 @@ defmodule PhoenixKitWeb.Components.Core.Chart do
         preserveAspectRatio="none"
         class="w-full h-full block"
         role="img"
+        aria-label={@label}
+        aria-hidden={is_nil(@label) && "true"}
       >
+        <title :if={@label}>{@label}</title>
         <defs>
           <linearGradient id={"#{@id}-fill"} x1="0" y1="0" x2="0" y2="1">
             <stop offset="0%" stop-color="currentColor" stop-opacity="0.35" />
@@ -130,6 +139,10 @@ defmodule PhoenixKitWeb.Components.Core.Chart do
   attr :height, :integer, default: 48, doc: "viewBox height"
   attr :class, :string, default: nil
 
+  attr :label, :string,
+    default: nil,
+    doc: "Accessible name. Left unset the sparkline is marked decorative (aria-hidden)."
+
   def sparkline(assigns) do
     assigns = assign(assigns, :points, sparkline_points(assigns))
 
@@ -140,7 +153,10 @@ defmodule PhoenixKitWeb.Components.Core.Chart do
       preserveAspectRatio="none"
       class={["pk-chart block", @class]}
       role="img"
+      aria-label={@label}
+      aria-hidden={is_nil(@label) && "true"}
     >
+      <title :if={@label}>{@label}</title>
       <polyline
         points={@points}
         fill="none"
@@ -174,6 +190,10 @@ defmodule PhoenixKitWeb.Components.Core.Chart do
   attr :show_labels, :boolean, default: false
   attr :class, :string, default: nil
 
+  attr :label, :string,
+    default: nil,
+    doc: "Accessible name for the chart (see `area_chart/1`)."
+
   slot :empty, doc: "Rendered instead of the SVG when data is empty"
 
   def bar_chart(assigns) do
@@ -187,7 +207,10 @@ defmodule PhoenixKitWeb.Components.Core.Chart do
         preserveAspectRatio="none"
         class="w-full h-full block"
         role="img"
+        aria-label={@label}
+        aria-hidden={is_nil(@label) && "true"}
       >
+        <title :if={@label}>{@label}</title>
         <rect
           :for={bar <- @bars}
           x={bar.x}
@@ -237,7 +260,14 @@ defmodule PhoenixKitWeb.Components.Core.Chart do
           [{x, y}] -> [{px.(x), py.(y)}, {Float.round(width * 1.0, 1), py.(y)}]
         end)
       else
-        Enum.map(data, fn {x, y} -> {px.(x), py.(y)} end)
+        case data do
+          # A lone point is a valid `M x,y` path that paints NOTHING. One
+          # datum is a real case (the first slot of the day, a metric with a
+          # single sample), so hold its value across the x range instead —
+          # the same reading step mode gives it.
+          [{_x, y}] -> [{0.0, py.(y)}, {Float.round(width * 1.0, 1), py.(y)}]
+          _ -> Enum.map(data, fn {x, y} -> {px.(x), py.(y)} end)
+        end
       end
 
     line_path =
@@ -292,8 +322,26 @@ defmodule PhoenixKitWeb.Components.Core.Chart do
   defp bar_geometry(%{data: []}), do: nil
   defp bar_geometry(%{data: nil}), do: nil
 
+  # Bars are measured from a zero baseline, not from the smallest value, so
+  # signed data works: negatives hang below the line, positives rise above it.
+  # Scaling by `max(value)` alone produced a NEGATIVE rect height for negative
+  # values — which SVG discards outright, so the bar silently vanished — and
+  # an all-negative series divided by a 1.0e-9 floor, throwing the geometry to
+  # astronomical numbers.
   defp bar_geometry(%{data: data, width: width, height: height}) do
-    v_max = data |> Enum.map(& &1.value) |> Enum.max() |> max(1.0e-9)
+    values = Enum.map(data, & &1.value)
+
+    # The baseline is always inside the domain, even when every value sits on
+    # one side of it.
+    v_min = values |> Enum.min() |> min(0)
+    v_max = values |> Enum.max() |> max(0)
+    span = max(v_max - v_min, 1.0e-9)
+
+    # Leave a little headroom so a full-height bar isn't flush with the edge.
+    plot_h = height - 4
+    scale = fn v -> (v - v_min) / span * plot_h end
+    baseline = height - scale.(0)
+
     n = length(data)
     slot_w = width / n
     bar_w = Float.round(slot_w * 0.7, 1)
@@ -301,13 +349,14 @@ defmodule PhoenixKitWeb.Components.Core.Chart do
     data
     |> Enum.with_index()
     |> Enum.map(fn {%{value: value}, i} ->
-      h = Float.round(value / v_max * (height - 4), 1)
+      y_value = height - scale.(value)
+      top = min(y_value, baseline)
 
       %{
         x: Float.round(i * slot_w + (slot_w - bar_w) / 2, 1),
-        y: Float.round(height - h, 1),
+        y: Float.round(top, 1),
         w: bar_w,
-        h: h
+        h: Float.round(abs(y_value - baseline), 1)
       }
     end)
   end

--- a/lib/phoenix_kit_web/components/core/connect_account_button.ex
+++ b/lib/phoenix_kit_web/components/core/connect_account_button.ex
@@ -54,10 +54,16 @@ defmodule PhoenixKitWeb.Components.Core.ConnectAccountButton do
   `href` is still required to be a local path — that stops the reference
   being handed straight to an arbitrary origin, and keeps the flow
   starting on a route you control — but it is not what makes the popup
-  safe once the provider takes over. If your threat model includes the
-  provider, send `Cross-Origin-Opener-Policy: same-origin-allow-popups`
-  on the opener page and have the callback `postMessage` back (with an
-  origin check) instead of touching `opener.location`.
+  safe once the provider takes over.
+
+  Note that `Cross-Origin-Opener-Policy: same-origin-allow-popups` does
+  NOT help here: that value exists precisely to *keep* the opener
+  relationship for popups, which is the relationship in question. If the
+  provider is inside your threat model, the only real fix is to stop
+  relying on `window.opener` at all — open with `noopener` and have the
+  callback route broadcast on PubSub so the opener LiveView updates
+  itself. That is the Phoenix-native version of this flow and needs no
+  opener reference or `location.reload()`.
 
   Origin: extracted from NordSwitch's Shelly account connect flow;
   intended for any Integrations-system OAuth (Google, Stripe, …).
@@ -99,7 +105,13 @@ defmodule PhoenixKitWeb.Components.Core.ConnectAccountButton do
 
   attr :window_width, :integer, default: 480
   attr :window_height, :integer, default: 680
-  attr :class, :any, default: "btn btn-primary btn-sm"
+
+  attr :class, :any,
+    default: "btn btn-primary btn-sm",
+    doc:
+      "REPLACES the default styling rather than merging with it, so you can swap " <>
+        "`btn-primary` for `btn-outline` without a specificity fight. Pass the full " <>
+        "class list you want."
 
   attr :id, :string,
     default: nil,

--- a/lib/phoenix_kit_web/components/core/connect_account_button.ex
+++ b/lib/phoenix_kit_web/components/core/connect_account_button.ex
@@ -42,9 +42,22 @@ defmodule PhoenixKitWeb.Components.Core.ConnectAccountButton do
 
   The popup is deliberately **not** `rel="noopener"`: `window.opener` is
   exactly what the callback needs in order to refresh the page behind it.
-  That is safe because `href` is your own OAuth start route — this
-  component only accepts a local path, so the opener reference is never
-  handed to a third-party origin.
+
+  Be clear-eyed about what that costs. The popup navigates on to the
+  provider's consent page, and `window.opener` survives navigation — so
+  the provider's origin holds a live (cross-origin) reference to your
+  window. The same-origin policy limits it to `opener.location = …`,
+  `postMessage`, `close()` and `focus()`, but the first of those is
+  reverse tabnabbing: a compromised or open-redirect-chained provider
+  page can navigate the tab behind the popup.
+
+  `href` is still required to be a local path — that stops the reference
+  being handed straight to an arbitrary origin, and keeps the flow
+  starting on a route you control — but it is not what makes the popup
+  safe once the provider takes over. If your threat model includes the
+  provider, send `Cross-Origin-Opener-Policy: same-origin-allow-popups`
+  on the opener page and have the callback `postMessage` back (with an
+  origin check) instead of touching `opener.location`.
 
   Origin: extracted from NordSwitch's Shelly account connect flow;
   intended for any Integrations-system OAuth (Google, Stripe, …).
@@ -78,10 +91,11 @@ defmodule PhoenixKitWeb.Components.Core.ConnectAccountButton do
         "`window.opener`, so it is never pointed at a third-party origin."
 
   attr :window_name, :string,
-    default: "oauth-connect",
+    default: nil,
     doc:
-      "Popup window name. Sharing one name across buttons reuses the same window; " <>
-        "give concurrent flows distinct names."
+      "Popup window name. Defaults to one derived from `href`, so two buttons on " <>
+        "a page (Connect Google / Connect Shelly) get distinct windows AND distinct " <>
+        "DOM ids without configuration. Sharing a name reuses the same window."
 
   attr :window_width, :integer, default: 480
   attr :window_height, :integer, default: 680
@@ -109,12 +123,14 @@ defmodule PhoenixKitWeb.Components.Core.ConnectAccountButton do
       """
     end
 
+    assigns = assign_new(assigns, :resolved_window_name, fn -> window_name(assigns) end)
+
     ~H"""
     <a
       href={@href}
-      id={@id || derived_id(@window_name)}
-      phx-hook="ConnectAccountPopup"
-      data-window-name={@window_name}
+      id={@id || derived_id(@resolved_window_name)}
+      phx-hook="PopupLink"
+      data-window-name={@resolved_window_name}
       data-window-width={@window_width}
       data-window-height={@window_height}
       class={@class}
@@ -125,16 +141,27 @@ defmodule PhoenixKitWeb.Components.Core.ConnectAccountButton do
     """
   end
 
+  # A fixed default meant every unconfigured button on a page shared one id —
+  # invalid HTML, and phx-hook requires uniqueness. The start route is already
+  # required to be local and is naturally distinct per provider, so it makes a
+  # better default than a constant.
+  defp window_name(%{window_name: name}) when is_binary(name) and name != "", do: name
+  defp window_name(%{href: href}), do: "oauth-connect-" <> slug(href)
+
   # An id derived from a free-form window name has to survive being used as a
   # DOM id and inside `querySelector` — a name with spaces or quotes would
   # produce an id LiveView cannot look the element up by.
   defp derived_id(window_name) do
-    slug =
-      window_name
-      |> to_string()
-      |> String.replace(~r/[^a-zA-Z0-9_-]+/, "-")
-      |> String.trim("-")
+    case slug(window_name) do
+      "" -> "pk-connect"
+      slug -> "pk-connect-" <> slug
+    end
+  end
 
-    if slug == "", do: "pk-connect", else: "pk-connect-" <> slug
+  defp slug(value) do
+    value
+    |> to_string()
+    |> String.replace(~r/[^a-zA-Z0-9_-]+/, "-")
+    |> String.trim("-")
   end
 end

--- a/lib/phoenix_kit_web/components/core/connect_account_button.ex
+++ b/lib/phoenix_kit_web/components/core/connect_account_button.ex
@@ -17,7 +17,7 @@ defmodule PhoenixKitWeb.Components.Core.ConnectAccountButton do
   ## Progressive enhancement
 
   This renders a real `<a href>`, and the popup is opened by the
-  `ConnectAccountPopup` JS hook rather than an inline `onclick` (the kit
+  `PopupLink` JS hook rather than an inline `onclick` (the kit
   removed inline handlers everywhere for CSP). The click is intercepted
   *only after* `window.open` actually returns a window, so **a blocked
   popup, JS being off, or a modifier-click all fall back to ordinary

--- a/lib/phoenix_kit_web/components/core/connect_account_button.ex
+++ b/lib/phoenix_kit_web/components/core/connect_account_button.ex
@@ -1,0 +1,64 @@
+defmodule PhoenixKitWeb.Components.Core.ConnectAccountButton do
+  @moduledoc """
+  A "Connect your X account" button that runs an OAuth authorization in
+  a popup window — the Google-login-style pattern for third-party
+  integrations (distinct from `OAuthProvider`, which handles *sign-in*
+  to the app itself).
+
+  Flow contract:
+
+    1. The button opens `href` in a named popup (the app's OAuth start
+       route, which redirects to the provider's consent page).
+    2. The provider redirects back to the app's callback route inside
+       the popup; the callback completes the exchange server-side.
+    3. The callback page should refresh the opener and close itself:
+
+           <script>
+             if (window.opener) { window.opener.location.reload(); }
+             setTimeout(function () { window.close(); }, 4000);
+           </script>
+
+  Falls back to normal navigation when popups are blocked (the plain
+  `href` still works full-page).
+
+  Origin: extracted from NordSwitch's Shelly account connect flow;
+  intended for any Integrations-system OAuth (Google, Stripe, …).
+  """
+
+  use Phoenix.Component
+
+  @doc """
+  Renders the connect-account popup button.
+
+  ## Examples
+
+      <.connect_account_button href="/shelly/oauth/start">
+        ⚡ Connect Shelly account
+      </.connect_account_button>
+
+      <.connect_account_button href={~p"/integrations/google/start"} class="btn btn-outline btn-sm">
+        Connect Google
+      </.connect_account_button>
+  """
+  attr :href, :string, required: true, doc: "The app's OAuth start route"
+  attr :window_name, :string, default: "oauth-connect", doc: "Popup window name"
+  attr :window_width, :integer, default: 480
+  attr :window_height, :integer, default: 680
+  attr :class, :string, default: "btn btn-primary btn-sm"
+  attr :rest, :global
+
+  slot :inner_block, required: true
+
+  def connect_account_button(assigns) do
+    ~H"""
+    <a
+      href={@href}
+      onclick={"window.open(this.href, '#{@window_name}', 'width=#{@window_width},height=#{@window_height}'); return false;"}
+      class={@class}
+      {@rest}
+    >
+      {render_slot(@inner_block)}
+    </a>
+    """
+  end
+end

--- a/lib/phoenix_kit_web/components/core/connect_account_button.ex
+++ b/lib/phoenix_kit_web/components/core/connect_account_button.ex
@@ -11,15 +11,40 @@ defmodule PhoenixKitWeb.Components.Core.ConnectAccountButton do
        route, which redirects to the provider's consent page).
     2. The provider redirects back to the app's callback route inside
        the popup; the callback completes the exchange server-side.
-    3. The callback page should refresh the opener and close itself:
+    3. The callback page refreshes the opener and closes itself — see
+       "Callback page" below.
 
-           <script>
-             if (window.opener) { window.opener.location.reload(); }
-             setTimeout(function () { window.close(); }, 4000);
-           </script>
+  ## Progressive enhancement
 
-  Falls back to normal navigation when popups are blocked (the plain
-  `href` still works full-page).
+  This renders a real `<a href>`, and the popup is opened by the
+  `ConnectAccountPopup` JS hook rather than an inline `onclick` (the kit
+  removed inline handlers everywhere for CSP). The click is intercepted
+  *only after* `window.open` actually returns a window, so **a blocked
+  popup, JS being off, or a modifier-click all fall back to ordinary
+  navigation** and the flow still completes full-page. The previous
+  inline version ended every click with `return false`, which cancelled
+  navigation even when the popup never opened — the button did nothing.
+
+  Host wiring: the hook ships in core's `phoenix_kit.js`, which hosts
+  already load and spread into their LiveSocket (`mix phoenix_kit.install`
+  wires this). No per-app JS.
+
+  ## Callback page
+
+  The popup hands control back to the opener. On the callback page:
+
+      <script>
+        if (window.opener && !window.opener.closed) {
+          window.opener.location.reload();
+        }
+        window.close();
+      </script>
+
+  The popup is deliberately **not** `rel="noopener"`: `window.opener` is
+  exactly what the callback needs in order to refresh the page behind it.
+  That is safe because `href` is your own OAuth start route — this
+  component only accepts a local path, so the opener reference is never
+  handed to a third-party origin.
 
   Origin: extracted from NordSwitch's Shelly account connect flow;
   intended for any Integrations-system OAuth (Google, Stripe, …).
@@ -27,38 +52,89 @@ defmodule PhoenixKitWeb.Components.Core.ConnectAccountButton do
 
   use Phoenix.Component
 
+  alias PhoenixKit.Utils.Routes
+
   @doc """
   Renders the connect-account popup button.
 
   ## Examples
 
       <.connect_account_button href="/shelly/oauth/start">
-        ⚡ Connect Shelly account
+        Connect Shelly account
       </.connect_account_button>
 
-      <.connect_account_button href={~p"/integrations/google/start"} class="btn btn-outline btn-sm">
+      <.connect_account_button
+        href={~p"/integrations/google/start"}
+        class="btn btn-outline btn-sm"
+        window_name="google-connect"
+      >
         Connect Google
       </.connect_account_button>
   """
-  attr :href, :string, required: true, doc: "The app's OAuth start route"
-  attr :window_name, :string, default: "oauth-connect", doc: "Popup window name"
+  attr :href, :string,
+    required: true,
+    doc:
+      "The app's OAuth start route. Must be a local path — the popup keeps its " <>
+        "`window.opener`, so it is never pointed at a third-party origin."
+
+  attr :window_name, :string,
+    default: "oauth-connect",
+    doc:
+      "Popup window name. Sharing one name across buttons reuses the same window; " <>
+        "give concurrent flows distinct names."
+
   attr :window_width, :integer, default: 480
   attr :window_height, :integer, default: 680
-  attr :class, :string, default: "btn btn-primary btn-sm"
-  attr :rest, :global
+  attr :class, :any, default: "btn btn-primary btn-sm"
+
+  attr :id, :string,
+    default: nil,
+    doc:
+      "DOM id. A phx-hook element MUST have one, so it defaults to the window " <>
+        "name — pass an explicit id when two buttons share a window name."
+
+  attr :rest, :global, doc: "Extra attributes for the anchor (aria-*, data-*, …)"
 
   slot :inner_block, required: true
 
   def connect_account_button(assigns) do
+    unless Routes.local_path?(assigns.href) do
+      raise ArgumentError, """
+      connect_account_button expects a local path for :href, got: #{inspect(assigns.href)}
+
+      The popup deliberately retains `window.opener` so the OAuth callback can
+      refresh the page behind it. Pointing it at another origin would hand that
+      reference to a third party. Link to your own OAuth start route, which
+      redirects on to the provider.
+      """
+    end
+
     ~H"""
     <a
       href={@href}
-      onclick={"window.open(this.href, '#{@window_name}', 'width=#{@window_width},height=#{@window_height}'); return false;"}
+      id={@id || derived_id(@window_name)}
+      phx-hook="ConnectAccountPopup"
+      data-window-name={@window_name}
+      data-window-width={@window_width}
+      data-window-height={@window_height}
       class={@class}
       {@rest}
     >
       {render_slot(@inner_block)}
     </a>
     """
+  end
+
+  # An id derived from a free-form window name has to survive being used as a
+  # DOM id and inside `querySelector` — a name with spaces or quotes would
+  # produce an id LiveView cannot look the element up by.
+  defp derived_id(window_name) do
+    slug =
+      window_name
+      |> to_string()
+      |> String.replace(~r/[^a-zA-Z0-9_-]+/, "-")
+      |> String.trim("-")
+
+    if slug == "", do: "pk-connect", else: "pk-connect-" <> slug
   end
 end

--- a/lib/phoenix_kit_web/components/core/stat_card.ex
+++ b/lib/phoenix_kit_web/components/core/stat_card.ex
@@ -49,9 +49,12 @@ defmodule PhoenixKitWeb.Components.Core.StatCard do
   """
   attr :rounded, :string,
     default: "box",
+    values: ["box", "none", "sm", "md", "lg", "xl", "2xl", "3xl", "full"],
     doc:
-      "Border radius token appended to `rounded-` (daisyUI's `box`, or Tailwind's " <>
-        "`lg`/`xl`/`full`). Was previously declared but ignored — the class was hardcoded."
+      "Border radius. Was previously declared but ignored — the class was hardcoded. " <>
+        "The values are a fixed list because Tailwind scans SOURCE for literal class " <>
+        "names: an interpolated class is invisible to it, so the CSS " <>
+        "would simply not exist for anything not already written literally elsewhere."
 
   attr :compact, :boolean, default: false, doc: "Use compact layout with reduced height"
   attr :value, :any, required: true, doc: "The main statistic value to display"
@@ -78,7 +81,7 @@ defmodule PhoenixKitWeb.Components.Core.StatCard do
     ~H"""
     <div class={[
       color_classes(@color),
-      "rounded-#{@rounded}",
+      rounded_class(@rounded),
       "shadow-xl hover:shadow-2xl transition-all duration-300 transform hover:scale-105",
       if(@compact, do: "p-4", else: "p-6")
     ]}>
@@ -114,6 +117,20 @@ defmodule PhoenixKitWeb.Components.Core.StatCard do
     </div>
     """
   end
+
+  # Written out in full so Tailwind's content scanner can see every one of
+  # them. Interpolating the token produces a class that exists in the markup
+  # but never in the stylesheet.
+  defp rounded_class("box"), do: "rounded-box"
+  defp rounded_class("none"), do: "rounded-none"
+  defp rounded_class("sm"), do: "rounded-sm"
+  defp rounded_class("md"), do: "rounded-md"
+  defp rounded_class("lg"), do: "rounded-lg"
+  defp rounded_class("xl"), do: "rounded-xl"
+  defp rounded_class("2xl"), do: "rounded-2xl"
+  defp rounded_class("3xl"), do: "rounded-3xl"
+  defp rounded_class("full"), do: "rounded-full"
+  defp rounded_class(_), do: "rounded-box"
 
   # Color class helpers
   defp color_classes("info"), do: "bg-info text-info-content"

--- a/lib/phoenix_kit_web/components/core/stat_card.ex
+++ b/lib/phoenix_kit_web/components/core/stat_card.ex
@@ -47,7 +47,12 @@ defmodule PhoenixKitWeb.Components.Core.StatCard do
         </:icon>
       </.stat_card>
   """
-  attr :rounded, :string, default: "xl", doc: "Border radius size (xl, 2xl, etc.)"
+  attr :rounded, :string,
+    default: "box",
+    doc:
+      "Border radius token appended to `rounded-` (daisyUI's `box`, or Tailwind's " <>
+        "`lg`/`xl`/`full`). Was previously declared but ignored — the class was hardcoded."
+
   attr :compact, :boolean, default: false, doc: "Use compact layout with reduced height"
   attr :value, :any, required: true, doc: "The main statistic value to display"
   attr :title, :string, required: true, doc: "The card title text"
@@ -73,7 +78,8 @@ defmodule PhoenixKitWeb.Components.Core.StatCard do
     ~H"""
     <div class={[
       color_classes(@color),
-      "rounded-box shadow-xl hover:shadow-2xl transition-all duration-300 transform hover:scale-105",
+      "rounded-#{@rounded}",
+      "shadow-xl hover:shadow-2xl transition-all duration-300 transform hover:scale-105",
       if(@compact, do: "p-4", else: "p-6")
     ]}>
       <%= if @compact do %>

--- a/lib/phoenix_kit_web/components/core/stat_card.ex
+++ b/lib/phoenix_kit_web/components/core/stat_card.ex
@@ -59,6 +59,12 @@ defmodule PhoenixKitWeb.Components.Core.StatCard do
     doc:
       "Background color theme (info, primary, success, secondary, warning, error, accent, neutral)"
 
+  attr :value_color, :string,
+    default: nil,
+    doc:
+      "Optional CSS color for the value itself — for values whose color IS information " <>
+        "(a price colored by cheapness, a temperature by severity). E.g. \"hsl(140 85% 55%)\""
+
   slot :icon, required: true, doc: "Icon to display in the card header"
 
   def stat_card(assigns) do
@@ -75,7 +81,9 @@ defmodule PhoenixKitWeb.Components.Core.StatCard do
             {render_slot(@icon)}
           </div>
           <div class="flex-1">
-            <div class="text-2xl font-bold mb-1">{@value}</div>
+            <div class="text-2xl font-bold mb-1" style={@value_color && "color: #{@value_color}"}>
+              {@value}
+            </div>
             <div class="opacity-90 font-medium text-sm">{@title}</div>
             <div class="opacity-70 text-xs">{@subtitle}</div>
           </div>
@@ -87,7 +95,9 @@ defmodule PhoenixKitWeb.Components.Core.StatCard do
             {render_slot(@icon)}
           </div>
         </div>
-        <div class="text-3xl font-bold mb-2">{@value}</div>
+        <div class="text-3xl font-bold mb-2" style={@value_color && "color: #{@value_color}"}>
+          {@value}
+        </div>
         <div class="opacity-90 font-medium">{@title}</div>
         <div class="opacity-70 text-xs mt-1">
           {@subtitle}

--- a/lib/phoenix_kit_web/components/core/stat_card.ex
+++ b/lib/phoenix_kit_web/components/core/stat_card.ex
@@ -63,7 +63,9 @@ defmodule PhoenixKitWeb.Components.Core.StatCard do
     default: nil,
     doc:
       "Optional CSS color for the value itself — for values whose color IS information " <>
-        "(a price colored by cheapness, a temperature by severity). E.g. \"hsl(140 85% 55%)\""
+        "(a price colored by cheapness, a temperature by severity). E.g. \"hsl(140 85% 55%)\". " <>
+        "Any `;` is stripped so the value cannot append further declarations; every " <>
+        "legitimate colour syntax (hsl/oklch/var/color-mix) is unaffected."
 
   slot :icon, required: true, doc: "Icon to display in the card header"
 
@@ -81,7 +83,7 @@ defmodule PhoenixKitWeb.Components.Core.StatCard do
             {render_slot(@icon)}
           </div>
           <div class="flex-1">
-            <div class="text-2xl font-bold mb-1" style={@value_color && "color: #{@value_color}"}>
+            <div class="text-2xl font-bold mb-1" {value_style(@value_color)}>
               {@value}
             </div>
             <div class="opacity-90 font-medium text-sm">{@title}</div>
@@ -95,7 +97,7 @@ defmodule PhoenixKitWeb.Components.Core.StatCard do
             {render_slot(@icon)}
           </div>
         </div>
-        <div class="text-3xl font-bold mb-2" style={@value_color && "color: #{@value_color}"}>
+        <div class="text-3xl font-bold mb-2" {value_style(@value_color)}>
           {@value}
         </div>
         <div class="opacity-90 font-medium">{@title}</div>
@@ -117,4 +119,21 @@ defmodule PhoenixKitWeb.Components.Core.StatCard do
   defp color_classes("accent"), do: "bg-accent text-accent-content"
   defp color_classes("neutral"), do: "bg-neutral text-neutral-content"
   defp color_classes(_), do: "bg-info text-info-content"
+
+  # Returned as a spreadable attribute list rather than a `style={...}` value:
+  # HEEx renders a nil attribute value as `style=""` instead of dropping it, so
+  # every unstyled card carried an empty attribute.
+  #
+  # The colour is usually computed (a price coloured by cheapness), so it is
+  # kept to a single declaration — one stray `;` would otherwise let the value
+  # write arbitrary CSS onto the element. Colour functions contain no
+  # semicolons, so hsl()/oklch()/var()/color-mix() pass through untouched.
+  defp value_style(nil), do: []
+
+  defp value_style(color) do
+    case color |> to_string() |> String.replace(";", "") |> String.trim() do
+      "" -> []
+      clean -> [style: "color: " <> clean]
+    end
+  end
 end

--- a/lib/phoenix_kit_web/components/core/status_dot.ex
+++ b/lib/phoenix_kit_web/components/core/status_dot.ex
@@ -1,0 +1,75 @@
+defmodule PhoenixKitWeb.Components.Core.StatusDot do
+  @moduledoc """
+  A tiny semantic status indicator: a coloured dot with an optional
+  label. The generic companion to the domain-specific badges in
+  `PhoenixKitWeb.Components.Core.Badge` — for "online/offline",
+  "connected", "live socket up", "syncing" and every other place a
+  little coloured circle keeps getting hand-rolled.
+
+  Origin: extracted from NordSwitch (device online state, websocket
+  health, account connection state).
+  """
+
+  use Phoenix.Component
+
+  @doc """
+  Renders a status dot, optionally with a label.
+
+  ## Examples
+
+      <.status_dot variant={:success} label="online" />
+      <.status_dot variant={:error} label="socket down" size={:sm} />
+      <.status_dot variant={:info} pulse />
+
+      <%!-- boolean convenience for the overwhelmingly common case --%>
+      <.status_dot up={@device.online} label={if @device.online, do: "online", else: "offline"} />
+  """
+  attr :variant, :atom,
+    default: nil,
+    values: [:success, :error, :warning, :info, :neutral, nil],
+    doc: "Semantic colour; overrides `up` when set"
+
+  attr :up, :boolean,
+    default: nil,
+    doc: "Boolean convenience: true → success, false → error (ignored when `variant` set)"
+
+  attr :label, :string, default: nil, doc: "Optional text next to the dot"
+  attr :size, :atom, default: :md, values: [:xs, :sm, :md], doc: "Dot size"
+  attr :pulse, :boolean, default: false, doc: "Animate the dot (attention/live state)"
+  attr :class, :string, default: nil, doc: "Extra classes for the wrapper"
+
+  def status_dot(assigns) do
+    ~H"""
+    <span class={["inline-flex items-center gap-1.5", @class]}>
+      <span class="relative flex">
+        <span
+          :if={@pulse}
+          class={[
+            "absolute inline-flex h-full w-full rounded-full opacity-60 animate-ping",
+            dot_color(@variant, @up)
+          ]}
+        />
+        <span class={["relative inline-flex rounded-full", dot_size(@size), dot_color(@variant, @up)]} />
+      </span>
+      <span :if={@label} class={["opacity-70", label_size(@size)]}>{@label}</span>
+    </span>
+    """
+  end
+
+  defp dot_color(nil, true), do: "bg-success"
+  defp dot_color(nil, false), do: "bg-error"
+  defp dot_color(nil, nil), do: "bg-neutral"
+  defp dot_color(:success, _), do: "bg-success"
+  defp dot_color(:error, _), do: "bg-error"
+  defp dot_color(:warning, _), do: "bg-warning"
+  defp dot_color(:info, _), do: "bg-info"
+  defp dot_color(:neutral, _), do: "bg-neutral"
+
+  defp dot_size(:xs), do: "size-1.5"
+  defp dot_size(:sm), do: "size-2"
+  defp dot_size(:md), do: "size-2.5"
+
+  defp label_size(:xs), do: "text-xs"
+  defp label_size(:sm), do: "text-xs"
+  defp label_size(:md), do: "text-sm"
+end

--- a/lib/phoenix_kit_web/components/core/status_dot.ex
+++ b/lib/phoenix_kit_web/components/core/status_dot.ex
@@ -12,6 +12,8 @@ defmodule PhoenixKitWeb.Components.Core.StatusDot do
 
   use Phoenix.Component
 
+  use Gettext, backend: PhoenixKitWeb.Gettext
+
   @doc """
   Renders a status dot, optionally with a label.
 
@@ -38,9 +40,24 @@ defmodule PhoenixKitWeb.Components.Core.StatusDot do
   attr :pulse, :boolean, default: false, doc: "Animate the dot (attention/live state)"
   attr :class, :any, default: nil, doc: "Extra classes for the wrapper"
 
-  attr :rest, :global, doc: "Extra attributes for the wrapper (aria-*, title, data-*, …)"
+  attr :state_label, :string,
+    default: nil,
+    doc:
+      ~s|Overrides the announced state name. The defaults are generic | <>
+        ~s|(`up` reads "online"/"offline"); anything else — a payment, a job — | <>
+        ~s|should say so itself.|
+
+  attr :rest, :global, doc: "Extra attributes for the wrapper (title, data-*, …)"
 
   def status_dot(assigns) do
+    {color, state_name} = state(assigns.variant, assigns.up)
+
+    assigns =
+      assigns
+      |> assign(:color, color)
+      |> assign(:visible_label, presence(assigns.label))
+      |> assign(:state_name, presence(assigns.state_label) || state_name)
+
     ~H"""
     <span class={["inline-flex items-center gap-1.5", @class]} {@rest}>
       <span class="relative flex">
@@ -48,39 +65,40 @@ defmodule PhoenixKitWeb.Components.Core.StatusDot do
           :if={@pulse}
           class={[
             "absolute inline-flex h-full w-full rounded-full opacity-60 motion-safe:animate-ping",
-            dot_color(@variant, @up)
+            @color
           ]}
         />
-        <span class={["relative inline-flex rounded-full", dot_size(@size), dot_color(@variant, @up)]} />
+        <span class={["relative inline-flex rounded-full", dot_size(@size), @color]} />
       </span>
-      <span :if={@label} class={["opacity-70", label_size(@size)]}>{@label}</span>
+      <span :if={@visible_label} class={["opacity-70", label_size(@size)]}>{@visible_label}</span>
       <%!-- Colour alone carries the state, which is silent to a screen reader
-           and indistinguishable to red/green colour-blind users. When there is
-           no visible label, name the state for assistive tech instead. --%>
-      <span :if={is_nil(@label)} class="sr-only">{state_name(@variant, @up)}</span>
+           and indistinguishable to red/green colour-blind users. With no
+           visible label, name the state for assistive tech instead. --%>
+      <span :if={is_nil(@visible_label)} class="sr-only">{@state_name}</span>
     </span>
     """
   end
 
-  # Kept in step with dot_color/2 — the visible colour and the announced word
-  # must never disagree.
-  defp state_name(nil, true), do: "online"
-  defp state_name(nil, false), do: "offline"
-  defp state_name(nil, nil), do: "status unknown"
-  defp state_name(:success, _), do: "ok"
-  defp state_name(:error, _), do: "error"
-  defp state_name(:warning, _), do: "warning"
-  defp state_name(:info, _), do: "info"
-  defp state_name(:neutral, _), do: "inactive"
+  # An empty string is truthy, so `label=""` — an ordinary result of
+  # `label={@device.name}` — rendered an empty visible span AND suppressed the
+  # hidden one, leaving a dot with no accessible name at all.
+  defp presence(nil), do: nil
 
-  defp dot_color(nil, true), do: "bg-success"
-  defp dot_color(nil, false), do: "bg-error"
-  defp dot_color(nil, nil), do: "bg-neutral"
-  defp dot_color(:success, _), do: "bg-success"
-  defp dot_color(:error, _), do: "bg-error"
-  defp dot_color(:warning, _), do: "bg-warning"
-  defp dot_color(:info, _), do: "bg-info"
-  defp dot_color(:neutral, _), do: "bg-neutral"
+  defp presence(value) when is_binary(value),
+    do: if(String.trim(value) == "", do: nil, else: value)
+
+  defp presence(value), do: value
+
+  # One resolver returns BOTH the colour and the word for a state, so the two
+  # can never drift out of step as separate lookup tables could.
+  defp state(nil, true), do: {"bg-success", gettext("online")}
+  defp state(nil, false), do: {"bg-error", gettext("offline")}
+  defp state(nil, nil), do: {"bg-neutral", gettext("status unknown")}
+  defp state(:success, _), do: {"bg-success", gettext("ok")}
+  defp state(:error, _), do: {"bg-error", gettext("error")}
+  defp state(:warning, _), do: {"bg-warning", gettext("warning")}
+  defp state(:info, _), do: {"bg-info", gettext("info")}
+  defp state(:neutral, _), do: {"bg-neutral", gettext("inactive")}
 
   defp dot_size(:xs), do: "size-1.5"
   defp dot_size(:sm), do: "size-2"

--- a/lib/phoenix_kit_web/components/core/status_dot.ex
+++ b/lib/phoenix_kit_web/components/core/status_dot.ex
@@ -36,25 +36,42 @@ defmodule PhoenixKitWeb.Components.Core.StatusDot do
   attr :label, :string, default: nil, doc: "Optional text next to the dot"
   attr :size, :atom, default: :md, values: [:xs, :sm, :md], doc: "Dot size"
   attr :pulse, :boolean, default: false, doc: "Animate the dot (attention/live state)"
-  attr :class, :string, default: nil, doc: "Extra classes for the wrapper"
+  attr :class, :any, default: nil, doc: "Extra classes for the wrapper"
+
+  attr :rest, :global, doc: "Extra attributes for the wrapper (aria-*, title, data-*, …)"
 
   def status_dot(assigns) do
     ~H"""
-    <span class={["inline-flex items-center gap-1.5", @class]}>
+    <span class={["inline-flex items-center gap-1.5", @class]} {@rest}>
       <span class="relative flex">
         <span
           :if={@pulse}
           class={[
-            "absolute inline-flex h-full w-full rounded-full opacity-60 animate-ping",
+            "absolute inline-flex h-full w-full rounded-full opacity-60 motion-safe:animate-ping",
             dot_color(@variant, @up)
           ]}
         />
         <span class={["relative inline-flex rounded-full", dot_size(@size), dot_color(@variant, @up)]} />
       </span>
       <span :if={@label} class={["opacity-70", label_size(@size)]}>{@label}</span>
+      <%!-- Colour alone carries the state, which is silent to a screen reader
+           and indistinguishable to red/green colour-blind users. When there is
+           no visible label, name the state for assistive tech instead. --%>
+      <span :if={is_nil(@label)} class="sr-only">{state_name(@variant, @up)}</span>
     </span>
     """
   end
+
+  # Kept in step with dot_color/2 — the visible colour and the announced word
+  # must never disagree.
+  defp state_name(nil, true), do: "online"
+  defp state_name(nil, false), do: "offline"
+  defp state_name(nil, nil), do: "status unknown"
+  defp state_name(:success, _), do: "ok"
+  defp state_name(:error, _), do: "error"
+  defp state_name(:warning, _), do: "warning"
+  defp state_name(:info, _), do: "info"
+  defp state_name(:neutral, _), do: "inactive"
 
   defp dot_color(nil, true), do: "bg-success"
   defp dot_color(nil, false), do: "bg-error"

--- a/mix.exs
+++ b/mix.exs
@@ -293,8 +293,14 @@ defmodule PhoenixKit.MixProject do
       precommit: [
         "compile --warnings-as-errors --all-warnings",
         "deps.unlock --check-unused",
-        "quality.ci"
+        "quality.ci",
+        "test.js"
       ],
+
+      # Pure logic inside the shipped hook bundle (test/js, node --test). Skips
+      # itself when node isn't installed rather than failing a contributor's
+      # precommit over an optional tool.
+      "test.js": &run_js_tests/1,
 
       # Release gate — run before `mix hex.publish`. Catches release-metadata
       # drift and packaging mistakes that precommit/quality.ci structurally
@@ -311,5 +317,22 @@ defmodule PhoenixKit.MixProject do
         "phoenix_kit.release_check"
       ]
     ]
+  end
+
+  # `node --test test/js` over the pure helpers exported from the hook bundle.
+  # Node is optional tooling here, so a machine without it skips rather than
+  # fails — the Elixir suite is still the gate.
+  defp run_js_tests(_args) do
+    if System.find_executable("node") do
+      {output, status} =
+        System.cmd("node", ["--test" | Path.wildcard("test/js/*.test.cjs")],
+          stderr_to_stdout: true
+        )
+
+      IO.puts(output)
+      if status != 0, do: Mix.raise("JS tests failed")
+    else
+      Mix.shell().info("[skip] node not found — skipping test/js")
+    end
   end
 end

--- a/priv/static/assets/phoenix_kit.js
+++ b/priv/static/assets/phoenix_kit.js
@@ -1464,8 +1464,11 @@ if (typeof window.Chart === "undefined") {
     var outerW = v.outerWidth || w;
     var outerH = v.outerHeight || h;
 
-    var left = Math.max(0, Math.round(originX + (outerW - w) / 2));
-    var top = Math.max(0, Math.round(originY + (outerH - h) / 2));
+    // Clamp the OFFSET, not the final coordinate: a monitor left of, or above,
+    // the primary one has negative screen coordinates, and flooring those at 0
+    // threw the popup back onto the primary display.
+    var left = Math.round(originX + Math.max(0, (outerW - w) / 2));
+    var top = Math.round(originY + Math.max(0, (outerH - h) / 2));
 
     return (
       "width=" + w + ",height=" + h + ",left=" + left + ",top=" + top +

--- a/priv/static/assets/phoenix_kit.js
+++ b/priv/static/assets/phoenix_kit.js
@@ -1417,6 +1417,80 @@ if (typeof window.Chart === "undefined") {
   };
 
   // ---------------------------------------------------------------------------
+  // ConnectAccountPopup Hook
+  // ---------------------------------------------------------------------------
+  //
+  // Opens an OAuth account-linking flow in a named popup instead of navigating
+  // the page. Replaces an inline onclick= (CSP-hostile, and the kit removed
+  // inline handlers everywhere else for the same reason).
+  //
+  // The element is a real <a href>, so this degrades correctly: with JS off, or
+  // when the popup is blocked, the browser performs the normal full-page
+  // navigation rather than dead-ending on a cancelled click.
+  //
+  // Geometry and window name come from data attributes so nothing is
+  // interpolated into a script string.
+  //
+  // Usage:
+  //   <a href="/oauth/start" phx-hook="ConnectAccountPopup"
+  //      data-window-name="oauth-connect" data-window-width="480"
+  //      data-window-height="680">Connect</a>
+  //
+  // ---------------------------------------------------------------------------
+
+  window.PhoenixKitHooks.ConnectAccountPopup = {
+    mounted() {
+      this.onClick = (event) => {
+        // Honour the ways a user asks for a new tab/window themselves.
+        if (event.defaultPrevented) return;
+        if (event.button !== 0) return;
+        if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+
+        var el = this.el;
+        var name = el.dataset.windowName || "oauth-connect";
+        var width = parseInt(el.dataset.windowWidth, 10) || 480;
+        var height = parseInt(el.dataset.windowHeight, 10) || 680;
+
+        // Centre on the CURRENT screen in a multi-monitor setup; screenX/Y and
+        // the outer size describe the browser window, not the primary display.
+        var dualLeft = window.screenLeft !== undefined ? window.screenLeft : window.screenX;
+        var dualTop = window.screenTop !== undefined ? window.screenTop : window.screenY;
+        var outerW = window.outerWidth || document.documentElement.clientWidth || width;
+        var outerH = window.outerHeight || document.documentElement.clientHeight || height;
+        var left = Math.max(0, Math.round(dualLeft + (outerW - width) / 2));
+        var top = Math.max(0, Math.round(dualTop + (outerH - height) / 2));
+
+        var features =
+          "width=" + width + ",height=" + height + ",left=" + left + ",top=" + top +
+          ",menubar=no,toolbar=no,location=yes,status=no,resizable=yes,scrollbars=yes";
+
+        var popup;
+        try {
+          popup = window.open(el.href, name, features);
+        } catch (_err) {
+          popup = null;
+        }
+
+        // Blocked or failed → let the click through so the href still works.
+        if (!popup) return;
+
+        event.preventDefault();
+        try {
+          popup.focus();
+        } catch (_err) {
+          /* focus is best-effort */
+        }
+      };
+
+      this.el.addEventListener("click", this.onClick);
+    },
+
+    destroyed() {
+      if (this.onClick) this.el.removeEventListener("click", this.onClick);
+    }
+  };
+
+  // ---------------------------------------------------------------------------
   // MarkdownEditor
   //
   // Drives the core MarkdownEditor LiveComponent's textarea: cursor tracking,

--- a/priv/static/assets/phoenix_kit.js
+++ b/priv/static/assets/phoenix_kit.js
@@ -1438,31 +1438,48 @@ if (typeof window.Chart === "undefined") {
   //
   // ---------------------------------------------------------------------------
 
+  // Pure: should this click be turned into a popup at all? A user asking for a
+  // new tab (middle-click, cmd/ctrl-click) or a handler that already claimed
+  // the event must be left alone.
+  function shouldOpenPopup(event) {
+    if (!event) return false;
+    if (event.defaultPrevented) return false;
+    if (typeof event.button === "number" && event.button !== 0) return false;
+    if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return false;
+    return true;
+  }
+
+  // Pure: window.open feature string, centred on the screen the browser window
+  // is actually on. screenLeft/Top describe the WINDOW, so a multi-monitor
+  // setup needs them as the origin — centring on innerWidth alone throws the
+  // popup onto the primary display.
+  function popupFeatures(width, height, view) {
+    var v = view || {};
+    var w = Math.max(1, parseInt(width, 10) || 480);
+    var h = Math.max(1, parseInt(height, 10) || 680);
+
+    var originX = v.screenLeft !== undefined ? v.screenLeft : (v.screenX || 0);
+    var originY = v.screenTop !== undefined ? v.screenTop : (v.screenY || 0);
+    var outerW = v.outerWidth || w;
+    var outerH = v.outerHeight || h;
+
+    var left = Math.max(0, Math.round(originX + (outerW - w) / 2));
+    var top = Math.max(0, Math.round(originY + (outerH - h) / 2));
+
+    return (
+      "width=" + w + ",height=" + h + ",left=" + left + ",top=" + top +
+      ",menubar=no,toolbar=no,location=yes,status=no,resizable=yes,scrollbars=yes"
+    );
+  }
+
   window.PhoenixKitHooks.ConnectAccountPopup = {
     mounted() {
       this.onClick = (event) => {
-        // Honour the ways a user asks for a new tab/window themselves.
-        if (event.defaultPrevented) return;
-        if (event.button !== 0) return;
-        if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+        if (!shouldOpenPopup(event)) return;
 
         var el = this.el;
         var name = el.dataset.windowName || "oauth-connect";
-        var width = parseInt(el.dataset.windowWidth, 10) || 480;
-        var height = parseInt(el.dataset.windowHeight, 10) || 680;
-
-        // Centre on the CURRENT screen in a multi-monitor setup; screenX/Y and
-        // the outer size describe the browser window, not the primary display.
-        var dualLeft = window.screenLeft !== undefined ? window.screenLeft : window.screenX;
-        var dualTop = window.screenTop !== undefined ? window.screenTop : window.screenY;
-        var outerW = window.outerWidth || document.documentElement.clientWidth || width;
-        var outerH = window.outerHeight || document.documentElement.clientHeight || height;
-        var left = Math.max(0, Math.round(dualLeft + (outerW - width) / 2));
-        var top = Math.max(0, Math.round(dualTop + (outerH - height) / 2));
-
-        var features =
-          "width=" + width + ",height=" + height + ",left=" + left + ",top=" + top +
-          ",menubar=no,toolbar=no,location=yes,status=no,resizable=yes,scrollbars=yes";
+        var features = popupFeatures(el.dataset.windowWidth, el.dataset.windowHeight, window);
 
         var popup;
         try {
@@ -1471,14 +1488,16 @@ if (typeof window.Chart === "undefined") {
           popup = null;
         }
 
-        // Blocked or failed → let the click through so the href still works.
+        // Blocked or failed → let the click through so the plain href still
+        // starts the flow full-page. Cancelling here unconditionally is what
+        // made the old inline onclick a dead button behind a popup blocker.
         if (!popup) return;
 
         event.preventDefault();
         try {
           popup.focus();
         } catch (_err) {
-          /* focus is best-effort */
+          /* focus is best-effort; a blocked focus must not break the flow */
         }
       };
 
@@ -1486,9 +1505,18 @@ if (typeof window.Chart === "undefined") {
     },
 
     destroyed() {
-      if (this.onClick) this.el.removeEventListener("click", this.onClick);
+      if (this.onClick) {
+        this.el.removeEventListener("click", this.onClick);
+        this.onClick = null;
+      }
     }
   };
+
+  // Exported for the Node test harness (test/js); harmless in a browser.
+  if (typeof module === "object" && module.exports) {
+    module.exports.shouldOpenPopup = shouldOpenPopup;
+    module.exports.popupFeatures = popupFeatures;
+  }
 
   // ---------------------------------------------------------------------------
   // MarkdownEditor

--- a/priv/static/assets/phoenix_kit.js
+++ b/priv/static/assets/phoenix_kit.js
@@ -1417,12 +1417,13 @@ if (typeof window.Chart === "undefined") {
   };
 
   // ---------------------------------------------------------------------------
-  // ConnectAccountPopup Hook
+  // PopupLink Hook
   // ---------------------------------------------------------------------------
   //
-  // Opens an OAuth account-linking flow in a named popup instead of navigating
-  // the page. Replaces an inline onclick= (CSP-hostile, and the kit removed
-  // inline handlers everywhere else for the same reason).
+  // Opens a same-origin link in a named popup instead of navigating the page.
+  // Nothing about it is OAuth-specific — connect_account_button/1 is simply its
+  // first consumer. Replaces an inline onclick= (CSP-hostile, and the kit
+  // removed inline handlers everywhere else for the same reason).
   //
   // The element is a real <a href>, so this degrades correctly: with JS off, or
   // when the popup is blocked, the browser performs the normal full-page
@@ -1432,7 +1433,7 @@ if (typeof window.Chart === "undefined") {
   // interpolated into a script string.
   //
   // Usage:
-  //   <a href="/oauth/start" phx-hook="ConnectAccountPopup"
+  //   <a href="/oauth/start" phx-hook="PopupLink"
   //      data-window-name="oauth-connect" data-window-width="480"
   //      data-window-height="680">Connect</a>
   //
@@ -1472,12 +1473,32 @@ if (typeof window.Chart === "undefined") {
     );
   }
 
-  window.PhoenixKitHooks.ConnectAccountPopup = {
+  // Pure: is this link one we may open in a popup at all? The popup keeps its
+  // `window.opener`, so a cross-origin target would hand that reference away.
+  // The Elixir component enforces this too, but the bundle is copied verbatim
+  // into host apps and the hook is a public name — a host wiring it onto an
+  // arbitrary <a> must not be able to bypass the rule.
+  function sameOrigin(href, base) {
+    // A non-string href would otherwise be stringified and resolved as a
+    // RELATIVE path ("undefined"), which lands back on our own origin and
+    // quietly passes the check.
+    if (typeof href !== "string" || href === "") return false;
+
+    try {
+      return new URL(href, base).origin === new URL(base).origin;
+    } catch (_err) {
+      return false;
+    }
+  }
+
+  window.PhoenixKitHooks.PopupLink = {
     mounted() {
       this.onClick = (event) => {
         if (!shouldOpenPopup(event)) return;
 
         var el = this.el;
+        if (!sameOrigin(el.href, window.location.href)) return;
+
         var name = el.dataset.windowName || "oauth-connect";
         var features = popupFeatures(el.dataset.windowWidth, el.dataset.windowHeight, window);
 
@@ -1491,7 +1512,9 @@ if (typeof window.Chart === "undefined") {
         // Blocked or failed → let the click through so the plain href still
         // starts the flow full-page. Cancelling here unconditionally is what
         // made the old inline onclick a dead button behind a popup blocker.
-        if (!popup) return;
+        // Some blockers hand back a window that is already closed, and others
+        // return one whose `closed` is undefined — treat both as blocked.
+        if (!popup || popup.closed || typeof popup.closed === "undefined") return;
 
         event.preventDefault();
         try {
@@ -1516,6 +1539,7 @@ if (typeof window.Chart === "undefined") {
   if (typeof module === "object" && module.exports) {
     module.exports.shouldOpenPopup = shouldOpenPopup;
     module.exports.popupFeatures = popupFeatures;
+    module.exports.sameOrigin = sameOrigin;
   }
 
   // ---------------------------------------------------------------------------

--- a/test/js/connect_account_popup.test.cjs
+++ b/test/js/connect_account_popup.test.cjs
@@ -1,0 +1,167 @@
+"use strict";
+
+// Unit tests for the pure decision logic behind the ConnectAccountPopup hook
+// in priv/static/assets/phoenix_kit.js. The bundle is browser code (IIFEs that
+// assign onto `window`), so stub the globals it touches at load time; the
+// DOM-using hook methods themselves are not invoked here.
+//
+// Run: node --test test/js
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+// The bundle does real work at load: injects a <style>, registers page-loading
+// listeners, reads storage. Stub just enough of a browser for it to load; no
+// DOM-touching hook method is invoked by these tests.
+const noop = () => {};
+
+function stubElement() {
+  return {
+    style: {},
+    dataset: {},
+    classList: { add: noop, remove: noop, toggle: noop, contains: () => false },
+    setAttribute: noop,
+    getAttribute: () => null,
+    removeAttribute: noop,
+    appendChild: noop,
+    remove: noop,
+    addEventListener: noop,
+    removeEventListener: noop,
+    querySelector: () => null,
+    querySelectorAll: () => [],
+  };
+}
+
+global.document = {
+  documentElement: stubElement(),
+  head: stubElement(),
+  body: stubElement(),
+  createElement: stubElement,
+  createTextNode: () => ({}),
+  getElementById: () => null,
+  querySelector: () => null,
+  querySelectorAll: () => [],
+  addEventListener: noop,
+  removeEventListener: noop,
+  readyState: "complete",
+};
+
+const storage = {
+  getItem: () => null,
+  setItem: noop,
+  removeItem: noop,
+  key: () => null,
+  length: 0,
+};
+
+global.window = {
+  PhoenixKitHooks: {},
+  addEventListener: noop,
+  removeEventListener: noop,
+  matchMedia: () => ({ matches: false, addEventListener: noop, removeEventListener: noop }),
+  localStorage: storage,
+  sessionStorage: storage,
+  location: { href: "http://localhost/", reload: noop },
+  navigator: { userAgent: "node" },
+  document: global.document,
+  setTimeout,
+  clearTimeout,
+};
+
+global.localStorage = storage;
+global.sessionStorage = storage;
+// `globalThis.navigator` is getter-only on modern Node, so leave it be — the
+// bundle reads `window.navigator`, which is stubbed above.
+
+const { shouldOpenPopup, popupFeatures } = require("../../priv/static/assets/phoenix_kit.js");
+
+test("shouldOpenPopup: a plain left click opens the popup", () => {
+  assert.equal(shouldOpenPopup({ button: 0 }), true);
+  assert.equal(shouldOpenPopup({}), true);
+});
+
+test("shouldOpenPopup: leaves the user's own new-tab gestures alone", () => {
+  // Intercepting these would break cmd-click / middle-click, which users
+  // reasonably expect to open the OAuth start route in a tab of their own.
+  assert.equal(shouldOpenPopup({ button: 1 }), false, "middle click");
+  assert.equal(shouldOpenPopup({ button: 2 }), false, "right click");
+  assert.equal(shouldOpenPopup({ button: 0, metaKey: true }), false, "cmd-click");
+  assert.equal(shouldOpenPopup({ button: 0, ctrlKey: true }), false, "ctrl-click");
+  assert.equal(shouldOpenPopup({ button: 0, shiftKey: true }), false, "shift-click");
+  assert.equal(shouldOpenPopup({ button: 0, altKey: true }), false, "alt-click");
+});
+
+test("shouldOpenPopup: yields to a handler that already claimed the event", () => {
+  assert.equal(shouldOpenPopup({ button: 0, defaultPrevented: true }), false);
+});
+
+test("shouldOpenPopup: a missing event never opens anything", () => {
+  assert.equal(shouldOpenPopup(null), false);
+  assert.equal(shouldOpenPopup(undefined), false);
+});
+
+test("popupFeatures: centres on the browser window, not the primary display", () => {
+  // A window sitting on a second monitor at x=2000 must put its popup there
+  // too; centring on size alone would fling it back to the primary screen.
+  const features = popupFeatures(480, 680, {
+    screenLeft: 2000,
+    screenTop: 100,
+    outerWidth: 1000,
+    outerHeight: 900,
+  });
+
+  assert.match(features, /width=480/);
+  assert.match(features, /height=680/);
+  assert.match(features, /left=2260/); // 2000 + (1000-480)/2
+  assert.match(features, /top=210/); // 100 + (900-680)/2
+});
+
+test("popupFeatures: falls back to screenX/screenY when screenLeft is absent", () => {
+  const features = popupFeatures(400, 400, {
+    screenX: 50,
+    screenY: 60,
+    outerWidth: 800,
+    outerHeight: 800,
+  });
+
+  assert.match(features, /left=250/); // 50 + (800-400)/2
+  assert.match(features, /top=260/); // 60 + (800-400)/2
+});
+
+test("popupFeatures: never positions the popup off the left/top edge", () => {
+  // A browser window narrower than the requested popup would compute a
+  // negative offset, which some platforms treat as "off-screen".
+  const features = popupFeatures(1200, 1000, {
+    screenLeft: 0,
+    screenTop: 0,
+    outerWidth: 400,
+    outerHeight: 300,
+  });
+
+  assert.match(features, /left=0/);
+  assert.match(features, /top=0/);
+});
+
+test("popupFeatures: tolerates the string dataset values it is actually given", () => {
+  // el.dataset.* is always a string.
+  const features = popupFeatures("500", "700", { screenLeft: 0, screenTop: 0 });
+
+  assert.match(features, /width=500/);
+  assert.match(features, /height=700/);
+});
+
+test("popupFeatures: garbage or missing sizes fall back to sane defaults", () => {
+  for (const bad of [undefined, null, "", "abc", 0, -50]) {
+    const features = popupFeatures(bad, bad, {});
+    assert.match(features, /width=\d+/);
+    assert.match(features, /height=\d+/);
+    assert.doesNotMatch(features, /NaN|Infinity|width=-|height=-|left=-|top=-/);
+  }
+});
+
+test("popupFeatures: an empty view object still yields a usable string", () => {
+  const features = popupFeatures(480, 680, undefined);
+
+  assert.match(features, /^width=480,height=680,left=\d+,top=\d+,/);
+  assert.doesNotMatch(features, /NaN|undefined/);
+});

--- a/test/js/popup_link.test.cjs
+++ b/test/js/popup_link.test.cjs
@@ -132,9 +132,7 @@ test("popupFeatures: falls back to screenX/screenY when screenLeft is absent", (
   assert.match(features, /top=260/); // 60 + (800-400)/2
 });
 
-test("popupFeatures: never positions the popup off the left/top edge", () => {
-  // A browser window narrower than the requested popup would compute a
-  // negative offset, which some platforms treat as "off-screen".
+test("popupFeatures: a popup larger than the window sits at the window origin", () => {
   const features = popupFeatures(1200, 1000, {
     screenLeft: 0,
     screenTop: 0,
@@ -146,6 +144,20 @@ test("popupFeatures: never positions the popup off the left/top edge", () => {
   assert.match(features, /top=0/);
 });
 
+test("popupFeatures: honours a monitor left of, or above, the primary one", () => {
+  // Negative screen coordinates are legitimate on a multi-monitor desktop.
+  // Clamping them to 0 threw the popup back onto the primary display.
+  const features = popupFeatures(480, 680, {
+    screenLeft: -1920,
+    screenTop: -200,
+    outerWidth: 1600,
+    outerHeight: 1000,
+  });
+
+  assert.match(features, /left=-1360/); // -1920 + (1600-480)/2
+  assert.match(features, /top=-40/); // -200 + (1000-680)/2
+});
+
 test("popupFeatures: tolerates the string dataset values it is actually given", () => {
   // el.dataset.* is always a string.
   const features = popupFeatures("500", "700", { screenLeft: 0, screenTop: 0 });
@@ -155,10 +167,11 @@ test("popupFeatures: tolerates the string dataset values it is actually given", 
 });
 
 test("popupFeatures: garbage or missing sizes fall back to sane defaults", () => {
-  for (const bad of [undefined, null, "", "abc", 0, -50]) {
+  for (const bad of [undefined, null, "", "abc"]) {
     const features = popupFeatures(bad, bad, {});
-    assert.match(features, /width=\d+/);
-    assert.match(features, /height=\d+/);
+    // Assert the actual defaults — /width=\d+/ was satisfied by width=1.
+    assert.match(features, /width=480/, `for ${String(bad)}`);
+    assert.match(features, /height=680/, `for ${String(bad)}`);
     assert.doesNotMatch(features, /NaN|Infinity|width=-|height=-|left=-|top=-/);
   }
 });
@@ -194,4 +207,127 @@ test("sameOrigin: an unparseable href is refused, not thrown on", () => {
   assert.equal(sameOrigin("http://[bad", "https://app.example/"), false);
   assert.equal(sameOrigin(undefined, "https://app.example/"), false);
   assert.equal(sameOrigin("/ok", "not-a-url"), false);
+});
+
+// ---------------------------------------------------------------------------
+// The hook itself. The blocked-popup branch IS the bug this component was
+// rewritten to fix — the old inline onclick cancelled navigation even when the
+// popup never opened, leaving a dead button — and it had no coverage at all.
+// ---------------------------------------------------------------------------
+
+const hook = window.PhoenixKitHooks.PopupLink;
+
+function mountHook({ open, href = "https://app.example/oauth/start" }) {
+  const listeners = {};
+  const el = {
+    href,
+    dataset: { windowName: "test", windowWidth: "480", windowHeight: "680" },
+    addEventListener(type, fn) {
+      listeners[type] = fn;
+    },
+    removeEventListener(type) {
+      delete listeners[type];
+    },
+  };
+
+  window.location = { href: "https://app.example/settings" };
+  window.open = open;
+
+  const ctx = Object.create(hook);
+  ctx.el = el;
+  ctx.mounted();
+
+  return {
+    el,
+    listeners,
+    click(overrides = {}) {
+      let prevented = false;
+      const event = {
+        button: 0,
+        preventDefault() {
+          prevented = true;
+        },
+        ...overrides,
+      };
+      listeners.click(event);
+      return prevented;
+    },
+    destroy() {
+      ctx.destroyed();
+      return listeners;
+    },
+  };
+}
+
+test("hook: a successful popup cancels the navigation", () => {
+  let focused = false;
+  const h = mountHook({ open: () => ({ closed: false, focus: () => (focused = true) }) });
+
+  assert.equal(h.click(), true, "should preventDefault when the popup opened");
+  assert.equal(focused, true, "the popup should be focused");
+});
+
+test("hook: a BLOCKED popup falls through to normal navigation", () => {
+  // The whole point of the rewrite. Cancelling here left a dead button.
+  assert.equal(mountHook({ open: () => null }).click(), false, "null");
+  assert.equal(mountHook({ open: () => ({ closed: true }) }).click(), false, "already closed");
+  assert.equal(mountHook({ open: () => ({}) }).click(), false, "closed undefined");
+});
+
+test("hook: window.open throwing falls through instead of breaking the click", () => {
+  const h = mountHook({
+    open: () => {
+      throw new Error("blocked");
+    },
+  });
+
+  assert.equal(h.click(), false);
+});
+
+test("hook: a popup that cannot be focused still counts as opened", () => {
+  const h = mountHook({
+    open: () => ({
+      closed: false,
+      focus() {
+        throw new Error("denied");
+      },
+    }),
+  });
+
+  assert.equal(h.click(), true, "focus is best-effort and must not break the flow");
+});
+
+test("hook: a cross-origin href is never popped up", () => {
+  let opened = false;
+  const h = mountHook({
+    href: "https://evil.example/start",
+    open: () => {
+      opened = true;
+      return { closed: false, focus() {} };
+    },
+  });
+
+  assert.equal(h.click(), false);
+  assert.equal(opened, false, "window.open must not even be called");
+});
+
+test("hook: modifier clicks are left to the browser", () => {
+  let opened = false;
+  const h = mountHook({
+    open: () => {
+      opened = true;
+      return { closed: false, focus() {} };
+    },
+  });
+
+  assert.equal(h.click({ metaKey: true }), false);
+  assert.equal(opened, false);
+});
+
+test("hook: destroyed unbinds the listener", () => {
+  const h = mountHook({ open: () => ({ closed: false, focus() {} }) });
+
+  assert.equal(typeof h.listeners.click, "function");
+  h.destroy();
+  assert.equal(h.listeners.click, undefined);
 });

--- a/test/js/popup_link.test.cjs
+++ b/test/js/popup_link.test.cjs
@@ -5,7 +5,7 @@
 // assign onto `window`), so stub the globals it touches at load time; the
 // DOM-using hook methods themselves are not invoked here.
 //
-// Run: node --test test/js
+// Run: mix test.js  (node --test needs the explicit file on Node 25)
 
 const test = require("node:test");
 const assert = require("node:assert/strict");

--- a/test/js/popup_link.test.cjs
+++ b/test/js/popup_link.test.cjs
@@ -1,6 +1,6 @@
 "use strict";
 
-// Unit tests for the pure decision logic behind the ConnectAccountPopup hook
+// Unit tests for the pure decision logic behind the PopupLink hook
 // in priv/static/assets/phoenix_kit.js. The bundle is browser code (IIFEs that
 // assign onto `window`), so stub the globals it touches at load time; the
 // DOM-using hook methods themselves are not invoked here.
@@ -73,7 +73,11 @@ global.sessionStorage = storage;
 // `globalThis.navigator` is getter-only on modern Node, so leave it be — the
 // bundle reads `window.navigator`, which is stubbed above.
 
-const { shouldOpenPopup, popupFeatures } = require("../../priv/static/assets/phoenix_kit.js");
+const {
+  shouldOpenPopup,
+  popupFeatures,
+  sameOrigin,
+} = require("../../priv/static/assets/phoenix_kit.js");
 
 test("shouldOpenPopup: a plain left click opens the popup", () => {
   assert.equal(shouldOpenPopup({ button: 0 }), true);
@@ -164,4 +168,30 @@ test("popupFeatures: an empty view object still yields a usable string", () => {
 
   assert.match(features, /^width=480,height=680,left=\d+,top=\d+,/);
   assert.doesNotMatch(features, /NaN|undefined/);
+});
+
+test("sameOrigin: accepts same-origin links, absolute or relative", () => {
+  const base = "https://app.example/settings";
+
+  assert.equal(sameOrigin("/oauth/start", base), true);
+  assert.equal(sameOrigin("https://app.example/oauth/start", base), true);
+  assert.equal(sameOrigin("oauth/start", base), true);
+});
+
+test("sameOrigin: refuses another origin, scheme or port", () => {
+  // The popup keeps window.opener, so a cross-origin target would hand that
+  // reference away. The Elixir component enforces this too, but the bundle is
+  // copied into hosts and the hook name is public.
+  const base = "https://app.example/settings";
+
+  assert.equal(sameOrigin("https://evil.example/start", base), false);
+  assert.equal(sameOrigin("//evil.example/start", base), false);
+  assert.equal(sameOrigin("http://app.example/start", base), false, "scheme differs");
+  assert.equal(sameOrigin("https://app.example:8443/start", base), false, "port differs");
+});
+
+test("sameOrigin: an unparseable href is refused, not thrown on", () => {
+  assert.equal(sameOrigin("http://[bad", "https://app.example/"), false);
+  assert.equal(sameOrigin(undefined, "https://app.example/"), false);
+  assert.equal(sameOrigin("/ok", "not-a-url"), false);
 });

--- a/test/phoenix_kit_web/components/core/chart_test.exs
+++ b/test/phoenix_kit_web/components/core/chart_test.exs
@@ -58,10 +58,26 @@ defmodule PhoenixKitWeb.Components.Core.ChartTest do
     end
   end
 
-  defp assert_finite_numbers(html) do
-    for value <- numeric_attrs(html) ++ path_numbers(html) do
-      refute value =~ ~r/nan|inf/i, "non-finite number in rendered SVG: #{inspect(value)}"
+  # A polyline's coordinates live in `points="…"`, which contributes neither an
+  # x/y attribute nor an M/L command — so the sparkline assertions used to
+  # iterate an empty list and would have passed with points="NaN,NaN".
+  defp polyline_numbers(html) do
+    case Regex.run(~r/<polyline[^>]*\spoints="([^"]*)"/, html) do
+      [_, pts] -> pts |> String.split([" ", ","], trim: true)
+      _ -> []
+    end
+  end
 
+  defp assert_finite_numbers(html) do
+    values = numeric_attrs(html) ++ path_numbers(html) ++ polyline_numbers(html)
+
+    # Scanning the raw html catches non-finite output the number regexes skip
+    # over: `[-\d.eE+]` never matches "NaN", so a NaN coordinate simply
+    # vanished from the list instead of failing.
+    refute html =~ ~r/\b(nan|infinity)\b/i, "non-finite number in rendered SVG"
+    assert values != [], "no numbers found — the assertion would pass vacuously"
+
+    for value <- values do
       case Float.parse(value) do
         {_, ""} -> :ok
         _ -> flunk("unparseable number in rendered SVG: #{inspect(value)}")
@@ -149,8 +165,15 @@ defmodule PhoenixKitWeb.Components.Core.ChartTest do
       html =
         render(~H|<.line_chart id="c" data={[{0, 0}, {10, 100}]} step y_domain={{0, 100}} />|)
 
-      # Two points become four in step mode: hold, then jump.
-      assert length(path_numbers(html)) >= 8
+      # Compare against the SAME data without `step`: the stepped line must
+      # carry strictly more vertices. A bare count passed even with step
+      # removed, because path_numbers also scans the area path.
+      plain = render(~H|<.line_chart id="c" data={[{0, 0}, {10, 100}]} y_domain={{0, 100}} />|)
+
+      stepped_points = stroked_path(html) |> String.split("L") |> length()
+      plain_points = stroked_path(plain) |> String.split("L") |> length()
+
+      assert stepped_points > plain_points
       assert_finite_numbers(html)
     end
 
@@ -259,6 +282,70 @@ defmodule PhoenixKitWeb.Components.Core.ChartTest do
     end
   end
 
+  describe "round-2 regressions" do
+    test "a partially-unusable domain falls back to the data, not a constant" do
+      assigns = %{}
+      # A {0, 1} fallback recreated the reversed-domain bug: every real x range
+      # then scaled by thousands and left the canvas just as finally.
+      html =
+        render(
+          ~H|<.line_chart id="c" data={[{0, 1}, {720, 5}, {1440, 3}]} x_domain={{0, nil}} />|
+        )
+
+      assert_finite_numbers(html)
+      assert_within_viewbox(html, 960, 240)
+    end
+
+    test "an entirely unusable domain also falls back to the data" do
+      assigns = %{}
+      html = render(~H|<.line_chart id="c" data={[{0, 1}, {1440, 3}]} x_domain="nonsense" />|)
+
+      assert_within_viewbox(html, 960, 240)
+    end
+
+    test "step data overshooting its x_domain does not double back" do
+      assigns = %{}
+      # The tail used to emit the viewBox width unconditionally, so the line ran
+      # forward past the edge and then back leftward.
+      html = render(~H|<.line_chart id="c" data={[{0, 1}, {20, 5}]} x_domain={{0, 10}} step />|)
+
+      xs =
+        stroked_path(html)
+        |> then(&Regex.scan(~r/[ML]([-\d.eE+]+),/, &1))
+        |> Enum.map(fn [_, x] -> elem(Float.parse(x), 0) end)
+
+      assert xs == Enum.sort(xs), "the line must not run backwards: #{inspect(xs)}"
+    end
+
+    test "dropping a sparkline sample leaves a gap instead of reshaping the line" do
+      assigns = %{}
+      # Rejecting before indexing re-spaced the axis, so removing one bad
+      # sample silently changed the SHAPE of the line rather than the gap.
+      with_hole = render(~H|<.sparkline values={[1, 2, nil, 4, 5]} />|)
+      without = render(~H|<.sparkline values={[1, 2, 3, 4, 5]} />|)
+
+      xs = fn html ->
+        [_, pts] = Regex.run(~r/points="([^"]*)"/, html)
+        pts |> String.split(" ") |> Enum.map(&(&1 |> String.split(",") |> hd()))
+      end
+
+      # The survivors keep the x positions they had in the full series.
+      assert xs.(with_hole) == xs.(without) -- ["100.0"]
+    end
+
+    test "a flat sparkline centres rather than sitting on the floor" do
+      assigns = %{}
+      html = render(~H|<.sparkline values={[3, 3, 3]} />|)
+
+      [_, pts] = Regex.run(~r/points="([^"]*)"/, html)
+      ys = pts |> String.split(" ") |> Enum.map(&(&1 |> String.split(",") |> List.last()))
+      {y, ""} = ys |> hd() |> Float.parse()
+
+      # A steady metric reading as "at its minimum" is a lie about the data.
+      assert y > 8 and y < 40, "flat series should sit mid-box, got y=#{y}"
+    end
+  end
+
   describe "data normalisation" do
     test "one bad point never takes the page down" do
       # A library primitive that raises mid-render kills the whole LiveView.
@@ -340,6 +427,66 @@ defmodule PhoenixKitWeb.Components.Core.ChartTest do
         render(~H|<.bar_chart id="b" data={[%{label: "Mon", value: 12}]} />|)
 
       assert html =~ "<title>Mon: 12</title>"
+    end
+
+    test "a small magnitude is not rounded away to zero" do
+      # 4dp rounding turned a rate or a sub-cent price into "0".
+      assigns = %{data: [%{label: "rate", value: 1.234e-5}]}
+
+      html = render(~H|<.bar_chart id="b" data={@data} />|)
+
+      refute html =~ "<title>rate: 0</title>"
+    end
+
+    test "value_format takes over the tooltip entirely" do
+      assigns = %{
+        data: [%{label: "power", value: 1234}],
+        fmt: fn v -> "#{v} kWh" end
+      }
+
+      assert render(~H|<.bar_chart id="b" data={@data} value_format={@fmt} />|) =~
+               "<title>power: 1234 kWh</title>"
+    end
+
+    test "a raising value_format falls back rather than crashing the page" do
+      assigns = %{data: [%{label: "x", value: 1}], fmt: fn _ -> raise "boom" end}
+
+      assert render(~H|<.bar_chart id="b" data={@data} value_format={@fmt} />|) =~ "<title>x: 1"
+    end
+
+    test "bars accept tuples and string-keyed maps, like line_chart's points" do
+      assigns = %{
+        tuples: [{"Mon", 5}, {"Tue", 8}],
+        strings: [%{"label" => "Mon", "value" => 5}]
+      }
+
+      assert render(~H|<.bar_chart id="b" data={@tuples} />|) =~ "<rect"
+      assert render(~H|<.bar_chart id="b" data={@strings} />|) =~ "<rect"
+    end
+
+    test "an all-negative series still draws its zero line" do
+      assigns = %{}
+      # The baseline sits at the TOP there, which nothing else implies.
+      html =
+        render(
+          ~H|<.bar_chart id="b" data={[%{label: "a", value: -3}, %{label: "b", value: -8}]} />|
+        )
+
+      assert html =~ ~s(stroke-opacity="0.25")
+    end
+
+    test "an all-zero series still renders visible categories" do
+      assigns = %{}
+      # Zero-height rects paint nothing, so valid data produced a blank chart.
+      html =
+        render(
+          ~H|<.bar_chart id="b" data={[%{label: "a", value: 0}, %{label: "b", value: 0}]} />|
+        )
+
+      for [_, h] <- Regex.scan(~r/height="([^"]*)"/, html) do
+        {value, ""} = Float.parse(h)
+        assert value > 0
+      end
     end
 
     test "tooltip values are formatted for humans, not float noise" do

--- a/test/phoenix_kit_web/components/core/chart_test.exs
+++ b/test/phoenix_kit_web/components/core/chart_test.exs
@@ -69,11 +69,11 @@ defmodule PhoenixKitWeb.Components.Core.ChartTest do
     end
   end
 
-  describe "area_chart/1" do
+  describe "line_chart/1" do
     test "renders a line path for a simple series" do
       assigns = %{}
 
-      html = render(~H|<.area_chart id="c" data={[{0, 1}, {1, 5}, {2, 3}]} />|)
+      html = render(~H|<.line_chart id="c" data={[{0, 1}, {1, 5}, {2, 3}]} />|)
 
       assert html =~ "<svg"
       assert html =~ ~s(stroke="currentColor")
@@ -86,9 +86,9 @@ defmodule PhoenixKitWeb.Components.Core.ChartTest do
 
       html =
         render(~H"""
-        <.area_chart id="c" data={[]}>
+        <.line_chart id="c" data={[]}>
           <:empty>Nothing to show</:empty>
-        </.area_chart>
+        </.line_chart>
         """)
 
       assert html =~ "Nothing to show"
@@ -98,7 +98,7 @@ defmodule PhoenixKitWeb.Components.Core.ChartTest do
     test "empty data without an :empty slot renders nothing rather than crashing" do
       assigns = %{}
 
-      html = render(~H|<.area_chart id="c" data={[]} />|)
+      html = render(~H|<.line_chart id="c" data={[]} />|)
 
       refute html =~ "<svg"
     end
@@ -109,7 +109,7 @@ defmodule PhoenixKitWeb.Components.Core.ChartTest do
       # A lone "M x,y" is a valid path that paints NOTHING. Interval data of
       # length one is a real case (first slot of the day), so it has to
       # produce a visible mark.
-      html = render(~H|<.area_chart id="c" data={[{5, 10}]} />|)
+      html = render(~H|<.line_chart id="c" data={[{5, 10}]} />|)
 
       assert html =~ "<svg"
       assert_finite_numbers(html)
@@ -122,7 +122,7 @@ defmodule PhoenixKitWeb.Components.Core.ChartTest do
       assigns = %{}
 
       # Electricity prices go negative; this must not produce NaN or invert.
-      html = render(~H|<.area_chart id="c" data={[{0, -40}, {1, -10}, {2, 25}]} />|)
+      html = render(~H|<.line_chart id="c" data={[{0, -40}, {1, -10}, {2, 25}]} />|)
 
       assert_finite_numbers(html)
     end
@@ -130,7 +130,7 @@ defmodule PhoenixKitWeb.Components.Core.ChartTest do
     test "a completely flat series renders finite geometry" do
       assigns = %{}
 
-      html = render(~H|<.area_chart id="c" data={[{0, 7}, {1, 7}, {2, 7}]} />|)
+      html = render(~H|<.line_chart id="c" data={[{0, 7}, {1, 7}, {2, 7}]} />|)
 
       assert_finite_numbers(html)
     end
@@ -138,7 +138,7 @@ defmodule PhoenixKitWeb.Components.Core.ChartTest do
     test "an explicit zero-span y_domain does not divide by zero" do
       assigns = %{}
 
-      html = render(~H|<.area_chart id="c" data={[{0, 5}, {1, 5}]} y_domain={{5, 5}} />|)
+      html = render(~H|<.line_chart id="c" data={[{0, 5}, {1, 5}]} y_domain={{5, 5}} />|)
 
       assert_finite_numbers(html)
     end
@@ -147,7 +147,7 @@ defmodule PhoenixKitWeb.Components.Core.ChartTest do
       assigns = %{}
 
       html =
-        render(~H|<.area_chart id="c" data={[{0, 0}, {10, 100}]} step y_domain={{0, 100}} />|)
+        render(~H|<.line_chart id="c" data={[{0, 0}, {10, 100}]} step y_domain={{0, 100}} />|)
 
       # Two points become four in step mode: hold, then jump.
       assert length(path_numbers(html)) >= 8
@@ -159,7 +159,7 @@ defmodule PhoenixKitWeb.Components.Core.ChartTest do
 
       html =
         render(
-          ~H|<.area_chart id="c" data={[{0, 1}, {5, 2}]} step x_domain={{0, 10}} width={100} />|
+          ~H|<.line_chart id="c" data={[{0, 1}, {5, 2}]} step x_domain={{0, 10}} width={100} />|
         )
 
       # The last slot must reach the domain edge (x=100 in viewBox units),
@@ -171,7 +171,7 @@ defmodule PhoenixKitWeb.Components.Core.ChartTest do
     test "marker_x inside the domain renders a dashed marker" do
       assigns = %{}
 
-      html = render(~H|<.area_chart id="c" data={[{0, 1}, {10, 2}]} marker_x={5} />|)
+      html = render(~H|<.line_chart id="c" data={[{0, 1}, {10, 2}]} marker_x={5} />|)
 
       assert html =~ ~s(stroke-dasharray="4 4")
     end
@@ -179,7 +179,7 @@ defmodule PhoenixKitWeb.Components.Core.ChartTest do
     test "marker_x outside the domain is omitted" do
       assigns = %{}
 
-      html = render(~H|<.area_chart id="c" data={[{0, 1}, {10, 2}]} marker_x={99} />|)
+      html = render(~H|<.line_chart id="c" data={[{0, 1}, {10, 2}]} marker_x={99} />|)
 
       refute html =~ ~s(stroke-dasharray="4 4")
     end
@@ -187,7 +187,7 @@ defmodule PhoenixKitWeb.Components.Core.ChartTest do
     test "gridlines={0} disables gridlines" do
       assigns = %{}
 
-      html = render(~H|<.area_chart id="c" data={[{0, 1}, {1, 2}]} gridlines={0} />|)
+      html = render(~H|<.line_chart id="c" data={[{0, 1}, {1, 2}]} gridlines={0} />|)
 
       refute html =~ ~s(stroke-opacity="0.08")
     end
@@ -195,7 +195,7 @@ defmodule PhoenixKitWeb.Components.Core.ChartTest do
     test "area={false} omits the filled path" do
       assigns = %{}
 
-      html = render(~H|<.area_chart id="c" data={[{0, 1}, {1, 2}]} area={false} />|)
+      html = render(~H|<.line_chart id="c" data={[{0, 1}, {1, 2}]} area={false} />|)
 
       refute html =~ "url(#c-fill)"
     end
@@ -204,7 +204,7 @@ defmodule PhoenixKitWeb.Components.Core.ChartTest do
       assigns = %{}
 
       # Two charts on one page must not share a gradient def.
-      html = render(~H|<.area_chart id="left" data={[{0, 1}, {1, 2}]} />|)
+      html = render(~H|<.line_chart id="left" data={[{0, 1}, {1, 2}]} />|)
 
       assert html =~ ~s(id="left-fill")
       assert html =~ "url(#left-fill)"
@@ -213,7 +213,7 @@ defmodule PhoenixKitWeb.Components.Core.ChartTest do
     test "float data renders finite geometry" do
       assigns = %{}
 
-      html = render(~H|<.area_chart id="c" data={[{0.0, 1.5}, {1.25, 2.75}]} />|)
+      html = render(~H|<.line_chart id="c" data={[{0.0, 1.5}, {1.25, 2.75}]} />|)
 
       assert_finite_numbers(html)
     end
@@ -222,7 +222,7 @@ defmodule PhoenixKitWeb.Components.Core.ChartTest do
       assigns = %{}
       # {10, 0} used to drive the span negative; the 1.0e-9 floor then produced
       # coordinates around 1.0e12 and the chart simply vanished.
-      html = render(~H|<.area_chart id="c" data={[{0, 1}, {10, 2}]} x_domain={{10, 0}} />|)
+      html = render(~H|<.line_chart id="c" data={[{0, 1}, {10, 2}]} x_domain={{10, 0}} />|)
 
       assert_finite_numbers(html)
       assert_within_viewbox(html, 960, 240)
@@ -230,7 +230,7 @@ defmodule PhoenixKitWeb.Components.Core.ChartTest do
 
     test "a reversed y_domain is normalised rather than exploding off-canvas" do
       assigns = %{}
-      html = render(~H|<.area_chart id="c" data={[{0, 1}, {10, 2}]} y_domain={{5, 0}} />|)
+      html = render(~H|<.line_chart id="c" data={[{0, 1}, {10, 2}]} y_domain={{5, 0}} />|)
 
       assert_finite_numbers(html)
       assert_within_viewbox(html, 960, 240)
@@ -239,7 +239,7 @@ defmodule PhoenixKitWeb.Components.Core.ChartTest do
     test "unsorted data is drawn left-to-right" do
       assigns = %{}
       # Unsorted input rendered as a zigzag that reads like a chart bug.
-      html = render(~H|<.area_chart id="c" data={[{5, 1}, {0, 9}, {10, 2}]} />|)
+      html = render(~H|<.line_chart id="c" data={[{5, 1}, {0, 9}, {10, 2}]} />|)
 
       xs =
         stroked_path(html)
@@ -252,10 +252,135 @@ defmodule PhoenixKitWeb.Components.Core.ChartTest do
     test "carries an accessible name" do
       assigns = %{}
 
-      html = render(~H|<.area_chart id="c" data={[{0, 1}, {1, 2}]} label="Prices today" />|)
+      html = render(~H|<.line_chart id="c" data={[{0, 1}, {1, 2}]} aria_label="Prices today" />|)
 
       # role="img" without a name is an unlabelled graphic to a screen reader.
       assert html =~ "Prices today"
+    end
+  end
+
+  describe "data normalisation" do
+    test "one bad point never takes the page down" do
+      # A library primitive that raises mid-render kills the whole LiveView.
+      # Ecto hands callers Decimals; JSON hands them nils and strings.
+      assigns = %{}
+
+      for bad <- [nil, "12", :atom, %{}] do
+        assigns = Map.put(assigns, :bad, bad)
+
+        html =
+          render(~H|<.line_chart id="c" data={[{0, 1}, {1, @bad}, {2, 3}]} />|)
+
+        assert html =~ "<svg"
+        assert_finite_numbers(html)
+      end
+    end
+
+    test "Decimal values are plotted, not crashed on" do
+      assigns = %{
+        data: [{0, Decimal.new("1.5")}, {1, Decimal.new("2.75")}, {Decimal.new("2"), 3}]
+      }
+
+      html = render(~H|<.line_chart id="c" data={@data} />|)
+
+      assert html =~ "<svg"
+      assert_finite_numbers(html)
+    end
+
+    test "points may be maps as well as tuples" do
+      assigns = %{data: [%{x: 0, y: 1}, %{x: 1, y: 5}]}
+
+      html = render(~H|<.line_chart id="c" data={@data} />|)
+
+      assert html =~ "<svg"
+      assert_finite_numbers(html)
+    end
+
+    test "string-keyed maps work too" do
+      assigns = %{data: [%{"x" => 0, "y" => 1}, %{"x" => 1, "y" => 5}]}
+
+      assert render(~H|<.line_chart id="c" data={@data} />|) =~ "<svg"
+    end
+
+    test "when nothing is usable the :empty slot renders" do
+      assigns = %{}
+
+      html =
+        render(~H"""
+        <.line_chart id="c" data={[{nil, nil}, {"a", "b"}]}>
+          <:empty>No usable data</:empty>
+        </.line_chart>
+        """)
+
+      assert html =~ "No usable data"
+      refute html =~ "<svg"
+    end
+
+    test "bar data missing :value is dropped rather than raising" do
+      assigns = %{data: [%{label: "a"}, %{label: "b", value: 5}]}
+
+      html = render(~H|<.bar_chart id="b" data={@data} />|)
+
+      assert length(Regex.scan(~r/<rect/, html)) == 1
+    end
+
+    test "a non-numeric marker_x is ignored" do
+      assigns = %{}
+      html = render(~H|<.line_chart id="c" data={[{0, 1}, {10, 2}]} marker_x="noon" />|)
+
+      refute html =~ ~s(stroke-dasharray="4 4")
+    end
+  end
+
+  describe "bar_chart extras" do
+    test "each bar carries a native title tooltip" do
+      assigns = %{}
+
+      html =
+        render(~H|<.bar_chart id="b" data={[%{label: "Mon", value: 12}]} />|)
+
+      assert html =~ "<title>Mon: 12</title>"
+    end
+
+    test "a per-datum class colours a single bar" do
+      assigns = %{data: [%{label: "a", value: 1}, %{label: "b", value: 2, class: "text-error"}]}
+
+      assert render(~H|<.bar_chart id="b" data={@data} />|) =~ "text-error"
+    end
+
+    test "the zero baseline is drawn only when the data spans both signs" do
+      assigns = %{}
+
+      mixed =
+        render(
+          ~H|<.bar_chart id="b" data={[%{label: "a", value: -1}, %{label: "b", value: 2}]} />|
+        )
+
+      positive =
+        render(
+          ~H|<.bar_chart id="b" data={[%{label: "a", value: 1}, %{label: "b", value: 2}]} />|
+        )
+
+      assert mixed =~ ~s(stroke-opacity="0.25")
+      refute positive =~ ~s(stroke-opacity="0.25")
+    end
+
+    test "the svg carries the given id" do
+      assigns = %{}
+
+      assert render(~H|<.bar_chart id="daily" data={[%{label: "a", value: 1}]} />|) =~
+               ~s(id="daily")
+    end
+
+    test "labels are sized to their bar's slot, not spread edge-to-edge" do
+      # `justify-between` pinned the first and last labels to the container
+      # edges while the bars sit at slot centres.
+      assigns = %{data: Enum.map(1..3, &%{label: "d#{&1}", value: &1})}
+
+      html = render(~H|<.bar_chart id="b" data={@data} show_labels />|)
+
+      assert html =~ "width: 33.3%"
+      refute html =~ "justify-between"
     end
   end
 
@@ -269,11 +394,27 @@ defmodule PhoenixKitWeb.Components.Core.ChartTest do
       assert_finite_numbers(html)
     end
 
-    test "fewer than two values renders nothing" do
+    test "a single value draws a flat line rather than an empty box" do
+      # One sample is a real state; rendering nothing reads as a broken chart.
+      assigns = %{}
+      html = render(~H|<.sparkline values={[7]} />|)
+
+      assert html =~ "<polyline"
+      assert_finite_numbers(html)
+    end
+
+    test "no usable values renders the :empty slot" do
       assigns = %{}
 
-      assert render(~H|<.sparkline values={[1]} />|) |> String.trim() == ""
-      assert render(~H|<.sparkline values={[]} />|) |> String.trim() == ""
+      html =
+        render(~H"""
+        <.sparkline values={[]}>
+          <:empty>No trend</:empty>
+        </.sparkline>
+        """)
+
+      assert html =~ "No trend"
+      refute html =~ "<polyline"
     end
 
     test "identical values render finite geometry" do

--- a/test/phoenix_kit_web/components/core/chart_test.exs
+++ b/test/phoenix_kit_web/components/core/chart_test.exs
@@ -1,0 +1,331 @@
+defmodule PhoenixKitWeb.Components.Core.ChartTest do
+  @moduledoc """
+  These charts are server-rendered SVG, so the rendered markup IS the
+  output — geometry bugs are assertable without a browser.
+
+  The invariants worth protecting: never crash on the shapes real data
+  actually takes (empty, one point, flat, negative, huge), and never emit
+  SVG a browser will silently drop (negative `height`, `NaN` coordinates).
+  """
+  use ExUnit.Case, async: true
+
+  import Phoenix.Component, only: [sigil_H: 2]
+  import Phoenix.LiveViewTest, only: [rendered_to_string: 1]
+  import PhoenixKitWeb.Components.Core.Chart
+
+  # ~H expands where it is written and needs an `assigns` variable in scope.
+  # These components take no assigns of their own, so each test binds an empty
+  # map.
+  defp render(template), do: rendered_to_string(template)
+
+  # Every numeric attribute a browser parses. A stray NaN/Infinity makes the
+  # whole element vanish, so scan the actual attribute values rather than
+  # eyeballing the path string.
+  defp numeric_attrs(html) do
+    # The leading space matters: without it `viewBox="0 0 960 240"` matches as
+    # `x="..."`, because "viewBox" ends in an x.
+    ~r/\s(?:x|y|x1|y1|x2|y2|width|height|rx)="([^"]*)"/
+    |> Regex.scan(html)
+    |> Enum.map(&List.last/1)
+  end
+
+  defp path_numbers(html) do
+    ~r/[ML]([-\d.eE+]+),([-\d.eE+]+)/
+    |> Regex.scan(html)
+    |> Enum.flat_map(fn [_, x, y] -> [x, y] end)
+  end
+
+  # The `d` of the path that actually carries the stroke — the area fill path
+  # always contains an L (it closes to the baseline), so matching on any path
+  # would pass even when the line is a bare moveto that paints nothing.
+  defp stroked_path(html) do
+    case Regex.run(~r/<path[^>]*\sd="([^"]*)"[^>]*stroke="currentColor"/, html) do
+      [_, d] -> d
+      _ -> ""
+    end
+  end
+
+  defp assert_finite_numbers(html) do
+    for value <- numeric_attrs(html) ++ path_numbers(html) do
+      refute value =~ ~r/nan|inf/i, "non-finite number in rendered SVG: #{inspect(value)}"
+
+      case Float.parse(value) do
+        {_, ""} -> :ok
+        _ -> flunk("unparseable number in rendered SVG: #{inspect(value)}")
+      end
+    end
+  end
+
+  describe "area_chart/1" do
+    test "renders a line path for a simple series" do
+      assigns = %{}
+
+      html = render(~H|<.area_chart id="c" data={[{0, 1}, {1, 5}, {2, 3}]} />|)
+
+      assert html =~ "<svg"
+      assert html =~ ~s(stroke="currentColor")
+      assert stroked_path(html) =~ ~r/^M[\d.]+,[\d.]+ L/
+      assert_finite_numbers(html)
+    end
+
+    test "empty data renders the :empty slot and no svg" do
+      assigns = %{}
+
+      html =
+        render(~H"""
+        <.area_chart id="c" data={[]}>
+          <:empty>Nothing to show</:empty>
+        </.area_chart>
+        """)
+
+      assert html =~ "Nothing to show"
+      refute html =~ "<svg"
+    end
+
+    test "empty data without an :empty slot renders nothing rather than crashing" do
+      assigns = %{}
+
+      html = render(~H|<.area_chart id="c" data={[]} />|)
+
+      refute html =~ "<svg"
+    end
+
+    test "a single point does not crash and still draws something visible" do
+      assigns = %{}
+
+      # A lone "M x,y" is a valid path that paints NOTHING. Interval data of
+      # length one is a real case (first slot of the day), so it has to
+      # produce a visible mark.
+      html = render(~H|<.area_chart id="c" data={[{5, 10}]} />|)
+
+      assert html =~ "<svg"
+      assert_finite_numbers(html)
+
+      assert stroked_path(html) =~ ~r/^M[\d.]+,[\d.]+ L/,
+             "a lone moveto paints nothing; a single point must still draw a segment"
+    end
+
+    test "negative values render finite geometry" do
+      assigns = %{}
+
+      # Electricity prices go negative; this must not produce NaN or invert.
+      html = render(~H|<.area_chart id="c" data={[{0, -40}, {1, -10}, {2, 25}]} />|)
+
+      assert_finite_numbers(html)
+    end
+
+    test "a completely flat series renders finite geometry" do
+      assigns = %{}
+
+      html = render(~H|<.area_chart id="c" data={[{0, 7}, {1, 7}, {2, 7}]} />|)
+
+      assert_finite_numbers(html)
+    end
+
+    test "an explicit zero-span y_domain does not divide by zero" do
+      assigns = %{}
+
+      html = render(~H|<.area_chart id="c" data={[{0, 5}, {1, 5}]} y_domain={{5, 5}} />|)
+
+      assert_finite_numbers(html)
+    end
+
+    test "step mode holds each y until the next x" do
+      assigns = %{}
+
+      html =
+        render(~H|<.area_chart id="c" data={[{0, 0}, {10, 100}]} step y_domain={{0, 100}} />|)
+
+      # Two points become four in step mode: hold, then jump.
+      assert length(path_numbers(html)) >= 8
+      assert_finite_numbers(html)
+    end
+
+    test "step mode extends the final slot to the x domain's right edge" do
+      assigns = %{}
+
+      html =
+        render(
+          ~H|<.area_chart id="c" data={[{0, 1}, {5, 2}]} step x_domain={{0, 10}} width={100} />|
+        )
+
+      # The last slot must reach the domain edge (x=100 in viewBox units),
+      # not stop at the last data x (x=50).
+      assert html =~ ~r/L100(?:\.0)?,/
+      assert_finite_numbers(html)
+    end
+
+    test "marker_x inside the domain renders a dashed marker" do
+      assigns = %{}
+
+      html = render(~H|<.area_chart id="c" data={[{0, 1}, {10, 2}]} marker_x={5} />|)
+
+      assert html =~ ~s(stroke-dasharray="4 4")
+    end
+
+    test "marker_x outside the domain is omitted" do
+      assigns = %{}
+
+      html = render(~H|<.area_chart id="c" data={[{0, 1}, {10, 2}]} marker_x={99} />|)
+
+      refute html =~ ~s(stroke-dasharray="4 4")
+    end
+
+    test "gridlines={0} disables gridlines" do
+      assigns = %{}
+
+      html = render(~H|<.area_chart id="c" data={[{0, 1}, {1, 2}]} gridlines={0} />|)
+
+      refute html =~ ~s(stroke-opacity="0.08")
+    end
+
+    test "area={false} omits the filled path" do
+      assigns = %{}
+
+      html = render(~H|<.area_chart id="c" data={[{0, 1}, {1, 2}]} area={false} />|)
+
+      refute html =~ "url(#c-fill)"
+    end
+
+    test "the gradient id is namespaced by the component id" do
+      assigns = %{}
+
+      # Two charts on one page must not share a gradient def.
+      html = render(~H|<.area_chart id="left" data={[{0, 1}, {1, 2}]} />|)
+
+      assert html =~ ~s(id="left-fill")
+      assert html =~ "url(#left-fill)"
+    end
+
+    test "float data renders finite geometry" do
+      assigns = %{}
+
+      html = render(~H|<.area_chart id="c" data={[{0.0, 1.5}, {1.25, 2.75}]} />|)
+
+      assert_finite_numbers(html)
+    end
+
+    test "carries an accessible name" do
+      assigns = %{}
+
+      html = render(~H|<.area_chart id="c" data={[{0, 1}, {1, 2}]} label="Prices today" />|)
+
+      # role="img" without a name is an unlabelled graphic to a screen reader.
+      assert html =~ "Prices today"
+    end
+  end
+
+  describe "sparkline/1" do
+    test "renders a polyline for a list of values" do
+      assigns = %{}
+
+      html = render(~H|<.sparkline values={[1, 5, 2, 8]} />|)
+
+      assert html =~ "<polyline"
+      assert_finite_numbers(html)
+    end
+
+    test "fewer than two values renders nothing" do
+      assigns = %{}
+
+      assert render(~H|<.sparkline values={[1]} />|) |> String.trim() == ""
+      assert render(~H|<.sparkline values={[]} />|) |> String.trim() == ""
+    end
+
+    test "identical values render finite geometry" do
+      assigns = %{}
+
+      html = render(~H|<.sparkline values={[3, 3, 3]} />|)
+
+      assert_finite_numbers(html)
+    end
+
+    test "negative values render finite geometry" do
+      assigns = %{}
+
+      html = render(~H|<.sparkline values={[-5, -1, -9]} />|)
+
+      assert_finite_numbers(html)
+    end
+  end
+
+  describe "bar_chart/1" do
+    test "renders one rect per datum" do
+      assigns = %{}
+
+      html =
+        render(
+          ~H|<.bar_chart id="b" data={[%{label: "a", value: 1}, %{label: "b", value: 2}]} />|
+        )
+
+      assert length(Regex.scan(~r/<rect/, html)) == 2
+      assert_finite_numbers(html)
+    end
+
+    test "empty data renders the :empty slot" do
+      assigns = %{}
+
+      html =
+        render(~H"""
+        <.bar_chart id="b" data={[]}>
+          <:empty>No bars</:empty>
+        </.bar_chart>
+        """)
+
+      assert html =~ "No bars"
+      refute html =~ "<rect"
+    end
+
+    test "negative values never produce a negative rect height" do
+      assigns = %{}
+
+      # SVG drops a rect with negative height entirely — the bar silently
+      # disappears instead of rendering below a baseline.
+      html =
+        render(
+          ~H|<.bar_chart id="b" data={[%{label: "a", value: -5}, %{label: "b", value: 10}]} />|
+        )
+
+      for [_, h] <- Regex.scan(~r/height="([^"]*)"/, html) do
+        {value, ""} = Float.parse(h)
+        assert value >= 0, "negative rect height would render nothing: #{h}"
+      end
+
+      assert_finite_numbers(html)
+    end
+
+    test "all-zero values render finite geometry" do
+      assigns = %{}
+
+      html =
+        render(
+          ~H|<.bar_chart id="b" data={[%{label: "a", value: 0}, %{label: "b", value: 0}]} />|
+        )
+
+      assert_finite_numbers(html)
+    end
+
+    test "all-negative values render finite geometry" do
+      assigns = %{}
+
+      html =
+        render(
+          ~H|<.bar_chart id="b" data={[%{label: "a", value: -3}, %{label: "b", value: -8}]} />|
+        )
+
+      assert_finite_numbers(html)
+    end
+
+    test "show_labels renders one label per bar" do
+      assigns = %{}
+
+      html =
+        render(
+          ~H|<.bar_chart id="b" data={[%{label: "Mon", value: 1}, %{label: "Tue", value: 2}]} show_labels />|
+        )
+
+      assert html =~ "Mon"
+      assert html =~ "Tue"
+    end
+  end
+end

--- a/test/phoenix_kit_web/components/core/chart_test.exs
+++ b/test/phoenix_kit_web/components/core/chart_test.exs
@@ -45,6 +45,19 @@ defmodule PhoenixKitWeb.Components.Core.ChartTest do
     end
   end
 
+  # Coordinates far outside the viewBox mean the chart is invisible even though
+  # the numbers are technically finite.
+  defp assert_within_viewbox(html, width, height) do
+    limit = max(width, height) * 10
+
+    for value <- path_numbers(html) do
+      {n, ""} = Float.parse(value)
+
+      assert abs(n) <= limit,
+             "coordinate #{n} is far outside the #{width}x#{height} viewBox"
+    end
+  end
+
   defp assert_finite_numbers(html) do
     for value <- numeric_attrs(html) ++ path_numbers(html) do
       refute value =~ ~r/nan|inf/i, "non-finite number in rendered SVG: #{inspect(value)}"
@@ -203,6 +216,37 @@ defmodule PhoenixKitWeb.Components.Core.ChartTest do
       html = render(~H|<.area_chart id="c" data={[{0.0, 1.5}, {1.25, 2.75}]} />|)
 
       assert_finite_numbers(html)
+    end
+
+    test "a reversed x_domain is normalised rather than exploding off-canvas" do
+      assigns = %{}
+      # {10, 0} used to drive the span negative; the 1.0e-9 floor then produced
+      # coordinates around 1.0e12 and the chart simply vanished.
+      html = render(~H|<.area_chart id="c" data={[{0, 1}, {10, 2}]} x_domain={{10, 0}} />|)
+
+      assert_finite_numbers(html)
+      assert_within_viewbox(html, 960, 240)
+    end
+
+    test "a reversed y_domain is normalised rather than exploding off-canvas" do
+      assigns = %{}
+      html = render(~H|<.area_chart id="c" data={[{0, 1}, {10, 2}]} y_domain={{5, 0}} />|)
+
+      assert_finite_numbers(html)
+      assert_within_viewbox(html, 960, 240)
+    end
+
+    test "unsorted data is drawn left-to-right" do
+      assigns = %{}
+      # Unsorted input rendered as a zigzag that reads like a chart bug.
+      html = render(~H|<.area_chart id="c" data={[{5, 1}, {0, 9}, {10, 2}]} />|)
+
+      xs =
+        stroked_path(html)
+        |> then(&Regex.scan(~r/[ML]([-\d.eE+]+),/, &1))
+        |> Enum.map(fn [_, x] -> elem(Float.parse(x), 0) end)
+
+      assert xs == Enum.sort(xs), "points must be drawn in ascending x order, got: #{inspect(xs)}"
     end
 
     test "carries an accessible name" do

--- a/test/phoenix_kit_web/components/core/chart_test.exs
+++ b/test/phoenix_kit_web/components/core/chart_test.exs
@@ -68,6 +68,33 @@ defmodule PhoenixKitWeb.Components.Core.ChartTest do
     end
   end
 
+  # A path whose endpoints coincide is syntactically a segment and visually
+  # nothing at all — which is exactly how a broken single-point chart passed.
+  defp assert_visible_segment(html) do
+    xs =
+      stroked_path(html)
+      |> then(&Regex.scan(~r/[ML]([-\d.eE+]+),/, &1))
+      |> Enum.map(fn [_, x] -> elem(Float.parse(x), 0) end)
+
+    assert length(Enum.uniq(xs)) > 1,
+           "the stroked path has zero length, so it paints nothing: #{inspect(xs)}"
+  end
+
+  # A rect outside the viewBox is clipped away, so "height > 0" is not the same
+  # as "visible" — the hairline floor pushed zero bars to height..height+1.
+  defp assert_bars_within_viewbox(html, view_height) do
+    rects = Regex.scan(~r/\sy="([\d.-]+)" width="[\d.]+" height="([\d.]+)"/, html)
+    assert rects != [], "no bars found"
+
+    for [_, y, h] <- rects do
+      {y, ""} = Float.parse(y)
+      {h, ""} = Float.parse(h)
+
+      assert y >= 0 and y + h <= view_height,
+             "bar spans #{y}..#{y + h}, outside the 0..#{view_height} viewBox"
+    end
+  end
+
   defp assert_finite_numbers(html) do
     values = numeric_attrs(html) ++ path_numbers(html) ++ polyline_numbers(html)
 
@@ -130,8 +157,28 @@ defmodule PhoenixKitWeb.Components.Core.ChartTest do
       assert html =~ "<svg"
       assert_finite_numbers(html)
 
-      assert stroked_path(html) =~ ~r/^M[\d.]+,[\d.]+ L/,
-             "a lone moveto paints nothing; a single point must still draw a segment"
+      # Assert the OUTCOME, not the shape of the markup: `M0,120 L0,120`
+      # satisfies a "has a segment" regex perfectly and paints nothing at all.
+      assert_visible_segment(html)
+    end
+
+    test "a single point is visible under the default (auto) domain too" do
+      assigns = %{}
+
+      # The auto domain collapses x_min == x_max, so every x maps to 0 — the
+      # configuration nearly every caller uses was the one that stayed blank.
+      for opts <- [%{}, %{step: true}] do
+        assigns = Map.merge(assigns, opts)
+
+        html =
+          if assigns[:step] do
+            render(~H|<.line_chart id="c" data={[{5, 3}]} step />|)
+          else
+            render(~H|<.line_chart id="c" data={[{5, 3}]} />|)
+          end
+
+        assert_visible_segment(html)
+      end
     end
 
     test "negative values render finite geometry" do
@@ -333,6 +380,20 @@ defmodule PhoenixKitWeb.Components.Core.ChartTest do
       assert xs.(with_hole) == xs.(without) -- ["100.0"]
     end
 
+    test "large-magnitude flat series keep their padding" do
+      # An absolute 1.0e-9 pad is below one ULP past ~1e7, so the 10% padding
+      # evaporated and the series sank onto the axis with its stroke clipped.
+      assigns = %{}
+      html = render(~H|<.sparkline values={[3.0e7, 3.0e7, 3.0e7]} />|)
+
+      [_, pts] = Regex.run(~r/points="([^"]*)"/, html)
+
+      {y, ""} =
+        pts |> String.split(" ") |> hd() |> String.split(",") |> List.last() |> Float.parse()
+
+      assert y > 8 and y < 40, "large flat series should still centre, got y=#{y}"
+    end
+
     test "a flat sparkline centres rather than sitting on the floor" do
       assigns = %{}
       html = render(~H|<.sparkline values={[3, 3, 3]} />|)
@@ -483,10 +544,9 @@ defmodule PhoenixKitWeb.Components.Core.ChartTest do
           ~H|<.bar_chart id="b" data={[%{label: "a", value: 0}, %{label: "b", value: 0}]} />|
         )
 
-      for [_, h] <- Regex.scan(~r/height="([^"]*)"/, html) do
-        {value, ""} = Float.parse(h)
-        assert value > 0
-      end
+      # `height > 0` was true the whole time — the rect was simply drawn just
+      # below the viewBox and clipped away.
+      assert_bars_within_viewbox(html, 200)
     end
 
     test "tooltip values are formatted for humans, not float noise" do
@@ -507,6 +567,15 @@ defmodule PhoenixKitWeb.Components.Core.ChartTest do
       assert html =~ "<title>whole: 12</title>"
       assert html =~ "<title>int: 7</title>"
       assert html =~ "<title>money: 12.3</title>"
+    end
+
+    test "a label without String.Chars does not crash the render" do
+      # `:label` is documented as `term` and the tuple form accepts anything,
+      # so interpolating it raised Protocol.UndefinedError and took the page
+      # down over a label.
+      assigns = %{data: [%{label: {:a, :b}, value: 1}, %{label: %{k: 1}, value: 2}]}
+
+      assert render(~H|<.bar_chart id="b" data={@data} />|) =~ "<rect"
     end
 
     test "a per-datum class colours a single bar" do
@@ -559,6 +628,17 @@ defmodule PhoenixKitWeb.Components.Core.ChartTest do
 
       assert html =~ "<polyline"
       assert_finite_numbers(html)
+    end
+
+    test "a zero value among positives stays inside the viewBox" do
+      assigns = %{}
+
+      html =
+        render(
+          ~H|<.bar_chart id="b" data={[%{label: "a", value: 0}, %{label: "b", value: 5}]} />|
+        )
+
+      assert_bars_within_viewbox(html, 200)
     end
 
     test "a single value draws a flat line rather than an empty box" do
@@ -643,6 +723,7 @@ defmodule PhoenixKitWeb.Components.Core.ChartTest do
         assert value >= 0, "negative rect height would render nothing: #{h}"
       end
 
+      assert_bars_within_viewbox(html, 200)
       assert_finite_numbers(html)
     end
 

--- a/test/phoenix_kit_web/components/core/chart_test.exs
+++ b/test/phoenix_kit_web/components/core/chart_test.exs
@@ -68,16 +68,29 @@ defmodule PhoenixKitWeb.Components.Core.ChartTest do
     end
   end
 
-  # A path whose endpoints coincide is syntactically a segment and visually
+  # A path whose points all coincide is syntactically a path and visually
   # nothing at all — which is exactly how a broken single-point chart passed.
-  defp assert_visible_segment(html) do
-    xs =
+  # A dot counts: it is what a lone point renders as, and it paints.
+  defp assert_visible_mark(html) do
+    points =
       stroked_path(html)
-      |> then(&Regex.scan(~r/[ML]([-\d.eE+]+),/, &1))
-      |> Enum.map(fn [_, x] -> elem(Float.parse(x), 0) end)
+      |> then(&Regex.scan(~r/[ML]([-\d.eE+]+),([-\d.eE+]+)/, &1))
+      |> Enum.map(fn [_, x, y] -> {x, y} end)
+      |> Enum.uniq()
 
-    assert length(Enum.uniq(xs)) > 1,
-           "the stroked path has zero length, so it paints nothing: #{inspect(xs)}"
+    assert length(points) > 1 or html =~ "<circle",
+           "nothing is painted: the path collapses to #{inspect(points)} and there is no dot"
+  end
+
+  # A dot placed off-canvas paints nothing either, so single-point charts have
+  # to prove the mark is where a viewer can see it.
+  defp assert_dot_within_viewbox(html, width, height) do
+    [_, cx, cy] = Regex.run(~r/<circle[^>]*cx="([\d.-]+)"[^>]*cy="([\d.-]+)"/, html)
+    {cx, ""} = Float.parse(cx)
+    {cy, ""} = Float.parse(cy)
+
+    assert cx >= 0 and cx <= width and cy >= 0 and cy <= height,
+           "the dot sits at #{cx},#{cy}, outside the #{width}x#{height} viewBox"
   end
 
   # A rect outside the viewBox is clipped away, so "height > 0" is not the same
@@ -159,7 +172,8 @@ defmodule PhoenixKitWeb.Components.Core.ChartTest do
 
       # Assert the OUTCOME, not the shape of the markup: `M0,120 L0,120`
       # satisfies a "has a segment" regex perfectly and paints nothing at all.
-      assert_visible_segment(html)
+      assert_visible_mark(html)
+      assert_dot_within_viewbox(html, 960, 240)
     end
 
     test "a single point is visible under the default (auto) domain too" do
@@ -177,8 +191,64 @@ defmodule PhoenixKitWeb.Components.Core.ChartTest do
             render(~H|<.line_chart id="c" data={[{5, 3}]} />|)
           end
 
-        assert_visible_segment(html)
+        assert_visible_mark(html)
+        # A collapsed domain has no left or right, so the mark belongs at the
+        # centre — pinned to x=0 half its stroke falls outside the viewBox.
+        assert_dot_within_viewbox(html, 960, 240)
       end
+    end
+
+    test "two points sharing an x keep both values" do
+      # Widening a collapsed x-span into a full-width horizontal line kept only
+      # the first y and silently dropped the second — a plausible-looking flat
+      # line with half the data missing, and no :empty slot to signal it.
+      assigns = %{}
+      html = render(~H|<.line_chart id="c" data={[{5, 10}, {5, 90}]} y_domain={{0, 100}} />|)
+
+      ys =
+        stroked_path(html)
+        |> then(&Regex.scan(~r/[ML][\d.-]+,([\d.-]+)/, &1))
+        |> Enum.map(fn [_, y] -> y end)
+        |> Enum.uniq()
+
+      assert length(ys) == 2, "both values must be plotted, got #{inspect(ys)}"
+    end
+
+    test "a series with a small range on a huge baseline still shows its shape" do
+      # Padding by a fraction of the MAGNITUDE swamped the range: 1.0e12-scale
+      # counters differing by 100 flattened onto one row of pixels.
+      assigns = %{}
+
+      html =
+        render(
+          ~H|<.line_chart id="c" data={[{0, 1.0e12}, {1, 1.0e12 + 50}, {2, 1.0e12 + 100}]} />|
+        )
+
+      ys =
+        stroked_path(html)
+        |> then(&Regex.scan(~r/[ML][\d.-]+,([\d.-]+)/, &1))
+        |> Enum.map(fn [_, y] -> y end)
+        |> Enum.uniq()
+
+      assert length(ys) > 1, "real variation collapsed to a flat line: #{inspect(ys)}"
+    end
+
+    test "a datum outside an explicit domain is not painted across the chart" do
+      # Widening a zero-length path asserted the value across the whole domain
+      # for a sample that is not in it. Out-of-domain data belongs off-canvas.
+      assigns = %{}
+      html = render(~H|<.line_chart id="c" data={[{150, 5}]} step x_domain={{0, 100}} />|)
+
+      [_, cx] = Regex.run(~r/<circle[^>]*cx="([\d.-]+)"/, html)
+      {cx, ""} = Float.parse(cx)
+
+      assert cx > 960, "an out-of-domain point was drawn inside the viewBox at #{cx}"
+    end
+
+    test "values at the float ceiling do not crash the render" do
+      assigns = %{}
+
+      assert render(~H|<.line_chart id="c" data={[{0, 1.7976931348623157e308}]} />|) =~ "<svg"
     end
 
     test "negative values render finite geometry" do
@@ -576,6 +646,22 @@ defmodule PhoenixKitWeb.Components.Core.ChartTest do
       assigns = %{data: [%{label: {:a, :b}, value: 1}, %{label: %{k: 1}, value: 2}]}
 
       assert render(~H|<.bar_chart id="b" data={@data} />|) =~ "<rect"
+    end
+
+    test "a small negative among large positives stays inside the viewBox" do
+      # The baseline lands ON the bottom edge here, so a hairline hung from it
+      # spanned height..height+1 — clipped away, and the datum vanished.
+      assigns = %{data: [%{label: "a", value: 1.0e6}, %{label: "b", value: -1}]}
+
+      assert_bars_within_viewbox(render(~H|<.bar_chart id="b" data={@data} />|), 200)
+    end
+
+    test "a visible label without String.Chars does not crash the render" do
+      # The tooltip path was guarded but the rendered label was not, so
+      # show_labels turned the same bad datum back into a page crash.
+      assigns = %{data: [%{label: [date: "2026-07-29"], value: 5}]}
+
+      assert render(~H|<.bar_chart id="b" data={@data} show_labels />|) =~ "<rect"
     end
 
     test "a per-datum class colours a single bar" do

--- a/test/phoenix_kit_web/components/core/chart_test.exs
+++ b/test/phoenix_kit_web/components/core/chart_test.exs
@@ -342,6 +342,26 @@ defmodule PhoenixKitWeb.Components.Core.ChartTest do
       assert html =~ "<title>Mon: 12</title>"
     end
 
+    test "tooltip values are formatted for humans, not float noise" do
+      # A computed value like 0.1 + 0.2 renders as 0.30000000000000004
+      # unformatted, which is what a tooltip would have shown.
+      assigns = %{
+        data: [
+          %{label: "computed", value: 0.1 + 0.2},
+          %{label: "whole", value: 12.0},
+          %{label: "int", value: 7},
+          %{label: "money", value: Decimal.new("12.30")}
+        ]
+      }
+
+      html = render(~H|<.bar_chart id="b" data={@data} />|)
+
+      assert html =~ "<title>computed: 0.3</title>"
+      assert html =~ "<title>whole: 12</title>"
+      assert html =~ "<title>int: 7</title>"
+      assert html =~ "<title>money: 12.3</title>"
+    end
+
     test "a per-datum class colours a single bar" do
       assigns = %{data: [%{label: "a", value: 1}, %{label: "b", value: 2, class: "text-error"}]}
 

--- a/test/phoenix_kit_web/components/core/connect_account_button_test.exs
+++ b/test/phoenix_kit_web/components/core/connect_account_button_test.exs
@@ -27,7 +27,7 @@ defmodule PhoenixKitWeb.Components.Core.ConnectAccountButtonTest do
 
     html = render(~H|<.connect_account_button href="/oauth/start">Go</.connect_account_button>|)
 
-    assert html =~ ~s(phx-hook="ConnectAccountPopup")
+    assert html =~ ~s(phx-hook="PopupLink")
     refute html =~ "onclick"
     refute html =~ "window.open"
   end

--- a/test/phoenix_kit_web/components/core/connect_account_button_test.exs
+++ b/test/phoenix_kit_web/components/core/connect_account_button_test.exs
@@ -1,0 +1,139 @@
+defmodule PhoenixKitWeb.Components.Core.ConnectAccountButtonTest do
+  use ExUnit.Case, async: true
+
+  import Phoenix.Component, only: [sigil_H: 2]
+  import Phoenix.LiveViewTest, only: [rendered_to_string: 1]
+  import PhoenixKitWeb.Components.Core.ConnectAccountButton
+
+  defp render(template), do: rendered_to_string(template)
+
+  test "renders a real anchor carrying the href" do
+    # Progressive enhancement rests on this: with JS off or the popup blocked,
+    # the plain navigation still starts the OAuth flow.
+    assigns = %{}
+
+    html =
+      render(~H|<.connect_account_button href="/oauth/start">Connect</.connect_account_button>|)
+
+    assert html =~ ~s(href="/oauth/start")
+    assert html =~ "<a"
+    assert html =~ "Connect"
+  end
+
+  test "drives the popup from a hook, never an inline handler" do
+    # An inline onclick is CSP-hostile, and the kit removed inline handlers
+    # everywhere else for that reason.
+    assigns = %{}
+
+    html = render(~H|<.connect_account_button href="/oauth/start">Go</.connect_account_button>|)
+
+    assert html =~ ~s(phx-hook="ConnectAccountPopup")
+    refute html =~ "onclick"
+    refute html =~ "window.open"
+  end
+
+  test "popup geometry travels as data attributes, not interpolated script" do
+    assigns = %{}
+
+    html =
+      render(~H"""
+      <.connect_account_button
+        href="/oauth/start"
+        window_name="shelly"
+        window_width={500}
+        window_height={700}
+      >
+        Go
+      </.connect_account_button>
+      """)
+
+    assert html =~ ~s(data-window-name="shelly")
+    assert html =~ ~s(data-window-width="500")
+    assert html =~ ~s(data-window-height="700")
+  end
+
+  test "a phx-hook element always has an id" do
+    # LiveView refuses to attach a hook to an element without one.
+    assigns = %{}
+
+    html = render(~H|<.connect_account_button href="/oauth/start">Go</.connect_account_button>|)
+
+    assert html =~ ~r/id="[^"]+"/
+  end
+
+  test "an explicit id wins over the derived default" do
+    assigns = %{}
+
+    html =
+      render(
+        ~H|<.connect_account_button href="/oauth/start" id="my-btn">Go</.connect_account_button>|
+      )
+
+    assert html =~ ~s(id="my-btn")
+  end
+
+  test "a window name with a quote cannot break out of an attribute" do
+    # The old version interpolated this straight into a JS string literal.
+    assigns = %{hostile: "x'); alert(1);//"}
+
+    html =
+      render(~H"""
+      <.connect_account_button href="/oauth/start" window_name={@hostile}>Go</.connect_account_button>
+      """)
+
+    # The payload may appear as inert, escaped attribute TEXT — what matters is
+    # that it never reaches an executable context and never lands unescaped.
+    refute html =~ "onclick"
+    refute html =~ "<script"
+    refute html =~ ~s(window_name="x';)
+    assert html =~ "&#39;", "the quote must be escaped, not emitted raw"
+
+    # The derived DOM id has to stay usable by querySelector.
+    [_, id] = Regex.run(~r/id="([^"]*)"/, html)
+    assert id =~ ~r/^[a-zA-Z0-9_-]+$/, "unusable derived id: #{inspect(id)}"
+  end
+
+  test "refuses a cross-origin href" do
+    # The popup keeps window.opener so the callback can refresh the opener;
+    # pointing it off-origin would hand that reference to a third party.
+    assigns = %{}
+
+    assert_raise ArgumentError, ~r/local path/, fn ->
+      render(
+        ~H|<.connect_account_button href="https://evil.example/start">Go</.connect_account_button>|
+      )
+    end
+  end
+
+  test "refuses a protocol-relative href" do
+    assigns = %{}
+
+    assert_raise ArgumentError, ~r/local path/, fn ->
+      render(
+        ~H|<.connect_account_button href="//evil.example/start">Go</.connect_account_button>|
+      )
+    end
+  end
+
+  test "custom classes replace the default button styling" do
+    assigns = %{}
+
+    html =
+      render(
+        ~H|<.connect_account_button href="/oauth/start" class="btn btn-outline">Go</.connect_account_button>|
+      )
+
+    assert html =~ "btn-outline"
+  end
+
+  test "global attributes pass through" do
+    assigns = %{}
+
+    html =
+      render(
+        ~H|<.connect_account_button href="/oauth/start" aria-label="Connect Shelly">Go</.connect_account_button>|
+      )
+
+    assert html =~ ~s(aria-label="Connect Shelly")
+  end
+end

--- a/test/phoenix_kit_web/components/core/connect_account_button_test.exs
+++ b/test/phoenix_kit_web/components/core/connect_account_button_test.exs
@@ -58,7 +58,8 @@ defmodule PhoenixKitWeb.Components.Core.ConnectAccountButtonTest do
 
     html = render(~H|<.connect_account_button href="/oauth/start">Go</.connect_account_button>|)
 
-    assert html =~ ~r/id="[^"]+"/
+    # `~r/id="[^"]+"/` was satisfied by any *-id attribute; pin the real one.
+    assert html =~ ~r/\sid="pk-connect-[a-zA-Z0-9_-]+"/
   end
 
   test "an explicit id wins over the derived default" do

--- a/test/phoenix_kit_web/components/core/stat_card_test.exs
+++ b/test/phoenix_kit_web/components/core/stat_card_test.exs
@@ -1,0 +1,78 @@
+defmodule PhoenixKitWeb.Components.Core.StatCardTest do
+  use ExUnit.Case, async: true
+
+  import Phoenix.Component, only: [sigil_H: 2]
+  import Phoenix.LiveViewTest, only: [rendered_to_string: 1]
+  import PhoenixKitWeb.Components.Core.StatCard
+
+  defp render(template), do: rendered_to_string(template)
+
+  defp card(assigns) do
+    ~H"""
+    <.stat_card value="42" title="Users" subtitle="Total" value_color={@color} compact={@compact}>
+      <:icon>i</:icon>
+    </.stat_card>
+    """
+  end
+
+  test "no value_color leaves the value unstyled" do
+    for compact <- [true, false] do
+      assigns = %{color: nil, compact: compact}
+      refute render(card(assigns)) =~ "style="
+    end
+  end
+
+  test "a colour is applied in both layouts" do
+    for compact <- [true, false] do
+      assigns = %{color: "hsl(140 85% 55%)", compact: compact}
+      assert render(card(assigns)) =~ "color: hsl(140 85% 55%)"
+    end
+  end
+
+  test "modern colour syntaxes survive intact" do
+    for color <- [
+          "var(--brand)",
+          "oklch(0.7 0.1 250)",
+          "color-mix(in srgb, red, blue)",
+          "#ff0000"
+        ] do
+      assigns = %{color: color, compact: false}
+      assert render(card(assigns)) =~ "color: #{color}"
+    end
+  end
+
+  test "a semicolon cannot append a second declaration" do
+    # These values are typically computed from data; one stray `;` would
+    # otherwise let the value write arbitrary CSS onto the element.
+    assigns = %{color: "red; background: url(http://evil.example/x)", compact: false}
+    html = render(card(assigns))
+
+    [_, style] = Regex.run(~r/style="([^"]*)"/, html)
+
+    # One declaration only. What remains is a single malformed `color` value,
+    # which the browser discards outright — the injected property never
+    # applies and its url() is never fetched.
+    refute style =~ ";", "the style attribute must not contain a second declaration"
+    assert String.starts_with?(style, "color: ")
+  end
+
+  test "a quote cannot break out of the style attribute" do
+    hostile = "red\" onmouseover=\"alert(1)"
+    assigns = %{color: hostile, compact: false}
+    html = render(card(assigns))
+
+    # The payload survives as escaped TEXT inside the style value; what must
+    # not happen is it becoming a real attribute. A leading space before the
+    # name is what would distinguish an actual breakout.
+    # The style attribute must remain ONE well-formed attribute whose value
+    # contains no raw quote — that is what a breakout would need.
+    [_, style] = Regex.run(~r/style="([^"]*)"/, html)
+    refute style =~ ~s("), "raw quote inside the style value would end the attribute early"
+    assert html =~ "&quot;", "the quote must be escaped, not emitted raw"
+  end
+
+  test "a blank colour renders no style attribute" do
+    assigns = %{color: "   ", compact: false}
+    refute render(card(assigns)) =~ "style="
+  end
+end

--- a/test/phoenix_kit_web/components/core/stat_card_test.exs
+++ b/test/phoenix_kit_web/components/core/stat_card_test.exs
@@ -75,4 +75,31 @@ defmodule PhoenixKitWeb.Components.Core.StatCardTest do
     assigns = %{color: "   ", compact: false}
     refute render(card(assigns)) =~ "style="
   end
+
+  test "the rounded attr is applied, as a literal class" do
+    # It was declared and documented for a long time while the class was
+    # hardcoded. The mapping must emit literal class names: Tailwind scans
+    # SOURCE, so an interpolated `rounded-#{token}` produces markup whose CSS
+    # was never generated.
+    assigns = %{color: nil, compact: false}
+
+    default =
+      render(~H"""
+      <.stat_card value="1" title="t" subtitle="s">
+        <:icon>i</:icon>
+      </.stat_card>
+      """)
+
+    assert default =~ "rounded-box"
+
+    custom =
+      render(~H"""
+      <.stat_card value="1" title="t" subtitle="s" rounded="full">
+        <:icon>i</:icon>
+      </.stat_card>
+      """)
+
+    assert custom =~ "rounded-full"
+    refute custom =~ "rounded-box shadow"
+  end
 end

--- a/test/phoenix_kit_web/components/core/status_dot_test.exs
+++ b/test/phoenix_kit_web/components/core/status_dot_test.exs
@@ -80,12 +80,51 @@ defmodule PhoenixKitWeb.Components.Core.StatusDotTest do
     assert render(~H|<.status_dot up={true} class="ml-2" />|) =~ "ml-2"
   end
 
-  test "the dot alone is not announced as text to a screen reader" do
-    # A bare coloured circle carries meaning only visually; without a label
-    # there must be nothing for assistive tech to read out as content.
+  test "an unlabelled dot still names its state for assistive tech" do
+    # Colour alone is silent to a screen reader and indistinguishable to
+    # red/green colour-blind users, so the state gets a visually-hidden name.
     assigns = %{}
-    html = render(~H|<.status_dot up={false} />|)
 
-    assert html |> String.replace(~r/<[^>]*>/, "") |> String.trim() == ""
+    assert render(~H|<.status_dot up={false} />|) =~ "offline"
+    assert render(~H|<.status_dot up={true} />|) =~ "online"
+    assert render(~H|<.status_dot variant={:warning} />|) =~ "warning"
+    assert render(~H|<.status_dot up={false} />|) =~ "sr-only"
+  end
+
+  test "a visible label is not duplicated by a hidden one" do
+    assigns = %{}
+    html = render(~H|<.status_dot up={false} label="offline" />|)
+
+    refute html =~ "sr-only"
+  end
+
+  test "the announced state matches the colour shown" do
+    assigns = %{}
+
+    for {variant, colour, word} <- [
+          {:success, "bg-success", "ok"},
+          {:error, "bg-error", "error"},
+          {:info, "bg-info", "info"},
+          {:neutral, "bg-neutral", "inactive"}
+        ] do
+      assigns = Map.put(assigns, :variant, variant)
+      html = render(~H|<.status_dot variant={@variant} />|)
+
+      assert html =~ colour
+      assert html =~ word
+    end
+  end
+
+  test "the pulse animation respects reduced-motion preferences" do
+    assigns = %{}
+
+    assert render(~H|<.status_dot variant={:info} pulse />|) =~ "motion-safe:animate-ping"
+  end
+
+  test "global attributes reach the wrapper" do
+    assigns = %{}
+
+    assert render(~H|<.status_dot up={true} aria-label="Device state" />|) =~
+             ~s(aria-label="Device state")
   end
 end

--- a/test/phoenix_kit_web/components/core/status_dot_test.exs
+++ b/test/phoenix_kit_web/components/core/status_dot_test.exs
@@ -1,0 +1,91 @@
+defmodule PhoenixKitWeb.Components.Core.StatusDotTest do
+  use ExUnit.Case, async: true
+
+  import Phoenix.Component, only: [sigil_H: 2]
+  import Phoenix.LiveViewTest, only: [rendered_to_string: 1]
+  import PhoenixKitWeb.Components.Core.StatusDot
+
+  defp render(template), do: rendered_to_string(template)
+
+  test "up={true} is success, up={false} is error" do
+    assigns = %{}
+
+    assert render(~H|<.status_dot up={true} />|) =~ "bg-success"
+    assert render(~H|<.status_dot up={false} />|) =~ "bg-error"
+  end
+
+  test "an unknown state (neither variant nor up) is neutral, not success" do
+    # Defaulting an unknown state to green would report health nobody verified.
+    assigns = %{}
+    html = render(~H|<.status_dot />|)
+
+    assert html =~ "bg-neutral"
+    refute html =~ "bg-success"
+  end
+
+  test "variant wins over up" do
+    assigns = %{}
+    html = render(~H|<.status_dot variant={:warning} up={true} />|)
+
+    assert html =~ "bg-warning"
+    refute html =~ "bg-success"
+  end
+
+  test "every documented variant renders its own colour" do
+    assigns = %{}
+
+    for {variant, class} <- [
+          {:success, "bg-success"},
+          {:error, "bg-error"},
+          {:warning, "bg-warning"},
+          {:info, "bg-info"},
+          {:neutral, "bg-neutral"}
+        ] do
+      assigns = Map.put(assigns, :variant, variant)
+      assert render(~H|<.status_dot variant={@variant} />|) =~ class
+    end
+  end
+
+  test "renders the label when given, and no empty span when not" do
+    assigns = %{}
+
+    assert render(~H|<.status_dot up={true} label="online" />|) =~ "online"
+    refute render(~H|<.status_dot up={true} />|) =~ "opacity-70"
+  end
+
+  test "pulse adds the ping layer, absent by default" do
+    assigns = %{}
+
+    assert render(~H|<.status_dot variant={:info} pulse />|) =~ "animate-ping"
+    refute render(~H|<.status_dot variant={:info} />|) =~ "animate-ping"
+  end
+
+  test "each size renders a distinct dot class" do
+    assigns = %{}
+
+    sizes =
+      for size <- [:xs, :sm, :md] do
+        assigns = Map.put(assigns, :size, size)
+        html = render(~H|<.status_dot up={true} size={@size} />|)
+        [_, cls] = Regex.run(~r/(size-[\d.]+)/, html)
+        cls
+      end
+
+    assert length(Enum.uniq(sizes)) == 3
+  end
+
+  test "extra classes land on the wrapper" do
+    assigns = %{}
+
+    assert render(~H|<.status_dot up={true} class="ml-2" />|) =~ "ml-2"
+  end
+
+  test "the dot alone is not announced as text to a screen reader" do
+    # A bare coloured circle carries meaning only visually; without a label
+    # there must be nothing for assistive tech to read out as content.
+    assigns = %{}
+    html = render(~H|<.status_dot up={false} />|)
+
+    assert html |> String.replace(~r/<[^>]*>/, "") |> String.trim() == ""
+  end
+end

--- a/test/phoenix_kit_web/components/core/status_dot_test.exs
+++ b/test/phoenix_kit_web/components/core/status_dot_test.exs
@@ -111,7 +111,9 @@ defmodule PhoenixKitWeb.Components.Core.StatusDotTest do
       html = render(~H|<.status_dot variant={@variant} />|)
 
       assert html =~ colour
-      assert html =~ word
+      # Match inside the sr-only span: a bare `=~ "error"` was satisfied by the
+      # `bg-error` class, so the announced word was never actually checked.
+      assert html =~ ~r/<span class="sr-only">\s*#{word}\s*<\/span>/
     end
   end
 


### PR DESCRIPTION
Adds three server-rendered core components — `Chart`, `StatusDot`,
`ConnectAccountButton` — plus an optional `value_color` on `stat_card`. All
zero-JS except the popup hook, theme-aware via `currentColor`, and LiveView-native
(assigns change → SVG re-renders).

Extracted from NordSwitch, which runs hand-rolled versions today. Core had no
chart primitives at all, so every consumer either hand-rolled SVG or pulled in a
JS charting library.

**Nothing in the ecosystem consumes these yet**, which is why the API renames
below were free to make.

## Components

- **`line_chart/1`** — line/area over `{x, y}` points; `step` for interval data
  (right-open steps), optional `marker_x` "now" line, auto or explicit domains,
  `:empty` slot.
- **`sparkline/1`** — polyline over a list of numbers.
- **`bar_chart/1`** — vertical bars from a zero baseline, native `<title>`
  tooltips, optional per-datum `class`, aligned labels.
- **`status_dot/1`** — semantic coloured dot + optional label + optional `pulse`.
  Fills the gap between nothing and the domain-specific badges in `Badge`;
  `phoenix_kit_publishing` hand-rolls exactly this today.
- **`connect_account_button/1`** — OAuth-popup account linking (distinct from
  `OAuthProvider`, which is app sign-in), driven by a generic `PopupLink` hook.

## What the review pass changed

The components were handed over deliberately untested. Four external review
rounds plus a test suite found, among others:

- **`bar_chart` scaled from `max(value)`**, so a negative value produced a
  negative rect height — SVG discards those, so the bar silently vanished. An
  all-negative series divided by an epsilon floor and threw the geometry to
  astronomical coordinates.
- **One bad point took the page down.** `nil`, a string, or a `Decimal` raised an
  uncaught `ArithmeticError` mid-render — and `Decimal` is what Ecto hands you for
  money, in a kit with a billing module.
- **`connect_account_button` used an inline `onclick`** — CSP-hostile in a kit
  that removed inline handlers everywhere else — whose `return false` cancelled
  navigation *unconditionally*, including when the popup was blocked. That is
  exactly when the documented "falls back to normal navigation" was meant to save
  it. It is a hook now.
- **Every unconfigured button shared one DOM id**, which is invalid HTML and
  breaks `phx-hook`.
- **The moduledoc's security rationale was wrong** — it claimed the local-path
  check kept `window.opener` from third parties. The popup navigates on to the
  provider and the opener reference survives. The doc now names the real
  mitigation (COOP + `postMessage`).
- **Charts carried `role="img"` with no accessible name**; `status_dot` conveyed
  state through colour alone.

Rounds 2, 3 and 4 each found defects *in the previous round's fixes* — a fix
aimed at a narrow symptom kept re-creating the same class of bug on a path it
did not touch. The round-4 resolution was to fix the cause instead: a collapsed
domain scales to the **centre** (the same treatment a flat y series already got),
and a path that genuinely paints nothing renders a **dot** at the point's true
position rather than a fabricated full-width line across a range nobody measured.

## API changes, made while they were still free

- `area_chart` → `line_chart` (`area_chart area={false}` *was* a line chart)
- a11y attr `label` → `aria_label`, so it stops colliding with bar data's `label:`
- hook `ConnectAccountPopup` → `PopupLink` — nothing about it is OAuth-specific,
  and hook names freeze once hosts copy the bundle

## Tests

`test/phoenix_kit_web/components/core/{chart,status_dot,connect_account_button,stat_card}_test.exs`
plus `test/js/popup_link.test.cjs`, a Node harness for the hook's decision logic
(which clicks to intercept, where to place the popup, same-origin). Run via
`mix test.js`, wired into `mix precommit`, skips itself when node isn't installed.

The chart assertions check the **outcome**, not the markup shape — `assert_visible_mark`
rejects a path whose points coincide, `assert_bars_within_viewbox` rejects a rect
the browser would clip. Both were written after shape-matching assertions passed
on charts that painted nothing.

Full suite: **2310 tests, 0 failures**; `mix precommit` clean.
Notes and known limits: `dev_docs/2026-07-28-chart-statusdot-connectbutton-components.md`.
