### PR TITLE
Fix an existing user being renamed when the admin form rebuilds its changeset

### DIFF
--- a/lib/phoenix_kit/users/auth/user.ex
+++ b/lib/phoenix_kit/users/auth/user.ex
@@ -694,27 +694,8 @@ defmodule PhoenixKit.Users.Auth.User do
 
   defp maybe_generate_username_from_email(changeset) do
     case get_change(changeset, :username) do
-      nil ->
-        email = get_change(changeset, :email) || get_field(changeset, :email)
-
-        # Only generate username if email contains "@" to ensure user finishes typing
-        if email && String.contains?(email, "@") do
-          generated_username = generate_unique_username_from_email(email)
-          put_change(changeset, :username, generated_username)
-        else
-          changeset
-        end
-
-      "" ->
-        # Treat empty string same as nil - allow generation if email has "@"
-        email = get_change(changeset, :email) || get_field(changeset, :email)
-
-        if email && String.contains?(email, "@") do
-          generated_username = generate_unique_username_from_email(email)
-          put_change(changeset, :username, generated_username)
-        else
-          changeset
-        end
+      username when username in [nil, ""] ->
+        maybe_put_generated_username(changeset)
 
       _ ->
         # User has manually entered a username, don't override it
@@ -722,22 +703,53 @@ defmodule PhoenixKit.Users.Auth.User do
     end
   end
 
+  # Generating is for a user who does not have a username yet. An existing one
+  # must never be rewritten here: this step runs on every registration changeset,
+  # including the ones the admin user form rebuilds while editing (toggling the
+  # password field, for one), and those carry no `username` param — so without
+  # this guard, opening an existing user and saving renamed them.
+  defp maybe_put_generated_username(changeset) do
+    email = get_change(changeset, :email) || get_field(changeset, :email)
+
+    cond do
+      present?(changeset.data.username) ->
+        changeset
+
+      # Only generate once the email looks finished, so a half-typed address
+      # does not mint a username from it.
+      is_binary(email) and String.contains?(email, "@") ->
+        put_change(
+          changeset,
+          :username,
+          generate_unique_username_from_email(email, changeset.data)
+        )
+
+      true ->
+        changeset
+    end
+  end
+
+  defp present?(value) when is_binary(value), do: String.trim(value) != ""
+  defp present?(_value), do: false
+
   # Generate a unique username from email by checking for collisions
-  defp generate_unique_username_from_email(email) do
+  defp generate_unique_username_from_email(email, data) do
     base_username = generate_username_from_email(email)
-    ensure_unique_username(base_username, 0)
+    ensure_unique_username(base_username, 0, data.uuid)
   end
 
   # Recursively ensure username is unique by adding numeric suffix if needed
-  defp ensure_unique_username(base_username, attempt) do
+  # `own_uuid` is the user the name is being generated for, when there is one:
+  # the row that already holds `maria` must not make `maria` look taken to
+  # maria herself, or every regeneration would walk her one suffix further
+  # (`maria` → `maria_1` → `maria_2`).
+  defp ensure_unique_username(base_username, attempt, own_uuid) do
     username = if attempt == 0, do: base_username, else: "#{base_username}_#{attempt}"
 
-    repo = PhoenixKit.RepoHelper.repo()
-
-    if repo.get_by(__MODULE__, username: username) do
-      ensure_unique_username(base_username, attempt + 1)
-    else
-      username
+    case PhoenixKit.RepoHelper.repo().get_by(__MODULE__, username: username) do
+      nil -> username
+      %__MODULE__{uuid: ^own_uuid} when not is_nil(own_uuid) -> username
+      %__MODULE__{} -> ensure_unique_username(base_username, attempt + 1, own_uuid)
     end
   end
 

--- a/lib/phoenix_kit_web/users/user_form.ex
+++ b/lib/phoenix_kit_web/users/user_form.ex
@@ -134,10 +134,6 @@ defmodule PhoenixKitWeb.Users.UserForm do
       if socket.assigns.mode == :edit do
         filtered_params = Map.put_new(filtered_params, "username", socket.assigns.user.username)
 
-        Logger.info(
-          "validate_user - user_params username: #{inspect(Map.get(user_params, "username"))}, filtered_params username: #{inspect(Map.get(filtered_params, "username"))}"
-        )
-
         filtered_params
       else
         filtered_params
@@ -620,19 +616,10 @@ defmodule PhoenixKitWeb.Users.UserForm do
   end
 
   defp update_user_profile_without_validation(user, attrs) do
-    Logger.info(
-      "update_user_profile_without_validation - attrs username: #{inspect(Map.get(attrs, "username"))}"
-    )
-
     changeset = Auth.User.profile_changeset(user, attrs, validate_email: false)
-
-    Logger.info(
-      "After profile_changeset, changeset changes username: #{inspect(Ecto.Changeset.get_change(changeset, :username))}, field: #{inspect(Ecto.Changeset.get_field(changeset, :username))}"
-    )
 
     case changeset |> PhoenixKit.RepoHelper.repo().update() do
       {:ok, updated_user} ->
-        Logger.info("After DB update, saved username: #{inspect(updated_user.username)}")
         Events.broadcast_user_updated(updated_user)
 
         {:ok, updated_user}
@@ -679,10 +666,6 @@ defmodule PhoenixKitWeb.Users.UserForm do
     # In both cases, we need to reload the user from the database to get the fresh data
     user_uuid = socket.assigns.user.uuid
     fresh_user = Auth.get_user!(user_uuid)
-
-    Logger.info(
-      "handle_update_result - fresh_user username from DB: #{inspect(fresh_user.username)}"
-    )
 
     socket =
       socket
@@ -818,14 +801,8 @@ defmodule PhoenixKitWeb.Users.UserForm do
   defp load_form_data(%{assigns: %{mode: :edit, user: user}} = socket) do
     # For edit mode, use profile_changeset instead of registration_changeset
     # profile_changeset doesn't call maybe_generate_username_from_email like registration_changeset does
-    Logger.info("Loading form for user #{user.uuid}: DB username=#{inspect(user.username)}")
-
     changeset =
       Auth.User.profile_changeset(user, %{"username" => user.username}, validate_email: false)
-
-    Logger.info(
-      "After creating changeset, changeset changes: #{inspect(Ecto.Changeset.get_change(changeset, :username))}, changeset field: #{inspect(Ecto.Changeset.get_field(changeset, :username))}"
-    )
 
     account_type = user.account_type || "person"
 

--- a/test/phoenix_kit/users/user_org_changeset_test.exs
+++ b/test/phoenix_kit/users/user_org_changeset_test.exs
@@ -232,4 +232,62 @@ defmodule PhoenixKit.Users.UserOrgChangesetTest do
       assert errors_on_field(changeset, :organization_name) == []
     end
   end
+
+  # --- username generation on an EXISTING user ---
+
+  describe "registration_changeset/3 — username of a saved user" do
+    setup do
+      {:ok, user} =
+        PhoenixKit.Users.Auth.register_user(%{
+          email: "maria@example.com",
+          password: "ValidPassword123!"
+        })
+
+      %{user: user}
+    end
+
+    test "editing a saved user without a username param leaves the username alone", %{user: user} do
+      # The admin user form rebuilds this changeset while editing (toggling the
+      # password field, for one) and sends no `username`. Before the fix the
+      # generator ran anyway, found the user's OWN row holding `maria`, decided
+      # the name was taken and renamed them to `maria_1`.
+      assert user.username == "maria"
+
+      changeset = User.registration_changeset(user, %{"email" => user.email})
+
+      assert get_change(changeset, :username) == nil
+      assert get_field(changeset, :username) == "maria"
+    end
+
+    test "an explicit username still wins", %{user: user} do
+      changeset = User.registration_changeset(user, %{"username" => "maria_updated"})
+      assert get_change(changeset, :username) == "maria_updated"
+    end
+
+    test "a brand new user still gets one generated from the email" do
+      changeset =
+        User.registration_changeset(%User{}, %{
+          "email" => "newcomer@example.com",
+          "password" => "ValidPassword123!"
+        })
+
+      assert get_change(changeset, :username) == "newcomer"
+    end
+
+    test "a second user with a colliding base name gets a suffix, not the taken name", %{
+      user: user
+    } do
+      # The suffix logic itself must keep working — it just must not fire for
+      # the holder of the name.
+      changeset =
+        User.registration_changeset(%User{}, %{
+          "email" => "maria@other.example.com",
+          "password" => "ValidPassword123!"
+        })
+
+      generated = get_change(changeset, :username)
+      assert generated != user.username
+      assert String.starts_with?(generated, "maria")
+    end
+  end
 end


### PR DESCRIPTION
## The bug

Open a user in the admin form, click "change password", save — and the user is renamed. `maria` becomes `maria_1`; do it again and she becomes `maria_2`.

## Why

Two things combine, both in `User`:

`maybe_generate_username_from_email/1` runs on **every** `registration_changeset/3`, and generates a username whenever the params carry none. That is right for a new user, but the admin form rebuilds this changeset for an already-saved user several times while editing — `reload_changeset_with_password/2` does it every time the password field is toggled — and those rebuilds send no `username`.

`ensure_unique_username/2` then asked the database whether the generated name was taken, without excluding the user it was generating *for*. Maria's own row made `maria` look unavailable to Maria, so the walk moved on to `maria_1`.

## The fix

- Generation is skipped for a persisted user that already has a username. A user without one (or a brand-new record) still gets one.
- The uniqueness walk ignores the user's own row, so the suffix is only reached on a genuine collision with somebody else.

An explicitly typed username still wins; a new user still gets one generated from their email; two different people whose emails share a local part still get `maria` and `maria_1`.

Also removes seven `Logger.info` calls left behind in `user_form.ex` from chasing this — they dumped the username at every step of validate / save / reload.

## Verification

Checked against a running host application on real data, building the same changesets the admin form builds (nothing saved):

| changeset | before | after |
|---|---|---|
| edit, no `username` param | `username` change to `fotkin_1` | no `username` change, field stays `fotkin` |
| edit, explicit `username` | honoured | honoured |
| brand-new user | generated from email | generated from email |

Regression tests added to `test/phoenix_kit/users/user_org_changeset_test.exs` (saved user keeps its name; explicit name wins; new user still generated; a real collision still gets a suffix). They are `:integration` — the environment this was written in has no PostgreSQL for the core suite, so **they were not executed here**; please run them with the suite.
