### PR TITLE
Add sign-in-as-user on an administrator's authority

### DIFF
--- a/lib/phoenix_kit_web/integration.ex
+++ b/lib/phoenix_kit_web/integration.ex
@@ -233,6 +233,7 @@ defmodule PhoenixKitWeb.Integration do
         delete "/users/log-out", Users.Session, :delete
         get "/users/log-out", Users.Session, :get_logout
         post "/users/session/accounts", Users.Session, :add_account
+        post "/users/session/impersonate/:user_uuid", Users.Session, :impersonate
         put "/users/session/active", Users.Session, :set_active_account
         delete "/users/session/accounts/:ref", Users.Session, :remove_account
         get "/users/magic-link/:token", Users.MagicLinkVerify, :verify
@@ -1113,6 +1114,7 @@ defmodule PhoenixKitWeb.Integration do
         delete "/users/log-out", Users.Session, :delete
         get "/users/log-out", Users.Session, :get_logout
         post "/users/session/accounts", Users.Session, :add_account
+        post "/users/session/impersonate/:user_uuid", Users.Session, :impersonate
         put "/users/session/active", Users.Session, :set_active_account
         delete "/users/session/accounts/:ref", Users.Session, :remove_account
         get "/users/magic-link/:token", Users.MagicLinkVerify, :verify

--- a/lib/phoenix_kit_web/users/multi_session.ex
+++ b/lib/phoenix_kit_web/users/multi_session.ex
@@ -211,6 +211,84 @@ defmodule PhoenixKitWeb.Users.MultiSession do
 
   def add_authenticated_user(_conn, %Auth.User{}), do: {:error, :inactive}
 
+  @doc """
+  Adds `target` to the session stack on an administrator's authority, without
+  their password — "log in as this user".
+
+  Shares every invariant of `add_authenticated_user/2` and adds the authority
+  checks that separate support access from account takeover:
+
+  - the **root** account decides, never the active one. Otherwise an
+    administrator could impersonate a user and, from inside that session,
+    impersonate someone the user could never reach;
+  - the root must hold the Owner or Admin **role**. Deliberately not
+    `can_access_admin_area?/1`: that is true for *any* permission holder, so a
+    customer granted one self-service permission would qualify — and could then
+    borrow another customer's account;
+  - an Owner is never a target. The one account that can undo anything must not
+    be reachable by borrowing it;
+  - an Admin root cannot take another Admin either — support access is for the
+    people being supported, not sideways between staff. An Owner root may,
+    because there is nothing above it to escalate to.
+
+  Logged as `session.impersonated` on the activity feed, always, before the
+  session changes — an impersonation nobody can see afterwards is the thing that
+  makes this feature dangerous.
+  """
+  @spec impersonate(Plug.Conn.t(), Auth.User.t()) ::
+          {:ok, Plug.Conn.t()}
+          | {:error,
+             :not_allowed
+             | :target_is_owner
+             | :target_is_staff
+             | :stack_full
+             | :already_in_stack
+             | :inactive
+             | :self}
+  def impersonate(conn, %Auth.User{} = target) do
+    session = get_session(conn)
+    actor = root_user(session)
+
+    with :ok <- authorize_impersonation(actor, target) do
+      case add_authenticated_user(conn, target) do
+        {:ok, conn} ->
+          log_event("session.impersonated", actor, target)
+          {:ok, conn}
+
+        {:error, _reason} = error ->
+          error
+      end
+    end
+  end
+
+  defp authorize_impersonation(nil, _target), do: {:error, :not_allowed}
+
+  defp authorize_impersonation(%Auth.User{} = actor, %Auth.User{} = target) do
+    system = Role.system_roles()
+    actor_roles = Auth.User.get_roles(actor)
+    target_roles = Auth.User.get_roles(target)
+
+    cond do
+      actor.uuid == target.uuid ->
+        {:error, :self}
+
+      not (system.owner in actor_roles or system.admin in actor_roles) ->
+        {:error, :not_allowed}
+
+      system.owner in target_roles ->
+        {:error, :target_is_owner}
+
+      system.owner in actor_roles ->
+        :ok
+
+      system.admin in target_roles ->
+        {:error, :target_is_staff}
+
+      true ->
+        :ok
+    end
+  end
+
   @doc "Activates a token already present in the stack, identified by `ref`."
   def switch_to(conn, ref) do
     session = get_session(conn)

--- a/lib/phoenix_kit_web/users/session.ex
+++ b/lib/phoenix_kit_web/users/session.ex
@@ -247,6 +247,58 @@ defmodule PhoenixKitWeb.Users.Session do
     end)
   end
 
+  @doc """
+  Adds a user to the session stack on an administrator's authority — the
+  "log in as this user" button in the admin area.
+
+  The authority checks live in `MultiSession.impersonate/2`; this action only
+  translates their outcome into a flash. Each refusal says which rule stopped it,
+  because "could not do that" on a support tool is how an operator ends up
+  guessing at permissions.
+  """
+  def impersonate(conn, %{"user_uuid" => user_uuid} = params) do
+    with_gate(conn, params, fn conn ->
+      case Auth.get_user(user_uuid) do
+        nil ->
+          conn |> put_flash(:error, gettext("User not found.")) |> redirect_back(params)
+
+        user ->
+          do_impersonate(conn, user, params)
+      end
+    end)
+  end
+
+  defp do_impersonate(conn, user, params) do
+    case MultiSession.impersonate(conn, user) do
+      {:ok, conn} ->
+        conn
+        |> put_flash(:info, gettext("You are now signed in as %{email}.", email: user.email))
+        |> redirect_back(params)
+
+      {:error, reason} ->
+        conn |> put_flash(:error, impersonation_error(reason)) |> redirect_back(params)
+    end
+  end
+
+  defp impersonation_error(:not_allowed),
+    do: gettext("You do not have permission to sign in as another user.")
+
+  defp impersonation_error(:target_is_owner), do: gettext("An owner account cannot be used.")
+
+  defp impersonation_error(:target_is_staff),
+    do: gettext("Only an owner can sign in as another administrator.")
+
+  defp impersonation_error(:self), do: gettext("That is already your account.")
+  defp impersonation_error(:inactive), do: gettext("That account is deactivated.")
+
+  defp impersonation_error(:stack_full),
+    do: gettext("Maximum number of accounts reached — remove one first.")
+
+  defp impersonation_error(:already_in_stack),
+    do: gettext("That account is already in your session — switch to it instead.")
+
+  defp impersonation_error(_reason), do: gettext("Could not sign in as that user.")
+
   def remove_account(conn, %{"ref" => ref} = params) do
     with_gate(conn, params, fn conn ->
       case MultiSession.remove_account(conn, ref) do

--- a/test/integration/users/multi_session_test.exs
+++ b/test/integration/users/multi_session_test.exs
@@ -328,4 +328,74 @@ defmodule PhoenixKit.Integration.Users.MultiSessionTest do
       assert {:error, :inactive} = MultiSession.add_authenticated_user(conn, inactive)
     end
   end
+
+  describe "impersonate/2" do
+    defp admin_user do
+      {:ok, user} = Auth.register_user(%{email: unique_email(), password: "ValidPassword123!"})
+      {:ok, user} = Auth.admin_confirm_user(user)
+      Roles.assign_role(user, "Admin")
+      Repo.get!(Auth.User, user.uuid)
+    end
+
+    test "an admin can take a plain user's account without their password" do
+      admin = admin_user()
+      target = plain_user()
+
+      assert {:ok, conn} = MultiSession.impersonate(conn_for(admin), target)
+
+      accounts = MultiSession.list_accounts(Plug.Conn.get_session(conn))
+      assert length(accounts) == 2
+      assert Enum.find(accounts, & &1.active?).email == target.email
+      # the admin's own account stays, and stays the root
+      assert Enum.find(accounts, & &1.root?).email == admin.email
+    end
+
+    test "the Owner account is never a target" do
+      assert {:error, :target_is_owner} =
+               MultiSession.impersonate(conn_for(admin_user()), owner_user())
+    end
+
+    test "an admin cannot take another admin — that is sideways, not support" do
+      assert {:error, :target_is_staff} =
+               MultiSession.impersonate(conn_for(admin_user()), admin_user())
+    end
+
+    test "an owner can take an admin, because there is nothing above it to reach" do
+      assert {:ok, _conn} = MultiSession.impersonate(conn_for(owner_user()), admin_user())
+    end
+
+    test "a permission holder who is not staff cannot impersonate at all" do
+      # The hole this guards: `can_access_admin_area?/1` is true for ANY
+      # permission holder, so a customer granted one self-service permission
+      # would qualify under a permission-based check and could borrow another
+      # customer's account. The rule is role-based for exactly this reason.
+      assert {:error, :not_allowed} =
+               MultiSession.impersonate(conn_for(custom_role_user("Client")), plain_user())
+    end
+
+    test "an anonymous session cannot impersonate" do
+      conn = Phoenix.ConnTest.build_conn() |> Phoenix.ConnTest.init_test_session(%{})
+      assert {:error, :not_allowed} = MultiSession.impersonate(conn, plain_user())
+    end
+
+    test "taking your own account is refused rather than duplicated" do
+      admin = admin_user()
+      assert {:error, :self} = MultiSession.impersonate(conn_for(admin), admin)
+    end
+
+    test "the same account cannot be taken twice" do
+      admin = admin_user()
+      target = plain_user()
+
+      assert {:ok, conn} = MultiSession.impersonate(conn_for(admin), target)
+      assert {:error, :already_in_stack} = MultiSession.impersonate(conn, target)
+    end
+
+    test "a deactivated account is refused" do
+      target = plain_user()
+      {:ok, target} = Auth.update_user_status(target, %{"is_active" => false})
+
+      assert {:error, :inactive} = MultiSession.impersonate(conn_for(admin_user()), target)
+    end
+  end
 end


### PR DESCRIPTION
## Why

An administrator supporting a customer has no way to see what that customer sees. Reproducing a "my order list is empty" report means either asking for their password or guessing.

## What this is not

It is not a new session mechanism. The multi-account stack already has every primitive this needs — `add_authenticated_user/2` appends a session for an already-authenticated user without a password, which is how the OAuth add-account callback works. This adds the authority layer on top: `MultiSession.impersonate/2`, one controller action, one route.

## The rules, and why they are role-based

Deliberately **not** `can_access_admin_area?/1`. That predicate is true for *any* permission holder — a customer granted a single self-service permission (a client portal, say) satisfies it. Gating on it would have let one customer borrow another customer's account, which is the opposite of the point.

- The **root** account decides, never the active one. Otherwise an administrator could impersonate a user and, from inside that session, reach someone the administrator could not.
- The root must hold the **Owner or Admin role**.
- An **Owner is never a target**. The account that can undo anything must not be reachable by borrowing it.
- An **Admin cannot take another Admin** — support access is for the people being supported, not sideways between staff. An **Owner can**, because there is nothing above it to escalate to.
- Self, inactive accounts, a full stack and an account already in the stack are all refused with distinct reasons, so the UI can say which rule stopped it instead of "could not do that".

Every attempt is written to the activity feed as `session.impersonated`, with actor and target, **before** the session changes. An impersonation nobody can see afterwards is what would make this dangerous.

The impersonated session joins the existing account switcher next to the administrator's own — they do not lose their own session, and returning is the switcher's existing "switch to" action.

## Verification

Exercised against a running host application on real accounts (`MultiSession.impersonate/2` directly, so the authority matrix is what is being tested, not the button):

| root | target | result |
|---|---|---|
| Admin | customer | allowed |
| Admin | Owner | `:target_is_owner` |
| Admin | Admin | `:target_is_staff` |
| Owner | Admin | allowed |
| Owner | customer | allowed |
| Owner | itself | `:self` |
| customer holding a portal permission | another customer | `:not_allowed` |

That last row is the one that matters: it fails on the actor check, which a permission-based rule would have passed.

Nine tests added to `test/integration/users/multi_session_test.exs` covering the same matrix plus the inactive / already-in-stack / anonymous cases. They are `:integration` and **were not executed here** — the environment this was written in has no PostgreSQL for the core suite. Please run them with the suite.

## Note for the host

The action is behind the same `multi_session_enabled` gate as the rest of the stack, so the button should only be offered where that setting is on. There is no UI in this PR: the endpoint is `POST /users/session/impersonate/:user_uuid` with an optional `return_to`, so a host can put the button wherever its user list lives.
