### PR TITLE
Bring the admin UI onto the framework's own components, full width and one header per page

### DIFF
--- a/lib/modules/maintenance/settings.ex
+++ b/lib/modules/maintenance/settings.ex
@@ -245,7 +245,7 @@ defmodule PhoenixKitWeb.Live.Modules.Maintenance.Settings do
       project_title={@project_title}
       current_locale={@current_locale}
     >
-      <div class="container mx-auto px-4 py-6">
+      <div class="px-4 py-6">
         <%!-- Overall Status --%>
         <%= if @active do %>
           <div class="alert alert-warning mb-6">

--- a/lib/modules/maintenance/settings.ex
+++ b/lib/modules/maintenance/settings.ex
@@ -309,29 +309,21 @@ defmodule PhoenixKitWeb.Live.Modules.Maintenance.Settings do
             <form phx-submit="save_schedule" class="space-y-4">
               <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div class="form-control">
-                  <label class="label">
-                    <span class="label-text font-semibold">
-                      {gettext("Start Time")} ({@tz_label})
-                    </span>
-                  </label>
-                  <input
+                  <.input
                     type="datetime-local"
                     name="start"
                     value={@scheduled_start}
                     min={@min_datetime}
-                    class="input input-bordered w-full"
+                    label={"#{gettext("Start Time")} (#{@tz_label})"}
                   />
                 </div>
                 <div class="form-control">
-                  <label class="label">
-                    <span class="label-text font-semibold">{gettext("End Time")} ({@tz_label})</span>
-                  </label>
-                  <input
+                  <.input
                     type="datetime-local"
                     name="end"
                     value={@scheduled_end}
                     min={@min_datetime}
-                    class="input input-bordered w-full"
+                    label={"#{gettext("End Time")} (#{@tz_label})"}
                   />
                 </div>
               </div>
@@ -372,15 +364,12 @@ defmodule PhoenixKitWeb.Live.Modules.Maintenance.Settings do
                 class="space-y-4"
               >
                 <div class="form-control">
-                  <label class="label">
-                    <span class="label-text font-semibold">{gettext("Header Text")}</span>
-                  </label>
-                  <input
+                  <.input
                     type="text"
                     name="header"
                     value={@header}
                     phx-debounce="150"
-                    class="input input-bordered w-full"
+                    label={gettext("Header Text")}
                     placeholder={gettext("Maintenance Mode")}
                     required
                   />
@@ -392,16 +381,15 @@ defmodule PhoenixKitWeb.Live.Modules.Maintenance.Settings do
                 </div>
 
                 <div class="form-control">
-                  <label class="label">
-                    <span class="label-text font-semibold">{gettext("Message Text")}</span>
-                  </label>
-                  <textarea
+                  <.textarea
                     name="subtext"
+                    value={@subtext}
                     phx-debounce="150"
-                    class="textarea textarea-bordered w-full h-32"
+                    label={gettext("Message Text")}
+                    class="h-32"
                     placeholder={gettext("We'll be back soon...")}
                     required
-                  >{@subtext}</textarea>
+                  />
                   <label class="label">
                     <span class="label-text-alt">
                       {gettext("Detailed message shown below the header")}

--- a/lib/modules/maintenance/settings.ex
+++ b/lib/modules/maintenance/settings.ex
@@ -237,7 +237,7 @@ defmodule PhoenixKitWeb.Live.Modules.Maintenance.Settings do
     <PhoenixKitWeb.Components.LayoutWrapper.app_layout
       flash={@flash}
       phoenix_kit_current_scope={assigns[:phoenix_kit_current_scope]}
-      page_title={"#{@project_title} - Maintenance Mode Settings"}
+      page_title={gettext("Maintenance Mode Settings")}
       page_section={gettext("Modules")}
       page_section_path={PhoenixKit.Utils.Routes.path("/admin/modules")}
       page_subtitle={gettext("Customize the maintenance page and schedule")}

--- a/lib/modules/maintenance/settings.ex
+++ b/lib/modules/maintenance/settings.ex
@@ -237,30 +237,15 @@ defmodule PhoenixKitWeb.Live.Modules.Maintenance.Settings do
     <PhoenixKitWeb.Components.LayoutWrapper.app_layout
       flash={@flash}
       phoenix_kit_current_scope={assigns[:phoenix_kit_current_scope]}
-      page_title="{@project_title} - Maintenance Mode Settings"
+      page_title={"#{@project_title} - Maintenance Mode Settings"}
+      page_section={gettext("Modules")}
+      page_section_path={PhoenixKit.Utils.Routes.path("/admin/modules")}
+      page_subtitle={gettext("Customize the maintenance page and schedule")}
       current_path={@current_path}
       project_title={@project_title}
       current_locale={@current_locale}
     >
       <div class="container mx-auto px-4 py-6">
-        <%!-- Header Section --%>
-        <header class="w-full relative mb-6">
-          <.link
-            navigate={PhoenixKit.Utils.Routes.path("/admin/modules")}
-            class="btn btn-ghost btn-sm"
-          >
-            <.icon name="hero-arrow-left" class="w-4 h-4" />
-          </.link>
-          <div class="text-center">
-            <h1 class="text-4xl font-bold text-base-content mb-3">
-              {gettext("Maintenance Mode Settings")}
-            </h1>
-            <p class="text-lg text-base-content/70">
-              {gettext("Customize the maintenance page and schedule")}
-            </p>
-          </div>
-        </header>
-
         <%!-- Overall Status --%>
         <%= if @active do %>
           <div class="alert alert-warning mb-6">

--- a/lib/modules/sitemap/web/settings.html.heex
+++ b/lib/modules/sitemap/web/settings.html.heex
@@ -9,7 +9,7 @@
   project_title={@project_title}
   current_locale={@current_locale}
 >
-  <div class="container flex flex-col mx-auto px-4 py-6">
+  <div class="flex flex-col px-4 py-6">
     <div class="flex items-center gap-2 justify-end mb-4">
       <label class="label cursor-pointer gap-2">
         <span class="label-text font-medium">

--- a/lib/modules/sitemap/web/settings.html.heex
+++ b/lib/modules/sitemap/web/settings.html.heex
@@ -542,19 +542,17 @@
                 <label class="label">
                   <span class="label-text font-medium">{gettext("Display Style")}</span>
                 </label>
-                <label class="select w-full">
-                  <select
-                    name="style"
-                    disabled={!@config.html_enabled}
-                  >
-                    <option value="table" selected={@config.html_style in ["table", "grouped"]}>
-                      {gettext("Table (Clean table layout)")}
-                    </option>
-                    <option value="minimal" selected={@config.html_style in ["minimal", "flat"]}>
-                      {gettext("Minimal (Simple list)")}
-                    </option>
-                  </select>
-                </label>
+                <.select
+                  name="style"
+                  disabled={!@config.html_enabled}
+                  value={
+                    if @config.html_style in ["table", "grouped"], do: "table", else: "minimal"
+                  }
+                  options={[
+                    {gettext("Table (Clean table layout)"), "table"},
+                    {gettext("Minimal (Simple list)"), "minimal"}
+                  ]}
+                />
               </form>
             </div>
           </div>
@@ -581,31 +579,20 @@
               class="flex items-center gap-4 mt-4"
             >
               <span class="text-sm">{gettext("Regenerate every")}</span>
-              <label class="select select-sm">
-                <select
-                  name="interval"
-                  disabled={!@config.schedule_enabled}
-                >
-                  <option value="1" selected={@config.schedule_interval_hours == 1}>
-                    {gettext("1 hour")}
-                  </option>
-                  <option value="6" selected={@config.schedule_interval_hours == 6}>
-                    {gettext("6 hours")}
-                  </option>
-                  <option value="12" selected={@config.schedule_interval_hours == 12}>
-                    {gettext("12 hours")}
-                  </option>
-                  <option value="24" selected={@config.schedule_interval_hours == 24}>
-                    {gettext("24 hours")}
-                  </option>
-                  <option value="48" selected={@config.schedule_interval_hours == 48}>
-                    {gettext("48 hours")}
-                  </option>
-                  <option value="168" selected={@config.schedule_interval_hours == 168}>
-                    {gettext("Weekly")}
-                  </option>
-                </select>
-              </label>
+              <.select
+                name="interval"
+                disabled={!@config.schedule_enabled}
+                value={@config.schedule_interval_hours}
+                options={[
+                  {gettext("1 hour"), "1"},
+                  {gettext("6 hours"), "6"},
+                  {gettext("12 hours"), "12"},
+                  {gettext("24 hours"), "24"},
+                  {gettext("48 hours"), "48"},
+                  {gettext("Weekly"), "168"}
+                ]}
+                class="select-sm"
+              />
             </form>
           </div>
         </div>
@@ -707,11 +694,12 @@
                   "One regular expression per line. Replaces the built-in defaults entirely when saved — an empty list means nothing is excluded."
                 )}
               </p>
-              <textarea
+              <.textarea
                 name="patterns"
+                value={@exclude_patterns_text}
                 rows="6"
-                class="textarea textarea-bordered font-mono text-xs w-full"
-              >{@exclude_patterns_text}</textarea>
+                class="font-mono text-xs"
+              />
               <div :if={@exclude_patterns_error} class="alert alert-error mt-2 py-2 text-xs">
                 {@exclude_patterns_error}
               </div>
@@ -729,11 +717,12 @@
                 {gettext("One pipeline name per line. Added on top of the built-in defaults:")}
                 <span class="font-mono">{@protected_pipelines_defaults_text}</span>
               </p>
-              <textarea
+              <.textarea
                 name="pipelines"
+                value={@protected_pipelines_text}
                 rows="6"
-                class="textarea textarea-bordered font-mono text-xs w-full"
-              >{@protected_pipelines_text}</textarea>
+                class="font-mono text-xs"
+              />
               <div :if={@protected_pipelines_error} class="alert alert-error mt-2 py-2 text-xs">
                 {@protected_pipelines_error}
               </div>
@@ -752,11 +741,12 @@
                   "JSON array of extra static URL entries (path, priority, changefreq, title, category)."
                 )}
               </p>
-              <textarea
+              <.textarea
                 name="json"
+                value={@custom_urls_text}
                 rows="8"
-                class="textarea textarea-bordered font-mono text-xs w-full"
-              >{@custom_urls_text}</textarea>
+                class="font-mono text-xs"
+              />
               <div :if={@custom_urls_error} class="alert alert-error mt-2 py-2 text-xs">
                 {@custom_urls_error}
               </div>
@@ -775,11 +765,12 @@
                   "JSON array of route configurations (plug or path, priority, changefreq, title, category). Replaces the built-in defaults entirely when saved — an empty list removes the homepage entry too."
                 )}
               </p>
-              <textarea
+              <.textarea
                 name="json"
+                value={@static_routes_text}
                 rows="8"
-                class="textarea textarea-bordered font-mono text-xs w-full"
-              >{@static_routes_text}</textarea>
+                class="font-mono text-xs"
+              />
               <div :if={@static_routes_error} class="alert alert-error mt-2 py-2 text-xs">
                 {@static_routes_error}
               </div>

--- a/lib/modules/sitemap/web/settings.html.heex
+++ b/lib/modules/sitemap/web/settings.html.heex
@@ -2,30 +2,27 @@
   flash={@flash}
   phoenix_kit_current_scope={assigns[:phoenix_kit_current_scope]}
   page_title={gettext("Sitemap Settings")}
+  page_section={gettext("Modules")}
+  page_section_path={Routes.path("/admin/modules", locale: @current_locale)}
+  page_subtitle={gettext("Configure sitemap generation and scheduling")}
   current_path={@current_path}
   project_title={@project_title}
   current_locale={@current_locale}
 >
   <div class="container flex flex-col mx-auto px-4 py-6">
-    <.admin_page_header
-      back={Routes.path("/admin/modules", locale: @current_locale)}
-      title={gettext("Sitemap Settings")}
-      subtitle={gettext("Configure sitemap generation and scheduling")}
-    >
-      <:actions>
-        <label class="label cursor-pointer gap-2">
-          <span class="label-text font-medium">
-            {if @config.enabled, do: gettext("Enabled"), else: gettext("Disabled")}
-          </span>
-          <input
-            type="checkbox"
-            class="toggle toggle-primary"
-            checked={@config.enabled}
-            phx-click="toggle_sitemap"
-          />
-        </label>
-      </:actions>
-    </.admin_page_header>
+    <div class="flex items-center gap-2 justify-end mb-4">
+      <label class="label cursor-pointer gap-2">
+        <span class="label-text font-medium">
+          {if @config.enabled, do: gettext("Enabled"), else: gettext("Disabled")}
+        </span>
+        <input
+          type="checkbox"
+          class="toggle toggle-primary"
+          checked={@config.enabled}
+          phx-click="toggle_sitemap"
+        />
+      </label>
+    </div>
 
     <div class="space-y-6">
       <%!-- Stats Cards --%>

--- a/lib/modules/storage/web/bucket_form.ex
+++ b/lib/modules/storage/web/bucket_form.ex
@@ -291,8 +291,8 @@ defmodule PhoenixKitWeb.Live.Modules.Storage.BucketForm do
     Storage.get_bucket(bucket_uuid)
   end
 
-  defp page_title(:new), do: "Add Storage Bucket"
-  defp page_title(:edit), do: "Edit Storage Bucket"
+  defp page_title(:new), do: gettext("Add Storage Bucket")
+  defp page_title(:edit), do: gettext("Edit Storage Bucket")
 
   # Helper function to get current path for navigation
   defp get_current_path(_socket, _session) do

--- a/lib/modules/storage/web/bucket_form.html.heex
+++ b/lib/modules/storage/web/bucket_form.html.heex
@@ -2,17 +2,14 @@
   flash={@flash}
   phoenix_kit_current_scope={assigns[:phoenix_kit_current_scope]}
   page_title={@page_title}
+  page_section={gettext("Media")}
+  page_section_path={PhoenixKit.Utils.Routes.path("/admin/settings/media")}
+  page_subtitle={gettext("Configure storage provider settings")}
   current_path={@current_path}
   current_locale={@current_locale}
   project_title={@project_title}
 >
   <div class="container mx-auto px-4 py-8 max-w-3xl">
-    <.admin_page_header
-      back={PhoenixKit.Utils.Routes.path("/admin/settings/media")}
-      title={@page_title}
-      subtitle={gettext("Configure storage provider settings")}
-    />
-
     <.form for={@changeset} phx-change="validate" phx-submit="save" class="space-y-6">
       <%!-- Basic Information --%>
       <div class="card bg-base-100 shadow-sm">

--- a/lib/modules/storage/web/bucket_form.html.heex
+++ b/lib/modules/storage/web/bucket_form.html.heex
@@ -9,7 +9,7 @@
   current_locale={@current_locale}
   project_title={@project_title}
 >
-  <div class="container mx-auto px-4 py-8 max-w-3xl">
+  <div class="mx-auto px-4 py-8 max-w-3xl">
     <.form for={@changeset} phx-change="validate" phx-submit="save" class="space-y-6">
       <%!-- Basic Information --%>
       <div class="card bg-base-100 shadow-sm">

--- a/lib/modules/storage/web/bucket_form.html.heex
+++ b/lib/modules/storage/web/bucket_form.html.heex
@@ -20,11 +20,11 @@
 
           <fieldset class="fieldset">
             <legend class="fieldset-legend font-semibold">{gettext("Bucket Name")} *</legend>
-            <input
+            <.input
               type="text"
               name="bucket[name]"
               value={Ecto.Changeset.get_field(@changeset, :name)}
-              class={"input input-bordered w-full #{input_class(@changeset, :name)}"}
+              class={input_class(@changeset, :name)}
               placeholder={gettext("e.g., Production Media, Backup Storage")}
               required
             />
@@ -38,41 +38,20 @@
               <legend class="fieldset-legend font-semibold">
                 {gettext("Storage Provider")} *
               </legend>
-              <label class={"select w-full #{input_class(@changeset, :provider)}"}>
-                <select name="bucket[provider]" required>
-                  <option value="">{gettext("Select provider...")}</option>
-                  <option
-                    value="local"
-                    selected={Ecto.Changeset.get_field(@changeset, :provider) == "local"}
-                  >
-                    {gettext("Local Filesystem")}
-                  </option>
-                  <option
-                    value="s3"
-                    selected={Ecto.Changeset.get_field(@changeset, :provider) == "s3"}
-                  >
-                    AWS S3
-                  </option>
-                  <option
-                    value="b2"
-                    selected={Ecto.Changeset.get_field(@changeset, :provider) == "b2"}
-                  >
-                    Backblaze B2
-                  </option>
-                  <option
-                    value="r2"
-                    selected={Ecto.Changeset.get_field(@changeset, :provider) == "r2"}
-                  >
-                    Cloudflare R2
-                  </option>
-                  <option
-                    value="tigris"
-                    selected={Ecto.Changeset.get_field(@changeset, :provider) == "tigris"}
-                  >
-                    Tigris
-                  </option>
-                </select>
-              </label>
+              <.select
+                name="bucket[provider]"
+                required
+                value={Ecto.Changeset.get_field(@changeset, :provider)}
+                class={input_class(@changeset, :provider)}
+                prompt={gettext("Select provider...")}
+                options={[
+                  {gettext("Local Filesystem"), "local"},
+                  {"AWS S3", "s3"},
+                  {"Backblaze B2", "b2"},
+                  {"Cloudflare R2", "r2"},
+                  {"Tigris", "tigris"}
+                ]}
+              />
             </fieldset>
           <% else %>
             <input type="hidden" name="bucket[provider]" value={@current_provider} />
@@ -112,11 +91,11 @@
 
             <fieldset class="fieldset">
               <legend class="fieldset-legend font-semibold">{gettext("Storage Path")} *</legend>
-              <input
+              <.input
                 type="text"
                 name="bucket[endpoint]"
                 value={Ecto.Changeset.get_field(@changeset, :endpoint)}
-                class={"input input-bordered w-full #{input_class(@changeset, :endpoint)}"}
+                class={input_class(@changeset, :endpoint)}
                 placeholder="/path/to/storage"
                 required
               />
@@ -195,11 +174,11 @@
                   _ -> gettext("Bucket Name")
                 end} *
               </legend>
-              <input
+              <.input
                 type="text"
                 name="bucket[bucket_name]"
                 value={Ecto.Changeset.get_field(@changeset, :bucket_name)}
-                class={"input input-bordered w-full #{input_class(@changeset, :bucket_name)}"}
+                class={input_class(@changeset, :bucket_name)}
                 placeholder="e.g., my-app-files"
                 required={@current_provider in ["b2", "r2", "tigris"]}
               />
@@ -215,11 +194,11 @@
                     _ -> gettext("Endpoint")
                   end} *
                 </legend>
-                <input
+                <.input
                   type="text"
                   name="bucket[endpoint]"
                   value={Ecto.Changeset.get_field(@changeset, :endpoint)}
-                  class={"input input-bordered w-full #{input_class(@changeset, :endpoint)}"}
+                  class={input_class(@changeset, :endpoint)}
                   placeholder={
                     case @current_provider do
                       "b2" -> "e.g., s3.us-west-002.backblazeb2.com"
@@ -247,11 +226,11 @@
                 <legend class="fieldset-legend font-semibold">
                   {gettext("Access Key ID")} *
                 </legend>
-                <input
+                <.input
                   type="text"
                   name="bucket[access_key_id]"
                   value={Ecto.Changeset.get_field(@changeset, :access_key_id)}
-                  class={"input input-bordered w-full #{input_class(@changeset, :access_key_id)}"}
+                  class={input_class(@changeset, :access_key_id)}
                   placeholder="AKIA..."
                   required={@current_provider in ["b2", "r2", "tigris"]}
                 />
@@ -261,11 +240,11 @@
                 <legend class="fieldset-legend font-semibold">
                   {gettext("Secret Access Key")} *
                 </legend>
-                <input
+                <.input
                   type="password"
                   name="bucket[secret_access_key]"
                   value={Ecto.Changeset.get_field(@changeset, :secret_access_key)}
-                  class={"input input-bordered w-full #{input_class(@changeset, :secret_access_key)}"}
+                  class={input_class(@changeset, :secret_access_key)}
                   placeholder="•••••••••••••••••••••••••••••••••"
                   required={@current_provider in ["b2", "r2", "tigris"]}
                 />
@@ -320,32 +299,24 @@
             <%= if @current_provider in ["s3", "b2", "r2", "tigris"] do %>
               <fieldset class="fieldset">
                 <legend class="fieldset-legend font-semibold">{gettext("Access Type")}</legend>
-                <label class="select w-full">
-                  <select name="bucket[access_type]">
-                    <option
-                      value="public"
-                      selected={Ecto.Changeset.get_field(@changeset, :access_type) == "public"}
-                    >
-                      {gettext("Public (direct URL)")}
-                    </option>
-                    <option
-                      value="private"
-                      selected={Ecto.Changeset.get_field(@changeset, :access_type) == "private"}
-                    >
-                      {gettext("Private (proxied)")}
-                    </option>
-                  </select>
-                </label>
+                <.select
+                  name="bucket[access_type]"
+                  value={Ecto.Changeset.get_field(@changeset, :access_type)}
+                  options={[
+                    {gettext("Public (direct URL)"), "public"},
+                    {gettext("Private (proxied)"), "private"}
+                  ]}
+                />
               </fieldset>
             <% end %>
 
             <fieldset class="fieldset">
               <legend class="fieldset-legend font-semibold">{gettext("Priority")}</legend>
-              <input
+              <.input
                 type="number"
                 name="bucket[priority]"
                 value={Ecto.Changeset.get_field(@changeset, :priority)}
-                class={"input input-bordered w-full #{input_class(@changeset, :priority)}"}
+                class={input_class(@changeset, :priority)}
                 placeholder="0"
                 min="0"
               />

--- a/lib/modules/storage/web/dimension_form.ex
+++ b/lib/modules/storage/web/dimension_form.ex
@@ -143,8 +143,8 @@ defmodule PhoenixKitWeb.Live.Modules.Storage.DimensionForm do
     socket
     |> assign(:changeset, changeset)
     |> assign(:dimension_type, dimension_type)
-    |> assign(:page_title, "Edit Storage Dimension")
-    |> assign(:form_action, "Update Dimension")
+    |> assign(:page_title, gettext("Edit Storage Dimension"))
+    |> assign(:form_action, gettext("Update Dimension"))
     |> assign_format_fields(changeset)
   end
 
@@ -172,9 +172,9 @@ defmodule PhoenixKitWeb.Live.Modules.Storage.DimensionForm do
     end)
   end
 
-  defp page_title_with_type(:new, "image"), do: "Add Image Dimension"
-  defp page_title_with_type(:new, "video"), do: "Add Video Dimension"
-  defp page_title_with_type(:new, _), do: "Add Storage Dimension"
+  defp page_title_with_type(:new, "image"), do: gettext("Add Image Dimension")
+  defp page_title_with_type(:new, "video"), do: gettext("Add Video Dimension")
+  defp page_title_with_type(:new, _), do: gettext("Add Storage Dimension")
 
   # Helper function for input validation styling
   defp input_class(changeset, field) do

--- a/lib/modules/storage/web/dimension_form.html.heex
+++ b/lib/modules/storage/web/dimension_form.html.heex
@@ -9,7 +9,7 @@
   current_locale={@current_locale}
   project_title={@project_title}
 >
-  <div class="container mx-auto px-4 py-8 max-w-3xl">
+  <div class="mx-auto px-4 py-8 max-w-3xl">
     <.form for={@changeset} phx-change="validate" phx-submit="save" class="space-y-6">
       <%!-- Basic Information --%>
       <div class="card bg-base-100 shadow-sm">

--- a/lib/modules/storage/web/dimension_form.html.heex
+++ b/lib/modules/storage/web/dimension_form.html.heex
@@ -2,17 +2,14 @@
   flash={@flash}
   phoenix_kit_current_scope={assigns[:phoenix_kit_current_scope]}
   page_title={@page_title}
+  page_section={gettext("Dimensions")}
+  page_section_path={PhoenixKit.Utils.Routes.path("/admin/settings/media/dimensions")}
+  page_subtitle={gettext("Configure dimension presets for automatic file variant generation")}
   current_path={@current_path}
   current_locale={@current_locale}
   project_title={@project_title}
 >
   <div class="container mx-auto px-4 py-8 max-w-3xl">
-    <.admin_page_header
-      back={PhoenixKit.Utils.Routes.path("/admin/settings/media/dimensions")}
-      title={@page_title}
-      subtitle={gettext("Configure dimension presets for automatic file variant generation")}
-    />
-
     <.form for={@changeset} phx-change="validate" phx-submit="save" class="space-y-6">
       <%!-- Basic Information --%>
       <div class="card bg-base-100 shadow-sm">

--- a/lib/modules/storage/web/dimension_form.html.heex
+++ b/lib/modules/storage/web/dimension_form.html.heex
@@ -22,12 +22,12 @@
             <legend class="fieldset-legend font-semibold">
               {gettext("Dimension Name")} *
             </legend>
-            <input
+            <.input
               type="text"
               name="dimension[name]"
               phx-debounce="blur"
               value={get_field_value(@changeset, :name)}
-              class={"input input-bordered w-full #{input_class(@changeset, :name)}"}
+              class={input_class(@changeset, :name)}
               placeholder={gettext("e.g., thumbnail, medium, 720p")}
               required
             />
@@ -75,12 +75,12 @@
                   {gettext("Width (px)")} *
                 <% end %>
               </legend>
-              <input
+              <.input
                 type="number"
                 name="dimension[width]"
                 phx-debounce="blur"
                 value={get_field_value(@changeset, :width)}
-                class={"input input-bordered w-full #{input_class(@changeset, :width)}"}
+                class={input_class(@changeset, :width)}
                 placeholder="800"
                 min="1"
                 required
@@ -93,12 +93,12 @@
                 <legend class="fieldset-legend font-semibold">
                   {gettext("Height (px)")} *
                 </legend>
-                <input
+                <.input
                   type="number"
                   name="dimension[height]"
                   phx-debounce="blur"
                   value={get_field_value(@changeset, :height)}
-                  class={"input input-bordered w-full #{input_class(@changeset, :height)}"}
+                  class={input_class(@changeset, :height)}
                   placeholder="600"
                   min="1"
                   required
@@ -127,12 +127,12 @@
                   {gettext("Quality")}
                 <% end %>
               </legend>
-              <input
+              <.input
                 type="number"
                 name="dimension[quality]"
                 phx-debounce="blur"
                 value={get_field_value(@changeset, :quality)}
-                class={"input input-bordered w-full #{input_class(@changeset, :quality)}"}
+                class={input_class(@changeset, :quality)}
                 placeholder={if @dimension_type == "video", do: "23", else: "85"}
                 min={if @dimension_type == "video", do: "0", else: "1"}
                 max={if @dimension_type == "video", do: "51", else: "100"}
@@ -156,19 +156,19 @@
                 <% end %>
               </legend>
               <% format_value = get_field_value(@changeset, :format) %>
-              <label class={"select w-full #{input_class(@changeset, :format)}"}>
-                <select name="dimension[format]">
-                  <option value="">{gettext("Preserve original")}</option>
-                  <%= if @dimension_type != "video" do %>
-                    <option value="jpg" selected={format_value == "jpg"}>JPEG</option>
-                    <option value="png" selected={format_value == "png"}>PNG</option>
-                    <option value="webp" selected={format_value == "webp"}>WebP</option>
-                  <% end %>
-                  <%= if @dimension_type == "video" do %>
-                    <option value="mp4" selected={format_value == "mp4"}>MP4</option>
-                  <% end %>
-                </select>
-              </label>
+              <.select
+                name="dimension[format]"
+                value={format_value}
+                class={input_class(@changeset, :format)}
+                prompt={gettext("Preserve original")}
+                options={
+                  if @dimension_type == "video" do
+                    [{"MP4", "mp4"}]
+                  else
+                    [{"JPEG", "jpg"}, {"PNG", "png"}, {"WebP", "webp"}]
+                  end
+                }
+              />
               {render_error(@changeset, :format)}
               <p class="text-xs text-base-content/50 mt-1">
                 {gettext("Leave empty to preserve the original file format")}

--- a/lib/modules/storage/web/dimensions.ex
+++ b/lib/modules/storage/web/dimensions.ex
@@ -36,8 +36,6 @@ defmodule PhoenixKitWeb.Live.Modules.Storage.Dimensions do
   end
 
   def handle_event("delete_dimension", %{"id" => id}, socket) do
-    Logger.info("Dimensions: delete_dimension event triggered for id=#{id}")
-
     dimension = Storage.get_dimension(id)
 
     case Storage.delete_dimension(dimension) do
@@ -59,8 +57,6 @@ defmodule PhoenixKitWeb.Live.Modules.Storage.Dimensions do
   end
 
   def handle_event("toggle_dimension", %{"id" => id}, socket) do
-    Logger.info("Dimensions: toggle_dimension event triggered for id=#{id}")
-
     dimension = Storage.get_dimension(id)
 
     case Storage.update_dimension(dimension, %{enabled: !dimension.enabled}) do

--- a/lib/modules/storage/web/dimensions.html.heex
+++ b/lib/modules/storage/web/dimensions.html.heex
@@ -47,14 +47,13 @@
     <div class="card bg-base-100 shadow-xl">
       <div class="card-body">
         <%= if length(@dimensions) == 0 do %>
-          <div class="text-center py-12">
-            <.icon name="hero-photo" class="w-16 h-16 mx-auto mb-4 text-base-content/30" />
-            <p class="text-lg text-base-content/70 mb-2">
-              {gettext("No dimensions configured")}
-            </p>
-            <p class="text-sm text-base-content/50 mb-4">
-              {gettext("Create your first dimension preset to start generating file variants.")}
-            </p>
+          <.empty_state
+            icon="hero-photo"
+            title={gettext("No dimensions configured")}
+            description={
+              gettext("Create your first dimension preset to start generating file variants.")
+            }
+          >
             <div class="flex justify-center gap-4">
               <.link
                 navigate={
@@ -73,7 +72,7 @@
                 <.icon name="hero-plus" class="w-4 h-4 mr-1" /> {gettext("Add Video Dimension")}
               </.link>
             </div>
-          </div>
+          </.empty_state>
         <% else %>
           <%!-- Image Dimensions --%>
           <div class="mb-8">

--- a/lib/modules/storage/web/dimensions.html.heex
+++ b/lib/modules/storage/web/dimensions.html.heex
@@ -26,6 +26,23 @@
       </div>
     </div>
 
+    <%!-- Page-level actions. Deliberately NOT in the image table's
+         `:toolbar_actions` slot: that table only renders when dimensions exist,
+         and restoring the defaults is exactly what an empty list needs. --%>
+    <div class="flex flex-wrap items-center gap-2 justify-end mb-4">
+      <button
+        phx-click="reset_dimensions_to_defaults"
+        data-confirm={
+          gettext(
+            "Are you sure? This will delete all current dimensions and restore the default 8 dimensions. This action cannot be undone."
+          )
+        }
+        class="btn btn-outline btn-error btn-sm"
+      >
+        <.icon name="hero-arrow-path" class="w-4 h-4 mr-1" /> {gettext("Reset to Defaults")}
+      </button>
+    </div>
+
     <%!-- Dimensions List --%>
     <div class="card bg-base-100 shadow-xl">
       <div class="card-body">
@@ -121,21 +138,6 @@
                 end
               }
             >
-              <:toolbar_actions>
-                <button
-                  phx-click="reset_dimensions_to_defaults"
-                  data-confirm={
-                    gettext(
-                      "Are you sure? This will delete all current dimensions and restore the default 8 dimensions. This action cannot be undone."
-                    )
-                  }
-                  class="btn btn-outline btn-error btn-sm"
-                >
-                  <.icon name="hero-arrow-path" class="w-4 h-4 mr-1" /> {gettext(
-                    "Reset to Defaults"
-                  )}
-                </button>
-              </:toolbar_actions>
               <.table_default_header>
                 <.table_default_row>
                   <.table_default_header_cell>{gettext("Name")}</.table_default_header_cell>

--- a/lib/modules/storage/web/dimensions.html.heex
+++ b/lib/modules/storage/web/dimensions.html.heex
@@ -2,31 +2,14 @@
   flash={@flash}
   phoenix_kit_current_scope={assigns[:phoenix_kit_current_scope]}
   page_title={gettext("Instance Dimensions")}
+  page_section={gettext("Media")}
+  page_section_path={PhoenixKit.Utils.Routes.path("/admin/settings/media")}
+  page_subtitle={gettext("Manage dimension presets for automatic file instance generation")}
   current_path={@current_path}
   current_locale={@current_locale}
   project_title={@project_title}
 >
   <div class="container mx-auto px-4 py-8 max-w-6xl">
-    <.admin_page_header
-      back={PhoenixKit.Utils.Routes.path("/admin/settings/media")}
-      title={gettext("Instance Dimensions")}
-      subtitle={gettext("Manage dimension presets for automatic file instance generation")}
-    >
-      <:actions>
-        <button
-          phx-click="reset_dimensions_to_defaults"
-          data-confirm={
-            gettext(
-              "Are you sure? This will delete all current dimensions and restore the default 8 dimensions. This action cannot be undone."
-            )
-          }
-          class="btn btn-outline btn-error btn-sm"
-        >
-          <.icon name="hero-arrow-path" class="w-4 h-4 mr-1" /> {gettext("Reset to Defaults")}
-        </button>
-      </:actions>
-    </.admin_page_header>
-
     <%!-- Info Alert --%>
     <div class="alert alert-info mb-6">
       <.icon name="hero-information-circle" class="w-5 h-5" />
@@ -138,6 +121,21 @@
                 end
               }
             >
+              <:toolbar_actions>
+                <button
+                  phx-click="reset_dimensions_to_defaults"
+                  data-confirm={
+                    gettext(
+                      "Are you sure? This will delete all current dimensions and restore the default 8 dimensions. This action cannot be undone."
+                    )
+                  }
+                  class="btn btn-outline btn-error btn-sm"
+                >
+                  <.icon name="hero-arrow-path" class="w-4 h-4 mr-1" /> {gettext(
+                    "Reset to Defaults"
+                  )}
+                </button>
+              </:toolbar_actions>
               <.table_default_header>
                 <.table_default_row>
                   <.table_default_header_cell>{gettext("Name")}</.table_default_header_cell>

--- a/lib/modules/storage/web/dimensions.html.heex
+++ b/lib/modules/storage/web/dimensions.html.heex
@@ -9,7 +9,7 @@
   current_locale={@current_locale}
   project_title={@project_title}
 >
-  <div class="container mx-auto px-4 py-8 max-w-6xl">
+  <div class="px-4 py-8">
     <%!-- Info Alert --%>
     <div class="alert alert-info mb-6">
       <.icon name="hero-information-circle" class="w-5 h-5" />

--- a/lib/modules/storage/web/health.html.heex
+++ b/lib/modules/storage/web/health.html.heex
@@ -2,17 +2,14 @@
   flash={@flash}
   phoenix_kit_current_scope={assigns[:phoenix_kit_current_scope]}
   page_title={@page_title}
+  page_section={gettext("Media")}
+  page_section_path={PhoenixKit.Utils.Routes.path("/admin/settings/media")}
+  page_subtitle={gettext("Check file redundancy against configured target")}
   current_path={@current_path}
   current_locale={@current_locale}
   project_title={@project_title}
 >
   <div class="container mx-auto px-4 py-8 max-w-5xl">
-    <.admin_page_header
-      back={PhoenixKit.Utils.Routes.path("/admin/settings/media")}
-      title={@page_title}
-      subtitle={gettext("Check file redundancy against configured target")}
-    />
-
     <%!-- Stats --%>
     <div class="stats stats-vertical lg:stats-horizontal shadow w-full mb-6">
       <div class="stat">

--- a/lib/modules/storage/web/health.html.heex
+++ b/lib/modules/storage/web/health.html.heex
@@ -9,7 +9,7 @@
   current_locale={@current_locale}
   project_title={@project_title}
 >
-  <div class="container mx-auto px-4 py-8 max-w-5xl">
+  <div class="px-4 py-8">
     <%!-- Stats --%>
     <div class="stats stats-vertical lg:stats-horizontal shadow w-full mb-6">
       <div class="stat">

--- a/lib/modules/storage/web/settings.html.heex
+++ b/lib/modules/storage/web/settings.html.heex
@@ -347,13 +347,13 @@
                   </span>
                 </div>
               <% end %>
-              <input
+              <.input
                 type="number"
                 name="form_redundancy"
                 value={@form_redundancy}
                 min="1"
                 max={@max_redundancy}
-                class={"input input-bordered #{if @form_redundancy > @max_redundancy, do: "input-warning", else: ""}"}
+                class={@form_redundancy > @max_redundancy && "input-warning"}
               />
               <p class="text-xs text-base-content/70 mt-1">
                 {gettext("Enter number of copies")} (1-{@max_redundancy}).
@@ -373,70 +373,51 @@
 
           <%!-- Auto-Variant Generation --%>
           <div class="form-control">
-            <label class="flex items-start gap-3 cursor-pointer py-2">
-              <input
-                type="checkbox"
-                name="form_auto_generate_variants"
-                checked={@form_auto_generate_variants}
-                phx-click="toggle_form_variants"
-                value="true"
-                class="checkbox checkbox-primary mt-0.5 flex-shrink-0"
-              />
-              <span>
-                <span class="font-semibold text-sm">{gettext("Auto-Generate Variants")}</span>
-                <span class="block text-xs text-base-content/70 mt-0.5">
-                  {gettext("Automatically resize images and videos to configured dimensions")}
-                </span>
-              </span>
-            </label>
+            <.checkbox
+              name="form_auto_generate_variants"
+              checked={@form_auto_generate_variants}
+              phx-click="toggle_form_variants"
+              class="mt-0.5 flex-shrink-0"
+              label={gettext("Auto-Generate Variants")}
+            >
+              <:description>
+                {gettext("Automatically resize images and videos to configured dimensions")}
+              </:description>
+            </.checkbox>
           </div>
 
           <%!-- Deep Zoom Tile Generation --%>
           <div class="form-control">
-            <label class="flex items-start gap-3 cursor-pointer py-2">
-              <input
-                type="checkbox"
-                name="form_tile_generation_enabled"
-                checked={@form_tile_generation_enabled}
-                phx-click="toggle_form_tile_generation"
-                value="true"
-                class="checkbox checkbox-primary mt-0.5 flex-shrink-0"
-              />
-              <span>
-                <span class="font-semibold text-sm">
-                  {gettext("Deep Zoom Tile Generation")}
-                </span>
-                <span class="block text-xs text-base-content/70 mt-0.5">
-                  {gettext(
-                    "Lazily generate DZI tile pyramids when users zoom deeply into images. With this off the MediaBrowser still swaps between medium/large variants while zooming, but never generates tiles or hits the lazy tile endpoint. ImageMagick is required when enabled."
-                  )}
-                </span>
-              </span>
-            </label>
+            <.checkbox
+              name="form_tile_generation_enabled"
+              checked={@form_tile_generation_enabled}
+              phx-click="toggle_form_tile_generation"
+              class="mt-0.5 flex-shrink-0"
+              label={gettext("Deep Zoom Tile Generation")}
+            >
+              <:description>
+                {gettext(
+                  "Lazily generate DZI tile pyramids when users zoom deeply into images. With this off the MediaBrowser still swaps between medium/large variants while zooming, but never generates tiles or hits the lazy tile endpoint. ImageMagick is required when enabled."
+                )}
+              </:description>
+            </.checkbox>
           </div>
 
           <%!-- Annotated Thumbnails --%>
           <div class="form-control">
-            <label class="flex items-start gap-3 cursor-pointer py-2">
-              <input
-                type="checkbox"
-                name="form_annotated_thumbnails_enabled"
-                checked={@form_annotated_thumbnails_enabled}
-                phx-click="toggle_form_annotated_thumbnails"
-                value="true"
-                class="checkbox checkbox-primary mt-0.5 flex-shrink-0"
-              />
-              <span>
-                <span class="font-semibold text-sm">
-                  {gettext("Annotated Thumbnails")}
-                </span>
-                <span class="block text-xs text-base-content/70 mt-0.5">
-                  {gettext(
-                    "Bake Etcher annotation shapes (rectangles, marker strokes, etc.) into a file's grid thumbnail, regenerated in the background when annotations change. With this off the grid shows the plain thumbnail and no annotated variant is generated. ImageMagick is required when enabled."
-                  )}
-                </span>
-              </span>
-            </label>
+            <.checkbox
+              name="form_annotated_thumbnails_enabled"
+              checked={@form_annotated_thumbnails_enabled}
+              phx-click="toggle_form_annotated_thumbnails"
+              class="mt-0.5 flex-shrink-0"
+              label={gettext("Annotated Thumbnails")}
+            >
+              <:description>
+                {gettext(
+                  "Bake Etcher annotation shapes (rectangles, marker strokes, etc.) into a file's grid thumbnail, regenerated in the background when annotations change. With this off the grid shows the plain thumbnail and no annotated variant is generated. ImageMagick is required when enabled."
+                )}
+              </:description>
+            </.checkbox>
           </div>
 
           <%!-- Max Upload Size --%>
@@ -447,12 +428,11 @@
                 {gettext("Maximum file size allowed per upload")}
               </span>
             </div>
-            <input
+            <.input
               type="number"
               name="form_max_upload_size_mb"
               value={@form_max_upload_size_mb}
               min="1"
-              class="input input-bordered"
             />
             <p class="text-xs text-base-content/70 mt-1">
               {gettext("Current limit: %{size} MB", size: @form_max_upload_size_mb)}

--- a/lib/modules/storage/web/settings.html.heex
+++ b/lib/modules/storage/web/settings.html.heex
@@ -13,7 +13,7 @@
   current_locale={@current_locale}
   project_title={@project_title}
 >
-  <div class="container mx-auto px-4 py-8">
+  <div class="px-4 py-8">
     <%!-- System Dependencies Check --%>
     <%= if match?({:error, :not_installed}, @imagemagick_status) do %>
       <div class="alert alert-error mb-6">

--- a/lib/modules/storage/web/settings.html.heex
+++ b/lib/modules/storage/web/settings.html.heex
@@ -2,21 +2,18 @@
   flash={@flash}
   phoenix_kit_current_scope={assigns[:phoenix_kit_current_scope]}
   page_title={gettext("Media Settings")}
+  page_section={gettext("Modules")}
+  page_section_path={PhoenixKit.Utils.Routes.path("/admin/modules")}
+  page_subtitle={
+    gettext(
+      "Media is a core system module that is always enabled and cannot be disabled — it provides essential file management functionality across PhoenixKit. Configure its storage buckets and file processing settings here."
+    )
+  }
   current_path={@current_path}
   current_locale={@current_locale}
   project_title={@project_title}
 >
   <div class="container mx-auto px-4 py-8">
-    <.admin_page_header
-      back={PhoenixKit.Utils.Routes.path("/admin/modules")}
-      title={gettext("Media Settings")}
-      subtitle={
-        gettext(
-          "Media is a core system module that is always enabled and cannot be disabled — it provides essential file management functionality across PhoenixKit. Configure its storage buckets and file processing settings here."
-        )
-      }
-    />
-
     <%!-- System Dependencies Check --%>
     <%= if match?({:error, :not_installed}, @imagemagick_status) do %>
       <div class="alert alert-error mb-6">

--- a/lib/phoenix_kit_web/components/core/input.ex
+++ b/lib/phoenix_kit_web/components/core/input.ex
@@ -80,7 +80,11 @@ defmodule PhoenixKitWeb.Components.Core.Input do
     ~H"""
     <div phx-feedback-for={@name} class={@wrapper_class}>
       <label :if={@label && @label != ""} class="label mb-2" for={@id}>
-        <span class="label-text font-semibold">{@label}</span>
+        <span class="font-semibold">{@label}</span>
+        <%!-- Required marker, rendered by the component so callers don't have to
+             append " *" to the label string — a plain string cannot carry the
+             error colour, and the hand-rolled markup this component replaced did. --%>
+        <span :if={@rest[:required]} class="text-error ml-0.5" aria-hidden="true">*</span>
       </label>
       <%!-- Icon-inside variant: daisyUI 5 puts the `input` class on a <label>
            wrapper so the icon sits inside the field. Focus color comes from

--- a/lib/phoenix_kit_web/components/core/pagination.ex
+++ b/lib/phoenix_kit_web/components/core/pagination.ex
@@ -44,9 +44,9 @@ defmodule PhoenixKitWeb.Components.Core.Pagination do
 
   def pagination_controls(assigns) do
     ~H"""
-    <div :if={@total_pages > 1} class={["btn-group", @class]}>
+    <div :if={@total_pages > 1} class={["join", @class]}>
       <%= if @page > 1 do %>
-        <.link patch={@build_url.(@page - 1)} class="btn btn-sm">
+        <.link patch={@build_url.(@page - 1)} class="join-item btn btn-sm">
           « Prev
         </.link>
       <% end %>
@@ -54,14 +54,14 @@ defmodule PhoenixKitWeb.Components.Core.Pagination do
       <%= for page_num <- pagination_range(@page, @total_pages) do %>
         <.link
           patch={@build_url.(page_num)}
-          class={["btn btn-sm", page_num == @page && "btn-active"]}
+          class={["join-item btn btn-sm", page_num == @page && "btn-active"]}
         >
           {page_num}
         </.link>
       <% end %>
 
       <%= if @page < @total_pages do %>
-        <.link patch={@build_url.(@page + 1)} class="btn btn-sm">
+        <.link patch={@build_url.(@page + 1)} class="join-item btn btn-sm">
           Next »
         </.link>
       <% end %>

--- a/lib/phoenix_kit_web/components/core/row_link.ex
+++ b/lib/phoenix_kit_web/components/core/row_link.ex
@@ -1,0 +1,43 @@
+defmodule PhoenixKitWeb.Components.Core.RowLink do
+  @moduledoc """
+  Stretched link that makes a whole table row (or card) clickable with a
+  single real `<a>` element.
+
+  Render it once at the START of the row's first cell. The row (or card)
+  must be a positioned ancestor (`relative`); the link paints an
+  `::after` overlay across it. Interactive siblings — row menus, buttons,
+  other links — need `relative z-10` to stay clickable above the overlay.
+  The link's accessible name comes from `label` (visually hidden).
+
+  ## Table rows need `row-link-host` (Safari)
+
+  Safari/WebKit ignores `position: relative` on `<tr>`, so on a `<tr>` host the
+  overlay escapes to the `<table>` and every row's overlay collapses onto the
+  last row — on iOS/iPadOS every row then navigates to the LAST one. Add the
+  `row-link-host` class (see `app.css`) to any `<tr>` host; it applies a
+  `transform` that WebKit *does* honor as a containing block. Card/`<div>`
+  hosts don't need it.
+
+  ## Example
+
+      <.table_default_row class="row-link-host relative cursor-pointer">
+        <.table_default_cell>
+          <.row_link navigate={~p"/orders/123"} label="Open order #123" />
+          #123
+        </.table_default_cell>
+        <.table_default_cell class="relative z-10"><.table_row_menu .../></.table_default_cell>
+      </.table_default_row>
+  """
+  use Phoenix.Component
+
+  attr :navigate, :string, required: true
+  attr :label, :string, required: true, doc: "accessible name for the link (rendered sr-only)"
+
+  def row_link(assigns) do
+    ~H"""
+    <.link navigate={@navigate} class="after:absolute after:inset-0 after:z-0">
+      <span class="sr-only">{@label}</span>
+    </.link>
+    """
+  end
+end

--- a/lib/phoenix_kit_web/components/core/row_link.ex
+++ b/lib/phoenix_kit_web/components/core/row_link.ex
@@ -9,18 +9,23 @@ defmodule PhoenixKitWeb.Components.Core.RowLink do
   other links — need `relative z-10` to stay clickable above the overlay.
   The link's accessible name comes from `label` (visually hidden).
 
-  ## Table rows need `row-link-host` (Safari)
+  ## Table rows need `transform-gpu` (Safari)
 
   Safari/WebKit ignores `position: relative` on `<tr>`, so on a `<tr>` host the
   overlay escapes to the `<table>` and every row's overlay collapses onto the
-  last row — on iOS/iPadOS every row then navigates to the LAST one. Add the
-  `row-link-host` class (see `app.css`) to any `<tr>` host; it applies a
-  `transform` that WebKit *does* honor as a containing block. Card/`<div>`
-  hosts don't need it.
+  last row — on iOS/iPadOS every row then navigates to the LAST one. Give any
+  `<tr>` host Tailwind's `transform-gpu` (`translateZ(0)`), which WebKit *does*
+  honor as a containing block. Card/`<div>` hosts don't need it.
+
+  `transform-gpu` is a stock Tailwind utility, so nothing has to be added to the
+  host application's stylesheet. Do **not** depend on a custom class such as
+  `row-link-host` for this: that rule lives in one host app's `app.css` and is
+  absent from every other consumer, where the failure is invisible in source and
+  only shows up on an iOS device.
 
   ## Example
 
-      <.table_default_row class="row-link-host relative cursor-pointer">
+      <.table_default_row class="relative transform-gpu cursor-pointer">
         <.table_default_cell>
           <.row_link navigate={~p"/orders/123"} label="Open order #123" />
           #123

--- a/lib/phoenix_kit_web/components/core/table_default.ex
+++ b/lib/phoenix_kit_web/components/core/table_default.ex
@@ -817,6 +817,11 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
   attr :name, :string, default: "search"
   attr :target, :any, default: nil
 
+  attr :id, :string,
+    default: nil,
+    doc:
+      "Id for the wrapping `<form>`. Without one, LiveView form recovery is silently disabled and host suites warn `missing_form_id`. Defaults to a value derived from the change event, which is unique per page in practice; pass an explicit id when two search toolbars share a page."
+
   attr :loading_indicator, :boolean,
     default: true,
     doc:
@@ -829,9 +834,11 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
       assigns
       |> assign(:placeholder, assigns.placeholder || dgettext("default", "Search..."))
       |> assign(:submit_event, assigns.on_submit || assigns.on_change)
+      |> assign(:id, assigns.id || "pk-search-toolbar-#{assigns.on_change}")
 
     ~H"""
     <form
+      id={@id}
       phx-submit={@submit_event}
       phx-target={@target}
       class={["flex items-center gap-2", @class]}

--- a/lib/phoenix_kit_web/components/core/textarea.ex
+++ b/lib/phoenix_kit_web/components/core/textarea.ex
@@ -43,7 +43,7 @@ defmodule PhoenixKitWeb.Components.Core.Textarea do
         id={@id}
         name={@name}
         class={[
-          "textarea textarea-bordered min-h-[6rem] w-full focus:input-primary",
+          "textarea min-h-[6rem] w-full focus:textarea-primary",
           @errors != [] && "textarea-error",
           @class
         ]}

--- a/lib/phoenix_kit_web/live/activity/index.ex
+++ b/lib/phoenix_kit_web/live/activity/index.ex
@@ -8,6 +8,10 @@ defmodule PhoenixKitWeb.Live.Activity.Index do
 
   use PhoenixKitWeb, :live_view
 
+  # Not wired project-wide (see PhoenixKitWeb.Components.Core.RowLink's
+  # commit message) — Andi's own row_link/1 import would become ambiguous.
+  import PhoenixKitWeb.Components.Core.RowLink, only: [row_link: 1]
+
   alias PhoenixKit.Activity
   alias PhoenixKit.PubSub.Manager, as: PubSubManager
   alias PhoenixKit.Settings

--- a/lib/phoenix_kit_web/live/activity/index.html.heex
+++ b/lib/phoenix_kit_web/live/activity/index.html.heex
@@ -342,7 +342,7 @@
           </.table_default_row>
         <% end %>
         <%= for entry <- @entries do %>
-          <.table_default_row class="row-link-host relative cursor-pointer">
+          <.table_default_row class="relative transform-gpu cursor-pointer">
             <.table_default_cell class="text-sm hidden md:table-cell">
               <%= if entry.module do %>
                 <span class="badge badge-outline badge-xs">{entry.module}</span>

--- a/lib/phoenix_kit_web/live/activity/index.html.heex
+++ b/lib/phoenix_kit_web/live/activity/index.html.heex
@@ -342,7 +342,7 @@
           </.table_default_row>
         <% end %>
         <%= for entry <- @entries do %>
-          <.table_default_row>
+          <.table_default_row class="row-link-host relative cursor-pointer">
             <.table_default_cell class="text-sm hidden md:table-cell">
               <%= if entry.module do %>
                 <span class="badge badge-outline badge-xs">{entry.module}</span>
@@ -360,6 +360,10 @@
               <% end %>
             </.table_default_cell>
             <.table_default_cell>
+              <.row_link
+                navigate={Routes.path("/admin/activity/#{entry.uuid}")}
+                label={entry.action}
+              />
               <span class={"badge badge-sm #{action_badge_color(entry.action)}"}>
                 {entry.action}
               </span>
@@ -438,7 +442,7 @@
                 {UtilsDate.format_time_with_user_format(entry.inserted_at)}
               </div>
             </.table_default_cell>
-            <.table_default_cell>
+            <.table_default_cell class="relative z-10">
               <.link
                 navigate={Routes.path("/admin/activity/#{entry.uuid}")}
                 class="btn btn-ghost btn-xs btn-square"
@@ -453,23 +457,18 @@
     </.table_default>
 
     <%!-- Pagination --%>
-    <%= if @total_pages > 1 do %>
-      <div class="flex justify-center mt-6">
-        <div class="join">
-          <%= for page <- max(1, @page - 2)..min(@total_pages, @page + 2) do %>
-            <.link
-              patch={
-                Routes.path(
-                  "/admin/activity?#{URI.encode_query(Enum.reject([{"page", page}, {"module", @filter_module}, {"mode", @filter_mode}, {"action", @filter_action}, {"resource_type", @filter_resource_type}], fn {_k, v} -> is_nil(v) or v == "" end))}"
-                )
-              }
-              class={["join-item btn btn-sm", if(page == @page, do: "btn-active", else: "")]}
-            >
-              {page}
-            </.link>
-          <% end %>
-        </div>
-      </div>
-    <% end %>
+    <.pagination
+      current_page={@page}
+      total_pages={@total_pages}
+      base_path={Routes.path("/admin/activity")}
+      params={
+        %{
+          "module" => @filter_module,
+          "mode" => @filter_mode,
+          "action" => @filter_action,
+          "resource_type" => @filter_resource_type
+        }
+      }
+    />
   </div>
 </PhoenixKitWeb.Components.LayoutWrapper.app_layout>

--- a/lib/phoenix_kit_web/live/activity/index.html.heex
+++ b/lib/phoenix_kit_web/live/activity/index.html.heex
@@ -8,7 +8,7 @@
   project_title={@project_title}
   current_locale={assigns[:current_locale]}
 >
-  <div class="container flex flex-col mx-auto px-4 py-6">
+  <div class="flex flex-col px-4 py-6">
     <%!-- Activity List --%>
     <.table_default
       id="activity-table"

--- a/lib/phoenix_kit_web/live/activity/show.html.heex
+++ b/lib/phoenix_kit_web/live/activity/show.html.heex
@@ -148,24 +148,26 @@
           <h3 class="font-semibold text-lg mb-4">{gettext("Metadata")}</h3>
 
           <%= if @entry.metadata && map_size(@entry.metadata) > 0 do %>
-            <div class="overflow-x-auto">
-              <table class="table table-sm">
-                <thead>
-                  <tr>
-                    <th class="w-1/3">{gettext("Key")}</th>
-                    <th>{gettext("Value")}</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <%= for {key, value} <- Enum.sort(@entry.metadata) do %>
-                    <tr>
-                      <td class="font-mono text-sm text-base-content/70">{key}</td>
-                      <td class="text-sm break-all">{to_string(value)}</td>
-                    </tr>
-                  <% end %>
-                </tbody>
-              </table>
-            </div>
+            <.table_default size="sm">
+              <.table_default_header>
+                <.table_default_row hover={false}>
+                  <.table_default_header_cell class="w-1/3">
+                    {gettext("Key")}
+                  </.table_default_header_cell>
+                  <.table_default_header_cell>{gettext("Value")}</.table_default_header_cell>
+                </.table_default_row>
+              </.table_default_header>
+              <.table_default_body>
+                <.table_default_row :for={{key, value} <- Enum.sort(@entry.metadata)}>
+                  <.table_default_cell class="font-mono text-sm text-base-content/70">
+                    {key}
+                  </.table_default_cell>
+                  <.table_default_cell class="text-sm break-all">
+                    {to_string(value)}
+                  </.table_default_cell>
+                </.table_default_row>
+              </.table_default_body>
+            </.table_default>
           <% else %>
             <div class="text-center py-4 text-base-content/50">
               {gettext("No metadata")}

--- a/lib/phoenix_kit_web/live/activity/show.html.heex
+++ b/lib/phoenix_kit_web/live/activity/show.html.heex
@@ -8,7 +8,7 @@
   project_title={@project_title}
   current_locale={assigns[:current_locale]}
 >
-  <div class="container flex flex-col mx-auto px-4 py-6">
+  <div class="flex flex-col px-4 py-6">
     <div class="max-w-4xl mx-auto w-full space-y-6">
       <%!-- Action & Status --%>
       <div class="card bg-base-100 shadow-sm">

--- a/lib/phoenix_kit_web/live/components/media_selector_modal.html.heex
+++ b/lib/phoenix_kit_web/live/components/media_selector_modal.html.heex
@@ -216,6 +216,7 @@
                         value={@search_query}
                         placeholder={gettext("Search by filename...")}
                         class="input-sm join-item flex-1"
+                        wrapper_class="contents"
                       />
                       <button type="submit" class="btn btn-primary btn-sm join-item">
                         <.icon name="hero-magnifying-glass" class="w-4 h-4" />

--- a/lib/phoenix_kit_web/live/components/media_selector_modal.html.heex
+++ b/lib/phoenix_kit_web/live/components/media_selector_modal.html.heex
@@ -210,12 +210,12 @@
                 <div class="flex-1">
                   <.form for={%{}} phx-submit="search" phx-target={@myself} class="w-full">
                     <div class="join w-full">
-                      <input
+                      <.input
                         type="text"
                         name="search[query]"
                         value={@search_query}
                         placeholder={gettext("Search by filename...")}
-                        class="input input-bordered input-sm join-item flex-1"
+                        class="input-sm join-item flex-1"
                       />
                       <button type="submit" class="btn btn-primary btn-sm join-item">
                         <.icon name="hero-magnifying-glass" class="w-4 h-4" />
@@ -225,23 +225,18 @@
                 </div>
                 <%!-- Filter by Type --%>
                 <div class="w-full md:w-40">
-                  <label class="select select-sm w-full">
-                    <select
-                      phx-change="filter_type"
-                      phx-target={@myself}
-                      name="filter"
-                    >
-                      <option value="all" selected={@file_type_filter == :all}>
-                        {gettext("All Files")}
-                      </option>
-                      <option value="image" selected={@file_type_filter == :image}>
-                        {gettext("Images Only")}
-                      </option>
-                      <option value="video" selected={@file_type_filter == :video}>
-                        {gettext("Videos Only")}
-                      </option>
-                    </select>
-                  </label>
+                  <.select
+                    name="filter"
+                    phx-change="filter_type"
+                    phx-target={@myself}
+                    value={@file_type_filter}
+                    options={[
+                      {gettext("All Files"), "all"},
+                      {gettext("Images Only"), "image"},
+                      {gettext("Videos Only"), "video"}
+                    ]}
+                    class="select-sm"
+                  />
                 </div>
               </div>
             </div>

--- a/lib/phoenix_kit_web/live/dashboard.html.heex
+++ b/lib/phoenix_kit_web/live/dashboard.html.heex
@@ -12,7 +12,7 @@
   project_title={@project_title}
   current_locale={@current_locale}
 >
-  <div class="container flex-col mx-auto px-4 py-8">
+  <div class="flex-col px-4 py-8">
     <%!-- Admin Menu Actions --%>
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6 gap-6 mb-8">
       <.link

--- a/lib/phoenix_kit_web/live/integrations/my_integration_form.ex
+++ b/lib/phoenix_kit_web/live/integrations/my_integration_form.ex
@@ -371,7 +371,7 @@ defmodule PhoenixKitWeb.Live.Integrations.MyIntegrationForm do
       project_title={@project_title}
       current_locale={assigns[:current_locale]}
     >
-      <div class="container mx-auto px-4 py-6">
+      <div class="px-4 py-6">
         <%!-- Step 1: Provider picker (new mode, no provider selected yet) --%>
         <div :if={@live_action == :new && @selected_provider == nil} class="max-w-4xl mx-auto">
           <.provider_picker providers={@providers} />

--- a/lib/phoenix_kit_web/live/integrations/my_integration_form.ex
+++ b/lib/phoenix_kit_web/live/integrations/my_integration_form.ex
@@ -364,17 +364,14 @@ defmodule PhoenixKitWeb.Live.Integrations.MyIntegrationForm do
       flash={@flash}
       phoenix_kit_current_scope={assigns[:phoenix_kit_current_scope]}
       page_title={@page_title}
+      page_section={gettext("Integrations")}
+      page_section_path={Routes.path("/admin/settings/integrations")}
+      page_subtitle={if @provider == nil, do: gettext("Choose a service to connect")}
       current_path={@url_path}
       project_title={@project_title}
       current_locale={assigns[:current_locale]}
     >
       <div class="container mx-auto px-4 py-6">
-        <.admin_page_header
-          back={Routes.path("/admin/settings/integrations")}
-          title={@page_title}
-          subtitle={if @provider == nil, do: gettext("Choose a service to connect")}
-        />
-
         <%!-- Step 1: Provider picker (new mode, no provider selected yet) --%>
         <div :if={@live_action == :new && @selected_provider == nil} class="max-w-4xl mx-auto">
           <.provider_picker providers={@providers} />

--- a/lib/phoenix_kit_web/live/integrations/my_integrations.ex
+++ b/lib/phoenix_kit_web/live/integrations/my_integrations.ex
@@ -197,7 +197,7 @@ defmodule PhoenixKitWeb.Live.Integrations.MyIntegrations do
             <.table_default_body>
               <.table_default_row
                 :for={conn <- @connections}
-                class="row-link-host relative cursor-pointer"
+                class="relative transform-gpu cursor-pointer"
               >
                 <.table_default_cell>
                   <.row_link

--- a/lib/phoenix_kit_web/live/integrations/my_integrations.ex
+++ b/lib/phoenix_kit_web/live/integrations/my_integrations.ex
@@ -17,6 +17,10 @@ defmodule PhoenixKitWeb.Live.Integrations.MyIntegrations do
 
   import PhoenixKitWeb.Components.Core.IntegrationsUI, only: [integration_status_badge: 1]
 
+  # Not wired project-wide (see PhoenixKitWeb.Components.Core.RowLink's
+  # commit message) — Andi's own row_link/1 import would become ambiguous.
+  import PhoenixKitWeb.Components.Core.RowLink, only: [row_link: 1]
+
   alias PhoenixKit.Integrations
   alias PhoenixKit.Integrations.Events
   alias PhoenixKit.Integrations.Providers
@@ -191,8 +195,15 @@ defmodule PhoenixKitWeb.Live.Integrations.MyIntegrations do
             </.table_default_header>
 
             <.table_default_body>
-              <.table_default_row :for={conn <- @connections}>
+              <.table_default_row
+                :for={conn <- @connections}
+                class="row-link-host relative cursor-pointer"
+              >
                 <.table_default_cell>
+                  <.row_link
+                    navigate={Routes.path("/admin/settings/integrations/#{conn.uuid}")}
+                    label={conn.provider.name}
+                  />
                   <div class="flex items-center gap-2">
                     <.icon name={conn.provider.icon} class="w-4 h-4 text-base-content/60" />
                     <span>{conn.provider.name}</span>
@@ -229,7 +240,7 @@ defmodule PhoenixKitWeb.Live.Integrations.MyIntegrations do
                     </div>
                   <% end %>
                 </.table_default_cell>
-                <.table_default_cell>
+                <.table_default_cell class="relative z-10">
                   <.table_row_menu
                     id={"my-integration-menu-#{conn.uuid}"}
                     mode="auto"

--- a/lib/phoenix_kit_web/live/integrations/my_integrations.ex
+++ b/lib/phoenix_kit_web/live/integrations/my_integrations.ex
@@ -130,7 +130,7 @@ defmodule PhoenixKitWeb.Live.Integrations.MyIntegrations do
       project_title={@project_title}
       current_locale={assigns[:current_locale]}
     >
-      <div class="container mx-auto px-4 py-6">
+      <div class="px-4 py-6">
         <%!-- Connections table --%>
         <div :if={@connections != []}>
           <.table_default

--- a/lib/phoenix_kit_web/live/modules.html.heex
+++ b/lib/phoenix_kit_web/live/modules.html.heex
@@ -8,7 +8,7 @@
   project_title={@project_title}
   current_locale={@current_locale}
 >
-  <div class="container flex flex-col mx-auto px-4 py-6">
+  <div class="flex flex-col px-4 py-6">
     <%!-- Dependency warnings --%>
     <div :if={@dep_warnings != []} class="mb-4 space-y-2">
       <div

--- a/lib/phoenix_kit_web/live/modules/jobs/index.html.heex
+++ b/lib/phoenix_kit_web/live/modules/jobs/index.html.heex
@@ -74,65 +74,45 @@
         <div class="card-body p-4">
           <div class="flex flex-wrap gap-4 mb-4">
             <form id="jobs-filter-queue-form" phx-change="filter_queue" class="form-control">
-              <label class="label py-1">
-                <span class="label-text text-xs">Queue</span>
-              </label>
-              <label class="select select-sm">
-                <select name="queue">
-                  <option value="all" selected={@filter_queue == "all"}>All Queues</option>
-                  <%= for {queue, _count} <- @queue_stats do %>
-                    <option value={queue} selected={@filter_queue == queue}>{queue}</option>
-                  <% end %>
-                </select>
-              </label>
+              <.select
+                name="queue"
+                value={@filter_queue}
+                label="Queue"
+                options={[{"All Queues", "all"} | Enum.map(@queue_stats, fn {q, _} -> {q, q} end)]}
+                class="select-sm"
+              />
             </form>
 
             <form id="jobs-filter-state-form" phx-change="filter_state" class="form-control">
-              <label class="label py-1">
-                <span class="label-text text-xs">State</span>
-              </label>
-              <label class="select select-sm">
-                <select name="state">
-                  <option value="all" selected={@filter_state == "all"}>All States</option>
-                  <option value="available" selected={@filter_state == "available"}>
-                    available
-                  </option>
-                  <option value="scheduled" selected={@filter_state == "scheduled"}>
-                    scheduled
-                  </option>
-                  <option value="executing" selected={@filter_state == "executing"}>
-                    executing
-                  </option>
-                  <option value="completed" selected={@filter_state == "completed"}>
-                    completed
-                  </option>
-                  <option value="retryable" selected={@filter_state == "retryable"}>
-                    retryable
-                  </option>
-                  <option value="discarded" selected={@filter_state == "discarded"}>
-                    discarded
-                  </option>
-                  <option value="cancelled" selected={@filter_state == "cancelled"}>
-                    cancelled
-                  </option>
-                </select>
-              </label>
+              <.select
+                name="state"
+                value={@filter_state}
+                label="State"
+                options={[
+                  {"All States", "all"},
+                  {"available", "available"},
+                  {"scheduled", "scheduled"},
+                  {"executing", "executing"},
+                  {"completed", "completed"},
+                  {"retryable", "retryable"},
+                  {"discarded", "discarded"},
+                  {"cancelled", "cancelled"}
+                ]}
+                class="select-sm"
+              />
             </form>
 
             <form id="jobs-filter-worker-form" phx-change="filter_worker" class="form-control">
-              <label class="label py-1">
-                <span class="label-text text-xs">Worker</span>
-              </label>
-              <label class="select select-sm">
-                <select name="worker">
-                  <option value="all" selected={@filter_worker == "all"}>All Workers</option>
-                  <%= for {worker, count} <- @worker_stats do %>
-                    <option value={worker} selected={@filter_worker == worker}>
-                      {short_worker_name(worker)} ({count})
-                    </option>
-                  <% end %>
-                </select>
-              </label>
+              <.select
+                name="worker"
+                value={@filter_worker}
+                label="Worker"
+                options={[
+                  {"All Workers", "all"}
+                  | Enum.map(@worker_stats, fn {w, c} -> {"#{short_worker_name(w)} (#{c})", w} end)
+                ]}
+                class="select-sm"
+              />
             </form>
 
             <div class="flex-1"></div>

--- a/lib/phoenix_kit_web/live/modules/jobs/index.html.heex
+++ b/lib/phoenix_kit_web/live/modules/jobs/index.html.heex
@@ -44,29 +44,19 @@
     </div>
 
     <%!-- Tabs --%>
-    <div role="tablist" class="tabs tabs-boxed mb-4 w-fit">
-      <button
-        type="button"
-        role="tab"
-        class={"tab #{if @active_tab == "oban", do: "tab-active"}"}
-        phx-click="switch_tab"
-        phx-value-tab="oban"
-      >
-        Oban Jobs
-      </button>
-      <button
-        type="button"
-        role="tab"
-        class={"tab #{if @active_tab == "scheduled", do: "tab-active"}"}
-        phx-click="switch_tab"
-        phx-value-tab="scheduled"
-      >
-        Scheduled Tasks
-        <%= if length(@scheduled_jobs) > 0 do %>
-          <span class="badge badge-sm ml-1">{length(@scheduled_jobs)}</span>
-        <% end %>
-      </button>
-    </div>
+    <% jobs_tabs = [
+      %{id: "oban", label: "Oban Jobs"},
+      Map.merge(
+        %{id: "scheduled", label: "Scheduled Tasks"},
+        (length(@scheduled_jobs) > 0 && %{badge: length(@scheduled_jobs)}) || %{}
+      )
+    ] %>
+    <.nav_tabs
+      active_tab={@active_tab}
+      on_change="switch_tab"
+      tabs={jobs_tabs}
+      class="mb-4 w-fit"
+    />
 
     <%!-- Oban Jobs Tab --%>
     <div class={if @active_tab != "oban", do: "hidden"}>

--- a/lib/phoenix_kit_web/live/modules/languages.html.heex
+++ b/lib/phoenix_kit_web/live/modules/languages.html.heex
@@ -169,13 +169,13 @@
 
         <%!-- Search Input --%>
         <div class="mb-4">
-          <input
+          <.input
             type="text"
+            name="search_query"
+            value={@search_query}
             placeholder="Search countries or languages..."
-            class="input input-bordered w-full"
             phx-keyup="search_countries"
             phx-debounce="150"
-            value={@search_query}
           />
         </div>
 

--- a/lib/phoenix_kit_web/live/modules/languages.html.heex
+++ b/lib/phoenix_kit_web/live/modules/languages.html.heex
@@ -10,7 +10,7 @@
 >
   <div
     id="languages-content"
-    class="container flex flex-col mx-auto px-4 py-6"
+    class="flex flex-col px-4 py-6"
     phx-hook="PreserveScroll"
   >
     <%!-- Summary Section --%>

--- a/lib/phoenix_kit_web/live/settings.html.heex
+++ b/lib/phoenix_kit_web/live/settings.html.heex
@@ -55,11 +55,11 @@
                 {gettext("Application name display")}
               </span>
             </label>
-            <input
+            <.input
               name="settings[project_title]"
               type="text"
               value={@settings["project_title"]}
-              class="input input-bordered w-full focus:input-primary"
+              class="focus:input-primary"
               placeholder={gettext("Enter project title")}
               phx-debounce="500"
             />
@@ -253,11 +253,11 @@
                       {gettext("Default Tab Title")}
                     </span>
                   </label>
-                  <input
+                  <.input
                     name="settings[default_tab_title]"
                     type="text"
                     value={@settings["default_tab_title"]}
-                    class="input input-bordered w-full focus:input-primary"
+                    class="focus:input-primary"
                     placeholder={@settings["project_title"] || gettext("e.g. Welcome to My Site")}
                     phx-debounce="300"
                   />
@@ -291,11 +291,11 @@
                 {gettext("Public base URL of this application")}
               </span>
             </label>
-            <input
+            <.input
               name="settings[site_url]"
               type="url"
               value={@settings["site_url"]}
-              class="input input-bordered w-full focus:input-primary"
+              class="focus:input-primary"
               placeholder="https://site.com"
               phx-debounce="500"
             />
@@ -337,12 +337,12 @@
             <label class="label pt-3">
               <span class="label-text">{gettext("Default notification link")}</span>
             </label>
-            <input
+            <.input
               type="text"
               name="settings[notification_default_link]"
               value={@settings["notification_default_link"] || "/dashboard"}
               placeholder="/dashboard"
-              class="input input-bordered input-sm w-full max-w-md"
+              class="input-sm max-w-md"
             />
             <div class="label">
               <span class="label-text-alt text-xs text-base-content/50">
@@ -366,15 +366,12 @@
                   {gettext("Mode every content editor opens in")}
                 </span>
               </label>
-              <label class="select w-full focus:select-primary">
-                <select name="settings[editor_default_mode]">
-                  <%= for {label, value} <- @setting_options["editor_default_mode"] do %>
-                    <option value={value} selected={value == @settings["editor_default_mode"]}>
-                      {label}
-                    </option>
-                  <% end %>
-                </select>
-              </label>
+              <.select
+                name="settings[editor_default_mode]"
+                value={@settings["editor_default_mode"]}
+                options={@setting_options["editor_default_mode"]}
+                class="focus-within:select-primary"
+              />
               <div class="label">
                 <span class="label-text-alt text-xs text-base-content/50">
                   {gettext(
@@ -405,15 +402,12 @@
                   {gettext("First day of the week")}
                 </span>
               </label>
-              <label class="select w-full focus:select-primary">
-                <select name="settings[week_start_day]">
-                  <%= for {label, value} <- @setting_options["week_start_day"] do %>
-                    <option value={value} selected={value == @settings["week_start_day"]}>
-                      {label}
-                    </option>
-                  <% end %>
-                </select>
-              </label>
+              <.select
+                name="settings[week_start_day]"
+                value={@settings["week_start_day"]}
+                options={@setting_options["week_start_day"]}
+                class="focus-within:select-primary"
+              />
               <.unsaved_hint
                 dirty={@settings["week_start_day"] != @saved_settings["week_start_day"]}
                 saved={
@@ -433,15 +427,12 @@
                   {gettext("System default timezone")}
                 </span>
               </label>
-              <label class="select w-full focus:select-primary">
-                <select name="settings[time_zone]">
-                  <%= for {label, value} <- @setting_options["time_zone"] do %>
-                    <option value={value} selected={value == @settings["time_zone"]}>
-                      {label}
-                    </option>
-                  <% end %>
-                </select>
-              </label>
+              <.select
+                name="settings[time_zone]"
+                value={@settings["time_zone"]}
+                options={@setting_options["time_zone"]}
+                class="focus-within:select-primary"
+              />
               <.unsaved_hint
                 dirty={@settings["time_zone"] != @saved_settings["time_zone"]}
                 saved={get_timezone_label(@saved_settings["time_zone"], @setting_options)}
@@ -456,15 +447,12 @@
                   {gettext("How dates are displayed")}
                 </span>
               </label>
-              <label class="select w-full focus:select-primary">
-                <select name="settings[date_format]">
-                  <%= for {label, value} <- @setting_options["date_format"] do %>
-                    <option value={value} selected={value == @settings["date_format"]}>
-                      {label}
-                    </option>
-                  <% end %>
-                </select>
-              </label>
+              <.select
+                name="settings[date_format]"
+                value={@settings["date_format"]}
+                options={@setting_options["date_format"]}
+                class="focus-within:select-primary"
+              />
               <div class="label">
                 <span class="label-text-alt text-xs text-base-content/50">
                   {gettext("Example:")} {get_current_date_example(@settings["date_format"])}
@@ -489,15 +477,12 @@
                   {gettext("How times are displayed")}
                 </span>
               </label>
-              <label class="select w-full focus:select-primary">
-                <select name="settings[time_format]">
-                  <%= for {label, value} <- @setting_options["time_format"] do %>
-                    <option value={value} selected={value == @settings["time_format"]}>
-                      {label}
-                    </option>
-                  <% end %>
-                </select>
-              </label>
+              <.select
+                name="settings[time_format]"
+                value={@settings["time_format"]}
+                options={@setting_options["time_format"]}
+                class="focus-within:select-primary"
+              />
               <div class="label">
                 <span class="label-text-alt text-xs text-base-content/50">
                   {gettext("Example:")} {get_current_time_example(@settings["time_format"])}

--- a/lib/phoenix_kit_web/live/settings.html.heex
+++ b/lib/phoenix_kit_web/live/settings.html.heex
@@ -8,7 +8,7 @@
   project_title={@project_title}
   current_locale={@current_locale}
 >
-  <div class="container flex flex-col mx-auto px-4 py-6">
+  <div class="flex flex-col px-4 py-6">
     <%!-- Settings Form --%>
     <div class="card bg-base-100 shadow-xl">
       <div class="card-body">

--- a/lib/phoenix_kit_web/live/settings/authorization.html.heex
+++ b/lib/phoenix_kit_web/live/settings/authorization.html.heex
@@ -216,11 +216,11 @@
                 {gettext("Background Color")}
               </span>
             </label>
-            <input
+            <.input
               name="settings[auth_background_color]"
               type="text"
               value={@settings["auth_background_color"]}
-              class="input input-bordered w-full focus:input-primary"
+              class="focus:input-primary"
               placeholder={gettext("#1a1a2e or linear-gradient(135deg, #667eea, #764ba2)")}
               phx-debounce="500"
             />
@@ -275,18 +275,12 @@
               <div class="text-sm font-semibold text-base-content/70 mb-2">
                 {gettext("QR Code")}
               </div>
-              <div class="flex items-center gap-3 ml-4">
-                <input name="settings[qr_login_enabled]" type="hidden" value="false" />
-                <input
+              <div class="ml-4">
+                <.checkbox
                   name="settings[qr_login_enabled]"
-                  type="checkbox"
-                  value="true"
                   checked={@settings["qr_login_enabled"] == "true"}
-                  class="checkbox checkbox-primary"
+                  label={gettext("Enable QR code sign-in (scan from a signed-in phone)")}
                 />
-                <span class="label-text">
-                  {gettext("Enable QR code sign-in (scan from a signed-in phone)")}
-                </span>
               </div>
             </div>
 
@@ -360,28 +354,22 @@
 
                   <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
                     <div class="form-control">
-                      <label class="label">
-                        <span class="label-text">{gettext("Client ID")}</span>
-                      </label>
-                      <input
+                      <.input
                         type="text"
                         name="settings[oauth_google_client_id]"
                         value={@settings["oauth_google_client_id"] || ""}
+                        label={gettext("Client ID")}
                         placeholder={gettext("Your Google OAuth Client ID")}
-                        class="input input-bordered"
                       />
                     </div>
 
                     <div class="form-control">
-                      <label class="label">
-                        <span class="label-text">{gettext("Client Secret")}</span>
-                      </label>
-                      <input
+                      <.input
                         type="password"
                         name="settings[oauth_google_client_secret]"
                         value={@settings["oauth_google_client_secret"] || ""}
+                        label={gettext("Client Secret")}
                         placeholder={gettext("Your Google OAuth Client Secret")}
-                        class="input input-bordered"
                       />
                     </div>
                   </div>
@@ -446,28 +434,22 @@
 
                 <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
                   <div class="form-control">
-                    <label class="label">
-                      <span class="label-text">{gettext("Client ID")}</span>
-                    </label>
-                    <input
+                    <.input
                       type="text"
                       name="settings[oauth_github_client_id]"
                       value={@settings["oauth_github_client_id"] || ""}
+                      label={gettext("Client ID")}
                       placeholder={gettext("Your GitHub OAuth Client ID")}
-                      class="input input-bordered"
                     />
                   </div>
 
                   <div class="form-control">
-                    <label class="label">
-                      <span class="label-text">{gettext("Client Secret")}</span>
-                    </label>
-                    <input
+                    <.input
                       type="password"
                       name="settings[oauth_github_client_secret]"
                       value={@settings["oauth_github_client_secret"] || ""}
+                      label={gettext("Client Secret")}
                       placeholder={gettext("Your GitHub OAuth Client Secret")}
-                      class="input input-bordered"
                     />
                   </div>
                 </div>
@@ -535,28 +517,22 @@
 
                 <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
                   <div class="form-control">
-                    <label class="label">
-                      <span class="label-text">{gettext("App ID")}</span>
-                    </label>
-                    <input
+                    <.input
                       type="text"
                       name="settings[oauth_facebook_app_id]"
                       value={@settings["oauth_facebook_app_id"] || ""}
+                      label={gettext("App ID")}
                       placeholder={gettext("Your Facebook App ID")}
-                      class="input input-bordered"
                     />
                   </div>
 
                   <div class="form-control">
-                    <label class="label">
-                      <span class="label-text">{gettext("App Secret")}</span>
-                    </label>
-                    <input
+                    <.input
                       type="password"
                       name="settings[oauth_facebook_app_secret]"
                       value={@settings["oauth_facebook_app_secret"] || ""}
+                      label={gettext("App Secret")}
                       placeholder={gettext("Your Facebook App Secret")}
-                      class="input input-bordered"
                     />
                   </div>
                 </div>

--- a/lib/phoenix_kit_web/live/settings/authorization.html.heex
+++ b/lib/phoenix_kit_web/live/settings/authorization.html.heex
@@ -8,7 +8,7 @@
   project_title={@project_title}
   current_locale={@current_locale}
 >
-  <div class="container flex flex-col mx-auto px-4 py-6">
+  <div class="flex flex-col px-4 py-6">
     <%!-- Settings Form --%>
     <div class="card bg-base-100 shadow-xl">
       <div class="card-body">

--- a/lib/phoenix_kit_web/live/settings/email_sending.html.heex
+++ b/lib/phoenix_kit_web/live/settings/email_sending.html.heex
@@ -8,7 +8,7 @@
   project_title={@project_title}
   current_locale={@current_locale}
 >
-  <div class="container flex flex-col mx-auto px-4 py-6 gap-6">
+  <div class="flex flex-col px-4 py-6 gap-6">
     <.form_section
       title={gettext("Sender Identity")}
       icon="hero-identification"

--- a/lib/phoenix_kit_web/live/settings/integration_form.html.heex
+++ b/lib/phoenix_kit_web/live/settings/integration_form.html.heex
@@ -10,7 +10,7 @@
   project_title={@project_title}
   current_locale={@current_locale}
 >
-  <div class="container mx-auto px-4 py-6">
+  <div class="px-4 py-6">
     <%!-- Flash messages --%>
     <div :if={@success} class="alert alert-success mb-4" phx-click="dismiss">
       <span>{@success}</span>

--- a/lib/phoenix_kit_web/live/settings/integration_form.html.heex
+++ b/lib/phoenix_kit_web/live/settings/integration_form.html.heex
@@ -192,15 +192,12 @@
                  current name pre-filled. Backend's `save_form`
                  detects rename via params["name"] vs @name. --%>
             <div class="form-control">
-              <label class="label" for="field-name">
-                <span class="label-text">{gettext("Connection Name")}</span>
-              </label>
-              <input
+              <.input
                 type="text"
                 id="field-name"
                 name="name"
                 value={@name || @new_name}
-                class="input input-bordered w-full"
+                label={gettext("Connection Name")}
                 placeholder={gettext("e.g. Main, Personal, My Company Drive")}
                 required
               />

--- a/lib/phoenix_kit_web/live/settings/integration_form.html.heex
+++ b/lib/phoenix_kit_web/live/settings/integration_form.html.heex
@@ -2,22 +2,15 @@
   socket={@socket}
   flash={@flash}
   phoenix_kit_current_scope={assigns[:phoenix_kit_current_scope]}
-  page_title={"#{@project_title} - #{@page_title}"}
+  page_title={@page_title}
+  page_section={gettext("Integrations")}
+  page_section_path={PhoenixKit.Utils.Routes.path("/admin/settings/integrations/website")}
+  page_subtitle={if @provider == nil, do: gettext("Choose a service to connect")}
   current_path={@current_path}
   project_title={@project_title}
   current_locale={@current_locale}
 >
   <div class="container mx-auto px-4 py-6">
-    <%!-- Page header — title only. Provider name + description + status
-         live in the provider info card below; repeating the name as a
-         subtitle here just doubled it visually. The picker step gets
-         a subtitle since there's no provider context yet. --%>
-    <.admin_page_header
-      back={PhoenixKit.Utils.Routes.path("/admin/settings/integrations/website")}
-      title={@page_title}
-      subtitle={if @provider == nil, do: gettext("Choose a service to connect")}
-    />
-
     <%!-- Flash messages --%>
     <div :if={@success} class="alert alert-success mb-4" phx-click="dismiss">
       <span>{@success}</span>

--- a/lib/phoenix_kit_web/live/settings/integrations.ex
+++ b/lib/phoenix_kit_web/live/settings/integrations.ex
@@ -9,6 +9,10 @@ defmodule PhoenixKitWeb.Live.Settings.Integrations do
   use PhoenixKitWeb, :live_view
   use Gettext, backend: PhoenixKitWeb.Gettext
 
+  # Not wired project-wide (see PhoenixKitWeb.Components.Core.RowLink's
+  # commit message) — Andi's own row_link/1 import would become ambiguous.
+  import PhoenixKitWeb.Components.Core.RowLink, only: [row_link: 1]
+
   alias PhoenixKit.Integrations
   alias PhoenixKit.Integrations.Events
   alias PhoenixKit.Integrations.Providers

--- a/lib/phoenix_kit_web/live/settings/integrations.html.heex
+++ b/lib/phoenix_kit_web/live/settings/integrations.html.heex
@@ -83,7 +83,7 @@
         <.table_default_body>
           <.table_default_row
             :for={conn <- @connections}
-            class="row-link-host relative cursor-pointer"
+            class="relative transform-gpu cursor-pointer"
           >
             <.table_default_cell>
               <.row_link

--- a/lib/phoenix_kit_web/live/settings/integrations.html.heex
+++ b/lib/phoenix_kit_web/live/settings/integrations.html.heex
@@ -8,7 +8,7 @@
   project_title={@project_title}
   current_locale={@current_locale}
 >
-  <div class="container mx-auto px-4 py-6">
+  <div class="px-4 py-6">
     <%!-- Flash messages --%>
     <%!-- Connections table --%>
     <div :if={@connections != []}>

--- a/lib/phoenix_kit_web/live/settings/integrations.html.heex
+++ b/lib/phoenix_kit_web/live/settings/integrations.html.heex
@@ -81,8 +81,19 @@
         </.table_default_header>
 
         <.table_default_body>
-          <.table_default_row :for={conn <- @connections}>
+          <.table_default_row
+            :for={conn <- @connections}
+            class="row-link-host relative cursor-pointer"
+          >
             <.table_default_cell>
+              <.row_link
+                navigate={
+                  PhoenixKit.Utils.Routes.path(
+                    "/admin/settings/integrations/website/#{conn.uuid}"
+                  )
+                }
+                label={conn.provider.name}
+              />
               <div class="flex items-center gap-2">
                 <.icon name={conn.provider.icon} class="w-4 h-4 text-base-content/60" />
                 <span>{conn.provider.name}</span>
@@ -119,7 +130,7 @@
                 </div>
               <% end %>
             </.table_default_cell>
-            <.table_default_cell>
+            <.table_default_cell class="relative z-10">
               <.table_row_menu
                 id={"integration-menu-#{conn.uuid}"}
                 mode="auto"
@@ -216,16 +227,18 @@
     </div>
 
     <%!-- Empty state --%>
-    <div :if={@connections == []} class="text-center py-12">
-      <.icon name="hero-link" class="h-16 w-16 mx-auto text-base-content/40 mb-4" />
-      <h3 class="text-lg font-medium mb-2">{gettext("No integrations configured")}</h3>
-      <p class="text-base-content/70 mb-4">
-        {gettext("Connect external services like %{providers}.", providers: @provider_names)}
-      </p>
+    <.empty_state
+      :if={@connections == []}
+      icon="hero-link"
+      title={gettext("No integrations configured")}
+      description={
+        gettext("Connect external services like %{providers}.", providers: @provider_names)
+      }
+    >
       <.pk_link navigate="/admin/settings/integrations/website/new" class="btn btn-primary btn-sm">
         <.icon name="hero-plus" class="w-4 h-4" />
         {gettext("Add Integration")}
       </.pk_link>
-    </div>
+    </.empty_state>
   </div>
 </PhoenixKitWeb.Components.LayoutWrapper.app_layout>

--- a/lib/phoenix_kit_web/live/settings/organization.html.heex
+++ b/lib/phoenix_kit_web/live/settings/organization.html.heex
@@ -8,7 +8,7 @@
   project_title={@project_title}
   current_locale={@current_locale}
 >
-  <div class="container mx-auto px-4 py-6">
+  <div class="px-4 py-6">
     <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
       <%!-- Company Information --%>
       <div class="card bg-base-100 shadow-xl">

--- a/lib/phoenix_kit_web/live/settings/organization.html.heex
+++ b/lib/phoenix_kit_web/live/settings/organization.html.heex
@@ -25,40 +25,26 @@
             <%!-- Row: Company Name + Country --%>
             <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <div class="form-control">
-                <label class="label">
-                  <span class="label-text">
-                    {gettext("Company Name")} <span class="text-error">*</span>
-                  </span>
-                </label>
-                <input
+                <.input
                   type="text"
                   name="company_name"
                   value={@company_name}
-                  class="input input-bordered w-full"
+                  label={gettext("Company Name") <> " *"}
                   placeholder={gettext("Your Company Name")}
                   required
                 />
               </div>
 
               <div class="form-control">
-                <label class="label">
-                  <span class="label-text">
-                    {gettext("Country")} <span class="text-error">*</span>
-                  </span>
-                </label>
-                <select
+                <.select
                   name="company_country"
-                  class="select select-bordered w-full"
+                  value={@company_country}
                   phx-change="country_changed"
                   required
-                >
-                  <option value="">{gettext("Select country...")}</option>
-                  <%= for {name, code} <- @countries do %>
-                    <option value={code} selected={@company_country == code}>
-                      {name}
-                    </option>
-                  <% end %>
-                </select>
+                  label={gettext("Country") <> " *"}
+                  prompt={gettext("Select country...")}
+                  options={@countries}
+                />
               </div>
             </div>
 
@@ -66,16 +52,11 @@
 
             <%!-- Row: Street Address --%>
             <div class="form-control">
-              <label class="label">
-                <span class="label-text">
-                  {gettext("Street Address")} <span class="text-error">*</span>
-                </span>
-              </label>
-              <input
+              <.input
                 type="text"
                 name="company_address_line1"
                 value={@company_address_line1}
-                class="input input-bordered w-full"
+                label={gettext("Street Address") <> " *"}
                 placeholder={gettext("123 Business Street")}
                 required
               />
@@ -83,14 +64,11 @@
 
             <%!-- Row: Address Line 2 --%>
             <div class="form-control">
-              <label class="label">
-                <span class="label-text">{gettext("Address Line 2")}</span>
-              </label>
-              <input
+              <.input
                 type="text"
                 name="company_address_line2"
                 value={@company_address_line2}
-                class="input input-bordered w-full"
+                label={gettext("Address Line 2")}
                 placeholder={gettext("Suite, Floor, Building (optional)")}
               />
             </div>
@@ -98,44 +76,34 @@
             <%!-- Row: City + State/Province + Postal Code --%>
             <div class="grid grid-cols-3 gap-4">
               <div class="form-control">
-                <label class="label">
-                  <span class="label-text">
-                    {gettext("City")} <span class="text-error">*</span>
-                  </span>
-                </label>
-                <input
+                <.input
                   type="text"
                   name="company_city"
                   value={@company_city}
-                  class="input input-bordered w-full"
+                  label={gettext("City") <> " *"}
                   placeholder={gettext("City")}
                   required
                 />
               </div>
 
               <div class="form-control">
-                <label class="label">
-                  <span class="label-text">{@subdivision_label}</span>
-                </label>
-                <input
+                <.input
                   type="text"
                   name="company_state"
                   value={@company_state}
-                  class="input input-bordered w-full"
+                  label={@subdivision_label}
                   placeholder={gettext("(optional)")}
                 />
               </div>
 
               <div class="form-control">
-                <label class="label">
-                  <span class="label-text">{gettext("Postal Code")}</span>
-                </label>
-                <input
+                <.input
                   type="text"
                   name="company_postal_code"
                   value={@company_postal_code}
-                  class="input input-bordered w-full font-mono"
+                  label={gettext("Postal Code")}
                   placeholder="10115"
+                  class="font-mono"
                 />
               </div>
             </div>
@@ -145,20 +113,16 @@
             <%!-- Row: VAT Number + Registration Number --%>
             <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <div class="form-control">
-                <label class="label">
-                  <span class="label-text">
-                    {gettext("VAT Number")} <span class="text-error">*</span>
-                  </span>
-                </label>
-                <input
+                <.input
                   type="text"
                   name="company_vat"
                   value={@company_vat}
-                  class="input input-bordered w-full font-mono"
+                  label={gettext("VAT Number") <> " *"}
                   placeholder={
                     if @eu_country, do: "#{@company_country}123456789", else: gettext("Tax ID")
                   }
                   required
+                  class="font-mono"
                 />
                 <%= if @eu_country do %>
                   <label class="label">
@@ -171,15 +135,13 @@
               </div>
 
               <div class="form-control">
-                <label class="label">
-                  <span class="label-text">{gettext("Registration Number")}</span>
-                </label>
-                <input
+                <.input
                   type="text"
                   name="company_registration"
                   value={@company_registration}
-                  class="input input-bordered w-full font-mono"
+                  label={gettext("Registration Number")}
                   placeholder={gettext("Business reg. number (optional)")}
+                  class="font-mono"
                 />
               </div>
             </div>
@@ -209,14 +171,11 @@
 
             <form phx-submit="save_bank" class="space-y-4 mt-4">
               <div class="form-control">
-                <label class="label">
-                  <span class="label-text">{gettext("Bank Name")}</span>
-                </label>
-                <input
+                <.input
                   type="text"
                   name="bank_name"
                   value={@bank_name}
-                  class="input input-bordered w-full"
+                  label={gettext("Bank Name")}
                   placeholder={gettext("Bank Name")}
                 />
               </div>
@@ -224,28 +183,24 @@
               <%!-- Row: IBAN + SWIFT --%>
               <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
                 <div class="form-control sm:col-span-2">
-                  <label class="label">
-                    <span class="label-text">{gettext("IBAN")}</span>
-                  </label>
-                  <input
+                  <.input
                     type="text"
                     name="bank_iban"
                     value={@bank_iban}
-                    class="input input-bordered w-full font-mono"
+                    label={gettext("IBAN")}
                     placeholder="EE00 0000 0000 0000 0000"
+                    class="font-mono"
                   />
                 </div>
 
                 <div class="form-control">
-                  <label class="label">
-                    <span class="label-text">{gettext("SWIFT/BIC")}</span>
-                  </label>
-                  <input
+                  <.input
                     type="text"
                     name="bank_swift"
                     value={@bank_swift}
-                    class="input input-bordered w-full font-mono"
+                    label={gettext("SWIFT/BIC")}
                     placeholder="XXXXEEHH"
+                    class="font-mono"
                   />
                 </div>
               </div>
@@ -285,14 +240,14 @@
                     <span class="label-text">{gettext("Default Tax Rate")}</span>
                   </label>
                   <div class="join">
-                    <input
+                    <.input
                       type="number"
                       name="tax_rate"
                       value={@tax_rate}
                       min="0"
                       max="100"
                       step="0.01"
-                      class="input input-bordered join-item w-24 font-mono"
+                      class="join-item w-24 font-mono"
                       phx-change="tax_rate_changed"
                       phx-debounce="300"
                     />

--- a/lib/phoenix_kit_web/live/settings/organization.html.heex
+++ b/lib/phoenix_kit_web/live/settings/organization.html.heex
@@ -29,7 +29,7 @@
                   type="text"
                   name="company_name"
                   value={@company_name}
-                  label={gettext("Company Name") <> " *"}
+                  label={gettext("Company Name")}
                   placeholder={gettext("Your Company Name")}
                   required
                 />
@@ -41,7 +41,7 @@
                   value={@company_country}
                   phx-change="country_changed"
                   required
-                  label={gettext("Country") <> " *"}
+                  label={gettext("Country")}
                   prompt={gettext("Select country...")}
                   options={@countries}
                 />
@@ -56,7 +56,7 @@
                 type="text"
                 name="company_address_line1"
                 value={@company_address_line1}
-                label={gettext("Street Address") <> " *"}
+                label={gettext("Street Address")}
                 placeholder={gettext("123 Business Street")}
                 required
               />
@@ -80,7 +80,7 @@
                   type="text"
                   name="company_city"
                   value={@company_city}
-                  label={gettext("City") <> " *"}
+                  label={gettext("City")}
                   placeholder={gettext("City")}
                   required
                 />
@@ -117,7 +117,7 @@
                   type="text"
                   name="company_vat"
                   value={@company_vat}
-                  label={gettext("VAT Number") <> " *"}
+                  label={gettext("VAT Number")}
                   placeholder={
                     if @eu_country, do: "#{@company_country}123456789", else: gettext("Tax ID")
                   }
@@ -248,6 +248,7 @@
                       max="100"
                       step="0.01"
                       class="join-item w-24 font-mono"
+                      wrapper_class="contents"
                       phx-change="tax_rate_changed"
                       phx-debounce="300"
                     />

--- a/lib/phoenix_kit_web/live/settings/send_profile_form.html.heex
+++ b/lib/phoenix_kit_web/live/settings/send_profile_form.html.heex
@@ -123,16 +123,13 @@
 
               <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div :for={field <- @provider_fields}>
-                  <label class="label" for={"send_profile_advanced_#{field.key}"}>
-                    {field.label}
-                  </label>
-                  <input
+                  <.input
                     type={if field.type == :number, do: "number", else: "text"}
                     id={"send_profile_advanced_#{field.key}"}
                     name={"send_profile[advanced][#{field.key}]"}
                     value={ProviderOptions.to_input_value(field, @advanced)}
+                    label={field.label}
                     placeholder={field.placeholder}
-                    class="input w-full"
                   />
                   <p class="text-xs text-base-content/60 mt-1">{field.help}</p>
                 </div>

--- a/lib/phoenix_kit_web/live/settings/send_profile_form.html.heex
+++ b/lib/phoenix_kit_web/live/settings/send_profile_form.html.heex
@@ -8,7 +8,7 @@
   current_path={@current_path}
   project_title={@project_title}
 >
-  <div class="container flex-col mx-auto px-4 py-6">
+  <div class="flex-col px-4 py-6">
     <div class="max-w-2xl">
       <.form_section title={gettext("Profile Details")} icon="hero-adjustments-horizontal">
         <.form id="send-profile-form" for={@form} phx-change="validate" phx-submit="save">

--- a/lib/phoenix_kit_web/live/settings/send_profiles.ex
+++ b/lib/phoenix_kit_web/live/settings/send_profiles.ex
@@ -10,6 +10,10 @@ defmodule PhoenixKitWeb.Live.Settings.SendProfiles do
   use PhoenixKitWeb, :live_view
   use Gettext, backend: PhoenixKitWeb.Gettext
 
+  # Not wired project-wide (see PhoenixKitWeb.Components.Core.RowLink's
+  # commit message) — Andi's own row_link/1 import would become ambiguous.
+  import PhoenixKitWeb.Components.Core.RowLink, only: [row_link: 1]
+
   alias PhoenixKit.Email.SendProfiles
   alias PhoenixKit.Settings
   alias PhoenixKit.Utils.Routes

--- a/lib/phoenix_kit_web/live/settings/send_profiles.html.heex
+++ b/lib/phoenix_kit_web/live/settings/send_profiles.html.heex
@@ -56,7 +56,7 @@
         <.table_default_body>
           <.table_default_row
             :for={send_profile <- @send_profiles}
-            class="row-link-host relative cursor-pointer"
+            class="relative transform-gpu cursor-pointer"
           >
             <.table_default_cell>
               <.row_link

--- a/lib/phoenix_kit_web/live/settings/send_profiles.html.heex
+++ b/lib/phoenix_kit_web/live/settings/send_profiles.html.heex
@@ -8,7 +8,7 @@
   current_path={@current_path}
   project_title={@project_title}
 >
-  <div class="container flex-col mx-auto px-4 py-6">
+  <div class="flex-col px-4 py-6">
     <%!-- Send Profiles table --%>
     <div :if={@send_profiles != []}>
       <.table_default

--- a/lib/phoenix_kit_web/live/settings/send_profiles.html.heex
+++ b/lib/phoenix_kit_web/live/settings/send_profiles.html.heex
@@ -54,8 +54,17 @@
         </.table_default_header>
 
         <.table_default_body>
-          <.table_default_row :for={send_profile <- @send_profiles}>
+          <.table_default_row
+            :for={send_profile <- @send_profiles}
+            class="row-link-host relative cursor-pointer"
+          >
             <.table_default_cell>
+              <.row_link
+                navigate={
+                  Routes.path("/admin/settings/email-sending/profiles/#{send_profile.uuid}/edit")
+                }
+                label={send_profile.name}
+              />
               <div class="font-medium">{send_profile.name}</div>
               <span :if={send_profile.is_default} class="badge badge-xs badge-info mt-0.5">
                 {gettext("Default Newsletter Profile")}
@@ -81,7 +90,7 @@
             <.table_default_cell>
               <.enabled_badge enabled={send_profile.enabled} />
             </.table_default_cell>
-            <.table_default_cell>
+            <.table_default_cell class="relative z-10">
               <.table_row_menu
                 id={"send-profile-menu-#{send_profile.uuid}"}
                 mode="dropdown"

--- a/lib/phoenix_kit_web/live/settings/seo.html.heex
+++ b/lib/phoenix_kit_web/live/settings/seo.html.heex
@@ -12,7 +12,7 @@
   project_title={@project_title}
   current_locale={@current_locale}
 >
-  <div class="container mx-auto px-4 py-6 space-y-6">
+  <div class="px-4 py-6 space-y-6">
     <div class="card bg-base-100 shadow-xl border border-base-200">
       <div class="card-body space-y-4">
         <div class="flex items-start justify-between gap-4">

--- a/lib/phoenix_kit_web/live/settings/users.html.heex
+++ b/lib/phoenix_kit_web/live/settings/users.html.heex
@@ -177,13 +177,12 @@
                       {gettext("After-login path")}
                     </span>
                   </label>
-                  <input
+                  <.input
                     id="settings_after_login_path"
                     type="text"
                     name="settings[after_login_path]"
                     value={@settings["after_login_path"]}
                     placeholder="/"
-                    class="input input-bordered w-full"
                   />
                   <div class="text-xs text-base-content/60 mt-1">
                     {gettext("Local path users land on after signing in.")}
@@ -195,13 +194,12 @@
                       {gettext("After-registration path")}
                     </span>
                   </label>
-                  <input
+                  <.input
                     id="settings_after_registration_path"
                     type="text"
                     name="settings[after_registration_path]"
                     value={@settings["after_registration_path"]}
                     placeholder={gettext("Same as after login")}
-                    class="input input-bordered w-full"
                   />
                   <div class="text-xs text-base-content/60 mt-1">
                     {gettext(
@@ -231,15 +229,12 @@
                     {gettext("Role assigned to new user registrations")}
                   </span>
                 </label>
-                <label class="select w-full focus:select-primary">
-                  <select name="settings[new_user_default_role]">
-                    <%= for {label, value} <- @setting_options["new_user_default_role"] do %>
-                      <option value={value} selected={value == @settings["new_user_default_role"]}>
-                        {label}
-                      </option>
-                    <% end %>
-                  </select>
-                </label>
+                <.select
+                  name="settings[new_user_default_role]"
+                  value={@settings["new_user_default_role"]}
+                  options={@setting_options["new_user_default_role"]}
+                  class="focus-within:select-primary"
+                />
                 <.unsaved_hint
                   dirty={
                     @settings["new_user_default_role"] != @saved_settings["new_user_default_role"]
@@ -281,18 +276,12 @@
                     {gettext("Active status for new user registrations")}
                   </span>
                 </label>
-                <label class="select w-full focus:select-primary">
-                  <select name="settings[new_user_default_status]">
-                    <%= for {label, value} <- @setting_options["new_user_default_status"] do %>
-                      <option
-                        value={value}
-                        selected={value == @settings["new_user_default_status"]}
-                      >
-                        {label}
-                      </option>
-                    <% end %>
-                  </select>
-                </label>
+                <.select
+                  name="settings[new_user_default_status]"
+                  value={@settings["new_user_default_status"]}
+                  options={@setting_options["new_user_default_status"]}
+                  class="focus-within:select-primary"
+                />
                 <.unsaved_hint
                   dirty={
                     @settings["new_user_default_status"] !=
@@ -578,11 +567,10 @@
                     <label class="label">
                       <span class="label-text">{gettext("Field Key")} *</span>
                     </label>
-                    <input
+                    <.input
                       type="text"
                       name="field[key]"
                       value={if @editing_field, do: @editing_field["key"], else: ""}
-                      class="input input-bordered"
                       placeholder="phone_number"
                       required
                       disabled={!!@editing_field}
@@ -599,11 +587,10 @@
                     <label class="label">
                       <span class="label-text">{gettext("Label")} *</span>
                     </label>
-                    <input
+                    <.input
                       type="text"
                       name="field[label]"
                       value={if @editing_field, do: @editing_field["label"], else: ""}
-                      class="input input-bordered"
                       placeholder={gettext("Phone Number")}
                       required
                     />
@@ -614,22 +601,18 @@
                     <label class="label">
                       <span class="label-text">{gettext("Type")} *</span>
                     </label>
-                    <label class="select">
-                      <select
-                        name="field[type]"
-                        required
-                        phx-change="field_type_changed"
-                      >
-                        <%= for type <- ~w(text textarea number boolean date email url uuid select radio checkbox) do %>
-                          <option
-                            value={type}
-                            selected={@field_form_type == type}
-                          >
-                            {String.capitalize(type)}
-                          </option>
-                        <% end %>
-                      </select>
-                    </label>
+                    <.select
+                      name="field[type]"
+                      value={@field_form_type}
+                      phx-change="field_type_changed"
+                      required
+                      options={
+                        Enum.map(
+                          ~w(text textarea number boolean date email url uuid select radio checkbox),
+                          &{String.capitalize(&1), &1}
+                        )
+                      }
+                    />
                   </div>
 
                   <%!-- Required Checkbox --%>
@@ -692,13 +675,14 @@
 
                       <%!-- Add option input --%>
                       <div class="flex gap-2">
-                        <input
+                        <.input
                           type="text"
+                          id="new_option_input"
+                          name="new_option_value"
                           value={@new_option_value}
-                          class="input input-bordered input-sm flex-1"
                           placeholder={gettext("Enter option value")}
                           phx-keyup="update_new_option"
-                          id="new_option_input"
+                          class="input-sm flex-1"
                         />
                         <button
                           type="button"

--- a/lib/phoenix_kit_web/live/settings/users.html.heex
+++ b/lib/phoenix_kit_web/live/settings/users.html.heex
@@ -8,7 +8,7 @@
   project_title={@project_title}
   current_locale={@current_locale}
 >
-  <div class="container flex flex-col mx-auto px-4 py-6">
+  <div class="flex flex-col px-4 py-6">
     <%!-- Settings Form --%>
     <div class="space-y-6">
       <%!-- User Configuration Settings Card --%>

--- a/lib/phoenix_kit_web/live/users/live_sessions.html.heex
+++ b/lib/phoenix_kit_web/live/users/live_sessions.html.heex
@@ -119,20 +119,15 @@
       <:toolbar_title>
         <div class="flex flex-wrap items-center gap-2">
           <%!-- Search --%>
-          <form id="live-sessions-search-form" phx-change="search" class="contents">
-            <label class="input input-sm w-40 sm:w-52 lg:w-64 min-w-0">
-              <.icon name="hero-magnifying-glass" class="h-4 w-4 opacity-50" />
-              <input
-                type="search"
-                name="search"
-                value={@search_query}
-                placeholder={gettext("Search by IP, User-Agent, email...")}
-                class="grow"
-                phx-debounce="300"
-              />
-            </label>
-          </form>
-          <%!-- Filter Tabs --%>
+          <.search_toolbar
+            value={@search_query}
+            placeholder={gettext("Search by IP, User-Agent, email...")}
+            class="w-40 sm:w-52 lg:w-64 min-w-0"
+          />
+          <%!-- Filter Tabs (kept hand-rolled: <.nav_tabs> hardcodes phx-value-tab,
+               but this page's handler reads phx-value-type — converting would
+               desync the param key from handle_event("filter_by", %{"type" => ...}),
+               and live_sessions.ex is outside this batch's file scope) --%>
           <div class="tabs tabs-boxed tabs-sm">
             <button
               phx-click="filter_by"
@@ -207,16 +202,12 @@
       <.table_default_body>
         <%= if Enum.empty?(@sessions) do %>
           <.table_default_row>
-            <.table_default_cell class="text-center py-12" colspan={6}>
-              <div class="text-base-content/50 mb-4">
-                <.icon name="hero-inbox" class="w-16 h-16 mx-auto" />
-              </div>
-              <h3 class="text-lg font-medium text-base-content mb-2">
-                {gettext("No active sessions")}
-              </h3>
-              <p class="text-base-content/70">
-                {gettext("There are currently no active sessions to display.")}
-              </p>
+            <.table_default_cell colspan={6}>
+              <.empty_state
+                icon="hero-inbox"
+                title={gettext("No active sessions")}
+                description={gettext("There are currently no active sessions to display.")}
+              />
             </.table_default_cell>
           </.table_default_row>
         <% else %>

--- a/lib/phoenix_kit_web/live/users/live_sessions.html.heex
+++ b/lib/phoenix_kit_web/live/users/live_sessions.html.heex
@@ -7,7 +7,7 @@
   current_path={@url_path}
   project_title={@project_title}
 >
-  <div class="container mx-auto px-4 py-8">
+  <div class="px-4 py-8">
     <%!-- Slim action bar: title/subtitle now live in the navbar; keep the
          live-updated timestamp and the live-monitoring controls. --%>
     <div class="flex flex-wrap items-center justify-between gap-2 mb-4 sm:mb-6">

--- a/lib/phoenix_kit_web/live/users/media_detail.html.heex
+++ b/lib/phoenix_kit_web/live/users/media_detail.html.heex
@@ -123,39 +123,38 @@
               <%= if @edit_mode do %>
                 <form phx-submit="save_metadata" class="space-y-3">
                   <div>
-                    <label for="title" class="label label-text text-xs">Title</label>
-                    <input
+                    <.input
                       type="text"
                       id="title"
                       name="title"
                       value={@file_data.title}
-                      class="input input-bordered input-sm w-full"
+                      label="Title"
                       placeholder="Enter title"
+                      class="input-sm"
                     />
                   </div>
 
                   <div>
-                    <label for="description" class="label label-text text-xs">Description</label>
-                    <textarea
+                    <.textarea
                       id="description"
                       name="description"
-                      class="textarea textarea-bordered textarea-sm w-full"
-                      rows="3"
+                      value={@file_data.description}
+                      label="Description"
                       placeholder="Enter description"
-                    >{@file_data.description}</textarea>
+                      rows="3"
+                      class="textarea-sm"
+                    />
                   </div>
 
                   <div>
-                    <label for="tags" class="label label-text text-xs">
-                      Tags (comma-separated)
-                    </label>
-                    <input
+                    <.input
                       type="text"
                       id="tags"
                       name="tags"
                       value={Enum.join(@file_data.tags, ", ")}
-                      class="input input-bordered input-sm w-full"
+                      label="Tags (comma-separated)"
                       placeholder="tag1, tag2"
+                      class="input-sm"
                     />
                   </div>
 

--- a/lib/phoenix_kit_web/live/users/media_detail.html.heex
+++ b/lib/phoenix_kit_web/live/users/media_detail.html.heex
@@ -8,29 +8,27 @@
   current_locale={@current_locale}
 >
   <div class="p-6">
-    <.admin_page_header>
-      <div class="flex items-center gap-3">
-        <%!--
-          Browser-back so the user returns to exactly where they were before
-          opening this file — the folder grid they came from (the MediaBrowser
-          keeps the open folder in the `?folder=` query, and the click here was
-          a push_navigate, so the previous history entry is that folder view).
-          Falls back to the media root for a direct/shared load with no history.
-        --%>
-        <button
-          type="button"
-          onclick={"if (window.history.length > 1) { window.history.back() } else { window.location.href = '#{Routes.path("/admin/media")}' }"}
-          class="btn btn-ghost btn-circle"
-          title={gettext("Back")}
-          aria-label={gettext("Back")}
-        >
-          <.icon name="hero-arrow-left" class="w-7 h-7" />
-        </button>
-        <h1 class="text-xl sm:text-2xl lg:text-3xl font-bold text-base-content">
-          Media Detail
-        </h1>
-      </div>
-    </.admin_page_header>
+    <%!--
+      Browser-back so the user returns to exactly where they were before
+      opening this file — the folder grid they came from (the MediaBrowser
+      keeps the open folder in the `?folder=` query, and the click here was
+      a push_navigate, so the previous history entry is that folder view).
+      Falls back to the media root for a direct/shared load with no history.
+      Left-aligned (not the toolbar's default right-alignment): a lone back
+      affordance flush against the right edge reads oddly with nothing else
+      in the row.
+    --%>
+    <div class="flex items-center gap-2 mb-4">
+      <button
+        type="button"
+        onclick={"if (window.history.length > 1) { window.history.back() } else { window.location.href = '#{Routes.path("/admin/media")}' }"}
+        class="btn btn-ghost btn-sm btn-circle"
+        title={gettext("Back")}
+        aria-label={gettext("Back")}
+      >
+        <.icon name="hero-arrow-left" class="w-7 h-7" />
+      </button>
+    </div>
 
     <%= if @file_data do %>
       <%!-- Main Layout: 3/4 Preview + 1/4 Info --%>

--- a/lib/phoenix_kit_web/live/users/media_detail.html.heex
+++ b/lib/phoenix_kit_web/live/users/media_detail.html.heex
@@ -2,7 +2,7 @@
   socket={@socket}
   flash={@flash}
   phoenix_kit_current_scope={assigns[:phoenix_kit_current_scope]}
-  page_title="Media Detail"
+  page_title={gettext("Media Detail")}
   current_path={Routes.path("/admin/media/#{@file_uuid}")}
   project_title={@project_title}
   current_locale={@current_locale}

--- a/lib/phoenix_kit_web/live/users/media_selector.ex
+++ b/lib/phoenix_kit_web/live/users/media_selector.ex
@@ -54,7 +54,7 @@ defmodule PhoenixKitWeb.Live.Users.MediaSelector do
       |> assign(:current_locale, locale)
       |> assign(:current_path, Routes.path("/admin/media/selector"))
       |> assign(:project_title, project_title)
-      |> assign(:page_title, "Select Media")
+      |> assign(:page_title, gettext("Select Media"))
       |> assign(:return_to, return_to)
       |> assign(:selection_mode, mode)
       |> assign(:selected_uuids, selected_uuids)
@@ -425,6 +425,17 @@ defmodule PhoenixKitWeb.Live.Users.MediaSelector do
   defp parse_filter(_), do: :all
 
   defp format_file_size(bytes), do: Format.bytes(bytes, decimals: 2, unknown: "0 B")
+
+  # Folds the old in-body subtitle text + selection-count badge into a single
+  # string for `page_subtitle` (string-only attr, can't carry a colored pill).
+  defp selection_subtitle(:single, _count), do: gettext("Click on an image to select it")
+
+  defp selection_subtitle(:multiple, 0), do: gettext("Select one or more images")
+
+  defp selection_subtitle(:multiple, count) do
+    gettext("Select one or more images") <>
+      " — " <> ngettext("%{count} selected", "%{count} selected", count, count: count)
+  end
 
   defp pagination_range(current_page, total_pages) do
     cond do

--- a/lib/phoenix_kit_web/live/users/media_selector.html.heex
+++ b/lib/phoenix_kit_web/live/users/media_selector.html.heex
@@ -3,50 +3,28 @@
   flash={@flash}
   phoenix_kit_current_scope={assigns[:phoenix_kit_current_scope]}
   page_title={@page_title}
+  page_subtitle={selection_subtitle(@selection_mode, length(@selected_uuids))}
   current_path={@current_path}
   current_locale={@current_locale}
   project_title={@project_title}
 >
   <div class="container mx-auto px-4 py-8 max-w-7xl">
-    <%!-- Header with Actions --%>
-    <header class="w-full mb-6">
-      <div class="flex justify-between items-center">
-        <div>
-          <h1 class="text-2xl sm:text-4xl font-bold text-base-content mb-2">
-            {gettext("Select Media")}
-          </h1>
-          <p class="text-base sm:text-lg text-base-content/70">
-            <%= if @selection_mode == :single do %>
-              {gettext("Click on an image to select it")}
-            <% else %>
-              {gettext("Select one or more images")}
-            <% end %>
-            <%= if @selected_uuids != [] do %>
-              <span class="badge badge-primary ml-2">
-                {ngettext(
-                  "%{count} selected",
-                  "%{count} selected",
-                  length(@selected_uuids),
-                  count: length(@selected_uuids)
-                )}
-              </span>
-            <% end %>
-          </p>
-        </div>
-        <div class="flex gap-2">
-          <button phx-click="cancel_selection" class="btn btn-outline">
-            <.icon name="hero-x-mark" class="w-4 h-4 mr-1" /> {gettext("Cancel")}
-          </button>
-          <button
-            phx-click="confirm_selection"
-            class="btn btn-primary"
-            disabled={@selected_uuids == []}
-          >
-            <.icon name="hero-check" class="w-4 h-4 mr-1" /> {gettext("Confirm Selection")}
-          </button>
-        </div>
-      </div>
-    </header>
+    <%!-- Actions row: Cancel / Confirm Selection. The count badge from the old
+         in-body subtitle doesn't survive as markup here (page_subtitle is
+         string-only) — folded into the subtitle text instead, see
+         selection_subtitle/2. --%>
+    <div class="flex flex-wrap items-center gap-2 justify-end mb-4">
+      <button phx-click="cancel_selection" class="btn btn-outline">
+        <.icon name="hero-x-mark" class="w-4 h-4 mr-1" /> {gettext("Cancel")}
+      </button>
+      <button
+        phx-click="confirm_selection"
+        class="btn btn-primary"
+        disabled={@selected_uuids == []}
+      >
+        <.icon name="hero-check" class="w-4 h-4 mr-1" /> {gettext("Confirm Selection")}
+      </button>
+    </div>
 
     <%!-- Upload Section --%>
     <div class="card bg-base-100 shadow-xl mb-6">

--- a/lib/phoenix_kit_web/live/users/media_selector.html.heex
+++ b/lib/phoenix_kit_web/live/users/media_selector.html.heex
@@ -78,12 +78,12 @@
           <div class="flex-1">
             <.form for={%{}} phx-submit="search" class="w-full">
               <div class="join w-full">
-                <input
+                <.input
                   type="text"
                   name="search[query]"
                   value={@search_query}
                   placeholder={gettext("Search by filename...")}
-                  class="input input-bordered join-item flex-1"
+                  class="input-bordered join-item flex-1"
                 />
                 <button type="submit" class="btn btn-primary join-item">
                   <.icon name="hero-magnifying-glass" class="w-4 h-4" />
@@ -94,22 +94,16 @@
 
           <%!-- Filter by Type --%>
           <div class="w-full md:w-48">
-            <label class="select w-full">
-              <select
-                phx-change="filter_type"
-                name="filter"
-              >
-                <option value="all" selected={@file_type_filter == :all}>
-                  {gettext("All Files")}
-                </option>
-                <option value="image" selected={@file_type_filter == :image}>
-                  {gettext("Images Only")}
-                </option>
-                <option value="video" selected={@file_type_filter == :video}>
-                  {gettext("Videos Only")}
-                </option>
-              </select>
-            </label>
+            <.select
+              name="filter"
+              phx-change="filter_type"
+              value={@file_type_filter}
+              options={[
+                {gettext("All Files"), "all"},
+                {gettext("Images Only"), "image"},
+                {gettext("Videos Only"), "video"}
+              ]}
+            />
           </div>
         </div>
       </div>

--- a/lib/phoenix_kit_web/live/users/media_selector.html.heex
+++ b/lib/phoenix_kit_web/live/users/media_selector.html.heex
@@ -8,7 +8,7 @@
   current_locale={@current_locale}
   project_title={@project_title}
 >
-  <div class="container mx-auto px-4 py-8 max-w-7xl">
+  <div class="px-4 py-8">
     <%!-- Actions row: Cancel / Confirm Selection. The count badge from the old
          in-body subtitle doesn't survive as markup here (page_subtitle is
          string-only) — folded into the subtitle text instead, see

--- a/lib/phoenix_kit_web/live/users/media_selector.html.heex
+++ b/lib/phoenix_kit_web/live/users/media_selector.html.heex
@@ -83,7 +83,8 @@
                   name="search[query]"
                   value={@search_query}
                   placeholder={gettext("Search by filename...")}
-                  class="input-bordered join-item flex-1"
+                  class="join-item flex-1"
+                  wrapper_class="contents"
                 />
                 <button type="submit" class="btn btn-primary join-item">
                   <.icon name="hero-magnifying-glass" class="w-4 h-4" />

--- a/lib/phoenix_kit_web/live/users/permissions_matrix.html.heex
+++ b/lib/phoenix_kit_web/live/users/permissions_matrix.html.heex
@@ -8,7 +8,7 @@
   project_title={@project_title}
   current_locale={@current_locale}
 >
-  <div class="container flex-col mx-auto px-4 py-6">
+  <div class="flex-col px-4 py-6">
     <%!-- Matrix Table --%>
     <div class="bg-base-100">
       <div class="rounded-lg shadow-md overflow-x-auto overflow-y-clip">

--- a/lib/phoenix_kit_web/live/users/permissions_matrix.html.heex
+++ b/lib/phoenix_kit_web/live/users/permissions_matrix.html.heex
@@ -11,148 +11,148 @@
   <div class="flex-col px-4 py-6">
     <%!-- Matrix Table --%>
     <div class="bg-base-100">
-      <div class="rounded-lg shadow-md overflow-x-auto overflow-y-clip">
-        <table class="table table-sm table-zebra">
-          <thead class="bg-primary text-primary-content">
-            <tr>
-              <th class="sticky left-0 z-0 whitespace-nowrap">{gettext("Module")}</th>
-              <%= for role <- @roles do %>
-                <th class="text-center min-w-[100px]">
-                  <.pk_link navigate="/admin/users/roles" class="link link-hover">
-                    {role.name}
-                  </.pk_link>
-                </th>
-              <% end %>
-            </tr>
-          </thead>
-          <tbody>
-            <%!-- Full Access (wildcard superadmin key) — a single blanket grant
+      <.table_default variant="zebra" size="sm">
+        <.table_default_header class="bg-primary text-primary-content">
+          <.table_default_row hover={false}>
+            <.table_default_header_cell class="sticky left-0 z-0 whitespace-nowrap">
+              {gettext("Module")}
+            </.table_default_header_cell>
+            <%= for role <- @roles do %>
+              <.table_default_header_cell class="text-center min-w-[100px]">
+                <.pk_link navigate="/admin/users/roles" class="link link-hover">
+                  {role.name}
+                </.pk_link>
+              </.table_default_header_cell>
+            <% end %>
+          </.table_default_row>
+        </.table_default_header>
+        <.table_default_body>
+          <%!-- Full Access (wildcard superadmin key) — a single blanket grant
                  that makes a role Owner-equivalent and stays complete as new
                  modules are added. Only Owner or an existing holder can grant it
                  (the toggle authorizes against the editor's own held keys). --%>
-            <tr class="bg-warning/10">
-              <td
-                colspan={length(@roles) + 1}
-                class="sticky left-0 bg-warning/10 font-semibold text-xs uppercase tracking-wide text-warning py-2"
-              >
-                {gettext("Full Access")}
-              </td>
-            </tr>
+          <tr class="bg-warning/10">
+            <td
+              colspan={length(@roles) + 1}
+              class="sticky left-0 bg-warning/10 font-semibold text-xs uppercase tracking-wide text-warning py-2"
+            >
+              {gettext("Full Access")}
+            </td>
+          </tr>
+          <.permission_row
+            :for={key <- @superadmin_keys}
+            key={key}
+            label={PhoenixKit.Users.Permissions.localized_module_label(key)}
+            roles={@roles}
+            matrix={@matrix}
+            uneditable_role_uuids={@uneditable_role_uuids}
+          />
+
+          <%!-- Core Sections Header --%>
+          <tr class="bg-primary/10">
+            <td
+              colspan={length(@roles) + 1}
+              class="sticky left-0 bg-primary/10 font-semibold text-xs uppercase tracking-wide text-primary py-2"
+            >
+              {gettext("Core Sections")}
+            </td>
+          </tr>
+          <.permission_row
+            :for={key <- @core_keys}
+            key={key}
+            label={PhoenixKit.Users.Permissions.localized_module_label(key)}
+            roles={@roles}
+            matrix={@matrix}
+            uneditable_role_uuids={@uneditable_role_uuids}
+          />
+
+          <%!-- Integrations Header (two independent keys: personal + system) --%>
+          <tr class="bg-primary/10">
+            <td
+              colspan={length(@roles) + 1}
+              class="sticky left-0 bg-primary/10 font-semibold text-xs uppercase tracking-wide text-primary py-2"
+            >
+              {gettext("Integrations")}
+            </td>
+          </tr>
+          <.permission_row
+            :for={key <- @integration_keys}
+            key={key}
+            label={PhoenixKit.Users.Permissions.localized_module_label(key)}
+            roles={@roles}
+            matrix={@matrix}
+            uneditable_role_uuids={@uneditable_role_uuids}
+          />
+
+          <%!-- Feature Modules Header --%>
+          <tr class="bg-primary/10">
+            <td
+              colspan={length(@roles) + 1}
+              class="sticky left-0 bg-primary/10 font-semibold text-xs uppercase tracking-wide text-primary py-2"
+            >
+              {gettext("Feature Modules")}
+            </td>
+          </tr>
+          <%= for key <- @feature_keys do %>
             <.permission_row
-              :for={key <- @superadmin_keys}
               key={key}
               label={PhoenixKit.Users.Permissions.localized_module_label(key)}
               roles={@roles}
               matrix={@matrix}
               uneditable_role_uuids={@uneditable_role_uuids}
             />
-
-            <%!-- Core Sections Header --%>
-            <tr class="bg-primary/10">
-              <td
-                colspan={length(@roles) + 1}
-                class="sticky left-0 bg-primary/10 font-semibold text-xs uppercase tracking-wide text-primary py-2"
-              >
-                {gettext("Core Sections")}
-              </td>
-            </tr>
-            <.permission_row
-              :for={key <- @core_keys}
-              key={key}
-              label={PhoenixKit.Users.Permissions.localized_module_label(key)}
-              roles={@roles}
-              matrix={@matrix}
-              uneditable_role_uuids={@uneditable_role_uuids}
-            />
-
-            <%!-- Integrations Header (two independent keys: personal + system) --%>
-            <tr class="bg-primary/10">
-              <td
-                colspan={length(@roles) + 1}
-                class="sticky left-0 bg-primary/10 font-semibold text-xs uppercase tracking-wide text-primary py-2"
-              >
-                {gettext("Integrations")}
-              </td>
-            </tr>
-            <.permission_row
-              :for={key <- @integration_keys}
-              key={key}
-              label={PhoenixKit.Users.Permissions.localized_module_label(key)}
-              roles={@roles}
-              matrix={@matrix}
-              uneditable_role_uuids={@uneditable_role_uuids}
-            />
-
-            <%!-- Feature Modules Header --%>
-            <tr class="bg-primary/10">
-              <td
-                colspan={length(@roles) + 1}
-                class="sticky left-0 bg-primary/10 font-semibold text-xs uppercase tracking-wide text-primary py-2"
-              >
-                {gettext("Feature Modules")}
-              </td>
-            </tr>
-            <%= for key <- @feature_keys do %>
-              <.permission_row
-                key={key}
-                label={PhoenixKit.Users.Permissions.localized_module_label(key)}
-                roles={@roles}
-                matrix={@matrix}
-                uneditable_role_uuids={@uneditable_role_uuids}
-              />
-              <%!-- Fine-grained sub-permissions, indented under their module.
+            <%!-- Fine-grained sub-permissions, indented under their module.
                    Granting one auto-grants the module key; revoking the module
                    key cascades these off. --%>
-              <.permission_row
-                :for={sub <- Map.get(@sub_permissions, key, [])}
-                key={sub.key}
-                label={PhoenixKit.Users.Permissions.localized_module_label(sub.key)}
-                sub
-                roles={@roles}
-                matrix={@matrix}
-                uneditable_role_uuids={@uneditable_role_uuids}
-              />
-            <% end %>
-            <%!-- Custom (permission keys registered by parent app) --%>
-            <%= if length(@custom_keys) > 0 do %>
-              <tr class="bg-primary/10">
-                <td
-                  colspan={length(@roles) + 1}
-                  class="sticky left-0 bg-primary/10 font-semibold text-xs uppercase tracking-wide text-primary py-2"
-                >
-                  {gettext("Custom")}
-                </td>
-              </tr>
-              <.permission_row
-                :for={key <- @custom_keys}
-                key={key}
-                label={PhoenixKit.Users.Permissions.localized_module_label(key)}
-                roles={@roles}
-                matrix={@matrix}
-                uneditable_role_uuids={@uneditable_role_uuids}
-              />
-            <% end %>
-
-            <%!-- Summary Row --%>
-            <tr class="font-semibold">
-              <td class="sticky left-0 z-[1] whitespace-nowrap">
-                {gettext("Total")}
+            <.permission_row
+              :for={sub <- Map.get(@sub_permissions, key, [])}
+              key={sub.key}
+              label={PhoenixKit.Users.Permissions.localized_module_label(sub.key)}
+              sub
+              roles={@roles}
+              matrix={@matrix}
+              uneditable_role_uuids={@uneditable_role_uuids}
+            />
+          <% end %>
+          <%!-- Custom (permission keys registered by parent app) --%>
+          <%= if length(@custom_keys) > 0 do %>
+            <tr class="bg-primary/10">
+              <td
+                colspan={length(@roles) + 1}
+                class="sticky left-0 bg-primary/10 font-semibold text-xs uppercase tracking-wide text-primary py-2"
+              >
+                {gettext("Custom")}
               </td>
-              <%= for role <- @roles do %>
-                <td class="text-center">
-                  <%= if role.name == "Owner" do %>
-                    {MapSet.size(@visible_keys)} / {MapSet.size(@visible_keys)}
-                  <% else %>
-                    {Map.get(@matrix, to_string(role.uuid), MapSet.new())
-                    |> MapSet.intersection(@visible_keys)
-                    |> MapSet.size()} / {MapSet.size(@visible_keys)}
-                  <% end %>
-                </td>
-              <% end %>
             </tr>
-          </tbody>
-        </table>
-      </div>
+            <.permission_row
+              :for={key <- @custom_keys}
+              key={key}
+              label={PhoenixKit.Users.Permissions.localized_module_label(key)}
+              roles={@roles}
+              matrix={@matrix}
+              uneditable_role_uuids={@uneditable_role_uuids}
+            />
+          <% end %>
+
+          <%!-- Summary Row --%>
+          <tr class="font-semibold">
+            <td class="sticky left-0 z-[1] whitespace-nowrap">
+              {gettext("Total")}
+            </td>
+            <%= for role <- @roles do %>
+              <td class="text-center">
+                <%= if role.name == "Owner" do %>
+                  {MapSet.size(@visible_keys)} / {MapSet.size(@visible_keys)}
+                <% else %>
+                  {Map.get(@matrix, to_string(role.uuid), MapSet.new())
+                  |> MapSet.intersection(@visible_keys)
+                  |> MapSet.size()} / {MapSet.size(@visible_keys)}
+                <% end %>
+              </td>
+            <% end %>
+          </tr>
+        </.table_default_body>
+      </.table_default>
     </div>
 
     <%!-- Help Info --%>

--- a/lib/phoenix_kit_web/live/users/roles.ex
+++ b/lib/phoenix_kit_web/live/users/roles.ex
@@ -44,7 +44,7 @@ defmodule PhoenixKitWeb.Live.Users.Roles do
       |> assign(:permissions_role_keys, MapSet.new())
       |> assign(:permissions_grantable_keys, MapSet.new())
       |> assign(:permissions_preserved_keys, MapSet.new())
-      |> assign(:page_title, gettext("Roles"))
+      |> assign(:page_title, gettext("Role Management"))
       |> assign(:role_stats, role_stats)
       |> assign(:project_title, project_title)
       |> assign(:can_manage_permissions, false)

--- a/lib/phoenix_kit_web/live/users/roles.html.heex
+++ b/lib/phoenix_kit_web/live/users/roles.html.heex
@@ -239,21 +239,15 @@
         </.table_default>
       <% else %>
         <%!-- Empty state --%>
-        <div class="text-center py-12">
-          <.icon name="hero-shield-check" class="h-16 w-16 mx-auto text-base-content/40 mb-4" />
-          <h3 class="text-lg font-medium text-base-content mb-2">
-            {gettext("No roles found")}
-          </h3>
-          <p class="text-base-content/70 mb-4">
-            {gettext("Start by creating your first custom role.")}
-          </p>
-          <button
-            phx-click="show_create_form"
-            class="btn btn-primary"
-          >
+        <.empty_state
+          icon="hero-shield-check"
+          title={gettext("No roles found")}
+          description={gettext("Start by creating your first custom role.")}
+        >
+          <button phx-click="show_create_form" class="btn btn-primary">
             {gettext("Create First Role")}
           </button>
-        </div>
+        </.empty_state>
       <% end %>
     </div>
 

--- a/lib/phoenix_kit_web/live/users/roles.html.heex
+++ b/lib/phoenix_kit_web/live/users/roles.html.heex
@@ -356,16 +356,14 @@
           </h4>
           <div class="space-y-2">
             <%= for key <- PhoenixKit.Users.Permissions.core_section_keys(), MapSet.member?(@permissions_grantable_keys, key) do %>
-              <label class="flex items-center gap-3 cursor-pointer p-2 rounded-lg hover:bg-base-200 transition-colors">
-                <input
-                  type="checkbox"
-                  class="checkbox checkbox-sm checkbox-primary"
-                  checked={MapSet.member?(@permissions_role_keys, key)}
-                  phx-click="toggle_permission"
-                  phx-value-key={key}
-                />
-                <span class="text-sm">{PhoenixKit.Users.Permissions.localized_module_label(key)}</span>
-              </label>
+              <.checkbox
+                name={"perm_#{key}"}
+                checked={MapSet.member?(@permissions_role_keys, key)}
+                phx-click="toggle_permission"
+                phx-value-key={key}
+                class="checkbox-sm checkbox-primary"
+                label={PhoenixKit.Users.Permissions.localized_module_label(key)}
+              />
             <% end %>
           </div>
         </div>
@@ -377,32 +375,27 @@
           </h4>
           <div class="space-y-2 max-h-80 overflow-y-auto">
             <%= for key <- PhoenixKit.Users.Permissions.feature_module_keys(), MapSet.member?(@permissions_grantable_keys, key) do %>
-              <label class="flex items-center gap-3 cursor-pointer p-2 rounded-lg hover:bg-base-200 transition-colors">
-                <input
-                  type="checkbox"
-                  class="checkbox checkbox-sm checkbox-primary"
-                  checked={MapSet.member?(@permissions_role_keys, key)}
-                  phx-click="toggle_permission"
-                  phx-value-key={key}
-                />
-                <span class="text-sm">{PhoenixKit.Users.Permissions.localized_module_label(key)}</span>
-              </label>
+              <.checkbox
+                name={"perm_#{key}"}
+                checked={MapSet.member?(@permissions_role_keys, key)}
+                phx-click="toggle_permission"
+                phx-value-key={key}
+                class="checkbox-sm checkbox-primary"
+                label={PhoenixKit.Users.Permissions.localized_module_label(key)}
+              />
               <%!-- Fine-grained sub-permissions, indented under their module.
                    Checking one also checks the module; unchecking the module
                    unchecks these with it (mirrors the save-time invariant). --%>
               <%= for sub <- PhoenixKit.Users.Permissions.sub_permissions_for(key), MapSet.member?(@permissions_grantable_keys, sub.key) do %>
-                <label class="flex items-center gap-3 cursor-pointer p-2 pl-8 rounded-lg hover:bg-base-200 transition-colors">
-                  <input
-                    type="checkbox"
-                    class="checkbox checkbox-xs checkbox-primary"
-                    checked={MapSet.member?(@permissions_role_keys, sub.key)}
-                    phx-click="toggle_permission"
-                    phx-value-key={sub.key}
-                  />
-                  <span class="text-sm text-base-content/80">
-                    {PhoenixKit.Users.Permissions.localized_module_label(sub.key)}
-                  </span>
-                </label>
+                <.checkbox
+                  name={"perm_#{sub.key}"}
+                  checked={MapSet.member?(@permissions_role_keys, sub.key)}
+                  phx-click="toggle_permission"
+                  phx-value-key={sub.key}
+                  class="checkbox-xs checkbox-primary"
+                  wrapper_class="pl-8"
+                  label={PhoenixKit.Users.Permissions.localized_module_label(sub.key)}
+                />
               <% end %>
             <% end %>
           </div>
@@ -417,16 +410,15 @@
           </h4>
           <div class="columns-1 md:columns-2 gap-x-6">
             <%= for key <- PhoenixKit.Users.Permissions.custom_keys(), MapSet.member?(@permissions_grantable_keys, key) do %>
-              <label class="flex items-center gap-3 cursor-pointer p-2 rounded-lg hover:bg-base-200 transition-colors break-inside-avoid">
-                <input
-                  type="checkbox"
-                  class="checkbox checkbox-sm checkbox-primary"
-                  checked={MapSet.member?(@permissions_role_keys, key)}
-                  phx-click="toggle_permission"
-                  phx-value-key={key}
-                />
-                <span class="text-sm">{PhoenixKit.Users.Permissions.localized_module_label(key)}</span>
-              </label>
+              <.checkbox
+                name={"perm_#{key}"}
+                checked={MapSet.member?(@permissions_role_keys, key)}
+                phx-click="toggle_permission"
+                phx-value-key={key}
+                class="checkbox-sm checkbox-primary"
+                wrapper_class="break-inside-avoid"
+                label={PhoenixKit.Users.Permissions.localized_module_label(key)}
+              />
             <% end %>
           </div>
         </div>

--- a/lib/phoenix_kit_web/live/users/roles.html.heex
+++ b/lib/phoenix_kit_web/live/users/roles.html.heex
@@ -8,7 +8,7 @@
   project_title={@project_title}
   current_locale={@current_locale}
 >
-  <div class="container flex-col mx-auto px-4 py-6">
+  <div class="flex-col px-4 py-6">
     <%!-- Create Role Modal --%>
     <.modal show={@show_create_form} on_close="hide_form" max_width="2xl">
       <:title>{gettext("Create New Role")}</:title>

--- a/lib/phoenix_kit_web/live/users/roles.html.heex
+++ b/lib/phoenix_kit_web/live/users/roles.html.heex
@@ -2,7 +2,7 @@
   socket={@socket}
   flash={@flash}
   phoenix_kit_current_scope={assigns[:phoenix_kit_current_scope]}
-  page_title={gettext("Role Management")}
+  page_title={@page_title}
   page_subtitle={gettext("Create and manage user roles")}
   current_path={@url_path}
   project_title={@project_title}

--- a/lib/phoenix_kit_web/live/users/sessions.ex
+++ b/lib/phoenix_kit_web/live/users/sessions.ex
@@ -39,7 +39,7 @@ defmodule PhoenixKitWeb.Live.Users.Sessions do
       |> assign(:per_page, @per_page)
       |> assign(:search_query, "")
       |> assign(:filter_user_status, "all")
-      |> assign(:page_title, gettext("Sessions"))
+      |> assign(:page_title, gettext("Session Management"))
       |> assign(:project_title, project_title)
       |> assign(:current_locale, locale)
       |> assign(:show_revoke_modal, false)

--- a/lib/phoenix_kit_web/live/users/sessions.html.heex
+++ b/lib/phoenix_kit_web/live/users/sessions.html.heex
@@ -8,7 +8,7 @@
   project_title={@project_title}
   current_locale={@current_locale}
 >
-  <div class="container flex-col mx-auto px-4 py-6">
+  <div class="flex-col px-4 py-6">
     <%!-- Session Statistics --%>
     <div class="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6">
       <PhoenixKitWeb.Components.Core.StatCard.stat_card

--- a/lib/phoenix_kit_web/live/users/sessions.html.heex
+++ b/lib/phoenix_kit_web/live/users/sessions.html.heex
@@ -196,23 +196,18 @@
           phx-change="filter_by_user_status"
           class="contents"
         >
-          <select class="select select-sm w-40 min-w-0" name="status">
-            <option value="all" selected={@filter_user_status == "all"}>
-              {gettext("All Users")}
-            </option>
-            <option value="active" selected={@filter_user_status == "active"}>
-              {gettext("Active Users")}
-            </option>
-            <option value="inactive" selected={@filter_user_status == "inactive"}>
-              {gettext("Inactive Users")}
-            </option>
-            <option value="confirmed" selected={@filter_user_status == "confirmed"}>
-              {gettext("Confirmed Email")}
-            </option>
-            <option value="pending" selected={@filter_user_status == "pending"}>
-              {gettext("Pending Email")}
-            </option>
-          </select>
+          <.select
+            name="status"
+            value={@filter_user_status}
+            options={[
+              {gettext("All Users"), "all"},
+              {gettext("Active Users"), "active"},
+              {gettext("Inactive Users"), "inactive"},
+              {gettext("Confirmed Email"), "confirmed"},
+              {gettext("Pending Email"), "pending"}
+            ]}
+            class="select-sm w-40"
+          />
         </form>
         <button phx-click="refresh_sessions" class="btn btn-sm btn-primary">
           <.icon name="hero-arrow-path" class="w-4 h-4" /> {gettext("Refresh")}

--- a/lib/phoenix_kit_web/live/users/sessions.html.heex
+++ b/lib/phoenix_kit_web/live/users/sessions.html.heex
@@ -172,19 +172,11 @@
       }
     >
       <:toolbar_title>
-        <form id="sessions-search-form" phx-change="search" class="contents">
-          <label class="input input-sm w-40 sm:w-52 lg:w-64 min-w-0">
-            <.icon name="hero-magnifying-glass" class="h-4 w-4 opacity-50" />
-            <input
-              type="search"
-              name="search"
-              value={@search_query}
-              placeholder={gettext("Search by email or token...")}
-              class="grow"
-              phx-debounce="300"
-            />
-          </label>
-        </form>
+        <.search_toolbar
+          value={@search_query}
+          placeholder={gettext("Search by email or token...")}
+          class="w-40 sm:w-52 lg:w-64 min-w-0"
+        />
       </:toolbar_title>
       <:toolbar_actions>
         <%!-- Filter by User Status --%>

--- a/lib/phoenix_kit_web/live/users/sessions.html.heex
+++ b/lib/phoenix_kit_web/live/users/sessions.html.heex
@@ -2,7 +2,7 @@
   socket={@socket}
   flash={@flash}
   phoenix_kit_current_scope={assigns[:phoenix_kit_current_scope]}
-  page_title={gettext("Session Management")}
+  page_title={@page_title}
   page_subtitle={gettext("Monitor and manage active user sessions")}
   current_path={@url_path}
   project_title={@project_title}

--- a/lib/phoenix_kit_web/live/users/user_details.ex
+++ b/lib/phoenix_kit_web/live/users/user_details.ex
@@ -657,14 +657,30 @@ defmodule PhoenixKitWeb.Live.Users.UserDetails do
       "true" -> gettext("Yes")
       false -> gettext("No")
       "false" -> gettext("No")
-      _ -> to_string(value)
+      _ -> printable(value)
     end
   end
 
   defp format_custom_field_value(value, type, field_key)
        when type in ["select", "radio", "checkbox"] do
-    CustomFields.get_option_text(field_key, value) || to_string(value)
+    CustomFields.get_option_text(field_key, value) || printable(value)
   end
 
-  defp format_custom_field_value(value, _type, _field_key), do: to_string(value)
+  defp format_custom_field_value(value, _type, _field_key), do: printable(value)
+
+  # `custom_fields` is free-form JSONB, so a value can be a map or a list — the
+  # media browser stores `media_expanded_folders` as a list and the etcher stores
+  # `etcher_line_params` as a map. `to_string/1` raises Protocol.UndefinedError on
+  # a map, which took the whole user page down with a 500 for any user who had
+  # ever used those features. Render structured values as JSON instead of
+  # crashing; a list of strings is joined, since `to_string/1` would silently
+  # concatenate it into one unreadable run.
+  defp printable(value) when is_map(value), do: Jason.encode!(value)
+
+  defp printable(value) when is_list(value) do
+    Enum.map_join(value, ", ", &printable/1)
+  end
+
+  defp printable(value) when is_binary(value), do: value
+  defp printable(value), do: to_string(value)
 end

--- a/lib/phoenix_kit_web/live/users/user_details.ex
+++ b/lib/phoenix_kit_web/live/users/user_details.ex
@@ -9,6 +9,10 @@ defmodule PhoenixKitWeb.Live.Users.UserDetails do
   """
   use PhoenixKitWeb, :live_view
 
+  # Not wired project-wide (see PhoenixKitWeb.Components.Core.RowLink's
+  # commit message) — Andi's own row_link/1 import would become ambiguous.
+  import PhoenixKitWeb.Components.Core.RowLink, only: [row_link: 1]
+
   @compile {:no_warn_undefined, PhoenixKitUserConnections}
 
   alias PhoenixKit.Admin.Events

--- a/lib/phoenix_kit_web/live/users/user_details.html.heex
+++ b/lib/phoenix_kit_web/live/users/user_details.html.heex
@@ -75,59 +75,25 @@
     </div>
 
     <%!-- Tabs Navigation --%>
+    <% user_detail_tabs =
+      [
+        %{id: "profile", label: gettext("Profile"), icon: "hero-user"},
+        @connections_enabled &&
+          %{id: "connections", label: gettext("Connections"), icon: "hero-user-group"},
+        Map.merge(
+          %{id: "notes", label: gettext("Notes"), icon: "hero-document-text"},
+          (length(@admin_notes) > 0 && %{badge: length(@admin_notes)}) || %{}
+        ),
+        @org_accounts_enabled && @user.account_type == "organization" &&
+          Map.merge(
+            %{id: "members", label: gettext("Members"), icon: "hero-user-group"},
+            (length(@organization_members) > 0 &&
+               %{badge: length(@organization_members)}) || %{}
+          )
+      ]
+      |> Enum.filter(& &1) %>
     <div class="flex justify-center mb-6">
-      <div role="tablist" class="tabs tabs-boxed bg-base-200 p-1">
-        <button
-          type="button"
-          role="tab"
-          class={"tab gap-2 #{if @active_tab == "profile", do: "tab-active"}"}
-          phx-click="change_tab"
-          phx-value-tab="profile"
-        >
-          <.icon name="hero-user" class="w-4 h-4" />
-          {gettext("Profile")}
-        </button>
-        <%= if @connections_enabled do %>
-          <button
-            type="button"
-            role="tab"
-            class={"tab gap-2 #{if @active_tab == "connections", do: "tab-active"}"}
-            phx-click="change_tab"
-            phx-value-tab="connections"
-          >
-            <.icon name="hero-user-group" class="w-4 h-4" />
-            {gettext("Connections")}
-          </button>
-        <% end %>
-        <button
-          type="button"
-          role="tab"
-          class={"tab gap-2 #{if @active_tab == "notes", do: "tab-active"}"}
-          phx-click="change_tab"
-          phx-value-tab="notes"
-        >
-          <.icon name="hero-document-text" class="w-4 h-4" />
-          {gettext("Notes")}
-          <%= if length(@admin_notes) > 0 do %>
-            <span class="badge badge-sm h-auto">{length(@admin_notes)}</span>
-          <% end %>
-        </button>
-        <%= if @org_accounts_enabled && @user.account_type == "organization" do %>
-          <button
-            type="button"
-            role="tab"
-            class={"tab gap-2 #{if @active_tab == "members", do: "tab-active"}"}
-            phx-click="change_tab"
-            phx-value-tab="members"
-          >
-            <.icon name="hero-user-group" class="w-4 h-4" />
-            {gettext("Members")}
-            <%= if length(@organization_members) > 0 do %>
-              <span class="badge badge-sm h-auto">{length(@organization_members)}</span>
-            <% end %>
-          </button>
-        <% end %>
-      </div>
+      <.nav_tabs active_tab={@active_tab} on_change="change_tab" tabs={user_detail_tabs} />
     </div>
 
     <%!-- Tab Content --%>
@@ -630,78 +596,81 @@
           <div class="card-body">
             <h3 class="card-title text-lg mb-4">{gettext("Organization Members")}</h3>
             <%= if Enum.empty?(@organization_members) do %>
-              <div class="text-center py-8 text-base-content/70">
-                <.icon name="hero-user-group" class="w-12 h-12 mx-auto mb-2 opacity-50" />
-                <p>{gettext("No members yet")}</p>
-                <p class="text-sm mt-1">{gettext("Add members from the user edit page")}</p>
-              </div>
+              <.empty_state
+                icon="hero-user-group"
+                title={gettext("No members yet")}
+                description={gettext("Add members from the user edit page")}
+              />
             <% else %>
-              <div class="overflow-x-auto">
-                <table class="table table-zebra">
-                  <thead>
-                    <tr>
-                      <th>{gettext("Name")}</th>
-                      <th>{gettext("Email")}</th>
-                      <th>{gettext("Status")}</th>
-                      <th>{gettext("Actions")}</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <%= for member <- @organization_members do %>
-                      <tr>
-                        <td>
-                          <div class="flex items-center gap-3">
-                            <.user_avatar user={member} size="sm" />
-                            <div>
-                              <div class="font-medium">
-                                {PhoenixKit.Users.Auth.User.full_name(member) || "-"}
-                              </div>
-                              <%= if member.username do %>
-                                <div class="text-xs text-base-content/60">@{member.username}</div>
-                              <% end %>
-                            </div>
+              <.table_default variant="zebra">
+                <.table_default_header>
+                  <.table_default_row>
+                    <.table_default_header_cell>{gettext("Name")}</.table_default_header_cell>
+                    <.table_default_header_cell>{gettext("Email")}</.table_default_header_cell>
+                    <.table_default_header_cell>{gettext("Status")}</.table_default_header_cell>
+                    <.table_default_header_cell>{gettext("Actions")}</.table_default_header_cell>
+                  </.table_default_row>
+                </.table_default_header>
+                <.table_default_body>
+                  <.table_default_row
+                    :for={member <- @organization_members}
+                    class="row-link-host relative cursor-pointer"
+                  >
+                    <.table_default_cell>
+                      <.row_link
+                        navigate={
+                          PhoenixKit.Utils.Routes.path("/admin/users/view/#{member.uuid}")
+                        }
+                        label={PhoenixKit.Users.Auth.User.full_name(member) || member.email}
+                      />
+                      <div class="flex items-center gap-3">
+                        <.user_avatar user={member} size="sm" />
+                        <div>
+                          <div class="font-medium">
+                            {PhoenixKit.Users.Auth.User.full_name(member) || "-"}
                           </div>
-                        </td>
-                        <td>{member.email}</td>
-                        <td>
-                          <%= if member.is_active do %>
-                            <span class="badge badge-success badge-sm h-auto">
-                              {gettext("Active")}
-                            </span>
-                          <% else %>
-                            <span class="badge badge-error badge-sm h-auto">
-                              {gettext("Inactive")}
-                            </span>
+                          <%= if member.username do %>
+                            <div class="text-xs text-base-content/60">@{member.username}</div>
                           <% end %>
-                        </td>
-                        <td>
-                          <div class="flex gap-1">
-                            <.pk_link
-                              navigate={"/admin/users/view/#{member.uuid}"}
-                              class="btn btn-ghost btn-xs"
-                              title={gettext("View")}
-                            >
-                              <.icon name="hero-eye" class="w-4 h-4" />
-                            </.pk_link>
-                            <button
-                              type="button"
-                              class="btn btn-ghost btn-xs text-error"
-                              phx-click="remove_member"
-                              phx-value-uuid={member.uuid}
-                              title={gettext("Remove from organization")}
-                              data-confirm={
-                                gettext("Are you sure you want to remove this member?")
-                              }
-                            >
-                              <.icon name="hero-x-mark" class="w-4 h-4" />
-                            </button>
-                          </div>
-                        </td>
-                      </tr>
-                    <% end %>
-                  </tbody>
-                </table>
-              </div>
+                        </div>
+                      </div>
+                    </.table_default_cell>
+                    <.table_default_cell>{member.email}</.table_default_cell>
+                    <.table_default_cell>
+                      <%= if member.is_active do %>
+                        <span class="badge badge-success badge-sm h-auto">
+                          {gettext("Active")}
+                        </span>
+                      <% else %>
+                        <span class="badge badge-error badge-sm h-auto">
+                          {gettext("Inactive")}
+                        </span>
+                      <% end %>
+                    </.table_default_cell>
+                    <.table_default_cell class="relative z-10">
+                      <div class="flex gap-1">
+                        <.pk_link
+                          navigate={"/admin/users/view/#{member.uuid}"}
+                          class="btn btn-ghost btn-xs"
+                          title={gettext("View")}
+                        >
+                          <.icon name="hero-eye" class="w-4 h-4" />
+                        </.pk_link>
+                        <button
+                          type="button"
+                          class="btn btn-ghost btn-xs text-error"
+                          phx-click="remove_member"
+                          phx-value-uuid={member.uuid}
+                          title={gettext("Remove from organization")}
+                          data-confirm={gettext("Are you sure you want to remove this member?")}
+                        >
+                          <.icon name="hero-x-mark" class="w-4 h-4" />
+                        </button>
+                      </div>
+                    </.table_default_cell>
+                  </.table_default_row>
+                </.table_default_body>
+              </.table_default>
             <% end %>
           </div>
         </div>

--- a/lib/phoenix_kit_web/live/users/user_details.html.heex
+++ b/lib/phoenix_kit_web/live/users/user_details.html.heex
@@ -517,12 +517,12 @@
                 class="space-y-4"
               >
                 <div class="form-control">
-                  <textarea
-                    name="admin_note[content]"
-                    class="textarea textarea-bordered w-full h-24"
+                  <.textarea
+                    field={@note_form[:content]}
                     placeholder={gettext("Write a note about this user...")}
+                    class="h-24"
                     required
-                  >{Phoenix.HTML.Form.input_value(@note_form, :content)}</textarea>
+                  />
                 </div>
                 <div class="flex justify-end gap-2">
                   <%= if @editing_note_uuid do %>
@@ -781,21 +781,12 @@
             <%= for role <- @all_roles do %>
               <% owner_role? = role.name == PhoenixKit.Users.Role.system_roles().owner %>
               <div class="form-control">
-                <label
-                  class={[
-                    "label justify-start gap-3",
-                    owner_role? && "cursor-not-allowed opacity-70"
-                  ]}
-                  title={if owner_role?, do: gettext("Owner role cannot be modified"), else: nil}
+                <.checkbox
+                  name={"roles[#{role.name}]"}
+                  checked={role.name in user_role_names}
+                  disabled={owner_role?}
+                  title={owner_role? && gettext("Owner role cannot be modified")}
                 >
-                  <input
-                    type="checkbox"
-                    name={"roles[#{role.name}]"}
-                    value={role.name}
-                    class="checkbox"
-                    checked={role.name in user_role_names}
-                    disabled={owner_role?}
-                  />
                   <div class="flex flex-wrap items-center gap-2">
                     <.role_badge role={role} size={:sm} />
                     <%= if role.is_system_role do %>
@@ -807,7 +798,7 @@
                       <span class="text-sm text-base-content/70">- {role.description}</span>
                     <% end %>
                   </div>
-                </label>
+                </.checkbox>
               </div>
             <% end %>
           </div>

--- a/lib/phoenix_kit_web/live/users/user_details.html.heex
+++ b/lib/phoenix_kit_web/live/users/user_details.html.heex
@@ -5,78 +5,74 @@
   page_title={@page_title}
   page_section={@page_section}
   page_section_path={@page_section_path}
+  page_subtitle={@user.email}
+  page_action={
+    %{
+      icon: "hero-pencil",
+      label: gettext("Edit"),
+      navigate: PhoenixKit.Utils.Routes.path("/admin/users/edit/#{@user.uuid}?return_to=view")
+    }
+  }
   current_path={@url_path}
   project_title={@project_title}
   current_locale={@current_locale}
 >
   <div class="container flex-col mx-auto px-4 py-6">
-    <.admin_page_header back={PhoenixKit.Utils.Routes.path("/admin/users")}>
-      <h1 class="text-xl sm:text-2xl lg:text-3xl font-bold text-base-content break-words min-w-0">
-        {@page_title}
-      </h1>
-      <p class="text-sm text-base-content/60 mt-0.5 break-words">{@user.email}</p>
-      <:actions>
-        <.link
-          navigate={
-            PhoenixKit.Utils.Routes.path("/admin/users/edit/#{@user.uuid}?return_to=view")
-          }
-          class="btn btn-primary btn-sm"
-        >
-          <PhoenixKitWeb.Components.Core.Icons.icon_edit /> {gettext("Edit")}
-        </.link>
-
-        <%!-- Same actions offered by the "..." menu on the Users list, so nothing
-             there is unreachable from this page. --%>
-        <.table_row_menu id="user-detail-actions" label={gettext("More actions")}>
-          <%= if @user.uuid != @phoenix_kit_current_user.uuid do %>
-            <.table_row_menu_button
-              phx-click="show_role_management"
-              icon="hero-user-group"
-              label={gettext("Roles")}
-              variant="primary"
-            />
-          <% else %>
-            <.table_row_menu_link
-              navigate={PhoenixKit.Utils.Routes.path("/dashboard/settings")}
-              icon="hero-cog-6-tooth"
-              label={gettext("Settings")}
-              variant="info"
-            />
-          <% end %>
-          <%= if @user.uuid != @phoenix_kit_current_user.uuid && !target_is_owner?(@user) do %>
-            <.table_row_menu_divider />
-            <.table_row_menu_button
-              phx-click="request_confirmation_toggle"
-              phx-value-is_confirmed={to_string(!!@user.confirmed_at)}
-              icon={if @user.confirmed_at, do: "hero-envelope-open", else: "hero-envelope"}
-              label={
-                if @user.confirmed_at,
-                  do: gettext("Unconfirm Email"),
-                  else: gettext("Confirm Email")
-              }
-              variant={if @user.confirmed_at, do: "success", else: "warning"}
-            />
-            <.table_row_menu_button
-              phx-click="request_status_toggle"
-              phx-value-is_active={to_string(@user.is_active)}
-              icon={if @user.is_active, do: "hero-check-circle", else: "hero-x-circle"}
-              label={if @user.is_active, do: gettext("Deactivate"), else: gettext("Activate")}
-              variant={if @user.is_active, do: "success", else: "warning"}
-            />
-          <% end %>
-        </.table_row_menu>
-
-        <%= if Auth.can_delete_user?(@user, @phoenix_kit_current_user) do %>
-          <button
-            type="button"
-            class="btn btn-error btn-sm btn-outline"
-            phx-click="show_delete_modal"
-          >
-            <PhoenixKitWeb.Components.Core.Icons.icon_trash /> {gettext("Delete")}
-          </button>
+    <%!-- Actions row: user-level actions that must stay visible regardless of
+         which tab is active or the user's account type (the org-members table
+         below is tab-gated and organization-only, so it can't own these). --%>
+    <div class="flex flex-wrap items-center gap-2 justify-end mb-4">
+      <%!-- Same actions offered by the "..." menu on the Users list, so nothing
+           there is unreachable from this page. --%>
+      <.table_row_menu id="user-detail-actions" label={gettext("More actions")}>
+        <%= if @user.uuid != @phoenix_kit_current_user.uuid do %>
+          <.table_row_menu_button
+            phx-click="show_role_management"
+            icon="hero-user-group"
+            label={gettext("Roles")}
+            variant="primary"
+          />
+        <% else %>
+          <.table_row_menu_link
+            navigate={PhoenixKit.Utils.Routes.path("/dashboard/settings")}
+            icon="hero-cog-6-tooth"
+            label={gettext("Settings")}
+            variant="info"
+          />
         <% end %>
-      </:actions>
-    </.admin_page_header>
+        <%= if @user.uuid != @phoenix_kit_current_user.uuid && !target_is_owner?(@user) do %>
+          <.table_row_menu_divider />
+          <.table_row_menu_button
+            phx-click="request_confirmation_toggle"
+            phx-value-is_confirmed={to_string(!!@user.confirmed_at)}
+            icon={if @user.confirmed_at, do: "hero-envelope-open", else: "hero-envelope"}
+            label={
+              if @user.confirmed_at,
+                do: gettext("Unconfirm Email"),
+                else: gettext("Confirm Email")
+            }
+            variant={if @user.confirmed_at, do: "success", else: "warning"}
+          />
+          <.table_row_menu_button
+            phx-click="request_status_toggle"
+            phx-value-is_active={to_string(@user.is_active)}
+            icon={if @user.is_active, do: "hero-check-circle", else: "hero-x-circle"}
+            label={if @user.is_active, do: gettext("Deactivate"), else: gettext("Activate")}
+            variant={if @user.is_active, do: "success", else: "warning"}
+          />
+        <% end %>
+      </.table_row_menu>
+
+      <%= if Auth.can_delete_user?(@user, @phoenix_kit_current_user) do %>
+        <button
+          type="button"
+          class="btn btn-error btn-sm btn-outline"
+          phx-click="show_delete_modal"
+        >
+          <PhoenixKitWeb.Components.Core.Icons.icon_trash /> {gettext("Delete")}
+        </button>
+      <% end %>
+    </div>
 
     <%!-- Tabs Navigation --%>
     <div class="flex justify-center mb-6">

--- a/lib/phoenix_kit_web/live/users/user_details.html.heex
+++ b/lib/phoenix_kit_web/live/users/user_details.html.heex
@@ -750,12 +750,26 @@
             <%= for role <- @all_roles do %>
               <% owner_role? = role.name == PhoenixKit.Users.Role.system_roles().owner %>
               <div class="form-control">
-                <.checkbox
-                  name={"roles[#{role.name}]"}
-                  checked={role.name in user_role_names}
-                  disabled={owner_role?}
-                  title={owner_role? && gettext("Owner role cannot be modified")}
+                <%!-- DO NOT convert to <.checkbox>: the submitted VALUE is the payload.
+                     `sync_user_roles` reads Map.values(params["roles"]) and diffs that
+                     list against the user's current roles, so a component hardcoding
+                     "true"/"false" strips every role the user holds. render_submit
+                     injects params directly, so no test catches it. --%>
+                <label
+                  class={[
+                    "label justify-start gap-3",
+                    owner_role? && "cursor-not-allowed opacity-70"
+                  ]}
+                  title={if owner_role?, do: gettext("Owner role cannot be modified"), else: nil}
                 >
+                  <input
+                    type="checkbox"
+                    name={"roles[#{role.name}]"}
+                    value={role.name}
+                    class="checkbox"
+                    checked={role.name in user_role_names}
+                    disabled={owner_role?}
+                  />
                   <div class="flex flex-wrap items-center gap-2">
                     <.role_badge role={role} size={:sm} />
                     <%= if role.is_system_role do %>
@@ -767,7 +781,7 @@
                       <span class="text-sm text-base-content/70">- {role.description}</span>
                     <% end %>
                   </div>
-                </.checkbox>
+                </label>
               </div>
             <% end %>
           </div>

--- a/lib/phoenix_kit_web/live/users/user_details.html.heex
+++ b/lib/phoenix_kit_web/live/users/user_details.html.heex
@@ -17,7 +17,7 @@
   project_title={@project_title}
   current_locale={@current_locale}
 >
-  <div class="container flex-col mx-auto px-4 py-6">
+  <div class="flex-col px-4 py-6">
     <%!-- Actions row: user-level actions that must stay visible regardless of
          which tab is active or the user's account type (the org-members table
          below is tab-gated and organization-only, so it can't own these). --%>

--- a/lib/phoenix_kit_web/live/users/users.ex
+++ b/lib/phoenix_kit_web/live/users/users.ex
@@ -6,6 +6,10 @@ defmodule PhoenixKitWeb.Live.Users.Users do
   """
   use PhoenixKitWeb, :live_view
 
+  # Not wired project-wide (see PhoenixKitWeb.Components.Core.RowLink's
+  # commit message) — Andi's own row_link/1 import would become ambiguous.
+  import PhoenixKitWeb.Components.Core.RowLink, only: [row_link: 1]
+
   alias PhoenixKit.Admin.Events
   alias PhoenixKit.Settings
   alias PhoenixKit.Users.Auth

--- a/lib/phoenix_kit_web/live/users/users.html.heex
+++ b/lib/phoenix_kit_web/live/users/users.html.heex
@@ -363,7 +363,7 @@
             </.table_default_row>
           <% else %>
             <%= for user <- @users do %>
-              <.table_default_row class="row-link-host relative cursor-pointer">
+              <.table_default_row class="relative transform-gpu cursor-pointer">
                 <%= for column_id <- @selected_columns do %>
                   <%= if should_render_column?(column_id) do %>
                     <.table_default_cell class={[
@@ -499,11 +499,14 @@
                                       )
                                     }
                                   >
+                                    <%!-- relative z-10: this link sits inside a row that
+                                         carries the row_link overlay, and without it the
+                                         overlay swallows the click and opens the user. --%>
                                     <.link
                                       navigate={
                                         PhoenixKit.Utils.Routes.path("/admin/settings/users")
                                       }
-                                      class="inline-flex items-center gap-1 text-xs text-base-content/50 hover:text-primary hover:underline"
+                                      class="relative z-10 inline-flex items-center gap-1 text-xs text-base-content/50 hover:text-primary hover:underline"
                                     >
                                       <.icon name="hero-information-circle" class="w-3.5 h-3.5" />
                                       {gettext("Tracking disabled")}

--- a/lib/phoenix_kit_web/live/users/users.html.heex
+++ b/lib/phoenix_kit_web/live/users/users.html.heex
@@ -22,12 +22,29 @@
               <%= for role <- @all_roles do %>
                 <% owner_role? = role.name == PhoenixKit.Users.Role.system_roles().owner %>
                 <div class="form-control">
-                  <.checkbox
-                    name={"roles[#{role.name}]"}
-                    checked={role.name in @user_roles}
-                    disabled={owner_role?}
-                    title={owner_role? && gettext("Owner role cannot be modified")}
+                  <%!-- DO NOT convert to <.checkbox>: the submitted VALUE is the
+                       payload here. `sync_user_roles` reads Map.values(params["roles"])
+                       and the context diffs that list against the user's current roles,
+                       so a component that hardcodes "true"/"false" makes every held role
+                       look absent and strips them all. Tests do not catch it —
+                       render_submit injects params and never serializes the DOM. --%>
+                  <label
+                    class={[
+                      "label justify-start gap-3",
+                      owner_role? && "cursor-not-allowed opacity-70"
+                    ]}
+                    title={
+                      if owner_role?, do: gettext("Owner role cannot be modified"), else: nil
+                    }
                   >
+                    <input
+                      type="checkbox"
+                      name={"roles[#{role.name}]"}
+                      value={role.name}
+                      class="checkbox"
+                      checked={role.name in @user_roles}
+                      disabled={owner_role?}
+                    />
                     <div class="flex flex-wrap items-center gap-2">
                       <.role_badge role={role} size={:sm} />
                       <%= if role.is_system_role do %>
@@ -39,7 +56,7 @@
                         <span class="text-sm text-base-content/70">- {role.description}</span>
                       <% end %>
                     </div>
-                  </.checkbox>
+                  </label>
                 </div>
               <% end %>
             </div>

--- a/lib/phoenix_kit_web/live/users/users.html.heex
+++ b/lib/phoenix_kit_web/live/users/users.html.heex
@@ -22,23 +22,12 @@
               <%= for role <- @all_roles do %>
                 <% owner_role? = role.name == PhoenixKit.Users.Role.system_roles().owner %>
                 <div class="form-control">
-                  <label
-                    class={[
-                      "label justify-start gap-3",
-                      owner_role? && "cursor-not-allowed opacity-70"
-                    ]}
-                    title={
-                      if owner_role?, do: gettext("Owner role cannot be modified"), else: nil
-                    }
+                  <.checkbox
+                    name={"roles[#{role.name}]"}
+                    checked={role.name in @user_roles}
+                    disabled={owner_role?}
+                    title={owner_role? && gettext("Owner role cannot be modified")}
                   >
-                    <input
-                      type="checkbox"
-                      name={"roles[#{role.name}]"}
-                      value={role.name}
-                      class="checkbox"
-                      checked={role.name in @user_roles}
-                      disabled={owner_role?}
-                    />
                     <div class="flex flex-wrap items-center gap-2">
                       <.role_badge role={role} size={:sm} />
                       <%= if role.is_system_role do %>
@@ -50,7 +39,7 @@
                         <span class="text-sm text-base-content/70">- {role.description}</span>
                       <% end %>
                     </div>
-                  </label>
+                  </.checkbox>
                 </div>
               <% end %>
             </div>

--- a/lib/phoenix_kit_web/live/users/users.html.heex
+++ b/lib/phoenix_kit_web/live/users/users.html.heex
@@ -322,37 +322,45 @@
               <.table_default_cell colspan={
                 Enum.count(@selected_columns, &should_render_column?/1)
               }>
-                <div class="text-center py-12">
-                  <PhoenixKitWeb.Components.Core.Icons.icon_users_multiple class="h-16 w-16 mx-auto text-base-content/40 mb-4" />
-                  <h3 class="text-lg font-medium text-base-content mb-2">
-                    {gettext("No users found")}
-                  </h3>
-                  <% filters_active? =
-                    @search_query != "" or @filter_role != "all" or
-                      @filter_account_type != "all" %>
-                  <p class="text-base-content/70 mb-4">
-                    <%= if filters_active? do %>
-                      {gettext("Try adjusting your search or filter criteria.")}
-                    <% else %>
-                      {gettext("No users are registered yet.")}
-                    <% end %>
-                  </p>
-                  <%= if filters_active? do %>
-                    <button class="btn btn-outline btn-sm" phx-click="clear_filters">
-                      {gettext("Clear Filters")}
-                    </button>
-                  <% end %>
-                </div>
+                <% filters_active? =
+                  @search_query != "" or @filter_role != "all" or
+                    @filter_account_type != "all" %>
+                <.empty_state
+                  icon="hero-users"
+                  title={gettext("No users found")}
+                  description={
+                    if filters_active?,
+                      do: gettext("Try adjusting your search or filter criteria."),
+                      else: gettext("No users are registered yet.")
+                  }
+                >
+                  <button
+                    :if={filters_active?}
+                    class="btn btn-outline btn-sm"
+                    phx-click="clear_filters"
+                  >
+                    {gettext("Clear Filters")}
+                  </button>
+                </.empty_state>
               </.table_default_cell>
             </.table_default_row>
           <% else %>
             <%= for user <- @users do %>
-              <.table_default_row>
+              <.table_default_row class="row-link-host relative cursor-pointer">
                 <%= for column_id <- @selected_columns do %>
                   <%= if should_render_column?(column_id) do %>
-                    <.table_default_cell class={mobile_col_class(column_id)}>
+                    <.table_default_cell class={[
+                      mobile_col_class(column_id),
+                      column_id == "actions" && "relative z-10"
+                    ]}>
                       <%= cond do %>
                         <% column_id == "email" -> %>
+                          <.row_link
+                            navigate={
+                              PhoenixKit.Utils.Routes.path("/admin/users/view/#{user.uuid}")
+                            }
+                            label={user.email}
+                          />
                           <.link
                             navigate={
                               PhoenixKit.Utils.Routes.path("/admin/users/view/#{user.uuid}")

--- a/lib/phoenix_kit_web/users/user_form.ex
+++ b/lib/phoenix_kit_web/users/user_form.ex
@@ -822,8 +822,8 @@ defmodule PhoenixKitWeb.Users.UserForm do
     |> assign(:custom_fields_data, user.custom_fields || %{})
   end
 
-  defp page_title(:new), do: "Create User"
-  defp page_title(:edit), do: "Edit User"
+  defp page_title(:new), do: gettext("Create User")
+  defp page_title(:edit), do: gettext("Edit User")
 
   defp reload_changeset_with_password(socket, show_password_field) do
     case socket.assigns.mode do

--- a/lib/phoenix_kit_web/users/user_form.html.heex
+++ b/lib/phoenix_kit_web/users/user_form.html.heex
@@ -5,33 +5,15 @@
   page_title={@page_title}
   page_section={@page_section}
   page_section_path={@page_section_path}
+  page_subtitle={
+    if @mode == :new,
+      do: gettext("Create a new user account"),
+      else: gettext("Edit user information")
+  }
   current_path={@url_path}
   current_locale={@current_locale}
 >
   <div class="container flex-col mx-auto px-4 py-6">
-    <%!-- Header Section --%>
-    <header class="w-full mb-6">
-      <%!-- Back Button (Left aligned) --%>
-      <.link
-        navigate={PhoenixKit.Utils.Routes.path("/admin/users")}
-        class="btn btn-ghost btn-sm"
-      >
-        <.icon name="hero-arrow-left" class="w-4 h-4" /> Users
-      </.link>
-
-      <%!-- Title Section --%>
-      <div class="text-center">
-        <h1 class="text-2xl sm:text-4xl font-bold text-base-content mb-3">{@page_title}</h1>
-        <p class="text-base sm:text-lg text-base-content">
-          <%= if @mode == :new do %>
-            Create a new user account
-          <% else %>
-            Edit user information
-          <% end %>
-        </p>
-      </div>
-    </header>
-
     <%!-- User Form --%>
     <div class="max-w-2xl mx-auto">
       <div class="bg-base-100 rounded-lg shadow-md p-6">

--- a/lib/phoenix_kit_web/users/user_form.html.heex
+++ b/lib/phoenix_kit_web/users/user_form.html.heex
@@ -229,17 +229,12 @@
                   <span class="label-text font-semibold">{gettext("Organization")}</span>
                   <span class="label-text-alt text-base-content/60">{gettext("Optional")}</span>
                 </label>
-                <select name="user[organization_uuid]" class="select select-bordered w-full">
-                  <option value="">— No organization —</option>
-                  <%= for org <- @organizations do %>
-                    <option
-                      value={org.uuid}
-                      selected={Map.get(@form_data, "organization_uuid") == to_string(org.uuid)}
-                    >
-                      {org.organization_name}
-                    </option>
-                  <% end %>
-                </select>
+                <.select
+                  name="user[organization_uuid]"
+                  value={Map.get(@form_data, "organization_uuid")}
+                  prompt="— No organization —"
+                  options={Enum.map(@organizations, &{&1.organization_name, to_string(&1.uuid)})}
+                />
                 <div class="text-xs text-base-content/60 mt-1">
                   Link this person to an organization account
                 </div>
@@ -521,18 +516,19 @@
                 <%!-- Dynamic input based on field type --%>
                 <%= case field_def["type"] do %>
                   <% "textarea" -> %>
-                    <textarea
+                    <.textarea
                       name={"user[custom_fields][#{field_key}]"}
-                      class={"textarea textarea-bordered w-full #{if field_error, do: "textarea-error", else: ""}"}
+                      value={field_value}
+                      class={field_error && "textarea-error"}
                       placeholder={field_def["label"]}
                       required={field_def["required"]}
-                    >{field_value}</textarea>
+                    />
                   <% "number" -> %>
-                    <input
+                    <.input
                       type="number"
                       name={"user[custom_fields][#{field_key}]"}
                       value={field_value}
-                      class={"input input-bordered w-full #{if field_error, do: "input-error", else: ""}"}
+                      class={field_error && "input-error"}
                       placeholder={field_def["label"]}
                       required={field_def["required"]}
                     />
@@ -544,63 +540,55 @@
                       wrapper_class="mt-2"
                     />
                   <% "date" -> %>
-                    <input
+                    <.input
                       type="date"
                       name={"user[custom_fields][#{field_key}]"}
                       value={field_value}
-                      class={"input input-bordered w-full #{if field_error, do: "input-error", else: ""}"}
+                      class={field_error && "input-error"}
                       required={field_def["required"]}
                     />
                   <% "email" -> %>
-                    <input
+                    <.input
                       type="email"
                       name={"user[custom_fields][#{field_key}]"}
                       value={field_value}
-                      class={"input input-bordered w-full #{if field_error, do: "input-error", else: ""}"}
+                      class={field_error && "input-error"}
                       placeholder="user@example.com"
                       required={field_def["required"]}
                     />
                   <% "url" -> %>
-                    <input
+                    <.input
                       type="url"
                       name={"user[custom_fields][#{field_key}]"}
                       value={field_value}
-                      class={"input input-bordered w-full #{if field_error, do: "input-error", else: ""}"}
+                      class={field_error && "input-error"}
                       placeholder="https://example.com"
                       required={field_def["required"]}
                     />
                   <% "uuid" -> %>
-                    <input
+                    <.input
                       type="text"
                       name={"user[custom_fields][#{field_key}]"}
                       value={field_value}
-                      class={"input input-bordered w-full #{if field_error, do: "input-error", else: ""} font-mono text-sm"}
+                      class={["font-mono text-sm", field_error && "input-error"]}
                       readonly
                     />
                   <% "select" -> %>
-                    <label class={"select w-full #{if field_error, do: "select-error", else: ""}"}>
-                      <select
-                        name={"user[custom_fields][#{field_key}]"}
-                        required={field_def["required"]}
-                      >
-                        <option value="">Select an option</option>
-                        <%= for {option, index} <- Enum.with_index(field_def["options"] || []) do %>
-                          <option
-                            value={index}
-                            selected={to_string(field_value) == to_string(index)}
-                          >
-                            {option}
-                          </option>
-                        <% end %>
-                      </select>
-                    </label>
+                    <.select
+                      name={"user[custom_fields][#{field_key}]"}
+                      value={field_value}
+                      required={field_def["required"]}
+                      class={field_error && "select-error"}
+                      prompt="Select an option"
+                      options={(field_def["options"] || []) |> Enum.with_index()}
+                    />
                   <% _default -> %>
                     <%!-- text, radio, checkbox, and other types default to text input --%>
-                    <input
+                    <.input
                       type="text"
                       name={"user[custom_fields][#{field_key}]"}
                       value={field_value}
-                      class={"input input-bordered w-full #{if field_error, do: "input-error", else: ""}"}
+                      class={field_error && "input-error"}
                       placeholder={field_def["label"]}
                       required={field_def["required"]}
                     />

--- a/lib/phoenix_kit_web/users/user_form.html.heex
+++ b/lib/phoenix_kit_web/users/user_form.html.heex
@@ -13,7 +13,7 @@
   current_path={@url_path}
   current_locale={@current_locale}
 >
-  <div class="container flex-col mx-auto px-4 py-6">
+  <div class="flex-col px-4 py-6">
     <%!-- User Form --%>
     <div class="max-w-2xl mx-auto">
       <div class="bg-base-100 rounded-lg shadow-md p-6">


### PR DESCRIPTION
Brings the admin surface onto one set of conventions: the framework's own components, full-window pages, one header per page, and real links on rows that have a destination.

## What changed

- **`row_link` component** (new). One real `<a>` in the first cell paints a stretched `::after` overlay across the row, so a row with a destination is a genuine link — middle-click, ctrl-click and "open in new tab" all work. Adopted on users, activity, integrations, my_integrations, send_profiles and org-members. The Safari `<tr>` caveat is handled with Tailwind's stock `transform-gpu`, so nothing has to be added to a host stylesheet.
- **~70 hand-rolled form controls → `<.input>` / `<.select>` / `<.checkbox>` / `<.textarea>`** across 17 files. Six controls were deliberately left alone (CSS-only `.collapse` toggles with no name and no events) and two role-management groups were reverted after review — see below.
- **Width caps removed** from ~32 page wrappers. Tailwind v4 compiles `.container` to a real `max-width`, so those pages stopped filling the content area. A narrow `max-w-*` on a single-column form card is intentional and stays.
- **Duplicated headers removed** from 13 pages. Live controls that used to sit in the removed header moved into the page's table `<:toolbar_actions>` slot, or into an action row where the page has no table — nothing was dropped. Two dead `page_title` assigns now agree with what the template renders.
- **Shared components adopted** for five hand-rolled paginations, six hand-rolled empty states, raw `<table>`s, search toolbars and nav tabs.
- **daisyUI v4 leftovers cleared** in the components this work adopts: `pagination_controls/1` used `btn-group` with unjoined children while `pagination/1` in the same file already used `join`; `input.ex` carried the removed `label-text`; `textarea.ex` carried `textarea-bordered` plus `focus:input-primary` — an input class on a textarea.

## Fixes found while reviewing this work

Two rounds of independent review ran against the change set. They caught real problems, all fixed in the branch:

- **Role management was broken by the checkbox conversion.** `<.checkbox>` hardcodes `value="true"`, but `sync_user_roles` reads `Map.values(params["roles"])` and diffs that against the roles a user holds — so every held role looked absent and was removed. Both role-management groups are back to raw inputs carrying `value={role.name}`, with a comment explaining why they must stay that way. No test caught this: `render_submit` injects params and never serializes the DOM.
- **"Reset to Defaults" became unreachable on an empty dimension list** — it had moved into a table that only renders when the list is non-empty. Now a page-level action row.
- **Maintenance settings lost its only translated title.**
- **A link in the users table sat under the row overlay** and opened the user instead of the settings page.
- **The user detail page crashed (500) on a structured custom field.** `custom_fields` is free-form JSONB and real accounts hold lists and maps there; `to_string/1` raises on a map. Pre-existing, not introduced here.
- Smaller: `search_toolbar` renders a `<form>` with no `id` (form recovery silently disabled), `<.input>` inside a `.join` broke the join geometry, required-field asterisks lost their colour, and two page titles were still bare English literals.

## Verification

- `mix compile --warnings-as-errors` clean, `mix format --check-formatted` clean.
- Pages were verified by **rendering** under a real authenticated session, not by reading — several findings only showed up in rendered output.
- Behaviour checks: same param names and nesting, `phx-*` bindings intact, every control that lived in a removed header still reachable, permissions matrix still classic (no card view), the six excluded controls byte-identical.

## Notes

- `row_link` is deliberately **not** added to `core_components/0`. A host app in this workspace has its own `row_link` and the ambient import would make every call site ambiguous. Pages import it explicitly.
- `page_section` and `page_subtitle` render `hidden sm:flex` / `hidden md:inline` in the layout, so content moved into them is desktop-only. Worth deciding upstream whether that should change.
