### PR TITLE
Never render a failed email as sent, and surface a CRM contact on the user page

### DIFF
--- a/lib/phoenix_kit_web/components/core/email_activity_badges.ex
+++ b/lib/phoenix_kit_web/components/core/email_activity_badges.ex
@@ -84,7 +84,33 @@ defmodule PhoenixKitWeb.Components.Core.EmailActivityBadges do
         {acc ++ [{badge_class, formatted_text, type}], new_date}
       end)
 
-    badges
+    badges ++ status_only_badge(log, badges)
+  end
+
+  # A badge built from `status` alone, for the case where the status says the
+  # send ended badly but no timestamp or event backs it up.
+  #
+  # These badges are otherwise built purely from timestamps, and their meaning is
+  # carried by colour, not by text. That makes a log with `status: "failed"` and
+  # no `failed_at` render as a plain blue "sent" badge — the list claims the
+  # message went out while the detail page, which reads `status`, says it failed.
+  # A writer that sets one without the other is a bug in that writer, but this
+  # component must not present a failure as a success in the meantime.
+  @failure_statuses ~w(failed bounced hard_bounced soft_bounced rejected complained)
+  @failure_event_types ~w(failed rejected complaint bounce hard_bounce soft_bounce
+                          rendering_failure)
+
+  defp status_only_badge(log, badges) do
+    # Compare on event type, not badge colour: a soft bounce is deliberately
+    # amber, so a colour check would miss it and render a second badge.
+    already_shown? =
+      Enum.any?(badges, fn {_class, _text, type} -> type in @failure_event_types end)
+
+    if log.status in @failure_statuses and not already_shown? do
+      [{"badge-error", log.status, log.status}]
+    else
+      []
+    end
   end
 
   # Get event timestamp from log's events association

--- a/lib/phoenix_kit_web/live/users/user_details.ex
+++ b/lib/phoenix_kit_web/live/users/user_details.ex
@@ -15,6 +15,9 @@ defmodule PhoenixKitWeb.Live.Users.UserDetails do
   import PhoenixKitWeb.Components.Core.RowLink, only: [row_link: 1]
 
   @compile {:no_warn_undefined, PhoenixKitUserConnections}
+  # Guarded soft-dependency on the optional CRM module, same shape as the
+  # PhoenixKitUserConnections guard above — core cannot hard-depend on it.
+  @compile {:no_warn_undefined, [PhoenixKitCRM, PhoenixKitCRM.Contacts]}
 
   alias PhoenixKit.Admin.Events
   alias PhoenixKit.Settings
@@ -57,6 +60,14 @@ defmodule PhoenixKitWeb.Live.Users.UserDetails do
              }}
           else
             {false, nil}
+          end
+
+        # Load the linked CRM contact, if any, when the optional CRM module is
+        # installed and enabled. Guarded exactly like the connections stats
+        # above: core has no hard dependency on phoenix_kit_crm.
+        crm_contact =
+          if Code.ensure_loaded?(PhoenixKitCRM) and PhoenixKitCRM.enabled?() do
+            PhoenixKitCRM.Contacts.get_by_user_uuid(user.uuid)
           end
 
         # Load admin notes
@@ -104,6 +115,7 @@ defmodule PhoenixKitWeb.Live.Users.UserDetails do
           |> assign(:show_delete_modal, false)
           |> assign(:connections_enabled, connections_enabled)
           |> assign(:connections_stats, connections_stats)
+          |> assign(:crm_contact, crm_contact)
           |> assign(:admin_notes, admin_notes)
           |> assign(:note_form, to_form(Auth.change_admin_note(%AdminNote{})))
           |> assign(:editing_note_uuid, nil)

--- a/lib/phoenix_kit_web/live/users/user_details.html.heex
+++ b/lib/phoenix_kit_web/live/users/user_details.html.heex
@@ -366,6 +366,26 @@
               </div>
             </div>
 
+            <%!-- CRM contact (guarded: only rendered when the optional CRM
+                 module is installed, enabled, and this user has a linked
+                 contact — see the mount/3 guard for @crm_contact). --%>
+            <div :if={@crm_contact} class="card bg-base-200 shadow-sm">
+              <div class="card-body">
+                <h3 class="card-title text-lg">{gettext("CRM")}</h3>
+                <p class="text-sm text-base-content/70">
+                  {gettext("This user is linked to a CRM contact.")}
+                </p>
+                <.link
+                  navigate={
+                    PhoenixKit.Utils.Routes.path("/admin/crm/contacts/#{@crm_contact.uuid}")
+                  }
+                  class="link link-primary text-sm"
+                >
+                  {@crm_contact.name}
+                </.link>
+              </div>
+            </div>
+
             <%!-- Custom Fields --%>
             <%= if @custom_field_definitions && length(@custom_field_definitions) > 0 do %>
               <div class="card bg-base-200 shadow-sm">


### PR DESCRIPTION
Two independent fixes that both touch the admin surface.

## Never render a failed email as merely sent

`<.email_activity_badges>` builds its badges purely from event rows and timestamp columns, and their meaning is carried by colour rather than text. A log with `status: "failed"` but no `failed_at` therefore rendered as queued + sent — the list said the message went out while the detail page, which reads `status`, said it failed. Both were reading the truth, from different fields.

When the status is one of the failure states and no failure badge was produced from a timestamp, the component now appends one built from the status itself.

The comparison is on event type rather than badge colour, because a soft bounce is deliberately amber and a colour check would miss it and emit a duplicate.

The writer that left `failed_at` empty is fixed separately in `phoenix_kit_emails` (BeamLabEU/phoenix_kit_emails#23), but this component should not present a failure as a success regardless of which writer produced the row.

Verified by rendering the badges for a real log row (`status: "failed"`, `failed_at: nil`): three badges now, with the failure visible; two before.

## A guarded CRM contact card on the user detail page

The user page had no path to that person's commercial record, even though `PhoenixKitCRM.Contacts.get_by_user_uuid/1` exists for exactly this.

Core cannot depend on an optional module, so the card uses the guarded soft-dependency idiom this page already uses for `PhoenixKitUserConnections`: `@compile {:no_warn_undefined, ...}` plus `Code.ensure_loaded?/1` and the module's own `enabled?/0`. With the module absent or disabled the page renders exactly as before; no dependency was added to `mix.exs`.