### PR TITLE
Guard the atomic custom_fields merge/delete against a NULL column

### DIFF
--- a/lib/phoenix_kit/users/auth.ex
+++ b/lib/phoenix_kit/users/auth.ex
@@ -1566,7 +1566,13 @@ defmodule PhoenixKit.Users.Auth do
   while URLs continue to use base codes (e.g., /en/).
   The locale is stored in the `custom_fields` JSONB column.
 
-  Uses `update_user_custom_fields/2` internally for consistency.
+  Writes through the atomic single-key primitives —
+  `merge_user_custom_fields/3` to set, `delete_user_custom_field/3` to
+  clear — so a concurrent writer of a different custom_fields key is
+  never lost. Passes `ensure_definitions: false` deliberately: the
+  locale is an internal preference, not an admin-managed custom field,
+  so the first write no longer auto-registers a field definition
+  (the old whole-map path did, as a side effect).
 
   ## Examples
 
@@ -1690,7 +1696,12 @@ defmodule PhoenixKit.Users.Auth do
         where: u.uuid == ^user.uuid,
         update: [
           set: [
-            custom_fields: fragment("? || ?", u.custom_fields, type(^additions, :map)),
+            # COALESCE first: the column is nullable (V18) and
+            # `NULL || jsonb` is NULL — without it a NULL row would
+            # swallow the additions with no error. Same defensive idiom
+            # the V30 migration uses for its own atomic merge.
+            custom_fields:
+              fragment("COALESCE(?, '{}'::jsonb) || ?", u.custom_fields, type(^additions, :map)),
             updated_at: ^UtilsDate.utc_now()
           ]
         ],
@@ -2026,6 +2037,10 @@ defmodule PhoenixKit.Users.Auth do
 
       iex> set_user_custom_field(user, "department", "Product")
       {:ok, %User{}}
+
+  Returns `{:error, :not_found}` (not a changeset error) if the user
+  row was deleted concurrently — same contract as
+  `merge_user_custom_fields/3`, which this delegates to.
   """
   def set_user_custom_field(%User{} = user, key, value) when is_binary(key) do
     # Delegates to the atomic merge rather than the historical
@@ -2059,7 +2074,10 @@ defmodule PhoenixKit.Users.Auth do
         where: u.uuid == ^user.uuid,
         update: [
           set: [
-            custom_fields: fragment("? - ?::text", u.custom_fields, ^key),
+            # COALESCE for the same NULL gap as the merge (`NULL - key`
+            # stays NULL); also preserves the old path's side effect of
+            # normalizing a NULL column to '{}' on any delete.
+            custom_fields: fragment("COALESCE(?, '{}'::jsonb) - ?::text", u.custom_fields, ^key),
             updated_at: ^UtilsDate.utc_now()
           ]
         ],

--- a/test/integration/users/profile_test.exs
+++ b/test/integration/users/profile_test.exs
@@ -188,6 +188,24 @@ defmodule PhoenixKit.Integration.Users.ProfileTest do
       assert DateTime.compare(merged.updated_at, stale) == :gt
     end
 
+    test "merging into a NULL custom_fields column keeps the additions (COALESCE guard)" do
+      user = create_user()
+      # The column is nullable (V18); NULL || jsonb would be NULL, so a
+      # missing COALESCE silently swallows the additions.
+      import Ecto.Query
+
+      PhoenixKit.RepoHelper.update_all(
+        from(u in PhoenixKit.Users.Auth.User,
+          where: u.uuid == ^user.uuid,
+          update: [set: [custom_fields: nil]]
+        ),
+        []
+      )
+
+      {:ok, merged} = Auth.merge_user_custom_fields(user, %{"survives" => "yes"})
+      assert merged.custom_fields == %{"survives" => "yes"}
+    end
+
     test "ensure_definitions: false skips field-definition registration, same as update_user_custom_fields/3" do
       user = create_user()
       unique_key = "merge_check_#{System.unique_integer([:positive])}"
@@ -233,6 +251,24 @@ defmodule PhoenixKit.Integration.Users.ProfileTest do
       {:ok, cleared} = Auth.delete_user_custom_field(user, "never_set")
 
       assert DateTime.compare(cleared.updated_at, stale) == :gt
+    end
+
+    test "deleting from a NULL custom_fields column normalizes it to an empty map" do
+      user = create_user()
+      import Ecto.Query
+
+      PhoenixKit.RepoHelper.update_all(
+        from(u in PhoenixKit.Users.Auth.User,
+          where: u.uuid == ^user.uuid,
+          update: [set: [custom_fields: nil]]
+        ),
+        []
+      )
+
+      # Mirrors the old Map.delete(nil || %{}, key) side effect: any
+      # delete leaves the column at '{}', never NULL.
+      assert {:ok, normalized} = Auth.delete_user_custom_field(user, "anything")
+      assert normalized.custom_fields == %{}
     end
 
     test "returns {:error, :not_found} for a deleted user" do


### PR DESCRIPTION
The `custom_fields` JSONB column is nullable (V18), and in Postgres both
`NULL || jsonb` and `NULL - key` evaluate to NULL. `merge_user_custom_fields/3`
and `delete_user_custom_field/3` build exactly those fragments, so on a user row
whose `custom_fields` is still NULL the merge silently swallows the additions
(no error, `{:ok, user}`, nothing written) — the same gap the V30 migration
already guards against with COALESCE for its own atomic merge.

## Changes

- `merge_user_custom_fields/3`: `COALESCE(?, {}::jsonb) || ?`
- `delete_user_custom_field/3`: `COALESCE(?, {}::jsonb) - ?::text` — also
  preserves the old read-modify-write path's side effect of normalizing a NULL
  column to `{}` on any delete
- Docs: the locale path now writes through the atomic single-key primitives
  (`merge_user_custom_fields/3` / `delete_user_custom_field/3`) with
  `ensure_definitions: false`, which the moduledoc did not say; and
  `set_user_custom_field/2` returns `{:error, :not_found}` (not a changeset
  error) when the row was deleted concurrently, same contract as the merge it
  delegates to.

## Tests

Two new cases in `test/integration/users/profile_test.exs`: merging into a NULL
column keeps the additions, deleting from a NULL column normalizes it to `%{}`.
Full file green (37 tests); the suite otherwise matches main.