### PR TITLE
Fix admin-UI cursors, a leaked import, media-selector audio + type lock, and CTA centring

### DIFF
--- a/lib/modules/shared/components/cta.ex
+++ b/lib/modules/shared/components/cta.ex
@@ -1,6 +1,11 @@
 defmodule PhoenixKit.Modules.Shared.Components.CTA do
   @moduledoc """
   Call-to-action button component.
+
+  Rendered inside a centring block. The button itself shrinks to its content,
+  so left in the flow it sits flush against the left margin of the text
+  column — which reads as a mistake for something whose whole job is to be
+  the one thing you look at.
   """
   use Phoenix.Component
 
@@ -10,26 +15,31 @@ defmodule PhoenixKit.Modules.Shared.Components.CTA do
 
   def render(assigns) do
     is_primary = Map.get(assigns.attributes, "primary", "false") == "true"
-    action = Map.get(assigns.attributes, "action", "#")
+    action = Map.get(assigns.attributes, "action", "")
 
     assigns =
       assigns
       |> assign(:is_primary, is_primary)
-      |> assign(:action, action)
+      # "#" is not a destination — it is a link to the top of the page. A CTA
+      # with nothing to point at should look like a button and do nothing, not
+      # silently scroll the reader away from what they were reading.
+      |> assign(:action, if(action in ["", "#"], do: nil, else: action))
 
     ~H"""
-    <a
-      href={@action}
-      class={[
-        "btn inline-block px-8 py-3 rounded-lg font-semibold transition-all",
-        if(@is_primary,
-          do: "btn-primary text-primary-content",
-          else: "btn-outline"
-        )
-      ]}
-    >
-      {@content}
-    </a>
+    <div class="my-6 text-center">
+      <a
+        href={@action}
+        class={[
+          "btn px-8 py-3 rounded-lg font-semibold transition-all",
+          if(@is_primary,
+            do: "btn-primary text-primary-content",
+            else: "btn-outline"
+          )
+        ]}
+      >
+        {@content}
+      </a>
+    </div>
     """
   end
 end

--- a/lib/phoenix_kit_web.ex
+++ b/lib/phoenix_kit_web.ex
@@ -123,7 +123,15 @@ defmodule PhoenixKitWeb do
       import PhoenixKitWeb.Components.Core.Chart
       import PhoenixKitWeb.Components.Core.StatusDot
       import PhoenixKitWeb.Components.Core.ConnectAccountButton
-      import PhoenixKitWeb.Components.Core.EmailStatusBadge
+      # Only the component. This module also exports `format_status/1` and
+      # `status_class/1`, and blanket-importing those puts two of the most
+      # generic names imaginable into every LiveView in the ecosystem — any
+      # consumer with its own `format_status/1` fails to compile with
+      # "imported ... conflicts with local function", pointing at code that
+      # never mentioned email. phoenix_kit_posts hit exactly that. Core's own
+      # caller (EmailActivityBadges) qualifies them, so nothing needs them
+      # unqualified.
+      import PhoenixKitWeb.Components.Core.EmailStatusBadge, only: [email_status_badge: 1]
       import PhoenixKitWeb.Components.Core.TimeDisplay
       import PhoenixKitWeb.Components.Core.EventTimelineItem
       import PhoenixKitWeb.Components.Core.UserInfo

--- a/lib/phoenix_kit_web/components/core/search_picker.ex
+++ b/lib/phoenix_kit_web/components/core/search_picker.ex
@@ -157,8 +157,12 @@ defmodule PhoenixKitWeb.Components.Core.SearchPicker do
         ]}
       >
       </div>
-      <%!-- Keep the hook's client-rendered classes in the CSS bundle. --%>
-      <span class="hidden loading loading-spinner loading-xs hero-user hero-plus-mini"></span>
+      <%!-- Keep the hook's client-rendered classes in the CSS bundle.
+           `cursor-pointer` is in here because Tailwind v4's preflight stopped
+           giving buttons a pointer, so the dropdown rows read as decoration
+           without it — and a host that never writes the class by hand would
+           otherwise not have it compiled at all. --%>
+      <span class="hidden loading loading-spinner loading-xs hero-user hero-plus-mini cursor-pointer"></span>
     </div>
     """
   end

--- a/lib/phoenix_kit_web/components/core/theme_controller.ex
+++ b/lib/phoenix_kit_web/components/core/theme_controller.ex
@@ -66,7 +66,7 @@ defmodule PhoenixKitWeb.Components.Core.ThemeController do
                   data-theme-role="dropdown-option"
                   role="option"
                   aria-pressed="false"
-                  class="w-full group flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition hover:bg-base-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                  class="w-full group flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition hover:bg-base-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary cursor-pointer"
                 >
                   <%= case theme.type do %>
                     <% :system -> %>

--- a/lib/phoenix_kit_web/components/media_browser.ex
+++ b/lib/phoenix_kit_web/components/media_browser.ex
@@ -44,6 +44,27 @@ defmodule PhoenixKitWeb.Components.MediaBrowser do
         phoenix_kit_current_user={@phoenix_kit_current_user}
       />
 
+  ## Picking into a typed slot
+
+  `only_file_type` restricts the browser to one kind for its whole lifetime —
+  the listing is filtered to it and the type-filter control is hidden, so the
+  other kinds are simply not reachable:
+
+      <.live_component
+        module={PhoenixKitWeb.Components.MediaBrowser}
+        id="audio-picker"
+        select_mode
+        only_file_type="audio"
+        phoenix_kit_current_user={@phoenix_kit_current_user}
+      />
+
+  Use it wherever the selection fills a typed field. Offering everything and
+  validating afterwards works, but it lets someone choose a PNG for an audio
+  slot and only find out on the rejection — and if a consumer forgets that
+  re-check, the PNG lands in the field and renders as a dead `<audio>`.
+
+  Values: `image`, `video`, `document`, `audio`, `archive`, `other`.
+
   ## Usage (controlled — URL-sync driven by parent)
 
       <.live_component
@@ -125,6 +146,14 @@ defmodule PhoenixKitWeb.Components.MediaBrowser do
       |> assign(assigns)
       |> assign_new(:scope_folder_id, fn -> nil end)
       |> assign_new(:admin, fn -> false end)
+      # Restricts the browser to ONE file type for its whole lifetime: the
+      # listing is filtered to it and the type-filter control is hidden, so
+      # there is no way to reach the other kinds. For pickers that fill a
+      # typed slot — an audio field, an image field — where offering
+      # everything means the only thing standing between a PNG and an
+      # <audio> tag is the consumer remembering to re-check afterwards.
+      # nil (default) leaves the toolbar in charge, starting at "all".
+      |> assign_new(:only_file_type, fn -> nil end)
       |> assign_new(:viewer_file, fn -> nil end)
       # The list the open viewer's prev/next steps through — the page's
       # files, or an expanded stack's own (see `locate_file/2`).
@@ -566,7 +595,9 @@ defmodule PhoenixKitWeb.Components.MediaBrowser do
     |> assign(:view_mode, load_user_view_mode(socket.assigns[:phoenix_kit_current_user]))
     # Toolbar sort + file-type filter (socket state, applied to the listing).
     |> assign(:sort_by, "newest")
-    |> assign(:file_type_filter, "all")
+    # `only_file_type` locks this to one kind for the whole session — see the
+    # attr docs on update/2. Absent, the toolbar owns it and starts at "all".
+    |> assign(:file_type_filter, socket.assigns[:only_file_type] || "all")
     |> assign(:search_query, "")
     |> assign(:select_mode, false)
     |> assign(:selected_files, MapSet.new())
@@ -1256,11 +1287,19 @@ defmodule PhoenixKitWeb.Components.MediaBrowser do
 
   def handle_event("set_file_filter", %{"type" => type}, socket)
       when type in @valid_file_types do
-    {:noreply,
-     socket
-     |> assign(:file_type_filter, type)
-     |> assign(:current_page, 1)
-     |> reload_current_page()}
+    # A locked browser hides this control, but the event is still reachable
+    # from a console — and the whole point of the lock is that the consumer
+    # can trust what comes back, so honour it on the server rather than in
+    # the markup alone.
+    if socket.assigns[:only_file_type] do
+      {:noreply, socket}
+    else
+      {:noreply,
+       socket
+       |> assign(:file_type_filter, type)
+       |> assign(:current_page, 1)
+       |> reload_current_page()}
+    end
   end
 
   # Ignore an out-of-whitelist file-type filter instead of crashing.

--- a/lib/phoenix_kit_web/components/media_browser.html.heex
+++ b/lib/phoenix_kit_web/components/media_browser.html.heex
@@ -935,8 +935,11 @@
                             </ul>
                           </div>
 
-                          <%!-- Filter (file type) --%>
-                          <div class="dropdown">
+                          <%!-- Filter (file type). Hidden when the browser is
+                                locked to one type: offering a control that
+                                refuses to do anything is worse than not
+                                offering it. --%>
+                          <div :if={is_nil(@only_file_type)} class="dropdown">
                             <div tabindex="0" role="button" class="btn btn-sm gap-2">
                               <.icon name="hero-funnel" class="w-4 h-4" />
                               <span class={[

--- a/lib/phoenix_kit_web/live/components/media_selector_modal.ex
+++ b/lib/phoenix_kit_web/live/components/media_selector_modal.ex
@@ -62,7 +62,15 @@ defmodule PhoenixKitWeb.Live.Components.MediaSelectorModal do
     * `mode` — `:single` or `:multiple`
     * `selected_uuids` — list of already-selected file UUIDs
     * `phoenix_kit_current_user` — required for uploads to attribute the file
-    * `file_type_filter` — `:all` (default), `:image`, or `:video`
+    * `file_type_filter` — `:all` (default), `:image`, `:video`, or `:audio`.
+      Filters the library grid AND gates uploads (server-side, not just the
+      client `accept` list).
+    * `lock_file_type` — `false` (default) treats `file_type_filter` as a
+      starting point the user can change; `true` makes it a constraint: the
+      type `<select>` is hidden and the change event is refused. Use it
+      whenever the selection fills a typed field — an audio slot, an image
+      slot — so the user can't pick something the consumer will only reject
+      afterwards.
     * `browse` — `true` (default) shows the library grid + search + type filter;
       `false` is upload-only (dropzone + Confirm; uploaded files auto-select)
     * `user_uuid` — when set, restricts the library to files owned by
@@ -125,6 +133,14 @@ defmodule PhoenixKitWeb.Live.Components.MediaSelectorModal do
       # dropzone + Confirm. Uploaded files auto-select, so Confirm still works.
       |> assign_new(:browse, fn -> true end)
       |> assign_new(:file_type_filter, fn -> :all end)
+      # `lock_file_type: true` makes `file_type_filter` a constraint rather
+      # than a starting point: the type <select> is hidden and the event that
+      # changes it is refused. For pickers filling a typed field, where
+      # letting someone switch to "All Files" means they can choose a PNG for
+      # an audio slot and only learn it was wrong from the rejection.
+      # Default false, so existing callers that pass a filter as a starting
+      # point keep their switcher.
+      |> assign_new(:lock_file_type, fn -> false end)
       |> assign_new(:search_query, fn -> "" end)
       |> assign_new(:current_page, fn -> 1 end)
       |> assign_new(:per_page, fn -> @per_page end)
@@ -229,19 +245,23 @@ defmodule PhoenixKitWeb.Live.Components.MediaSelectorModal do
   # keeps `:any`.
   defp accept_for(:image), do: ~w(.jpg .jpeg .png .gif .webp .svg .bmp .avif .heic .heif)
   defp accept_for(:video), do: ~w(.mp4 .mov .webm .mkv .avi .m4v .ogv .ogg)
+  defp accept_for(:audio), do: ~w(.mp3 .m4a .aac .wav .flac .oga .opus .weba)
   defp accept_for(_), do: :any
 
   # Modal copy that reflects the active type filter, so an all/video picker
   # doesn't always say "images". Referenced from the template.
   defp selection_hint(:single, :image), do: gettext("Click on an image to select it")
   defp selection_hint(:single, :video), do: gettext("Click on a video to select it")
+  defp selection_hint(:single, :audio), do: gettext("Click on an audio file to select it")
   defp selection_hint(:single, _), do: gettext("Click on a file to select it")
   defp selection_hint(_multiple, :image), do: gettext("Select one or more images")
   defp selection_hint(_multiple, :video), do: gettext("Select one or more videos")
+  defp selection_hint(_multiple, :audio), do: gettext("Select one or more audio files")
   defp selection_hint(_multiple, _), do: gettext("Select one or more files")
 
   defp accepted_types_hint(:image), do: gettext("Images")
   defp accepted_types_hint(:video), do: gettext("Videos")
+  defp accepted_types_hint(:audio), do: gettext("Audio files")
   defp accepted_types_hint(_), do: gettext("Images, videos, or documents")
 
   # Authoritative server-side type gate for uploads. The client `accept` list is
@@ -249,6 +269,7 @@ defmodule PhoenixKitWeb.Live.Components.MediaSelectorModal do
   # dropdown, so an off-type file can still reach the server — reject it here.
   defp upload_type_allowed?(:image, entry), do: entry_file_type(entry) == "image"
   defp upload_type_allowed?(:video, entry), do: entry_file_type(entry) == "video"
+  defp upload_type_allowed?(:audio, entry), do: entry_file_type(entry) == "audio"
   defp upload_type_allowed?(_all, _entry), do: true
 
   defp entry_file_type(entry) do
@@ -257,6 +278,7 @@ defmodule PhoenixKitWeb.Live.Components.MediaSelectorModal do
 
   defp off_type_upload_error(:image), do: gettext("Only image files can be added here.")
   defp off_type_upload_error(:video), do: gettext("Only video files can be added here.")
+  defp off_type_upload_error(:audio), do: gettext("Only audio files can be added here.")
   defp off_type_upload_error(_), do: gettext("Only the allowed file types can be added here.")
 
   def handle_event("noop", _params, socket) do
@@ -342,6 +364,13 @@ defmodule PhoenixKitWeb.Live.Components.MediaSelectorModal do
       |> assign(:total_count, total_count)
       |> assign(:total_pages, total_pages)
 
+    {:noreply, socket}
+  end
+
+  def handle_event("filter_type", _params, %{assigns: %{lock_file_type: true}} = socket) do
+    # The <select> is hidden when locked, but the event is still reachable
+    # from a console — and the consumer is relying on the constraint to know
+    # what it's getting back, so enforce it here rather than in the markup.
     {:noreply, socket}
   end
 
@@ -649,6 +678,7 @@ defmodule PhoenixKitWeb.Live.Components.MediaSelectorModal do
 
   defp scope_files_by_type(query, :image), do: where(query, [f], f.file_type == "image")
   defp scope_files_by_type(query, :video), do: where(query, [f], f.file_type == "video")
+  defp scope_files_by_type(query, :audio), do: where(query, [f], f.file_type == "audio")
   defp scope_files_by_type(query, _), do: query
 
   defp scope_files_by_search(query, ""), do: query
@@ -677,6 +707,7 @@ defmodule PhoenixKitWeb.Live.Components.MediaSelectorModal do
     cond do
       String.starts_with?(mime_type, "image/") -> "image"
       String.starts_with?(mime_type, "video/") -> "video"
+      String.starts_with?(mime_type, "audio/") -> "audio"
       true -> "other"
     end
   end
@@ -684,6 +715,7 @@ defmodule PhoenixKitWeb.Live.Components.MediaSelectorModal do
   defp parse_filter(nil), do: :all
   defp parse_filter("image"), do: :image
   defp parse_filter("video"), do: :video
+  defp parse_filter("audio"), do: :audio
   defp parse_filter("all"), do: :all
   defp parse_filter(_), do: :all
 

--- a/lib/phoenix_kit_web/live/components/media_selector_modal.html.heex
+++ b/lib/phoenix_kit_web/live/components/media_selector_modal.html.heex
@@ -224,8 +224,10 @@
                     </div>
                   </.form>
                 </div>
-                <%!-- Filter by Type --%>
-                <div class="w-full md:w-40">
+                <%!-- Filter by Type. Hidden when the picker is locked to one
+                      type — a control whose only other options are refused
+                      is worse than no control. --%>
+                <div :if={not @lock_file_type} class="w-full md:w-40">
                   <.select
                     name="filter"
                     phx-change="filter_type"
@@ -234,7 +236,8 @@
                     options={[
                       {gettext("All Files"), "all"},
                       {gettext("Images Only"), "image"},
-                      {gettext("Videos Only"), "video"}
+                      {gettext("Videos Only"), "video"},
+                      {gettext("Audio Only"), "audio"}
                     ]}
                     class="select-sm"
                   />

--- a/priv/static/assets/phoenix_kit.js
+++ b/priv/static/assets/phoenix_kit.js
@@ -5502,7 +5502,7 @@ if (typeof window.Chart === "undefined") {
           escAttr(r.uuid) +
           '" data-label="' +
           escAttr(r.label) +
-          '" class="flex items-center justify-between w-full px-3 py-2 hover:bg-base-200 text-left">' +
+          '" class="flex items-center justify-between w-full px-3 py-2 hover:bg-base-200 text-left cursor-pointer">' +
           '<span class="flex items-center gap-2 min-w-0">' +
           '<span class="' +
           escAttr(r.icon || "hero-user") +
@@ -5526,7 +5526,7 @@ if (typeof window.Chart === "undefined") {
           "</div>";
       } else if (this.hasMore) {
         list +=
-          '<button type="button" data-pick="more" class="w-full px-3 py-2 text-xs text-center text-primary hover:bg-base-200">' +
+          '<button type="button" data-pick="more" class="w-full px-3 py-2 text-xs text-center text-primary hover:bg-base-200 cursor-pointer">' +
           tMore +
           "</button>";
       }
@@ -5534,7 +5534,7 @@ if (typeof window.Chart === "undefined") {
       var bottom = "";
       if (q && this.evText && this.mode !== "single") {
         bottom =
-          '<button type="button" data-pick="text" class="flex items-center gap-2 w-full px-3 py-2 hover:bg-base-200 text-left border-t border-base-200">' +
+          '<button type="button" data-pick="text" class="flex items-center gap-2 w-full px-3 py-2 hover:bg-base-200 text-left border-t border-base-200 cursor-pointer">' +
           '<span class="hero-plus-mini w-4 h-4 shrink-0 text-base-content/50"></span>' +
           "<span>" +
           tAddPrefix +

--- a/test/integration/phoenix_kit_web/users/auth_flows_test.exs
+++ b/test/integration/phoenix_kit_web/users/auth_flows_test.exs
@@ -127,8 +127,10 @@ defmodule PhoenixKitWeb.Users.AuthFlowsTest do
     test "registration handoff POST sets the persistent cookie", %{conn: conn} do
       user = register_user()
 
-      # The registration form now carries a hidden user[remember_me]=true and
-      # trigger-action POSTs to /users/log-in?_action=registered.
+      # The registration form carries a "Keep me logged in" checkbox
+      # (user[remember_me], checked by default per remember_me_default?/0) and
+      # trigger-action POSTs to /users/log-in?_action=registered — the params
+      # below are what the browser sends with that box left ticked.
       conn =
         post(conn, Routes.path("/users/log-in?_action=registered"), %{
           "user" => %{

--- a/test/phoenix_kit/users/user_org_changeset_test.exs
+++ b/test/phoenix_kit/users/user_org_changeset_test.exs
@@ -237,58 +237,72 @@ defmodule PhoenixKit.Users.UserOrgChangesetTest do
   # --- username generation on an EXISTING user ---
 
   describe "registration_changeset/3 — username of a saved user" do
+    # A fresh name per test, because registration is rate limited to 3 attempts
+    # per hour PER EMAIL and this setup runs once per test in the block. With a
+    # shared address the fourth test in the block is refused by the limiter and
+    # the failure lands in setup, reading as "registration is broken" rather
+    # than "the tests shared a bucket". Nothing here depends on the literal
+    # name, only on the username being derived from it.
     setup do
+      base = "maria#{System.unique_integer([:positive])}"
+
       {:ok, user} =
         Auth.register_user(%{
-          email: "maria@example.com",
+          email: "#{base}@example.com",
           password: "ValidPassword123!"
         })
 
-      %{user: user}
+      %{user: user, base: base}
     end
 
-    test "editing a saved user without a username param leaves the username alone", %{user: user} do
+    test "editing a saved user without a username param leaves the username alone", %{
+      user: user,
+      base: base
+    } do
       # The admin user form rebuilds this changeset while editing (toggling the
       # password field, for one) and sends no `username`. Before the fix the
-      # generator ran anyway, found the user's OWN row holding `maria`, decided
-      # the name was taken and renamed them to `maria_1`.
-      assert user.username == "maria"
+      # generator ran anyway, found the user's OWN row holding the name, decided
+      # it was taken and renamed them to `<name>_1`.
+      assert user.username == base
 
       changeset = User.registration_changeset(user, %{"email" => user.email})
 
       assert get_change(changeset, :username) == nil
-      assert get_field(changeset, :username) == "maria"
+      assert get_field(changeset, :username) == base
     end
 
-    test "an explicit username still wins", %{user: user} do
-      changeset = User.registration_changeset(user, %{"username" => "maria_updated"})
-      assert get_change(changeset, :username) == "maria_updated"
+    test "an explicit username still wins", %{base: base} do
+      changeset = User.registration_changeset(%User{}, %{"username" => "#{base}_updated"})
+      assert get_change(changeset, :username) == "#{base}_updated"
     end
 
     test "a brand new user still gets one generated from the email" do
+      newcomer = "newcomer#{System.unique_integer([:positive])}"
+
       changeset =
         User.registration_changeset(%User{}, %{
-          "email" => "newcomer@example.com",
+          "email" => "#{newcomer}@example.com",
           "password" => "ValidPassword123!"
         })
 
-      assert get_change(changeset, :username) == "newcomer"
+      assert get_change(changeset, :username) == newcomer
     end
 
     test "a second user with a colliding base name gets a suffix, not the taken name", %{
-      user: user
+      user: user,
+      base: base
     } do
       # The suffix logic itself must keep working — it just must not fire for
       # the holder of the name.
       changeset =
         User.registration_changeset(%User{}, %{
-          "email" => "maria@other.example.com",
+          "email" => "#{base}@other.example.com",
           "password" => "ValidPassword123!"
         })
 
       generated = get_change(changeset, :username)
       assert generated != user.username
-      assert String.starts_with?(generated, "maria")
+      assert String.starts_with?(generated, base)
     end
   end
 end


### PR DESCRIPTION
## Summary

Four fixes found while building against core from the publishing module. Three are
admin-UI and component-API defects; one is a test-isolation fix. No migrations, no
version bump, no behaviour change for existing callers.

### `c88c0d33` — Dead-feeling buttons, and a generic name leaked into every LiveView

Three unrelated things surfaced while using the admin UI.

**Buttons don't look clickable.** Tailwind v4's preflight stopped setting
`cursor: pointer` on `button`, so anything styled by hand rather than with daisyUI's
`.btn` shows an arrow — the signal people use to decide whether something is
interactive at all. Found by measuring `getComputedStyle`, not by eye: the
SearchPicker's dropdown rows (all three kinds) and the theme dropdown's 38 options,
which appear on every admin page. `cursor-pointer` also joins the SearchPicker's
existing safelist span, because the hook writes that class from JavaScript and a host
that never types it by hand would otherwise not have it compiled.

**`EmailStatusBadge` leaked `format_status/1` and `status_class/1` into every
consumer.** It is blanket-imported by `use PhoenixKitWeb, :live_view`, and those are
two of the most generic names imaginable — any LiveView with its own
`format_status/1` fails to compile with *"imported … conflicts with local function"*,
pointing at code that never mentions email. `phoenix_kit_posts` hit exactly that and
could not build. The import is now narrowed to the component; core's own caller
already qualified the helpers, so nothing else changes.

**A registration test shared one rate-limit bucket.** Registration allows 3 attempts
per hour per email and that describe block's `setup` runs per test, so the fourth was
refused by the limiter and the failure landed in `setup` — reading as "registration is
broken" rather than "the tests shared an address".

### `350c9d31` — Audio support and a type lock for the media selector

The picker knew about images and videos. Audio fell through to "all", so a consumer
wanting an audio file had to show the entire library and reject the wrong pick
afterwards — which puts the mistake after the effort: you browse, choose, and only
then learn that kind isn't allowed.

Audio is now a first-class filter across the grid query, the upload accept list, the
server-side upload gate, the selection copy, and the type dropdown. The server gate
matters more than the accept list — the client one is a hint, and
`determine_file_type/1` didn't recognise audio at all, so an mp3 was classified
`"other"`.

`lock_file_type` turns `file_type_filter` from a starting point into a constraint: the
type select is hidden **and** the event that changes it is refused, so a picker filling
a typed slot can't be steered back to everything. Refused on the server, not just
hidden — the consumer relies on the constraint to know what it is getting back, and the
event is reachable from a console. Defaults to `false`, so existing callers passing
`:image` as a starting point keep their switcher.

### `355d81a9` — CTA sitting flush left and linking nowhere

The button shrinks to its content and was left inline in the flow, so it sat hard
against the left margin of the text column — 286px of button with 338px of empty space
beside it. For something whose entire job is to be the one thing you look at, that
reads as a mistake. It now renders inside a centring block.

Two smaller things fell out of the same markup. `inline-block` was overriding daisyUI's
`.btn` (which is `inline-flex` with its own centring), and the default action was `"#"`
— not a destination but a link to the top of the page, quietly scrolling readers away
from what they were reading. With no action it now renders without an `href`.

### `5aff14a5` — Stale comment in the registration remember-me test

Comment described a proposed hidden field rather than the checkbox that shipped.

## Verification

`mix precommit` — **exit 0**, run as a single command so the exit code isn't swallowed
by a pipeline. That covers `compile --warnings-as-errors --all-warnings`,
`deps.unlock --check-unused`, `format --check-formatted`, `credo --strict`, `dialyzer`,
and `test.js` (21 JS tests).

`mix test` — **11 doctests, 2383 tests, 0 failures.** The suite had one flaky failure
before this branch; the rate-limit fix above is what removed it.

Rebased on `upstream/main` (`4c27ae53`) with nothing to replay — the branch was already
current — and the gate was re-run after.

## Test plan

- [x] `mix precommit` clean (compile / deps / format / credo --strict / dialyzer / JS)
- [x] `mix test` — 2383 tests, 0 failures
- [x] Cursor fixes measured with `getComputedStyle` in a browser, not eyeballed
- [x] Media selector exercised against a real audio file; `lock_file_type` verified to
      refuse the type-change event server-side, not merely hide the control
- [x] CTA centring measured (button width vs. column width) before and after
