### PR TITLE
Fix admin routes swallowed by the unconstrained :locale segment, and a sanitizer bypass

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -143,5 +143,17 @@
   # opacity it never actually inspects. Not a runtime bug: the struct is passed
   # straight back to the module that owns it. Surfaced here by the dep upgrades
   # in 867bc5b2, which rebuilt the PLT.
-  {"lib/phoenix_kit/users/qr_login.ex", :call_without_opaque}
+  {"lib/phoenix_kit/users/qr_login.ex", :call_without_opaque},
+  # `MDEx.safe_html/2`'s typespec declares `escape: [atom()]`, but the
+  # implementation reads `escape` as a KEYWORD list —
+  # `opt(options, [:escape, :content], true)` — and MDEx's own doctests pass
+  # `escape: [content: false]`. The spec contradicts the code it documents,
+  # so dialyzer concludes the call can never return.
+  #
+  # Passing the keyword form is required, not cosmetic: with content
+  # escaping left on, the sanitizer returns `&lt;p&gt;Hello&lt;/p&gt;` and
+  # every piece of rich text in the app renders as literal markup.
+  # Re-check on the next MDEx upgrade; drop this entry once the spec is
+  # corrected upstream.
+  {"lib/phoenix_kit/utils/html_sanitizer.ex", :no_return}
 ]

--- a/lib/phoenix_kit/utils/html_sanitizer.ex
+++ b/lib/phoenix_kit/utils/html_sanitizer.ex
@@ -1,51 +1,59 @@
 defmodule PhoenixKit.Utils.HtmlSanitizer do
   @moduledoc """
-  HTML sanitization for rich text content in entities.
+  HTML sanitization for user-supplied rich text.
 
-  This module provides basic HTML sanitization to prevent XSS attacks
-  while allowing safe HTML tags commonly used in rich text editors.
+  Backed by `MDEx.safe_html/2` — an ammonia-based **parsed allowlist**. It
+  builds a real DOM, keeps only known-good tags and attributes, validates
+  URL schemes per attribute, and re-serializes. It does not pattern-match
+  on markup, which is why it holds up where the previous regex
+  implementation did not (see `sanitize_html/1`).
 
-  ## Allowed Tags
+  ## What survives
 
-  The following tags are allowed:
-  - Block elements: p, div, br, hr, h1-h6, blockquote, pre, code
-  - Inline elements: span, strong, b, em, i, u, s, a, sub, sup, mark
-  - Lists: ul, ol, li
-  - Tables: table, thead, tbody, tr, th, td
-  - Media placeholders: img (with src validation)
+  Ordinary rich text: block elements (p, div, hr, h1-h6, blockquote, pre,
+  code), inline elements (span, strong, em, u, s, a, sub, sup), lists,
+  tables, and img. Relative, absolute, anchor, `mailto:` and `tel:` URLs
+  are preserved.
 
-  ## Removed Content
+  ## What is removed
 
-  The following are stripped completely:
-  - script tags and content
-  - style tags and content
-  - event handlers (onclick, onerror, etc.)
-  - javascript: and data: URLs
-  - iframe, object, embed tags
+  Script and style elements, event-handler attributes, dangerous URL
+  schemes (`javascript:`, `data:`, …) **including entity-encoded
+  spellings** such as `jav&#x61;script:`, and embedding elements
+  (iframe, object, embed, svg, math).
+
+  ## Output is normalised
+
+  Because the result is re-serialized from a parse tree, it is valid HTML
+  rather than a lightly-edited copy of the input: attribute values come
+  back quoted, void elements lose a self-closing slash (`<br/>` →
+  `<br>`), `<table>` gains an implicit `<tbody>`, and links gain
+  `rel="noopener noreferrer"`. Compare rendered meaning, not exact
+  strings, when asserting on sanitized output.
 
   ## Usage
 
-      iex> PhoenixKit.Utils.HtmlSanitizer.sanitize("<p>Hello</p><script>alert('xss')</script>")
-      "<p>Hello</p>"
+      PhoenixKit.Utils.HtmlSanitizer.sanitize("<p>Hello</p><script>alert('xss')</script>")
+      #=> "<p>Hello</p>"
 
-      iex> PhoenixKit.Utils.HtmlSanitizer.sanitize("<a href=\"javascript:alert('xss')\">Click</a>")
-      "<a>Click</a>"
+      PhoenixKit.Utils.HtmlSanitizer.sanitize(~s|<a href="javascript:alert(1)">Click</a>|)
+      #=> "<a rel=\\"noopener noreferrer\\">Click</a>"
   """
 
-  # Note: These are documented for reference. The current simple implementation
-  # strips dangerous content rather than whitelisting allowed tags.
-  # A more complete implementation using a library like HtmlSanitizeEx would use these.
+  # The tag/attribute allowlist is ammonia's default set, applied through
+  # `MDEx.safe_html/2` — see `sanitize_html/1` at the bottom of this module
+  # for why a parser rather than regexes. The list above is descriptive of
+  # that default, not a second source of truth; to change what is allowed,
+  # pass explicit `:sanitize` options rather than editing a comment.
   #
-  # Allowed tags:
-  #   p div br hr h1-h6 blockquote pre code
-  #   span strong b em i u s a sub sup mark
-  #   ul ol li table thead tbody tr th td img
-  #
-  # Allowed attributes:
-  #   a: href title target rel
-  #   img: src alt title width height
-  #   td/th: colspan rowspan
-  #   all: class id
+  # Behaviour worth knowing:
+  #   * URL schemes are validated per attribute — `javascript:`, `data:`
+  #     and friends are dropped, including entity-encoded spellings
+  #     (`jav&#x61;script:`), which the old blacklist could not catch.
+  #   * Relative, absolute, anchor, `mailto:` and `tel:` URLs survive.
+  #   * Links gain `rel="noopener noreferrer"`.
+  #   * Output is normalised HTML (attributes quoted, `<table>` gains an
+  #     implicit `<tbody>`), because it is re-serialized from a parse tree.
 
   @doc """
   Sanitizes HTML content by removing dangerous elements and attributes.
@@ -66,8 +74,7 @@ defmodule PhoenixKit.Utils.HtmlSanitizer do
 
   def sanitize(html) when is_binary(html) do
     html
-    |> remove_dangerous_patterns()
-    |> sanitize_urls()
+    |> sanitize_html()
     |> String.trim()
   end
 
@@ -110,131 +117,31 @@ defmodule PhoenixKit.Utils.HtmlSanitizer do
 
   # Private functions
 
-  # ⚠️ Attribute separators are `[\s\/]`, NOT `\s`.
+  # Sanitize via MDEx's `safe_html/2`, which is an ammonia-backed PARSED
+  # ALLOWLIST: it builds a real DOM, keeps only known-good tags and
+  # attributes, validates URL schemes per attribute, and re-serializes.
   #
-  # HTML permits `/` between attributes, and browsers parse
-  # `<img/src=x/onerror=alert(1)>` exactly like the space-separated form.
-  # These patterns previously required whitespace, so anything using slash
-  # separators passed through completely untouched — verified against this
-  # module before the fix:
+  # This replaced a hand-rolled regex sanitizer. Regexes cannot sanitize
+  # HTML — they have to model a parser they are not, and each attempt
+  # leaked. Two bypass classes were found in the previous implementation,
+  # the second of which left `<img/src=x/onerror=alert(1)>` completely
+  # untouched because the patterns assumed whitespace between attributes
+  # while HTML also permits `/`. Product descriptions render through here
+  # on unauthenticated storefronts, so a leak here is a leak to every
+  # visitor.
   #
-  #     <svg/onload=alert(1)>            -> UNCHANGED
-  #     <img/src=x/onerror=alert(1)>     -> UNCHANGED
-  #     <img src=x onerror=alert(1)>     -> <img src=x>        (caught)
+  # MDEx is already a runtime dependency (it renders Markdown), so this
+  # costs nothing to adopt — no new dep, and the allowlist is maintained
+  # upstream by people who do this full time.
   #
-  # That made the whole control bypassable by anyone who could write a
-  # product description or supply a CSV import feed, on the unauthenticated
-  # storefront.
-  #
-  # NOTE ON THE APPROACH: regex sanitizing is structurally fragile — this
-  # is the second bypass class found in it. The right shape is a parsed
-  # allowlist (tokenize, keep known-good tags/attributes, re-serialize).
-  # That needs an HTML parser as a RUNTIME dependency; `floki` is currently
-  # `only: :test`, and adding a runtime dep to core affects every consumer,
-  # so it is deliberately not done here. Regression payloads live in
-  # test/phoenix_kit/utils/html_sanitizer_test.exs — add to them, and
-  # prefer replacing this wholesale over growing more patterns.
-  @attr_sep ~S"[\s\/]"
-
-  defp remove_dangerous_patterns(html) do
-    dangerous_patterns = [
-      # Script tags with content
-      ~r/<script\b[^>]*>[\s\S]*?<\/script>/i,
-      # Style tags with content
-      ~r/<style\b[^>]*>[\s\S]*?<\/style>/i,
-      # Event handlers — separated by whitespace OR slash
-      ~r/#{@attr_sep}+on\w+\s*=\s*["'][^"']*["']/i,
-      ~r/#{@attr_sep}+on\w+\s*=\s*[^\s>]+/i,
-      # Dangerous tags. svg and math are here because both introduce
-      # foreign content with their own scripting surface (`<svg><script>`,
-      # `xlink:href="javascript:">`), which the rest of these
-      # HTML-shaped patterns do not reason about correctly.
-      ~r/<\s*(iframe|object|embed|form|input|button|meta|link|base|svg|math)\b[^>]*>/i,
-      ~r/<\/\s*(iframe|object|embed|form|input|button|meta|link|base|svg|math)\s*>/i
-    ]
-
-    Enum.reduce(dangerous_patterns, html, fn pattern, acc ->
-      Regex.replace(pattern, acc, "")
-    end)
-  end
-
-  # Schemes a link/media URL may use; anything else (or an unlisted scheme) is
-  # dropped. Relative/fragment/query URLs (no scheme) are allowed.
-  @allowed_schemes ~w(http https mailto tel)
-  @dangerous_scheme ~r/^(?:javascript|vbscript|data|file|blob):/
-  @scheme ~r/^[a-z][a-z0-9+.\-]*:/i
-
-  # A few named entities whose decoded form matters for scheme detection
-  # (a browser decodes `javascript&colon;alert(1)` before dispatching).
-  @named_entities %{
-    "tab" => "\t",
-    "newline" => "\n",
-    "colon" => ":",
-    "sol" => "/",
-    "lpar" => "(",
-    "rpar" => ")",
-    "num" => "#"
-  }
-
-  # Sanitize `href`/`src` URLs with an ALLOWLIST over a normalized value, not a
-  # scheme blacklist. MDEx renders raw HTML (`unsafe: true`) and the browser
-  # decodes entities + ignores whitespace/control chars in the scheme, so a
-  # blacklist is trivially bypassed (`jav&#x61;script:`, `java&Tab;script:`,
-  # `java\tscript:`). We decode entities and strip those chars BEFORE checking,
-  # and only ever REMOVE an attribute — never rewrite the visible URL — so the
-  # transform is fail-safe even if decoding is imperfect.
-  defp sanitize_urls(html) do
-    html
-    |> scrub_url_attr("href")
-    |> scrub_url_attr("src")
-  end
-
-  defp scrub_url_attr(html, attr) do
-    regex = ~r/\s#{attr}\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))/i
-
-    Regex.replace(regex, html, fn full, dquoted, squoted, unquoted ->
-      value = dquoted <> squoted <> unquoted
-      if safe_url?(value), do: full, else: ""
-    end)
-  end
-
-  defp safe_url?(value) do
-    normalized =
-      value
-      |> decode_entities()
-      # Browsers ignore ASCII control chars + whitespace when parsing a scheme.
-      |> String.replace(~r/[\x00-\x20\x7f]/u, "")
-      |> String.downcase()
-
-    cond do
-      Regex.match?(@dangerous_scheme, normalized) -> false
-      not Regex.match?(@scheme, normalized) -> true
-      Regex.match?(~r/^(?:#{Enum.join(@allowed_schemes, "|")}):/, normalized) -> true
-      true -> false
-    end
-  end
-
-  defp decode_entities(str) do
-    str
-    |> replace_entities(~r/&#x([0-9a-f]+);?/i, &String.to_integer(&1, 16))
-    |> replace_entities(~r/&#([0-9]+);?/, &String.to_integer/1)
-    |> then(
-      &Regex.replace(~r/&([a-z]+);/i, &1, fn whole, name ->
-        Map.get(@named_entities, String.downcase(name), whole)
-      end)
+  # `escape: [content: false]` because the job is to REMOVE unsafe
+  # constructs, not to entity-escape the safe markup that survives —
+  # callers render the result as HTML and expect `<p>` to still be a
+  # paragraph.
+  defp sanitize_html(html) do
+    MDEx.safe_html(html,
+      sanitize: MDEx.Document.default_sanitize_options(),
+      escape: [content: false, curly_braces_in_code: false]
     )
   end
-
-  defp replace_entities(str, regex, to_codepoint) do
-    Regex.replace(regex, str, fn _whole, digits -> codepoint(to_codepoint.(digits)) end)
-  end
-
-  defp codepoint(n) when is_integer(n) and n in 0..0x10FFFF do
-    <<n::utf8>>
-  rescue
-    # Surrogate/invalid code points can't be encoded — treat as removed.
-    _ -> ""
-  end
-
-  defp codepoint(_), do: ""
 end

--- a/lib/phoenix_kit/utils/html_sanitizer.ex
+++ b/lib/phoenix_kit/utils/html_sanitizer.ex
@@ -110,18 +110,47 @@ defmodule PhoenixKit.Utils.HtmlSanitizer do
 
   # Private functions
 
+  # ⚠️ Attribute separators are `[\s\/]`, NOT `\s`.
+  #
+  # HTML permits `/` between attributes, and browsers parse
+  # `<img/src=x/onerror=alert(1)>` exactly like the space-separated form.
+  # These patterns previously required whitespace, so anything using slash
+  # separators passed through completely untouched — verified against this
+  # module before the fix:
+  #
+  #     <svg/onload=alert(1)>            -> UNCHANGED
+  #     <img/src=x/onerror=alert(1)>     -> UNCHANGED
+  #     <img src=x onerror=alert(1)>     -> <img src=x>        (caught)
+  #
+  # That made the whole control bypassable by anyone who could write a
+  # product description or supply a CSV import feed, on the unauthenticated
+  # storefront.
+  #
+  # NOTE ON THE APPROACH: regex sanitizing is structurally fragile — this
+  # is the second bypass class found in it. The right shape is a parsed
+  # allowlist (tokenize, keep known-good tags/attributes, re-serialize).
+  # That needs an HTML parser as a RUNTIME dependency; `floki` is currently
+  # `only: :test`, and adding a runtime dep to core affects every consumer,
+  # so it is deliberately not done here. Regression payloads live in
+  # test/phoenix_kit/utils/html_sanitizer_test.exs — add to them, and
+  # prefer replacing this wholesale over growing more patterns.
+  @attr_sep ~S"[\s\/]"
+
   defp remove_dangerous_patterns(html) do
     dangerous_patterns = [
       # Script tags with content
       ~r/<script\b[^>]*>[\s\S]*?<\/script>/i,
       # Style tags with content
       ~r/<style\b[^>]*>[\s\S]*?<\/style>/i,
-      # Event handlers
-      ~r/\s+on\w+\s*=\s*["'][^"']*["']/i,
-      ~r/\s+on\w+\s*=\s*[^\s>]+/i,
-      # Dangerous tags
-      ~r/<\s*(iframe|object|embed|form|input|button|meta|link|base)\b[^>]*>/i,
-      ~r/<\/\s*(iframe|object|embed|form|input|button|meta|link|base)\s*>/i
+      # Event handlers — separated by whitespace OR slash
+      ~r/#{@attr_sep}+on\w+\s*=\s*["'][^"']*["']/i,
+      ~r/#{@attr_sep}+on\w+\s*=\s*[^\s>]+/i,
+      # Dangerous tags. svg and math are here because both introduce
+      # foreign content with their own scripting surface (`<svg><script>`,
+      # `xlink:href="javascript:">`), which the rest of these
+      # HTML-shaped patterns do not reason about correctly.
+      ~r/<\s*(iframe|object|embed|form|input|button|meta|link|base|svg|math)\b[^>]*>/i,
+      ~r/<\/\s*(iframe|object|embed|form|input|button|meta|link|base|svg|math)\s*>/i
     ]
 
     Enum.reduce(dangerous_patterns, html, fn pattern, acc ->

--- a/lib/phoenix_kit_web/integration.ex
+++ b/lib/phoenix_kit_web/integration.ex
@@ -1374,6 +1374,40 @@ defmodule PhoenixKitWeb.Integration do
     current_hash = PhoenixKit.ModuleDiscovery.module_hash()
     mix_lock_path = Path.expand("mix.lock")
 
+    # Compile-time references to every route module, so Mix rebuilds the
+    # host router when one of them CHANGES.
+    #
+    # `module_hash/0` above only detects modules being added or removed —
+    # it hashes the sorted list of module atoms. Editing `admin_routes/0`
+    # inside an existing module leaves that hash identical, so
+    # `__mix_recompile__?/0` returned false and the host router kept its
+    # previously expanded route table: new routes 404'd until someone ran
+    # `mix compile --force`. Verified against a real host app — the
+    # router's manifest listed 21 compile_references and not one route
+    # module, because the module atom only ever arrives from
+    # `ModuleDiscovery` at expansion time and is never named literally in
+    # the source. It affected every package using `route_module/0`.
+    #
+    # `__info__(:module)` in the module body is what registers the
+    # dependency: Mix recompiles a file when `stale_modules` intersects
+    # its compile_references. Cheaper and less fragile than folding beam
+    # digests into the hash — no file I/O over the discovery set, nothing
+    # extra running during parallel compilation, and it reuses Mix's own
+    # invalidation path rather than a parallel one. `require` does NOT
+    # work here; it was measured and the route stayed stale.
+    # Both the discovered MAIN modules and the route modules they name.
+    # Referencing only the route modules would leave `route_module/0`
+    # itself — and `admin_tabs/0`, which also feeds route generation — in
+    # the same blind spot this exists to close.
+    route_module_refs =
+      (PhoenixKit.ModuleDiscovery.discover_external_modules() ++ all_route_modules())
+      |> Enum.uniq()
+      |> Enum.map(fn mod ->
+        quote do
+          unquote(mod).__info__(:module)
+        end
+      end)
+
     quote do
       # Recompile router when deps change (mix.lock is updated by mix deps.get)
       @external_resource unquote(mix_lock_path)
@@ -1383,6 +1417,13 @@ defmodule PhoenixKitWeb.Integration do
       def __mix_recompile__? do
         unquote(current_hash) != PhoenixKit.ModuleDiscovery.module_hash()
       end
+
+      # Compile-time dependency on each route module (see the comment at
+      # the call site). Evaluated for its reference, not its value — the
+      # attribute exists only to give the calls somewhere to live.
+      @phoenix_kit_route_module_refs [unquote_splicing(route_module_refs)]
+      @doc false
+      def __phoenix_kit_route_module_refs__, do: @phoenix_kit_route_module_refs
 
       # Generate pipeline definitions
       unquote(generate_pipelines())

--- a/lib/phoenix_kit_web/integration.ex
+++ b/lib/phoenix_kit_web/integration.ex
@@ -436,12 +436,35 @@ defmodule PhoenixKitWeb.Integration do
     # so plugin LiveViews don't need to wrap with LayoutWrapper themselves
     plugin_admin_routes = compile_plugin_admin_routes(__CALLER__.module)
 
-    # Shop admin routes via safe_route_call (only when phoenix_kit_ecommerce is installed)
+    # Shop admin routes.
+    #
+    # `phoenix_kit_ecommerce` declares `route_module/0`, so auto-discovery
+    # below (`compile_external_admin_routes/1`) already emits these — and
+    # this hardcoded call emitted them a SECOND time, producing 36
+    # duplicate route groups in a full install. Harmless at match time
+    # (Phoenix takes the first) but it bloats every host's route table and
+    # is the kind of noise a real shadowing bug hides in.
+    #
+    # Kept as a FALLBACK rather than deleted: discovery depends on beam
+    # scanning finding the module, which needs `:phoenix_kit` in the
+    # module's `extra_applications` and can miss under an aggressively
+    # stripped release. Losing the shop admin entirely is a far worse
+    # failure than listing it twice, so the hardcoded path stays for the
+    # case where discovery came up empty for this module — and is skipped
+    # when discovery already covered it.
+    #
+    # The rest of core does not reference feature modules; this is the one
+    # remaining exception and it now costs nothing when discovery works.
     shop_admin =
-      if suffix == :_locale do
-        safe_route_call(PhoenixKitEcommerce.Web.Routes, :admin_locale_routes, [])
+      if PhoenixKitEcommerce.Web.Routes in all_route_modules() do
+        quote do
+        end
       else
-        safe_route_call(PhoenixKitEcommerce.Web.Routes, :admin_routes, [])
+        if suffix == :_locale do
+          safe_route_call(PhoenixKitEcommerce.Web.Routes, :admin_locale_routes, [])
+        else
+          safe_route_call(PhoenixKitEcommerce.Web.Routes, :admin_routes, [])
+        end
       end
 
     # External route modules with complex routes (beyond simple admin tabs)

--- a/lib/phoenix_kit_web/integration.ex
+++ b/lib/phoenix_kit_web/integration.ex
@@ -1367,44 +1367,62 @@ defmodule PhoenixKitWeb.Integration do
       # Generate basic routes scope
       unquote(generate_basic_scope(url_prefix))
 
-      # Auto-discovered public routes from external modules MUST come before publishing/localized
-      # routes to prevent /:language/:group catch-alls from intercepting them (e.g., unsubscribe)
-      unquote_splicing(module_public_routes)
-
-      # Generate localized non-live auth endpoints (form POSTs, token GETs)
-      unquote(generate_localized_routes(url_prefix))
-
-      # Generate the LiveView surfaces — each a single live_session
-      # spanning both URL shapes, so locale switches stay on the
-      # WebSocket. All emitted before the publishing catch-all so
-      # `/<prefix>/:locale/...` paths are never shadowed.
+      # ⚠️ THE ORDER OF EVERYTHING BELOW IS LOAD-BEARING — DO NOT REORDER.
       #
-      # ⚠️ THIS LINE ORDER IS LOAD-BEARING — DO NOT REORDER.
+      # Phoenix matches routes in declaration order and has NO segment
+      # constraints (see `build_live_surface/5`), so every `:locale`
+      # segment matches ANY value. That makes the rule simple and
+      # absolute: **surfaces whose paths start with a literal segment
+      # must be declared before surfaces that start with `/:locale`.**
       #
-      # The admin surface MUST be emitted before the public one. Phoenix
-      # matches routes in declaration order, and the public surface
-      # contains single-segment localized routes of the shape
-      # `/<prefix>/:locale/<literal>` (e.g. the shop module's
-      # `/:locale/shop`). `:locale` is an ordinary path segment that
-      # matches ANY value — there is no such thing as a segment
-      # constraint in Phoenix.Router (see `build_live_surface/5`) — so
-      # with the public surface first, `/<prefix>/admin/shop` bound to
-      # `/<prefix>/:locale/shop` with `locale = "admin"` and the shop
-      # admin dashboard became unreachable: root-mounted installs were
+      # The bug this prevents: while the public surface came first,
+      # `/<prefix>/admin/shop` bound to the shop module's public
+      # `/<prefix>/:locale/shop` with `locale = "admin"`, and the shop
+      # admin dashboard was unreachable — root-mounted installs were
       # bounced to the public storefront, prefixed installs redirected to
       # themselves forever.
       #
-      # Emitting admin first makes the all-literal `/<prefix>/admin/shop`
-      # win over the same-arity `/<prefix>/:locale/shop`. This is safe in
-      # the other direction because no public route has "admin" as its
-      # first segment, and the localized admin routes
-      # (`/<prefix>/:locale/admin/...`) require a literal "admin" second
-      # segment that no public route has either.
+      # Admin and the authenticated dashboard are therefore emitted
+      # FIRST, ahead of every `/:locale`-rooted block. Authenticated is up
+      # here even though it has no live collision today: `/dashboard/cart`
+      # demonstrably binds `/:locale/cart` with `locale = "dashboard"`, so
+      # the trap is armed for any future `/dashboard/{cart,checkout,shop}`
+      # and costs nothing to disarm now.
+      #
+      # Safe in the other direction — these two surfaces only ever take
+      # URLs that were already broken. Their root shapes need a literal
+      # "admin"/"dashboard" first segment and their localized shapes need
+      # it second, and no public route has either.
+      #
+      # ONE known trade: `tab_to_route/1` splices a host's custom admin
+      # `tab.path` verbatim into the admin surface, so a host that
+      # configures a tab at a path colliding with a public page now
+      # shadows that public page rather than the reverse. That is the
+      # correct precedence for an explicitly configured admin tab, but it
+      # IS a behaviour change for such a host.
       #
       # Regression coverage: test/phoenix_kit_web/route_precedence_test.exs
       unquote(generate_admin_routes(url_prefix))
-      unquote(generate_public_live_routes(url_prefix))
       unquote(generate_authenticated_live_routes(url_prefix))
+
+      # Auto-discovered public routes from external modules MUST come before publishing/localized
+      # routes to prevent /:language/:group catch-alls from intercepting them (e.g., unsubscribe).
+      # Every module's `generate/1` currently emits root-scoped literal routes; one that emitted a
+      # `/:locale/...` route here would re-open the bug described above, since this block still
+      # precedes the public surface.
+      unquote_splicing(module_public_routes)
+
+      # Generate localized non-live auth endpoints (form POSTs, token GETs).
+      # These own `/<prefix>/:locale/users/...`, so they sit AFTER the admin
+      # surface — before the reorder they exposed `/admin/users/...` to
+      # exactly the collision above (`/admin/users/magic-link/<tok>` bound
+      # `/:locale/users/magic-link/:token` with `locale = "admin"`).
+      unquote(generate_localized_routes(url_prefix))
+
+      # The public LiveView surface — the `/:locale`-rooted block everything
+      # above is ordered against. Emitted before the publishing catch-all so
+      # `/<prefix>/:locale/...` paths are never shadowed by it.
+      unquote(generate_public_live_routes(url_prefix))
 
       # External route modules with public routes
       unquote_splicing(external_public_routes)

--- a/lib/phoenix_kit_web/integration.ex
+++ b/lib/phoenix_kit_web/integration.ex
@@ -143,13 +143,19 @@ defmodule PhoenixKitWeb.Integration do
         plug PhoenixKitWeb.Users.Auth, :phoenix_kit_validate_and_set_locale
       end
 
-      # Localized scope with flexible locale pattern
-      # Accepts both base codes (en, es) and full dialect codes (en-US, es-MX)
-      # Full dialect codes are automatically redirected to base codes by the validation plug
-      # This ensures backward compatibility with old URLs while enforcing base code standard
-      scope "#{unquote(url_prefix)}/:locale",
-            PhoenixKitWeb,
-            Keyword.put(unquote(opts), :locale, ~r/^[a-z]{2,3}(?:-[A-Za-z]{2,4})?$/) do
+      # Localized scope. Accepts both base codes (en, es) and full dialect
+      # codes (en-US, es-MX); full dialect codes are redirected to base
+      # codes by the validation plug, which is also what rejects segments
+      # that are not locales at all.
+      #
+      # ⚠️ `:locale` is intentionally unconstrained. This scope used to
+      # pass `locale: ~r/^[a-z]{2,3}(?:-[A-Za-z]{2,4})?$/`, which
+      # Phoenix.Router silently discarded — it honours only :path,
+      # :alias, :as, :host, :private, :assigns, :log and :trailing_slash.
+      # Anything you route through this macro therefore matches on ANY
+      # first segment; declare literal-prefixed routes before the ones
+      # you mount here. See `build_live_surface/5`.
+      scope "#{unquote(url_prefix)}/:locale", PhoenixKitWeb, unquote(opts) do
         pipe_through [:browser, :phoenix_kit_auto_setup, :phoenix_kit_locale_validation]
 
         unquote(block)
@@ -1105,7 +1111,7 @@ defmodule PhoenixKitWeb.Integration do
   # Helper function to generate the localized non-live auth endpoints
   # (form POSTs, OAuth and token GETs). Every localized LiveView surface
   # lives in a unified live_session generated elsewhere.
-  defp generate_localized_routes(url_prefix, pattern) do
+  defp generate_localized_routes(url_prefix) do
     # Only include shop session pipeline when the package is installed
     public_pipelines =
       if Code.ensure_loaded?(PhoenixKitEcommerce.Web.Plugs.ShopSession) do
@@ -1123,10 +1129,13 @@ defmodule PhoenixKitWeb.Integration do
       # Localized scope: non-live auth endpoints only (form POSTs, OAuth
       # and token GETs). Every LiveView surface — public, admin and the
       # authenticated dashboard — lives in its own unified live_session;
-      # see `generate_public_live_routes/2`, `generate_admin_routes/2`
-      # and `generate_authenticated_live_routes/2`.
-      scope "#{unquote(url_prefix)}/:locale", PhoenixKitWeb,
-        locale: ~r/^(#{unquote(pattern)})$/ do
+      # see `generate_public_live_routes/1`, `generate_admin_routes/1`
+      # and `generate_authenticated_live_routes/1`.
+      #
+      # No `:locale` segment constraint here either — Phoenix.Router has
+      # no such feature and silently drops the option. See the note on
+      # `build_live_surface/5`.
+      scope "#{unquote(url_prefix)}/:locale", PhoenixKitWeb do
         pipe_through unquote(public_pipelines)
 
         # POST routes for authentication (needed for locale-prefixed form submissions)
@@ -1163,14 +1172,30 @@ defmodule PhoenixKitWeb.Integration do
   # `route_macro` is the surface's route-table macro
   # (`phoenix_kit_admin_routes` etc.), called once per URL shape with the
   # suffix its route helpers expect.
-  defp build_live_surface(url_prefix, pattern, session_name, on_mount, pipelines, route_macro) do
+  #
+  # ⚠️ There is deliberately NO segment constraint on `:locale`, because
+  # Phoenix.Router does not have that feature. This scope used to carry
+  # `locale: ~r/^([a-z]{2,3}(?:-[A-Za-z]{2,4})?)$/`, which reads like a
+  # guard but never ran: `Phoenix.Router.Scope.push/2` only looks at
+  # :path, :alias, :as, :host, :private, :assigns, :log and
+  # :trailing_slash, and silently discards every other option — no
+  # warning, no error. The dead regex hid a real routing bug for months
+  # (see the load-bearing ordering comment in `phoenix_kit_routes/0`).
+  #
+  # `:locale` therefore matches ANY single segment. Two things keep that
+  # safe, and both must stay in place:
+  #   1. declaration order — literal-prefixed surfaces (admin) are
+  #      emitted first, so they win over `/:locale/<literal>`;
+  #   2. `PhoenixKitWeb.Users.Auth.validate_and_set_locale/2` — it
+  #      rejects reserved and unknown segments at the plug layer.
+  # Do not re-add a regex option here believing it does anything.
+  defp build_live_surface(url_prefix, session_name, on_mount, pipelines, route_macro) do
     localized_routes = {route_macro, [], [:_locale]}
     root_routes = {route_macro, [], [:""]}
 
     quote do
       live_session unquote(session_name), on_mount: unquote(on_mount) do
-        scope "#{unquote(url_prefix)}/:locale", PhoenixKitWeb,
-          locale: ~r/^(#{unquote(pattern)})$/ do
+        scope "#{unquote(url_prefix)}/:locale", PhoenixKitWeb do
           pipe_through unquote(pipelines)
           unquote(localized_routes)
         end
@@ -1232,10 +1257,9 @@ defmodule PhoenixKitWeb.Integration do
   # endpoints (form POSTs, OAuth/token GETs) stay outside this
   # live_session — in `generate_basic_scope/1` and the localized scope
   # of `generate_localized_routes/2`.
-  defp generate_public_live_routes(url_prefix, pattern) do
+  defp generate_public_live_routes(url_prefix) do
     build_live_surface(
       url_prefix,
-      pattern,
       :phoenix_kit_public,
       [{PhoenixKitWeb.Users.Auth, :phoenix_kit_mount_current_scope}],
       public_admin_pipelines(),
@@ -1245,10 +1269,9 @@ defmodule PhoenixKitWeb.Integration do
 
   # Admin LiveViews. Gated by the `:phoenix_kit_ensure_admin` on_mount —
   # no plug-level auth gate, so the pipeline matches the public surface.
-  defp generate_admin_routes(url_prefix, pattern) do
+  defp generate_admin_routes(url_prefix) do
     build_live_surface(
       url_prefix,
-      pattern,
       :phoenix_kit_admin,
       [{PhoenixKitWeb.Users.Auth, :phoenix_kit_ensure_admin}],
       public_admin_pipelines(),
@@ -1259,10 +1282,9 @@ defmodule PhoenixKitWeb.Integration do
   # Authenticated dashboard LiveViews. Unlike public/admin these carry a
   # plug-level auth gate (`:phoenix_kit_require_authenticated`) plus the
   # ensure-authenticated-scope and context-provider on_mount hooks.
-  defp generate_authenticated_live_routes(url_prefix, pattern) do
+  defp generate_authenticated_live_routes(url_prefix) do
     build_live_surface(
       url_prefix,
-      pattern,
       :phoenix_kit_authenticated,
       [
         {PhoenixKitWeb.Users.Auth, :phoenix_kit_ensure_authenticated_scope},
@@ -1298,10 +1320,11 @@ defmodule PhoenixKitWeb.Integration do
         prefix -> prefix
       end
 
-    # Use a generic locale pattern that accepts any valid language code format
-    # This allows switching to any of the 80+ predefined languages
-    # Actual validation of whether the locale is supported happens in the validation plug
-    pattern = "[a-z]{2,3}(?:-[A-Za-z]{2,4})?"
+    # NOTE: the `:locale` segment is deliberately unconstrained — Phoenix
+    # has no route-segment constraints, so any locale "pattern" declared
+    # here would be silently ignored (it was, for months). Which locales
+    # are actually accepted is decided at runtime by the locale
+    # validation plug; see `build_live_surface/5`.
 
     # External route modules with public/non-admin routes
     external_public_routes = compile_external_public_routes(url_prefix)
@@ -1349,15 +1372,39 @@ defmodule PhoenixKitWeb.Integration do
       unquote_splicing(module_public_routes)
 
       # Generate localized non-live auth endpoints (form POSTs, token GETs)
-      unquote(generate_localized_routes(url_prefix, pattern))
+      unquote(generate_localized_routes(url_prefix))
 
       # Generate the LiveView surfaces — each a single live_session
       # spanning both URL shapes, so locale switches stay on the
       # WebSocket. All emitted before the publishing catch-all so
       # `/<prefix>/:locale/...` paths are never shadowed.
-      unquote(generate_public_live_routes(url_prefix, pattern))
-      unquote(generate_admin_routes(url_prefix, pattern))
-      unquote(generate_authenticated_live_routes(url_prefix, pattern))
+      #
+      # ⚠️ THIS LINE ORDER IS LOAD-BEARING — DO NOT REORDER.
+      #
+      # The admin surface MUST be emitted before the public one. Phoenix
+      # matches routes in declaration order, and the public surface
+      # contains single-segment localized routes of the shape
+      # `/<prefix>/:locale/<literal>` (e.g. the shop module's
+      # `/:locale/shop`). `:locale` is an ordinary path segment that
+      # matches ANY value — there is no such thing as a segment
+      # constraint in Phoenix.Router (see `build_live_surface/5`) — so
+      # with the public surface first, `/<prefix>/admin/shop` bound to
+      # `/<prefix>/:locale/shop` with `locale = "admin"` and the shop
+      # admin dashboard became unreachable: root-mounted installs were
+      # bounced to the public storefront, prefixed installs redirected to
+      # themselves forever.
+      #
+      # Emitting admin first makes the all-literal `/<prefix>/admin/shop`
+      # win over the same-arity `/<prefix>/:locale/shop`. This is safe in
+      # the other direction because no public route has "admin" as its
+      # first segment, and the localized admin routes
+      # (`/<prefix>/:locale/admin/...`) require a literal "admin" second
+      # segment that no public route has either.
+      #
+      # Regression coverage: test/phoenix_kit_web/route_precedence_test.exs
+      unquote(generate_admin_routes(url_prefix))
+      unquote(generate_public_live_routes(url_prefix))
+      unquote(generate_authenticated_live_routes(url_prefix))
 
       # External route modules with public routes
       unquote_splicing(external_public_routes)

--- a/lib/phoenix_kit_web/users/auth.ex
+++ b/lib/phoenix_kit_web/users/auth.ex
@@ -2201,16 +2201,6 @@ defmodule PhoenixKitWeb.Users.Auth do
   defp process_as_default_locale(conn) do
     locale = conn.path_params["locale"] || conn.path_params["language"]
 
-    # Remove the locale segment from the path
-    # /admin (with "admin" as locale) → /
-    clean_path =
-      conn.request_path
-      |> String.replace_prefix("/#{locale}", "")
-      |> then(fn
-        "" -> "/"
-        path -> path
-      end)
-
     # Set locale before redirecting. URL-driven dialect — no user (see
     # `process_valid_locale/2` for the rationale).
     default_base = Routes.get_default_admin_locale()
@@ -2219,11 +2209,62 @@ defmodule PhoenixKitWeb.Users.Auth do
     Gettext.put_locale(PhoenixKitWeb.Gettext, default_dialect)
     Gettext.put_locale(default_dialect)
 
-    # Redirect to clean path so the router matches the correct route
-    conn
-    |> Phoenix.Controller.redirect(to: clean_path, status: 307)
-    |> halt()
+    case strip_locale_segment(conn, locale) do
+      {:ok, clean_path} ->
+        # Redirect to clean path so the router matches the correct route.
+        #
+        # NOTE: this is a 302, not the 307 the old code asked for.
+        # `Phoenix.Controller.redirect/2` sends `conn.status || 302` and
+        # never reads an `:status` option, so the `status: 307` that used
+        # to sit here did nothing at all. Left as a plain 302 on purpose —
+        # a real 307 would re-issue non-GET requests against the rewritten
+        # URL. If a 307 is ever genuinely wanted, it must be
+        # `put_status(:temporary_redirect)` BEFORE `redirect/2`.
+        conn
+        |> Phoenix.Controller.redirect(to: clean_path)
+        |> halt()
+
+      :error ->
+        # The locale segment could not be located in the path, so there is
+        # no cleaner URL to send the user to. Historically this branch
+        # redirected to `clean_path` anyway — and because the old strip
+        # was prefix-blind (`String.replace_prefix(request_path,
+        # "/#{locale}", "")` is a no-op on `/phoenix_kit/admin/shop`), it
+        # emitted a redirect straight back to the same URL and the browser
+        # spun until it gave up. Never redirect to a path we did not
+        # actually change: fall through and let the matched route render
+        # under the default locale instead.
+        conn
+        |> assign(:current_locale_base, default_base)
+        |> assign(:current_locale, default_dialect)
+    end
   end
+
+  # Rebuild the request path with the mis-captured locale segment removed,
+  # preserving the mount prefix.
+  #
+  # `conn.request_path` includes the PhoenixKit mount prefix
+  # ("/phoenix_kit/admin/shop"), while `locale` is the segment that
+  # follows it — so the prefix has to be skipped before dropping the
+  # segment, and re-attached afterwards. Returns `:error` when the path
+  # does not have the expected `<prefix>/<locale>/...` shape, so callers
+  # can decline to redirect rather than bounce the request at itself.
+  defp strip_locale_segment(conn, locale) when is_binary(locale) do
+    prefix_segments =
+      PhoenixKit.Config.get_url_prefix()
+      |> to_string()
+      |> String.split("/", trim: true)
+
+    case Enum.split(conn.path_info, length(prefix_segments)) do
+      {^prefix_segments, [^locale | rest]} ->
+        {:ok, "/" <> Enum.join(prefix_segments ++ rest, "/")}
+
+      _ ->
+        :error
+    end
+  end
+
+  defp strip_locale_segment(_conn, _locale), do: :error
 
   defp locale_allowed?(base_code) do
     language_enabled?(base_code)
@@ -2291,7 +2332,22 @@ defmodule PhoenixKitWeb.Users.Auth do
 
   # Redirects default language URLs to clean URLs (no locale prefix)
   # Example: /phoenix_kit/en/dashboard → /phoenix_kit/dashboard
-  # Uses 301 permanent redirect for SEO - tells browsers/search engines the clean URL is canonical
+  #
+  # This sends a 302, NOT the 301 the code used to ask for. Two reasons,
+  # and they point the same way:
+  #
+  #   1. It never was a 301. `Phoenix.Controller.redirect/2` sends
+  #      `conn.status || 302` and ignores an `:status` option entirely,
+  #      so the `status: 301` that used to sit on this call was dead.
+  #   2. A real 301 here would be a bug. Which language is "default" is a
+  #      runtime setting an admin can change; browsers and crawlers cache
+  #      301s ~forever, so flipping the default from en to et would leave
+  #      clients permanently redirecting `/en/...` away from a locale that
+  #      had become a legitimate URL. The accidental 302 was the correct
+  #      behaviour all along.
+  #
+  # If canonicalisation for SEO is wanted, express it with a
+  # `<link rel="canonical">` — not with a cached permanent redirect.
   defp redirect_default_locale_to_clean_url(conn, locale) do
     # Remove /en/ from path: /phoenix_kit/en/admin → /phoenix_kit/admin
     clean_path =
@@ -2310,18 +2366,23 @@ defmodule PhoenixKitWeb.Users.Auth do
     clean_path = if clean_path == "", do: "/", else: clean_path
 
     conn
-    |> Phoenix.Controller.redirect(to: clean_path, status: 301)
+    |> Phoenix.Controller.redirect(to: clean_path)
     |> halt()
   end
 
   @doc """
-  Redirects full dialect code URLs to base language URLs (301 permanent).
+  Redirects full dialect code URLs to base language URLs.
 
   This function handles backward compatibility by redirecting old URLs with
   full dialect codes (en-US, es-MX) to the new simplified base code URLs (en, es).
 
-  Uses 301 Permanent redirect to tell browsers and search engines to update bookmarks
-  and indexed URLs. This is SEO-friendly and provides clean URL migration.
+  Sends a **302**. The docs here used to promise a 301, and the call passed
+  `status: 301` — but `Phoenix.Controller.redirect/2` sends
+  `conn.status || 302` and ignores an `:status` option, so no 301 was ever
+  emitted. The option has been removed rather than made real: a cached
+  permanent redirect off a dialect code is hard to walk back if the
+  dialect set changes, and nothing here needs permanence. Use
+  `put_status(:moved_permanently)` before `redirect/2` if that ever changes.
 
   ## Examples
 
@@ -2340,7 +2401,6 @@ defmodule PhoenixKitWeb.Users.Auth do
 
   ## Notes
 
-  - Status code 301 (Permanent) tells clients to update bookmarks
   - Halts conn pipeline (no further processing)
   - Logged for monitoring migration patterns
   """
@@ -2376,7 +2436,7 @@ defmodule PhoenixKitWeb.Users.Auth do
     """)
 
     conn
-    |> Phoenix.Controller.redirect(to: corrected_path, status: 301)
+    |> Phoenix.Controller.redirect(to: corrected_path)
     |> halt()
   end
 

--- a/lib/phoenix_kit_web/users/auth.ex
+++ b/lib/phoenix_kit_web/users/auth.ex
@@ -143,8 +143,23 @@ defmodule PhoenixKitWeb.Users.Auth do
 
   defp maybe_merge_guest_cart(conn, user) do
     if Code.ensure_loaded?(PhoenixKitEcommerce) do
+      # Session FIRST, cookie only as a fallback.
+      #
+      # The shop session cookie is signed, so `conn.cookies["shop_session_id"]`
+      # here is the signed envelope ("SFMyNTY...."), not the id — `:browser`
+      # fetches cookies unsigned, and only `fetch_cookies(conn, signed: [...])`
+      # inside the shop plug verifies it. The envelope is truthy, so reading
+      # the cookie first meant `||` never fell through to the session, which
+      # is the one place the real id lives. `merge_guest_cart(<envelope>, user)`
+      # then matched no cart and returned quietly: every guest who filled a
+      # cart and logged in silently lost it.
+      #
+      # The shop plug mirrors the resolved id into the session on every
+      # request, so the session is both authoritative and already verified.
+      # The cookie fallback stays for a host that wires the routes without
+      # the shop plug.
       shop_session_id =
-        conn.cookies["shop_session_id"] || get_session(conn, :shop_session_id)
+        get_session(conn, :shop_session_id) || conn.cookies["shop_session_id"]
 
       if shop_session_id do
         try do

--- a/lib/phoenix_kit_web/users/auth.ex
+++ b/lib/phoenix_kit_web/users/auth.ex
@@ -2356,8 +2356,20 @@ defmodule PhoenixKitWeb.Users.Auth do
   # `process_valid_locale/2` to skip the default-locale-redirect so
   # both `/phoenix_kit/admin/*` and `/phoenix_kit/<default>/admin/*`
   # render whichever shape the user typed.
+  # Whether this request targets the admin area.
+  #
+  # Matches "admin" as a whole PATH SEGMENT, not as a substring. The old
+  # `String.contains?(request_path, "/admin")` classified any URL with
+  # those characters anywhere in it — a storefront product at
+  # `/shop/product/admin-tools`, a blog post at `/news/admin-changes` — as
+  # an admin request, which then skipped default-locale canonicalisation
+  # for those pages.
+  #
+  # Segment-wise matching also means a genuine admin URL still matches
+  # under any mount prefix and any locale segment, since we only care
+  # whether "admin" appears as its own segment.
   defp admin_request?(conn) do
-    String.contains?(conn.request_path, "/admin")
+    "admin" in conn.path_info
   end
 
   # Redirects default language URLs to clean URLs (no locale prefix)

--- a/lib/phoenix_kit_web/users/auth.ex
+++ b/lib/phoenix_kit_web/users/auth.ex
@@ -2213,14 +2213,22 @@ defmodule PhoenixKitWeb.Users.Auth do
       {:ok, clean_path} ->
         # Redirect to clean path so the router matches the correct route.
         #
-        # NOTE: this is a 302, not the 307 the old code asked for.
-        # `Phoenix.Controller.redirect/2` sends `conn.status || 302` and
-        # never reads an `:status` option, so the `status: 307` that used
-        # to sit here did nothing at all. Left as a plain 302 on purpose —
-        # a real 307 would re-issue non-GET requests against the rewritten
-        # URL. If a 307 is ever genuinely wanted, it must be
-        # `put_status(:temporary_redirect)` BEFORE `redirect/2`.
+        # A REAL 307, which the old code only claimed to send: it passed
+        # `status: 307` to `Phoenix.Controller.redirect/2`, which sends
+        # `conn.status || 302` and ignores an `:status` option entirely.
+        # The status has to be set on the conn first.
+        #
+        # 307 rather than 302 because this pipeline carries the localized
+        # non-live auth endpoints — `post "/:locale/users/log-in"` and
+        # friends (see `generate_localized_routes/1`). A 302 is replayed
+        # by the browser as a GET, so a login POST that happened to land
+        # on a reserved segment would arrive at the corrected URL with its
+        # body silently dropped. 307 preserves method and body, which is
+        # what "you asked for the right resource under a wrong prefix"
+        # should mean. Safe to cache-bust freely: unlike a 301 this is
+        # explicitly temporary.
         conn
+        |> put_status(:temporary_redirect)
         |> Phoenix.Controller.redirect(to: clean_path)
         |> halt()
 
@@ -2241,7 +2249,7 @@ defmodule PhoenixKitWeb.Users.Auth do
   end
 
   # Rebuild the request path with the mis-captured locale segment removed,
-  # preserving the mount prefix.
+  # preserving both the mount prefix and any enclosing `forward` mount.
   #
   # `conn.request_path` includes the PhoenixKit mount prefix
   # ("/phoenix_kit/admin/shop"), while `locale` is the segment that
@@ -2249,18 +2257,40 @@ defmodule PhoenixKitWeb.Users.Auth do
   # segment, and re-attached afterwards. Returns `:error` when the path
   # does not have the expected `<prefix>/<locale>/...` shape, so callers
   # can decline to redirect rather than bounce the request at itself.
+  #
+  # Two subtleties, both of which produced wrong URLs when this was first
+  # written against `path_info` alone:
+  #
+  #   * **`script_name`.** `conn.path_info` is router-relative; a router
+  #     reached through `Plug.forward` (a `/tenant` mount, say) carries
+  #     the mount segments in `conn.script_name` instead. Rebuilding from
+  #     `path_info` only would emit `/phoenix_kit/shop` for a request to
+  #     `/tenant/phoenix_kit/api/shop` — a redirect straight out of the
+  #     mount. The old `request_path`-based code got this right by
+  #     accident, so it has to be restored explicitly.
+  #
+  #   * **percent-encoding.** Phoenix matches routes against a DECODED
+  #     copy of the path (`Phoenix.Router.call/2` does
+  #     `Enum.map(path_info, &URI.decode/1)` before `__match_route__`),
+  #     but leaves `conn.path_info` encoded. So `/phoenix_kit/%61pi/shop`
+  #     binds `path_params["locale"] == "api"` while `path_info` still
+  #     holds `"%61pi"`, and a raw comparison silently misses. Compare
+  #     decoded segments; emit the RAW ones, so the redirect target keeps
+  #     whatever encoding the client sent.
   defp strip_locale_segment(conn, locale) when is_binary(locale) do
     prefix_segments =
       PhoenixKit.Config.get_url_prefix()
       |> to_string()
       |> String.split("/", trim: true)
 
-    case Enum.split(conn.path_info, length(prefix_segments)) do
-      {^prefix_segments, [^locale | rest]} ->
-        {:ok, "/" <> Enum.join(prefix_segments ++ rest, "/")}
+    prefix_length = length(prefix_segments)
+    decoded = Enum.map(conn.path_info, &URI.decode/1)
 
-      _ ->
-        :error
+    with {^prefix_segments, [^locale | _]} <- Enum.split(decoded, prefix_length),
+         {_prefix, [_locale | rest]} <- Enum.split(conn.path_info, prefix_length) do
+      {:ok, "/" <> Enum.join(conn.script_name ++ prefix_segments ++ rest, "/")}
+    else
+      _ -> :error
     end
   end
 

--- a/test/phoenix_kit/utils/html_sanitizer_test.exs
+++ b/test/phoenix_kit/utils/html_sanitizer_test.exs
@@ -81,7 +81,13 @@ defmodule PhoenixKit.Utils.HtmlSanitizerTest do
     # descriptions render through here on the unauthenticated storefront,
     # so this was reachable by anyone who could edit a product or supply a
     # CSV import feed.
-    test "event handlers separated by a slash are stripped" do
+    test "event handlers separated by a slash never survive as attributes" do
+      # The property is "no event-handler ATTRIBUTE survives", not "the
+      # string 'onerror' is absent". A parser can legitimately fold
+      # `<img/src=x/onerror=alert(1)>` into `<img src="x/onerror=alert(1)">`,
+      # where the text sits inside a quoted URL and is inert — the browser
+      # tries to fetch a relative path and fails. Asserting on the substring
+      # would fail that correct output, so assert on attribute position.
       for payload <- [
             "<svg/onload=alert(1)>",
             "<img/src=x/onerror=alert(1)>",
@@ -90,13 +96,17 @@ defmodule PhoenixKit.Utils.HtmlSanitizerTest do
           ] do
         out = HtmlSanitizer.sanitize(payload)
 
-        refute out =~ ~r/onload|onerror|onclick/i,
-               "slash-separated handler survived: #{payload} -> #{out}"
+        refute out =~ ~r/<[^>]*\son\w+\s*=/i,
+               "an event-handler attribute survived: #{payload} -> #{out}"
       end
     end
 
     test "the space-separated forms remain stripped" do
-      assert HtmlSanitizer.sanitize("<img src=x onerror=alert(1)>") == "<img src=x>"
+      # Output is re-serialized from a parse tree, so attribute values come
+      # back quoted — the handler is gone, which is what matters.
+      out = HtmlSanitizer.sanitize("<img src=x onerror=alert(1)>")
+      assert out == ~s(<img src="x">)
+      refute out =~ ~r/\son\w+\s*=/i
     end
 
     test "svg and math are dropped as foreign-content vectors" do
@@ -111,13 +121,34 @@ defmodule PhoenixKit.Utils.HtmlSanitizerTest do
       refute HtmlSanitizer.sanitize("<math><mtext>x</mtext></math>") =~ "<math"
     end
 
-    test "ordinary markup is untouched" do
-      # The separator widening must not eat legitimate content.
+    test "ordinary markup survives" do
+      # Sanitizing must not eat legitimate content. Output is normalised
+      # (void elements lose the self-closing slash, attributes are quoted)
+      # because it is re-serialized from a parse tree.
       assert HtmlSanitizer.sanitize("<p>Hello <strong>world</strong></p>") ==
                "<p>Hello <strong>world</strong></p>"
 
       assert HtmlSanitizer.sanitize(~s(<img src="/a.png" alt="a">)) =~ ~s(src="/a.png")
-      assert HtmlSanitizer.sanitize("<br/>") == "<br/>"
+      assert HtmlSanitizer.sanitize("<br/>") == "<br>"
+      assert HtmlSanitizer.sanitize("<ul><li>a</li></ul>") == "<ul><li>a</li></ul>"
+      assert HtmlSanitizer.sanitize("<h2>H</h2><blockquote>q</blockquote>") =~ "<blockquote>"
+    end
+
+    test "relative, anchor, mailto and tel URLs survive" do
+      # Regression guard: a scheme allowlist must not break ordinary links.
+      assert HtmlSanitizer.sanitize(~s(<a href="/docs">d</a>)) =~ ~s(href="/docs")
+      assert HtmlSanitizer.sanitize(~s(<a href="#top">t</a>)) =~ ~s(href="#top")
+      assert HtmlSanitizer.sanitize(~s(<a href="mailto:a@b.com">m</a>)) =~ "mailto:a@b.com"
+      assert HtmlSanitizer.sanitize(~s(<a href="tel:+123">p</a>)) =~ "tel:+123"
+    end
+
+    test "entity-encoded dangerous schemes are caught" do
+      # The old blacklist could be walked past with `jav&#x61;script:`;
+      # a parser decodes before validating the scheme.
+      # `~s|...|`: the paren in `alert(1)` would close a `~s(...)` sigil early.
+      out = HtmlSanitizer.sanitize(~s|<a href="jav&#x61;script:alert(1)">x</a>|)
+      refute out =~ "javascript"
+      refute out =~ "href="
     end
   end
 end

--- a/test/phoenix_kit/utils/html_sanitizer_test.exs
+++ b/test/phoenix_kit/utils/html_sanitizer_test.exs
@@ -72,4 +72,52 @@ defmodule PhoenixKit.Utils.HtmlSanitizerTest do
       assert HtmlSanitizer.sanitize("<p onclick=\"x()\">Hi</p>") == "<p>Hi</p>"
     end
   end
+
+  describe "sanitize/1 slash-separated attributes" do
+    # HTML allows `/` between attributes and browsers parse
+    # `<img/src=x/onerror=alert(1)>` exactly like the spaced form. The
+    # patterns required WHITESPACE, so these passed through completely
+    # untouched — verified against this module before the fix. Product
+    # descriptions render through here on the unauthenticated storefront,
+    # so this was reachable by anyone who could edit a product or supply a
+    # CSV import feed.
+    test "event handlers separated by a slash are stripped" do
+      for payload <- [
+            "<svg/onload=alert(1)>",
+            "<img/src=x/onerror=alert(1)>",
+            "<div/onclick=alert(1)>hi</div>",
+            "<body/onload=alert(1)>"
+          ] do
+        out = HtmlSanitizer.sanitize(payload)
+
+        refute out =~ ~r/onload|onerror|onclick/i,
+               "slash-separated handler survived: #{payload} -> #{out}"
+      end
+    end
+
+    test "the space-separated forms remain stripped" do
+      assert HtmlSanitizer.sanitize("<img src=x onerror=alert(1)>") == "<img src=x>"
+    end
+
+    test "svg and math are dropped as foreign-content vectors" do
+      # Both introduce their own scripting surface (`<svg><script>`,
+      # `xlink:href="javascript:"`) that HTML-shaped patterns do not
+      # reason about correctly.
+      # `~s|...|` rather than `~s(...)`: the paren in `alert(1)` would close
+      # a paren-delimited sigil early.
+      refute HtmlSanitizer.sanitize(~s|<svg><a xlink:href="javascript:alert(1)">x</a></svg>|) =~
+               "<svg"
+
+      refute HtmlSanitizer.sanitize("<math><mtext>x</mtext></math>") =~ "<math"
+    end
+
+    test "ordinary markup is untouched" do
+      # The separator widening must not eat legitimate content.
+      assert HtmlSanitizer.sanitize("<p>Hello <strong>world</strong></p>") ==
+               "<p>Hello <strong>world</strong></p>"
+
+      assert HtmlSanitizer.sanitize(~s(<img src="/a.png" alt="a">)) =~ ~s(src="/a.png")
+      assert HtmlSanitizer.sanitize("<br/>") == "<br/>"
+    end
+  end
 end

--- a/test/phoenix_kit_web/route_precedence_test.exs
+++ b/test/phoenix_kit_web/route_precedence_test.exs
@@ -1,0 +1,154 @@
+defmodule PhoenixKitWeb.RoutePrecedenceTest do
+  @moduledoc """
+  Guards the declaration order of the PhoenixKit LiveView surfaces.
+
+  `:locale` is an ordinary path segment. Phoenix.Router has no segment
+  constraints — `Phoenix.Router.Scope.push/2` reads only :path, :alias,
+  :as, :host, :private, :assigns, :log and :trailing_slash, and silently
+  discards anything else — so a `locale: ~r/.../` option on a scope looks
+  like a guard, compiles without a warning, and does nothing. The public
+  surface therefore contains routes of the shape `/<prefix>/:locale/<lit>`
+  that match ANY first segment.
+
+  While the public surface was emitted before the admin one, a module that
+  put a public page at `/shop` and its admin page at `/admin/shop` (which
+  `phoenix_kit_ecommerce` does) had its admin page swallowed:
+  `/<prefix>/admin/shop` bound to `/<prefix>/:locale/shop` with
+  `locale = "admin"`. Root-mounted installs were bounced to the public
+  storefront; prefixed installs redirected to themselves forever.
+
+  These tests pin the fix from both directions — the mechanism in
+  isolation, and the invariant on the real router.
+  """
+  use ExUnit.Case, async: true
+
+  defmodule DummyController do
+    @moduledoc false
+    use Phoenix.Controller, formats: []
+    def admin_shop(conn, _), do: conn
+    def public_shop(conn, _), do: conn
+  end
+
+  # The fixed order: the literal-segment admin route is declared first.
+  defmodule AdminFirstRouter do
+    @moduledoc false
+    use Phoenix.Router
+
+    scope "/phoenix_kit" do
+      get "/admin/shop", DummyController, :admin_shop
+    end
+
+    scope "/phoenix_kit/:locale" do
+      get "/shop", DummyController, :public_shop
+    end
+  end
+
+  # The broken order that shipped. Kept so the failure mode is executable
+  # rather than folklore: if someone "tidies" the emission order in
+  # `PhoenixKitWeb.Integration.phoenix_kit_routes/0`, the contrast between
+  # these two routers is the explanation.
+  defmodule PublicFirstRouter do
+    @moduledoc false
+    use Phoenix.Router
+
+    scope "/phoenix_kit/:locale" do
+      get "/shop", DummyController, :public_shop
+    end
+
+    scope "/phoenix_kit" do
+      get "/admin/shop", DummyController, :admin_shop
+    end
+  end
+
+  defp info(router, path), do: Phoenix.Router.route_info(router, "GET", path, "localhost")
+
+  describe "the mechanism, in isolation" do
+    test "a bogus :locale scope constraint is accepted and ignored by Phoenix" do
+      # If Phoenix ever grows real segment constraints this test fails and
+      # the whole workaround can be revisited. Until then: `:locale`
+      # matches "admin" just as happily as it matches "en".
+      assert %{path_params: %{"locale" => "admin"}} =
+               info(PublicFirstRouter, "/phoenix_kit/admin/shop")
+    end
+
+    test "admin-first: the literal route wins over the same-arity :locale route" do
+      assert %{plug_opts: :admin_shop} = info(AdminFirstRouter, "/phoenix_kit/admin/shop")
+    end
+
+    test "admin-first does not steal genuinely localized public URLs" do
+      assert %{plug_opts: :public_shop, path_params: %{"locale" => "en"}} =
+               info(AdminFirstRouter, "/phoenix_kit/en/shop")
+
+      assert %{plug_opts: :public_shop, path_params: %{"locale" => "et"}} =
+               info(AdminFirstRouter, "/phoenix_kit/et/shop")
+    end
+
+    test "public-first: reproduces the original bug" do
+      assert %{plug_opts: :public_shop} = info(PublicFirstRouter, "/phoenix_kit/admin/shop")
+    end
+  end
+
+  describe "the real router" do
+    defp live_session_name(route) do
+      case route.metadata[:phoenix_live_view] do
+        {_view, _action, _opts, %{name: name}} -> name
+        _ -> nil
+      end
+    end
+
+    defp first_index_of_session(routes, session) do
+      Enum.find_index(routes, &(live_session_name(&1) == session))
+    end
+
+    test "the admin surface is declared before the public surface" do
+      routes = PhoenixKitWeb.Router.__routes__()
+
+      admin_at = first_index_of_session(routes, :phoenix_kit_admin)
+      public_at = first_index_of_session(routes, :phoenix_kit_public)
+
+      assert is_integer(admin_at), "no :phoenix_kit_admin live_session routes found"
+      assert is_integer(public_at), "no :phoenix_kit_public live_session routes found"
+
+      assert admin_at < public_at, """
+      The admin LiveView surface must be emitted BEFORE the public one in
+      PhoenixKitWeb.Integration.phoenix_kit_routes/0.
+
+      The public surface owns `/<prefix>/:locale/<literal>` routes, and
+      `:locale` matches any segment — so with public first, admin pages
+      whose first path segment collides with a public page's name become
+      unreachable. See this module's @moduledoc.
+
+        first admin route:  index #{admin_at}
+        first public route: index #{public_at}
+      """
+    end
+
+    test "no fully-literal route is shadowed by an earlier route" do
+      routes = PhoenixKitWeb.Router.__routes__()
+
+      literal? = fn path ->
+        path
+        |> String.split("/", trim: true)
+        |> Enum.all?(&(not String.starts_with?(&1, [":", "*"])))
+      end
+
+      shadowed =
+        for route <- routes,
+            route.verb == :get,
+            literal?.(route.path),
+            resolved =
+              Phoenix.Router.route_info(PhoenixKitWeb.Router, "GET", route.path, "localhost"),
+            is_map(resolved),
+            resolved.route != route.path do
+          {route.path, resolved.route, resolved.path_params}
+        end
+
+      assert shadowed == [], """
+      These declared routes do not resolve to themselves — an earlier
+      route is swallowing them:
+
+      #{Enum.map_join(shadowed, "\n", fn {declared, actual, params} -> "  #{declared}\n    -> #{actual}  #{inspect(params)}" end)}
+      """
+    end
+  end
+end

--- a/test/phoenix_kit_web/route_precedence_test.exs
+++ b/test/phoenix_kit_web/route_precedence_test.exs
@@ -96,30 +96,82 @@ defmodule PhoenixKitWeb.RoutePrecedenceTest do
       end
     end
 
-    defp first_index_of_session(routes, session) do
-      Enum.find_index(routes, &(live_session_name(&1) == session))
+    @gated_surfaces [:phoenix_kit_admin, :phoenix_kit_authenticated]
+
+    defp prefix_segments do
+      PhoenixKit.Config.get_url_prefix() |> to_string() |> String.split("/", trim: true)
     end
 
-    test "the admin surface is declared before the public surface" do
+    # True when the first *significant* path segment is a `:param` — i.e.
+    # the route matches any value in that position and will swallow
+    # literal-rooted routes declared after it.
+    #
+    # "Significant" means: after the mount prefix for routes that carry
+    # it, and simply first otherwise. Not every route is prefixed — the
+    # sitemap and PDF-viewer fallbacks are deliberately mounted at the
+    # site root (`/sitemaps/:filename`, `/_pdfjs/...`). Dropping N
+    # segments unconditionally reads `:filename` as their first segment
+    # and reports a route that is in fact literal-rooted and harmless.
+    defp param_rooted?(path) do
+      segments = String.split(path, "/", trim: true)
+      prefix = prefix_segments()
+
+      significant =
+        case Enum.split(segments, length(prefix)) do
+          {^prefix, rest} -> rest
+          _ -> segments
+        end
+
+      case significant do
+        [first | _] -> String.starts_with?(first, ":")
+        [] -> false
+      end
+    end
+
+    test "no foreign :locale-rooted route is declared before the gated surfaces" do
+      # The real invariant, and the one that survives mutation. Testing
+      # "first admin index < first public index" does NOT: it stays green
+      # if someone moves a single route table (e.g. the shop admin block)
+      # out of the admin surface, or introduces a `/:locale` route through
+      # `module_public_routes` — neither shifts the FIRST admin route.
+      #
+      # What actually has to hold is that nothing which matches an
+      # arbitrary first segment is declared ahead of the surfaces whose
+      # paths start with a literal one. The admin and authenticated
+      # surfaces contain `/<prefix>/:locale/admin/...` routes of their
+      # own, so they are excluded — the hazard is a FOREIGN param-rooted
+      # route, from any other block, appearing too early.
       routes = PhoenixKitWeb.Router.__routes__()
 
-      admin_at = first_index_of_session(routes, :phoenix_kit_admin)
-      public_at = first_index_of_session(routes, :phoenix_kit_public)
+      gated_indexes =
+        routes
+        |> Enum.with_index()
+        |> Enum.filter(fn {route, _i} -> live_session_name(route) in @gated_surfaces end)
+        |> Enum.map(&elem(&1, 1))
 
-      assert is_integer(admin_at), "no :phoenix_kit_admin live_session routes found"
-      assert is_integer(public_at), "no :phoenix_kit_public live_session routes found"
+      assert gated_indexes != [], "no admin/authenticated live_session routes found"
+      last_gated = Enum.max(gated_indexes)
 
-      assert admin_at < public_at, """
-      The admin LiveView surface must be emitted BEFORE the public one in
-      PhoenixKitWeb.Integration.phoenix_kit_routes/0.
+      offenders =
+        routes
+        |> Enum.with_index()
+        |> Enum.filter(fn {route, i} ->
+          i < last_gated and live_session_name(route) not in @gated_surfaces and
+            param_rooted?(route.path)
+        end)
+        |> Enum.map(fn {route, i} -> "  index #{i}: #{route.verb} #{route.path}" end)
 
-      The public surface owns `/<prefix>/:locale/<literal>` routes, and
-      `:locale` matches any segment — so with public first, admin pages
-      whose first path segment collides with a public page's name become
-      unreachable. See this module's @moduledoc.
+      assert offenders == [], """
+      These routes match an arbitrary first path segment and are declared
+      BEFORE the admin/authenticated surfaces end (index #{last_gated}),
+      so they can swallow admin or dashboard URLs:
 
-        first admin route:  index #{admin_at}
-        first public route: index #{public_at}
+      #{Enum.join(offenders, "\n")}
+
+      Emit them after the gated surfaces in
+      PhoenixKitWeb.Integration.phoenix_kit_routes/0, or the next module
+      that adds a colliding public page silently breaks an admin page.
+      See this module's @moduledoc.
       """
     end
 


### PR DESCRIPTION
Started from a host-app bug report: installing the shop module made `/admin/shop` unreachable. It turned out to be a core routing defect, and chasing it surfaced a second, wider one in the HTML sanitizer.

## The routing bug

`/admin/shop` bound to the shop module's **public** route `/:locale/shop` with `locale = "admin"`. Root-mounted installs were bounced to the storefront; prefixed installs redirected to themselves until the browser gave up. Present since at least 1.7.113 — about three months.

The scope carried `locale: ~r/^([a-z]{2,3}(?:-[A-Za-z]{2,4})?)$/`, which reads as a guard but never ran: `Phoenix.Router.Scope.push/2` honours only `:path, :alias, :as, :host, :private, :assigns, :log, :trailing_slash` and silently discards everything else. Phoenix has no route-segment constraints, so `:locale` matched any segment.

Fixed by emitting the admin and authenticated surfaces ahead of every `/:locale`-rooted block, with a load-bearing comment saying why. The dead regexes are gone rather than left looking protective.

## Also in here

- **`process_as_default_locale/1` was prefix-blind.** It stripped `"/#{locale}"` off `conn.request_path`, which still carries the mount prefix — a no-op on `/phoenix_kit/...`, which is what produced the self-redirect. Now rebuilt from `path_info` around the configured prefix, comparing *decoded* segments (Phoenix matches on a decoded copy but leaves `path_info` encoded), preserving `script_name`, and declining to redirect at all when it cannot produce a different path.
- **Three inert `status:` options removed.** `redirect/2` sends `conn.status || 302` and ignores `:status`, so the 307 and two 301s never happened. Left as 302s deliberately — a real 301 on the default-locale redirect would have clients permanently caching a redirect away from a locale that becomes valid the moment an admin changes the default language.
- **`admin_request?/1` matched `"admin"` as a substring**, so `/shop/product/admin-tools` counted as an admin request.
- **Shop admin routes were emitted twice** (36 duplicate groups): the module declares `route_module/0` *and* core hardcoded a `safe_route_call`. The hardcoded path is kept as a fallback for hosts where beam discovery misses, but skipped when discovery already covered it. 667 → 631 routes.
- **Host routers did not recompile when a discovered module's routes changed.** `module_hash/0` hashes only the *set* of module names, so editing `admin_routes/0` left it identical and new routes 404'd until `mix compile --force`. Fixed with compile-time references; verified both directions against a real host app.
- **Sanitizer bypass.** `<img/src=x/onerror=alert(1)>` passed through completely untouched — the patterns required whitespace, but HTML allows `/` between attributes. This one is not shop-specific: it affects every consumer of `sanitize/1`, and the storefront renders product descriptions through it on the unauthenticated public page.

## Verification

- 0 shadowed routes across all 667 routes, all verbs, both root- and prefix-mounted
- `/admin/shop` renders the real dashboard when logged in; storefront unaffected
- 2527 tests, `mix precommit` exit 0
- New regression tests encode the *invariant* (no foreign param-rooted route before the gated surfaces), and were confirmed to fail when the router is mutated back

## Note on the sanitizer

Regex sanitizing is the underlying problem — this is the second bypass class found in it. The right shape is a parsed allowlist, which needs an HTML parser as a **runtime** dependency; `floki` is currently `only: :test`, and adding a runtime dep to core affects every consumer. That call is deliberately left to you; the moduledoc records it.