### PR TITLE
Accept enabled sibling-dialect locales in public URLs

### DIFF
--- a/lib/modules/sitemap/generator.ex
+++ b/lib/modules/sitemap/generator.ex
@@ -563,8 +563,14 @@ defmodule PhoenixKit.Modules.Sitemap.Generator do
       |> Enum.map(fn {canonical_path, entries} ->
         default_entry =
           Enum.find(entries, fn e ->
+            # Case-insensitive: enabled codes are stored BCP-47 ("en-GB")
+            # while sibling-dialect URLs render lowercase ("/en-gb/…") — a
+            # case-sensitive contains? let a sibling entry pass as the
+            # default and claim x-default.
+            loc_down = String.downcase(e.loc)
+
             not Enum.any?(non_default_codes, fn code ->
-              String.contains?(e.loc, "/#{code}/")
+              String.contains?(loc_down, "/#{String.downcase(code)}/")
             end)
           end) || List.first(entries)
 

--- a/lib/phoenix_kit_web/users/auth.ex
+++ b/lib/phoenix_kit_web/users/auth.ex
@@ -2166,6 +2166,15 @@ defmodule PhoenixKitWeb.Users.Auth do
           locale in @reserved_path_segments ->
             process_as_default_locale(conn)
 
+          # An ENABLED full dialect ("en-gb"/"en-GB" with en-GB enabled) is a
+          # real localized URL — publishing's sibling-dialect URLs (two
+          # enabled dialects of one base, the non-primary one addressed by
+          # its lowercase full code) depend on this branch. Only exact
+          # enabled membership qualifies, matched case-insensitively; every
+          # other hyphenated segment keeps the historical redirect to base.
+          dialect = enabled_full_dialect(locale) ->
+            process_enabled_dialect_locale(conn, dialect)
+
           # Check if this is a full dialect code (contains hyphen) → redirect to base
           String.contains?(locale, "-") ->
             redirect_to_base_locale(conn, locale)
@@ -2343,6 +2352,36 @@ defmodule PhoenixKitWeb.Users.Auth do
 
   defp locale_allowed?(base_code) do
     language_enabled?(base_code)
+  end
+
+  # The stored-case enabled code for a hyphenated URL segment ("en-gb" →
+  # "en-GB"), nil when the segment isn't an enabled dialect. An empty
+  # enabled list means the Languages module is effectively off — fall
+  # through to the historical hyphen→base redirect rather than accepting
+  # arbitrary dialects.
+  defp enabled_full_dialect(locale) do
+    if String.contains?(locale, "-") do
+      down = String.downcase(locale)
+
+      Enum.find_value(Languages.get_enabled_languages(), fn lang ->
+        if String.downcase(lang.code) == down, do: lang.code
+      end)
+    end
+  end
+
+  # Mirrors the else-branch of process_valid_locale/2 for an exact enabled
+  # dialect: the URL already names the full dialect, so there is nothing to
+  # resolve — set Gettext and expose base + full on the conn. The
+  # prefixless-primary redirect never applies here: only non-primary
+  # siblings are addressed by full-code URLs (the primary's URLs stay
+  # base-coded), so a dialect segment is never the default locale.
+  defp process_enabled_dialect_locale(conn, dialect) do
+    Gettext.put_locale(PhoenixKitWeb.Gettext, dialect)
+    Gettext.put_locale(dialect)
+
+    conn
+    |> assign(:current_locale_base, DialectMapper.extract_base(dialect))
+    |> assign(:current_locale, dialect)
   end
 
   # Check if a language (base code) is enabled in the system

--- a/test/integration/users/auth_locale_test.exs
+++ b/test/integration/users/auth_locale_test.exs
@@ -235,6 +235,75 @@ defmodule PhoenixKit.Integration.Users.AuthLocaleTest do
     end
   end
 
+  describe "enabled full-dialect locale segments" do
+    # Sibling-dialect public URLs (phoenix_kit_publishing): when two dialects
+    # of one base are enabled (en-US + en-GB), the non-primary sibling is
+    # addressed by its lowercase full code (/en-gb/...). The plug used to
+    # 301 EVERY hyphenated segment to its base, which made those URLs
+    # structurally impossible — an enabled dialect must process, matched
+    # case-insensitively; any other hyphenated segment keeps the redirect.
+
+    setup do
+      config = %{
+        "languages" => [
+          %{
+            "code" => "en-US",
+            "name" => "English (US)",
+            "is_default" => true,
+            "is_enabled" => true
+          },
+          %{
+            "code" => "en-GB",
+            "name" => "English (UK)",
+            "is_default" => false,
+            "is_enabled" => true
+          },
+          %{"code" => "es", "name" => "Spanish", "is_default" => false, "is_enabled" => true}
+        ]
+      }
+
+      Settings.update_json_setting("languages_config", config)
+      :ok
+    end
+
+    test "a lowercase enabled dialect processes with the stored-case locale" do
+      conn =
+        build_conn(:get, "/phoenix_kit/en-gb/blog")
+        |> Plug.Conn.fetch_query_params()
+        |> Map.put(:path_params, %{"locale" => "en-gb"})
+
+      conn = Auth.validate_and_set_locale(conn, [])
+
+      refute conn.halted
+      assert conn.assigns.current_locale == "en-GB"
+      assert conn.assigns.current_locale_base == "en"
+    end
+
+    test "the stored-case form processes identically" do
+      conn =
+        build_conn(:get, "/phoenix_kit/en-GB/blog")
+        |> Plug.Conn.fetch_query_params()
+        |> Map.put(:path_params, %{"locale" => "en-GB"})
+
+      conn = Auth.validate_and_set_locale(conn, [])
+
+      refute conn.halted
+      assert conn.assigns.current_locale == "en-GB"
+    end
+
+    test "a NON-enabled dialect keeps the historical redirect to its base" do
+      conn =
+        build_conn(:get, "/phoenix_kit/es-MX/blog")
+        |> Plug.Conn.fetch_query_params()
+        |> Map.put(:path_params, %{"locale" => "es-MX"})
+
+      conn = Auth.validate_and_set_locale(conn, [])
+
+      assert conn.halted
+      assert redirected_to(conn) =~ "/es/"
+    end
+  end
+
   defp build_invalid_locale_conn(path) do
     build_conn(:get, path)
     |> Plug.Conn.fetch_query_params()


### PR DESCRIPTION
Two small core changes that let publishing give each enabled sibling dialect of one base language its own public URL (paired with the phoenix_kit_publishing sibling-dialect PR — that PR's URL scheme needs this one to work end-to-end; without it, core 301s `/en-gb/...` back to `/en/...`).

## Changes

- **Locale plug accepts enabled full-dialect segments** instead of redirecting them to the base. A URL segment that case-insensitively matches an *enabled* dialect (`en-GB` → segment `en-gb`) is now served with that dialect's locale, canonicalized to lowercase; disabled dialects and unknown segments keep the existing redirect-to-base behavior. Three new integration pins in `auth_locale_test.exs`.
- **Sitemap x-default picks its entry case-insensitively**, so a full-code default language ("en-US") still matches its lowercase URL segment.

## Testing

- `mix precommit` clean (format, compile w/ warnings-as-errors, credo --strict)
- `mix test` green, including the three new locale pins
- Consumed by phoenix_kit_publishing's suite via `PHOENIX_KIT_PATH=../phoenix_kit mix test --include needs_unreleased_core` (1563 tests green)