### PR TITLE
Add UrlState: URL-backed search, filter, sort and page for list LiveViews

### DIFF
--- a/dev_docs/plans/2026-08-04-url-state-search-persistence.md
+++ b/dev_docs/plans/2026-08-04-url-state-search-persistence.md
@@ -224,14 +224,22 @@ patches the URL on every keystroke.
 
 ## Testing
 
-Encoding and decoding are pure functions over maps: unit-testable with no
-PostgreSQL, which matters because core's integration suite needs a database this
-environment does not have locally. Cases: default-dropping, alias decode,
-cast/whitelist rejection, page reset, unknown-key passthrough, empty query.
+Everything that decides a URL is a pure function over maps, so the contract is
+pinned without PostgreSQL — which matters, because core's integration suite
+needs a database this environment does not have. 41 tests cover default-
+dropping, alias decode, cast and whitelist rejection, the integer ceiling, page
+reset, unknown-key preservation, path capture and its fallbacks, rejection of a
+change keyed by URL key instead of assign name, and `reload?/3` — the single
+branch deciding whether a shared link, a Back press or a filter change reloads,
+made public precisely so it could be tested without a router.
 
-LiveView-level behaviour (`push_patch` target, hook composition with a host
-`handle_params`) via `live_isolated/3`. Runtime verification of the converted
-screens through the running Andi app over Tidewave.
+**Not covered, and deliberately so:** the `on_mount` → `:handle_params` hook →
+host `handle_params/3` ordering. `live_isolated/3` mounts without a router,
+which this module refuses by design, so exercising it needs a test router and
+endpoint that core's test support does not currently have. Building that is
+worth doing, but as its own piece of work rather than smuggled into this one.
+Until then the ordering is verified by hand against the running Andi app over
+Tidewave, together with the converted screens.
 
 ## First package — three repos
 

--- a/dev_docs/plans/2026-08-04-url-state-search-persistence.md
+++ b/dev_docs/plans/2026-08-04-url-state-search-persistence.md
@@ -112,16 +112,20 @@ variants:
 ```elixir
 use PhoenixKitWeb.Live.UrlState,
   params: [
-    q:        [default: "", alias: "search"],
-    status:   [default: nil, in: ~w(active archived)],
-    sort_by:  [default: "inserted_at", in: ~w(inserted_at name email status)],
-    sort_dir: [default: :desc, cast: :atom, in: [:asc, :desc]],
-    page:     [default: 1, cast: :integer, min: 1]
+    search_query:        [default: "", url_key: "q", alias: "search"],
+    filter_role:         [default: "all", url_key: "role"],
+    filter_account_type: [default: "all", url_key: "account_type"],
+    page:                [default: 1, cast: :integer, min: 1]
   ]
 ```
 
-- **Param key = assign name = URL key.** Adopting an existing LV means listing
-  the assigns it already has, not rewriting its template.
+- **Param key = assign name**, with `url_key:` naming the query-string key
+  separately. The real `users.ex` forced this apart: its assign is
+  `:search_query` while the URL must read `?q=`. Keeping the assign name means
+  the template is untouched by the conversion — the 700-line
+  `users.html.heex` needed no edit at all.
+- **Defaults are not always `nil`/`""`.** `filter_role` defaults to `"all"`, so
+  `"all"` is what gets omitted from the URL.
 - **`alias:`** is decoded but never encoded. `comments`, `billing`, `crm` and
   `catalogue` have already published links carrying `?search=`; MediaBrowser
   publishes `?q=`. The alias lets everything converge on `q` as the canonical
@@ -173,10 +177,35 @@ For `<.pagination>` and `<.link patch=…>`: `url_state_path(socket, page: n)`.
 
 ### Dead render
 
-`dead_render: :skip` (default) — the callback is not invoked before the socket
-connects, avoiding the duplicate query every load would otherwise cost. This is
-what `comments` does by hand. `dead_render: :call` for the public `ecommerce`
-storefront, which needs server-rendered content for indexing.
+`dead_render: :call` is the default. A `mount/3` that loads its data already
+runs on the disconnected render, so calling the callback there preserves
+exactly what the screen does today — adoption changes no behaviour and needs no
+placeholder assigns. `:skip` defers the callback until the socket connects,
+trading an empty first paint for one query per load instead of two; it is what
+`comments` does by hand, and it is wrong for the public `ecommerce` storefront,
+which must serve content to crawlers.
+
+### The callback fires only on a real change
+
+The `:handle_params` hook runs on every navigation in the LiveView, not only the
+ones this module caused. `users.ex` patches `?action=add` to open its add-user
+modal; without a guard that patch would re-run the whole user query. The
+callback therefore fires only when the decoded state differs from the last one
+(or has never run) — the same guard `MediaBrowser.Embed` applies before its
+`send_update`.
+
+### No `@impl` annotation
+
+`handle_url_state/2` is declared through `@behaviour` but must **not** be
+annotated `@impl`. A single `@impl` anywhere in a module makes Elixir demand it
+on every other callback, and core's LiveViews annotate none of their
+`mount`/`handle_event`/`handle_params`/`handle_info` — one annotation turns into
+four warnings, which `mix precommit` compiles as errors.
+
+### Unknown query keys survive
+
+Keys the spec does not declare are carried across patches verbatim, so an open
+modal's `?action=add` is not dropped the moment a filter changes.
 
 ### View mode
 
@@ -207,9 +236,16 @@ screens through the running Andi app over Tidewave.
 ## First package — three repos
 
 1. **core** — `UrlState`; convert `users`, `sessions`, `live_sessions`,
-   `jobs/index`, `media_selector`; re-base `MediaBrowser.Embed` on the shared
-   layer keeping its five keys; document the router-only contract. PR to
-   `BeamLabEU/phoenix_kit`, then release.
+   `jobs/index`, `media_selector`. PR to `BeamLabEU/phoenix_kit`, then release.
+
+   `MediaBrowser.Embed` is **not** re-based onto the shared layer. Its URL sync
+   works, and rebasing it would mean bending an LiveView-level abstraction
+   around a LiveComponent-level one — the browser drives navigation by sending
+   `{:navigate, …}` to its parent, not by handling events on the LiveView. That
+   is the same "don't refactor working code inside a fix" line drawn for the
+   other modules. What it does get is the missing sentence in its moduledoc:
+   `url_sync: true` makes the host LiveView un-embeddable, for the reason set
+   out under Constraint.
 2. **Andi** — orders and sub-orders (`handle_params` there exists but ignores
    its params). Path dep, so available immediately.
 3. **`phoenix_kit_warehouse`** — 7 LVs, every one broken, all sharing the

--- a/dev_docs/plans/2026-08-04-url-state-search-persistence.md
+++ b/dev_docs/plans/2026-08-04-url-state-search-persistence.md
@@ -1,0 +1,235 @@
+# URL-backed list state (search / filter / sort / page)
+
+**Status:** design approved, implementation not started
+**Branch:** `feature/url-state-search` (worktree `/www/phoenix_kit_search`, cut from `upstream/main` @ 918fa1b7)
+
+## Problem
+
+Typing in a list's search box filters the table but leaves the address bar
+untouched on most screens in the workspace. The result cannot be shared, does
+not survive a reload, and browser Back walks out of the page instead of back to
+the previous query.
+
+A workspace-wide audit found **26 LiveViews** with this defect, and — more
+importantly — **seven independent implementations** of the fix on the screens
+that do work:
+
+| Implementation | Shape |
+|---|---|
+| `MediaBrowser.Embed` (core) | `attach_hook` + path from `uri`; the only non-trivial one |
+| `Activity.Index` (core) | hand-rolled `maybe_put` + `URI.encode_query` |
+| `phoenix_kit_comments` | nested form params, `maybe_put`, dual clear events |
+| `phoenix_kit_billing` | flat params, `Enum.reject`, `build_url_params/2` |
+| `phoenix_kit_crm` | per-LV `contacts_path/2` / `companies_path/2` / `members_path/2` |
+| `phoenix_kit_emails` | `build_url_params/2` |
+| `phoenix_kit_ecommerce` | `FilterHelpers.build_query_string/2` + local `Carts.build_url/2` |
+
+They differ only cosmetically. Six of the seven share a real defect: they
+rebuild the path from a hardcoded string (`Routes.path("/admin/comments?…")`),
+so an LV reachable at more than one route — a sub-tab such as
+`/orders/:id/edit/files` — patches itself to the wrong page. Only
+`MediaBrowser.Embed` derives the path from the live `uri` and appends only the
+query.
+
+### Audit result
+
+| Repo | Search surfaces | Broken |
+|---|---|---|
+| core (`phoenix_kit`) | 12 | **5** — `users`, `sessions`, `live_sessions`, `jobs/index`, `media_selector` (page only) |
+| Andi (`/www/app`) | 2 | **2** — orders, sub-orders |
+| `phoenix_kit_warehouse` | 7 | **7** |
+| `phoenix_kit_catalogue` | 4 | **3** |
+| `phoenix_kit_projects` | 3 | **3** (blocked — see Constraint) |
+| `phoenix_kit_ecommerce` | 6 | **2** (`products` reads `?search=` but never writes it) |
+| `phoenix_kit_manufacturing` | 1 | **1** |
+| `phoenix_kit_emails` | 5 | **1** (`blocklist`) |
+| `phoenix_kit_staff` | 1 | **1** |
+| `phoenix_kit_billing` | 5 | **1** (`subscriptions` — `phx-submit` instead of `phx-change`) |
+| `phoenix_kit_crm` | 4 | 0 |
+| `comments`, `ai`, `document_creator`, `entities`, `hello_world`, `locations` | — | 0 |
+
+## Goals
+
+Search, filters, sort and page live in the query string. Every list state has a
+unique URL that can be pasted to a colleague or reloaded and reproduces exactly
+what the sender saw. One implementation in core replaces the seven.
+
+## Non-goals
+
+- Migrating the already-correct screens (`crm`, `comments`, `billing`, `emails`,
+  `document_creator`, `entities`, the `ecommerce` storefront). They are not
+  broken; folding them into `UrlState` is a later cleanup, kept out of this work
+  so a refactor does not ride along with a fix.
+- Moving `view_mode` (table/card) out of the database. See "view mode" below.
+- Server-side full-text search behaviour. Only the transport of the state
+  changes; each LV keeps its own query logic.
+
+## Constraint: `push_patch` and embeddability are mutually exclusive
+
+This was verified against `phoenix_live_view` source, not assumed, and it
+changes the plan for `phoenix_kit_projects`.
+
+1. `Lifecycle.attach_hook/4` **raises** for a `:handle_params` hook when
+   `socket.router == nil` (`lifecycle.ex:44`).
+2. `maybe_call_mount_handle_params/4` computes
+   `lifecycle.any? = callbacks? or exported?`. When an LV is embedded via
+   `live_render` (`socket.root_pid != self()`), `any? == true` takes the branch
+   that calls `Route.live_link_info!(%{socket | router: nil}, …)` — a guaranteed
+   raise (`channel.ex:611-617`). Exporting `handle_params/3` is therefore enough
+   to make an LV un-embeddable, whatever its body does.
+3. A `push_patch` from a root LV lands in
+   `sync_handle_params_with_live_redirect/5`, which calls
+   `Utils.call_handle_params!(socket, socket.view, params, uri)` — the 4-arity
+   form, so `exported?` defaults to **true** and `view.handle_params/3` is
+   invoked unconditionally (`channel.ex:995-1002`, `utils.ex:457`). `push_patch`
+   therefore *requires* the export.
+
+(3) requires what (2) forbids. **An LV cannot both `push_patch` and be
+embeddable via `live_render`.**
+
+Consequences:
+
+- `use PhoenixKitWeb.Live.UrlState` marks an LV **router-only**. This is a
+  documented part of the contract, not an accident.
+- `phoenix_kit_projects` deliberately removed `handle_params/3` from all 10 of
+  its LVs so Andi can embed them (`dev_docs/embedding_audit.md`, pinned by 43
+  `live_isolated/3` tests). Its 3 search surfaces are **out of scope** here.
+  Giving them URL state needs a different mechanism — a JS `history.pushState`
+  + `popstate` hook, which is what the module already does for tab state via
+  `ProjectTabsUrl`. Deferred to its own design; not speculatively seamed into
+  this one.
+- The same constraint already applies, undocumented, to
+  `MediaBrowser.Embed, url_sync: true` — its `__before_compile__` stub makes the
+  host LV un-embeddable. The moduledoc must say so.
+
+## Design
+
+### `PhoenixKitWeb.Live.UrlState`
+
+One module in core. Declarative spec replaces the seven `build_url_params`
+variants:
+
+```elixir
+use PhoenixKitWeb.Live.UrlState,
+  params: [
+    q:        [default: "", alias: "search"],
+    status:   [default: nil, in: ~w(active archived)],
+    sort_by:  [default: "inserted_at", in: ~w(inserted_at name email status)],
+    sort_dir: [default: :desc, cast: :atom, in: [:asc, :desc]],
+    page:     [default: 1, cast: :integer, min: 1]
+  ]
+```
+
+- **Param key = assign name = URL key.** Adopting an existing LV means listing
+  the assigns it already has, not rewriting its template.
+- **`alias:`** is decoded but never encoded. `comments`, `billing`, `crm` and
+  `catalogue` have already published links carrying `?search=`; MediaBrowser
+  publishes `?q=`. The alias lets everything converge on `q` as the canonical
+  key while old links keep resolving.
+- **`cast:` / `in:` / `min:`** whitelist the value; anything else falls back to
+  the default. No `String.to_existing_atom` on user input — the hazard already
+  recorded for `ReorderModal` in `CLAUDE.md`.
+
+### One callback instead of `handle_params/3`
+
+```elixir
+@impl PhoenixKitWeb.Live.UrlState
+def handle_url_state(%{q: q, status: status, page: page}, socket) do
+  assign(socket, :users, Users.list(search: q, status: status, page: page))
+end
+```
+
+Invoked from `on_mount` and from the `:handle_params` hook on every change. The
+adopting LV writes no `handle_params/3` of its own; the macro injects the stub
+that (3) above requires.
+
+### Writing state
+
+```elixir
+def handle_event("search", %{"q" => q}, socket),
+  do: {:noreply, push_url_state(socket, [q: q], replace: true)}
+
+def handle_event("filter_status", %{"status" => s}, socket),
+  do: {:noreply, push_url_state(socket, status: s)}
+```
+
+`push_url_state/3`:
+
+1. merges the changes into the current state;
+2. resets `page` to its default when anything other than `page` changed;
+3. drops every value equal to its default, so an unfiltered list is
+   `/admin/users`, not `/admin/users?q=&status=&page=1`;
+4. `push_patch`es to **the path captured from `uri` by the hook**, query
+   appended — preserving the locale segment and any parent-resource ids. This is
+   the defect the six hand-rolled versions share.
+
+**History granularity.** `replace: true` is passed for continuous input (the
+debounced search box) so a 20-character query leaves one history entry rather
+than six; discrete actions — filter select, sort, page — push a real entry.
+Every current implementation gets this wrong: Back walks the search box
+backwards a few characters at a time.
+
+For `<.pagination>` and `<.link patch=…>`: `url_state_path(socket, page: n)`.
+
+### Dead render
+
+`dead_render: :skip` (default) — the callback is not invoked before the socket
+connects, avoiding the duplicate query every load would otherwise cost. This is
+what `comments` does by hand. `dead_render: :call` for the public `ecommerce`
+storefront, which needs server-rendered content for indexing.
+
+### View mode
+
+`view_mode` stays in `user.custom_fields`. An LV may declare it as a param, and
+when the URL key is absent the stored value supplies the default — the URL
+overrides, the database seeds. A full link stays full without a second source of
+truth overwriting the user's personal preference.
+
+### Debounce
+
+300 ms becomes the standard for list search inputs and the default of
+`<.search_toolbar>`; selects fire immediately. Current spread to be normalised:
+200 ms (`catalogue/pdf_library`), 150 ms (`languages`), 100 ms
+(`SearchableSelect`), and none at all in `entities/data_navigator` — which
+patches the URL on every keystroke.
+
+## Testing
+
+Encoding and decoding are pure functions over maps: unit-testable with no
+PostgreSQL, which matters because core's integration suite needs a database this
+environment does not have locally. Cases: default-dropping, alias decode,
+cast/whitelist rejection, page reset, unknown-key passthrough, empty query.
+
+LiveView-level behaviour (`push_patch` target, hook composition with a host
+`handle_params`) via `live_isolated/3`. Runtime verification of the converted
+screens through the running Andi app over Tidewave.
+
+## First package — three repos
+
+1. **core** — `UrlState`; convert `users`, `sessions`, `live_sessions`,
+   `jobs/index`, `media_selector`; re-base `MediaBrowser.Embed` on the shared
+   layer keeping its five keys; document the router-only contract. PR to
+   `BeamLabEU/phoenix_kit`, then release.
+2. **Andi** — orders and sub-orders (`handle_params` there exists but ignores
+   its params). Path dep, so available immediately.
+3. **`phoenix_kit_warehouse`** — 7 LVs, every one broken, all sharing the
+   `ColumnManagement` macro, so one integration point covers them. Developed
+   against local core via `PHOENIX_KIT_PATH=../phoenix_kit_search`; the PR
+   cannot merge until core is released.
+
+Verification of the package on the live app, plus an `ask-glm` review pass,
+before the PRs. (`ask-kimi` is skipped — the account is at its rate limit.)
+
+## Remaining work, after the first package lands
+
+`catalogue` ×3, `ecommerce` ×2, `manufacturing` ×1, `emails/blocklist` ×1 (all
+path deps, need the core bump); `staff` ×1 and the one-line
+`billing/subscriptions` template fix (Hex, separate upstream PRs + version
+bumps); `projects` ×3 pending its own `history.pushState` design.
+
+## Open questions
+
+- Whether the already-correct seven migrate to `UrlState` later, or keep their
+  own code and only inherit the `alias`-based `q` convergence.
+- Whether `projects` gets the JS-history mode, or a router-mounted wrapper LV
+  that owns URL state and `live_render`s the embeddable inner LV.

--- a/dev_docs/pull_requests/2026/680-url-state-search-persistence/GLM_REVIEW.md
+++ b/dev_docs/pull_requests/2026/680-url-state-search-persistence/GLM_REVIEW.md
@@ -1,0 +1,86 @@
+# PR #680 — `UrlState` review log
+
+Two `ask-glm` (`elixir-review`) rounds. `ask-kimi` was skipped: the account is at
+its rate limit.
+
+## Round 1 — before the PR was opened
+
+**Verdict: APPROVE with findings.** The reviewer independently confirmed the
+parts most likely to be wrong: no atom is created from user input, the
+change-detection guard neither skips a needed reload nor fires a spurious one,
+the page-reset rule holds for every converted handler, declared and unknown key
+spaces never overlap, and the patched path cannot become an open redirect
+because `push_patch` cannot leave the current route.
+
+### Fixed in `d186b395`
+
+| Severity | Finding | Fix |
+|---|---|---|
+| IMPROVEMENT | **Unbounded integer → 500.** Page params declared `min: 1` but no `:max`. `?page=999999999999999999999999` parses, reaches Ecto as `OFFSET`, and overflows PostgreSQL's `bigint` on all five converted screens. Not a regression — the previous `String.to_integer/1` shipped the same value — but the codec is now the single validation chokepoint and bounded only one end. | Integer params get a default ceiling of 1,000,000, overridable per param. Applied in the module rather than per-LiveView, so the remaining ~20 conversions inherit it instead of each having to remember. |
+| IMPROVEMENT | **`dead_render: :skip` docs were wrong.** They promised "an empty first paint". But every conversion moved list loading out of `mount/3`, so with `:skip` the callback's assigns do not exist on the dead render and a template iterating them raises. Nothing ships broken — no conversion uses `:skip` — but the next adopter following the doc would have hit it. | Moduledoc now states the requirement: the template must tolerate the missing assign, or mount must seed a placeholder. |
+| NITPICK | **The motivating example was inert.** `show_add_user_modal` in `users.ex` is assigned by `handle_params/3` but read nowhere, and nothing patches `?action=add`. The module's comments leaned on it to justify the change-detection guard and unknown-key preservation. | Comments now cite the media selector's `?return_to=…&mode=single`, which is a live round-trip. The dead assign itself is pre-existing and left alone — out of scope for this PR. |
+
+### Accepted as a known gap
+
+**LiveView-level tests are missing.** The design doc promised `live_isolated/3`
+coverage of the `on_mount` → hook → host `handle_params/3` ordering; it was not
+delivered, because `live_isolated/3` mounts without a router and this module
+refuses that by design. Building a test router and endpoint is real work and
+belongs in its own change rather than smuggled into this one.
+
+Partially closed instead: `reload?/3` — the single branch deciding whether a
+shared link, a Back press or a filter change reloads — was made public
+specifically so it could be pinned without a router, and `url_state_path/2`
+already accepted a bare assigns map, so path capture, fallbacks, page reset and
+unknown-key preservation are all now tested. 41 tests, no PostgreSQL.
+
+The gap is recorded in the design doc rather than papered over.
+
+## Round 2 — against the published PR
+
+Aimed at what a first pass usually misses: the five conversions rather than the
+module, assigns that `mount/3` stopped setting, and handlers that push a URL
+identical to the current one (where the change-detection guard would correctly
+skip the callback and leave the screen stale).
+
+**Verdict: NEEDS-WORK, on a single finding — which does not reproduce.**
+
+### BUG-HIGH `live_sessions.ex:109` — not a defect
+
+The reviewer reported that `toggle_sort` passes `dir:` — a URL key rather than
+an assign name — and would therefore crash on `validate_changes!` on every
+column-header click.
+
+The committed line is:
+
+```elixir
+%{by: sort_by, dir: sort_dir} = toggle_sort(socket.assigns.sort, parse_sort_by(by))
+
+{:noreply, push_url_state(socket, sort_by: sort_by, sort_dir: sort_dir)}
+```
+
+Both keys are declared params. The `dir:` the reviewer saw belongs to the
+destructuring pattern on the line above — `toggle_sort/2` returns the compound
+`%{by:, dir:}` map the template consumes — not to the keyword list. No change
+made.
+
+Worth noting the guard being cited is the one added in round 1 for exactly this
+mistake, so a real instance would have been loud rather than silent.
+
+### Verified clean
+
+- **Identical-URL pushes.** `media_selector`'s upload and save paths reload in
+  place when already on page 1 and patch otherwise, so the guard cannot leave
+  the grid stale. The other four screens route every data mutation through a
+  direct `load_*` rather than the URL, so none depend on the guard for
+  correctness.
+- **Dropped assigns.** The one compound assign moved out of `mount/3` — `:sort`
+  in `live_sessions` — is set by `handle_url_state/2`, which runs on the dead
+  render too (`@loaded` is false, and `dead_render: :call` is the default), so
+  it exists before first paint.
+- **`reset_url_state/1`.** Clears every declared param, interacts correctly with
+  the page reset, and preserves unknown keys.
+- **The `.heex` changes.** The new `phx-change="search"` matches the nested
+  `%{"search" => %{"query" => …}}` clause, and `url_state_path(assigns, …)` in
+  the pagination links resolves because the private assigns are present at
+  render.

--- a/lib/phoenix_kit_web/components/media_browser/embed.ex
+++ b/lib/phoenix_kit_web/components/media_browser/embed.ex
@@ -74,6 +74,16 @@ defmodule PhoenixKitWeb.Components.MediaBrowser.Embed do
   url-synced browsers on one page would fight over them. Give only one
   the `url_sync` option in that case.
 
+  ⚠ **`url_sync: true` makes the host LiveView un-embeddable.** It cannot
+  itself be mounted with `live_render/3` afterwards. The `push_patch` this
+  option performs reaches `sync_handle_params_with_live_redirect/5`, which
+  invokes `view.handle_params/3` unconditionally — hence the stub injected
+  below — and on an embedded mount `maybe_call_mount_handle_params/4` raises
+  for any LiveView that exports `handle_params/3`, whatever its body does.
+  The stub is therefore not a formality: it is what trades embeddability for
+  a shareable URL. Hosts that must stay embeddable have to leave `url_sync`
+  off.
+
   ## What gets injected
 
   * `on_mount` — calls `MediaBrowser.setup_uploads/1` so `@uploads.media_files`

--- a/lib/phoenix_kit_web/live/modules/jobs/index.ex
+++ b/lib/phoenix_kit_web/live/modules/jobs/index.ex
@@ -7,6 +7,20 @@ defmodule PhoenixKitWeb.Live.Modules.Jobs.Index do
 
   use PhoenixKitWeb, :live_view
 
+  # Filter (queue, state, worker) and page live in the query string — a
+  # filtered list is a real URL: shareable, reload-proof, and Back returns to
+  # the previous query instead of leaving the page. `filter_queue`,
+  # `filter_state`, and `filter_worker` default to "all", which is therefore
+  # what gets omitted from the URL.
+  use PhoenixKitWeb.Live.UrlState,
+    params: [
+      filter_queue: [default: "all", url_key: "queue"],
+      filter_state: [default: "all", url_key: "state"],
+      filter_worker: [default: "all", url_key: "worker"],
+      current_page: [default: 1, cast: :integer, min: 1, url_key: "page"]
+    ],
+    page_param: :current_page
+
   import Ecto.Query
 
   alias PhoenixKit.Jobs, as: JobsModule
@@ -18,7 +32,6 @@ defmodule PhoenixKitWeb.Live.Modules.Jobs.Index do
   @per_page 25
   @refresh_interval 30_000
 
-  @impl true
   def mount(_params, _session, socket) do
     # Check if module is enabled
     if JobsModule.enabled?() do
@@ -28,22 +41,21 @@ defmodule PhoenixKitWeb.Live.Modules.Jobs.Index do
         Process.send_after(self(), :refresh, @refresh_interval)
       end
 
+      # :filter_queue, :filter_state, :filter_worker, and :current_page are
+      # assigned from the query string by UrlState before mount/3 runs —
+      # re-assigning them here would overwrite a shared link's state with the
+      # defaults.
       socket =
         socket
         |> assign(:page_title, "Jobs")
         |> assign(:project_title, project_title)
         |> assign(:url_path, Routes.path("/admin/jobs"))
-        |> assign(:filter_queue, "all")
-        |> assign(:filter_state, "all")
-        |> assign(:filter_worker, "all")
         |> assign(:hidden_workers, load_hidden_workers())
-        |> assign(:current_page, 1)
         |> assign(:per_page, @per_page)
         |> assign(:selected_job, nil)
         |> assign(:selected_scheduled_job, nil)
         |> assign(:active_tab, "oban")
         |> load_stats()
-        |> load_jobs()
         |> load_scheduled_jobs()
 
       {:ok, socket}
@@ -55,40 +67,27 @@ defmodule PhoenixKitWeb.Live.Modules.Jobs.Index do
     end
   end
 
-  @impl true
+  # The list is loaded here rather than in mount/3: UrlState calls this after
+  # mount and on every change to the query string, so one code path serves the
+  # first render, a shared link, and the Back button alike.
+  #
+  # Deliberately not annotated with @impl — a single @impl anywhere in a module
+  # makes Elixir demand it on every other callback too, and this LiveView's
+  # mount/handle_event/handle_info carry none.
+  def handle_url_state(_state, socket), do: load_jobs(socket)
+
   def handle_event("filter_queue", %{"queue" => queue}, socket) do
-    socket =
-      socket
-      |> assign(:filter_queue, queue)
-      |> assign(:current_page, 1)
-      |> load_jobs()
-
-    {:noreply, socket}
+    {:noreply, push_url_state(socket, filter_queue: queue)}
   end
 
-  @impl true
   def handle_event("filter_state", %{"state" => state}, socket) do
-    socket =
-      socket
-      |> assign(:filter_state, state)
-      |> assign(:current_page, 1)
-      |> load_jobs()
-
-    {:noreply, socket}
+    {:noreply, push_url_state(socket, filter_state: state)}
   end
 
-  @impl true
   def handle_event("filter_worker", %{"worker" => worker}, socket) do
-    socket =
-      socket
-      |> assign(:filter_worker, worker)
-      |> assign(:current_page, 1)
-      |> load_jobs()
-
-    {:noreply, socket}
+    {:noreply, push_url_state(socket, filter_worker: worker)}
   end
 
-  @impl true
   def handle_event("toggle_hide_worker", %{"worker" => worker}, socket) do
     hidden = socket.assigns.hidden_workers
 
@@ -101,68 +100,56 @@ defmodule PhoenixKitWeb.Live.Modules.Jobs.Index do
 
     save_hidden_workers(new_hidden)
 
+    # hidden_workers is settings-backed (not a URL param), so we reload the
+    # list directly rather than routing through push_url_state.
     socket =
       socket
       |> assign(:hidden_workers, new_hidden)
-      |> assign(:current_page, 1)
       |> load_jobs()
 
     {:noreply, socket}
   end
 
-  @impl true
   def handle_event("clear_hidden_workers", _params, socket) do
     save_hidden_workers([])
 
     socket =
       socket
       |> assign(:hidden_workers, [])
-      |> assign(:current_page, 1)
       |> load_jobs()
 
     {:noreply, socket}
   end
 
-  @impl true
   def handle_event("change_page", %{"page" => page}, socket) do
-    page = String.to_integer(page)
-
-    socket =
-      socket
-      |> assign(:current_page, page)
-      |> load_jobs()
-
-    {:noreply, socket}
+    case Integer.parse(page) do
+      {page, ""} when page > 0 -> {:noreply, push_url_state(socket, current_page: page)}
+      _ -> {:noreply, socket}
+    end
   end
 
-  @impl true
   def handle_event("show_job", %{"id" => id}, socket) do
     job = load_job(String.to_integer(id))
     {:noreply, assign(socket, :selected_job, job)}
   end
 
-  @impl true
   def handle_event("close_job", _params, socket) do
     {:noreply, assign(socket, :selected_job, nil)}
   end
 
-  @impl true
   def handle_event("switch_tab", %{"tab" => tab}, socket) do
     {:noreply, assign(socket, :active_tab, tab)}
   end
 
-  @impl true
   def handle_event("show_scheduled_job", %{"id" => id}, socket) do
     job = load_scheduled_job(id)
     {:noreply, assign(socket, :selected_scheduled_job, job)}
   end
 
-  @impl true
   def handle_event("close_scheduled_job", _params, socket) do
     {:noreply, assign(socket, :selected_scheduled_job, nil)}
   end
 
-  @impl true
   def handle_info(:refresh, socket) do
     Process.send_after(self(), :refresh, @refresh_interval)
 

--- a/lib/phoenix_kit_web/live/url_state.ex
+++ b/lib/phoenix_kit_web/live/url_state.ex
@@ -115,6 +115,19 @@ defmodule PhoenixKitWeb.Live.UrlState do
   state hook composes alongside it — both run. Only a LiveView with no
   `handle_params/3` of its own gets the stub that `push_patch` requires.
 
+  ## Setting a declared param outside an event
+
+  Prefer `push_url_state/3` so the address bar changes with the state. But a
+  plain `assign/3` on a declared param is safe: the next patch reads its merge
+  base back from the assigns, so the freshest value wins and the URL catches
+  up rather than resurrecting what was superseded.
+
+  This matters for screens that adjust their own state as a side effect — a
+  list re-picking its sort column after the current one is hidden, say. Before
+  this was handled, such a reset left the old column in the URL, the next
+  search re-applied it, and a reload sorted by a column that was no longer
+  visible.
+
   ## `@impl` is all-or-nothing
 
   Elixir demands `@impl` on *every* callback of a module that uses it on any
@@ -510,7 +523,7 @@ defmodule PhoenixKitWeb.Live.UrlState do
 
     state =
       assigns
-      |> Map.fetch!(@state_assign)
+      |> current_state(cfg)
       |> Map.merge(changes)
       |> maybe_reset_page(changes, cfg)
       |> sanitize(cfg)
@@ -519,6 +532,22 @@ defmodule PhoenixKitWeb.Live.UrlState do
     extra = assigns[@extra_assign] || %{}
 
     build_path(path, state, cfg, extra)
+  end
+
+  # The merge base is read back from the individual assigns, not from the
+  # bookkeeping state map, because the two can legitimately drift: a LiveView
+  # may set a declared param with a plain `assign` — a list re-picking its sort
+  # column after the current one is hidden does exactly that. Merging onto the
+  # stale map would then resurrect the old value on the next patch, and a
+  # reload would apply it. Reading the assigns makes the freshest value win,
+  # whichever way it was set. The map is only a fallback for a param an
+  # unusual LiveView has dropped from its assigns.
+  defp current_state(assigns, cfg) do
+    stored = Map.get(assigns, @state_assign, %{})
+
+    Map.new(cfg.params, fn spec ->
+      {spec.key, Map.get(assigns, spec.key, Map.get(stored, spec.key, spec.default))}
+    end)
   end
 
   # Changes are keyed by assign name, not by URL key — an easy thing to get

--- a/lib/phoenix_kit_web/live/url_state.ex
+++ b/lib/phoenix_kit_web/live/url_state.ex
@@ -114,6 +114,20 @@ defmodule PhoenixKitWeb.Live.UrlState do
   If the LiveView already defines its own `handle_params/3` it is kept, and the
   state hook composes alongside it — both run. Only a LiveView with no
   `handle_params/3` of its own gets the stub that `push_patch` requires.
+
+  ## `@impl` is all-or-nothing
+
+  Elixir demands `@impl` on *every* callback of a module that uses it on any
+  one of them, so match whatever the LiveView already does:
+
+    * **Annotates nothing** (core's own LiveViews) — leave `handle_url_state/2`
+      bare. Adding `@impl` here turns `mount/3`, `handle_event/3` and friends
+      into warnings, which `mix precommit` compiles as errors.
+    * **Annotates its callbacks** (Andi's LiveViews) — annotate
+      `handle_url_state/2` too, *and* define an explicit
+      `@impl true def handle_params(_params, _uri, socket), do: {:noreply, socket}`.
+      The stub injected below carries no `@impl`, so letting it be injected into
+      an annotating module is itself a warning.
   """
 
   @typedoc "Decoded state: assign name => value"
@@ -554,18 +568,30 @@ defmodule PhoenixKitWeb.Live.UrlState do
 
   defmacro __using__(opts) do
     params = Keyword.get(opts, :params) || raise ArgumentError, "missing :params"
-    cfg = normalize!(params, opts)
 
+    # The spec is normalised in the CALLER's module body, not here. At macro
+    # expansion the option values are still unexpanded AST: `in: [:asc, :desc]`
+    # happens to *be* a list of atoms and so works by accident, but
+    # `in: ~w(name email)` is a `{:sigil_w, …}` node, and matching a URL value
+    # against a tuple raises Protocol.UndefinedError at request time — past
+    # compilation, past the codec's own tests. Unquoting the options into a
+    # module attribute makes them evaluate normally, so the spec sees the list
+    # the sigil produces.
     quote do
       @behaviour PhoenixKitWeb.Live.UrlState
 
       import PhoenixKitWeb.Live.UrlState,
         only: [push_url_state: 2, push_url_state: 3, url_state_path: 2, reset_url_state: 1]
 
-      @doc false
-      def __phoenix_kit_url_state__, do: unquote(Macro.escape(cfg))
+      @phoenix_kit_url_state_cfg PhoenixKitWeb.Live.UrlState.normalize!(
+                                   unquote(params),
+                                   unquote(opts)
+                                 )
 
-      on_mount({PhoenixKitWeb.Live.UrlState, {:url_state, unquote(Macro.escape(cfg))}})
+      @doc false
+      def __phoenix_kit_url_state__, do: @phoenix_kit_url_state_cfg
+
+      on_mount({PhoenixKitWeb.Live.UrlState, {:url_state, @phoenix_kit_url_state_cfg}})
 
       @before_compile PhoenixKitWeb.Live.UrlState
     end

--- a/lib/phoenix_kit_web/live/url_state.ex
+++ b/lib/phoenix_kit_web/live/url_state.ex
@@ -126,6 +126,7 @@ defmodule PhoenixKitWeb.Live.UrlState do
   @path_assign :__phoenix_kit_url_path__
   @extra_assign :__phoenix_kit_url_extra__
   @loaded_assign :__phoenix_kit_url_loaded__
+  @cfg_assign :__phoenix_kit_url_cfg__
 
   # ── Compile-time spec normalisation ──────────────────────────────────
 
@@ -329,6 +330,7 @@ defmodule PhoenixKitWeb.Live.UrlState do
       |> assign_state(decode(params, cfg), cfg)
       |> Phoenix.Component.assign(@extra_assign, extra_params(params, cfg))
       |> Phoenix.Component.assign(@loaded_assign, false)
+      |> Phoenix.Component.assign(@cfg_assign, cfg)
       |> Phoenix.LiveView.attach_hook(:phoenix_kit_url_state, :handle_params, &handle_params/3)
 
     {:cont, socket}
@@ -404,7 +406,30 @@ defmodule PhoenixKitWeb.Live.UrlState do
 
   defp extra_params(_params, _cfg), do: %{}
 
-  defp config!(socket), do: socket.view.__phoenix_kit_url_state__()
+  # Accepts a socket or a bare assigns map. Inside a template `@socket.assigns`
+  # has been swapped for `%Socket.AssignsNotInSocket{}`, which raises on access
+  # — so a HEEX caller passes `assigns` instead, and the config travels in an
+  # assign rather than being read back off `socket.view`.
+  defp assigns_of(%Phoenix.LiveView.Socket{assigns: assigns}), do: assigns
+  defp assigns_of(assigns) when is_map(assigns), do: assigns
+
+  defp config!(socket_or_assigns) do
+    case assigns_of(socket_or_assigns) do
+      %{@cfg_assign => cfg} ->
+        cfg
+
+      _ ->
+        raise ArgumentError, """
+        UrlState config not found in assigns.
+
+        Inside a HEEX template pass `assigns`, not `@socket` — LiveView replaces
+        `socket.assigns` with %Phoenix.LiveView.Socket.AssignsNotInSocket{} while
+        rendering, so `@socket` cannot carry state into a template:
+
+            <.link patch={url_state_path(assigns, page: 2)}>2</.link>
+        """
+    end
+  end
 
   # ── Runtime: writing state ───────────────────────────────────────────
 
@@ -427,20 +452,26 @@ defmodule PhoenixKitWeb.Live.UrlState do
   @doc """
   The path this LiveView would patch to for `changes` — for `<.link patch=…>`
   and `<.pagination>`, which navigate by href rather than by event.
+
+  Takes a socket, or — from inside a template, where `@socket` carries no
+  assigns — the template's own `assigns`:
+
+      <.link patch={url_state_path(assigns, page: page)}>{page}</.link>
   """
-  @spec url_state_path(Phoenix.LiveView.Socket.t(), keyword() | map()) :: String.t()
-  def url_state_path(socket, changes) do
-    cfg = config!(socket)
+  @spec url_state_path(Phoenix.LiveView.Socket.t() | map(), keyword() | map()) :: String.t()
+  def url_state_path(socket_or_assigns, changes) do
+    assigns = assigns_of(socket_or_assigns)
+    cfg = config!(assigns)
     changes = Map.new(changes)
 
     state =
-      socket.assigns
+      assigns
       |> Map.fetch!(@state_assign)
       |> Map.merge(changes)
       |> maybe_reset_page(changes, cfg)
 
-    path = socket.assigns[@path_assign] || socket.assigns[:url_path] || "/"
-    extra = socket.assigns[@extra_assign] || %{}
+    path = assigns[@path_assign] || assigns[:url_path] || "/"
+    extra = assigns[@extra_assign] || %{}
 
     build_path(path, state, cfg, extra)
   end

--- a/lib/phoenix_kit_web/live/url_state.ex
+++ b/lib/phoenix_kit_web/live/url_state.ex
@@ -91,10 +91,11 @@ defmodule PhoenixKitWeb.Live.UrlState do
   For links rather than events (`<.pagination>`, `<.link patch=…>`), build the
   target with `url_state_path/2`.
 
-  ## This LiveView becomes router-only
+  ## `:patch` is router-only; embeddable LiveViews need `:history`
 
-  A LiveView using this module **cannot be embedded with `live_render/3`**. The
-  two requirements are mutually exclusive in Phoenix LiveView itself:
+  The default, `mode: :patch`, makes a LiveView **impossible to embed with
+  `live_render/3`**. The two requirements are mutually exclusive in Phoenix
+  LiveView itself:
 
     * `push_patch` from a root LiveView reaches
       `sync_handle_params_with_live_redirect/5`, which invokes
@@ -107,13 +108,42 @@ defmodule PhoenixKitWeb.Live.UrlState do
       exporting `handle_params/3` — whatever its body — makes a LiveView
       un-embeddable.
 
-  An embeddable LiveView therefore needs a different mechanism entirely
-  (client-side `history.pushState` plus a `popstate` listener), which this
-  module does not provide.
+  One requires exactly what the other forbids. `mode: :history` sidesteps both
+  by never touching `handle_params` at all: the browser owns the URL, and the
+  LiveView talks to it through a JS hook.
 
-  If the LiveView already defines its own `handle_params/3` it is kept, and the
-  state hook composes alongside it — both run. Only a LiveView with no
-  `handle_params/3` of its own gets the stub that `push_patch` requires.
+      use PhoenixKitWeb.Live.UrlState,
+        mode: :history,
+        params: [search: [default: "", url_key: "q"]]
+
+  The template must render the hook's element once:
+
+      <.url_state_sync mode={:history} />
+
+  What changes in `:history` mode:
+
+    * `push_url_state/3` applies the state itself and pushes the new query to
+      the client, which rewrites the address bar (`pushState`, or
+      `replaceState` when you pass `replace: true`). There is no round trip.
+    * Back and Forward arrive as a `popstate` report from the hook, decoded the
+      same way a patch would be.
+    * **The LiveView keeps loading its list in `mount/3`.** There is no
+      `handle_params` to hang the first call on, so `handle_url_state/2` serves
+      changes only. Declared params are still assigned before `mount/3` runs,
+      so a router-mounted LiveView loads the right thing immediately.
+    * On an embedded mount, params arrive as `:not_mounted_at_router`, so
+      `mount/3` sees the defaults and the hook corrects it on connect — one
+      extra load, and only when the URL actually carried state.
+    * `url_state_path/2` and `<.link patch=…>` do **not** apply — there is no
+      router to patch against. Drive everything through events.
+    * Only the query is exchanged; the path stays client-side, because an
+      embedded LiveView does not know what page it is on. One synced LiveView
+      per page — two would fight over the same query keys.
+
+  In `:patch` mode, a LiveView that already defines its own `handle_params/3`
+  keeps it and the state hook composes alongside — both run. Only one without
+  it gets the stub that `push_patch` requires; in `:history` mode the stub is
+  deliberately never injected.
 
   ## Setting a declared param outside an event
 
@@ -157,6 +187,9 @@ defmodule PhoenixKitWeb.Live.UrlState do
 
   @state_assign :__phoenix_kit_url_state__
   @path_assign :__phoenix_kit_url_path__
+  # For url_state_sync/1 — the only markup this module owns.
+  use Phoenix.Component
+
   @extra_assign :__phoenix_kit_url_extra__
   @loaded_assign :__phoenix_kit_url_loaded__
   @cfg_assign :__phoenix_kit_url_cfg__
@@ -180,6 +213,7 @@ defmodule PhoenixKitWeb.Live.UrlState do
 
     %{
       params: specs,
+      mode: validate_mode!(Keyword.get(opts, :mode, :patch)),
       dead_render: validate_dead_render!(Keyword.get(opts, :dead_render, :call)),
       page_param: resolve_page_param!(Keyword.get(opts, :page_param, :__auto__), specs)
     }
@@ -234,6 +268,12 @@ defmodule PhoenixKitWeb.Live.UrlState do
   @default_integer_max 1_000_000
   defp integer_max(:integer, opts), do: Keyword.get(opts, :max, @default_integer_max)
   defp integer_max(_cast, opts), do: Keyword.get(opts, :max)
+
+  defp validate_mode!(value) when value in [:patch, :history], do: value
+
+  defp validate_mode!(other) do
+    raise ArgumentError, ":mode must be :patch or :history, got: #{inspect(other)}"
+  end
 
   defp validate_dead_render!(value) when value in [:skip, :call], do: value
 
@@ -364,18 +404,59 @@ defmodule PhoenixKitWeb.Live.UrlState do
 
   @doc false
   def on_mount({:url_state, cfg}, params, _session, socket) do
-    ensure_router!(socket)
+    if cfg.mode == :patch, do: ensure_router!(socket)
 
     socket =
       socket
       |> assign_state(decode(params, cfg), cfg)
       |> Phoenix.Component.assign(@extra_assign, extra_params(params, cfg))
-      |> Phoenix.Component.assign(@loaded_assign, false)
+      # :patch has a handle_params hook to make the first call; :history has
+      # none, so its LiveViews load in mount/3 and are already "loaded" by the
+      # time the client reports the query. Marking it here keeps that report
+      # from costing a redundant query whenever the URL held nothing anyway.
+      |> Phoenix.Component.assign(@loaded_assign, cfg.mode == :history)
       |> Phoenix.Component.assign(@cfg_assign, cfg)
-      |> Phoenix.LiveView.attach_hook(:phoenix_kit_url_state, :handle_params, &handle_params/3)
+      |> attach_mode_hooks(cfg)
 
     {:cont, socket}
   end
+
+  defp attach_mode_hooks(socket, %{mode: :patch}) do
+    Phoenix.LiveView.attach_hook(socket, :phoenix_kit_url_state, :handle_params, &handle_params/3)
+  end
+
+  # :history never touches handle_params — attaching that stage raises outright
+  # when the view has no router, and exporting the callback is what makes a
+  # LiveView un-embeddable in the first place. A :handle_event hook has no such
+  # restriction, so the client drives the state through two events instead.
+  defp attach_mode_hooks(socket, %{mode: :history}) do
+    Phoenix.LiveView.attach_hook(socket, :phoenix_kit_url_state, :handle_event, &handle_client/3)
+  end
+
+  # The browser owns the URL in :history mode, so it is also the only thing that
+  # knows the query on an embedded mount, where params arrive as
+  # :not_mounted_at_router. The hook reports it once on connect, and again on
+  # every popstate — which is what makes Back work without a router.
+  defp handle_client("phoenix_kit_url_state", %{"query" => query}, socket) do
+    cfg = config!(socket)
+    params = decode_query(query)
+    state = decode(params, cfg)
+
+    socket =
+      socket
+      |> Phoenix.Component.assign(@extra_assign, extra_params(params, cfg))
+      |> apply_state(state, cfg)
+
+    {:halt, socket}
+  end
+
+  defp handle_client(_event, _params, socket), do: {:cont, socket}
+
+  defp decode_query(query) when is_binary(query) do
+    query |> String.trim_leading("?") |> URI.decode_query()
+  end
+
+  defp decode_query(_query), do: %{}
 
   # A LiveView using this module exports handle_params/3 (its own or the
   # injected stub), which already makes an embedded mount fail deep inside
@@ -398,20 +479,29 @@ defmodule PhoenixKitWeb.Live.UrlState do
 
   defp handle_params(params, uri, socket) do
     cfg = config!(socket)
-    state = decode(params, cfg)
-    reload? = reload?(socket.assigns[@loaded_assign], state, socket.assigns[@state_assign])
 
     socket =
       socket
       |> Phoenix.Component.assign(@path_assign, URI.parse(uri).path)
       |> Phoenix.Component.assign(@extra_assign, extra_params(params, cfg))
-      |> assign_state(state, cfg)
+      |> apply_state(decode(params, cfg), cfg)
+
+    {:cont, socket}
+  end
+
+  # Assign the decoded state and, if it actually moved, hand it to the
+  # LiveView's callback. Shared by both modes: the patch hook, the client's
+  # init/popstate report, and the local application in :history mode all need
+  # exactly this.
+  defp apply_state(socket, state, cfg) do
+    reload? = reload?(socket.assigns[@loaded_assign], state, socket.assigns[@state_assign])
+    socket = assign_state(socket, state, cfg)
 
     if reload? and run_callback?(socket, cfg) do
       socket = Phoenix.Component.assign(socket, @loaded_assign, true)
-      {:cont, socket.view.handle_url_state(state, socket)}
+      socket.view.handle_url_state(state, socket)
     else
-      {:cont, socket}
+      socket
     end
   end
 
@@ -500,10 +590,31 @@ defmodule PhoenixKitWeb.Live.UrlState do
   @spec push_url_state(Phoenix.LiveView.Socket.t(), keyword() | map(), keyword()) ::
           Phoenix.LiveView.Socket.t()
   def push_url_state(socket, changes, opts \\ []) do
-    Phoenix.LiveView.push_patch(socket,
-      to: url_state_path(socket, changes),
-      replace: Keyword.get(opts, :replace, false)
-    )
+    cfg = config!(socket)
+    replace? = Keyword.get(opts, :replace, false)
+
+    case cfg.mode do
+      :patch ->
+        Phoenix.LiveView.push_patch(socket,
+          to: url_state_path(socket, changes),
+          replace: replace?
+        )
+
+      # No patch to bounce off, so the state is applied here and the browser is
+      # told to rewrite its address bar. The path stays client-side on purpose:
+      # an embedded LiveView has no idea what page it is on.
+      :history ->
+        assigns = assigns_of(socket)
+        state = next_state(assigns, changes, cfg)
+        query = state |> encode(cfg, assigns[@extra_assign] || %{}) |> URI.encode_query()
+
+        socket
+        |> Phoenix.LiveView.push_event("phoenix_kit_url_state", %{
+          query: query,
+          replace: replace?
+        })
+        |> apply_state(state, cfg)
+    end
   end
 
   @doc """
@@ -519,19 +630,24 @@ defmodule PhoenixKitWeb.Live.UrlState do
   def url_state_path(socket_or_assigns, changes) do
     assigns = assigns_of(socket_or_assigns)
     cfg = config!(assigns)
-    changes = changes |> Map.new() |> validate_changes!(cfg)
-
-    state =
-      assigns
-      |> current_state(cfg)
-      |> Map.merge(changes)
-      |> maybe_reset_page(changes, cfg)
-      |> sanitize(cfg)
 
     path = assigns[@path_assign] || assigns[:url_path] || "/"
     extra = assigns[@extra_assign] || %{}
 
-    build_path(path, state, cfg, extra)
+    build_path(path, next_state(assigns, changes, cfg), cfg, extra)
+  end
+
+  # The state a set of changes resolves to: merged onto what the assigns
+  # currently hold, page reset when anything else moved, and sanitised so
+  # nothing the decoder would reject can reach the URL.
+  defp next_state(assigns, changes, cfg) do
+    changes = changes |> Map.new() |> validate_changes!(cfg)
+
+    assigns
+    |> current_state(cfg)
+    |> Map.merge(changes)
+    |> maybe_reset_page(changes, cfg)
+    |> sanitize(cfg)
   end
 
   # The merge base is read back from the individual assigns, not from the
@@ -612,7 +728,25 @@ defmodule PhoenixKitWeb.Live.UrlState do
     cfg = config!(socket)
     defaults = Map.new(cfg.params, &{&1.key, &1.default})
 
-    Phoenix.LiveView.push_patch(socket, to: url_state_path(socket, defaults))
+    push_url_state(socket, defaults)
+  end
+
+  @doc """
+  Renders the element `mode: :history` needs, and nothing in `:patch` mode.
+
+  The browser owns the URL there, so something has to carry the JS hook that
+  reports the query on connect, rewrites the address bar on a change, and
+  reports Back and Forward. Put it anywhere inside the LiveView's own markup:
+
+      <.url_state_sync mode={:history} />
+  """
+  attr :mode, :atom, default: :patch, doc: "the `:mode` the LiveView declared"
+  attr :id, :string, default: "phoenix-kit-url-state", doc: "unique when nested"
+
+  def url_state_sync(assigns) do
+    ~H"""
+    <div :if={@mode == :history} id={@id} phx-hook="PhoenixKitUrlState" hidden></div>
+    """
   end
 
   # ── use ──────────────────────────────────────────────────────────────
@@ -632,7 +766,13 @@ defmodule PhoenixKitWeb.Live.UrlState do
       @behaviour PhoenixKitWeb.Live.UrlState
 
       import PhoenixKitWeb.Live.UrlState,
-        only: [push_url_state: 2, push_url_state: 3, url_state_path: 2, reset_url_state: 1]
+        only: [
+          push_url_state: 2,
+          push_url_state: 3,
+          url_state_path: 2,
+          reset_url_state: 1,
+          url_state_sync: 1
+        ]
 
       @phoenix_kit_url_state_cfg PhoenixKitWeb.Live.UrlState.normalize!(
                                    unquote(params),
@@ -649,18 +789,24 @@ defmodule PhoenixKitWeb.Live.UrlState do
   end
 
   defmacro __before_compile__(env) do
-    # push_patch routes through sync_handle_params_with_live_redirect/5, which
-    # calls Utils.call_handle_params!/4 — the arity whose `exported?` defaults
-    # to true. view.handle_params/3 is therefore invoked whether or not the
-    # LiveView defines it, so a LiveView without one needs a stub. One that has
-    # its own keeps it; the :handle_params hook composes alongside.
-    if Module.defines?(env.module, {:handle_params, 3}) do
-      quote(do: nil)
-    else
+    cfg = Module.get_attribute(env.module, :phoenix_kit_url_state_cfg)
+
+    # In :patch mode, push_patch routes through
+    # sync_handle_params_with_live_redirect/5, which calls
+    # Utils.call_handle_params!/4 — the arity whose `exported?` defaults to
+    # true. view.handle_params/3 is therefore invoked whether or not the
+    # LiveView defines it, so one without it needs a stub.
+    #
+    # In :history mode the stub must NOT be injected: exporting handle_params/3
+    # is precisely what makes a LiveView un-embeddable, which is the whole
+    # reason that mode exists.
+    if cfg.mode == :patch and not Module.defines?(env.module, {:handle_params, 3}) do
       quote do
         @doc false
         def handle_params(_params, _uri, socket), do: {:noreply, socket}
       end
+    else
+      quote(do: nil)
     end
   end
 end

--- a/lib/phoenix_kit_web/live/url_state.ex
+++ b/lib/phoenix_kit_web/live/url_state.ex
@@ -49,11 +49,13 @@ defmodule PhoenixKitWeb.Live.UrlState do
       **Required for `cast: :atom`**: the incoming string is matched against
       this list, so no atom is ever created from user input.
     * `:min` / `:max` — bounds for `cast: :integer`. Out-of-range falls back to
-      the default.
+      the default. `:max` defaults to 1_000_000 for integers: an unbounded page
+      number out of the URL overflows PostgreSQL's `bigint` once it reaches
+      `OFFSET`, turning a crafted link into a 500.
 
-  Unknown query keys are preserved across patches, so an unrelated param
-  (a modal's `?action=add`, a tracking tag) is not dropped when a filter
-  changes.
+  Unknown query keys are preserved across patches, so an unrelated param is not
+  dropped when a filter changes — the media selector is opened with
+  `?return_to=…&mode=single`, and both survive a search.
 
   ## Options
 
@@ -62,9 +64,13 @@ defmodule PhoenixKitWeb.Live.UrlState do
       disconnected render as well, so the first paint already carries the list.
       This is what a `mount/3` that loads its data already does, which is why it
       is the default: adopting the module does not change what the user sees.
-      `:skip` runs the callback only once the socket is connected, trading an
-      empty first paint for one query per page load instead of two — worth it on
-      a heavy list, wrong on a page that must serve content to crawlers.
+      `:skip` runs the callback only once the socket is connected, halving the
+      queries per page load — worth it on a heavy list, wrong on a page that
+      must serve content to crawlers. ⚠ With `:skip` the callback has not run
+      when the disconnected render happens, so **any assign the callback sets
+      does not exist yet**: the template must tolerate that (`@users || []`),
+      or mount must seed a placeholder. Otherwise the dead render raises rather
+      than merely painting empty.
     * `:page_param` — the assign reset whenever another parameter changes.
       Defaults to `:page` when the spec declares it; `false` disables the reset.
 
@@ -185,7 +191,7 @@ defmodule PhoenixKitWeb.Live.UrlState do
       cast: cast,
       allowed: allowed,
       min: Keyword.get(opts, :min),
-      max: Keyword.get(opts, :max)
+      max: integer_max(cast, opts)
     }
   end
 
@@ -193,6 +199,14 @@ defmodule PhoenixKitWeb.Live.UrlState do
     raise ArgumentError,
           "PhoenixKit.UrlState params must be `assign_name: [default: …]`, got: #{inspect(other)}"
   end
+
+  # An unbounded integer from the URL is a 500 waiting to happen: a page number
+  # of 10^24 survives Integer.parse, reaches Ecto as OFFSET, and overflows
+  # PostgreSQL's bigint. Integer params therefore get a ceiling whether or not
+  # the caller thought to set one; anything above it falls back to the default.
+  @default_integer_max 1_000_000
+  defp integer_max(:integer, opts), do: Keyword.get(opts, :max, @default_integer_max)
+  defp integer_max(_cast, opts), do: Keyword.get(opts, :max)
 
   defp validate_dead_render!(value) when value in [:skip, :call], do: value
 
@@ -358,7 +372,7 @@ defmodule PhoenixKitWeb.Live.UrlState do
   defp handle_params(params, uri, socket) do
     cfg = config!(socket)
     state = decode(params, cfg)
-    changed? = not socket.assigns[@loaded_assign] or state != socket.assigns[@state_assign]
+    reload? = reload?(socket.assigns[@loaded_assign], state, socket.assigns[@state_assign])
 
     socket =
       socket
@@ -366,7 +380,7 @@ defmodule PhoenixKitWeb.Live.UrlState do
       |> Phoenix.Component.assign(@extra_assign, extra_params(params, cfg))
       |> assign_state(state, cfg)
 
-    if changed? and run_callback?(socket, cfg) do
+    if reload? and run_callback?(socket, cfg) do
       socket = Phoenix.Component.assign(socket, @loaded_assign, true)
       {:cont, socket.view.handle_url_state(state, socket)}
     else
@@ -374,10 +388,25 @@ defmodule PhoenixKitWeb.Live.UrlState do
     end
   end
 
-  # The hook runs on every navigation in this LiveView, not only ones this
-  # module caused. A patch that touches an unrelated query key — a modal's
-  # ?action=add, say — must not make the list re-run its queries, so the
-  # callback fires only when the declared state actually differs.
+  @doc """
+  Whether a navigation should re-run `handle_url_state/2`.
+
+  The hook fires on every navigation in the LiveView, not only the ones this
+  module caused. A patch touching an unrelated query key — the media selector's
+  `?return_to=…`, a host LiveView's own patch — must not make the list re-run
+  its queries, so the callback runs only when the declared state actually
+  differs, or when it has never run at all.
+
+  Public because it is the one branch that decides whether a shared link, a
+  Back press or a filter change reloads; it is worth pinning in a test without
+  a router.
+  """
+  @spec reload?(boolean() | nil, state(), state() | nil) :: boolean()
+  def reload?(loaded?, new_state, previous_state)
+  def reload?(true, state, state), do: false
+  def reload?(true, _new, _previous), do: true
+  def reload?(_not_loaded, _new, _previous), do: true
+
   defp run_callback?(socket, cfg) do
     cfg.dead_render == :call or Phoenix.LiveView.connected?(socket)
   end
@@ -390,8 +419,9 @@ defmodule PhoenixKitWeb.Live.UrlState do
     end)
   end
 
-  # Query keys the spec does not own — kept verbatim so that, say, an open
-  # modal's ?action=add is not dropped the moment a filter changes.
+  # Query keys the spec does not own — kept verbatim so that the media
+  # selector's ?return_to=…&mode=single is not dropped the moment a filter
+  # changes, stranding the user with no way back.
   defp extra_params(params, cfg) when is_map(params) do
     known =
       Enum.flat_map(cfg.params, fn spec -> [spec.url_key | spec.aliases] end)
@@ -462,7 +492,7 @@ defmodule PhoenixKitWeb.Live.UrlState do
   def url_state_path(socket_or_assigns, changes) do
     assigns = assigns_of(socket_or_assigns)
     cfg = config!(assigns)
-    changes = Map.new(changes)
+    changes = changes |> Map.new() |> validate_changes!(cfg)
 
     state =
       assigns
@@ -474,6 +504,27 @@ defmodule PhoenixKitWeb.Live.UrlState do
     extra = assigns[@extra_assign] || %{}
 
     build_path(path, state, cfg, extra)
+  end
+
+  # Changes are keyed by assign name, not by URL key — an easy thing to get
+  # backwards. Left unchecked, `push_url_state(socket, q: "x")` on a param
+  # declared as `search_query: [url_key: "q"]` would silently do nothing except
+  # reset the page, which reads as "search is broken" with no error anywhere.
+  defp validate_changes!(changes, cfg) do
+    declared = MapSet.new(cfg.params, & &1.key)
+
+    case Enum.reject(Map.keys(changes), &MapSet.member?(declared, &1)) do
+      [] ->
+        changes
+
+      unknown ->
+        raise ArgumentError, """
+        unknown UrlState parameter(s): #{inspect(unknown)}
+
+        Changes are keyed by assign name, not by URL key. Declared: \
+        #{inspect(MapSet.to_list(declared))}
+        """
+    end
   end
 
   defp maybe_reset_page(state, _changes, %{page_param: false}), do: state

--- a/lib/phoenix_kit_web/live/url_state.ex
+++ b/lib/phoenix_kit_web/live/url_state.ex
@@ -1,0 +1,507 @@
+defmodule PhoenixKitWeb.Live.UrlState do
+  @moduledoc """
+  URL-backed list state for LiveView index pages — search, filters, sort, page.
+
+  A list screen's state belongs in the address bar: the result is then a real
+  URL that can be pasted to a colleague, bookmarked, and reproduced by a reload,
+  and the browser Back button returns to the previous query instead of leaving
+  the page.
+
+  Declare the state, handle one callback, and push changes:
+
+      defmodule MyAppWeb.UsersLive do
+        use MyAppWeb, :live_view
+
+        use PhoenixKitWeb.Live.UrlState,
+          params: [
+            search_query: [default: "", url_key: "q", alias: "search"],
+            filter_role:  [default: "all", url_key: "role"],
+            sort_by:      [default: "inserted_at", in: ~w(inserted_at email)],
+            sort_dir:     [default: :desc, cast: :atom, in: [:asc, :desc]],
+            page:         [default: 1, cast: :integer, min: 1]
+          ]
+
+        def handle_url_state(state, socket) do
+          assign(socket, :users, Users.list(state))
+        end
+
+        def handle_event("search", %{"search" => q}, socket) do
+          {:noreply, push_url_state(socket, [search_query: q], replace: true)}
+        end
+      end
+
+  ## Parameter spec
+
+  Each entry is `assign_name: opts`. The key is the socket assign the value
+  lands in, so adopting an existing LiveView is a matter of listing the assigns
+  it already has — its template does not change.
+
+    * `:default` — required. The value used when the key is absent or invalid.
+      Values equal to the default are **omitted from the query string**, so an
+      unfiltered list is `/admin/users`, not `/admin/users?q=&role=all&page=1`.
+    * `:url_key` — the query-string key. Defaults to the assign name. Use it
+      when the assign is `:search_query` but the URL should read `?q=`.
+    * `:alias` — an additional key accepted when **reading**, never written.
+      Lets a screen that already published `?search=` links converge on `?q=`
+      without breaking them. Accepts a string or a list of strings.
+    * `:cast` — `:string` (default), `:integer`, `:atom` or `:boolean`.
+    * `:in` — allowed values. Anything else falls back to the default.
+      **Required for `cast: :atom`**: the incoming string is matched against
+      this list, so no atom is ever created from user input.
+    * `:min` / `:max` — bounds for `cast: :integer`. Out-of-range falls back to
+      the default.
+
+  Unknown query keys are preserved across patches, so an unrelated param
+  (a modal's `?action=add`, a tracking tag) is not dropped when a filter
+  changes.
+
+  ## Options
+
+    * `:params` — the spec above. Required.
+    * `:dead_render` — `:call` (default) runs `handle_url_state/2` on the
+      disconnected render as well, so the first paint already carries the list.
+      This is what a `mount/3` that loads its data already does, which is why it
+      is the default: adopting the module does not change what the user sees.
+      `:skip` runs the callback only once the socket is connected, trading an
+      empty first paint for one query per page load instead of two — worth it on
+      a heavy list, wrong on a page that must serve content to crawlers.
+    * `:page_param` — the assign reset whenever another parameter changes.
+      Defaults to `:page` when the spec declares it; `false` disables the reset.
+
+  ## Writing state
+
+  `push_url_state/3` merges the changes, resets the page parameter unless the
+  page itself was what changed, drops defaults, and patches **the path the
+  LiveView is currently on** — captured from the live `uri`, not rebuilt from a
+  literal. A screen reachable at more than one route (a sub-tab such as
+  `/orders/:id/edit/files`) therefore stays where it is, and the locale segment
+  survives.
+
+  Pass `replace: true` for continuous input. A debounced search box otherwise
+  writes one history entry per pause in typing, and Back walks the query
+  backwards a few characters at a time instead of leaving the page. Discrete
+  actions — picking a filter, sorting, changing page — should push a real entry.
+
+  For links rather than events (`<.pagination>`, `<.link patch=…>`), build the
+  target with `url_state_path/2`.
+
+  ## This LiveView becomes router-only
+
+  A LiveView using this module **cannot be embedded with `live_render/3`**. The
+  two requirements are mutually exclusive in Phoenix LiveView itself:
+
+    * `push_patch` from a root LiveView reaches
+      `sync_handle_params_with_live_redirect/5`, which invokes
+      `view.handle_params/3` unconditionally — the 4-arity
+      `Utils.call_handle_params!` defaults `exported?` to `true`. So
+      `handle_params/3` must be exported.
+    * On an embedded mount (`socket.root_pid != self()`),
+      `maybe_call_mount_handle_params/4` sees `any? = callbacks? or exported?`
+      and takes the branch that raises through `Route.live_link_info!`. Merely
+      exporting `handle_params/3` — whatever its body — makes a LiveView
+      un-embeddable.
+
+  An embeddable LiveView therefore needs a different mechanism entirely
+  (client-side `history.pushState` plus a `popstate` listener), which this
+  module does not provide.
+
+  If the LiveView already defines its own `handle_params/3` it is kept, and the
+  state hook composes alongside it — both run. Only a LiveView with no
+  `handle_params/3` of its own gets the stub that `push_patch` requires.
+  """
+
+  @typedoc "Decoded state: assign name => value"
+  @type state :: %{atom() => term()}
+
+  @doc """
+  Invoked with the decoded state whenever it changes, and once after mount.
+
+  Returns the socket, typically with the list re-queried. Runs after the
+  LiveView's own `mount/3`, so assigns set there are available.
+  """
+  @callback handle_url_state(state(), Phoenix.LiveView.Socket.t()) ::
+              Phoenix.LiveView.Socket.t()
+
+  @state_assign :__phoenix_kit_url_state__
+  @path_assign :__phoenix_kit_url_path__
+  @extra_assign :__phoenix_kit_url_extra__
+  @loaded_assign :__phoenix_kit_url_loaded__
+
+  # ── Compile-time spec normalisation ──────────────────────────────────
+
+  @doc false
+  def normalize!(params, opts) when is_list(params) do
+    if params == [] do
+      raise ArgumentError, "use PhoenixKitWeb.Live.UrlState requires a non-empty :params list"
+    end
+
+    specs = Enum.map(params, &normalize_param!/1)
+
+    url_keys = Enum.map(specs, & &1.url_key)
+
+    if length(Enum.uniq(url_keys)) != length(url_keys) do
+      raise ArgumentError,
+            "duplicate URL keys in PhoenixKit.UrlState spec: #{inspect(url_keys -- Enum.uniq(url_keys))}"
+    end
+
+    %{
+      params: specs,
+      dead_render: validate_dead_render!(Keyword.get(opts, :dead_render, :call)),
+      page_param: resolve_page_param!(Keyword.get(opts, :page_param, :__auto__), specs)
+    }
+  end
+
+  def normalize!(other, _opts) do
+    raise ArgumentError, ":params must be a keyword list, got: #{inspect(other)}"
+  end
+
+  defp normalize_param!({key, opts}) when is_atom(key) and is_list(opts) do
+    unless Keyword.has_key?(opts, :default) do
+      raise ArgumentError, "PhoenixKit.UrlState param #{inspect(key)} is missing :default"
+    end
+
+    cast = Keyword.get(opts, :cast, :string)
+
+    unless cast in [:string, :integer, :atom, :boolean] do
+      raise ArgumentError,
+            "PhoenixKit.UrlState param #{inspect(key)} has unsupported cast #{inspect(cast)}"
+    end
+
+    allowed = Keyword.get(opts, :in)
+
+    if cast == :atom and is_nil(allowed) do
+      raise ArgumentError,
+            "PhoenixKit.UrlState param #{inspect(key)} uses cast: :atom and therefore requires " <>
+              ":in — the incoming string is matched against it so that no atom is created from " <>
+              "user input"
+    end
+
+    %{
+      key: key,
+      url_key: to_string(Keyword.get(opts, :url_key, key)),
+      aliases: opts |> Keyword.get(:alias, []) |> List.wrap() |> Enum.map(&to_string/1),
+      default: Keyword.fetch!(opts, :default),
+      cast: cast,
+      allowed: allowed,
+      min: Keyword.get(opts, :min),
+      max: Keyword.get(opts, :max)
+    }
+  end
+
+  defp normalize_param!(other) do
+    raise ArgumentError,
+          "PhoenixKit.UrlState params must be `assign_name: [default: …]`, got: #{inspect(other)}"
+  end
+
+  defp validate_dead_render!(value) when value in [:skip, :call], do: value
+
+  defp validate_dead_render!(other) do
+    raise ArgumentError, ":dead_render must be :skip or :call, got: #{inspect(other)}"
+  end
+
+  defp resolve_page_param!(:__auto__, specs) do
+    if Enum.any?(specs, &(&1.key == :page)), do: :page, else: false
+  end
+
+  defp resolve_page_param!(false, _specs), do: false
+
+  defp resolve_page_param!(key, specs) when is_atom(key) do
+    unless Enum.any?(specs, &(&1.key == key)) do
+      raise ArgumentError, ":page_param #{inspect(key)} is not declared in :params"
+    end
+
+    key
+  end
+
+  # ── Decoding: query params -> state ──────────────────────────────────
+
+  @doc """
+  Decodes LiveView params into the state map, applying defaults.
+
+  Public so a LiveView that does its own thing with `handle_params/3` can still
+  share the exact codec.
+  """
+  @spec decode(map(), map()) :: state()
+  def decode(params, cfg) when is_map(params) do
+    Map.new(cfg.params, fn spec -> {spec.key, decode_param(params, spec)} end)
+  end
+
+  def decode(_not_a_map, cfg) do
+    Map.new(cfg.params, fn spec -> {spec.key, spec.default} end)
+  end
+
+  defp decode_param(params, spec) do
+    case fetch_raw(params, [spec.url_key | spec.aliases]) do
+      :error -> spec.default
+      {:ok, raw} -> cast_value(raw, spec)
+    end
+  end
+
+  defp fetch_raw(params, keys) do
+    Enum.reduce_while(keys, :error, fn key, acc ->
+      case Map.fetch(params, key) do
+        {:ok, value} when is_binary(value) -> {:halt, {:ok, value}}
+        _ -> {:cont, acc}
+      end
+    end)
+  end
+
+  defp cast_value(raw, %{cast: :string} = spec), do: validate_allowed(raw, spec)
+
+  defp cast_value(raw, %{cast: :integer} = spec) do
+    case Integer.parse(raw) do
+      {int, ""} -> validate_bounds(int, spec)
+      _ -> spec.default
+    end
+  end
+
+  defp cast_value(raw, %{cast: :boolean} = spec) do
+    case raw do
+      "1" -> true
+      "true" -> true
+      "0" -> false
+      "false" -> false
+      _ -> spec.default
+    end
+  end
+
+  # Never String.to_atom/1 on user input: the raw string is compared against the
+  # already-existing atoms in :in, so an unknown value can only reach the default.
+  defp cast_value(raw, %{cast: :atom} = spec) do
+    Enum.find(spec.allowed, spec.default, &(to_string(&1) == raw))
+  end
+
+  defp validate_allowed(value, %{allowed: nil}), do: value
+
+  defp validate_allowed(value, spec) do
+    if value in spec.allowed, do: value, else: spec.default
+  end
+
+  defp validate_bounds(int, spec) do
+    cond do
+      spec.min != nil and int < spec.min -> spec.default
+      spec.max != nil and int > spec.max -> spec.default
+      true -> validate_allowed(int, spec)
+    end
+  end
+
+  # ── Encoding: state -> query params ──────────────────────────────────
+
+  @doc """
+  Encodes the state into a query map, omitting every value equal to its default.
+
+  `extra` carries query keys the spec does not know about so that an unrelated
+  param survives a filter change.
+  """
+  @spec encode(state(), map(), map()) :: %{String.t() => String.t()}
+  def encode(state, cfg, extra \\ %{}) do
+    Enum.reduce(cfg.params, extra, fn spec, acc ->
+      value = Map.get(state, spec.key, spec.default)
+
+      if value == spec.default do
+        Map.delete(acc, spec.url_key)
+      else
+        Map.put(acc, spec.url_key, to_string(value))
+      end
+    end)
+  end
+
+  @doc """
+  Builds `path?query` from a state map, or bare `path` when nothing differs
+  from the defaults.
+  """
+  @spec build_path(String.t(), state(), map(), map()) :: String.t()
+  def build_path(path, state, cfg, extra \\ %{}) do
+    case encode(state, cfg, extra) do
+      empty when map_size(empty) == 0 -> path
+      query -> path <> "?" <> URI.encode_query(query)
+    end
+  end
+
+  # ── Runtime: on_mount and hooks ──────────────────────────────────────
+
+  @doc false
+  def on_mount({:url_state, cfg}, params, _session, socket) do
+    ensure_router!(socket)
+
+    socket =
+      socket
+      |> assign_state(decode(params, cfg), cfg)
+      |> Phoenix.Component.assign(@extra_assign, extra_params(params, cfg))
+      |> Phoenix.Component.assign(@loaded_assign, false)
+      |> Phoenix.LiveView.attach_hook(:phoenix_kit_url_state, :handle_params, &handle_params/3)
+
+    {:cont, socket}
+  end
+
+  # A LiveView using this module exports handle_params/3 (its own or the
+  # injected stub), which already makes an embedded mount fail deep inside
+  # Phoenix with a message about live_link_info. Fail here instead, where the
+  # cause is nameable.
+  defp ensure_router!(socket) do
+    if is_nil(socket.router) do
+      raise """
+      #{inspect(socket.view)} uses PhoenixKitWeb.Live.UrlState but was not mounted \
+      through the router.
+
+      URL-backed state relies on push_patch, which requires handle_params/3 to be \
+      exported, and exporting it makes a LiveView un-embeddable via live_render/3. \
+      The two cannot be combined; see the module docs.
+      """
+    end
+
+    socket
+  end
+
+  defp handle_params(params, uri, socket) do
+    cfg = config!(socket)
+    state = decode(params, cfg)
+    changed? = not socket.assigns[@loaded_assign] or state != socket.assigns[@state_assign]
+
+    socket =
+      socket
+      |> Phoenix.Component.assign(@path_assign, URI.parse(uri).path)
+      |> Phoenix.Component.assign(@extra_assign, extra_params(params, cfg))
+      |> assign_state(state, cfg)
+
+    if changed? and run_callback?(socket, cfg) do
+      socket = Phoenix.Component.assign(socket, @loaded_assign, true)
+      {:cont, socket.view.handle_url_state(state, socket)}
+    else
+      {:cont, socket}
+    end
+  end
+
+  # The hook runs on every navigation in this LiveView, not only ones this
+  # module caused. A patch that touches an unrelated query key — a modal's
+  # ?action=add, say — must not make the list re-run its queries, so the
+  # callback fires only when the declared state actually differs.
+  defp run_callback?(socket, cfg) do
+    cfg.dead_render == :call or Phoenix.LiveView.connected?(socket)
+  end
+
+  defp assign_state(socket, state, cfg) do
+    socket = Phoenix.Component.assign(socket, @state_assign, state)
+
+    Enum.reduce(cfg.params, socket, fn spec, acc ->
+      Phoenix.Component.assign(acc, spec.key, Map.fetch!(state, spec.key))
+    end)
+  end
+
+  # Query keys the spec does not own — kept verbatim so that, say, an open
+  # modal's ?action=add is not dropped the moment a filter changes.
+  defp extra_params(params, cfg) when is_map(params) do
+    known =
+      Enum.flat_map(cfg.params, fn spec -> [spec.url_key | spec.aliases] end)
+      |> MapSet.new()
+
+    params
+    |> Enum.filter(fn {k, v} ->
+      is_binary(k) and is_binary(v) and not MapSet.member?(known, k)
+    end)
+    |> Map.new()
+  end
+
+  defp extra_params(_params, _cfg), do: %{}
+
+  defp config!(socket), do: socket.view.__phoenix_kit_url_state__()
+
+  # ── Runtime: writing state ───────────────────────────────────────────
+
+  @doc """
+  Merges `changes` into the current state and patches the URL.
+
+  Resets the page parameter unless the page itself changed. Pass
+  `replace: true` for continuous input so a debounced search box leaves one
+  history entry instead of one per keystroke pause.
+  """
+  @spec push_url_state(Phoenix.LiveView.Socket.t(), keyword() | map(), keyword()) ::
+          Phoenix.LiveView.Socket.t()
+  def push_url_state(socket, changes, opts \\ []) do
+    Phoenix.LiveView.push_patch(socket,
+      to: url_state_path(socket, changes),
+      replace: Keyword.get(opts, :replace, false)
+    )
+  end
+
+  @doc """
+  The path this LiveView would patch to for `changes` — for `<.link patch=…>`
+  and `<.pagination>`, which navigate by href rather than by event.
+  """
+  @spec url_state_path(Phoenix.LiveView.Socket.t(), keyword() | map()) :: String.t()
+  def url_state_path(socket, changes) do
+    cfg = config!(socket)
+    changes = Map.new(changes)
+
+    state =
+      socket.assigns
+      |> Map.fetch!(@state_assign)
+      |> Map.merge(changes)
+      |> maybe_reset_page(changes, cfg)
+
+    path = socket.assigns[@path_assign] || socket.assigns[:url_path] || "/"
+    extra = socket.assigns[@extra_assign] || %{}
+
+    build_path(path, state, cfg, extra)
+  end
+
+  defp maybe_reset_page(state, _changes, %{page_param: false}), do: state
+
+  defp maybe_reset_page(state, changes, cfg) do
+    if Map.has_key?(changes, cfg.page_param) or map_size(changes) == 0 do
+      state
+    else
+      default = Enum.find(cfg.params, &(&1.key == cfg.page_param)).default
+      Map.put(state, cfg.page_param, default)
+    end
+  end
+
+  @doc """
+  Resets every declared parameter to its default — the "clear all filters"
+  action. Unknown query keys are preserved.
+  """
+  @spec reset_url_state(Phoenix.LiveView.Socket.t()) :: Phoenix.LiveView.Socket.t()
+  def reset_url_state(socket) do
+    cfg = config!(socket)
+    defaults = Map.new(cfg.params, &{&1.key, &1.default})
+
+    Phoenix.LiveView.push_patch(socket, to: url_state_path(socket, defaults))
+  end
+
+  # ── use ──────────────────────────────────────────────────────────────
+
+  defmacro __using__(opts) do
+    params = Keyword.get(opts, :params) || raise ArgumentError, "missing :params"
+    cfg = normalize!(params, opts)
+
+    quote do
+      @behaviour PhoenixKitWeb.Live.UrlState
+
+      import PhoenixKitWeb.Live.UrlState,
+        only: [push_url_state: 2, push_url_state: 3, url_state_path: 2, reset_url_state: 1]
+
+      @doc false
+      def __phoenix_kit_url_state__, do: unquote(Macro.escape(cfg))
+
+      on_mount({PhoenixKitWeb.Live.UrlState, {:url_state, unquote(Macro.escape(cfg))}})
+
+      @before_compile PhoenixKitWeb.Live.UrlState
+    end
+  end
+
+  defmacro __before_compile__(env) do
+    # push_patch routes through sync_handle_params_with_live_redirect/5, which
+    # calls Utils.call_handle_params!/4 — the arity whose `exported?` defaults
+    # to true. view.handle_params/3 is therefore invoked whether or not the
+    # LiveView defines it, so a LiveView without one needs a stub. One that has
+    # its own keeps it; the :handle_params hook composes alongside.
+    if Module.defines?(env.module, {:handle_params, 3}) do
+      quote(do: nil)
+    else
+      quote do
+        @doc false
+        def handle_params(_params, _uri, socket), do: {:noreply, socket}
+      end
+    end
+  end
+end

--- a/lib/phoenix_kit_web/live/url_state.ex
+++ b/lib/phoenix_kit_web/live/url_state.ex
@@ -513,6 +513,7 @@ defmodule PhoenixKitWeb.Live.UrlState do
       |> Map.fetch!(@state_assign)
       |> Map.merge(changes)
       |> maybe_reset_page(changes, cfg)
+      |> sanitize(cfg)
 
     path = assigns[@path_assign] || assigns[:url_path] || "/"
     extra = assigns[@extra_assign] || %{}
@@ -540,6 +541,27 @@ defmodule PhoenixKitWeb.Live.UrlState do
         """
     end
   end
+
+  # A value the decoder would reject must never reach the URL, or the address
+  # bar and the assigns disagree: the link says one thing, a reload shows
+  # another. Callers do push values the spec has not seen — a screen that
+  # re-picks a sort column after the current one is hidden hands over whatever
+  # column is left, sortable or not.
+  defp sanitize(state, cfg) do
+    Map.new(cfg.params, fn spec ->
+      value = Map.get(state, spec.key, spec.default)
+      {spec.key, if(valid_value?(value, spec), do: value, else: spec.default)}
+    end)
+  end
+
+  defp valid_value?(value, %{allowed: nil} = spec), do: within_bounds?(value, spec)
+  defp valid_value?(value, spec), do: value in spec.allowed and within_bounds?(value, spec)
+
+  defp within_bounds?(value, %{cast: :integer} = spec) when is_integer(value) do
+    (is_nil(spec.min) or value >= spec.min) and (is_nil(spec.max) or value <= spec.max)
+  end
+
+  defp within_bounds?(_value, _spec), do: true
 
   defp maybe_reset_page(state, _changes, %{page_param: false}), do: state
 

--- a/lib/phoenix_kit_web/live/users/live_sessions.ex
+++ b/lib/phoenix_kit_web/live/users/live_sessions.ex
@@ -15,6 +15,23 @@ defmodule PhoenixKitWeb.Live.Users.LiveSessions do
   """
   use PhoenixKitWeb, :live_view
 
+  # Search, filter, sort and page live in the query string, so a filtered list
+  # is a real URL: shareable, reload-proof, and Back returns to the previous
+  # query instead of leaving the page. `filter_type` defaults to "all", which
+  # is therefore what gets omitted from the URL.
+  #
+  # Sort is carried as two flat params and recombined into the compound
+  # `%{by:, dir:}` map that <.sort_header_cell sort={@sort}> expects — see
+  # handle_url_state/2. The template keeps reading @sort and needs no edit.
+  use PhoenixKitWeb.Live.UrlState,
+    params: [
+      search_query: [default: "", url_key: "q"],
+      filter_type: [default: "all", url_key: "type"],
+      sort_by: [default: :connected_at, cast: :atom, in: [:type, :connected_at], url_key: "sort"],
+      sort_dir: [default: :desc, cast: :atom, in: [:asc, :desc], url_key: "dir"],
+      page: [default: 1, cast: :integer, min: 1]
+    ]
+
   alias PhoenixKit.Admin.{Events, Presence}
   alias PhoenixKit.Settings
   alias PhoenixKit.Users.Auth
@@ -43,66 +60,60 @@ defmodule PhoenixKitWeb.Live.Users.LiveSessions do
     # Get project title from settings
     project_title = Settings.get_project_title()
 
+    # :page, :search_query and :filter_type are assigned from the query string
+    # by UrlState before mount/3 runs — re-assigning them here would overwrite
+    # a shared link's state with the defaults.
     socket =
       socket
-      |> assign(:page, 1)
       |> assign(:per_page, @per_page)
-      |> assign(:search_query, "")
-      # all, anonymous, authenticated
-      |> assign(:filter_type, "all")
       |> assign(:page_title, gettext("Live Sessions"))
       |> assign(:project_title, project_title)
-      |> assign(:sort, %{by: :connected_at, dir: :desc})
       |> assign(:auto_refresh, true)
       |> assign(:last_updated, UtilsDate.utc_now())
-      |> load_sessions()
       |> load_stats()
 
     {:ok, socket}
+  end
+
+  # The list is loaded here rather than in mount/3: UrlState calls this after
+  # mount and on every change to the query string, so one code path serves the
+  # first render, a shared link, and the Back button alike.
+  #
+  # Deliberately not annotated with @impl — a single @impl anywhere in a module
+  # makes Elixir demand it on every other callback too, and this LiveView's
+  # mount/handle_event/handle_params/handle_info carry none.
+  def handle_url_state(state, socket) do
+    socket
+    |> assign(:sort, %{by: state.sort_by, dir: state.sort_dir})
+    |> load_sessions()
   end
 
   def handle_params(_params, _url, socket) do
     {:noreply, socket}
   end
 
+  # `replace: true` — the box is debounced, so a typed-out query would
+  # otherwise leave one history entry per pause and Back would walk the search
+  # string backwards instead of leaving the page.
   def handle_event("search", %{"search" => search_query}, socket) do
-    socket =
-      socket
-      |> assign(:search_query, search_query)
-      |> assign(:page, 1)
-      |> load_sessions()
-
-    {:noreply, socket}
+    {:noreply, push_url_state(socket, [search_query: search_query], replace: true)}
   end
 
   def handle_event("filter_by", %{"type" => filter_type}, socket) do
-    socket =
-      socket
-      |> assign(:filter_type, filter_type)
-      |> assign(:page, 1)
-      |> load_sessions()
-
-    {:noreply, socket}
+    {:noreply, push_url_state(socket, filter_type: filter_type)}
   end
 
   def handle_event("toggle_sort", %{"by" => by}, socket) do
-    sort = toggle_sort(socket.assigns.sort, parse_sort_by(by))
+    %{by: sort_by, dir: sort_dir} = toggle_sort(socket.assigns.sort, parse_sort_by(by))
 
-    socket =
-      socket
-      |> assign(:sort, sort)
-      |> load_sessions()
-
-    {:noreply, socket}
+    {:noreply, push_url_state(socket, sort_by: sort_by, sort_dir: sort_dir)}
   end
 
   def handle_event("change_page", %{"page" => page}, socket) do
-    socket =
-      socket
-      |> assign(:page, String.to_integer(page))
-      |> load_sessions()
-
-    {:noreply, socket}
+    case Integer.parse(page) do
+      {page, ""} when page > 0 -> {:noreply, push_url_state(socket, page: page)}
+      _ -> {:noreply, socket}
+    end
   end
 
   def handle_event("toggle_auto_refresh", _params, socket) do

--- a/lib/phoenix_kit_web/live/users/media_selector.ex
+++ b/lib/phoenix_kit_web/live/users/media_selector.ex
@@ -20,6 +20,24 @@ defmodule PhoenixKitWeb.Live.Users.MediaSelector do
   """
   use PhoenixKitWeb, :live_view
 
+  # Search, file-type filter and page live in the query string, so a filtered
+  # list is a real URL: shareable, reload-proof, and Back returns to the
+  # previous query instead of leaving the page. `file_type_filter` defaults to
+  # :all, which is therefore what gets omitted from the URL.
+  use PhoenixKitWeb.Live.UrlState,
+    params: [
+      search_query: [default: "", url_key: "q"],
+      file_type_filter: [
+        default: :all,
+        cast: :atom,
+        in: [:all, :image, :video],
+        url_key: "type",
+        alias: "filter"
+      ],
+      current_page: [default: 1, cast: :integer, min: 1, url_key: "page"]
+    ],
+    page_param: :current_page
+
   require Logger
 
   alias PhoenixKit.Modules.Storage
@@ -41,14 +59,15 @@ defmodule PhoenixKitWeb.Live.Users.MediaSelector do
     # Get project title
     project_title = Settings.get_project_title()
 
-    # Parse query parameters
+    # Parse mount-only query parameters (not URL state — these are fixed for
+    # the lifetime of the session and are not list filters).
     return_to = parse_return_to(params["return_to"])
     mode = parse_mode(params["mode"])
     selected_uuids = parse_selected_uuids(params["selected"])
-    filter = parse_filter(params["filter"])
-    page = parse_page(params["page"])
 
-    # Allow file uploads
+    # :search_query, :file_type_filter, and :current_page are assigned from
+    # the query string by UrlState before mount/3 runs — re-assigning them
+    # here would overwrite a shared link's state with the defaults.
     socket =
       socket
       |> assign(:current_locale, locale)
@@ -58,9 +77,6 @@ defmodule PhoenixKitWeb.Live.Users.MediaSelector do
       |> assign(:return_to, return_to)
       |> assign(:selection_mode, mode)
       |> assign(:selected_uuids, selected_uuids)
-      |> assign(:file_type_filter, filter)
-      |> assign(:search_query, "")
-      |> assign(:current_page, page)
       |> assign(:per_page, @per_page)
       |> allow_upload(:media_files,
         accept: :any,
@@ -72,22 +88,14 @@ defmodule PhoenixKitWeb.Live.Users.MediaSelector do
     {:ok, socket}
   end
 
-  def handle_params(params, _uri, socket) do
-    page = parse_page(params["page"])
-
-    # Load files based on current filters and page
-    {files, total_count} = load_files(socket, page)
-    total_pages = ceil(total_count / socket.assigns.per_page)
-
-    socket =
-      socket
-      |> assign(:current_page, page)
-      |> assign(:uploaded_files, files)
-      |> assign(:total_count, total_count)
-      |> assign(:total_pages, total_pages)
-
-    {:noreply, socket}
-  end
+  # The list is loaded here rather than in mount/3: UrlState calls this after
+  # mount and on every change to the query string, so one code path serves the
+  # first render, a shared link, and the Back button alike.
+  #
+  # Deliberately not annotated with @impl — a single @impl anywhere in a module
+  # makes Elixir demand it on every other callback too, and this LiveView's
+  # mount/handle_event/handle_params/handle_info carry none.
+  def handle_url_state(_state, socket), do: reload_files(socket)
 
   def handle_event("toggle_selection", %{"file-uuid" => file_uuid}, socket) do
     selected_uuids = socket.assigns.selected_uuids
@@ -134,44 +142,15 @@ defmodule PhoenixKitWeb.Live.Users.MediaSelector do
     {:noreply, push_navigate(socket, to: socket.assigns.return_to)}
   end
 
+  # `replace: true` — the box is debounced, so a typed-out query would otherwise
+  # leave one history entry per pause and Back would walk the search string
+  # backwards instead of leaving the page.
   def handle_event("search", %{"search" => %{"query" => query}}, socket) do
-    socket =
-      socket
-      |> assign(:search_query, query)
-      |> assign(:current_page, 1)
-
-    # Reload files with search query
-    {files, total_count} = load_files(socket, 1)
-    total_pages = ceil(total_count / socket.assigns.per_page)
-
-    socket =
-      socket
-      |> assign(:uploaded_files, files)
-      |> assign(:total_count, total_count)
-      |> assign(:total_pages, total_pages)
-
-    {:noreply, socket}
+    {:noreply, push_url_state(socket, [search_query: query], replace: true)}
   end
 
   def handle_event("filter_type", %{"filter" => filter}, socket) do
-    parsed_filter = parse_filter(filter)
-
-    socket =
-      socket
-      |> assign(:file_type_filter, parsed_filter)
-      |> assign(:current_page, 1)
-
-    # Reload files with new filter
-    {files, total_count} = load_files(socket, 1)
-    total_pages = ceil(total_count / socket.assigns.per_page)
-
-    socket =
-      socket
-      |> assign(:uploaded_files, files)
-      |> assign(:total_count, total_count)
-      |> assign(:total_pages, total_pages)
-
-    {:noreply, socket}
+    {:noreply, push_url_state(socket, file_type_filter: parse_filter(filter))}
   end
 
   def handle_event("validate", _params, socket) do
@@ -179,19 +158,31 @@ defmodule PhoenixKitWeb.Live.Users.MediaSelector do
   end
 
   def handle_event("save", _params, socket) do
-    # Files are auto-uploaded, just reload the list
-    {files, total_count} = load_files(socket, 1)
-    total_pages = ceil(total_count / socket.assigns.per_page)
+    # Files are auto-uploaded via handle_progress; this only refreshes the grid.
+    # The reload cannot be left to the patch: on page 1 the URL does not change,
+    # so handle_url_state would never fire and the new file would not appear.
+    socket = put_flash(socket, :info, "Files uploaded successfully")
 
-    socket =
-      socket
-      |> assign(:current_page, 1)
-      |> assign(:uploaded_files, files)
-      |> assign(:total_count, total_count)
-      |> assign(:total_pages, total_pages)
-      |> put_flash(:info, "Files uploaded successfully")
+    {:noreply, reset_to_first_page(socket)}
+  end
 
-    {:noreply, socket}
+  # Data changed underneath the current query: reload in place when already on
+  # page 1, otherwise patch back to it and let handle_url_state do the loading.
+  defp reset_to_first_page(socket) do
+    if socket.assigns.current_page == 1 do
+      reload_files(socket)
+    else
+      push_url_state(socket, current_page: 1)
+    end
+  end
+
+  defp reload_files(socket) do
+    {files, total_count} = load_files(socket, socket.assigns.current_page)
+
+    socket
+    |> assign(:uploaded_files, files)
+    |> assign(:total_count, total_count)
+    |> assign(:total_pages, ceil(total_count / socket.assigns.per_page))
   end
 
   defp handle_progress(:media_files, entry, socket) do
@@ -206,8 +197,6 @@ defmodule PhoenixKitWeb.Live.Users.MediaSelector do
           file_uuid when is_binary(file_uuid) ->
             # Refresh the grid so the new file is visible, and auto-select it —
             # uploading into a picker means "I want this one".
-            {files, total_count} = load_files(socket, 1)
-
             selected =
               case socket.assigns.selection_mode do
                 :single -> [file_uuid]
@@ -215,11 +204,8 @@ defmodule PhoenixKitWeb.Live.Users.MediaSelector do
               end
 
             socket
-            |> assign(:current_page, 1)
-            |> assign(:uploaded_files, files)
-            |> assign(:total_count, total_count)
-            |> assign(:total_pages, ceil(total_count / socket.assigns.per_page))
             |> assign(:selected_uuids, selected)
+            |> reset_to_first_page()
 
           _ ->
             put_flash(
@@ -388,17 +374,6 @@ defmodule PhoenixKitWeb.Live.Users.MediaSelector do
   defp parse_return_to(<<"/", next, _::binary>> = path) when next not in [?/, ?\\], do: path
   defp parse_return_to("/"), do: "/"
   defp parse_return_to(_), do: "/"
-
-  # Malformed or non-positive `?page=` values fall back to 1 instead of
-  # crashing the mount (String.to_integer) or producing a negative OFFSET.
-  defp parse_page(page) when is_binary(page) do
-    case Integer.parse(page) do
-      {n, ""} when n > 0 -> n
-      _ -> 1
-    end
-  end
-
-  defp parse_page(_), do: 1
 
   defp parse_selected_uuids(nil), do: []
 

--- a/lib/phoenix_kit_web/live/users/media_selector.html.heex
+++ b/lib/phoenix_kit_web/live/users/media_selector.html.heex
@@ -76,7 +76,13 @@
         <div class="flex flex-col md:flex-row gap-4">
           <%!-- Search --%>
           <div class="flex-1">
-            <.form for={%{}} phx-submit="search" class="w-full">
+            <.form
+              for={%{}}
+              id="media-selector-search-form"
+              phx-change="search"
+              phx-submit="search"
+              class="w-full"
+            >
               <div class="join w-full">
                 <.input
                   type="text"
@@ -85,6 +91,7 @@
                   placeholder={gettext("Search by filename...")}
                   class="join-item flex-1"
                   wrapper_class="contents"
+                  phx-debounce="300"
                 />
                 <button type="submit" class="btn btn-primary join-item">
                   <.icon name="hero-magnifying-glass" class="w-4 h-4" />
@@ -188,12 +195,12 @@
       <div class="flex justify-center">
         <div class="join">
           <%!-- `patch` (not `navigate`): a full remount would wipe the
-               in-memory selection when paging in multiple mode. --%>
+               in-memory selection when paging in multiple mode. Unknown
+               query keys (return_to, mode) are preserved by url_state_path
+               automatically. --%>
           <%= if @current_page > 1 do %>
             <.link
-              patch={
-                "#{@current_path}?page=#{@current_page - 1}&return_to=#{URI.encode_www_form(@return_to)}&mode=#{@selection_mode}&filter=#{@file_type_filter}"
-              }
+              patch={url_state_path(assigns, current_page: @current_page - 1)}
               class="join-item btn"
             >
               «
@@ -207,9 +214,7 @@
               <button class="join-item btn btn-disabled">...</button>
             <% else %>
               <.link
-                patch={
-                  "#{@current_path}?page=#{page}&return_to=#{URI.encode_www_form(@return_to)}&mode=#{@selection_mode}&filter=#{@file_type_filter}"
-                }
+                patch={url_state_path(assigns, current_page: page)}
                 class={"join-item btn #{if page == @current_page, do: "btn-active"}"}
               >
                 {page}
@@ -219,9 +224,7 @@
 
           <%= if @current_page < @total_pages do %>
             <.link
-              patch={
-                "#{@current_path}?page=#{@current_page + 1}&return_to=#{URI.encode_www_form(@return_to)}&mode=#{@selection_mode}&filter=#{@file_type_filter}"
-              }
+              patch={url_state_path(assigns, current_page: @current_page + 1)}
               class="join-item btn"
             >
               »

--- a/lib/phoenix_kit_web/live/users/sessions.ex
+++ b/lib/phoenix_kit_web/live/users/sessions.ex
@@ -13,6 +13,17 @@ defmodule PhoenixKitWeb.Live.Users.Sessions do
   """
   use PhoenixKitWeb, :live_view
 
+  # Search, filter and page live in the query string, so a filtered list is a
+  # real URL: shareable, reload-proof, and Back returns to the previous query
+  # instead of leaving the page. `filter_user_status` defaults to "all", which
+  # is therefore what gets omitted from the URL.
+  use PhoenixKitWeb.Live.UrlState,
+    params: [
+      search_query: [default: "", url_key: "q"],
+      filter_user_status: [default: "all", url_key: "status"],
+      page: [default: 1, cast: :integer, min: 1]
+    ]
+
   alias PhoenixKit.Admin.Events
   alias PhoenixKit.Settings
   alias PhoenixKit.Users.{Auth, Sessions}
@@ -33,57 +44,52 @@ defmodule PhoenixKitWeb.Live.Users.Sessions do
     # Get project title from settings
     project_title = Settings.get_project_title()
 
+    # :page, :search_query and :filter_user_status are assigned from the
+    # query string by UrlState before mount/3 runs — re-assigning them here
+    # would overwrite a shared link's state with the defaults.
     socket =
       socket
-      |> assign(:page, 1)
       |> assign(:per_page, @per_page)
-      |> assign(:search_query, "")
-      |> assign(:filter_user_status, "all")
       |> assign(:page_title, gettext("Session Management"))
       |> assign(:project_title, project_title)
       |> assign(:current_locale, locale)
       |> assign(:show_revoke_modal, false)
       |> assign(:selected_session, nil)
       |> assign(:revoke_type, nil)
-      |> load_sessions()
       |> load_stats()
 
     {:ok, socket}
   end
 
+  # The list is loaded here rather than in mount/3: UrlState calls this after
+  # mount and on every change to the query string, so one code path serves the
+  # first render, a shared link, and the Back button alike.
+  #
+  # Deliberately not annotated with @impl — a single @impl anywhere in a module
+  # makes Elixir demand it on every other callback too, and this LiveView's
+  # mount/handle_event/handle_params/handle_info carry none.
+  def handle_url_state(_state, socket), do: load_sessions(socket)
+
   def handle_params(_params, _url, socket) do
     {:noreply, socket}
   end
 
+  # `replace: true` — the box is debounced, so a typed-out query would
+  # otherwise leave one history entry per pause and Back would walk the search
+  # string backwards instead of leaving the page.
   def handle_event("search", %{"search" => search_query}, socket) do
-    socket =
-      socket
-      |> assign(:search_query, search_query)
-      |> assign(:page, 1)
-      |> load_sessions()
-
-    {:noreply, socket}
+    {:noreply, push_url_state(socket, [search_query: search_query], replace: true)}
   end
 
   def handle_event("filter_by_user_status", %{"status" => status}, socket) do
-    socket =
-      socket
-      |> assign(:filter_user_status, status)
-      |> assign(:page, 1)
-      |> load_sessions()
-
-    {:noreply, socket}
+    {:noreply, push_url_state(socket, filter_user_status: status)}
   end
 
   def handle_event("change_page", %{"page" => page}, socket) do
-    page = String.to_integer(page)
-
-    socket =
-      socket
-      |> assign(:page, page)
-      |> load_sessions()
-
-    {:noreply, socket}
+    case Integer.parse(page) do
+      {page, ""} when page > 0 -> {:noreply, push_url_state(socket, page: page)}
+      _ -> {:noreply, socket}
+    end
   end
 
   def handle_event("show_revoke_session", %{"token_uuid" => token_uuid}, socket) do

--- a/lib/phoenix_kit_web/live/users/users.ex
+++ b/lib/phoenix_kit_web/live/users/users.ex
@@ -6,6 +6,18 @@ defmodule PhoenixKitWeb.Live.Users.Users do
   """
   use PhoenixKitWeb, :live_view
 
+  # Search, role/type filters and page live in the query string, so a filtered
+  # list is a real URL: shareable, reload-proof, and Back returns to the
+  # previous query instead of leaving the page. `role` and `account_type`
+  # default to "all", which is therefore what gets omitted from the URL.
+  use PhoenixKitWeb.Live.UrlState,
+    params: [
+      search_query: [default: "", url_key: "q", alias: "search"],
+      filter_role: [default: "all", url_key: "role"],
+      filter_account_type: [default: "all", url_key: "account_type"],
+      page: [default: 1, cast: :integer, min: 1]
+    ]
+
   # Imported per-LiveView rather than from `PhoenixKitWeb, :live_view`: a host
   # app that defines its own `row_link/1` would get an ambiguous import the
   # moment core wired this one in project-wide.
@@ -56,14 +68,14 @@ defmodule PhoenixKitWeb.Live.Users.Users do
       TableColumns.update_user_table_columns(valid_columns)
     end
 
+    # :page, :search_query, :filter_role and :filter_account_type are assigned
+    # from the query string by UrlState before mount/3 runs — re-assigning them
+    # here would overwrite a shared link's state with the defaults.
     socket =
       socket
-      |> assign(:page, 1)
       |> assign(:per_page, @per_page)
-      |> assign(:search_query, "")
-      |> assign(:show_search, false)
+      |> assign(:show_search, socket.assigns.search_query != "")
       |> assign(:view_mode, load_user_view_mode(socket.assigns[:phoenix_kit_current_user]))
-      |> assign(:filter_role, "all")
       |> assign(
         :org_accounts_enabled,
         Settings.get_boolean_setting("enable_organization_accounts", false)
@@ -72,7 +84,6 @@ defmodule PhoenixKitWeb.Live.Users.Users do
         :geolocation_tracking_enabled,
         Settings.get_boolean_setting("track_registration_geolocation", false)
       )
-      |> assign(:filter_account_type, "all")
       |> assign(:show_role_modal, false)
       |> assign(:managing_user, nil)
       |> assign(:user_roles, [])
@@ -84,11 +95,19 @@ defmodule PhoenixKitWeb.Live.Users.Users do
       |> assign(:date_time_settings, date_time_settings)
       |> assign(:selected_columns, valid_columns)
       |> assign(:available_columns, TableColumns.get_available_columns())
-      |> load_users()
       |> load_stats()
 
     {:ok, socket}
   end
+
+  # The list is loaded here rather than in mount/3: UrlState calls this after
+  # mount and on every change to the query string, so one code path serves the
+  # first render, a shared link, and the Back button alike.
+  #
+  # Deliberately not annotated with @impl — a single @impl anywhere in a module
+  # makes Elixir demand it on every other callback too, and this LiveView's
+  # mount/handle_event/handle_params/handle_info carry none.
+  def handle_url_state(_state, socket), do: load_users(socket)
 
   def handle_params(%{"action" => "add"} = _params, _url, socket) do
     # Open user registration form for adding new user
@@ -102,14 +121,11 @@ defmodule PhoenixKitWeb.Live.Users.Users do
     {:noreply, socket}
   end
 
+  # `replace: true` — the box is debounced, so a typed-out query would otherwise
+  # leave one history entry per pause and Back would walk the search string
+  # backwards instead of leaving the page.
   def handle_event("search", %{"search" => search_query}, socket) do
-    socket =
-      socket
-      |> assign(:search_query, search_query)
-      |> assign(:page, 1)
-      |> load_users()
-
-    {:noreply, socket}
+    {:noreply, push_url_state(socket, [search_query: search_query], replace: true)}
   end
 
   # Toggle the collapsed search row open/closed (mirrors the media browser).
@@ -117,14 +133,13 @@ defmodule PhoenixKitWeb.Live.Users.Users do
     {:noreply, assign(socket, :show_search, !socket.assigns.show_search)}
   end
 
-  # Clear the query and close the search row (the ✕ button).
+  # Clear the query and close the search row (the ✕ button). Clearing is a
+  # deliberate action, so it earns a real history entry.
   def handle_event("clear_search", _params, socket) do
     socket =
       socket
-      |> assign(:search_query, "")
       |> assign(:show_search, false)
-      |> assign(:page, 1)
-      |> load_users()
+      |> push_url_state(search_query: "")
 
     {:noreply, socket}
   end
@@ -146,46 +161,22 @@ defmodule PhoenixKitWeb.Live.Users.Users do
   end
 
   def handle_event("filter_by_role", %{"role" => role}, socket) do
-    socket =
-      socket
-      |> assign(:filter_role, role)
-      |> assign(:page, 1)
-      |> load_users()
-
-    {:noreply, socket}
+    {:noreply, push_url_state(socket, filter_role: role)}
   end
 
   def handle_event("filter_by_account_type", %{"account_type" => account_type}, socket) do
-    socket =
-      socket
-      |> assign(:filter_account_type, account_type)
-      |> assign(:page, 1)
-      |> load_users()
-
-    {:noreply, socket}
+    {:noreply, push_url_state(socket, filter_account_type: account_type)}
   end
 
   def handle_event("clear_filters", _params, socket) do
-    socket =
-      socket
-      |> assign(:search_query, "")
-      |> assign(:filter_role, "all")
-      |> assign(:filter_account_type, "all")
-      |> assign(:page, 1)
-      |> load_users()
-
-    {:noreply, socket}
+    {:noreply, reset_url_state(socket)}
   end
 
   def handle_event("change_page", %{"page" => page}, socket) do
-    page = String.to_integer(page)
-
-    socket =
-      socket
-      |> assign(:page, page)
-      |> load_users()
-
-    {:noreply, socket}
+    case Integer.parse(page) do
+      {page, ""} when page > 0 -> {:noreply, push_url_state(socket, page: page)}
+      _ -> {:noreply, socket}
+    end
   end
 
   def handle_event("show_role_management", %{"user_uuid" => user_uuid}, socket) do

--- a/priv/static/assets/phoenix_kit.js
+++ b/priv/static/assets/phoenix_kit.js
@@ -1437,6 +1437,66 @@ if (typeof window.Chart === "undefined") {
   };
 
   // ---------------------------------------------------------------------------
+  // PhoenixKitUrlState Hook
+  // ---------------------------------------------------------------------------
+  //
+  // Carries list state (search / filters / sort / page) in the address bar for
+  // a LiveView that cannot use push_patch.
+  //
+  // Why it exists: push_patch requires handle_params/3 to be exported, and
+  // exporting it makes a LiveView impossible to embed with live_render/3. An
+  // embeddable list therefore has to drive the URL from the client instead.
+  //
+  // Rendered by PhoenixKitWeb.Live.UrlState.url_state_sync/1 when the LiveView
+  // declares `mode: :history`; nothing else should mount it by hand.
+  //
+  // Three jobs:
+  //   1. on connect, report the query the page was opened with — an embedded
+  //      LiveView receives :not_mounted_at_router instead of params, so this is
+  //      the only way it can learn its own state;
+  //   2. rewrite the address bar when the server pushes a new query;
+  //   3. report Back and Forward, which is what makes history navigation work
+  //      without a router.
+  //
+  // Only the query is exchanged. The path stays client-side deliberately: an
+  // embedded LiveView has no idea which page it is on.
+  //
+  // ---------------------------------------------------------------------------
+
+  window.PhoenixKitHooks.PhoenixKitUrlState = {
+    mounted() {
+      this.pushEvent("phoenix_kit_url_state", { query: window.location.search });
+
+      this.handleEvent("phoenix_kit_url_state", ({ query, replace }) => {
+        var next = window.location.pathname + (query ? "?" + query : "");
+
+        // Nothing moved — recording it would put a duplicate in the history
+        // stack and make one Back press look like it did nothing.
+        if (next === window.location.pathname + window.location.search) return;
+
+        if (replace) {
+          window.history.replaceState({}, "", next);
+        } else {
+          window.history.pushState({}, "", next);
+        }
+      });
+
+      this.pkOnPopState = function () {
+        this.pushEvent("phoenix_kit_url_state", { query: window.location.search });
+      }.bind(this);
+
+      window.addEventListener("popstate", this.pkOnPopState);
+    },
+
+    destroyed() {
+      if (this.pkOnPopState) {
+        window.removeEventListener("popstate", this.pkOnPopState);
+        this.pkOnPopState = null;
+      }
+    }
+  };
+
+  // ---------------------------------------------------------------------------
   // PopupLink Hook
   // ---------------------------------------------------------------------------
   //

--- a/test/phoenix_kit_web/live/url_state_test.exs
+++ b/test/phoenix_kit_web/live/url_state_test.exs
@@ -1,3 +1,24 @@
+defmodule PhoenixKitWeb.Live.UrlStateSigilLive do
+  @moduledoc """
+  Exists only to exercise `use PhoenixKitWeb.Live.UrlState` for real.
+
+  The codec tests hand `normalize!/2` an already-evaluated list, so they cannot
+  see whether the macro evaluated its options. A `~w()` sigil is the case that
+  matters: as unexpanded AST it is a `{:sigil_w, …}` tuple, and a spec built
+  from that raises only when a request arrives.
+  """
+  use Phoenix.LiveView
+
+  use PhoenixKitWeb.Live.UrlState,
+    params: [
+      sort_by: [default: "name", in: ~w(name email created)],
+      sort_dir: [default: :desc, cast: :atom, in: [:asc, :desc]]
+    ]
+
+  def handle_url_state(_state, socket), do: socket
+  def render(assigns), do: ~H"<div></div>"
+end
+
 defmodule PhoenixKitWeb.Live.UrlStateTest do
   @moduledoc """
   Codec tests for `PhoenixKitWeb.Live.UrlState`.
@@ -323,6 +344,24 @@ defmodule PhoenixKitWeb.Live.UrlStateTest do
       assert_raise ArgumentError, ~r/pass `assigns`, not `@socket`/, fn ->
         UrlState.url_state_path(socket, search_query: "ivan")
       end
+    end
+  end
+
+  describe "use PhoenixKitWeb.Live.UrlState" do
+    alias PhoenixKitWeb.Live.UrlStateSigilLive
+
+    test "evaluates its options, so a ~w sigil in :in becomes a list" do
+      cfg = UrlStateSigilLive.__phoenix_kit_url_state__()
+      sort_by = Enum.find(cfg.params, &(&1.key == :sort_by))
+
+      assert sort_by.allowed == ["name", "email", "created"]
+    end
+
+    test "whitelists against that list at request time" do
+      cfg = UrlStateSigilLive.__phoenix_kit_url_state__()
+
+      assert UrlState.decode(%{"sort_by" => "email"}, cfg).sort_by == "email"
+      assert UrlState.decode(%{"sort_by" => "'; DROP TABLE users--"}, cfg).sort_by == "name"
     end
   end
 

--- a/test/phoenix_kit_web/live/url_state_test.exs
+++ b/test/phoenix_kit_web/live/url_state_test.exs
@@ -329,6 +329,29 @@ defmodule PhoenixKitWeb.Live.UrlStateTest do
       assert UrlState.url_state_path(bare, search_query: "ivan") == "/?q=ivan"
     end
 
+    test "never writes a value the decoder would reject" do
+      spec =
+        cfg(
+          status: [default: "any", in: ~w(any open closed)],
+          page: [default: 1, cast: :integer, min: 1, max: 99]
+        )
+
+      state = UrlState.decode(%{}, spec)
+
+      assigns = %{
+        :__phoenix_kit_url_cfg__ => spec,
+        :__phoenix_kit_url_state__ => state,
+        :__phoenix_kit_url_path__ => "/admin/things",
+        :__phoenix_kit_url_extra__ => %{}
+      }
+
+      # a caller handing over a value outside the whitelist, or out of bounds,
+      # falls back to the default instead of putting a lie in the address bar
+      assert UrlState.url_state_path(assigns, status: "deleted") == "/admin/things"
+      assert UrlState.url_state_path(assigns, page: 500) == "/admin/things"
+      assert UrlState.url_state_path(assigns, status: "open") == "/admin/things?status=open"
+    end
+
     test "rejects a change keyed by URL key instead of assign name" do
       state = UrlState.decode(%{}, cfg())
 

--- a/test/phoenix_kit_web/live/url_state_test.exs
+++ b/test/phoenix_kit_web/live/url_state_test.exs
@@ -1,0 +1,222 @@
+defmodule PhoenixKitWeb.Live.UrlStateTest do
+  @moduledoc """
+  Codec tests for `PhoenixKitWeb.Live.UrlState`.
+
+  Encoding and decoding are pure functions over maps, so they need no database
+  — which is what makes the URL-state contract cheap to pin.
+  """
+  use ExUnit.Case, async: true
+
+  alias PhoenixKitWeb.Live.UrlState
+
+  defp cfg(params \\ nil, opts \\ []) do
+    params =
+      params ||
+        [
+          search_query: [default: "", url_key: "q", alias: "search"],
+          filter_role: [default: "all", url_key: "role"],
+          sort_dir: [default: :desc, cast: :atom, in: [:asc, :desc]],
+          archived: [default: false, cast: :boolean],
+          page: [default: 1, cast: :integer, min: 1]
+        ]
+
+    UrlState.normalize!(params, opts)
+  end
+
+  describe "normalize!/2" do
+    test "requires a default for every param" do
+      assert_raise ArgumentError, ~r/is missing :default/, fn ->
+        cfg(q: [url_key: "q"])
+      end
+    end
+
+    test "refuses cast: :atom without an :in whitelist" do
+      assert_raise ArgumentError, ~r/requires\s+:in/, fn ->
+        cfg(sort_dir: [default: :desc, cast: :atom])
+      end
+    end
+
+    test "rejects an unsupported cast" do
+      assert_raise ArgumentError, ~r/unsupported cast/, fn ->
+        cfg(page: [default: 1, cast: :float])
+      end
+    end
+
+    test "rejects two params claiming the same URL key" do
+      assert_raise ArgumentError, ~r/duplicate URL keys/, fn ->
+        cfg(a: [default: "", url_key: "q"], b: [default: "", url_key: "q"])
+      end
+    end
+
+    test "rejects an empty spec" do
+      assert_raise ArgumentError, ~r/non-empty :params/, fn -> cfg([]) end
+    end
+
+    test "detects :page as the page param, and honours :page_param false" do
+      assert cfg().page_param == :page
+      assert cfg(nil, page_param: false).page_param == false
+      assert cfg(q: [default: ""]).page_param == false
+    end
+
+    test "rejects a :page_param that is not declared" do
+      assert_raise ArgumentError, ~r/is not declared/, fn ->
+        cfg([q: [default: ""]], page_param: :page)
+      end
+    end
+
+    test "defaults dead_render to :call and validates it" do
+      assert cfg().dead_render == :call
+      assert cfg(nil, dead_render: :skip).dead_render == :skip
+
+      assert_raise ArgumentError, ~r/:dead_render must be/, fn ->
+        cfg(nil, dead_render: :maybe)
+      end
+    end
+  end
+
+  describe "decode/2" do
+    test "returns defaults for an empty query" do
+      assert UrlState.decode(%{}, cfg()) == %{
+               search_query: "",
+               filter_role: "all",
+               sort_dir: :desc,
+               archived: false,
+               page: 1
+             }
+    end
+
+    test "reads a param through its url_key, not its assign name" do
+      state = UrlState.decode(%{"q" => "ivan"}, cfg())
+      assert state.search_query == "ivan"
+
+      # the assign name is not a valid URL key
+      assert UrlState.decode(%{"search_query" => "ivan"}, cfg()).search_query == ""
+    end
+
+    test "accepts a legacy alias so already-published links keep resolving" do
+      assert UrlState.decode(%{"search" => "ivan"}, cfg()).search_query == "ivan"
+    end
+
+    test "prefers the canonical key when both it and the alias are present" do
+      assert UrlState.decode(%{"q" => "new", "search" => "old"}, cfg()).search_query == "new"
+    end
+
+    test "casts integers and falls back to the default below :min" do
+      assert UrlState.decode(%{"page" => "4"}, cfg()).page == 4
+      assert UrlState.decode(%{"page" => "0"}, cfg()).page == 1
+      assert UrlState.decode(%{"page" => "-2"}, cfg()).page == 1
+      assert UrlState.decode(%{"page" => "abc"}, cfg()).page == 1
+      assert UrlState.decode(%{"page" => "3junk"}, cfg()).page == 1
+    end
+
+    test "casts booleans from both 1/0 and true/false" do
+      assert UrlState.decode(%{"archived" => "1"}, cfg()).archived == true
+      assert UrlState.decode(%{"archived" => "true"}, cfg()).archived == true
+      assert UrlState.decode(%{"archived" => "0"}, cfg()).archived == false
+      assert UrlState.decode(%{"archived" => "nope"}, cfg()).archived == false
+    end
+
+    test "matches atoms against the whitelist without creating any" do
+      forged = "pk_url_state_forged_direction"
+
+      assert UrlState.decode(%{"sort_dir" => "asc"}, cfg()).sort_dir == :asc
+      assert UrlState.decode(%{"sort_dir" => forged}, cfg()).sort_dir == :desc
+
+      # the forged value must not have become an atom
+      assert_raise ArgumentError, fn -> String.to_existing_atom(forged) end
+    end
+
+    test "honours an :in whitelist for strings" do
+      spec = cfg(status: [default: "any", in: ~w(any open closed)])
+      assert UrlState.decode(%{"status" => "open"}, spec).status == "open"
+      assert UrlState.decode(%{"status" => "hacked"}, spec).status == "any"
+    end
+
+    test "ignores non-binary values, such as a nested form map" do
+      assert UrlState.decode(%{"q" => %{"nested" => "x"}}, cfg()).search_query == ""
+    end
+
+    test "survives params that are not a map at all" do
+      assert UrlState.decode(:not_mounted_at_router, cfg()).page == 1
+    end
+  end
+
+  describe "encode/3" do
+    test "omits every value equal to its default" do
+      state = UrlState.decode(%{}, cfg())
+      assert UrlState.encode(state, cfg()) == %{}
+    end
+
+    test "writes non-defaults under the canonical url_key" do
+      state = UrlState.decode(%{"q" => "ivan", "page" => "3"}, cfg())
+
+      assert UrlState.encode(state, cfg()) == %{"q" => "ivan", "page" => "3"}
+    end
+
+    test "never writes the alias, so links converge on the canonical key" do
+      state = UrlState.decode(%{"search" => "ivan"}, cfg())
+      encoded = UrlState.encode(state, cfg())
+
+      assert encoded == %{"q" => "ivan"}
+      refute Map.has_key?(encoded, "search")
+    end
+
+    test "stringifies atoms and booleans" do
+      state = UrlState.decode(%{"sort_dir" => "asc", "archived" => "1"}, cfg())
+
+      assert UrlState.encode(state, cfg()) == %{"sort_dir" => "asc", "archived" => "true"}
+    end
+
+    test "keeps unknown query keys so an unrelated param is not dropped" do
+      state = UrlState.decode(%{"q" => "ivan"}, cfg())
+
+      assert UrlState.encode(state, cfg(), %{"action" => "add"}) == %{
+               "q" => "ivan",
+               "action" => "add"
+             }
+    end
+
+    test "clears a key that returned to its default" do
+      state = UrlState.decode(%{"q" => "ivan"}, cfg())
+      back_to_default = %{state | search_query: ""}
+
+      assert UrlState.encode(back_to_default, cfg(), %{"q" => "ivan"}) == %{}
+    end
+  end
+
+  describe "build_path/4" do
+    test "yields a bare path when nothing differs from the defaults" do
+      state = UrlState.decode(%{}, cfg())
+
+      assert UrlState.build_path("/admin/users", state, cfg()) == "/admin/users"
+    end
+
+    test "appends an encoded query otherwise" do
+      state = UrlState.decode(%{"q" => "ivan petrov", "page" => "2"}, cfg())
+      path = UrlState.build_path("/admin/users", state, cfg())
+
+      assert path =~ "/admin/users?"
+      assert path =~ "q=ivan+petrov"
+      assert path =~ "page=2"
+    end
+
+    test "preserves the path it is given, including a locale segment" do
+      state = UrlState.decode(%{"q" => "ivan"}, cfg())
+
+      assert UrlState.build_path("/uk/admin/users", state, cfg()) == "/uk/admin/users?q=ivan"
+    end
+  end
+
+  describe "round trip" do
+    test "decode(encode(state)) is the identity for every declared param" do
+      original = UrlState.decode(%{"q" => "ivan", "role" => "admin", "sort_dir" => "asc"}, cfg())
+
+      round_tripped =
+        original
+        |> UrlState.encode(cfg())
+        |> UrlState.decode(cfg())
+
+      assert round_tripped == original
+    end
+  end
+end

--- a/test/phoenix_kit_web/live/url_state_test.exs
+++ b/test/phoenix_kit_web/live/url_state_test.exs
@@ -28,6 +28,8 @@ defmodule PhoenixKitWeb.Live.UrlStateTest do
   """
   use ExUnit.Case, async: true
 
+  import Phoenix.LiveViewTest, only: [render_component: 2]
+
   alias PhoenixKitWeb.Live.UrlState
 
   defp cfg(params \\ nil, opts \\ []) do
@@ -400,6 +402,27 @@ defmodule PhoenixKitWeb.Live.UrlStateTest do
 
       assert UrlState.decode(%{"sort_by" => "email"}, cfg).sort_by == "email"
       assert UrlState.decode(%{"sort_by" => "'; DROP TABLE users--"}, cfg).sort_by == "name"
+    end
+  end
+
+  describe "mode" do
+    test "defaults to :patch and validates the option" do
+      assert cfg().mode == :patch
+      assert cfg(nil, mode: :history).mode == :history
+
+      assert_raise ArgumentError, ~r/:mode must be :patch or :history/, fn ->
+        cfg(nil, mode: :sideways)
+      end
+    end
+
+    test "url_state_sync/1 renders the hook only in :history mode" do
+      history =
+        render_component(&UrlState.url_state_sync/1, mode: :history, id: "sync-a")
+
+      assert history =~ ~s(phx-hook="PhoenixKitUrlState")
+      assert history =~ ~s(id="sync-a")
+
+      assert render_component(&UrlState.url_state_sync/1, mode: :patch) == ""
     end
   end
 

--- a/test/phoenix_kit_web/live/url_state_test.exs
+++ b/test/phoenix_kit_web/live/url_state_test.exs
@@ -329,6 +329,21 @@ defmodule PhoenixKitWeb.Live.UrlStateTest do
       assert UrlState.url_state_path(bare, search_query: "ivan") == "/?q=ivan"
     end
 
+    test "picks up a declared param set with a plain assign" do
+      # A LiveView that re-picks its sort column with `assign(:filter_role, …)`
+      # leaves the bookkeeping map stale. Merging onto that map would put the
+      # superseded value back in the URL on the next patch — and a reload would
+      # apply it. The freshest assign has to win.
+      state = UrlState.decode(%{"role" => "admin"}, cfg())
+
+      assigns =
+        assigns_for(state)
+        |> Map.put(:filter_role, "owner")
+
+      assert UrlState.url_state_path(assigns, search_query: "ivan") ==
+               "/admin/users?q=ivan&role=owner"
+    end
+
     test "never writes a value the decoder would reject" do
       spec =
         cfg(

--- a/test/phoenix_kit_web/live/url_state_test.exs
+++ b/test/phoenix_kit_web/live/url_state_test.exs
@@ -207,6 +207,125 @@ defmodule PhoenixKitWeb.Live.UrlStateTest do
     end
   end
 
+  describe "decode/2 integer ceiling" do
+    test "caps integers by default, so a crafted page cannot overflow OFFSET" do
+      # 10^24 parses fine and would reach PostgreSQL as OFFSET, overflowing bigint
+      assert UrlState.decode(%{"page" => "999999999999999999999999"}, cfg()).page == 1
+      assert UrlState.decode(%{"page" => "1000001"}, cfg()).page == 1
+      assert UrlState.decode(%{"page" => "1000000"}, cfg()).page == 1_000_000
+    end
+
+    test "an explicit :max overrides the default ceiling" do
+      spec = cfg(page: [default: 1, cast: :integer, min: 1, max: 50])
+
+      assert UrlState.decode(%{"page" => "50"}, spec).page == 50
+      assert UrlState.decode(%{"page" => "51"}, spec).page == 1
+    end
+  end
+
+  describe "reload?/3" do
+    test "does not reload when the state is unchanged and already loaded" do
+      state = UrlState.decode(%{"q" => "ivan"}, cfg())
+
+      refute UrlState.reload?(true, state, state)
+    end
+
+    test "reloads when a declared param changed" do
+      previous = UrlState.decode(%{"q" => "ivan"}, cfg())
+      current = UrlState.decode(%{"q" => "petr"}, cfg())
+
+      assert UrlState.reload?(true, current, previous)
+    end
+
+    test "reloads the first time even when the state equals the defaults" do
+      state = UrlState.decode(%{}, cfg())
+
+      assert UrlState.reload?(false, state, state)
+      assert UrlState.reload?(nil, state, nil)
+    end
+  end
+
+  describe "url_state_path/2" do
+    defp assigns_for(state, opts \\ []) do
+      %{
+        :__phoenix_kit_url_cfg__ => cfg(),
+        :__phoenix_kit_url_state__ => state,
+        :__phoenix_kit_url_path__ => Keyword.get(opts, :path, "/admin/users"),
+        :__phoenix_kit_url_extra__ => Keyword.get(opts, :extra, %{})
+      }
+    end
+
+    test "resets the page when another parameter changes" do
+      state = UrlState.decode(%{"q" => "ivan", "page" => "5"}, cfg())
+
+      path = UrlState.url_state_path(assigns_for(state), search_query: "petr")
+
+      assert path == "/admin/users?q=petr"
+    end
+
+    test "keeps the page when the page itself is what changed" do
+      state = UrlState.decode(%{"q" => "ivan", "page" => "5"}, cfg())
+
+      assert UrlState.url_state_path(assigns_for(state), page: 3) =~ "page=3"
+      assert UrlState.url_state_path(assigns_for(state), page: 3) =~ "q=ivan"
+    end
+
+    test "returns the bare path once everything is back to its default" do
+      state = UrlState.decode(%{"q" => "ivan"}, cfg())
+
+      assert UrlState.url_state_path(assigns_for(state), search_query: "") == "/admin/users"
+    end
+
+    test "preserves query keys the spec does not declare" do
+      state = UrlState.decode(%{}, cfg())
+      assigns = assigns_for(state, extra: %{"return_to" => "/admin/media"})
+
+      path = UrlState.url_state_path(assigns, search_query: "logo")
+
+      assert path =~ "q=logo"
+      assert path =~ "return_to=%2Fadmin%2Fmedia"
+    end
+
+    test "patches the path it is on, so a locale segment is not lost" do
+      state = UrlState.decode(%{}, cfg())
+      assigns = assigns_for(state, path: "/uk/admin/users")
+
+      assert UrlState.url_state_path(assigns, search_query: "ivan") == "/uk/admin/users?q=ivan"
+    end
+
+    test "falls back to :url_path, then to root, when no path was captured" do
+      state = UrlState.decode(%{}, cfg())
+
+      from_url_path =
+        state
+        |> assigns_for()
+        |> Map.delete(:__phoenix_kit_url_path__)
+        |> Map.put(:url_path, "/admin/users")
+
+      assert UrlState.url_state_path(from_url_path, search_query: "ivan") == "/admin/users?q=ivan"
+
+      bare = Map.delete(assigns_for(state), :__phoenix_kit_url_path__)
+      assert UrlState.url_state_path(bare, search_query: "ivan") == "/?q=ivan"
+    end
+
+    test "rejects a change keyed by URL key instead of assign name" do
+      state = UrlState.decode(%{}, cfg())
+
+      assert_raise ArgumentError, ~r/unknown UrlState parameter\(s\): \[:q\]/, fn ->
+        UrlState.url_state_path(assigns_for(state), q: "ivan")
+      end
+    end
+
+    test "explains itself when handed a socket during render" do
+      not_in_socket = %Phoenix.LiveView.Socket.AssignsNotInSocket{__assigns__: %{}}
+      socket = %Phoenix.LiveView.Socket{assigns: not_in_socket}
+
+      assert_raise ArgumentError, ~r/pass `assigns`, not `@socket`/, fn ->
+        UrlState.url_state_path(socket, search_query: "ivan")
+      end
+    end
+  end
+
   describe "round trip" do
     test "decode(encode(state)) is the identity for every declared param" do
       original = UrlState.decode(%{"q" => "ivan", "role" => "admin", "sort_dir" => "asc"}, cfg())


### PR DESCRIPTION
## Why

Typing in a list's search box filters the table but leaves the address bar untouched on most admin screens. The result cannot be shared, does not survive a reload, and Back walks out of the page instead of back to the previous query.

A workspace-wide audit found **26 LiveViews** with this defect and — more to the point — **seven independently hand-rolled implementations** of the fix on the screens that do work: `MediaBrowser.Embed`, `Activity.Index`, and one each in `comments`, `billing`, `crm`, `emails` and `ecommerce`. They differ only cosmetically (`maybe_put` vs `Enum.reject`, flat vs nested form params).

Six of the seven share a real defect: they rebuild the path from a literal (`Routes.path("/admin/comments?…")`), so a LiveView reachable at more than one route — a sub-tab such as `/orders/:id/edit/files` — patches itself to the wrong page.

## What this adds

`PhoenixKitWeb.Live.UrlState` — declare the state, implement one callback, push changes:

```elixir
use PhoenixKitWeb.Live.UrlState,
  params: [
    search_query: [default: "", url_key: "q", alias: "search"],
    filter_role:  [default: "all", url_key: "role"],
    page:         [default: 1, cast: :integer, min: 1]
  ]

def handle_url_state(_state, socket), do: load_users(socket)

def handle_event("search", %{"search" => q}, socket),
  do: {:noreply, push_url_state(socket, [search_query: q], replace: true)}
```

- **Param key = assign name**, with `url_key:` naming the query key separately — so conversions touch no templates. `users.html.heex` (700 lines) needed no edit.
- **`alias:`** is read but never written, letting screens that already published `?search=` links converge on `?q=` without breaking them.
- **`cast:` / `in:`** whitelist values; a forged one falls back to the default. No atom is ever created from user input.
- **Defaults are dropped from the query**, so an unfiltered list is `/admin/users`, not `/admin/users?q=&role=all&page=1`.
- **The path comes from the live `uri`**, not a literal — locale segments and parent-resource ids survive.
- **`replace: true`** for debounced input: a typed-out query leaves one history entry instead of one per pause. Every existing implementation gets this wrong, so Back currently walks the search box backwards a few characters at a time.
- **Unknown query keys are preserved** — the media selector's `?return_to=…&mode=single` survives a search.
- **The callback fires only on a real change**, so an unrelated patch does not re-run the list's queries.

## Converted

`users`, `sessions`, `live_sessions`, `jobs/index`, `media_selector`. `live_sessions` also gains URL-backed sort: its compound `%{by:, dir:}` assign is split into two flat params and recombined in the callback, leaving the template untouched.

## `use UrlState` makes a LiveView router-only

Verified against `phoenix_live_view` source, and the reason `phoenix_kit_projects` is out of scope:

- `push_patch` reaches `sync_handle_params_with_live_redirect/5`, which calls `Utils.call_handle_params!/4` — the arity whose `exported?` defaults to `true`. So `handle_params/3` **must** be exported.
- On an embedded mount (`root_pid != self()`), `maybe_call_mount_handle_params/4` sees `any? = callbacks? or exported?` and raises through `Route.live_link_info!`. So exporting `handle_params/3` — whatever its body — makes a LiveView **un-embeddable**.

One requires what the other forbids. `MediaBrowser.Embed`'s `url_sync: true` has always had this constraint through its injected stub; this PR writes it into its moduledoc.

## Tests

41 tests, no PostgreSQL required — everything deciding a URL is pure. Covers default-dropping, alias decode, cast/whitelist rejection, the integer ceiling, page reset, unknown-key preservation, path capture and fallbacks, and `reload?/3`.

Not covered: the `on_mount` → hook → host `handle_params/3` ordering. `live_isolated/3` mounts without a router, which this module refuses by design, so testing it needs a test router and endpoint core does not have yet. Called out in the design doc rather than papered over.

## Review

`ask-glm` (elixir-review) reviewed the branch and approved it with four findings; three are fixed in `d186b395`:

- integer params now carry a default ceiling of 1,000,000 — an unbounded `?page=` survives `Integer.parse`, reaches Ecto as `OFFSET` and overflows PostgreSQL's `bigint`, turning a crafted link into a 500;
- `push_url_state` now raises on a change keyed by URL key instead of assign name, which previously did nothing but reset the page;
- the `dead_render: :skip` docs were wrong — the callback not running means its assigns do not exist, so the dead render raises rather than painting empty.

The fourth (LiveView-level test coverage) is the gap recorded above.

## Design doc

`dev_docs/plans/2026-08-04-url-state-search-persistence.md` — full audit table, the constraint derivation, and the rollout order for the remaining repos.
