### PR TITLE
Add V161: case-insensitive phoenix_kit_users.username via citext

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 ## Workflow
 
 1. Make changes
-2. `mix precommit` (runs format + compile + credo --strict)
+2. `mix precommit` — compile (warnings as errors) + `deps.unlock --check-unused` + `quality.ci` (format-check, credo --strict, dialyzer) + JS tests. **It does not run `mix test`** — run that separately, see "CI/CD" below.
 3. Fix problems
 4. `git diff` / `git status` → commit
 
@@ -64,8 +64,18 @@ ast-grep --lang elixir --pattern 'def $FUNC($$$ARGS) do $$$BODY end' lib/
 
 ## Pull Requests
 
-- **Branch:** core integrates on **`main`** — open PRs against `main` (`gh pr create --base main --head mdon:main`). The `dev` branch was **retired 2026-06-01**; do not target it.
-- **CI/CD:** `.github/workflows/ci.yml` is **manual-only** (`workflow_dispatch`) — the equivalent checks run locally via `mix precommit` / `mix quality.ci` (format, credo, dialyzer, compile with warnings as errors, deps audit, tests with PostgreSQL).
+- **Branch:** core integrates on **`main`** — open PRs against `main` (`gh pr create --base main --head <your-fork-owner>:<branch>`; the previous example hardcoded one contributor's fork and branch). The `dev` branch was **retired 2026-06-01**; do not target it.
+- **CI/CD:** `.github/workflows/ci.yml` is **manual-only** (`on: workflow_dispatch`) — nothing runs on push or on a PR. When dispatched it provisions `postgres:16` and runs `mix format --check-formatted`, `mix credo --strict`, `mix dialyzer`, `mix deps.unlock --check-unused`, and `mix test.setup` + `mix test`.
+
+  ⚠️ **Nothing runs the Elixir suite automatically — not CI, and not `precommit`.** `mix precommit` covers compile-with-warnings-as-errors, unused deps, `quality.ci` and the JS tests, but **not `mix test`** (this section previously claimed otherwise). Running the suite is a manual step, and for anything touching the schema it is not optional: a `mix test` with no database silently excludes every `:integration` test and still reports success.
+
+  Pointing the suite at a database: `PGHOST`/`PGUSER`/`PGPASSWORD` were always read, and `PGDATABASE`/`PGPOOL` were added 2026-08-04 so you can use a database you already have. The old code hardcoded `phoenix_kit_test`, which forced a role with `CREATEDB` — precisely what a shared or managed instance withholds. On a busy shared server also bound the concurrency, or the pool starves and the failures look like product bugs:
+
+  ```bash
+  PGHOST=… PGUSER=… PGPASSWORD=… PGDATABASE=my_scratch_db PGPOOL=20 mix test --max-cases 8
+  ```
+
+  Adding `mix test` to `precommit` was tried on 2026-08-04 and reverted: the suite is not green from a clean checkout (with no database ~5 "unit" tests still fail, because `Settings` reads hit the DB on a cache miss), so the gate would be permanently red. Fixing that is worth doing separately — until then, treat the suite as a deliberate manual step, not an oversight.
 - **Commit messages:** start with `Add`, `Update`, `Fix`, `Remove`, `Merge`.
 - **Version management:** `mix.exs` `@version` + `CHANGELOG.md`. Run `mix compile`, `mix test`, `mix format`, `mix credo --strict` before committing. Get current versions:
   ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,15 +67,15 @@ ast-grep --lang elixir --pattern 'def $FUNC($$$ARGS) do $$$BODY end' lib/
 - **Branch:** core integrates on **`main`** — open PRs against `main` (`gh pr create --base main --head <your-fork-owner>:<branch>`; the previous example hardcoded one contributor's fork and branch). The `dev` branch was **retired 2026-06-01**; do not target it.
 - **CI/CD:** `.github/workflows/ci.yml` is **manual-only** (`on: workflow_dispatch`) — nothing runs on push or on a PR. When dispatched it provisions `postgres:16` and runs `mix format --check-formatted`, `mix credo --strict`, `mix dialyzer`, `mix deps.unlock --check-unused`, and `mix test.setup` + `mix test`.
 
-  ⚠️ **Nothing runs the Elixir suite automatically — not CI, and not `precommit`.** `mix precommit` covers compile-with-warnings-as-errors, unused deps, `quality.ci` and the JS tests, but **not `mix test`** (this section previously claimed otherwise). Running the suite is a manual step, and for anything touching the schema it is not optional: a `mix test` with no database silently excludes every `:integration` test and still reports success.
+  ⚠️ **Nothing runs the Elixir suite automatically — not CI, and not `precommit`.** `mix precommit` covers compile-with-warnings-as-errors, unused deps, `quality.ci` and the JS tests, but **not `mix test`** (this section previously claimed otherwise). Running the suite is a manual step, and for anything touching the schema it is not optional: with no database reachable, `test_helper.exs` prints a warning banner and excludes every `:integration` test — but the run still **exits 0 and reports success**, so a green summary proves nothing about a migration.
 
-  Pointing the suite at a database: `PGHOST`/`PGUSER`/`PGPASSWORD` were always read, and `PGDATABASE`/`PGPOOL` were added 2026-08-04 so you can use a database you already have. The old code hardcoded `phoenix_kit_test`, which forced a role with `CREATEDB` — precisely what a shared or managed instance withholds. On a busy shared server also bound the concurrency, or the pool starves and the failures look like product bugs:
+  Pointing the suite at a database: `PGHOST`/`PGUSER`/`PGPASSWORD` were always read, and `PGDATABASE`/`PGPOOL` were added so you can use a database you already have. The old code hardcoded `phoenix_kit_test`, which forced a role with `CREATEDB` — precisely what a shared or managed instance withholds. On a busy shared server also bound the concurrency, or the pool starves and the failures look like product bugs:
 
   ```bash
   PGHOST=… PGUSER=… PGPASSWORD=… PGDATABASE=my_scratch_db PGPOOL=20 mix test --max-cases 8
   ```
 
-  Adding `mix test` to `precommit` was tried on 2026-08-04 and reverted: the suite is not green from a clean checkout (with no database ~5 "unit" tests still fail, because `Settings` reads hit the DB on a cache miss), so the gate would be permanently red. Fixing that is worth doing separately — until then, treat the suite as a deliberate manual step, not an oversight.
+  Adding `mix test` to `precommit` was tried and reverted: the suite is not green from a clean checkout (with no database ~5 "unit" tests still fail, because `Settings` reads hit the DB on a cache miss), so the gate would be permanently red. Fixing that is worth doing separately — until then, treat the suite as a deliberate manual step, not an oversight.
 - **Commit messages:** start with `Add`, `Update`, `Fix`, `Remove`, `Merge`.
 - **Version management:** `mix.exs` `@version` + `CHANGELOG.md`. Run `mix compile`, `mix test`, `mix format`, `mix credo --strict` before committing. Get current versions:
   ```bash

--- a/config/test.exs
+++ b/config/test.exs
@@ -10,9 +10,15 @@ config :phoenix_kit, PhoenixKit.Test.Repo,
   username: System.get_env("PGUSER", "postgres"),
   password: System.get_env("PGPASSWORD", "postgres"),
   hostname: System.get_env("PGHOST", "localhost"),
-  database: "phoenix_kit_test#{System.get_env("MIX_TEST_PARTITION")}",
+  # `PGDATABASE`/`PGPOOL` let you point the suite at a database you already
+  # have instead of one this role is allowed to CREATE — without them the
+  # only way to run the integration half is a Postgres account with
+  # CREATEDB, which is exactly what a shared or managed instance withholds.
+  # Defaults are unchanged, so `mix test` on a local Postgres behaves as before.
+  database:
+    System.get_env("PGDATABASE", "phoenix_kit_test#{System.get_env("MIX_TEST_PARTITION")}"),
   pool: Ecto.Adapters.SQL.Sandbox,
-  pool_size: System.schedulers_online() * 2,
+  pool_size: String.to_integer(System.get_env("PGPOOL", "#{System.schedulers_online() * 2}")),
   priv: "test/support/postgres"
 
 # Wire repo for library code that calls PhoenixKit.Config.get(:repo)

--- a/config/test.exs
+++ b/config/test.exs
@@ -6,19 +6,42 @@ import Config
 # Configure test database - embedded test repo for library-level integration tests
 config :phoenix_kit, ecto_repos: [PhoenixKit.Test.Repo]
 
+# `PGDATABASE`/`PGPOOL` let you point the suite at a database you already have
+# instead of one this role is allowed to CREATE — without them the only way to
+# run the integration half is a Postgres account with CREATEDB, which is
+# exactly what a shared or managed instance withholds. Defaults are unchanged,
+# so `mix test` against a local Postgres behaves as before.
+#
+# Read through these two helpers rather than `System.get_env/2`, which falls
+# back only when the variable is UNSET: a set-but-empty `PGPOOL=` (trivial to
+# produce from a shell, or from `PGPOOL:` with no value in YAML) yields "" and
+# would abort config loading with an ArgumentError that never names the
+# variable.
+pg_test_db =
+  case System.get_env("PGDATABASE") do
+    value when is_binary(value) and value != "" -> String.trim(value)
+    _ -> "phoenix_kit_test#{System.get_env("MIX_TEST_PARTITION")}"
+  end
+
+pg_test_pool =
+  case System.get_env("PGPOOL") do
+    value when is_binary(value) and value != "" ->
+      case Integer.parse(String.trim(value)) do
+        {size, ""} when size > 0 -> size
+        _ -> raise "PGPOOL must be a positive integer, got: #{inspect(value)}"
+      end
+
+    _ ->
+      System.schedulers_online() * 2
+  end
+
 config :phoenix_kit, PhoenixKit.Test.Repo,
   username: System.get_env("PGUSER", "postgres"),
   password: System.get_env("PGPASSWORD", "postgres"),
   hostname: System.get_env("PGHOST", "localhost"),
-  # `PGDATABASE`/`PGPOOL` let you point the suite at a database you already
-  # have instead of one this role is allowed to CREATE — without them the
-  # only way to run the integration half is a Postgres account with
-  # CREATEDB, which is exactly what a shared or managed instance withholds.
-  # Defaults are unchanged, so `mix test` on a local Postgres behaves as before.
-  database:
-    System.get_env("PGDATABASE", "phoenix_kit_test#{System.get_env("MIX_TEST_PARTITION")}"),
+  database: pg_test_db,
   pool: Ecto.Adapters.SQL.Sandbox,
-  pool_size: String.to_integer(System.get_env("PGPOOL", "#{System.schedulers_online() * 2}")),
+  pool_size: pg_test_pool,
   priv: "test/support/postgres"
 
 # Wire repo for library code that calls PhoenixKit.Config.get(:repo)

--- a/dev_docs/pull_requests/2026/681-case-insensitive-username/CLAUDE_REVIEW.md
+++ b/dev_docs/pull_requests/2026/681-case-insensitive-username/CLAUDE_REVIEW.md
@@ -1,0 +1,106 @@
+# PR #681: Add V161: case-insensitive phoenix_kit_users.username via citext
+
+**Author**: @timujinne
+**Reviewer**: @timujinne (Claude)
+**Status**: 🔄 In Review
+**Commit**: `upstream/main..fix/case-insensitive-username`
+**Date**: 2026-08-05
+
+## Goal
+
+`phoenix_kit_users.username` is a plain `varchar` under a plain btree unique index, so `Pavel` and
+`pavel` are two different accounts. That happened in production. V161 converts the column to
+`citext` so uniqueness *and* every lookup become case-insensitive from the column type outward.
+
+## What Was Changed
+
+| File | Change |
+|------|--------|
+| `lib/phoenix_kit/migrations/postgres/v161.ex` | New migration: collision pre-check, then idempotent `ALTER … TYPE citext`; `down/1` back to `varchar(255)` |
+| `lib/phoenix_kit/migrations/postgres.ex` | `@current_version` 160 → 161, catalogue moduledoc entry |
+| `test/phoenix_kit/migrations/v161_test.exs` | New: schema-state pins + pre-check SQL shape |
+| `test/integration/users/registration_test.exs` | Inverts the test that pinned exact-match username lookup as intended |
+| `config/test.exs` | `PGDATABASE` / `PGPOOL` so the suite can use an existing database |
+| `AGENTS.md`, `mix.exs` | Corrects what `precommit` and CI actually run |
+
+## Review Findings
+
+Reviewed by an independent model (GLM-5.2 at max effort) against the code, then every finding
+re-verified by hand before being accepted. Findings from an earlier pass on the migration itself
+were already folded into commit 2 of this branch.
+
+### IMPROVEMENT - MEDIUM — `config/test.exs`: set-but-empty env var aborted config loading
+
+`System.get_env/2` falls back to its default only when the variable is **unset**. A set-but-empty
+`PGPOOL=` returns `""`, and `String.to_integer("")` raised an `ArgumentError` during config
+loading — before any test started, with a message that never named `PGPOOL`.
+
+Trivially reachable: `PGPOOL= mix test` from a shell, or `PGPOOL:` with no value in a YAML
+pipeline. Verified by running it, not by reading.
+
+**Resolved** in this branch: both `PGDATABASE` and `PGPOOL` now treat empty as absent, trim
+whitespace, and a non-numeric `PGPOOL` raises a message that names the variable and the value.
+Checked across all four cases — unset, set-empty, valid, whitespace-padded.
+
+### NITPICK — internal chronology in upstream-facing docs
+
+Comments read "tried on 2026-08-04 and reverted" — a bare date without an actor reads as one
+team's internal history in a public library.
+
+**Resolved**: dates dropped, the reasoning kept.
+
+### Self-correction — the docs this PR fixes contained an inaccuracy of their own
+
+This PR's own wording claimed `mix test` with no database "silently" excludes integration tests.
+It is not silent: `test_helper.exs` prints a warning banner. The substantive point survives and is
+what matters — the run still **exits 0 and reports success**, so a green summary proves nothing
+about a migration. Wording corrected.
+
+### Verified and found correct (so a maintainer knows these are closed)
+
+- **Dispatch**: `Module.concat([__MODULE__, "V#{pad_idx}"])` by version number plus the
+  `@current_version` bump is the whole wiring — no registry to forget.
+- **Pre-check cannot false-positive**: `WHERE username IS NOT NULL` is the load-bearing clause;
+  without it `GROUP BY` folds every NULL into one group and two username-less accounts abort the
+  upgrade. Pinned by test.
+- **Re-running on an installation already at 161** is a no-op: the coordinator skips it, and even
+  if DDL was once dropped, the `DO` block is guarded on `udt_name` and the pre-check returns empty
+  on a citext column.
+- **Prefix-safety**: both existence checks anchor on `table_schema`; no `::regclass` in an
+  IMMEDIATE check; `escaped_prefix` is escaped at the entry point. Same shape as V151.
+- **Auth needs no changes**: `get_user_by_username/1`, `unsafe_validate_unique/3` and
+  `ensure_unique_username/3` all ride the column's semantics.
+- **No internal infrastructure leaked** into the diff (checked for paths, hostnames, team names).
+
+## Testing
+
+- [x] Unit tests added/updated
+- [x] Integration tests pass — 41/41 for the migration and registration suites
+- [x] Migration tested on a real database — PostgreSQL 17.4, empty database, full chain V01→V161
+- [x] Backward compatibility verified — see below
+- [x] Documentation updated
+
+Verified on the real run, not inferred: column became `citext`, `email` untouched, schema version
+comment `161`, the unique index survived the `ALTER` with the same name and predicate, inserting
+`'ALICE'` against an existing `'alice'` is rejected, and `WHERE username = 'BOB'` finds `'bob'` —
+the exact SQL shape `Repo.get_by` emits.
+
+Full suite against that database: 3 failures, all in `MaintenanceTest` (scheduling windows on an
+unseeded database), which V161 does not touch. `mix precommit` green.
+
+## Migration Notes
+
+An installation that already contains case-variant usernames stops with a raise naming the
+conflicting value, before any DDL. The operator renames or merges and re-runs — the same
+experience V106 already establishes. Nothing is merged or renamed automatically.
+
+`citext` has been a required extension since V01, so there is no new database prerequisite.
+
+The behavioural change is the fix itself: username lookup and uniqueness become case-insensitive.
+Anything relying on case-sensitive username matching would change behaviour — nothing in core does.
+
+## Related
+
+- Migration: `lib/phoenix_kit/migrations/postgres/v161.ex`
+- Prior art for the pre-check shape: `lib/phoenix_kit/migrations/postgres/v106.ex`
+- Prior art for the citext conversion: `lib/phoenix_kit/migrations/postgres/v151.ex`, `v01.ex`

--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -529,7 +529,23 @@ defmodule PhoenixKit.Migrations.Postgres do
   - Replaces unique index with partial index (slug-mode only, WHERE slug IS NOT NULL)
   - Adds unique index on `(group_uuid, post_date, post_time)` for timestamp-mode posts
 
-  ### V160 - Settings `value` widened to TEXT ⚡ LATEST
+  ### V161 - Case-insensitive `phoenix_kit_users.username` (citext) ⚡ LATEST
+  - `username` was `VARCHAR(255)` (V08's `:string`) — comparison semantics
+    come from the column type, not the Ecto schema field, so every lookup
+    (`get_user_by_username/1`, `unsafe_validate_unique`, the unique index
+    itself) was exact-match; `alice` and `Alice` could both register
+  - Converts the column to `citext`, same fix already applied to `email`
+    in V01 and the CRM party email columns in V151
+  - Pre-check (mirrors V106's down-step) raises on any existing
+    case-insensitive collision before the DDL runs, naming the offending
+    value; `WHERE username IS NOT NULL` guards against nullable rows
+    false-colliding under `GROUP BY`
+  - `varchar` → `citext` is binary-coercible (`pg_cast.castmethod = 'b'`),
+    confirmed live — no table rewrite; the column's B-tree index does get
+    rebuilt (also confirmed live), which is what makes it enforce
+    case-insensitive uniqueness right after the `ALTER`
+
+  ### V160 - Settings `value` widened to TEXT
   - `phoenix_kit_settings.value` was `VARCHAR(255)` (V03's `:string`) while
     `Settings.Setting` validated it at `max: 1000` — anything in between
     passed the changeset and then raised a raw `Postgrex.Error`
@@ -1423,7 +1439,7 @@ defmodule PhoenixKit.Migrations.Postgres do
   alias PhoenixKit.Migrations.Postgres.Helpers
 
   @initial_version 1
-  @current_version 160
+  @current_version 161
   @default_prefix "public"
 
   # First version whose SQL references uuid_generate_v7(). Chains that

--- a/lib/phoenix_kit/migrations/postgres/v161.ex
+++ b/lib/phoenix_kit/migrations/postgres/v161.ex
@@ -1,0 +1,159 @@
+defmodule PhoenixKit.Migrations.Postgres.V161 do
+  @moduledoc """
+  V161: Case-insensitive `phoenix_kit_users.username` via `citext`.
+
+  V08 created `username` as `:string` (`VARCHAR(255)`, `v08.ex:38`) with a
+  partial unique index on non-null values
+  (`phoenix_kit_users_username_uidx`). Postgres resolves comparison
+  semantics from the *column's* type, not from how the Ecto schema declares
+  the field — so despite the schema, every lookup (`Auth.get_user_by_username/1`
+  → bare `Repo.get_by(User, username: ...)`, the `unsafe_validate_unique`
+  changeset check, and the unique index itself) has always been exact-match.
+  Two accounts differing only by case — `alice` / `Alice` — could both
+  register, and `get_user_by_username("ALICE")` would find neither.
+
+  `email` already gets this for free — it's been `citext` since V01
+  (`v01.ex:49`) and is explicitly out of scope here (already correct,
+  verified live). This migration brings `username` to the same shape: one
+  `ALTER COLUMN ... TYPE citext` fixes writes, reads, and the uniqueness
+  constraint at once, and makes it structurally impossible for future code
+  to reintroduce case-sensitive comparison by accident — the same fix
+  already applied to the CRM party email columns in V151.
+
+  ## Pre-check
+
+  Before any DDL, `up/1` scans for existing rows that would collide once
+  comparison becomes case-insensitive (`GROUP BY lower(username) HAVING
+  count(*) > 1`, mirroring V106's down-step pre-check). `username` is
+  nullable, and `GROUP BY` folds every `NULL` into one group — the scan
+  filters `WHERE username IS NOT NULL` so two username-less accounts don't
+  register as a false collision and abort the upgrade. If a real collision
+  is found, `up/1` raises and names the offending value before touching the
+  schema; operators resolve it (rename or merge) and re-run.
+
+  ## Cost: catalog-only, no table rewrite
+
+  `varchar` → `citext` is binary-coercible in Postgres — confirmed against
+  `pg_cast` rather than assumed:
+
+      SELECT castmethod, castfunc, castcontext FROM pg_cast
+      WHERE castsource = 'varchar'::regtype AND casttarget = 'citext'::regtype;
+      -- castmethod = 'b' (binary coercion), castfunc = 0, castcontext = 'a'
+
+  `castmethod = 'b'` means Postgres reinterprets the on-disk bytes as-is —
+  no per-row validation pass, no **table** rewrite. The `username` B-tree
+  index is a different story: verified live against a throwaway table that
+  `ALTER COLUMN ... TYPE citext` DOES rebuild any index on that column
+  (`relfilenode` changes) — expected and necessary, since citext orders and
+  compares values differently from `varchar` (`lower()`-based, not raw
+  byte order), and it's exactly what makes
+  `phoenix_kit_users_username_uidx` start rejecting case-variant
+  duplicates right after the `ALTER` (confirmed on the same probe:
+  inserting `'ALICE'` against an existing `'alice'` row raised
+  `unique_violation` immediately post-conversion). So the honest cost
+  statement is: no table heap rewrite, but the index rebuild's cost scales
+  with the number of non-null `username` values — cheap in absolute terms,
+  not a zero-cost catalog flip. The `ALTER TABLE` holds an `ACCESS
+  EXCLUSIVE` lock for that (brief) duration, which is why this migration
+  keeps `@disable_ddl_transaction true` (core convention — `v154.ex:30`,
+  `v159.ex:36`) so the lock is never held for the length of a whole
+  migration transaction.
+
+  The `ALTER COLUMN` itself is idempotent, guarded by a `udt_name` check on
+  `information_schema.columns` (same shape as V151's email conversion,
+  `v151.ex:97-113`), and `prefix` is honored throughout.
+  """
+
+  use Ecto.Migration
+
+  alias PhoenixKit.Migrations.Postgres.Helpers
+
+  @disable_ddl_transaction true
+
+  def up(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    escaped_prefix = Map.get(opts, :escaped_prefix, prefix)
+    p = prefix_str(prefix)
+
+    # Pre-check: a case-insensitive collision must be resolved BEFORE the
+    # column becomes citext, or the existing unique index would reject one
+    # of the colliding rows mid-migration with a generic Postgres error.
+    # `WHERE username IS NOT NULL` is required: GROUP BY treats every NULL
+    # as equal, so without the filter any two username-less users would
+    # look like a duplicate and abort the upgrade for no reason.
+    case repo().query!(
+           "SELECT lower(username) FROM #{p}phoenix_kit_users " <>
+             "WHERE username IS NOT NULL GROUP BY lower(username) HAVING count(*) > 1 LIMIT 1",
+           [],
+           log: false
+         ) do
+      %{rows: []} ->
+        :ok
+
+      %{rows: [[duplicate]]} ->
+        raise """
+        Cannot apply V161: username #{inspect(duplicate)} (case-insensitive) \
+        is shared by more than one user. Resolve the collision — rename or \
+        merge the accounts — before upgrading. Converting `username` to \
+        `citext` makes comparison case-insensitive, and the existing unique \
+        index (`phoenix_kit_users_username_uidx`) would then reject one of \
+        these rows outright.\
+        """
+    end
+
+    # no-op when citext is already installed (core dependency since V01)
+    Helpers.ensure_extension!("citext")
+
+    execute("""
+    DO $$
+    BEGIN
+      IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = '#{escaped_prefix}'
+        AND table_name = 'phoenix_kit_users'
+        AND column_name = 'username'
+        AND udt_name <> 'citext'
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_users
+        ALTER COLUMN username TYPE citext;
+      END IF;
+    END $$;
+    """)
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '161'")
+  end
+
+  @doc """
+  Reverts `username` to `VARCHAR(255)` (its V08 shape).
+
+  No pre-check needed on the way down: while the column is still `citext`,
+  the unique index already refuses any new case-variant duplicate from
+  appearing, so there is nothing for a rollback to collide with.
+  """
+  def down(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    escaped_prefix = Map.get(opts, :escaped_prefix, prefix)
+    p = prefix_str(prefix)
+
+    execute("""
+    DO $$
+    BEGIN
+      IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = '#{escaped_prefix}'
+        AND table_name = 'phoenix_kit_users'
+        AND column_name = 'username'
+        AND udt_name = 'citext'
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_users
+        ALTER COLUMN username TYPE VARCHAR(255);
+      END IF;
+    END $$;
+    """)
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '160'")
+  end
+
+  defp prefix_str("public"), do: "public."
+  defp prefix_str(prefix), do: "#{prefix}."
+end

--- a/lib/phoenix_kit/migrations/postgres/v161.ex
+++ b/lib/phoenix_kit/migrations/postgres/v161.ex
@@ -31,6 +31,18 @@ defmodule PhoenixKit.Migrations.Postgres.V161 do
   is found, `up/1` raises and names the offending value before touching the
   schema; operators resolve it (rename or merge) and re-run.
 
+  The pre-check is **best-effort, not a lock**. `@disable_ddl_transaction`
+  means it runs as its own statement, separate from the `ALTER`, so on a
+  live system two concurrent registrations of `alice` and `Alice` can still
+  slip into that window — the old varchar index is case-sensitive and
+  admits both. The real guard is the index rebuild inside the `ALTER`,
+  which then fails with Postgres' generic `duplicate key value violates
+  unique constraint` instead of the readable message above. Nothing is
+  corrupted and the column is left unconverted; a re-run catches the pair
+  through the pre-check. Closing that window would mean holding pre-check
+  and `ALTER` in one transaction — exactly the long `ACCESS EXCLUSIVE` that
+  `@disable_ddl_transaction` exists to avoid — so the gap is deliberate.
+
   ## Cost: catalog-only, no table rewrite
 
   `varchar` → `citext` is binary-coercible in Postgres — confirmed against
@@ -53,7 +65,10 @@ defmodule PhoenixKit.Migrations.Postgres.V161 do
   `unique_violation` immediately post-conversion). So the honest cost
   statement is: no table heap rewrite, but the index rebuild's cost scales
   with the number of non-null `username` values — cheap in absolute terms,
-  not a zero-cost catalog flip. The `ALTER TABLE` holds an `ACCESS
+  not a zero-cost catalog flip. The pre-check adds a second pass of the
+  same order: `GROUP BY lower(username)` has no index to use, so it is a
+  full scan of every non-null `username`. It takes no locks and runs before
+  any DDL, so it lengthens the migration without lengthening the outage. The `ALTER TABLE` holds an `ACCESS
   EXCLUSIVE` lock for that (brief) duration, which is why this migration
   keeps `@disable_ddl_transaction true` (core convention — `v154.ex:30`,
   `v159.ex:36`) so the lock is never held for the length of a whole

--- a/mix.exs
+++ b/mix.exs
@@ -311,7 +311,7 @@ defmodule PhoenixKit.MixProject do
       quality: ["format", "credo --strict", "dialyzer"],
       "quality.ci": ["format --check-formatted", "credo --strict", "dialyzer"],
       # NOTE: `mix test` is deliberately NOT here — see AGENTS.md "CI/CD".
-      # Adding it was tried on 2026-08-04 and reverted: the suite is not
+      # Adding it was tried and reverted: the suite is not
       # green from a clean checkout (Settings reads hit the DB on a cache
       # miss, so ~5 "unit" tests fail with no database at all; with one,
       # unbounded concurrency exhausts the pool). A gate that is always red

--- a/mix.exs
+++ b/mix.exs
@@ -310,6 +310,14 @@ defmodule PhoenixKit.MixProject do
       # Code quality
       quality: ["format", "credo --strict", "dialyzer"],
       "quality.ci": ["format --check-formatted", "credo --strict", "dialyzer"],
+      # NOTE: `mix test` is deliberately NOT here — see AGENTS.md "CI/CD".
+      # Adding it was tried on 2026-08-04 and reverted: the suite is not
+      # green from a clean checkout (Settings reads hit the DB on a cache
+      # miss, so ~5 "unit" tests fail with no database at all; with one,
+      # unbounded concurrency exhausts the pool). A gate that is always red
+      # gets ignored, which is worse than an honest gap. Run the suite
+      # explicitly — `mix test` — and see AGENTS.md for pointing it at a
+      # database you already have.
       precommit: [
         "compile --warnings-as-errors --all-warnings",
         "deps.unlock --check-unused",
@@ -324,7 +332,8 @@ defmodule PhoenixKit.MixProject do
 
       # Release gate — run before `mix hex.publish`. Catches release-metadata
       # drift and packaging mistakes that precommit/quality.ci structurally
-      # cannot. Deliberately DB-free (no `mix test` here — CI owns that).
+      # cannot. Deliberately DB-free — running `mix test` is a separate
+      # manual step, see AGENTS.md "CI/CD".
       prerelease: [
         "deps.get --check-locked",
         "deps.unlock --check-unused",

--- a/test/integration/users/registration_test.exs
+++ b/test/integration/users/registration_test.exs
@@ -51,6 +51,13 @@ defmodule PhoenixKit.Integration.Users.RegistrationTest do
       assert "has already been taken" in errors_on(changeset).email
     end
 
+    test "enforces case-insensitive unique username" do
+      {:ok, _} = Auth.register_user(valid_attrs(%{username: "CaseTest"}))
+      {:error, changeset} = Auth.register_user(valid_attrs(%{username: "casetest"}))
+
+      assert "has already been taken" in errors_on(changeset).username
+    end
+
     test "validates email format" do
       {:error, changeset} = Auth.register_user(valid_attrs(%{email: "not-an-email"}))
 
@@ -148,11 +155,13 @@ defmodule PhoenixKit.Integration.Users.RegistrationTest do
       assert is_nil(Auth.get_user_by_username("nonexistent_user_xyz"))
     end
 
-    test "username lookup is exact match" do
-      {:ok, _user} = Auth.register_user(valid_attrs(%{username: "exactmatch"}))
+    test "username lookup is case-insensitive (V161)" do
+      {:ok, user} = Auth.register_user(valid_attrs(%{username: "exactmatch"}))
 
-      # Different case should not match (username stored as-is)
-      assert is_nil(Auth.get_user_by_username("EXACTMATCH"))
+      # `username` is `citext` as of V161 — comparison is case-insensitive,
+      # same as `email` has been since V01.
+      found = Auth.get_user_by_username("EXACTMATCH")
+      assert found.uuid == user.uuid
     end
   end
 

--- a/test/phoenix_kit/migrations/v161_test.exs
+++ b/test/phoenix_kit/migrations/v161_test.exs
@@ -58,10 +58,17 @@ defmodule PhoenixKit.Migrations.Postgres.V161Test do
     udt_name
   end
 
-  # Mirrors V161.up's pre-check SELECT verbatim (modulo the row source —
-  # see moduledoc), so a future edit to the migration that breaks the
-  # pre-check (wrong column, dropped NULL guard, wrong HAVING) would also
-  # break this helper, surfacing the regression in tests.
+  # A COPY of V161.up's pre-check SELECT (modulo the row source — see
+  # moduledoc), not a call into it: once the column is citext the unique
+  # index makes a real collision impossible to stage, so the SQL shape is
+  # exercised against `unnest` instead.
+  #
+  # ⚠️ That means the two are only linked by hand. Editing the pre-check in
+  # `v161.ex` does NOT fail this test — keep them in sync deliberately. What
+  # this does buy is coverage of the subtle parts of the shape itself: the
+  # `WHERE username IS NOT NULL` guard (without it every username-less
+  # account folds into one NULL group and falsely aborts the upgrade), the
+  # `lower()` grouping, and the `HAVING count(*) > 1` threshold.
   defp find_case_insensitive_duplicate(usernames) do
     Repo.query!(
       "SELECT lower(username) FROM unnest($1::varchar[]) AS username " <>

--- a/test/phoenix_kit/migrations/v161_test.exs
+++ b/test/phoenix_kit/migrations/v161_test.exs
@@ -1,0 +1,133 @@
+defmodule PhoenixKit.Migrations.Postgres.V161Test do
+  @moduledoc """
+  Tests V161's schema state and its `up/1` pre-check.
+
+  V161.up/down can't be invoked outside an `Ecto.Migrator` runner (they
+  rely on `Ecto.Migration.execute/1` and `repo()`, which both check for a
+  runner process) — same constraint as V106Test/V145Test/V152Test/etc. The
+  schema is verified at boot: `test_helper.exs` runs `ensure_current/2`
+  (now through V161) before any test, so the schema-state assertions below
+  pin the post-V161 shape.
+
+  ## Pre-check coverage
+
+  By the time this test runs, `phoenix_kit_users.username` is already
+  `citext` with its unique index enforcing case-insensitive uniqueness —
+  which means the exact collision V161's pre-check exists to catch can no
+  longer be reproduced by inserting into the real table (the fix works!).
+  So the pre-check's `GROUP BY lower(username) HAVING count(*) > 1` SQL is
+  pinned against an inline `unnest($1::varchar[])` row source instead of
+  `phoenix_kit_users` — same query shape (`lower(username)` / `WHERE
+  username IS NOT NULL` / `GROUP BY` / `HAVING`), controlled input, no risk
+  of colliding with the live unique index or other tests' data.
+  """
+
+  use PhoenixKit.DataCase, async: false
+
+  alias PhoenixKit.Test.Repo
+
+  defp column(table, column) do
+    %{rows: rows} =
+      Repo.query!(
+        """
+        SELECT data_type, is_nullable, column_default
+        FROM information_schema.columns
+        WHERE table_name = $1 AND column_name = $2
+        """,
+        [table, column]
+      )
+
+    case rows do
+      [[data_type, is_nullable, default]] ->
+        %{type: data_type, nullable: is_nullable, default: default}
+
+      [] ->
+        nil
+    end
+  end
+
+  # information_schema reports citext columns as data_type "USER-DEFINED";
+  # udt_name carries the real type name (same helper as V151/V152's tests).
+  defp column_udt_name(table, column) do
+    %{rows: [[udt_name]]} =
+      Repo.query!(
+        "SELECT udt_name FROM information_schema.columns WHERE table_name = $1 AND column_name = $2",
+        [table, column]
+      )
+
+    udt_name
+  end
+
+  # Mirrors V161.up's pre-check SELECT verbatim (modulo the row source —
+  # see moduledoc), so a future edit to the migration that breaks the
+  # pre-check (wrong column, dropped NULL guard, wrong HAVING) would also
+  # break this helper, surfacing the regression in tests.
+  defp find_case_insensitive_duplicate(usernames) do
+    Repo.query!(
+      "SELECT lower(username) FROM unnest($1::varchar[]) AS username " <>
+        "WHERE username IS NOT NULL GROUP BY lower(username) HAVING count(*) > 1 LIMIT 1",
+      [usernames],
+      log: false
+    )
+  end
+
+  describe "up/1 — case-insensitive collision pre-check" do
+    test "no usernames → no duplicate" do
+      assert %{rows: []} = find_case_insensitive_duplicate([])
+    end
+
+    test "all-distinct usernames → no duplicate" do
+      assert %{rows: []} = find_case_insensitive_duplicate(["alice", "bob", "carol"])
+    end
+
+    test "two users with no username (NULL) do not falsely collide" do
+      # The exact regression the `WHERE username IS NOT NULL` guard exists
+      # to prevent: GROUP BY treats every NULL as one group, so without the
+      # filter this would report a false collision and abort the upgrade.
+      assert %{rows: []} = find_case_insensitive_duplicate([nil, nil, "dave"])
+    end
+
+    test "same username differing only by case is detected" do
+      assert %{rows: [["duptest"]]} =
+               find_case_insensitive_duplicate(["duptest", "DupTest"])
+    end
+
+    test "exact duplicate (same case) is also detected" do
+      assert %{rows: [["sameuser"]]} =
+               find_case_insensitive_duplicate(["sameuser", "sameuser"])
+    end
+
+    test "a NULL alongside a real collision still surfaces the collision" do
+      assert %{rows: [["mixed"]]} =
+               find_case_insensitive_duplicate([nil, "mixed", "MIXED", nil])
+    end
+  end
+
+  describe "phoenix_kit_users.username" do
+    test "column type is citext" do
+      assert column_udt_name("phoenix_kit_users", "username") == "citext"
+    end
+
+    test "stays nullable, varchar-length shape otherwise unchanged" do
+      assert %{nullable: "YES"} = column("phoenix_kit_users", "username")
+    end
+  end
+
+  describe "phoenix_kit_users.email — unaffected by V161" do
+    test "still citext (V01 — out of scope for this migration)" do
+      assert column_udt_name("phoenix_kit_users", "email") == "citext"
+    end
+  end
+
+  describe "version marker" do
+    test "phoenix_kit table comment is at or past V161" do
+      %{rows: [[comment]]} =
+        Repo.query!("SELECT obj_description('phoenix_kit'::regclass, 'pg_class')")
+
+      # >= rather than ==: pinning the exact latest version breaks this
+      # test every time a newer migration ships. What V161 owns is "the
+      # chain reached at least me".
+      assert String.to_integer(comment) >= 161
+    end
+  end
+end


### PR DESCRIPTION
## Why

Two accounts existed in production with the usernames `Pavel` and `pavel`. Nobody created a duplicate on purpose — the system allowed it end to end:

- `phoenix_kit_users_username_uidx` is a plain btree on a `varchar` column, so the two values are distinct keys.
- `unsafe_validate_unique(:username, …)` compares exactly.
- `get_user_by_username/1` is `Repo.get_by(User, username: …)` — also exact.

The mechanism that actually produced the duplicate is worth spelling out, because it is systematic rather than a fluke: `generate_username_from_email/1` **force-downcases**, while `ensure_unique_username/3` checks availability case-sensitively. A username set manually with a capital is therefore invisible to the generator — it proposes the lowercase form, finds it "free", and adds no suffix.

The consequence worse than the duplicate itself: signing in by username is case-sensitive too, so typing your own name with different capitalisation lands you in a *different account*. To the user that reads as "my permissions disappeared", with no error anywhere.

`email` is unaffected — it has been `citext` since V01 and is deliberately left alone.

## What

V161 converts `phoenix_kit_users.username` to `citext`.

Postgres decides comparison semantics from the **column type**, so one `ALTER` fixes uniqueness *and* every lookup, including a bare `Repo.get_by`. A functional unique index on `lower(username)` would have fixed only the constraint and left every read exact-match — and nothing would stop the next lookup from forgetting about case again. This is also the pattern already used in this schema (`email` in V01, CRM columns in V151), not a new one.

- Pre-check before any DDL: `GROUP BY lower(username) HAVING count(*) > 1`, raising and naming the offending value (same shape as V106's). `WHERE username IS NOT NULL` matters — without it `GROUP BY` folds every NULL into one group and two username-less accounts abort the upgrade.
- Idempotent `ALTER` guarded on `udt_name`, `prefix` honored, `@disable_ddl_transaction true`.
- `down/1` converts back to `varchar(255)`.

## Verification

Run against a real PostgreSQL 17.4, empty database, so the whole chain executed from V01 to V161:

- `username` → `citext`, `email` untouched, schema version comment `161`
- `phoenix_kit_users_username_uidx` survived the `ALTER` with the same name and predicate
- inserting `'ALICE'` against an existing `'alice'` is rejected by the index
- `WHERE username = 'BOB'` finds the row stored as `'bob'` — the exact SQL shape `Repo.get_by` emits
- `varchar → citext` confirmed binary-coercible against `pg_cast` (`castmethod = 'b'`), so no table rewrite; the index rebuild was confirmed on a scratch table (`relfilenode` changes), which is what makes the constraint start rejecting case variants

Full suite with a database: 3 failures, all in `MaintenanceTest` (scheduling windows on an unseeded database), which V161 does not touch. `mix precommit` green.

## Also here

Verifying the above was harder than it should be, so two adjacent fixes ride along:

- `config/test.exs` hardcoded `phoenix_kit_test`, which forces a role with `CREATEDB` — precisely what a shared or managed instance withholds. `PGDATABASE`/`PGPOOL` now let you point the suite at a database you already have. Defaults unchanged.
- `AGENTS.md` described `mix precommit` as the local equivalent of CI "including tests with PostgreSQL". It never ran `mix test`, and CI is `workflow_dispatch`, so in practice nothing ran the Elixir suite. Adding `mix test` to precommit was tried and reverted — the suite is not green from a clean checkout (with no database ~5 "unit" tests fail because `Settings` reads hit the DB on a cache miss), and a permanently red gate teaches people to ignore the gate. The docs now say running the suite is manual, and warn that `mix test` with no database excludes every integration test and still reports success — the failure mode that matters most when the change is a migration.

## Compatibility

An installation that already contains case-variant usernames stops at V160 with a raise naming the conflict, resolves it, and re-runs — the same operator experience V106 already establishes. Nothing is merged or renamed automatically. Installations without collisions are unaffected. `citext` has been a required extension since V01, so there is no new database prerequisite.

The behavioural change is the fix itself: username lookup and uniqueness become case-insensitive. `registration_test.exs` had a test pinning the old exact-match behaviour as intended; it is inverted here.
