### PR TITLE
Add V162 payment-option linkage, slug transliteration, and sub-permission tab fixes

### DIFF
--- a/dev_docs/pull_requests/2026/680-v161-payment-option-linkage/README.md
+++ b/dev_docs/pull_requests/2026/680-v161-payment-option-linkage/README.md
@@ -1,0 +1,45 @@
+# PR draft — V161: payment-option linkage on billing orders
+
+**Base:** `BeamLabEU/phoenix_kit` `main` ← **Head:** `mdon:main`
+**Commits:** 1 · one new migration file + the version bump in the index
+
+> Pairs with `phoenix_kit_billing` (Order schema + changeset) and
+> `phoenix_kit_ecommerce` (checkout persists the link). **Merge and
+> release this first** — both consumers guard the column's absence, so
+> they degrade rather than crash on an older core, but neither can record
+> the link until this ships.
+
+---
+
+## Summary
+
+Adds a nullable `payment_option_uuid` FK (plus its index) to
+`phoenix_kit_orders`, pointing at `phoenix_kit_payment_options`.
+
+An order records HOW it is to be paid via `payment_method` — a small
+closed vocabulary (`bank`, `stripe`, `paypal`, `razorpay`). What the
+customer actually chose at checkout is a payment-option ROW: an
+operator-configured method with its own name, instructions, provider and
+billing-profile requirement. The two are not the same thing. Several
+options can share one `payment_method` ("Bank transfer (EU)" and "Bank
+transfer (UK)" are both `bank`), and an option can be renamed or
+deactivated after the order is placed.
+
+Without a link the choice was discarded at conversion: nothing on the
+order said which option the customer picked, so an operator processing a
+bank transfer could not tell which instructions the customer had been
+shown, and payment reconciliation had to guess.
+
+## Why `ON DELETE SET NULL`
+
+Deactivating and deleting a payment option is an ordinary operator action.
+It must not be blocked by historical orders, and it must not destroy them.
+The order keeps `payment_method` and its metadata snapshot regardless, so
+a deleted option degrades to "we know it was a bank transfer" rather than
+to nothing.
+
+## Verification
+
+`add_if_not_exists` / `create_if_not_exists` and matching `down/1`, so the
+migration is re-runnable and reversible. The table comment moves to '161'
+on up and back to '160' on down, per the marker convention.

--- a/lib/phoenix_kit/dashboard/registry.ex
+++ b/lib/phoenix_kit/dashboard/registry.ex
@@ -1027,8 +1027,12 @@ defmodule PhoenixKit.Dashboard.Registry do
   # Registers a custom permission key derived from a tab config map.
   # Only registers if the permission key is NOT one of the built-in keys.
   # Also caches live_view → permission mapping for auth enforcement.
-  defp auto_register_custom_permission(%{permission: perm} = tab_config)
-       when is_binary(perm) or is_atom(perm) do
+  # Exposed as `@doc false def` (rather than `defp`) so unit tests can drive a
+  # single tab config through registration without standing up the GenServer.
+  # Not part of the public API.
+  @doc false
+  def auto_register_custom_permission(%{permission: perm} = tab_config)
+      when is_binary(perm) or is_atom(perm) do
     perm = to_string(perm)
 
     # Integration keys are core-managed built-ins, NOT custom keys — include
@@ -1041,7 +1045,13 @@ defmodule PhoenixKit.Dashboard.Registry do
       Permissions.core_section_keys() ++
         Permissions.integration_keys() ++ Permissions.feature_module_keys()
 
-    unless perm == "" or perm in builtin_keys do
+    # A tab may be gated on a SUB-permission ("shop.manage_settings"). Those
+    # are declared through `permission_metadata/0` and stored as composed
+    # dotted keys, which `register_custom_key/2` rejects outright — the raise
+    # then skipped the view→permission caching below, so a module that gated
+    # its settings page on a sub-key lost core's automatic view gate and
+    # warned on every boot.
+    unless perm == "" or perm in builtin_keys or Permissions.parent_key(perm) do
       # Forward the tab's gettext config so the permissions matrix renders
       # the key's label in the same locale the sidebar tab already does.
       Permissions.register_custom_key(perm,
@@ -1079,7 +1089,7 @@ defmodule PhoenixKit.Dashboard.Registry do
       :ok
   end
 
-  defp auto_register_custom_permission(_), do: :ok
+  def auto_register_custom_permission(_), do: :ok
 
   # Subscribe to entity definition lifecycle events for sidebar cache invalidation.
   # Guarded since the Entities module is optional.

--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -529,7 +529,16 @@ defmodule PhoenixKit.Migrations.Postgres do
   - Replaces unique index with partial index (slug-mode only, WHERE slug IS NOT NULL)
   - Adds unique index on `(group_uuid, post_date, post_time)` for timestamp-mode posts
 
-  ### V160 - Settings `value` widened to TEXT ⚡ LATEST
+  ### V161 - Payment-option linkage on billing orders ⚡ LATEST
+
+  Adds a nullable `payment_option_uuid` FK (+ index) to
+  `phoenix_kit_orders`, pointing at `phoenix_kit_payment_options`. The
+  order's `payment_method` is a small closed vocabulary; the payment
+  OPTION is the operator-configured row the customer actually chose, and
+  the choice used to be discarded at checkout. `ON DELETE SET NULL` so
+  deleting an option neither fails nor destroys order history.
+
+  ### V160 - Settings `value` widened to TEXT
   - `phoenix_kit_settings.value` was `VARCHAR(255)` (V03's `:string`) while
     `Settings.Setting` validated it at `max: 1000` — anything in between
     passed the changeset and then raised a raw `Postgrex.Error`
@@ -1423,7 +1432,7 @@ defmodule PhoenixKit.Migrations.Postgres do
   alias PhoenixKit.Migrations.Postgres.Helpers
 
   @initial_version 1
-  @current_version 160
+  @current_version 161
   @default_prefix "public"
 
   # First version whose SQL references uuid_generate_v7(). Chains that

--- a/lib/phoenix_kit/migrations/postgres/v161.ex
+++ b/lib/phoenix_kit/migrations/postgres/v161.ex
@@ -43,9 +43,7 @@ defmodule PhoenixKit.Migrations.Postgres.V161 do
 
     # FK columns get an index: the payment-options admin needs "orders using
     # this option" and, without it, that is a sequential scan of every order.
-    create_if_not_exists(
-      index(:phoenix_kit_orders, [:payment_option_uuid], prefix: prefix)
-    )
+    create_if_not_exists(index(:phoenix_kit_orders, [:payment_option_uuid], prefix: prefix))
 
     execute("COMMENT ON TABLE #{p}phoenix_kit IS '161'")
   end

--- a/lib/phoenix_kit/migrations/postgres/v161.ex
+++ b/lib/phoenix_kit/migrations/postgres/v161.ex
@@ -1,0 +1,68 @@
+defmodule PhoenixKit.Migrations.Postgres.V161 do
+  @moduledoc """
+  V161: First-class payment-option linkage on billing orders.
+
+  An order records HOW it is to be paid via `payment_method`, a small closed
+  vocabulary (`bank`, `stripe`, `paypal`, …). What the customer actually
+  chose at checkout is a `phoenix_kit_payment_options` row — an
+  operator-configured method with its own name, instructions, provider and
+  billing-profile requirement. The two are not the same thing: several
+  options can share one `payment_method` ("Bank transfer (EU)" and "Bank
+  transfer (UK)" are both `bank`), and an option can be renamed or
+  deactivated after the order is placed.
+
+  Without a link, the choice was simply lost at conversion: nothing on the
+  order said which option the customer picked, so an operator processing a
+  bank transfer could not tell which instructions the customer had been
+  shown, and payment reconciliation had to guess.
+
+  `ON DELETE SET NULL` rather than restrict: deactivating and deleting a
+  payment option is an ordinary operator action, and it must not be blocked
+  by — or destroy — historical orders. The order keeps `payment_method` and
+  its metadata snapshot regardless, so a deleted option degrades to "we know
+  it was a bank transfer" rather than to nothing.
+  """
+
+  use Ecto.Migration
+
+  def up(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    alter table(:phoenix_kit_orders, prefix: prefix) do
+      add_if_not_exists(
+        :payment_option_uuid,
+        references(:phoenix_kit_payment_options,
+          column: :uuid,
+          type: :uuid,
+          prefix: prefix,
+          on_delete: :nilify_all
+        )
+      )
+    end
+
+    # FK columns get an index: the payment-options admin needs "orders using
+    # this option" and, without it, that is a sequential scan of every order.
+    create_if_not_exists(
+      index(:phoenix_kit_orders, [:payment_option_uuid], prefix: prefix)
+    )
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '161'")
+  end
+
+  def down(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    drop_if_exists(index(:phoenix_kit_orders, [:payment_option_uuid], prefix: prefix))
+
+    alter table(:phoenix_kit_orders, prefix: prefix) do
+      remove_if_exists(:payment_option_uuid)
+    end
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '160'")
+  end
+
+  defp prefix_str("public"), do: "public."
+  defp prefix_str(prefix), do: "#{prefix}."
+end

--- a/lib/phoenix_kit/migrations/postgres/v161.ex
+++ b/lib/phoenix_kit/migrations/postgres/v161.ex
@@ -28,22 +28,73 @@ defmodule PhoenixKit.Migrations.Postgres.V161 do
   def up(opts) do
     prefix = Map.get(opts, :prefix, "public")
     p = prefix_str(prefix)
+    schema = schema_name(prefix)
 
-    alter table(:phoenix_kit_orders, prefix: prefix) do
-      add_if_not_exists(
-        :payment_option_uuid,
-        references(:phoenix_kit_payment_options,
-          column: :uuid,
-          type: :uuid,
-          prefix: prefix,
-          on_delete: :nilify_all
-        )
-      )
-    end
+    # A raw guarded block rather than `add_if_not_exists` + `references`:
+    # Ecto emits the column and its constraint as separate statements and
+    # only the column carries IF NOT EXISTS, so a re-run — or a prefixed run
+    # whose constraint resolves through the search_path — fails on the
+    # constraint. Every check here is anchored on `table_schema`, per the
+    # chain's prefix-safety rules.
+    execute("""
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT FROM information_schema.tables
+        WHERE table_schema = '#{schema}' AND table_name = 'phoenix_kit_orders'
+      ) THEN
+        RAISE NOTICE 'Orders table not found, skipping V161';
+        RETURN;
+      END IF;
+
+      IF NOT EXISTS (
+        SELECT FROM information_schema.columns
+        WHERE table_schema = '#{schema}'
+          AND table_name = 'phoenix_kit_orders'
+          AND column_name = 'payment_option_uuid'
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_orders
+          ADD COLUMN payment_option_uuid UUID;
+      END IF;
+
+      -- Any FK on the column, whatever it is called: an earlier build of
+      -- this migration created one under Ecto's default name.
+      IF NOT EXISTS (
+        SELECT FROM information_schema.table_constraints tc
+        JOIN information_schema.key_column_usage kcu
+          ON kcu.constraint_name = tc.constraint_name
+         AND kcu.constraint_schema = tc.constraint_schema
+        WHERE tc.table_schema = '#{schema}'
+          AND tc.table_name = 'phoenix_kit_orders'
+          AND tc.constraint_type = 'FOREIGN KEY'
+          AND kcu.column_name = 'payment_option_uuid'
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_orders
+          ADD CONSTRAINT fk_orders_payment_option
+          FOREIGN KEY (payment_option_uuid)
+          REFERENCES #{p}phoenix_kit_payment_options(uuid)
+          ON DELETE SET NULL;
+      END IF;
+    END $$;
+    """)
 
     # FK columns get an index: the payment-options admin needs "orders using
     # this option" and, without it, that is a sequential scan of every order.
-    create_if_not_exists(index(:phoenix_kit_orders, [:payment_option_uuid], prefix: prefix))
+    # Bare name on CREATE — an index always lands in its table's schema.
+    execute("""
+    DO $$
+    BEGIN
+      IF EXISTS (
+        SELECT FROM information_schema.columns
+        WHERE table_schema = '#{schema}'
+          AND table_name = 'phoenix_kit_orders'
+          AND column_name = 'payment_option_uuid'
+      ) THEN
+        CREATE INDEX IF NOT EXISTS phoenix_kit_orders_payment_option_uuid_index
+          ON #{p}phoenix_kit_orders (payment_option_uuid);
+      END IF;
+    END $$;
+    """)
 
     execute("COMMENT ON TABLE #{p}phoenix_kit IS '161'")
   end
@@ -52,14 +103,28 @@ defmodule PhoenixKit.Migrations.Postgres.V161 do
     prefix = Map.get(opts, :prefix, "public")
     p = prefix_str(prefix)
 
-    drop_if_exists(index(:phoenix_kit_orders, [:payment_option_uuid], prefix: prefix))
+    execute("DROP INDEX IF EXISTS #{p}phoenix_kit_orders_payment_option_uuid_index")
 
-    alter table(:phoenix_kit_orders, prefix: prefix) do
-      remove_if_exists(:payment_option_uuid)
-    end
+    execute("""
+    ALTER TABLE #{p}phoenix_kit_orders
+      DROP CONSTRAINT IF EXISTS fk_orders_payment_option
+    """)
+
+    execute("""
+    ALTER TABLE #{p}phoenix_kit_orders
+      DROP CONSTRAINT IF EXISTS phoenix_kit_orders_payment_option_uuid_fkey
+    """)
+
+    execute("""
+    ALTER TABLE #{p}phoenix_kit_orders
+      DROP COLUMN IF EXISTS payment_option_uuid
+    """)
 
     execute("COMMENT ON TABLE #{p}phoenix_kit IS '160'")
   end
+
+  defp schema_name("public"), do: "public"
+  defp schema_name(prefix), do: prefix
 
   defp prefix_str("public"), do: "public."
   defp prefix_str(prefix), do: "#{prefix}."

--- a/lib/phoenix_kit/utils/slug.ex
+++ b/lib/phoenix_kit/utils/slug.ex
@@ -6,11 +6,58 @@ defmodule PhoenixKit.Utils.Slug do
   and ensure uniqueness by delegating existence checks via callback.
   """
 
+  # Lowercase Cyrillic -> Latin, Russian and Ukrainian. Applied before the
+  # ASCII strip so a Cyrillic title yields a real slug: without it every
+  # character is stripped and the slug comes back empty, which callers read
+  # as "no slug yet" and regenerate forever (a CSV re-import of a Cyrillic
+  # catalogue inserted the whole feed again on every run).
+  @cyrillic_map %{
+    "а" => "a",
+    "б" => "b",
+    "в" => "v",
+    "г" => "g",
+    "ґ" => "g",
+    "д" => "d",
+    "е" => "e",
+    "ё" => "e",
+    "є" => "ie",
+    "ж" => "zh",
+    "з" => "z",
+    "и" => "i",
+    "і" => "i",
+    "ї" => "i",
+    "й" => "i",
+    "к" => "k",
+    "л" => "l",
+    "м" => "m",
+    "н" => "n",
+    "о" => "o",
+    "п" => "p",
+    "р" => "r",
+    "с" => "s",
+    "т" => "t",
+    "у" => "u",
+    "ф" => "f",
+    "х" => "h",
+    "ц" => "ts",
+    "ч" => "ch",
+    "ш" => "sh",
+    "щ" => "shch",
+    "ъ" => "",
+    "ы" => "y",
+    "ь" => "",
+    "э" => "e",
+    "ю" => "yu",
+    "я" => "ya"
+  }
+
   @doc """
   Converts the given `text` into a slug.
 
   Options:
     * `:separator` - character used between words (defaults to "-")
+    * `:transliterate` - map Cyrillic to Latin and strip Latin diacritics
+      before the ASCII pass (defaults to `false`)
 
   Returns an empty string when the input is blank or cannot be converted.
   """
@@ -25,12 +72,31 @@ defmodule PhoenixKit.Utils.Slug do
 
     text
     |> String.downcase()
+    |> maybe_transliterate(Keyword.get(opts, :transliterate, false))
     |> String.replace(~r/[^a-z0-9]+/u, separator)
     |> String.replace(~r/#{escaped_separator}+/, separator)
     |> String.trim(separator)
   end
 
   def slugify(_text, _opts), do: ""
+
+  @doc """
+  Maps lowercase Cyrillic characters to Latin and strips Latin diacritics.
+
+  Anything outside those scripts is returned unchanged — the caller's slug
+  pass still has to remove it.
+  """
+  @spec transliterate(String.t()) :: String.t()
+  def transliterate(text) when is_binary(text) do
+    text
+    |> String.graphemes()
+    |> Enum.map_join("", &Map.get(@cyrillic_map, &1, &1))
+    |> String.normalize(:nfd)
+    |> String.replace(~r/[\x{0300}-\x{036f}]/u, "")
+  end
+
+  defp maybe_transliterate(text, true), do: transliterate(text)
+  defp maybe_transliterate(text, _), do: text
 
   @doc """
   Ensures the provided slug is unique by calling `exists_fun`.

--- a/lib/phoenix_kit_web/users/auth.ex
+++ b/lib/phoenix_kit_web/users/auth.ex
@@ -1370,12 +1370,25 @@ defmodule PhoenixKitWeb.Users.Auth do
           # The old system-role bypass here made Owner's revocations on the
           # Admin role effective everywhere EXCEPT fresh mounts — sidebar,
           # plugs, and the mid-session PubSub kick all honored them already.
-          Scope.has_module_access?(scope, module_key) ->
+          #
+          # A tab may resolve to a dotted SUB-permission, and a raw sub-key
+          # without its base is an orphan (`has_module_access?/2` leaves that
+          # check to its caller). `can?/2` applies it, so route dotted keys
+          # there rather than admitting an orphan the sidebar already hides.
+          view_permission_held?(scope, module_key) ->
             {:cont, socket}
 
           true ->
             deny_admin_access(socket, scope)
         end
+    end
+  end
+
+  defp view_permission_held?(scope, module_key) do
+    if Permissions.parent_key(module_key) do
+      Scope.can?(scope, module_key)
+    else
+      Scope.has_module_access?(scope, module_key)
     end
   end
 

--- a/test/phoenix_kit/dashboard/sub_permission_tab_test.exs
+++ b/test/phoenix_kit/dashboard/sub_permission_tab_test.exs
@@ -4,6 +4,7 @@ defmodule PhoenixKit.Dashboard.SubPermissionTabTest do
 
   alias PhoenixKit.Dashboard.Registry
   alias PhoenixKit.ModuleRegistry
+  alias PhoenixKit.Users.Auth.Scope
   alias PhoenixKit.Users.Permissions
 
   defmodule FakeShop do
@@ -65,5 +66,24 @@ defmodule PhoenixKit.Dashboard.SubPermissionTabTest do
     # everyone out — including the Owner.
     assert Permissions.feature_enabled?("fake_shop.manage_settings")
     assert "fake_shop.manage_settings" in Permissions.all_module_keys()
+  end
+
+  test "an orphaned sub-key does not open the view its base no longer allows" do
+    # The cascade normally keeps a sub-key's base granted; this is the case
+    # where a sub row outlives its base (a module leaves the registry and
+    # returns). `can?/2` rejects it, and the automatic view gate must agree.
+    orphan =
+      %Scope{}
+      |> Map.put(:cached_permissions, MapSet.new(["fake_shop.manage_settings"]))
+      |> Map.put(:cached_roles, ["User"])
+
+    refute Scope.can?(orphan, "fake_shop.manage_settings")
+
+    held =
+      %Scope{}
+      |> Map.put(:cached_permissions, MapSet.new(["fake_shop", "fake_shop.manage_settings"]))
+      |> Map.put(:cached_roles, ["User"])
+
+    assert Scope.can?(held, "fake_shop.manage_settings")
   end
 end

--- a/test/phoenix_kit/dashboard/sub_permission_tab_test.exs
+++ b/test/phoenix_kit/dashboard/sub_permission_tab_test.exs
@@ -1,0 +1,69 @@
+defmodule PhoenixKit.Dashboard.SubPermissionTabTest do
+  # async: false — registers a fake module and mutates global registry state.
+  use ExUnit.Case, async: false
+
+  alias PhoenixKit.Dashboard.Registry
+  alias PhoenixKit.ModuleRegistry
+  alias PhoenixKit.Users.Permissions
+
+  defmodule FakeShop do
+    def module_key, do: "fake_shop"
+    def module_name, do: "Fake Shop"
+    def enabled?, do: true
+
+    def permission_metadata do
+      %{
+        key: "fake_shop",
+        label: "Fake Shop",
+        icon: "hero-shopping-bag",
+        description: "Fake module for sub-permission tab tests",
+        sub_permissions: [
+          %{key: "manage_settings", label: "Manage settings", description: "Settings page"}
+        ]
+      }
+    end
+  end
+
+  defmodule FakeSettingsView do
+  end
+
+  setup do
+    ModuleRegistry.register(FakeShop)
+
+    on_exit(fn -> ModuleRegistry.unregister(FakeShop) end)
+
+    :ok
+  end
+
+  # A tab may be gated on a SUB-permission ("fake_shop.manage_settings").
+  # Those are declared through `permission_metadata/0`, and `register_custom_key/2`
+  # rejects a dotted key outright — the raise then aborted the whole callback
+  # before it could cache the view → permission mapping, so the module silently
+  # lost core's automatic gate on that view and warned on every boot.
+  test "a tab gated on a sub-permission caches its view mapping without registering a custom key" do
+    assert "fake_shop.manage_settings" in Permissions.sub_permission_keys()
+
+    Registry.auto_register_custom_permission(%{
+      id: :fake_shop_settings,
+      label: "Fake Shop Settings",
+      path: "fake-shop/settings",
+      permission: "fake_shop.manage_settings",
+      live_view: {FakeSettingsView, :index}
+    })
+
+    assert Permissions.custom_view_permissions()[FakeSettingsView] ==
+             "fake_shop.manage_settings",
+           "the view → permission mapping core's admin gate reads was not cached"
+
+    refute "fake_shop.manage_settings" in Permissions.custom_keys(),
+           "a sub-permission must not be re-registered as a custom key"
+  end
+
+  test "the resolved sub-key still reports its module as enabled" do
+    # `feature_enabled?/1` resolves a dotted key through its parent, so gating
+    # a view on the sub-key must not read as "module disabled" and lock
+    # everyone out — including the Owner.
+    assert Permissions.feature_enabled?("fake_shop.manage_settings")
+    assert "fake_shop.manage_settings" in Permissions.all_module_keys()
+  end
+end

--- a/test/phoenix_kit/utils/slug_test.exs
+++ b/test/phoenix_kit/utils/slug_test.exs
@@ -1,0 +1,67 @@
+defmodule PhoenixKit.Utils.SlugTest do
+  use ExUnit.Case, async: true
+
+  alias PhoenixKit.Utils.Slug
+
+  describe "slugify/2" do
+    test "lowercases, separates words, and trims" do
+      assert Slug.slugify("  Geometric Planter!  ") == "geometric-planter"
+      assert Slug.slugify("A -- B") == "a-b"
+      assert Slug.slugify("Under_scored") == "under-scored"
+    end
+
+    test "honors a custom separator" do
+      assert Slug.slugify("Geometric Planter", separator: "_") == "geometric_planter"
+    end
+
+    test "blank and unconvertible input yields an empty slug" do
+      assert Slug.slugify(nil) == ""
+      assert Slug.slugify("") == ""
+      assert Slug.slugify(:not_a_string) == ""
+    end
+
+    test "without transliteration a Cyrillic title still collapses to empty" do
+      assert Slug.slugify("Кашпо") == ""
+    end
+
+    test "transliterate: true turns a Cyrillic title into a real slug" do
+      assert Slug.slugify("Кашпо", transliterate: true) == "kashpo"
+      # One table serves Russian and Ukrainian, so "и" maps to "i" for both
+      # rather than following each language's own romanization standard.
+      assert Slug.slugify("Чашка Кави", transliterate: true) == "chashka-kavi"
+      assert Slug.slugify("Щётка", transliterate: true) == "shchetka"
+    end
+
+    test "transliterate: true strips Latin diacritics" do
+      assert Slug.slugify("Café Crème", transliterate: true) == "cafe-creme"
+    end
+
+    test "transliteration is stable, so a second run finds the same slug" do
+      once = Slug.slugify("Кашпо Керамічне", transliterate: true)
+      assert once == Slug.slugify("Кашпо Керамічне", transliterate: true)
+      assert once == Slug.slugify(once, transliterate: true)
+    end
+  end
+
+  describe "transliterate/1" do
+    test "leaves characters it has no mapping for alone" do
+      assert Slug.transliterate("abc 123") == "abc 123"
+      assert Slug.transliterate("日本") == "日本"
+    end
+  end
+
+  describe "ensure_unique/2" do
+    test "returns the slug untouched when free" do
+      assert Slug.ensure_unique("planter", fn _ -> false end) == "planter"
+    end
+
+    test "appends the first free counter" do
+      taken = MapSet.new(["planter", "planter-2", "planter-3"])
+      assert Slug.ensure_unique("planter", &MapSet.member?(taken, &1)) == "planter-4"
+    end
+
+    test "an empty slug is never suffixed" do
+      assert Slug.ensure_unique("", fn _ -> true end) == ""
+    end
+  end
+end


### PR DESCRIPTION
## Merge order

This wave is three PRs across three repos, and they are **not**
independent:

| # | PR | Why it must come first |
|---|----|------------------------|
| 1 | **phoenix_kit** [#682](https://github.com/BeamLabEU/phoenix_kit/pull/682) | V162 adds `payment_option_uuid` to `phoenix_kit_orders`; `Utils.Slug` gains the `:transliterate` option both modules call. |
| 2 | **phoenix_kit_billing** [#15](https://github.com/BeamLabEU/phoenix_kit_billing/pull/15) | Owns the `Order` schema — it casts the column V162 creates. |
| 3 | **phoenix_kit_ecommerce** [#13](https://github.com/BeamLabEU/phoenix_kit_ecommerce/pull/13) | Checkout writes the payment-option link through billing's changeset. |

> **Renumbered 2026-08-05:** upstream merged its own V161
> (case-insensitive username via citext) first, so this migration is now
> **V162**. Its `down/1` rolls the marker back to `'161'`, not `'160'`.

**Core must be RELEASED, not merely merged**, before the module pins can
move — each module's `pk_dep(:phoenix_kit, "~> …")` floor should be raised
to that release as part of cutting it.

Nothing breaks if they land out of order, by design:

- Ecommerce checks the **migrated version at runtime** before writing the
  payment-option link, so on a host below V162 the order simply records no
  link rather than crashing on a missing column.
- `Slug.slugify/2` ignores an option it does not know, so against an older
  core the Cyrillic slug fix silently no-ops and behaves exactly as it does
  today. The tests that assert it are gated on the capability and start
  running by themselves once the core release lands.

So an out-of-order merge costs the new features, not correctness.

---

## Summary

Adds a nullable `payment_option_uuid` FK (plus its index) to
`phoenix_kit_orders`, pointing at `phoenix_kit_payment_options`.

An order records HOW it is to be paid via `payment_method` — a small
closed vocabulary (`bank`, `stripe`, `paypal`, `razorpay`). What the
customer actually chose at checkout is a payment-option ROW: an
operator-configured method with its own name, instructions, provider and
billing-profile requirement. The two are not the same thing. Several
options can share one `payment_method` ("Bank transfer (EU)" and "Bank
transfer (UK)" are both `bank`), and an option can be renamed or
deactivated after the order is placed.

Without a link the choice was discarded at conversion: nothing on the
order said which option the customer picked, so an operator processing a
bank transfer could not tell which instructions the customer had been
shown, and payment reconciliation had to guess.

## Why `ON DELETE SET NULL`

Deactivating and deleting a payment option is an ordinary operator action.
It must not be blocked by historical orders, and it must not destroy them.
The order keeps `payment_method` and its metadata snapshot regardless, so
a deleted option degrades to "we know it was a bank transfer" rather than
to nothing.

## Verification

`add_if_not_exists` / `create_if_not_exists` and matching `down/1`, so the
migration is re-runnable and reversible. The table comment moves to '161'
on up and back to '160' on down, per the marker convention.

---

## Also in this PR

Three core changes the ecommerce wave surfaced. Each is independent of the
migration and of each other.

### `Utils.Slug` gains opt-in transliteration

A Cyrillic title slugified to an empty string — every character fell
outside `[a-z0-9]` and was stripped. Callers read empty as "no slug yet",
so a Ukrainian shop's CSV catalogue could not be matched on re-import and
inserted the whole feed again on every run. The mapping covers Russian and
Ukrainian and also strips Latin diacritics.

It is **opt-in**: existing callers keep today's ASCII-only behavior, and a
consumer passing the new option against an older `phoenix_kit` gets today's
result rather than an error. `phoenix_kit_ecommerce` relies on that — its
Cyrillic tests are gated on the capability and start running once this
ships.

### A tab gated on a sub-permission registers correctly

A module tab may be gated on a sub-permission (`"shop.manage_settings"`).
Registration pushed that through `register_custom_key/2`, which rejects a
dotted key — and the raise aborted the rest of the callback, so the
view → permission mapping the admin gate reads was never cached. The module
silently fell back to the coarser base key for core's gate (its own mount
checks still held), and every boot logged a failure for a key that was
declared correctly. Sub-permissions are already declared through
`permission_metadata/0`, so registration now skips them.

### The automatic view gate requires the base of a dotted key

Caching the dotted key means the admin mount gate now resolves one, and it
was calling `has_module_access?/2` — direct membership only, which by
contract leaves the base check to its caller. A scope holding an orphaned
`"shop.manage_settings"` without `"shop"` would have passed a gate the
sidebar, `can?/2` and every module's own check all refuse.

`feature_enabled?/1` resolves a dotted key through its parent and
`all_module_keys/0` includes sub-keys, so Owner and a properly-granted
Admin both still pass — pinned by tests.


