### PR TITLE
Skip route-module references that cannot be resolved yet

### DIFF
--- a/lib/phoenix_kit_web/integration.ex
+++ b/lib/phoenix_kit_web/integration.ex
@@ -1399,9 +1399,24 @@ defmodule PhoenixKitWeb.Integration do
     # Referencing only the route modules would leave `route_module/0`
     # itself — and `admin_tabs/0`, which also feeds route generation — in
     # the same blind spot this exists to close.
+    #
+    # Only for modules that actually resolve at expansion time. A host may
+    # register its OWN app module in `config :phoenix_kit, :modules` —
+    # documented practice, since beam discovery cannot see the host while
+    # the host is still compiling — and this macro also expands inside
+    # phoenix_kit's own router, which is built as a dependency, long before
+    # any parent-app module exists. Emitting the reference unconditionally
+    # made that dependency build die with
+    # `function TheHost.__info__/1 is undefined`, taking the whole host
+    # down with it. `Code.ensure_compiled/1` costs nothing where the module
+    # is genuinely reachable — inside the host's own router it blocks on
+    # the parallel compiler and returns `{:module, _}`, so the recompile
+    # tracking this exists for is unchanged — and skips exactly the case
+    # that cannot be referenced yet.
     route_module_refs =
       (PhoenixKit.ModuleDiscovery.discover_external_modules() ++ all_route_modules())
       |> Enum.uniq()
+      |> Enum.filter(&match?({:module, _}, Code.ensure_compiled(&1)))
       |> Enum.map(fn mod ->
         quote do
           unquote(mod).__info__(:module)


### PR DESCRIPTION
A host app that registers its own module in `config :phoenix_kit, :modules`
cannot compile against 1.7.232 at all:

    == Compilation error in file lib/phoenix_kit_web/router.ex ==
    ** (UndefinedFunctionError) function TheHost.__info__/1 is undefined
       (module TheHost is not available)
        TheHost.__info__(:module)
        lib/phoenix_kit_web/router.ex:36: (module)
    could not compile dependency :phoenix_kit

## Why

1.7.232 added a compile-time `mod.__info__(:module)` reference for every
discovered/configured route module, so Mix rebuilds a host router when one of
them changes — a good fix for genuinely stale route tables. But the reference is
emitted unconditionally, and `phoenix_kit_routes()` also expands inside
phoenix_kit's **own** router (`lib/phoenix_kit_web/router.ex:36`), which is built
as a dependency — long before any parent-app module exists.

Beam discovery finds nothing at that point, so this only bites through the
configured list. Registering the host module there is documented practice rather
than misuse: discovery cannot see the host app while the host is still
compiling, so an `admin_tabs/0` defined on the host module is invisible without
it.

## The fix

Filter the list through `Code.ensure_compiled/1` before emitting references.

Inside the host's own router the module is genuinely reachable —
`ensure_compiled/1` blocks on the parallel compiler and returns `{:module, _}` —
so the reference is still emitted and the recompile tracking added in 1.7.232 is
unchanged. Verified on a real host:

    $ mix xref graph --sink lib/the_host.ex --label compile
    lib/the_host_web/router.ex
    └── lib/the_host.ex (compile)

Only the case that cannot be referenced yet is skipped.

## Verification

Host app compiles again with `--warnings-as-errors`, boots, serves, and its
suite is green (173 tests). In this repo `mix compile --warnings-as-errors`,
credo and the format check pass (the pre-commit gate ran them).