### PR TITLE
Add V163: repair uuid columns that are not primary keys

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -2,6 +2,7 @@
   # Mix functions are only available during Mix compilation context
   {"lib/mix/tasks/phoenix_kit.gen.migration.ex", :unknown_function},
   {"lib/mix/tasks/phoenix_kit.doctor.ex", :unknown_function},
+  {"lib/mix/tasks/phoenix_kit.repair_uuid.ex", :unknown_function},
   {"lib/mix/tasks/phoenix_kit.release_check.ex", :unknown_function},
   {"lib/mix/tasks/phoenix_kit.install.ex", :unknown_function},
   {"lib/mix/tasks/phoenix_kit.update.ex", :unknown_function},
@@ -22,6 +23,7 @@
   # Note: Mix.Task behaviour info is not available to Dialyzer (compile-time only)
   # Adding @impl Mix.Task does not fix this warning
   {"lib/mix/tasks/phoenix_kit.doctor.ex", :callback_info_missing, 1},
+  {"lib/mix/tasks/phoenix_kit.repair_uuid.ex", :callback_info_missing, 1},
   {"lib/mix/tasks/phoenix_kit.release_check.ex", :callback_info_missing, 1},
   {"lib/mix/tasks/phoenix_kit.gen.migration.ex", :callback_info_missing, 1},
   {"lib/mix/tasks/phoenix_kit.install.ex", :callback_info_missing, 2},

--- a/lib/mix/tasks/phoenix_kit.doctor.ex
+++ b/lib/mix/tasks/phoenix_kit.doctor.ex
@@ -91,6 +91,7 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
       run_check("Schema Drift", fn -> check_schema_drift(prefix) end),
       run_check("Pending Migrations", fn -> check_pending_migrations() end),
       run_check("UUID Column Types", fn -> check_uuid_column_types(prefix) end),
+      run_check("UUID Primary Keys", fn -> check_uuid_primary_keys(prefix) end),
       run_check("NULL UUIDs in FK Sources", fn -> check_null_uuids(prefix) end),
       run_check("Orphaned FK References", fn -> check_orphaned_fk_refs(prefix) end),
       run_check("Lock Conflicts", fn -> check_lock_conflicts() end),
@@ -419,6 +420,53 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
   # Pre-migration: check for varchar/text uuid columns that should be native uuid type.
   # A varchar uuid column on phoenix_kit_settings crashes the Ecto schema loader on startup,
   # blocking migrations from even running.
+  # A missing primary key is what the varchar column actually COST, and the type
+  # check could not see it: a table can have a perfectly typed uuid column and
+  # still have no key. Reported by a host whose phoenix_kit_email_events had
+  # both problems and whose doctor run named only the first.
+  defp check_uuid_primary_keys(prefix) do
+    repo = get_repo!()
+
+    query = """
+    SELECT t.table_name
+    FROM information_schema.tables t
+    WHERE t.table_schema = $1
+      AND t.table_name LIKE 'phoenix\\_kit\\_%'
+      AND t.table_type = 'BASE TABLE'
+      AND EXISTS (
+        SELECT 1 FROM information_schema.columns c
+        WHERE c.table_name = t.table_name
+          AND c.table_schema = t.table_schema
+          AND c.column_name = 'uuid'
+      )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint pc
+        JOIN pg_class pcl ON pcl.oid = pc.conrelid
+        JOIN pg_namespace pn ON pn.oid = pcl.relnamespace
+        WHERE pcl.relname = t.table_name
+          AND pn.nspname = t.table_schema
+          AND pc.contype = 'p'
+      )
+    ORDER BY t.table_name
+    """
+
+    case repo.query(query, [prefix], log: false) do
+      {:ok, %{rows: []}} ->
+        {:pass, "Every phoenix_kit table with a uuid column has a primary key"}
+
+      {:ok, %{rows: rows}} ->
+        tables = Enum.map_join(rows, "\n       ", fn [t] -> t end)
+
+        {:fail,
+         "#{length(rows)} table(s) have a uuid column but NO primary key:\n       #{tables}\n       " <>
+           "Fix: mix phoenix_kit.repair_uuid  (or upgrade — V163 repairs this automatically)"}
+
+      _ ->
+        {:warn, "Could not check (phoenix_kit tables may not exist yet)"}
+    end
+  end
+
   defp check_uuid_column_types(prefix) do
     repo = get_repo!()
     escaped_prefix = String.replace(prefix, "'", "\\'")
@@ -443,9 +491,14 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
             "#{table} (#{dtype})"
           end)
 
+        # The remedy is a task, not a single ALTER. The ALTER alone restores the
+        # TYPE and leaves the column nullable, without a UUIDv7 default and
+        # without a primary key — anyone following it literally ends up in a
+        # state that still fails this doctor. Reported by a host who did.
         {:fail,
-         "#{length(rows)} table(s) have varchar uuid columns (will crash Ecto on load):\n       #{tables}\n       " <>
-           "Fix: ALTER TABLE <table> ALTER COLUMN uuid TYPE uuid USING uuid::uuid"}
+         "#{length(rows)} table(s) have a varchar uuid column:\n       #{tables}\n       " <>
+           "These break any Ecto schema that maps to them, and cannot carry a uuid primary key.\n       " <>
+           "Fix: mix phoenix_kit.repair_uuid  (or upgrade — V163 repairs this automatically)"}
 
       _ ->
         {:warn, "Could not check (phoenix_kit tables may not exist yet)"}

--- a/lib/mix/tasks/phoenix_kit.repair_uuid.ex
+++ b/lib/mix/tasks/phoenix_kit.repair_uuid.ex
@@ -1,0 +1,128 @@
+defmodule Mix.Tasks.PhoenixKit.RepairUuid do
+  @shortdoc "Repairs phoenix_kit tables whose uuid column is not a proper primary key"
+
+  @moduledoc """
+  Repairs `phoenix_kit_*` tables whose `uuid` column is the wrong type, nullable,
+  or not the primary key.
+
+  V163 performs this repair automatically during `mix ecto.migrate`, but skips
+  any table large enough that the rewrite's `ACCESS EXCLUSIVE` lock would be an
+  outage rather than a pause. This task is the deliberate, operator-chosen path
+  for those — run it in a maintenance window.
+
+      mix phoenix_kit.repair_uuid                       # every table that needs it
+      mix phoenix_kit.repair_uuid phoenix_kit_email_events
+      mix phoenix_kit.repair_uuid --dry-run             # show the SQL, change nothing
+      mix phoenix_kit.repair_uuid --prefix tenant_a
+
+  ## What it costs
+
+  `ALTER COLUMN … TYPE uuid` rewrites the table and holds an `ACCESS EXCLUSIVE`
+  lock for the duration — no reads, no writes, and behind a connection pooler
+  that means the pool fills rather than merely waiting. There is no concurrent
+  form of a type change; the size of the table is the size of the outage.
+
+  The primary key is cheaper here than in the migration: outside a transaction
+  the unique index is built `CONCURRENTLY` and then attached, so the exclusive
+  lock covers only the attach. That is why this task is not simply "V163 without
+  the limit".
+
+  ## Safety
+
+  Nothing is destructive except de-duplication, which deletes rows that share a
+  uuid — on a table that has run without a primary key those are the same
+  logical row stored twice, and a duplicate makes `ADD PRIMARY KEY` impossible.
+  `--dry-run` prints every statement, including the delete, without executing.
+
+  Values that cannot be cast to `uuid` abort that table with the query to
+  inspect them; other tables still proceed.
+  """
+
+  use Mix.Task
+
+  alias PhoenixKit.Install.PrefixConfig
+  alias PhoenixKit.Migrations.UUIDIntegrity
+
+  @requirements ["app.start"]
+
+  @switches [dry_run: :boolean, prefix: :string]
+
+  @impl Mix.Task
+  def run(args) do
+    {opts, tables} = OptionParser.parse!(args, strict: @switches)
+
+    # Same resolution the doctor and installer use: --prefix > app config > public
+    prefix = PrefixConfig.resolve_prefix(opts)
+    dry_run? = opts[:dry_run] || false
+    repo = PhoenixKit.RepoHelper.repo()
+
+    broken =
+      repo
+      |> UUIDIntegrity.broken_tables(prefix)
+      |> filter_requested(tables)
+
+    case broken do
+      [] ->
+        Mix.shell().info([:green, "✓ Every phoenix_kit table has a proper uuid primary key."])
+
+      found ->
+        Mix.shell().info("Tables needing repair: #{length(found)}")
+        Enum.each(found, &repair(repo, prefix, &1, dry_run?))
+        report(dry_run?)
+    end
+  end
+
+  defp filter_requested(broken, []), do: broken
+
+  defp filter_requested(broken, requested) do
+    Enum.filter(broken, &(&1.name in requested))
+  end
+
+  defp repair(repo, prefix, %{name: name} = table, dry_run?) do
+    qualified = UUIDIntegrity.qualify(prefix, name)
+
+    if UUIDIntegrity.castable?(repo, qualified, table) do
+      rows = UUIDIntegrity.estimated_rows(repo, prefix, name)
+      Mix.shell().info([:cyan, "\n#{name}", :reset, " (~#{rows} rows) #{describe(table)}"])
+
+      # concurrent_index: this task runs outside a transaction, so the unique
+      # index can be built without holding the table against readers.
+      qualified
+      |> UUIDIntegrity.repair_statements(prefix, table, concurrent_index: true)
+      |> Enum.each(&run_statement(repo, &1, dry_run?))
+    else
+      Mix.shell().error("""
+      #{name}: uuid holds values that are not valid UUIDs — skipped. Inspect with:
+        SELECT uuid FROM #{qualified}
+         WHERE uuid IS NOT NULL AND uuid !~* '#{uuid_regex()}' LIMIT 20;
+      """)
+    end
+  end
+
+  defp run_statement(_repo, sql, true), do: Mix.shell().info(["  [dry-run] ", String.trim(sql)])
+
+  defp run_statement(repo, sql, false) do
+    Mix.shell().info(["  ", String.trim(sql)])
+    repo.query!(sql, [], timeout: :infinity)
+  end
+
+  defp describe(%{type: type, nullable: nullable, has_pk: has_pk}) do
+    [
+      if(type != "uuid", do: "type=#{type}"),
+      if(nullable, do: "nullable"),
+      if(not has_pk, do: "no primary key")
+    ]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join(", ")
+  end
+
+  defp report(true) do
+    Mix.shell().info([:yellow, "\nDry run — nothing was changed."])
+  end
+
+  defp report(false) do
+    Mix.shell().info([:green, "\n✓ Repair complete. Re-run mix phoenix_kit.doctor to confirm."])
+  end
+
+  defp uuid_regex, do: "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+end

--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -529,7 +529,8 @@ defmodule PhoenixKit.Migrations.Postgres do
   - Replaces unique index with partial index (slug-mode only, WHERE slug IS NOT NULL)
   - Adds unique index on `(group_uuid, post_date, post_time)` for timestamp-mode posts
 
-  ### V162 - Payment-option linkage on billing orders ⚡ LATEST
+  ### V162 - Payment-option linkage on billing orders
+  ### V163 - UUID primary-key integrity (catalog-driven repair) ⚡ LATEST
 
   Adds a nullable `payment_option_uuid` FK (+ index) to
   `phoenix_kit_orders`, pointing at `phoenix_kit_payment_options`. The
@@ -1448,7 +1449,7 @@ defmodule PhoenixKit.Migrations.Postgres do
   alias PhoenixKit.Migrations.Postgres.Helpers
 
   @initial_version 1
-  @current_version 162
+  @current_version 163
   @default_prefix "public"
 
   # First version whose SQL references uuid_generate_v7(). Chains that

--- a/lib/phoenix_kit/migrations/postgres/v163.ex
+++ b/lib/phoenix_kit/migrations/postgres/v163.ex
@@ -1,0 +1,165 @@
+defmodule PhoenixKit.Migrations.Postgres.V163 do
+  @moduledoc """
+  V163: UUID primary-key integrity.
+
+  Repairs any `phoenix_kit_*` table whose `uuid` column is the wrong type,
+  nullable, or not the primary key — the state V40/V56/V74 are each supposed to
+  make impossible, and which a production install reached anyway.
+
+  ## The reported state
+
+  On a database upgraded through the whole chain since V01,
+  `phoenix_kit_email_events` had `uuid` as `character varying(255)`, nullable,
+  no default, and the table had **no primary key at all**. 149 other tables were
+  correct, so this was one table falling out of the conversion rather than a
+  broken upgrade.
+
+  ## Why the chain missed it, twice
+
+  1. **V40's guard tests EXISTENCE, not TYPE.** An older release created that
+     column as Ecto `:string`, so `unless column_exists?(table, :uuid, …)` was
+     already true and V40 skipped the table wholesale — not just the `ADD
+     COLUMN`, but the backfill, the `SET NOT NULL` and the unique index with it.
+     The table *is* in V40's `@tables_to_migrate`; being listed did not help.
+
+  2. **V56's type conversion shipped after some hosts had already passed V56.**
+     `ensure_all_uuid_columns_native_type/2` — which converts exactly this
+     varchar column — was added to V56 on 2026-03-02, seventeen days after V56
+     itself (2026-02-13). A recorded version never re-runs, so every host that
+     crossed V56 in that window kept the broken column permanently. V56's
+     `NOT NULL` and index repairs also run off hardcoded table lists that
+     `phoenix_kit_email_events` appears in none of.
+
+  V74 then dropped the legacy bigint `id` but could not promote `uuid` to
+  primary key — wrong type, nullable — and did not verify its own documented
+  post-condition ("after V74, every PhoenixKit table has uuid as its PK").
+  Nothing raised.
+
+  ## Why this migration is catalog-driven
+
+  Every previous attempt enumerated tables by hand, and this table was missing
+  from every list. This one asks the catalog which tables are actually broken,
+  so a table nobody remembered to list is repaired anyway — and so a table that
+  is already correct is skipped without needing to be named.
+
+  ## Large tables are deferred, not silently rewritten
+
+  `ALTER COLUMN … TYPE uuid` rewrites the table under an `ACCESS EXCLUSIVE`
+  lock, and `ADD PRIMARY KEY` builds a unique index under the same lock. Both
+  are O(rows). On a big events table behind PgBouncer that is connection-pool
+  exhaustion during `mix ecto.migrate`, not a pause — so above two million rows
+  the rewrite is skipped and logged with the exact command to run in a
+  maintenance window. Setting the default and backfilling
+  are catalog-cheap or index-free and always run.
+
+  This migration never raises on the happy path. A library does not own its
+  hosts' deploy runbooks, and turning a latent problem (one audit table without
+  a PK, on a version where no schema maps to it) into a failed deploy across a
+  fleet is a worse outcome than the problem. `mix phoenix_kit.doctor` is the
+  loud channel and reports precisely what was deferred.
+  """
+
+  use Ecto.Migration
+
+  require Logger
+
+  alias PhoenixKit.Migrations.Postgres.Helpers
+  alias PhoenixKit.Migrations.UUIDIntegrity
+
+  # Above this, the rewrite is deferred to a maintenance window. ~2M rows is a
+  # few seconds of exclusive lock on ordinary hardware; an order of magnitude
+  # more is not. Override with `up(%{uuid_rewrite_row_limit: n})`.
+  @rewrite_row_limit 2_000_000
+
+  # A repair that cannot get its lock quickly is deferred, not waited on.
+  @lock_timeout_ms 5_000
+
+  def up(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    limit = Map.get(opts, :uuid_rewrite_row_limit, @rewrite_row_limit)
+
+    # Repaired tables need the generator to exist even if V40 never reached them.
+    Helpers.ensure_uuid_v7_function(prefix)
+
+    # Fail fast rather than queue behind a long-running reader. The generated
+    # upgrade migration carries @disable_ddl_transaction, so this is autocommit:
+    # without a timeout an ALTER blocked by an open transaction waits forever and
+    # the deploy hangs rather than erroring.
+    execute("SET lock_timeout = '#{@lock_timeout_ms}ms'")
+
+    repo()
+    |> UUIDIntegrity.broken_tables(prefix)
+    |> Enum.each(&repair(&1, prefix, limit))
+
+    execute("RESET lock_timeout")
+
+    # ALWAYS recorded, even if a table above was skipped. The marker is the only
+    # thing the chain consults, so failing to write it would make V163 re-run
+    # forever — and, worse, a stale marker is how this codebase has previously
+    # had migrations skipped permanently. Tables that did not get repaired are
+    # logged and still reported by `mix phoenix_kit.doctor`; they are not lost.
+    execute("COMMENT ON TABLE #{prefix_str(prefix)}phoenix_kit IS '163'")
+  end
+
+  # Irreversible by design. Rolling back would mean re-breaking a primary key —
+  # recreating the reported defect on a healthy table — and the prior state is
+  # not recoverable anyway: which rows held NULL uuids before the backfill is
+  # not recorded. Only the version marker moves.
+  def down(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    execute("COMMENT ON TABLE #{prefix_str(prefix)}phoenix_kit IS '162'")
+  end
+
+  defp repair(%{name: name} = table, prefix, limit) do
+    qualified = UUIDIntegrity.qualify(prefix, name)
+
+    cond do
+      not UUIDIntegrity.castable?(repo(), qualified, table) ->
+        # Aborting the migration over one table's bad data would strand every
+        # other repair in this run, so this table is skipped and named.
+        Logger.error("""
+        [PhoenixKit V163] #{name}: the uuid column holds values that are not \
+        valid UUIDs, so it cannot be converted. Left unchanged. Inspect with:
+          SELECT uuid FROM #{qualified} WHERE uuid IS NOT NULL
+           AND uuid !~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$' LIMIT 20;
+        """)
+
+      UUIDIntegrity.rewrite_needed?(table) and
+          UUIDIntegrity.estimated_rows(repo(), prefix, name) > limit ->
+        Logger.warning("""
+        [PhoenixKit V163] #{name}: needs a uuid column rewrite but holds more \
+        than #{limit} rows. Skipped, because ALTER COLUMN TYPE takes an ACCESS \
+        EXCLUSIVE lock for the length of a full table rewrite. Run this in a \
+        maintenance window:
+          mix phoenix_kit.repair_uuid #{name}
+        `mix phoenix_kit.doctor` will keep reporting it until you do.
+        """)
+
+      true ->
+        run_isolated(qualified, prefix, table)
+    end
+  end
+
+  # One table's failure must not take the rest of the run with it. Autocommit
+  # means the statements already applied stay applied, and every prefix of the
+  # sequence leaves the table further along than it started rather than
+  # corrupted — so continuing is strictly better than aborting. The most likely
+  # failure by far is `lock_not_available` from the timeout above, which means
+  # "busy right now", not "broken".
+  defp run_isolated(qualified, prefix, table) do
+    qualified
+    |> UUIDIntegrity.repair_statements(prefix, table)
+    |> Enum.each(&execute/1)
+  rescue
+    error ->
+      Logger.error("""
+      [PhoenixKit V163] #{table.name}: repair failed and was skipped — \
+      #{Exception.message(error)}
+      Other tables were not affected. Re-run with:
+        mix phoenix_kit.repair_uuid #{table.name}
+      """)
+  end
+
+  defp prefix_str("public"), do: "public."
+  defp prefix_str(prefix), do: "#{prefix}."
+end

--- a/lib/phoenix_kit/migrations/postgres/v163.ex
+++ b/lib/phoenix_kit/migrations/postgres/v163.ex
@@ -150,6 +150,12 @@ defmodule PhoenixKit.Migrations.Postgres.V163 do
     qualified
     |> UUIDIntegrity.repair_statements(prefix, table)
     |> Enum.each(&execute/1)
+
+    # `execute/1` only QUEUES a command; without this the statements are flushed
+    # after `up/1` returns — outside the rescue below — and the isolation this
+    # function exists for would silently never fire. `flush/0` runs everything
+    # pending here, in scope, so a failure is caught and the next table proceeds.
+    flush()
   rescue
     error ->
       Logger.error("""

--- a/lib/phoenix_kit/migrations/uuid_integrity.ex
+++ b/lib/phoenix_kit/migrations/uuid_integrity.ex
@@ -180,13 +180,15 @@ defmodule PhoenixKit.Migrations.UUIDIntegrity do
 
   defp pk_statements(_qualified, %{has_pk: true}, _concurrent?), do: []
 
-  defp pk_statements(qualified, _table, concurrent?) do
+  defp pk_statements(qualified, table, concurrent?) do
     dedupe = """
     DELETE FROM #{qualified} a USING #{qualified} b
      WHERE a.ctid < b.ctid AND a.uuid = b.uuid
     """
 
-    index_name = quote_ident("#{unqualified(qualified)}_uuid_pk_idx")
+    # Built from the catalog name directly — parsing it back out of the quoted
+    # qualified string would corrupt any name containing a dot or a quote.
+    index_name = quote_ident("#{table.name}_uuid_pk_idx")
 
     if concurrent? do
       [
@@ -212,8 +214,4 @@ defmodule PhoenixKit.Migrations.UUIDIntegrity do
 
   @doc false
   def quote_ident(ident), do: ~s("#{String.replace(ident, ~s("), ~s(""))}")
-
-  defp unqualified(qualified) do
-    qualified |> String.split(".") |> List.last() |> String.replace(~s("), "")
-  end
 end

--- a/lib/phoenix_kit/migrations/uuid_integrity.ex
+++ b/lib/phoenix_kit/migrations/uuid_integrity.ex
@@ -1,0 +1,219 @@
+defmodule PhoenixKit.Migrations.UUIDIntegrity do
+  @moduledoc """
+  Finds and repairs `phoenix_kit_*` tables whose `uuid` column is not a proper
+  primary key.
+
+  The invariant the chain claims — every PhoenixKit table has a non-null `uuid`
+  of type `uuid`, defaulted to `uuid_generate_v7()`, as its primary key — was
+  violated on a production install, and by three separate migrations in
+  sequence. See `PhoenixKit.Migrations.Postgres.V163` for how.
+
+  ## Why the SQL lives here rather than in the migration
+
+  Two callers need exactly the same repair with different execution and
+  different risk appetite:
+
+    * `V163` runs during `mix ecto.migrate`, inside a transaction, via
+      `Ecto.Migration.execute/1`, and defers tables large enough that the
+      rewrite's `ACCESS EXCLUSIVE` lock would be an outage.
+    * `mix phoenix_kit.repair_uuid` runs when an operator chooses, outside a
+      transaction, via the repo directly, with no size limit and with the index
+      built `CONCURRENTLY` where that is possible.
+
+  Writing the statements twice would guarantee they drift, and drift in a
+  primary-key repair is how a table ends up half-fixed. This module owns the
+  SQL; the callers own how and when it runs.
+
+  ## Detection is catalog-driven
+
+  `broken_tables/2` asks PostgreSQL which tables are actually wrong rather than
+  consulting a hardcoded list. Every earlier attempt used a list, and the table
+  that prompted this work was absent from all of them — including the list in
+  the migration that was specifically written to repair its class of problem.
+  """
+
+  alias PhoenixKit.Migrations.Postgres.Helpers
+
+  @uuid_regex "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+
+  @doc """
+  Every `phoenix_kit_*` base table whose `uuid` column needs work.
+
+  Returns maps of `%{name, type, nullable, has_pk}`. A table is included when
+  the column is the wrong type, is nullable, or the table has no primary key —
+  the predicate the earlier guards should have used. `column_exists?/3` is true
+  for a `character varying` uuid, which is precisely why V40 skipped the table
+  it was listed in.
+  """
+  def broken_tables(repo, prefix) do
+    query = """
+    SELECT c.table_name,
+           c.data_type,
+           c.is_nullable,
+           EXISTS (
+             SELECT 1
+             FROM pg_constraint pc
+             JOIN pg_class pcl ON pcl.oid = pc.conrelid
+             JOIN pg_namespace pn ON pn.oid = pcl.relnamespace
+             WHERE pcl.relname = c.table_name
+               AND pn.nspname = c.table_schema
+               AND pc.contype = 'p'
+           ) AS has_pk
+    FROM information_schema.columns c
+    JOIN information_schema.tables t
+      ON t.table_name = c.table_name
+     AND t.table_schema = c.table_schema
+    WHERE c.table_schema = $1
+      AND c.table_name LIKE 'phoenix\\_kit\\_%'
+      AND c.column_name = 'uuid'
+      AND t.table_type = 'BASE TABLE'
+    ORDER BY c.table_name
+    """
+
+    case repo.query(query, [prefix], log: false) do
+      {:ok, %{rows: rows}} ->
+        rows
+        |> Enum.map(fn [name, type, nullable, has_pk] ->
+          %{name: name, type: type, nullable: nullable == "YES", has_pk: has_pk}
+        end)
+        |> Enum.filter(&needs_repair?/1)
+
+      {:error, _} ->
+        []
+    end
+  end
+
+  @doc "Whether this table's uuid column is not a proper primary key."
+  def needs_repair?(%{type: type, nullable: nullable, has_pk: has_pk}) do
+    type != "uuid" or nullable or not has_pk
+  end
+
+  @doc "Whether repairing this table requires rewriting it (a type change)."
+  def rewrite_needed?(%{type: type}), do: type != "uuid"
+
+  @doc """
+  Whether every non-null value in the column can be cast to `uuid`.
+
+  Checked BEFORE any DDL: `ALTER … USING uuid::uuid` aborts the surrounding
+  transaction on the first malformed value, which in a migration means taking
+  every other table's repair down with it.
+  """
+  def castable?(_repo, _qualified, %{type: "uuid"}), do: true
+
+  def castable?(repo, qualified, _table) do
+    sql = """
+    SELECT count(*) FROM #{qualified}
+     WHERE uuid IS NOT NULL AND uuid !~* '#{@uuid_regex}'
+    """
+
+    match?({:ok, %{rows: [[0]]}}, repo.query(sql, [], log: false))
+  end
+
+  @doc """
+  Estimated row count, from the planner's statistics rather than a count(*).
+
+  A sequential scan to decide whether to avoid an expensive operation is
+  self-defeating. `reltuples` of -1 means "never analyzed" and is reported as 0,
+  so an un-analyzed table is repaired rather than skipped — being wrong in that
+  direction leaves the table correct.
+  """
+  def estimated_rows(repo, prefix, name) do
+    # A name-based pg_class + pg_namespace JOIN, never `'schema.table'::regclass`:
+    # regclass RAISES when the relation does not exist, which inside a migration
+    # aborts the surrounding transaction and takes every other repair with it.
+    # This is the chain's documented prefix-safety rule.
+    sql = """
+    SELECT COALESCE(NULLIF(c.reltuples, -1), 0)::bigint
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relname = $1 AND n.nspname = $2
+    """
+
+    case repo.query(sql, [name, prefix], log: false) do
+      {:ok, %{rows: [[n]]}} -> n
+      _ -> 0
+    end
+  end
+
+  @doc """
+  The ordered SQL statements that repair one table.
+
+  Order is load-bearing and each step depends on the one before:
+
+    1. **type** — before anything is built on the column, so the index and the
+       primary key are built on `uuid`, not on the `varchar` it replaces.
+    2. **default** — so rows inserted between here and the backfill get a value.
+    3. **backfill** — before `SET NOT NULL`, or the constraint aborts on exactly
+       the NULLs it exists to prevent.
+    4. **NOT NULL** — before the primary key, which requires it.
+    5. **de-duplicate** — a table that has run without a key can hold duplicate
+       uuids, and `ADD PRIMARY KEY` aborts on them. Rows sharing a uuid are the
+       same logical row twice; `ctid` picks one deterministically.
+    6. **primary key** — last, once uniqueness and NOT NULL both hold.
+
+  `concurrent_index: true` splits the key into a `CREATE UNIQUE INDEX
+  CONCURRENTLY` plus `ADD PRIMARY KEY USING INDEX`, which holds the exclusive
+  lock only for the attach rather than the whole build. It cannot run inside a
+  transaction, so it is available to the mix task and not to the migration.
+  """
+  def repair_statements(qualified, prefix, table, opts \\ []) do
+    # Helpers.uuid_v7_call/1 resolves the function's real schema, so the call
+    # works regardless of the connecting role's search_path.
+    uuid_v7 = Helpers.uuid_v7_call(prefix)
+    concurrent? = Keyword.get(opts, :concurrent_index, false)
+
+    type_stmt =
+      if rewrite_needed?(table) do
+        ["ALTER TABLE #{qualified} ALTER COLUMN uuid TYPE uuid USING uuid::uuid"]
+      else
+        []
+      end
+
+    common = [
+      "ALTER TABLE #{qualified} ALTER COLUMN uuid SET DEFAULT #{uuid_v7}",
+      "UPDATE #{qualified} SET uuid = #{uuid_v7} WHERE uuid IS NULL",
+      "ALTER TABLE #{qualified} ALTER COLUMN uuid SET NOT NULL"
+    ]
+
+    type_stmt ++ common ++ pk_statements(qualified, table, concurrent?)
+  end
+
+  defp pk_statements(_qualified, %{has_pk: true}, _concurrent?), do: []
+
+  defp pk_statements(qualified, _table, concurrent?) do
+    dedupe = """
+    DELETE FROM #{qualified} a USING #{qualified} b
+     WHERE a.ctid < b.ctid AND a.uuid = b.uuid
+    """
+
+    index_name = quote_ident("#{unqualified(qualified)}_uuid_pk_idx")
+
+    if concurrent? do
+      [
+        dedupe,
+        "CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS #{index_name} ON #{qualified} (uuid)",
+        "ALTER TABLE #{qualified} ADD PRIMARY KEY USING INDEX #{index_name}"
+      ]
+    else
+      [dedupe, "ALTER TABLE #{qualified} ADD PRIMARY KEY (uuid)"]
+    end
+  end
+
+  @doc """
+  Fully-qualified, QUOTED table name.
+
+  The prefix is validated upstream, but the table name comes from the catalog
+  and is interpolated into DDL. Quoting it means a legal-but-unusual identifier
+  — a space, a capital, a reserved word — produces valid SQL rather than a
+  syntax error that aborts the run. PostgreSQL escapes an embedded quote by
+  doubling it.
+  """
+  def qualify(prefix, name), do: "#{quote_ident(prefix)}.#{quote_ident(name)}"
+
+  @doc false
+  def quote_ident(ident), do: ~s("#{String.replace(ident, ~s("), ~s(""))}")
+
+  defp unqualified(qualified) do
+    qualified |> String.split(".") |> List.last() |> String.replace(~s("), "")
+  end
+end

--- a/test/integration/v163_uuid_integrity_test.exs
+++ b/test/integration/v163_uuid_integrity_test.exs
@@ -1,0 +1,287 @@
+defmodule PhoenixKit.Integration.V163UUIDIntegrityTest do
+  @moduledoc """
+  V163 repairs a state that no fresh install produces, so every test here has to
+  MANUFACTURE the damage first. That is the point: the reported database was
+  reached by an upgrade path that no longer exists in the tree, and the only way
+  to prove the repair works is to recreate the shape it left behind —
+  `character varying(255)` uuid, nullable, no default, no primary key.
+
+  Each test builds its own scratch table rather than damaging a real PhoenixKit
+  one, so a failure cannot corrupt the suite's schema for whatever runs next.
+  """
+  use PhoenixKit.DataCase, async: false
+
+  alias PhoenixKit.Migrations.UUIDIntegrity
+
+  @prefix "public"
+
+  setup do
+    # `phoenix_kit_` prefix so discovery finds it; `zz_` so it sorts last and
+    # cannot be confused with a real table.
+    table = "phoenix_kit_zz_v163_#{System.unique_integer([:positive])}"
+    on_exit(fn -> drop(table) end)
+    {:ok, table: table}
+  end
+
+  defp repo, do: PhoenixKit.RepoHelper.repo()
+  defp sql!(q, p \\ []), do: Repo.query!(q, p)
+  defp drop(t), do: Repo.query("DROP TABLE IF EXISTS #{t}", [])
+
+  # The reported shape, exactly.
+  defp create_broken(table) do
+    sql!("""
+    CREATE TABLE #{table} (
+      uuid character varying(255),
+      payload text
+    )
+    """)
+  end
+
+  defp create_healthy(table) do
+    sql!("""
+    CREATE TABLE #{table} (
+      uuid uuid PRIMARY KEY DEFAULT public.uuid_generate_v7(),
+      payload text
+    )
+    """)
+  end
+
+  defp repair!(table) do
+    tbl = Enum.find(UUIDIntegrity.broken_tables(repo(), @prefix), &(&1.name == table))
+    refute is_nil(tbl), "#{table} was not detected as broken"
+
+    UUIDIntegrity.qualify(@prefix, table)
+    |> UUIDIntegrity.repair_statements(@prefix, tbl)
+    |> Enum.each(&sql!/1)
+  end
+
+  defp column(table) do
+    %{rows: [[type, nullable, default]]} =
+      sql!(
+        """
+        SELECT data_type, is_nullable, column_default
+        FROM information_schema.columns
+        WHERE table_schema = $1 AND table_name = $2 AND column_name = 'uuid'
+        """,
+        [@prefix, table]
+      )
+
+    %{type: type, nullable: nullable == "YES", default: default}
+  end
+
+  defp has_pk?(table) do
+    %{rows: [[n]]} =
+      sql!(
+        """
+        SELECT count(*) FROM pg_constraint pc
+        JOIN pg_class pcl ON pcl.oid = pc.conrelid
+        JOIN pg_namespace pn ON pn.oid = pcl.relnamespace
+        WHERE pcl.relname = $1 AND pn.nspname = $2 AND pc.contype = 'p'
+        """,
+        [table, @prefix]
+      )
+
+    n > 0
+  end
+
+  describe "detection" do
+    test "finds the reported shape", %{table: table} do
+      create_broken(table)
+
+      found = Enum.find(UUIDIntegrity.broken_tables(repo(), @prefix), &(&1.name == table))
+
+      assert found.type == "character varying"
+      assert found.nullable
+      refute found.has_pk
+    end
+
+    test "a healthy table is NOT reported", %{table: table} do
+      create_healthy(table)
+      refute Enum.any?(UUIDIntegrity.broken_tables(repo(), @prefix), &(&1.name == table))
+    end
+
+    test "a correctly typed but PK-less table is still reported", %{table: table} do
+      # The case the doctor's type check could never see: right type, no key.
+      sql!("CREATE TABLE #{table} (uuid uuid NOT NULL, payload text)")
+
+      found = Enum.find(UUIDIntegrity.broken_tables(repo(), @prefix), &(&1.name == table))
+      assert found.type == "uuid"
+      refute found.has_pk
+    end
+
+    test "every real phoenix_kit table in this database is already healthy" do
+      # A canary: if the suite's own schema ever regresses into this state, the
+      # scratch-table tests above would still pass and hide it.
+      real =
+        repo()
+        |> UUIDIntegrity.broken_tables(@prefix)
+        |> Enum.reject(&String.starts_with?(&1.name, "phoenix_kit_zz_"))
+
+      assert real == [], "tables in a broken uuid state: #{inspect(Enum.map(real, & &1.name))}"
+    end
+  end
+
+  describe "repair" do
+    test "converts type, sets default, backfills, and adds the primary key", %{table: table} do
+      create_broken(table)
+      sql!("INSERT INTO #{table} (uuid, payload) VALUES ($1, 'kept')", [Ecto.UUID.generate()])
+      sql!("INSERT INTO #{table} (uuid, payload) VALUES (NULL, 'null-uuid')")
+
+      repair!(table)
+
+      col = column(table)
+      assert col.type == "uuid"
+      refute col.nullable
+      assert col.default =~ "uuid_generate_v7"
+      assert has_pk?(table)
+
+      # No row was lost and no uuid is null.
+      %{rows: [[count]]} = sql!("SELECT count(*) FROM #{table}")
+      assert count == 2
+      %{rows: [[nulls]]} = sql!("SELECT count(*) FROM #{table} WHERE uuid IS NULL")
+      assert nulls == 0
+    end
+
+    test "preserves the uuid values that were already there", %{table: table} do
+      create_broken(table)
+      existing = Ecto.UUID.generate()
+      sql!("INSERT INTO #{table} (uuid, payload) VALUES ($1, 'keepme')", [existing])
+
+      repair!(table)
+
+      %{rows: [[stored]]} = sql!("SELECT uuid::text FROM #{table} WHERE payload = 'keepme'")
+      assert stored == existing
+    end
+
+    test "de-duplicates before adding the key, keeping one row per uuid", %{table: table} do
+      create_broken(table)
+      dup = Ecto.UUID.generate()
+      sql!("INSERT INTO #{table} (uuid, payload) VALUES ($1, 'a')", [dup])
+      sql!("INSERT INTO #{table} (uuid, payload) VALUES ($1, 'b')", [dup])
+
+      repair!(table)
+
+      assert has_pk?(table)
+      %{rows: [[count]]} = sql!("SELECT count(*) FROM #{table} WHERE uuid::text = $1", [dup])
+      assert count == 1
+    end
+
+    test "is idempotent — a second pass is a no-op", %{table: table} do
+      create_broken(table)
+      sql!("INSERT INTO #{table} (uuid, payload) VALUES (NULL, 'x')")
+      repair!(table)
+
+      %{rows: [[before_count]]} = sql!("SELECT count(*) FROM #{table}")
+
+      # After repair the table is no longer detected, which IS the idempotency:
+      # nothing runs a second time.
+      refute Enum.any?(UUIDIntegrity.broken_tables(repo(), @prefix), &(&1.name == table))
+
+      %{rows: [[after_count]]} = sql!("SELECT count(*) FROM #{table}")
+      assert before_count == after_count
+      assert has_pk?(table)
+    end
+
+    test "a table that only lacks a key gets one without a rewrite", %{table: table} do
+      sql!("CREATE TABLE #{table} (uuid uuid NOT NULL, payload text)")
+
+      sql!("INSERT INTO #{table} (uuid, payload) VALUES ($1::text::uuid, 'x')", [
+        Ecto.UUID.generate()
+      ])
+
+      tbl = Enum.find(UUIDIntegrity.broken_tables(repo(), @prefix), &(&1.name == table))
+      refute UUIDIntegrity.rewrite_needed?(tbl), "a uuid-typed column must not be rewritten"
+
+      repair!(table)
+      assert has_pk?(table)
+    end
+  end
+
+  describe "castability guard" do
+    test "refuses a column holding values that are not UUIDs", %{table: table} do
+      create_broken(table)
+      sql!("INSERT INTO #{table} (uuid, payload) VALUES ('not-a-uuid', 'bad')")
+
+      tbl = Enum.find(UUIDIntegrity.broken_tables(repo(), @prefix), &(&1.name == table))
+      qualified = UUIDIntegrity.qualify(@prefix, table)
+
+      # Must be caught BEFORE any DDL: the cast would abort the surrounding
+      # transaction and take every other table's repair down with it.
+      refute UUIDIntegrity.castable?(repo(), qualified, tbl)
+    end
+
+    test "accepts a column whose values are all valid UUIDs", %{table: table} do
+      create_broken(table)
+      sql!("INSERT INTO #{table} (uuid, payload) VALUES ($1, 'ok')", [Ecto.UUID.generate()])
+
+      tbl = Enum.find(UUIDIntegrity.broken_tables(repo(), @prefix), &(&1.name == table))
+      assert UUIDIntegrity.castable?(repo(), UUIDIntegrity.qualify(@prefix, table), tbl)
+    end
+
+    test "a NULL-only column is castable", %{table: table} do
+      create_broken(table)
+      sql!("INSERT INTO #{table} (uuid, payload) VALUES (NULL, 'x')")
+
+      tbl = Enum.find(UUIDIntegrity.broken_tables(repo(), @prefix), &(&1.name == table))
+      assert UUIDIntegrity.castable?(repo(), UUIDIntegrity.qualify(@prefix, table), tbl)
+    end
+  end
+
+  describe "identifier quoting" do
+    test "an unusual but legal table name produces valid SQL", %{table: _t} do
+      # Catalog-derived names are interpolated into DDL. An identifier with a
+      # space or a capital must yield valid SQL rather than a syntax error that
+      # aborts the whole run.
+      odd = "phoenix_kit_zz_odd name_#{System.unique_integer([:positive])}"
+      on_exit(fn -> Repo.query(~s|DROP TABLE IF EXISTS "#{odd}"|, []) end)
+      sql!(~s|CREATE TABLE "#{odd}" (uuid character varying(255), payload text)|)
+
+      tbl = Enum.find(UUIDIntegrity.broken_tables(repo(), @prefix), &(&1.name == odd))
+      refute is_nil(tbl), "a quoted-identifier table must still be discovered"
+
+      UUIDIntegrity.qualify(@prefix, odd)
+      |> UUIDIntegrity.repair_statements(@prefix, tbl)
+      |> Enum.each(&sql!/1)
+
+      assert has_pk?(odd)
+    end
+
+    test "quote_ident doubles an embedded quote" do
+      assert UUIDIntegrity.quote_ident(~s(a"b)) == ~s("a""b")
+    end
+  end
+
+  describe "statement ordering" do
+    test "the type change precedes the primary key", %{table: table} do
+      create_broken(table)
+      tbl = Enum.find(UUIDIntegrity.broken_tables(repo(), @prefix), &(&1.name == table))
+
+      stmts = UUIDIntegrity.repair_statements(UUIDIntegrity.qualify(@prefix, table), @prefix, tbl)
+      idx = fn frag -> Enum.find_index(stmts, &String.contains?(&1, frag)) end
+
+      # A key built on the varchar would have to be rebuilt after the rewrite.
+      assert idx.("TYPE uuid") < idx.("PRIMARY KEY")
+      # SET NOT NULL aborts on the very NULLs the backfill exists to remove.
+      assert idx.("WHERE uuid IS NULL") < idx.("SET NOT NULL")
+      # The key requires NOT NULL to already hold.
+      assert idx.("SET NOT NULL") < idx.("PRIMARY KEY")
+    end
+
+    test "concurrent_index splits the key into a CONCURRENTLY build plus attach",
+         %{table: table} do
+      create_broken(table)
+      tbl = Enum.find(UUIDIntegrity.broken_tables(repo(), @prefix), &(&1.name == table))
+
+      stmts =
+        UUIDIntegrity.repair_statements(UUIDIntegrity.qualify(@prefix, table), @prefix, tbl,
+          concurrent_index: true
+        )
+
+      assert Enum.any?(stmts, &String.contains?(&1, "CREATE UNIQUE INDEX CONCURRENTLY"))
+      assert Enum.any?(stmts, &String.contains?(&1, "ADD PRIMARY KEY USING INDEX"))
+      # CONCURRENTLY cannot run in a transaction, so the migration must not emit it.
+      plain = UUIDIntegrity.repair_statements(UUIDIntegrity.qualify(@prefix, table), @prefix, tbl)
+      refute Enum.any?(plain, &String.contains?(&1, "CONCURRENTLY"))
+    end
+  end
+end


### PR DESCRIPTION
Fixes a reported production defect: `phoenix_kit_email_events` with `uuid` as `character varying(255)`, nullable, no default, and **no primary key**, on a database upgraded through the whole chain since V01. 149 other tables were correct, so this was one table falling out of the conversion rather than a broken upgrade.

## Why the chain missed it — three times

The reporter identified V40's guard. There is a second cause they could not see from outside the repo, and it is the one that explains why they are *still* broken at V162.

**1. V40's guard tests EXISTENCE, not TYPE.** An older release created the column as Ecto `:string`, so `unless column_exists?(table, :uuid, …)` was already true and V40 skipped the table wholesale — not just the `ADD COLUMN`, but the backfill, the `SET NOT NULL` and the unique index with it. The table *is* in V40's `@tables_to_migrate`; being listed did not help.

**2. V56's type conversion shipped 17 days after V56 did.** `ensure_all_uuid_columns_native_type/2` converts exactly this varchar column — and it was added to V56 on **2026-03-02**, while V56 itself shipped **2026-02-13**. A recorded version never re-runs, so every host that crossed V56 in that window kept the broken column permanently. V56's `NOT NULL` and index repairs also run off hardcoded table lists that `phoenix_kit_email_events` appears in none of.

**3. V74 did not verify its own post-condition.** It dropped the legacy bigint `id` but could not promote `uuid` to primary key — wrong type, nullable — and its moduledoc's claim ("after V74, every PhoenixKit table has uuid as its PK") silently became false.

## What this adds

**V163** — catalog-driven repair. Every previous attempt enumerated tables by hand and this table was absent from every list, *including the list in the migration written to repair its class of problem*. V163 asks the catalog which tables are actually wrong, so a table nobody remembered to list is repaired anyway.

**`PhoenixKit.Migrations.UUIDIntegrity`** — the detection and SQL, shared by the migration and the task so they cannot drift. Drift in a primary-key repair is how a table ends up half-fixed.

**`mix phoenix_kit.repair_uuid`** — the operator path for tables too large to rewrite during a deploy. Supports `--dry-run`, `--prefix`, and specific table names, and builds the unique index `CONCURRENTLY` because it runs outside a transaction.

**Doctor** — a new primary-key check, plus a correction to the existing one.

## Deliberate decisions

**Large tables are deferred, not silently rewritten.** `ALTER COLUMN TYPE` rewrites under `ACCESS EXCLUSIVE` and `ADD PRIMARY KEY` builds an index under the same lock — both O(rows). On a big events table behind PgBouncer (which the reporter runs) that is pool exhaustion during `mix ecto.migrate`, not a pause. Above two million rows the repair is skipped and logged with the exact command; the doctor keeps reporting it until it is done.

**Nothing raises on the happy path.** The reporter suggested V74 verify and fail. Raising on an already-shipped chain would strand every affected host mid-deploy, and a library does not own its hosts' deploy runbooks. Turning "one audit table lacks a PK, on a version where no schema maps to it" into a fleet-wide failed deploy is the worse outcome. The doctor is the loud channel.

**The version marker is written even when a table is skipped.** An unwritten marker is how this codebase has previously had migrations skipped *permanently*. A skipped table stays visible; a stale marker does not.

**The doctor's remedy was incomplete and is corrected.** It suggested `ALTER TABLE <t> ALTER COLUMN uuid TYPE uuid USING uuid::uuid`, which restores the type but not the `NOT NULL`, the UUIDv7 default, or the primary key — anyone following it literally was left in a state that still fails the check. It now points at the task. The "will crash Ecto on load" wording is also softened: on 1.7.235 no schema maps to this table, so it overstated the impact, exactly as the reporter noted.

## Review found two defects in this change

Both were caught by an adversarial pass over the diff and are fixed here:

- **The per-table isolation could never have fired.** `Ecto.Migration.execute/1` *queues* a command, so the statements were flushed after `up/1` returned — outside the `rescue`. A locked table would still have aborted every later repair and skipped the marker. `flush/0` now runs them in scope. This compiled and read correctly while doing nothing, which is the kind of defect a diff hides.
- **Identifiers were interpolated unquoted.** A legal-but-unusual table name produced a syntax error that aborted the run. `quote_ident/1` now quotes both prefix and table; there is a test with a space in the name.

## Verification

- 2881 tests, 0 failures; `mix precommit` exit 0
- 16 new integration tests, all against a **synthesized** broken database — no fresh install produces this state, so the damage has to be manufactured to prove the repair. Covers detection, type conversion, backfill, NOT NULL, PK, value preservation, de-duplication, idempotency, the non-castable abort, statement ordering, and identifier quoting.
- Applied end-to-end on a real 164-table dev database: correctly found nothing to repair, wrote the marker, `V162 → V163`, doctor's new check PASS.
- Prefix-safe: no `::regclass` anywhere (it raises when the relation is absent and aborts the transaction), every existence check anchored on `table_schema`/`nspname`, `Helpers.uuid_v7_call/1` for the generator.

**No version bump or CHANGELOG entry** — left at the current version deliberately.

One thing I could not attribute: an intermittent single failure in `test/integration/phoenix_kit_web/live/users/media_test.exs` ("orphan filter false omits orphaned param"). It passes in isolation on both a clean tree and this branch, appears seed-dependent, and is unrelated to migrations — but it did not appear on the one clean-tree full run I did, so I am flagging it rather than asserting it is pre-existing.
