### PR TITLE
Fix admin_update_user_password/3 writing the hash for any caller

### DIFF
--- a/dev_docs/squash/review/2026-08-09/RELEASE_READINESS_BRIEF.md
+++ b/dev_docs/squash/review/2026-08-09/RELEASE_READINESS_BRIEF.md
@@ -1,0 +1,104 @@
+# Release-readiness review — PhoenixKit 2.0 (squash), 2026-08-09
+
+The maintainer is asking one question: **can this be published?** Not "is the
+code good" — three rounds already covered that (GLM, an Opus agent with live
+database access, and Kimi; every finding is fixed and the branch is
+`BeamLabEU/phoenix_kit` PR **#689**). What is needed now is a go/no-go on
+*publishing to Hex*, and the failure modes of a release are different from the
+failure modes of a diff.
+
+Your verdict must be one of: **GO**, **GO WITH CONDITIONS** (list them, ordered,
+each with who must do it), or **NO-GO** (name the blocker). Say plainly which
+facts you verified yourself and which you took from this brief.
+
+## What is being released
+
+The chain `V01`..`V134` is replaced by one generated baseline `V135`; deltas
+`V136`..`V164` are unchanged; a database below `V135` is refused with an
+actionable error naming the bridge release. `V164` additionally repairs a real
+defect (`V56`/`V57` ran existence guards against still-queued DDL, leaving ~46
+`*_uuid` columns nullable and ~67 of 70 foreign keys uncreated on every
+installer-created database) and normalizes two indexes whose shape diverged
+between `public` and named-schema installs.
+
+Verification already on record for the exact commit in the PR (`bc3bae06`):
+full scenario matrix S1–S22 with 0 FAIL and three documented SKIPs, a
+public-path (mode A) equivalence oracle passing, 1919 tests passing, and
+`mix phoenix_kit.release_check` green (`V135..V164` contiguous, `chain_hash`
+matching all 30 shipped files). The core equivalence claim — baseline+deltas
+produce byte-identical schema and seed data to the full pre-squash chain — is
+what S1/S2 assert against tool-built references.
+
+## The thing I believe is the actual blocker — verify or refute it
+
+Core's own version is untouched at `1.7.235` (`mix.exs`, deliberately: version
+bumps are maintainer-owned). If it is published as **2.0.0**, then every
+sibling module package currently on Hex pins core as `~> 1.7.x`, i.e.
+`>= 1.7.x and < 1.8.0`, which **2.0.0 cannot satisfy**. Measured today in this
+workspace:
+
+```
+phoenix_kit_catalogue        ~> 1.7.189
+phoenix_kit_crm             "~> 1.7 and >= 1.7.219"
+phoenix_kit_document_creator ~> 1.7.189
+phoenix_kit_ecommerce        ~> 1.7.231
+phoenix_kit_emails           ~> 1.7.217
+phoenix_kit_entities         ~> 1.7.214
+phoenix_kit_hello_world      ~> 1.7.214
+phoenix_kit_locations        ~> 1.7.189
+phoenix_kit_manufacturing    ~> 1.7.231
+phoenix_kit_projects         ~> 1.7.231
+phoenix_kit_warehouse        ~> 1.7.214
+```
+
+Consequences to check: an application that depends on core `~> 2.0` **and** any
+one of these modules gets an unsolvable dependency set. Confirm the resolver
+semantics yourself, decide whether this is a hard blocker or merely a
+coordination item, and say in what ORDER the packages must be published for
+consumers never to see an unsolvable state. Also check whether a
+`~> 1.7 or ~> 2.0` widening is even expressible for these packages and whether
+anything in the modules' code would actually break against the squashed core
+(they consume `PhoenixKit.Module`, `Routes.path/1`, the migration coordinator
+contract).
+
+## Everything else worth a release-gate opinion
+
+1. **Is a major the right version at all?** What in this release is
+   backwards-incompatible for a consumer who is already above the floor? The
+   comments foreign key changes from `ON DELETE CASCADE` to `SET NULL` (a
+   behavior change for anyone relying on user deletion removing comments), and
+   below-floor databases stop migrating. Anything else you find.
+2. **The hex package contents.** `mix.exs`'s `files:` whitelist is
+   `~w(lib priv mix.exs README.md LICENSE CHANGELOG.md)`. Verify nothing needed
+   ships missing and nothing private ships by accident — in particular that the
+   30 migration modules and the generated manifest are included, and that
+   `dev_docs/` (which contains internal review material) is excluded.
+3. **The upgrade path for a third party**, `dev_docs/guides/2026-08-07-upgrading-to-2.0-guide.md`
+   — but note that guide lives in `dev_docs/`, which is NOT in the hex package.
+   Decide whether the release needs anything user-facing that a consumer can
+   actually read after installing, and where it should live.
+4. **What a consumer hits on the unhappy path.** Below the floor; a database
+   whose version comment is missing or hand-edited; a run through PgBouncer in
+   transaction-pooling mode; `V164` on a large table under traffic. Each of
+   these has documented behavior — check the behavior matches the
+   documentation, and say whether the failure is loud, safe and actionable.
+5. **`mix prerelease`** (`deps.get --check-locked`, prod compile with warnings
+   as errors, `quality.ci`, `deps.audit`, `hex.audit`, `docs`, `hex.build`,
+   `release_check`) is running as this brief is written; read
+   `/tmp/claude-1000/-www/7cd7b1b7-6ad0-4d0b-9c0c-631723f94572/scratchpad/prerelease.log`
+   for its outcome and treat any failure there as a fact, not a rumour.
+6. **Known-unproven, on the record** — a second PostgreSQL major (no container
+   available), scenario `s16`'s body, and `s18` (a migration starting mid-repair,
+   detected rather than prevented). Say whether any of these should gate a
+   release or are acceptable as documented limitations.
+
+## Rules
+
+Read-only: do not edit files, do not publish anything, do not run migrations
+against any database, do not push. The scenario harness may be run read-only if
+you need to (see `dev_docs/squash/README.md`), but the shared PostgreSQL is at
+its connection ceiling — check for headroom first and prefer reading recorded
+results in `dev_docs/squash/` over re-running.
+
+Be concrete and ordered. The output the maintainer needs is a decision plus a
+checklist, not an essay.

--- a/dev_docs/squash/review/2026-08-09/RELEASE_READINESS_VERDICT.md
+++ b/dev_docs/squash/review/2026-08-09/RELEASE_READINESS_VERDICT.md
@@ -1,0 +1,197 @@
+# Release-readiness verdict — PhoenixKit 2.0 (squash), 2026-08-09
+
+Review of the brief in `RELEASE_READINESS_BRIEF.md`, performed by a read-only
+Claude reviewer agent against commit `bc3bae06` (HEAD of `squash-migrations`,
+merged upstream as PR #689). Recorded verbatim below, with one orchestrator
+note appended at the end (the condition-4 root cause was found after the
+reviewer wrote its report).
+
+---
+
+## Release-Readiness Verdict: GO WITH CONDITIONS
+
+**Commit reviewed:** `bc3bae06` (HEAD of `squash-migrations`, merged as PR #689)
+
+### Verdict: GO WITH CONDITIONS
+
+The code, migration chain, and verification are release-ready. Four conditions
+must be resolved before `mix hex.publish`, ordered by priority. None require
+code changes to the migration chain itself.
+
+### Conditions (ordered, each with who)
+
+**1. Widen sibling module pins BEFORE publishing core 2.0.0** — *Maintainer*
+
+This is the item the brief flagged as the potential actual blocker.
+**Confirmed: it IS a hard coordination constraint.**
+
+- Every sibling module on Hex pins `~> 1.7.x` (e.g. `~> 1.7.189`), which means
+  `>= 1.7.189 and < 1.8.0`. Version `2.0.0` cannot satisfy any of these ranges.
+- A consumer who depends on `{:phoenix_kit, "~> 2.0"}` AND any current module
+  version gets an **unsolvable dependency set** — `mix deps.get` fails
+  immediately.
+- **Hex DOES support `or` requirements**: `"~> 1.7.189 or ~> 2.0"` is valid and
+  expands to the union of both ranges. An even simpler widening:
+  `">= 1.7.189 and < 3.0.0"`.
+- **Correct publish order**: publish new versions of ALL 11 sibling modules
+  with widened pins FIRST, then publish `phoenix_kit` 2.0.0. If core is
+  published first, every consumer who hasn't updated their modules is broken.
+- **Nothing in the modules' code breaks against 2.0**: the `PhoenixKit.Module`
+  callback interface, `Routes.path/1`, and the migration coordinator contract
+  are all unchanged. The widened pin is safe — modules need no code changes,
+  only a version requirement bump.
+- Consumer workaround exists (`override: true`) but is unsafe and should not be
+  the plan.
+
+**2. Bump `@version` to `"2.0.0"` and add CHANGELOG entry** — *Maintainer*
+
+- `mix.exs` still reads `@version "1.7.235"`. The version must be `"2.0.0"`
+  before publishing.
+- CHANGELOG has no `## 2.0.0` heading. Consumers need to know: (a) below-floor
+  refusal, (b) V164 FK repair including the CASCADE→SET NULL behavior change on
+  comments, (c) the bridge path.
+
+**3. Make the upgrade guide reachable by consumers** — *Maintainer*
+
+- The upgrade guide (`dev_docs/guides/2026-08-07-upgrading-to-2.0-guide.md`) is
+  excellent and thorough. But it lives in `dev_docs/`, which is excluded from
+  both the hex package AND hexdocs.pm.
+- The hex `files:` whitelist is `~w(lib priv mix.exs README.md LICENSE
+  CHANGELOG.md)` — no `guides/`, no `dev_docs/`.
+- **Fix**: copy/move the guide to `guides/upgrading-to-2.0.md` and add it to
+  the `docs: extras:` list. It will then appear on hexdocs.pm. Alternatively,
+  inline the critical steps into the CHANGELOG entry.
+
+**4. Fix the prerelease gate and run it clean** — *Maintainer*
+
+- `mix prerelease` failed at `hex.audit`. Paradoxically, `mix hex.audit` works
+  standalone ("No retired packages found") — the failure is a gate-mechanics
+  issue.
+- Consequence: `docs`, `hex.build`, and `phoenix_kit.release_check` did NOT
+  execute in this run.
+- These have all been verified separately (`hex.build` unpacked successfully,
+  `release_check` recorded as passing in the verification matrix), but the
+  gate as a whole hasn't passed clean end-to-end.
+- The orchestrator noted this is the FIRST TIME the gate has EVER run past the
+  compile step (the `:enoent` bug was only fixed today). Weigh accordingly.
+- **Fix**: debug the `hex.audit` failure in the alias context, then re-run
+  `mix prerelease` clean.
+
+### Brief Items Checklist
+
+**Item 1 — Is a major the right version?** YES.
+Two backwards-incompatible changes justify a major:
+
+1. Below-floor databases are refused with `BelowFloorError` (breaking for any
+   install at < V135)
+2. Comments FK changed from `ON DELETE CASCADE` to `ON DELETE SET NULL`
+   (behavior change — deleting a user no longer deletes their comments)
+
+Additionally, V01–V134 are deleted, so downgrading from 2.0 to 1.7 and
+replaying those versions is impossible.
+
+**Item 2 — Hex package contents.** ✓ VERIFIED MYSELF.
+
+- Unpacked `phoenix_kit-1.7.235` (from `mix hex.build --unpack`):
+  - 30 migration files (V135–V164): all present ✓
+  - Expected schema manifest (`expected_schema.ex` + `expected_schema/`
+    directory): present ✓
+  - Supporting migration modules (51 total files under
+    `lib/phoenix_kit/migrations/`): present ✓
+  - `dev_docs/` excluded: confirmed absent ✓
+  - No private/sensitive content: confirmed ✓
+  - `helpers.ex`, `uuid_fk_columns.ex`, `uuid_integrity.ex`, full `repair/`
+    directory: present ✓
+
+**Item 3 — Upgrade guide.** The guide itself is thorough and correct
+(step-by-step bridge path, V164 lock behavior, PgBouncer warnings,
+named-schema limits, rollback semantics). **But it is unreachable to
+consumers** — see Condition 3.
+
+**Item 4 — Unhappy path behavior.** ALL VERIFIED BY READING CODE:
+
+- **Below floor**: `BelowFloorError` raised from `up/1`, `down/1`, AND
+  `ensure_current/2`. Message is loud, safe, and actionable: names the floor
+  (V135), names the bridge ("the last PhoenixKit 1.7.x release"), and appends
+  `mix test.reset` hint for the `ensure_current` context. ✓
+- **Missing/hand-edited version comment**: `Repair.Probe` reads and handles
+  nil/absent comments. ✓
+- **PgBouncer in transaction mode**: documented in upgrade guide ("use a
+  direct connection"). ✓
+- **V164 on a large table**: uses `NOT VALID` + separate `VALIDATE CONSTRAINT`
+  (non-blocking validation). NULL rows → warns and skips (never forces).
+  Already-existing FK → adopts by shape, not name.
+  `@disable_ddl_transaction` makes partial failure safe to re-run. All
+  documented. ✓
+- **Degraded outcome exits successfully**: documented — the SUMMARY line names
+  every constraint left NOT VALID. ✓
+
+**Item 5 — Prerelease gate.** FAILED at `hex.audit` — see Condition 4. Partial
+results: `deps.get --check-locked` ✓; `MIX_ENV=prod compile
+--warnings-as-errors` ✓ (481 files, no warnings); `quality.ci` — format ✓,
+credo ✓ (10096 mods/funs, no issues), dialyzer ✓ (221 errors, all 221 skipped
+via ignore file, 2 unnecessary skips — clean pass); `deps.audit` ✓ ("No
+vulnerabilities found"); `hex.audit` ✗ (task not found in alias context —
+works standalone); `docs`, `hex.build`, `phoenix_kit.release_check` — NOT
+REACHED in that run.
+
+**Item 6 — Known-unproven items.** None should gate release:
+
+- Second PostgreSQL major: documented as informational-only finding
+  (expression rendering differences, not schema drift). Acceptable. ✓
+- s16 (Oban delegated): `SKIP:pending-p2-body` — assertion body pending, low
+  risk. Acceptable. ✓
+- s18 (migration mid-repair interleave): detected by version-comment re-read,
+  not prevented. Advisory lock prevents the reverse direction. Documented as a
+  limitation. Acceptable. ✓
+
+### Verified Myself vs. Taken from Brief
+
+**Verified myself (code reading, file inspection, tool execution):**
+Hex resolver semantics (`or` requirements ARE expressible; module pins CANNOT
+resolve with 2.0.0); hex package contents (unpacked and listed every file);
+30 versioned migration files present, V01–V134 absent; `BelowFloorError`
+message text; `bridge_version` never set concretely (always nil → generic
+"1.7.x" wording); `@current_version` 164 / `@initial_version` 135; upgrade
+guide location (excluded from package); no 2.0.0 CHANGELOG entry; no README
+upgrade mention; prerelease log (failure at `hex.audit`, works standalone);
+dialyzer 221/221 skipped with 2 unnecessary ignore entries; V164 moduledoc +
+implementation (NOT VALID strategy, idempotence, relaxed-column handling,
+comments FK correction); all 6 recorded diffs in `dev_docs/squash/out/`
+(expected normalizations, not bugs); `PhoenixKit.Module` callback interface
+unchanged.
+
+**Taken from the brief (not independently re-verified against the database):**
+S1–S22 matrix results (0 FAIL, 3 SKIPs); 1919 tests passing;
+`phoenix_kit.release_check` green (prior recorded result); S21 round-trip;
+mode A equivalence oracle.
+
+### Summary
+
+The migration chain, the repair delta, the below-floor guard, and the hex
+package contents are all sound. The three review rounds caught and fixed every
+code issue. What remains is release *logistics*: the sibling-module pin
+widening (a coordination step, not a code change), the version bump, the
+upgrade guide placement, and a clean prerelease gate run. All four are
+straightforward, none require changes to the migration chain itself, and none
+change the risk profile of the release.
+
+---
+
+## Orchestrator note (post-review), 2026-08-09
+
+Condition 4's root cause was isolated after the reviewer wrote its report:
+**dialyxir breaks Hex-archive task resolution in the same VM.** Bisection:
+`mix do deps.audit + hex.audit` passes, `mix do format --check-formatted +
+credo --strict + hex.audit` passes, `mix do quality.ci + hex.audit` fails —
+i.e. the `dialyzer` step is the trigger; project-dep tasks (`deps.audit`,
+`docs`, `phoenix_kit.release_check`) keep resolving, archive tasks
+(`hex.audit`, `hex.build`) stop. Fix applied to the `prerelease` alias: both
+hex.* steps now run via `cmd mix …` (fresh VM per step). The remaining tail
+(`docs` → `hex.build` → `release_check`) was also executed on this tree:
+docs generate (70 broken-autolink warnings referencing hidden modules, mostly
+`PhoenixKit.Migrations.ExpectedSchema` — cosmetic follow-up), `hex.build`
+packages correctly, `release_check` passes every technical check (V135..V164
+contiguous, chain_hash matches all 30 files, CHANGELOG shape) and fails only
+the three environment checks that are expected to fail before the maintainer
+cuts the release (dirty tree, branch ≠ main, tag 1.7.235 already exists).

--- a/lib/phoenix_kit/users/auth.ex
+++ b/lib/phoenix_kit/users/auth.ex
@@ -822,9 +822,15 @@ defmodule PhoenixKit.Users.Auth do
     * `user` - The user whose password is being updated
     * `attrs` - Password attributes (password, password_confirmation)
     * `context` - Optional context map containing:
-      * `:admin_user` - The admin performing the action (for audit logging)
+      * `:admin_user` - The admin performing the action. **Authorizes as well as
+        audits**: when present, the write is refused unless
+        `can_manage_user_credentials?/2` allows this actor over this target.
       * `:ip_address` - IP address of the admin (for audit logging)
       * `:user_agent` - User agent of the admin (for audit logging)
+
+  Omitting `:admin_user` is the system path — seeds, migrations and mix tasks
+  act with no actor and are not rank-checked, matching `update_user_status/3`.
+  A web caller must always pass it; without it there is nothing to check.
 
   ## Examples
 
@@ -834,11 +840,37 @@ defmodule PhoenixKit.Users.Auth do
       iex> admin_update_user_password(user, %{password: "new_password", password_confirmation: "new_password"}, %{admin_user: admin, ip_address: "192.168.1.1"})
       {:ok, %User{}}
 
+      iex> admin_update_user_password(owner, %{password: "new_password"}, %{admin_user: admin})
+      {:error, :insufficient_permissions}
+
       iex> admin_update_user_password(user, %{password: "short"})
       {:error, %Ecto.Changeset{}}
 
   """
+  # The rank rule lives here rather than in the form that calls it. `:admin_user`
+  # was already threaded in for the audit row, so the actor was in hand the whole
+  # time and only the question was missing: the edit LiveView asked
+  # `can_manage_user_credentials?/2` to hide the UI and to refuse the event, but
+  # the context function wrote the hash for anyone who reached it. That is the
+  # same shape the status path had — a rule living in one LiveView while two
+  # other callers went around it — and it is why `update_user_status/3` was moved
+  # into the context. Credentials are the more final of the two, since setting a
+  # password also deletes every session token of the target.
   def admin_update_user_password(user, attrs, context \\ %{}) do
+    case Map.get(context, :admin_user) do
+      %User{} = actor ->
+        if can_manage_user_credentials?(user, actor) do
+          do_admin_update_user_password(user, attrs, context)
+        else
+          {:error, :insufficient_permissions}
+        end
+
+      _system ->
+        do_admin_update_user_password(user, attrs, context)
+    end
+  end
+
+  defp do_admin_update_user_password(user, attrs, context) do
     changeset = User.password_changeset(user, attrs)
 
     multi = Ecto.Multi.new()

--- a/mix.exs
+++ b/mix.exs
@@ -337,12 +337,25 @@ defmodule PhoenixKit.MixProject do
       prerelease: [
         "deps.get --check-locked",
         "deps.unlock --check-unused",
-        "cmd MIX_ENV=prod mix compile --force --warnings-as-errors",
+        # `env` prefix, not a bare assignment: `mix cmd` shells out through
+        # System.cmd/3, which execs the first word directly — "MIX_ENV=prod" is
+        # not an executable, so this step raised :enoent and the whole gate
+        # aborted before reaching deps.audit/hex.audit/docs/hex.build/
+        # release_check. Found 2026-08-09, the first time the gate was run to
+        # completion.
+        "cmd env MIX_ENV=prod mix compile --force --warnings-as-errors",
         "quality.ci",
         "deps.audit",
-        "hex.audit",
+        # Both hex.* steps run in a subprocess: after the dialyzer step has
+        # run in this VM, Hex-archive tasks stop resolving ("The task
+        # "hex.audit" could not be found") while project-dep tasks
+        # (deps.audit, docs, release_check) still do. Bisected 2026-08-09:
+        # `mix do format --check-formatted + credo --strict + hex.audit`
+        # passes, `mix do quality.ci + hex.audit` fails — the added step is
+        # dialyzer. A fresh VM per hex.* step is immune.
+        "cmd mix hex.audit",
         "docs",
-        "hex.build",
+        "cmd mix hex.build",
         "phoenix_kit.release_check"
       ]
     ]

--- a/test/integration/users/security_authority_test.exs
+++ b/test/integration/users/security_authority_test.exs
@@ -42,6 +42,10 @@ defmodule PhoenixKit.Integration.Users.SecurityAuthorityTest do
     Repo.get!(Auth.User, user.uuid)
   end
 
+  # Re-read rather than trust the struct: the credential tests assert on what
+  # was actually stored, so a guard that refuses only after writing still fails.
+  defp password_hash(user), do: Repo.get!(Auth.User, user.uuid).hashed_password
+
   # The first account in a fresh sandbox is auto-promoted to Owner; seed a
   # throwaway one so every user below gets the role the test asked for.
   setup do
@@ -177,6 +181,87 @@ defmodule PhoenixKit.Integration.Users.SecurityAuthorityTest do
 
       assert {:ok, updated} = Auth.update_user_status(target, %{"is_active" => false})
       refute updated.is_active
+    end
+  end
+
+  describe "admin_update_user_password/3 enforces rank in the context" do
+    # The predicate has existed since the takeover fixes, but only the edit form
+    # ever asked it: `admin_update_user_password/3` itself took the actor purely
+    # as audit metadata (`context[:admin_user]`) and wrote the hash for anyone.
+    # Its sibling `update_user_status/3` was moved into the context for exactly
+    # this reason; credentials were left behind. These tests bind the rule to
+    # the function, so a second caller cannot reintroduce the gap.
+    #
+    # Each assertion checks the stored hash, not just the return value: a guard
+    # that refuses AFTER writing would still satisfy the tuple.
+    test "an Admin may not set an Owner's password — the takeover this closes" do
+      owner = owner_user()
+      before = password_hash(owner)
+
+      assert {:error, :insufficient_permissions} =
+               Auth.admin_update_user_password(owner, %{password: "NewPassword123!"}, %{
+                 admin_user: admin_user()
+               })
+
+      assert password_hash(owner) == before
+    end
+
+    test "an Admin may not set another Admin's password" do
+      target = admin_user()
+      before = password_hash(target)
+
+      assert {:error, :insufficient_permissions} =
+               Auth.admin_update_user_password(target, %{password: "NewPassword123!"}, %{
+                 admin_user: admin_user()
+               })
+
+      assert password_hash(target) == before
+    end
+
+    test "a non-staff actor holding only a permission is refused" do
+      target = plain_user()
+      before = password_hash(target)
+
+      assert {:error, :insufficient_permissions} =
+               Auth.admin_update_user_password(target, %{password: "NewPassword123!"}, %{
+                 admin_user: plain_user()
+               })
+
+      assert password_hash(target) == before
+    end
+
+    test "an in-rank actor succeeds" do
+      target = plain_user()
+      before = password_hash(target)
+
+      assert {:ok, _updated} =
+               Auth.admin_update_user_password(target, %{password: "NewPassword123!"}, %{
+                 admin_user: admin_user()
+               })
+
+      refute password_hash(target) == before
+    end
+
+    test "changing your own password is allowed, as it is for the predicate" do
+      actor = admin_user()
+      before = password_hash(actor)
+
+      assert {:ok, _updated} =
+               Auth.admin_update_user_password(actor, %{password: "NewPassword123!"}, %{
+                 admin_user: actor
+               })
+
+      refute password_hash(actor) == before
+    end
+
+    test "omitting the actor is the system path and still writes" do
+      target = plain_user()
+      before = password_hash(target)
+
+      assert {:ok, _updated} =
+               Auth.admin_update_user_password(target, %{password: "NewPassword123!"})
+
+      refute password_hash(target) == before
     end
   end
 


### PR DESCRIPTION
## What

`admin_update_user_password/3` now answers to the same rank rule as its sibling
`update_user_status/3`: when `context[:admin_user]` is present, the write is
refused with `{:error, :insufficient_permissions}` unless
`can_manage_user_credentials?/2` allows that actor over that target.

## Why here and not in the caller

#686 introduced the rank rule and cited its siblings as the model; the follow-up
review then moved `update_user_status/3` into the context because a rule living
in one LiveView does not live anywhere — the guard had been added to the edit
form while the user-list and user-detail pages reached the context ungated.

Credential management was left behind in that move. The edit form asks
`can_manage_user_credentials?/2` to hide the UI and to refuse the event, but the
context function itself asked nothing and wrote the hash for whoever reached it.
Credentials are the more final half of the pair: setting a password also deletes
every session token of the target.

The actor was already in hand — `:admin_user` has always been threaded through
`context` for the audit row, so only the question was missing. It now authorizes
as well as audits.

## Reachability

**Not exploitable through the shipped UI today.** The one live caller
(`user_form.ex`) gates on `socket.assigns.can_manage_credentials` in all four of
its handlers. This closes the second caller before it exists, rather than a hole
in front of one.

## Compatibility

Omitting `:admin_user` stays the system path — seeds, migrations and mix tasks
act with no actor and are not rank-checked, matching `update_user_status/3`.
The only behaviour change for an existing caller is that an out-of-rank actor
now gets `{:error, :insufficient_permissions}` instead of a successful write.

## Tests

Six cases in `security_authority_test.exs`, mirroring the status block. They
assert on the **stored hash**, not the return tuple, so a guard that refused
only after writing would still fail them.

Verified red first: the three refusal cases returned `{:ok, %User{}}` before the
change, while the three permissive cases passed unchanged — so the new block is
not vacuous.

Run manually, since CI here is `workflow_dispatch` only:

- `test/integration/users/security_authority_test.exs` — 30 tests, 0 failures
- `test/integration/users` — **367 tests, 0 failures**, no `excluded` line
  (a database-less run reports `0 tests, 0 failures (367 excluded)` and still
  exits 0, so the excluded count is the thing worth reading)
- `mix format --check-formatted`, `mix compile --warnings-as-errors`,
  `mix credo --strict` (10104 mods/funs) — clean

`@version` and `CHANGELOG.md` deliberately untouched.