### PR TITLE
Fix the credential rank rule being bypassable through custom_fields

### DIFF
--- a/lib/phoenix_kit/users/auth.ex
+++ b/lib/phoenix_kit/users/auth.ex
@@ -865,8 +865,17 @@ defmodule PhoenixKit.Users.Auth do
           {:error, :insufficient_permissions}
         end
 
-      _system ->
+      # Only an ABSENT actor is the system path — seeds, migrations and mix
+      # tasks pass no context at all. A value that is present but not a `%User{}`
+      # (a map decoded from JSON by a host controller, a bare uuid string) is a
+      # caller that meant to supply an actor and got the shape wrong; treating
+      # that as "no actor" would hand it the unchecked path. This is a library,
+      # so it cannot see its hosts' callers — it fails closed instead.
+      nil ->
         do_admin_update_user_password(user, attrs, context)
+
+      _malformed ->
+        {:error, :insufficient_permissions}
     end
   end
 

--- a/lib/phoenix_kit/users/auth.ex
+++ b/lib/phoenix_kit/users/auth.ex
@@ -862,7 +862,7 @@ defmodule PhoenixKit.Users.Auth do
         if can_manage_user_credentials?(user, actor) do
           do_admin_update_user_password(user, attrs, context)
         else
-          {:error, :insufficient_permissions}
+          refuse_credential_write(user, actor)
         end
 
       # Only an ABSENT actor is the system path — seeds, migrations and mix
@@ -875,8 +875,25 @@ defmodule PhoenixKit.Users.Auth do
         do_admin_update_user_password(user, attrs, context)
 
       _malformed ->
+        Logger.warning(
+          "PhoenixKit: refused a password write for #{user.uuid} — :admin_user was present but not a %User{}"
+        )
+
         {:error, :insufficient_permissions}
     end
+  end
+
+  # A refusal that leaves no trace is a guard nobody can tell fired. The whole
+  # point of moving this rule into the context is the caller that does not exist
+  # yet; when it arrives and is blocked, the operator needs to be able to see
+  # that rather than debug a silent no-op. `do_deactivate_user/2` already sets
+  # this precedent for a milder refusal (see the last-Owner branch below).
+  defp refuse_credential_write(%User{} = user, %User{} = actor) do
+    Logger.warning(
+      "PhoenixKit: refused a password write for #{user.uuid} by #{actor.uuid} — actor is out of rank"
+    )
+
+    {:error, :insufficient_permissions}
   end
 
   defp do_admin_update_user_password(user, attrs, context) do

--- a/lib/phoenix_kit_web/users/user_form.ex
+++ b/lib/phoenix_kit_web/users/user_form.ex
@@ -554,9 +554,30 @@ defmodule PhoenixKitWeb.Users.UserForm do
     end
   end
 
+  # Names that `Auth.update_user_fields/2` routes OUT of `custom_fields` and into
+  # the schema: it resolves each key with `String.to_existing_atom/1` and writes
+  # the value through `profile_changeset` when the name matches one of these.
+  @schema_identity_fields ~w(email username first_name last_name user_timezone)
+
   defp update_user(socket, user_params) do
     user = socket.assigns.user
-    custom_fields_params = Map.get(user_params, "custom_fields", %{})
+
+    # Dropped unconditionally, not only when the actor is out of rank. The form
+    # renders a real input for every one of these, so a `custom_fields` entry
+    # carrying one is never a legitimate submission from this page — and an
+    # unconditional filter cannot go stale the way an authority assign computed
+    # at mount can.
+    #
+    # Without this, the credential rank rule was bypassable end to end: the
+    # `Map.drop` in `update_user_profile/3` guards `profile_params`, and
+    # `custom_fields` went straight to `Auth.update_user_fields/2`, which wrote
+    # `:email` into the schema with no confirmation-token flow. An actor holding
+    # only the `users` permission could point an Owner's address at their own
+    # inbox and then take the account through the public password-reset page.
+    custom_fields_params =
+      user_params
+      |> Map.get("custom_fields", %{})
+      |> drop_schema_identity_fields()
 
     # Include pending avatar if it was changed via media selector
     custom_fields_params =
@@ -614,6 +635,11 @@ defmodule PhoenixKitWeb.Users.UserForm do
       {:error, :custom_fields_save} ->
         handle_custom_fields_save_error(socket)
 
+      # Without this clause the `with` raises `WithClauseError`: the atom matches
+      # neither the changeset clause above nor the binary one below.
+      {:error, :insufficient_permissions} ->
+        {:noreply, deny_credential_action(socket)}
+
       {:error, reason} when is_binary(reason) ->
         {:noreply, put_flash(socket, :error, reason)}
     end
@@ -639,8 +665,17 @@ defmodule PhoenixKitWeb.Users.UserForm do
     # link is delivered to takes an account just as surely as setting the
     # password does — so an actor who may not manage this record's credentials
     # gets both fields dropped here, whatever the params say.
+    #
+    # Asked again here rather than read off `@can_manage_credentials`, which is
+    # computed once in `mount/3`. The context re-evaluates the same rule when the
+    # password is written, so a stale assign made the two disagree: the form
+    # would write the credential fields on the strength of the old answer and
+    # then take a refusal from the context, leaving a partial write behind — and
+    # the refusal arrived as `{:error, :insufficient_permissions}`, which the
+    # clause below expects to be a changeset. The assign stays as the UI's
+    # answer; the write path asks for a fresh one.
     profile_params =
-      if socket.assigns.can_manage_credentials do
+      if credential_authority_now(socket, user) do
         profile_params
       else
         # `username` goes with them: it is the second thing
@@ -718,6 +753,15 @@ defmodule PhoenixKitWeb.Users.UserForm do
       {:error, _changeset} -> {:error, :custom_fields_save}
     end
   end
+
+  # Params arrive string-keyed from the wire; a non-map (a client sending
+  # `custom_fields=1`) is passed through untouched so the existing validation
+  # rejects it, rather than crashing here.
+  defp drop_schema_identity_fields(params) when is_map(params) do
+    Map.drop(params, @schema_identity_fields)
+  end
+
+  defp drop_schema_identity_fields(params), do: params
 
   defp update_account_type_fields(user, user_params) do
     account_type = Map.get(user_params, "account_type")
@@ -933,6 +977,26 @@ defmodule PhoenixKitWeb.Users.UserForm do
     assign(socket, :changeset, changeset)
   end
 
+  # The rule itself stays in the context — this only re-asks it against the
+  # target as it is RIGHT NOW, instead of as it was when the page mounted.
+  #
+  # The reload is the load-bearing part. `socket.assigns.user` carries a
+  # `:roles` list preloaded at mount, and `Auth.has_system_role?/2` reads that
+  # list when it is loaded rather than querying — so passing the mounted struct
+  # re-asks the question against the same stale answer and agrees with itself.
+  # The context, handed a struct whose association is not loaded, queries and
+  # gets the truth. That disagreement was the crash: the form wrote on the old
+  # answer, the context refused on the new one.
+  defp credential_authority_now(socket, user) do
+    case Auth.get_user(user.uuid) do
+      %Auth.User{} = fresh ->
+        Auth.can_manage_user_credentials?(fresh, socket.assigns[:phoenix_kit_current_user])
+
+      _ ->
+        false
+    end
+  end
+
   defp update_profile_and_password(socket, user, user_params) do
     # First validate profile update
     profile_params = Map.delete(user_params, "password")
@@ -948,6 +1012,15 @@ defmodule PhoenixKitWeb.Users.UserForm do
         case Auth.admin_update_user_password(updated_user, password_params, context) do
           {:ok, final_user} ->
             {:ok, final_user}
+
+          # The context refuses with an atom, not a changeset. Passed straight
+          # through, because `merge_password_errors/2` below would call `.errors`
+          # on it and take the LiveView down with a `BadMapError`. Reaching this
+          # clause means the fresh authority check above and the context's own
+          # disagreed, which should not happen — but a crash is a poor way to
+          # find that out.
+          {:error, :insufficient_permissions} ->
+            {:error, :insufficient_permissions}
 
           {:error, password_changeset} ->
             # If password update failed, return a combined changeset

--- a/test/integration/users/security_authority_test.exs
+++ b/test/integration/users/security_authority_test.exs
@@ -11,6 +11,7 @@ defmodule PhoenixKit.Integration.Users.SecurityAuthorityTest do
   use PhoenixKitWeb.ConnCase, async: true
 
   alias PhoenixKit.Users.Auth
+  alias PhoenixKit.Users.Permissions
   alias PhoenixKit.Users.RoleAssignment
   alias PhoenixKit.Users.Roles
   alias PhoenixKitWeb.Users.MultiSession
@@ -45,6 +46,31 @@ defmodule PhoenixKit.Integration.Users.SecurityAuthorityTest do
   # Re-read rather than trust the struct: the credential tests assert on what
   # was actually stored, so a guard that refuses only after writing still fails.
   defp password_hash(user), do: Repo.get!(Auth.User, user.uuid).hashed_password
+
+  # The actor this whole series exists to stop: a role that holds the `users`
+  # permission — which is what admits it to the user pages — and no staff role.
+  #
+  # Built properly rather than approximated with `plain_user/0`. Three tests here
+  # were named for this actor while handing the predicate a bare default-role
+  # user, so they passed for the wrong reason: the rule refuses an actor with no
+  # staff role whether or not it holds any permission, and the test could not
+  # tell those two cases apart. If `validate_admin_authority_over/2` ever starts
+  # consulting `Permissions`, the difference is the whole finding.
+  defp users_permission_holder do
+    user = plain_user()
+    suffix = System.unique_integer([:positive])
+
+    {:ok, role} =
+      Roles.create_role(%{
+        name: "SecTestUsersOnly#{suffix}",
+        description: "Holds the users permission and no staff rank"
+      })
+
+    {:ok, _} = Permissions.grant_permission(role.uuid, "users")
+    {:ok, _} = Roles.assign_role(user, role.name)
+
+    Repo.get!(Auth.User, user.uuid)
+  end
 
   # The first account in a fresh sandbox is auto-promoted to Owner; seed a
   # throwaway one so every user below gets the role the test asked for.
@@ -81,7 +107,7 @@ defmodule PhoenixKit.Integration.Users.SecurityAuthorityTest do
     test "holding a permission is not holding a rank: a non-staff user may manage nobody" do
       # The `users` permission is what admits a visitor to /admin/users. It must
       # not decide whether they may take over an account there.
-      staffless = plain_user()
+      staffless = users_permission_holder()
 
       refute Auth.can_manage_user_credentials?(plain_user(), staffless)
       refute Auth.can_manage_user_credentials?(admin_user(), staffless)
@@ -162,7 +188,9 @@ defmodule PhoenixKit.Integration.Users.SecurityAuthorityTest do
       target = plain_user()
 
       assert {:error, :insufficient_permissions} =
-               Auth.update_user_status(target, %{"is_active" => false}, actor: plain_user())
+               Auth.update_user_status(target, %{"is_active" => false},
+                 actor: users_permission_holder()
+               )
 
       assert Repo.get!(Auth.User, target.uuid).is_active
     end
@@ -224,7 +252,7 @@ defmodule PhoenixKit.Integration.Users.SecurityAuthorityTest do
 
       assert {:error, :insufficient_permissions} =
                Auth.admin_update_user_password(target, %{password: "NewPassword123!"}, %{
-                 admin_user: plain_user()
+                 admin_user: users_permission_holder()
                })
 
       assert password_hash(target) == before
@@ -305,7 +333,7 @@ defmodule PhoenixKit.Integration.Users.SecurityAuthorityTest do
     end
 
     test "a holder of the users permission with no staff role may delete nobody" do
-      staffless = plain_user()
+      staffless = users_permission_holder()
       target = plain_user()
 
       refute Auth.can_delete_user?(target, staffless)

--- a/test/integration/users/security_authority_test.exs
+++ b/test/integration/users/security_authority_test.exs
@@ -254,6 +254,27 @@ defmodule PhoenixKit.Integration.Users.SecurityAuthorityTest do
       refute password_hash(actor) == before
     end
 
+    test "a present but malformed actor is refused rather than taking the system path" do
+      # The system path exists for seeds, migrations and mix tasks, which pass no
+      # actor at all. A value that is present but not a `%User{}` — a map decoded
+      # from JSON by a host application's controller, a bare uuid string — is a
+      # caller that meant to supply an actor and got the shape wrong, and letting
+      # it through unchecked is the worst of both readings. PhoenixKit is a
+      # library: it cannot see its hosts' callers, so this fails closed.
+      target = plain_user()
+      before = password_hash(target)
+
+      for malformed <- [%{"uuid" => Ecto.UUID.generate()}, "some-uuid-string", false, 42] do
+        assert {:error, :insufficient_permissions} =
+                 Auth.admin_update_user_password(target, %{password: "NewPassword123!"}, %{
+                   admin_user: malformed
+                 }),
+               "a #{inspect(malformed)} actor took the unchecked path"
+      end
+
+      assert password_hash(target) == before
+    end
+
     test "omitting the actor is the system path and still writes" do
       target = plain_user()
       before = password_hash(target)

--- a/test/integration/users/user_form_authority_test.exs
+++ b/test/integration/users/user_form_authority_test.exs
@@ -1,0 +1,157 @@
+defmodule PhoenixKit.Integration.Users.UserFormAuthorityTest do
+  @moduledoc """
+  The credential rank rule as the admin form actually enforces it.
+
+  `security_authority_test.exs` pins the rule at the context functions. This
+  file pins it at the form, because the form is where the params arrive — and
+  the takeover these rules exist to stop was reachable through a param the
+  context rules never see.
+  """
+  use PhoenixKitWeb.ConnCase, async: true
+
+  alias PhoenixKit.Users.Auth
+  alias PhoenixKit.Users.RoleAssignment
+  alias PhoenixKit.Users.Roles
+  alias PhoenixKit.Utils.Routes
+
+  defp unique_email, do: "form_#{System.unique_integer([:positive])}@example.com"
+
+  defp plain_user do
+    {:ok, user} = Auth.register_user(%{email: unique_email(), password: "ValidPassword123!"})
+    {:ok, user} = Auth.admin_confirm_user(user)
+    Repo.get!(Auth.User, user.uuid)
+  end
+
+  # `Roles.assign_role/3` refuses the Owner role by design, so insert it.
+  defp owner_user do
+    user = plain_user()
+    owner_role = Roles.get_role_by_name("Owner")
+
+    {:ok, _} =
+      %RoleAssignment{}
+      |> RoleAssignment.changeset(%{user_uuid: user.uuid, role_uuid: owner_role.uuid})
+      |> Repo.insert(on_conflict: :nothing, conflict_target: [:user_uuid, :role_uuid])
+
+    Repo.get!(Auth.User, user.uuid)
+  end
+
+  defp admin_user do
+    user = plain_user()
+    Roles.assign_role(user, "Admin")
+    Repo.get!(Auth.User, user.uuid)
+  end
+
+  setup do
+    {:ok, seed} = Auth.register_user(%{email: unique_email(), password: "ValidPassword123!"})
+    {:ok, _} = Auth.admin_confirm_user(seed)
+    :ok
+  end
+
+  describe "custom_fields cannot carry schema identity fields past the rank rule" do
+    # `Auth.update_user_fields/2` resolves each key with `String.to_existing_atom/1`
+    # and writes `:email` / `:username` straight into the schema when the name
+    # matches. The form was handing it `params["custom_fields"]` verbatim, so the
+    # `Map.drop` that protects the profile params never saw these — an actor who
+    # may not manage the target's credentials could rewrite the address a reset
+    # link is delivered to, which is the whole takeover in one request.
+    # The event is pushed straight at the LiveView rather than through `form/3`.
+    # That is not a shortcut, it is the threat model: `form/3` refuses params
+    # with no matching rendered input, and the form renders no
+    # `custom_fields[email]` box — but nothing stops a client from putting the
+    # key on the wire, which is exactly how this reaches the context.
+    test "an Admin cannot rewrite an Owner's email through custom_fields", %{conn: conn} do
+      owner = owner_user()
+      conn = log_in_user(conn, admin_user())
+
+      {:ok, view, _html} = live(conn, Routes.path("/admin/users/edit/#{owner.uuid}"))
+
+      render_submit(view, "save_user", %{
+        "user" => %{
+          "first_name" => "Harmless",
+          "custom_fields" => %{"email" => "attacker@example.com"}
+        }
+      })
+
+      assert Repo.get!(Auth.User, owner.uuid).email == owner.email
+    end
+
+    test "an Admin cannot rewrite an Owner's username through custom_fields", %{conn: conn} do
+      owner = owner_user()
+      conn = log_in_user(conn, admin_user())
+
+      {:ok, view, _html} = live(conn, Routes.path("/admin/users/edit/#{owner.uuid}"))
+
+      render_submit(view, "save_user", %{
+        "user" => %{
+          "first_name" => "Harmless",
+          "custom_fields" => %{"username" => "attacker"}
+        }
+      })
+
+      assert Repo.get!(Auth.User, owner.uuid).username == owner.username
+    end
+
+    test "a stale authority assign refuses cleanly instead of crashing", %{conn: conn} do
+      # `can_manage_credentials` is computed once at mount. The context rule is
+      # evaluated again at write time, so the two can disagree: mount while the
+      # target is an ordinary user, promote them, then save with a password.
+      #
+      # Before this was handled, the context's `{:error, :insufficient_permissions}`
+      # fell into the clause that expects a changeset, `merge_password_errors/2`
+      # called `.errors` on the atom and the LiveView died — after the profile
+      # write had already committed, leaving a partial update behind.
+      target = plain_user()
+      conn = log_in_user(conn, admin_user())
+
+      {:ok, view, _html} = live(conn, Routes.path("/admin/users/edit/#{target.uuid}"))
+
+      owner_role = Roles.get_role_by_name("Owner")
+
+      {:ok, _} =
+        %RoleAssignment{}
+        |> RoleAssignment.changeset(%{user_uuid: target.uuid, role_uuid: owner_role.uuid})
+        |> Repo.insert(on_conflict: :nothing, conflict_target: [:user_uuid, :role_uuid])
+
+      before = Repo.get!(Auth.User, target.uuid)
+
+      # A crash inside `handle_event/3` surfaces here as a raise from
+      # `render_submit/3`, so the call itself is the liveness assertion — and a
+      # clean refusal (or a redirect after saving the non-credential fields) is
+      # not a failure. What must hold either way is that neither credential of an
+      # account this actor no longer outranks was rewritten.
+      #
+      # `email` is in the payload on purpose. It is what makes this test
+      # discriminating: the password is protected by the context regardless, but
+      # the address is dropped only by the form — and only if the form asks the
+      # rank question against the target as it is now rather than as it was at
+      # mount. Revert the reload and this assertion goes red.
+      try do
+        render_submit(view, "save_user", %{
+          "user" => %{
+            "first_name" => "Renamed",
+            "email" => "attacker@example.com",
+            "password" => "AttackerPassword123!"
+          }
+        })
+      catch
+        :exit, {{:shutdown, {:redirect, _, _}}, _} -> :ok
+      end
+
+      after_submit = Repo.get!(Auth.User, target.uuid)
+      assert after_submit.hashed_password == before.hashed_password
+      assert after_submit.email == before.email
+    end
+
+    test "an Admin may still set these fields on a user they do outrank", %{conn: conn} do
+      target = plain_user()
+      conn = log_in_user(conn, admin_user())
+      new_email = unique_email()
+
+      {:ok, view, _html} = live(conn, Routes.path("/admin/users/edit/#{target.uuid}"))
+
+      render_submit(view, "save_user", %{"user" => %{"email" => new_email}})
+
+      assert Repo.get!(Auth.User, target.uuid).email == new_email
+    end
+  end
+end


### PR DESCRIPTION
Follow-up to #690, which merged before this landed. **The takeover #686 and #690
set out to close is still open on `main` today** — this closes it.

## The bypass

`user_form.ex` took `params["custom_fields"]` verbatim and handed it to
`Auth.update_user_fields/2`, which resolves each key with
`String.to_existing_atom/1` and, when the name matches
`[:first_name, :last_name, :email, :username, :user_timezone]`, writes it
**into the schema** through `profile_changeset` — no confirmation-token flow.

The credential defence from #686 is a `Map.drop` over `profile_params`. It never
saw `custom_fields`.

Do X: as an Admin (or any holder of the `users` permission), open an Owner's
edit form — the page correctly refuses you, the password toggle is not even
rendered — then push the form's own event:

```elixir
render_submit(view, "save_user", %{"user" => %{"custom_fields" => %{"email" => "attacker@example.com"}}})
```

Observe Y: the Owner's `email` column is rewritten. Public password-reset page,
and the account is gone. `"username"` goes the same way, removing the victim's
second sign-in route.

Found by a three-reviewer round on #690 (Kimi K3, GLM-5.2, and an Opus agent
that reproduced it end to end against a live database). Reproduced here as a
LiveView test before the fix.

## What changed

- **The five schema identity names are dropped from `custom_fields`
  unconditionally**, not only when the actor is out of rank. The form renders a
  real input for each, so such a key is never a legitimate submission from this
  page — and an unconditional filter cannot go stale the way an authority assign
  computed at mount can.
- **The write path re-asks the rank rule against the target reloaded from the
  database**, instead of reading `@can_manage_credentials` from `mount/3`. A
  target promoted between mount and submit made the form and the context
  disagree: the form wrote the credential fields on the old answer, then took
  `{:error, :insufficient_permissions}` from the context, which the clause below
  expects to be a changeset — `merge_password_errors/2` called `.errors` on an
  atom and the LiveView died, after a partial write. The reload is load-bearing:
  the mounted struct carries a preloaded `:roles` list, so re-asking with it
  would only agree with itself.
- **Only an absent actor is the system path.** A `:admin_user` that is present
  but not a `%User{}` — a map decoded from JSON by a host controller, a bare uuid
  string — took the unchecked branch, and then crashed in the audit write.
- **Refusals are logged.** A guard nobody can tell fired is the failure mode this
  whole series is about; `do_deactivate_user/2` already set the precedent.
- **`users_permission_holder/0`** builds the actor three existing tests were
  named for and never created: a role holding `users` and no staff rank. They
  passed for a reason that could not distinguish it from a bare default-role
  user.

## Tests

The bypass is pinned at the form, where the params arrive, by pushing the event
straight at the LiveView — `form/3` refuses params with no matching rendered
input, which is exactly the gap the attack uses.

The stale-assign test carries `email` in its payload on purpose: that is what
makes it discriminating. Reverting only the reload turns it red (verified —
observed `attacker@example.com`).

- `test/integration/users` — **372 tests, 0 failures**, no `excluded` line
- `mix format --check-formatted`, `mix compile --warnings-as-errors`,
  `mix credo --strict` (10114 mods/funs) — clean

`@version` and `CHANGELOG.md` untouched. The reviewers also asked for a
`### Security` entry; that is maintainer-owned here, so it is flagged rather
than written.

## Not in this PR

Recorded in the #690 thread and still open: `/admin/users/sessions` revokes any
account's sessions with no rank check and no audit row (pre-existing, needs no
second caller); `update_user_profile/2` should carry the rank rule in the
context rather than only at its caller; `cmd mix hex.audit` turns a deferred
exit code into an immediate alias abort.