### PR TITLE
Add cross-module mentions, one canonical display name, and stop publishing email addresses

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -52,6 +52,13 @@
   # is correct and well-covered.
   ~r/lib\/phoenix_kit\/users\/qr_login\.ex:.*call_without_opaque/,
 
+  # Mentions.Users.pingable?/1 pipes a User through Scope.for_user/1 into
+  # Scope.can_access_admin_area?/1. Scope carries an opaque MapSet in
+  # :cached_permissions, so dialyzer widens it across the pipe and flags the
+  # call — the same false positive as the auth.ex and qr_login.ex entries
+  # above. The code is correct and covered.
+  ~r/lib\/phoenix_kit\/mentions\/users\.ex:.*call_without_opaque/,
+
   # Connections module (extracted to phoenix_kit_user_connections) — conditional calls via Code.ensure_loaded?
   {"lib/phoenix_kit_web/live/users/user_details.ex", :unknown_function},
 

--- a/lib/modules/storage/services/image_processor.ex
+++ b/lib/modules/storage/services/image_processor.ex
@@ -212,6 +212,20 @@ defmodule PhoenixKit.Modules.Storage.ImageProcessor do
       {:error, "Image center-crop failed: #{inspect(e)}"}
   end
 
+  # 40 megapixels — comfortably above any real camera or screenshot, far
+  # below what it takes to hurt. `-resize` bounds the OUTPUT; the decoder
+  # still rasterizes the input in full first, so a 5MB PNG declaring
+  # 50000x50000 is ~10GB of RAM before a single pixel is written. The
+  # `-limit` flags turn that into a failure rather than an outage, but
+  # reading the header and refusing costs nothing and never starts it.
+  @sanitize_max_pixels 40_000_000
+
+  defp check_pixel_budget(width, height, max_pixels)
+       when is_integer(width) and is_integer(height) and width * height > max_pixels,
+       do: {:error, "image is too large"}
+
+  defp check_pixel_budget(_width, _height, _max_pixels), do: :ok
+
   @doc """
   Re-encodes an image to known-good bytes, discarding everything else.
 
@@ -248,42 +262,64 @@ defmodule PhoenixKit.Modules.Storage.ImageProcessor do
     quality = Keyword.get(opts, :quality, 82)
     format = Keyword.get(opts, :format, "jpeg")
 
-    case extract_dimensions(input_path) do
-      {:ok, {width, height}} ->
-        args = [
-          # `[0]` takes the FIRST frame only. Without it a multi-frame GIF
-          # or a multi-page TIFF writes N output files, and an animation
-          # bomb is a cheap way to burn CPU and disk.
-          "#{input_path}[0]",
-          "-auto-orient",
-          # Strip metadata before anything else: EXIF, IPTC, XMP, colour
-          # profiles, comments. GPS coordinates in a bug report screenshot
-          # are a privacy leak the reporter did not intend.
-          "-strip",
-          "-alpha",
-          if(format == "png", do: "on", else: "remove"),
-          "-resize",
-          "#{max_edge}x#{max_edge}>",
-          "-quality",
-          Integer.to_string(quality),
-          "#{format}:#{output_path}"
-        ]
+    max_pixels = Keyword.get(opts, :max_pixels, @sanitize_max_pixels)
 
-        Logger.info("Sanitizing upload #{input_path} (#{width}x#{height}) -> #{output_path}")
+    with {:ok, {width, height}} <- extract_dimensions(input_path),
+         :ok <- check_pixel_budget(width, height, max_pixels),
+         {:ok, detected} <- detect_format(input_path) do
+      args =
+        [
+          # Resource ceilings, applied HERE rather than trusted to the
+          # host's policy.xml. A decompression bomb is a small file that
+          # decodes to gigabytes, and "the sysadmin configured ImageMagick
+          # correctly" is not a control this code can rely on.
+          "-limit",
+          "memory",
+          "256MiB",
+          "-limit",
+          "map",
+          "512MiB",
+          "-limit",
+          "disk",
+          "1GiB",
+          "-limit",
+          "time",
+          "20"
+        ] ++
+          [
+            # `[0]` takes the FIRST frame only: without it a multi-frame
+            # GIF writes N output files, which is a cheap way to burn disk.
+            # The format prefix pins how the bytes are decoded, so a file
+            # can never be interpreted as a coder we did not allow.
+            "#{detected}:#{input_path}[0]",
+            "-auto-orient",
+            # Strip metadata before anything else: EXIF, IPTC, XMP, colour
+            # profiles, comments. GPS coordinates in a bug report screenshot
+            # are a privacy leak the reporter did not intend.
+            "-strip",
+            "-alpha",
+            if(format == "png", do: "on", else: "remove"),
+            "-resize",
+            "#{max_edge}x#{max_edge}>",
+            "-quality",
+            Integer.to_string(quality),
+            "#{format}:#{output_path}"
+          ]
 
-        case System.cmd("convert", args, stderr_to_stdout: true) do
-          {_output, 0} ->
-            {:ok, output_path}
+      Logger.info(
+        "Sanitizing #{detected} upload #{input_path} (#{width}x#{height}) -> #{output_path}"
+      )
 
-          {output, exit_code} ->
-            Logger.warning("Upload sanitize failed (#{exit_code}): #{output}")
-            {:error, "could not process image"}
-        end
+      case System.cmd("convert", args, stderr_to_stdout: true) do
+        {_output, 0} ->
+          {:ok, output_path}
 
-      {:error, _reason} ->
-        # Unreadable as an image, whatever the filename or the claimed
-        # content type said.
-        {:error, "not a readable image"}
+        {output, exit_code} ->
+          Logger.warning("Upload sanitize failed (#{exit_code}): #{output}")
+          {:error, "could not process image"}
+      end
+    else
+      {:error, reason} -> {:error, reason}
     end
   rescue
     e ->
@@ -292,6 +328,28 @@ defmodule PhoenixKit.Modules.Storage.ImageProcessor do
   end
 
   # Private functions
+
+  # What ImageMagick actually thinks this is, checked against a short
+  # allowlist. The extension and the browser's content-type are both the
+  # uploader's claims; this is the only reading that counts, and it does
+  # not depend on the host having configured policy.xml.
+  @sanitize_formats ~w(PNG JPEG JPG WEBP GIF)
+
+  defp detect_format(path) do
+    case System.cmd("identify", ["-format", "%m", "#{path}[0]"], stderr_to_stdout: true) do
+      {output, 0} ->
+        format = output |> String.trim() |> String.upcase()
+
+        if format in @sanitize_formats,
+          do: {:ok, format},
+          else: {:error, "unsupported image format"}
+
+      _ ->
+        {:error, "not a readable image"}
+    end
+  rescue
+    _ -> {:error, "not a readable image"}
+  end
 
   defp calculate_resize_spec(current_width, current_height, target_width, target_height) do
     case {target_width, target_height} do

--- a/lib/modules/storage/services/image_processor.ex
+++ b/lib/modules/storage/services/image_processor.ex
@@ -212,6 +212,85 @@ defmodule PhoenixKit.Modules.Storage.ImageProcessor do
       {:error, "Image center-crop failed: #{inspect(e)}"}
   end
 
+  @doc """
+  Re-encodes an image to known-good bytes, discarding everything else.
+
+  For uploads from people you do not trust. The point is not to *inspect*
+  the file — that is a losing game — but to stop serving the uploader's
+  bytes at all: what ends up stored is this encoder's output, produced by
+  decoding the input and writing a fresh image. A polyglot file (valid
+  GIF, valid JavaScript), an EXIF payload, a trailing ZIP, an embedded
+  colour profile — none of them survive being decoded to pixels and
+  written out again.
+
+  Also enforces a maximum edge length, because a 30000×30000 PNG is a
+  decompression bomb whatever its byte size, and rejects anything
+  ImageMagick cannot read as an image regardless of what the upload
+  claimed to be.
+
+  Returns `{:ok, output_path}` or `{:error, reason}`. Never raises.
+
+  ## Options
+
+    * `:max_edge` — longest side in pixels (default 2500); larger images
+      are scaled down, never up
+    * `:quality` — output quality (default 82)
+    * `:format` — output format (default "jpeg"; use "png" to keep
+      transparency)
+
+  ## Example
+
+      ImageProcessor.sanitize(upload.path, dest, format: "png")
+  """
+  @spec sanitize(String.t(), String.t(), keyword()) :: {:ok, String.t()} | {:error, String.t()}
+  def sanitize(input_path, output_path, opts \\ []) do
+    max_edge = Keyword.get(opts, :max_edge, 2500)
+    quality = Keyword.get(opts, :quality, 82)
+    format = Keyword.get(opts, :format, "jpeg")
+
+    case extract_dimensions(input_path) do
+      {:ok, {width, height}} ->
+        args = [
+          # `[0]` takes the FIRST frame only. Without it a multi-frame GIF
+          # or a multi-page TIFF writes N output files, and an animation
+          # bomb is a cheap way to burn CPU and disk.
+          "#{input_path}[0]",
+          "-auto-orient",
+          # Strip metadata before anything else: EXIF, IPTC, XMP, colour
+          # profiles, comments. GPS coordinates in a bug report screenshot
+          # are a privacy leak the reporter did not intend.
+          "-strip",
+          "-alpha",
+          if(format == "png", do: "on", else: "remove"),
+          "-resize",
+          "#{max_edge}x#{max_edge}>",
+          "-quality",
+          Integer.to_string(quality),
+          "#{format}:#{output_path}"
+        ]
+
+        Logger.info("Sanitizing upload #{input_path} (#{width}x#{height}) -> #{output_path}")
+
+        case System.cmd("convert", args, stderr_to_stdout: true) do
+          {_output, 0} ->
+            {:ok, output_path}
+
+          {output, exit_code} ->
+            Logger.warning("Upload sanitize failed (#{exit_code}): #{output}")
+            {:error, "could not process image"}
+        end
+
+      {:error, _reason} ->
+        # Unreadable as an image, whatever the filename or the claimed
+        # content type said.
+        {:error, "not a readable image"}
+    end
+  rescue
+    e ->
+      Logger.warning("Upload sanitize raised: #{Exception.message(e)}")
+      {:error, "could not process image"}
+  end
+
   # Private functions
 
   defp calculate_resize_spec(current_width, current_height, target_width, target_height) do

--- a/lib/modules/storage/storage.ex
+++ b/lib/modules/storage/storage.ex
@@ -2086,6 +2086,19 @@ defmodule PhoenixKit.Modules.Storage do
 
     # Optional module tables — only included if the table exists
     optional_checks = [
+      # Portal submissions hold their attachments in a JSONB array rather
+      # than an FK column, so the reference is invisible to a plain join —
+      # which would make every PUBLISHED issue image look like an orphan
+      # and hand it to the delete job. `?` is the file uuid as text; the
+      # `jsonb` cast is what lets `?` match an element of the array.
+      {"phoenix_kit_project_portal_submissions",
+       dynamic(
+         [f],
+         fragment(
+           "NOT EXISTS (SELECT 1 FROM phoenix_kit_project_portal_submissions ps WHERE ps.file_uuids @> to_jsonb(ARRAY[?::text]))",
+           f.uuid
+         )
+       )},
       {"phoenix_kit_post_media",
        dynamic(
          [f],

--- a/lib/phoenix_kit/mentions.ex
+++ b/lib/phoenix_kit/mentions.ex
@@ -1,0 +1,558 @@
+defmodule PhoenixKit.Mentions do
+  @moduledoc """
+  Cross-module `@` pings and `#` record links.
+
+  Typing `@` anywhere a person can write free text offers people; typing `#`
+  offers records from every installed module. The picked result is stored as
+  a self-contained token (`PhoenixKit.Mentions.Token`), indexed for reverse
+  lookup (`PhoenixKit.Mentions.Mention`), and rendered per viewer.
+
+  ## The three halves
+
+    * **Search** — `search/2` fans out across every module that declares a
+      searchable resource type, in parallel, with a hard deadline. A module
+      that is slow, raises, or has no index costs its own results and
+      nothing else: the popup shows what came back.
+
+    * **Resolve** — reuses `PhoenixKit.ResourceLinks`, which already turns
+      `(type, uuid)` into a title and a deep-link for the Activity feed and
+      Comments. Batched per type, so a page of mentions costs one call per
+      distinct type, not one per mention.
+
+    * **Visibility** — `visible/3` asks each type's handler which of these
+      uuids THIS viewer may see. Separate from resolution on purpose: the
+      searcher and the later reader are different people, and a record that
+      was visible when it was linked may not be when it is read.
+
+  ## What a viewer sees
+
+  | Situation | Rendered as |
+  |---|---|
+  | Resolves, viewer may see it | live title, real deep-link |
+  | Gone, or its module uninstalled | the author's stored label, plain text |
+  | Exists, viewer may NOT see it | a redacted chip — never the title |
+
+  The middle row is why the label lives in the text. The bottom row is the
+  rule that matters: a mention must never show a viewer a title they are not
+  allowed to know, and it must never *refresh* one. What it does show is
+  that something is there — the Discord model — with a way to ask for
+  access, because "you can't see this" is only useful with a next step.
+
+  ## Making a module's records mentionable
+
+  Add the type to `resource_links/0` pointing at a handler module, then give
+  that handler two functions beyond the `resolve_comment_resources/1` it
+  already needs for Activity and Comments:
+
+      defmodule MyApp.Widgets.Links do
+        # Already required for deep-linking in Activity/Comments
+        def resolve_comment_resources(uuids), do: %{...}
+
+        # New: the `#` typeahead. MUST scope to the searcher.
+        def search_resources(query, opts) do
+          user_uuid = opts[:user_uuid]
+          ...
+          [%{type: "widget", uuid: w.uuid, title: w.name, subtitle: "Widget"}]
+        end
+
+        # New: which of these may this viewer see? Batched.
+        def visible_resource_uuids(uuids, opts), do: [...]
+      end
+
+  Both are optional. A handler without `search_resources/2` is resolvable but
+  not offerable — reasonable for a type that should be linkable from an
+  activity row yet never suggested. A handler without
+  `visible_resource_uuids/2` is treated as **public**: everything it resolves
+  is shown, which is right for genuinely public records and wrong for
+  anything else, so the fail-open is documented rather than silent.
+  """
+
+  import Ecto.Query
+
+  require Logger
+
+  alias PhoenixKit.Activity
+  alias PhoenixKit.Mentions.{Mention, Token, Users}
+  alias PhoenixKit.RepoHelper
+  alias PhoenixKit.ResourceLinks
+  alias PhoenixKit.Settings
+
+  # A typeahead that takes longer than this is worse than one with fewer
+  # results: the popup has to keep up with typing. Whatever has answered by
+  # the deadline is what gets shown.
+  @search_deadline_ms 250
+  @search_concurrency 6
+  @default_limit 8
+
+  @enabled_setting "mentions_enabled"
+
+  defp repo, do: RepoHelper.repo()
+
+  @doc """
+  Master switch. Defaults ON — the feature is additive and inert until
+  someone actually types a trigger.
+  """
+  @spec enabled?() :: boolean()
+  def enabled? do
+    Settings.get_boolean_setting(@enabled_setting, true)
+  rescue
+    _ -> false
+  catch
+    :exit, _ -> false
+  end
+
+  @spec enabled_setting_key() :: String.t()
+  def enabled_setting_key, do: @enabled_setting
+
+  # ── Search ──────────────────────────────────────────────────────────
+
+  @doc """
+  Candidates for the typeahead.
+
+  `kind` is `:user` for `@` (core's users only — a ping is always a person)
+  or `:resource` for `#` (every module that opted in).
+
+  Options:
+
+    * `:user_uuid` — who is searching. Handlers MUST scope to this; a
+      typeahead that offers records the searcher cannot open is itself the
+      leak.
+    * `:limit` — max results overall (default #{@default_limit}).
+
+  Never raises: a handler that blows up contributes nothing and is logged.
+  """
+  @spec search(:user | :resource, String.t(), keyword()) :: [map()]
+  def search(kind, query, opts \\ [])
+
+  def search(_kind, query, _opts) when not is_binary(query), do: []
+
+  def search(kind, query, opts) do
+    query = String.trim(query)
+    limit = Keyword.get(opts, :limit, @default_limit)
+
+    cond do
+      not enabled?() -> []
+      kind == :user -> search_users(query, limit, opts)
+      true -> search_resources(query, limit, opts)
+    end
+  end
+
+  defp search_users(query, limit, opts) do
+    Users.search(query, Keyword.put(opts, :limit, limit))
+  rescue
+    e ->
+      Logger.warning("[Mentions] user search failed: #{Exception.message(e)}")
+      []
+  end
+
+  defp search_resources(query, limit, opts) do
+    # One call per MODULE, not per type. A handler that owns several types
+    # (projects owns both `project` and `project_task`) answers for all of
+    # them in one call and stamps each result with its own type — calling
+    # it once per registered type ran the same search twice and returned
+    # every row twice.
+    handlers =
+      searchable_handlers()
+      |> Enum.group_by(fn {_type, mod} -> mod end, fn {type, _mod} -> type end)
+      |> Enum.map(fn {mod, types} -> {List.first(Enum.sort(types)), mod} end)
+
+    handlers
+    |> Task.async_stream(
+      fn {type, mod} -> safe_search(mod, type, query, opts) end,
+      max_concurrency: @search_concurrency,
+      timeout: @search_deadline_ms,
+      on_timeout: :kill_task,
+      ordered: false
+    )
+    |> Enum.flat_map(fn
+      {:ok, results} -> results
+      # A module that timed out or died costs only its own results. The
+      # popup showing three of four modules beats showing nothing.
+      {:exit, _} -> []
+    end)
+    # A handler that stamps its own types can still hand back the same
+    # record twice; the popup must never show a duplicate row.
+    |> Enum.uniq_by(&{&1[:type], &1[:uuid]})
+    |> rank(query)
+    |> Enum.take(limit)
+  end
+
+  defp safe_search(mod, type, query, opts) do
+    # apply/3, not a direct call: the module is discovered at runtime and
+    # may not exist in this install at all.
+    # credo:disable-for-next-line Credo.Check.Refactor.Apply
+    results = apply(mod, :search_resources, [query, opts])
+
+    results
+    |> List.wrap()
+    |> Enum.map(fn result ->
+      result
+      |> Map.take([:type, :uuid, :title, :subtitle, :icon])
+      |> Map.put_new(:type, type)
+      |> Map.put(:kind, :resource)
+    end)
+    |> Enum.filter(&(is_binary(&1[:uuid]) and is_binary(&1[:title])))
+  rescue
+    e ->
+      Logger.warning(
+        "[Mentions] #{inspect(mod)} search_resources failed: #{Exception.message(e)}"
+      )
+
+      []
+  catch
+    :exit, _ -> []
+  end
+
+  # Exact title, then prefix, then the rest — alphabetical inside each tier
+  # so the order is stable between keystrokes. Cross-module relevance
+  # scoring is a thing to add when there is real usage to tune it against;
+  # inventing weights now would be guessing.
+  defp rank(results, query) do
+    q = String.downcase(query)
+
+    Enum.sort_by(results, fn r ->
+      title = String.downcase(r[:title] || "")
+
+      tier =
+        cond do
+          title == q -> 0
+          String.starts_with?(title, q) -> 1
+          true -> 2
+        end
+
+      {tier, title}
+    end)
+  end
+
+  @doc """
+  Handler modules that can be searched, as `%{resource_type => module}`.
+
+  Derived from the same `resource_links/0` registry that powers deep-linking
+  — a type is offerable only if it is already resolvable, so a mention can
+  never be created that cannot later be rendered.
+  """
+  @spec searchable_handlers() :: %{String.t() => module()}
+  def searchable_handlers do
+    ResourceLinks.handlers()
+    |> Enum.filter(fn {_type, mod} -> exports?(mod, :search_resources, 2) end)
+    |> Map.new()
+  end
+
+  # ── Visibility ──────────────────────────────────────────────────────
+
+  @doc """
+  Of `uuids` for `type`, the ones this viewer may see.
+
+  A handler with no `visible_resource_uuids/2` is treated as public — see
+  the moduledoc. Anything that raises fails CLOSED (nothing visible): a
+  broken permission check must not become an open door.
+  """
+  # A plain list, not a MapSet: dialyzer treats MapSet as opaque and flags
+  # every spec that names it (the same false positive the flag resolver
+  # works around). Callers that need membership build their own set.
+  @spec visible(String.t(), [String.t()], keyword()) :: [String.t()]
+  def visible(_type, [], _opts), do: []
+
+  def visible(type, uuids, opts) do
+    case Map.get(ResourceLinks.handlers(), type) do
+      nil ->
+        uuids
+
+      mod ->
+        if exports?(mod, :visible_resource_uuids, 2) do
+          # credo:disable-for-next-line Credo.Check.Refactor.Apply
+          mod |> apply(:visible_resource_uuids, [uuids, opts]) |> List.wrap()
+        else
+          uuids
+        end
+    end
+  rescue
+    e ->
+      Logger.warning("[Mentions] visibility check for #{type} failed: #{Exception.message(e)}")
+      []
+  catch
+    :exit, _ -> []
+  end
+
+  # ── Resolution for rendering ────────────────────────────────────────
+
+  @doc """
+  Everything a renderer needs for the mentions in `text`, in one pass.
+
+  Returns `%{{type, uuid} => %{state, title, path, prefixed}}` where `state`
+  is `:ok`, `:missing`, or `:forbidden`. Batched per type: a page with
+  thirty mentions across three types costs three resolve calls and three
+  visibility calls.
+  """
+  @spec context(String.t() | nil, keyword()) :: map()
+  def context(text, opts \\ []) do
+    tokens = Token.parse(text)
+
+    if tokens == [] do
+      %{}
+    else
+      tokens
+      |> Enum.group_by(& &1.type)
+      |> Enum.reduce(%{}, fn {type, group}, acc ->
+        uuids = group |> Enum.map(& &1.uuid) |> Enum.uniq()
+        allowed = type |> visible(uuids, opts) |> MapSet.new()
+
+        # Resolve ONLY what the viewer may see. Resolving the rest would
+        # pull titles nobody is allowed to read into memory a template
+        # could accidentally print.
+        resolved = allowed |> Enum.to_list() |> resolve_titles(type)
+
+        Enum.reduce(group, acc, fn token, inner ->
+          Map.put_new(inner, {type, token.uuid}, state_for(token, allowed, resolved))
+        end)
+      end)
+    end
+  end
+
+  defp state_for(token, allowed, resolved) do
+    cond do
+      not MapSet.member?(allowed, token.uuid) ->
+        %{state: :forbidden}
+
+      info = Map.get(resolved, token.uuid) ->
+        %{
+          state: :ok,
+          title: info[:title] || token.label,
+          path: info[:path],
+          prefixed: Map.get(info, :prefixed, true)
+        }
+
+      true ->
+        %{state: :missing}
+    end
+  end
+
+  defp resolve_titles([], _type), do: %{}
+
+  defp resolve_titles(uuids, type) do
+    uuids
+    |> Enum.map(&%{resource_type: type, resource_uuid: &1})
+    |> ResourceLinks.resolve()
+    |> Map.new(fn {{_type, uuid}, info} -> {uuid, info} end)
+  rescue
+    e ->
+      Logger.warning("[Mentions] resolve for #{type} failed: #{Exception.message(e)}")
+      %{}
+  end
+
+  # ── Index ───────────────────────────────────────────────────────────
+
+  @doc """
+  Rebuilds the index for one field of one record from its text, and returns
+  the mentions that are NEW since last time.
+
+  Call this from the durable save — creating or updating the comment, the
+  task, the note. Never from a keystroke or an autosave draft: the return
+  value is what gets notified, and a debounce would ping on every pause.
+
+  The delete-then-insert is scoped to this `source_field`, so a record with
+  two mentionable fields keeps them independent.
+  """
+  @spec sync(String.t(), String.t(), String.t() | nil, keyword()) ::
+          {:ok, [Mention.t()]} | {:error, term()}
+  def sync(source_type, source_uuid, text, opts \\ []) do
+    field = Keyword.get(opts, :field, "body")
+    actor_uuid = Keyword.get(opts, :actor_uuid)
+    tokens = text |> Token.parse() |> Enum.uniq_by(&{&1.type, &1.uuid})
+
+    existing = list_for_source(source_type, source_uuid, field)
+    existing_keys = MapSet.new(existing, &{&1.target_type, &1.target_uuid})
+
+    repo().transaction(fn ->
+      from(m in Mention,
+        where:
+          m.source_type == ^source_type and m.source_uuid == ^source_uuid and
+            m.source_field == ^field
+      )
+      |> repo().delete_all()
+
+      Enum.map(tokens, fn token ->
+        %Mention{}
+        |> Mention.changeset(%{
+          source_type: source_type,
+          source_uuid: source_uuid,
+          source_field: field,
+          kind: Atom.to_string(token.kind),
+          target_type: token.type,
+          target_uuid: token.uuid,
+          label: token.label,
+          actor_uuid: actor_uuid,
+          # Carry the delivered mark across a re-save: the row is recreated
+          # every time the text is saved, and without this every edit would
+          # look like a brand-new mention and ping again.
+          notified_at: previously_notified_at(existing, token)
+        })
+        |> repo().insert!()
+      end)
+    end)
+    |> case do
+      {:ok, inserted} ->
+        {:ok,
+         Enum.reject(inserted, &MapSet.member?(existing_keys, {&1.target_type, &1.target_uuid}))}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  rescue
+    e ->
+      Logger.warning("[Mentions] sync failed: #{Exception.message(e)}")
+      {:error, Exception.message(e)}
+  end
+
+  defp previously_notified_at(existing, token) do
+    Enum.find_value(existing, fn m ->
+      if m.target_type == token.type and m.target_uuid == token.uuid, do: m.notified_at
+    end)
+  end
+
+  @doc "Every mention recorded for one field of one record."
+  @spec list_for_source(String.t(), String.t(), String.t()) :: [Mention.t()]
+  def list_for_source(source_type, source_uuid, field \\ "body") do
+    from(m in Mention,
+      where:
+        m.source_type == ^source_type and m.source_uuid == ^source_uuid and
+          m.source_field == ^field
+    )
+    |> repo().all()
+  rescue
+    _ -> []
+  end
+
+  @doc """
+  What links here: every record mentioning this one, newest first.
+
+  The backlink panel on a record's own page. Not permission-filtered — the
+  caller knows who is asking and what their own module's rules are.
+  """
+  @spec list_backlinks(String.t(), String.t(), keyword()) :: [Mention.t()]
+  def list_backlinks(target_type, target_uuid, opts \\ []) do
+    limit = Keyword.get(opts, :limit, 50)
+
+    from(m in Mention,
+      where: m.target_type == ^target_type and m.target_uuid == ^target_uuid,
+      order_by: [desc: m.inserted_at],
+      limit: ^limit
+    )
+    |> repo().all()
+  rescue
+    _ -> []
+  end
+
+  @doc """
+  Delivers the `@` pings among `mentions` and marks them sent.
+
+  Call it with what `sync/4` returned — those are the ones that are new.
+  Everything else is filtered here rather than by the caller:
+
+    * `#` links never notify. Telling a record's watchers it was referenced
+      is a different product (and a noisy one); the reverse index is enough
+      to build a "mentioned in" panel when that is actually wanted.
+    * mentioning yourself does nothing.
+    * someone who cannot open the containing record is not told about it.
+      An email about a comment that 403s on click is worse than silence.
+
+  Delivery itself is core's activity → notification bridge, so a ping lands
+  wherever that person already reads things and obeys their existing
+  preferences and channels.
+  """
+  @spec notify(list(), keyword()) :: :ok
+  def notify(mentions, opts \\ [])
+
+  def notify([], _opts), do: :ok
+
+  def notify(mentions, opts) do
+    source_type = Keyword.get(opts, :source_type)
+    source_uuid = Keyword.get(opts, :source_uuid)
+    preview = opts |> Keyword.get(:preview) |> preview_text()
+
+    delivered =
+      mentions
+      |> Enum.filter(&(&1.kind == "user" and is_nil(&1.notified_at)))
+      |> Enum.reject(&(&1.target_uuid == &1.actor_uuid))
+      |> Enum.filter(&can_open_source?(&1, source_type, source_uuid))
+      |> Enum.map(fn mention ->
+        Activity.log(%{
+          action: "mention.created",
+          module: "mentions",
+          mode: "manual",
+          actor_uuid: mention.actor_uuid,
+          resource_type: source_type || mention.source_type,
+          resource_uuid: source_uuid || mention.source_uuid,
+          target_uuid: mention.target_uuid,
+          metadata: %{
+            "notification_text" => "You were mentioned",
+            "preview" => preview
+          }
+        })
+
+        mention
+      end)
+
+    mark_notified(delivered)
+  rescue
+    e ->
+      Logger.warning("[Mentions] notify failed: #{Exception.message(e)}")
+      :ok
+  end
+
+  # Can the mentioned person actually open the thing they'd be notified
+  # about? Asked through the same per-type visibility contract everything
+  # else uses. A source type with no handler is assumed reachable — the
+  # same documented fail-open as `visible/3`, and the alternative would
+  # silently drop every ping in every module that hasn't opted in yet.
+  defp can_open_source?(mention, source_type, source_uuid) do
+    type = source_type || mention.source_type
+    uuid = source_uuid || mention.source_uuid
+
+    case Map.get(ResourceLinks.handlers(), type) do
+      nil ->
+        true
+
+      mod ->
+        if exports?(mod, :visible_resource_uuids, 2) do
+          args = [[uuid], [user_uuid: mention.target_uuid]]
+          # credo:disable-for-next-line Credo.Check.Refactor.Apply
+          allowed = apply(mod, :visible_resource_uuids, args)
+          uuid in List.wrap(allowed)
+        else
+          true
+        end
+    end
+  rescue
+    _ -> false
+  end
+
+  defp preview_text(nil), do: nil
+
+  defp preview_text(text) do
+    text
+    |> Token.to_plain_text()
+    |> String.trim()
+    |> String.slice(0, 140)
+  end
+
+  @doc "Marks mentions delivered so a later re-save can't ping them again."
+  @spec mark_notified([Mention.t()]) :: :ok
+  def mark_notified([]), do: :ok
+
+  def mark_notified(mentions) do
+    uuids = Enum.map(mentions, & &1.uuid)
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    from(m in Mention, where: m.uuid in ^uuids)
+    |> repo().update_all(set: [notified_at: now])
+
+    :ok
+  rescue
+    _ -> :ok
+  end
+
+  defp exports?(mod, fun, arity) do
+    is_atom(mod) and Code.ensure_loaded?(mod) and function_exported?(mod, fun, arity)
+  end
+end

--- a/lib/phoenix_kit/mentions.ex
+++ b/lib/phoenix_kit/mentions.ex
@@ -59,12 +59,17 @@ defmodule PhoenixKit.Mentions do
         def visible_resource_uuids(uuids, opts), do: [...]
       end
 
-  Both are optional. A handler without `search_resources/2` is resolvable but
-  not offerable — reasonable for a type that should be linkable from an
-  activity row yet never suggested. A handler without
-  `visible_resource_uuids/2` is treated as **public**: everything it resolves
-  is shown, which is right for genuinely public records and wrong for
-  anything else, so the fail-open is documented rather than silent.
+  A handler without `search_resources/2` is resolvable but not offerable —
+  reasonable for a type that should be linkable from an activity row yet
+  never suggested by the typeahead.
+
+  `visible_resource_uuids/2` is what makes a type mentionable at all.
+  Without it, a mention of that type renders REDACTED, because a token can
+  be typed by hand into any textarea and "the module didn't implement the
+  check" must never mean "show it to everyone". The only exception is
+  `user`: the `@` typeahead already lists every pingable account to anyone
+  who can reach the admin area, so a name is not something a mention can
+  leak.
   """
 
   import Ecto.Query
@@ -247,24 +252,42 @@ defmodule PhoenixKit.Mentions do
   the moduledoc. Anything that raises fails CLOSED (nothing visible): a
   broken permission check must not become an open door.
   """
+  # Types whose records are not secret, and which therefore need no
+  # per-viewer check. Only people: the `@` typeahead already lists every
+  # pingable account to anyone who can reach the admin area, so a name is
+  # not something a mention can leak. Everything else must opt in.
+  @public_types ~w(user)
+
   # A plain list, not a MapSet: dialyzer treats MapSet as opaque and flags
   # every spec that names it (the same false positive the flag resolver
   # works around). Callers that need membership build their own set.
+  #
+  # FAIL-CLOSED for anything not on @public_types. A token can be typed by
+  # hand into any textarea, so "this type didn't implement the check" must
+  # not mean "show it to everyone" — most registered types (posts, files,
+  # CRM contacts and companies, integrations) declare no check at all, and
+  # treating silence as consent renders their titles and live links to any
+  # reader who is handed a uuid.
   @spec visible(String.t(), [String.t()], keyword()) :: [String.t()]
   def visible(_type, [], _opts), do: []
 
   def visible(type, uuids, opts) do
-    case Map.get(ResourceLinks.handlers(), type) do
-      nil ->
+    cond do
+      type in @public_types ->
         uuids
 
-      mod ->
+      mod = Map.get(ResourceLinks.handlers(), type) ->
         if exports?(mod, :visible_resource_uuids, 2) do
           # credo:disable-for-next-line Credo.Check.Refactor.Apply
           mod |> apply(:visible_resource_uuids, [uuids, opts]) |> List.wrap()
         else
-          uuids
+          []
         end
+
+      true ->
+        # No handler at all: nothing can resolve it either, so this renders
+        # as the author's stored label — plain text, no link, no leak.
+        uuids
     end
   rescue
     e ->
@@ -470,30 +493,30 @@ defmodule PhoenixKit.Mentions do
     source_uuid = Keyword.get(opts, :source_uuid)
     preview = opts |> Keyword.get(:preview) |> preview_text()
 
-    delivered =
-      mentions
-      |> Enum.filter(&(&1.kind == "user" and is_nil(&1.notified_at)))
-      |> Enum.reject(&(&1.target_uuid == &1.actor_uuid))
-      |> Enum.filter(&can_open_source?(&1, source_type, source_uuid))
-      |> Enum.map(fn mention ->
-        Activity.log(%{
-          action: "mention.created",
-          module: "mentions",
-          mode: "manual",
-          actor_uuid: mention.actor_uuid,
-          resource_type: source_type || mention.source_type,
-          resource_uuid: source_uuid || mention.source_uuid,
-          target_uuid: mention.target_uuid,
-          metadata: %{
-            "notification_text" => "You were mentioned",
-            "preview" => preview
-          }
-        })
+    mentions
+    |> Enum.filter(&(&1.kind == "user" and is_nil(&1.notified_at)))
+    |> Enum.reject(&(&1.target_uuid == &1.actor_uuid))
+    |> Enum.filter(&can_open_source?(&1, source_type, source_uuid))
+    # Claim BEFORE sending: whoever wins the conditional update sends, and
+    # a concurrent save of the same text wins nothing and sends nothing.
+    |> claim_for_delivery()
+    |> Enum.each(fn mention ->
+      Activity.log(%{
+        action: "mention.created",
+        module: "mentions",
+        mode: "manual",
+        actor_uuid: mention.actor_uuid,
+        resource_type: source_type || mention.source_type,
+        resource_uuid: source_uuid || mention.source_uuid,
+        target_uuid: mention.target_uuid,
+        metadata: %{
+          "notification_text" => "You were mentioned",
+          "preview" => preview
+        }
+      })
+    end)
 
-        mention
-      end)
-
-    mark_notified(delivered)
+    :ok
   rescue
     e ->
       Logger.warning("[Mentions] notify failed: #{Exception.message(e)}")
@@ -536,20 +559,33 @@ defmodule PhoenixKit.Mentions do
     |> String.slice(0, 140)
   end
 
-  @doc "Marks mentions delivered so a later re-save can't ping them again."
-  @spec mark_notified([Mention.t()]) :: :ok
-  def mark_notified([]), do: :ok
+  @doc """
+  CLAIMS delivery for these mentions, returning the ones this caller won.
 
-  def mark_notified(mentions) do
+  `WHERE notified_at IS NULL` is what makes it a claim rather than a
+  stamp: two saves of the same field racing (a double submit, two tabs)
+  both see an unnotified row and would both send. Only the update that
+  actually changes a row may deliver.
+  """
+  @spec claim_for_delivery([Mention.t()]) :: [Mention.t()]
+  def claim_for_delivery([]), do: []
+
+  def claim_for_delivery(mentions) do
     uuids = Enum.map(mentions, & &1.uuid)
     now = DateTime.utc_now() |> DateTime.truncate(:second)
 
-    from(m in Mention, where: m.uuid in ^uuids)
-    |> repo().update_all(set: [notified_at: now])
+    {_count, claimed} =
+      from(m in Mention, where: m.uuid in ^uuids and is_nil(m.notified_at), select: m.uuid)
+      |> repo().update_all([set: [notified_at: now]], returning: false)
+      |> case do
+        {count, nil} -> {count, []}
+        other -> other
+      end
 
-    :ok
+    claimed = MapSet.new(claimed || [])
+    Enum.filter(mentions, &MapSet.member?(claimed, &1.uuid))
   rescue
-    _ -> :ok
+    _ -> []
   end
 
   defp exports?(mod, fun, arity) do

--- a/lib/phoenix_kit/mentions.ex
+++ b/lib/phoenix_kit/mentions.ex
@@ -81,6 +81,7 @@ defmodule PhoenixKit.Mentions do
   alias PhoenixKit.RepoHelper
   alias PhoenixKit.ResourceLinks
   alias PhoenixKit.Settings
+  alias PhoenixKit.Utils.Routes
 
   # A typeahead that takes longer than this is worse than one with fewer
   # results: the popup has to keep up with typing. Whatever has answered by
@@ -361,6 +362,70 @@ defmodule PhoenixKit.Mentions do
     e ->
       Logger.warning("[Mentions] resolve for #{type} failed: #{Exception.message(e)}")
       %{}
+  end
+
+  @doc """
+  Rewrites the mentions in `text` as MARKDOWN, resolved for this viewer.
+
+  For surfaces that render markdown rather than HEEx — comments, notes,
+  anything going through `MDEx`. Same three states as the component, with
+  one honest limitation: markdown output is sanitised afterwards, so a
+  redacted mention here is plain text rather than a button. The reader
+  still learns that something exists and that it isn't theirs; they just
+  can't ask for access from inside a rendered comment.
+
+      Mentions.to_markdown(comment.content, scope: scope)
+
+  Text with no mentions is returned unchanged, so this is safe to put in
+  front of every markdown render.
+  """
+  @spec to_markdown(String.t() | nil, keyword()) :: String.t()
+  def to_markdown(text, opts \\ [])
+
+  def to_markdown(text, _opts) when not is_binary(text), do: ""
+
+  def to_markdown(text, opts) do
+    tokens = Token.parse(text)
+
+    if tokens == [] do
+      text
+    else
+      context = context(text, opts)
+
+      text
+      |> Token.split()
+      |> Enum.map_join(fn
+        %Token{} = token -> token_markdown(token, Map.get(context, {token.type, token.uuid}))
+        piece -> piece
+      end)
+    end
+  end
+
+  defp token_markdown(token, %{state: :ok, title: title, path: path}) when is_binary(path) do
+    "[#{prefix(token)}#{escape_md(title)}](#{Routes.path(path)})"
+  end
+
+  defp token_markdown(token, %{state: :ok, title: title}) do
+    "#{prefix(token)}#{escape_md(title)}"
+  end
+
+  defp token_markdown(_token, %{state: :forbidden}), do: "🔒 no access"
+
+  defp token_markdown(token, _), do: "#{prefix(token)}#{escape_md(token.label)}"
+
+  defp prefix(%Token{kind: :user}), do: "@"
+  defp prefix(_), do: ""
+
+  # The label is attacker-controlled (a token can be hand-typed), and it is
+  # about to be spliced into markdown link syntax. `]` and `|` can't occur —
+  # the grammar refuses them — but `[`, `\` and backticks can, and an
+  # unescaped `[` splits the link.
+  defp escape_md(value) do
+    value
+    |> Kernel.to_string()
+    |> String.replace("\\", "\\\\")
+    |> String.replace("[", "\\[")
+    |> String.replace("`", "\\`")
   end
 
   # ── Index ───────────────────────────────────────────────────────────

--- a/lib/phoenix_kit/mentions.ex
+++ b/lib/phoenix_kit/mentions.ex
@@ -496,11 +496,15 @@ defmodule PhoenixKit.Mentions do
     mentions
     |> Enum.filter(&(&1.kind == "user" and is_nil(&1.notified_at)))
     |> Enum.reject(&(&1.target_uuid == &1.actor_uuid))
-    |> Enum.filter(&can_open_source?(&1, source_type, source_uuid))
+    |> Enum.map(&{&1, source_visibility(&1, source_type, source_uuid)})
+    |> Enum.reject(fn {_mention, visibility} -> visibility == :no end)
     # Claim BEFORE sending: whoever wins the conditional update sends, and
     # a concurrent save of the same text wins nothing and sends nothing.
-    |> claim_for_delivery()
-    |> Enum.each(fn mention ->
+    |> then(fn pairs ->
+      claimed = pairs |> Enum.map(&elem(&1, 0)) |> claim_for_delivery() |> MapSet.new(& &1.uuid)
+      Enum.filter(pairs, fn {mention, _} -> MapSet.member?(claimed, mention.uuid) end)
+    end)
+    |> Enum.each(fn {mention, visibility} ->
       Activity.log(%{
         action: "mention.created",
         module: "mentions",
@@ -511,7 +515,10 @@ defmodule PhoenixKit.Mentions do
         target_uuid: mention.target_uuid,
         metadata: %{
           "notification_text" => "You were mentioned",
-          "preview" => preview
+          # Only when something affirmatively said this person may read the
+          # source. Otherwise they get the ping and a link, and the link
+          # answers for itself.
+          "preview" => if(visibility == :yes, do: preview)
         }
       })
     end)
@@ -523,31 +530,40 @@ defmodule PhoenixKit.Mentions do
       :ok
   end
 
-  # Can the mentioned person actually open the thing they'd be notified
-  # about? Asked through the same per-type visibility contract everything
-  # else uses. A source type with no handler is assumed reachable — the
-  # same documented fail-open as `visible/3`, and the alternative would
-  # silently drop every ping in every module that hasn't opted in yet.
-  defp can_open_source?(mention, source_type, source_uuid) do
+  # Can the mentioned person open the thing they're being told about?
+  #
+  # Three-valued on purpose. `:yes` is an affirmative answer from the
+  # source type's own handler. `:unknown` means nothing can answer — the
+  # type has no handler, or its handler declares no visibility check —
+  # which is every source type except projects today.
+  #
+  # `:unknown` still delivers, because failing closed here would silently
+  # drop every ping in every module that hasn't adopted the contract, and
+  # a notification whose link 403s is a dead end, not a disclosure. What
+  # `:unknown` must NOT do is carry a preview of the text: that is the one
+  # place content actually leaves the system, and mailing an excerpt of a
+  # comment to someone the renderer would have shown a locked chip is the
+  # notify path quietly overruling the render path.
+  defp source_visibility(mention, source_type, source_uuid) do
     type = source_type || mention.source_type
     uuid = source_uuid || mention.source_uuid
 
     case Map.get(ResourceLinks.handlers(), type) do
       nil ->
-        true
+        :unknown
 
       mod ->
         if exports?(mod, :visible_resource_uuids, 2) do
           args = [[uuid], [user_uuid: mention.target_uuid]]
           # credo:disable-for-next-line Credo.Check.Refactor.Apply
           allowed = apply(mod, :visible_resource_uuids, args)
-          uuid in List.wrap(allowed)
+          if uuid in List.wrap(allowed), do: :yes, else: :no
         else
-          true
+          :unknown
         end
     end
   rescue
-    _ -> false
+    _ -> :no
   end
 
   defp preview_text(nil), do: nil

--- a/lib/phoenix_kit/mentions.ex
+++ b/lib/phoenix_kit/mentions.ex
@@ -91,6 +91,7 @@ defmodule PhoenixKit.Mentions do
   @default_limit 8
 
   @enabled_setting "mentions_enabled"
+  @redact_setting "mentions_redact_titles"
 
   defp repo, do: RepoHelper.repo()
 
@@ -109,6 +110,26 @@ defmodule PhoenixKit.Mentions do
 
   @spec enabled_setting_key() :: String.t()
   def enabled_setting_key, do: @enabled_setting
+
+  @doc """
+  Extra-security mode: withhold the TITLE of a mention the viewer cannot
+  open, showing the label the author stored instead of a live one.
+
+  Off by default. On, a record renamed after being mentioned never shows
+  its new name to someone who can't open it — worth having where the name
+  itself is the sensitive part, and unnecessary noise where it isn't.
+  """
+  @spec redact_titles?() :: boolean()
+  def redact_titles? do
+    Settings.get_boolean_setting(@redact_setting, false)
+  rescue
+    _ -> false
+  catch
+    :exit, _ -> false
+  end
+
+  @spec redact_setting_key() :: String.t()
+  def redact_setting_key, do: @redact_setting
 
   # ── Search ──────────────────────────────────────────────────────────
 
@@ -321,10 +342,18 @@ defmodule PhoenixKit.Mentions do
         uuids = group |> Enum.map(& &1.uuid) |> Enum.uniq()
         allowed = type |> visible(uuids, opts) |> MapSet.new()
 
-        # Resolve ONLY what the viewer may see. Resolving the rest would
-        # pull titles nobody is allowed to read into memory a template
-        # could accidentally print.
-        resolved = allowed |> Enum.to_list() |> resolve_titles(type)
+        # Titles are resolved for EVERYTHING by default, including records
+        # the viewer can't open: a mention should read as the thing it
+        # names, and hiding the title leaves a hole where a noun should be.
+        # What the viewer still doesn't get is a way in — no link, and a
+        # lock saying so.
+        #
+        # `redact_titles?` is the opt-in for installs where a record's NAME
+        # is itself sensitive. There it resolves only what the viewer may
+        # see, and a forbidden mention falls back to the label the author
+        # stored — never a title refreshed after the fact.
+        to_resolve = if redact_titles?(), do: Enum.to_list(allowed), else: uuids
+        resolved = resolve_titles(to_resolve, type)
 
         Enum.reduce(group, acc, fn token, inner ->
           Map.put_new(inner, {type, token.uuid}, state_for(token, allowed, resolved))
@@ -336,7 +365,11 @@ defmodule PhoenixKit.Mentions do
   defp state_for(token, allowed, resolved) do
     cond do
       not MapSet.member?(allowed, token.uuid) ->
-        %{state: :forbidden}
+        # A title, but deliberately no path: the reader learns what it is
+        # called and that it isn't theirs to open. Falls back to the
+        # author's stored label when the title was withheld or the record
+        # is gone.
+        %{state: :forbidden, title: title_for(token, resolved)}
 
       info = Map.get(resolved, token.uuid) ->
         %{
@@ -348,6 +381,13 @@ defmodule PhoenixKit.Mentions do
 
       true ->
         %{state: :missing}
+    end
+  end
+
+  defp title_for(token, resolved) do
+    case Map.get(resolved, token.uuid) do
+      %{title: title} when is_binary(title) and title != "" -> title
+      _ -> token.label
     end
   end
 
@@ -409,7 +449,12 @@ defmodule PhoenixKit.Mentions do
     "#{prefix(token)}#{escape_md(title)}"
   end
 
-  defp token_markdown(_token, %{state: :forbidden}), do: "🔒 no access"
+  # Title plus a lock, and no link — same rule as the component. Markdown
+  # can't carry the request-access button (the output is sanitised), so the
+  # lock is where it ends here.
+  defp token_markdown(token, %{state: :forbidden} = info) do
+    "#{prefix(token)}#{escape_md(info[:title] || token.label)} 🔒"
+  end
 
   defp token_markdown(token, _), do: "#{prefix(token)}#{escape_md(token.label)}"
 

--- a/lib/phoenix_kit/mentions.ex
+++ b/lib/phoenix_kit/mentions.ex
@@ -352,17 +352,45 @@ defmodule PhoenixKit.Mentions do
         # is itself sensitive. There it resolves only what the viewer may
         # see, and a forbidden mention falls back to the label the author
         # stored — never a title refreshed after the fact.
-        to_resolve = if redact_titles?(), do: Enum.to_list(allowed), else: uuids
+        withhold = withhold_titles?(opts)
+        to_resolve = if redact_titles?() or withhold, do: Enum.to_list(allowed), else: uuids
         resolved = resolve_titles(to_resolve, type)
 
         Enum.reduce(group, acc, fn token, inner ->
-          Map.put_new(inner, {type, token.uuid}, state_for(token, allowed, resolved))
+          Map.put_new(inner, {type, token.uuid}, state_for(token, allowed, resolved, withhold))
         end)
       end)
     end
   end
 
-  defp state_for(token, allowed, resolved) do
+  # A PUBLIC surface asks for this. The global `redact_titles?` setting is
+  # a judgement about internal readers — "our record names are not secret"
+  # — and it is a perfectly reasonable one to leave off. It says nothing
+  # about the open web, and the two audiences share one renderer, so a page
+  # anyone can read has to be able to withhold on its own account.
+  defp withhold_titles?(opts), do: Keyword.get(opts, :withhold_titles, false) == true
+
+  # Neither the live title NOR the author's stored label. The label is the
+  # record's name as of writing, so falling back to it publishes exactly
+  # what withholding was meant to prevent — just a staler copy of it.
+  defp state_for(token, allowed, resolved, true) do
+    if MapSet.member?(allowed, token.uuid) do
+      # In scope for this reader: renders as it always did, minus one thing.
+      # A `user` mention is allowed for everyone (users are a public type),
+      # and its path is `/admin/users/view/:uuid` — so linking it from a
+      # public page hands an anonymous reader an admin URL and a user uuid,
+      # and quietly reads "listed inside the admin app" as "public on the
+      # open web". On a withheld surface a person is a NAME, not a door.
+      case state_for(token, allowed, resolved, false) do
+        %{state: :ok} = state when token.kind == :user -> Map.delete(state, :path)
+        state -> state
+      end
+    else
+      %{state: :private}
+    end
+  end
+
+  defp state_for(token, allowed, resolved, _withhold) do
     cond do
       not MapSet.member?(allowed, token.uuid) ->
         # A title, but deliberately no path: the reader learns what it is
@@ -455,6 +483,12 @@ defmodule PhoenixKit.Mentions do
   defp token_markdown(token, %{state: :forbidden} = info) do
     "#{prefix(token)}#{escape_md(info[:title] || token.label)} 🔒"
   end
+
+  # A withheld surface asked for no name, and the catch-all below would have
+  # handed back `token.label` — the record's name as of writing, which is
+  # the very thing withholding exists to suppress. Without this clause,
+  # passing `withhold_titles` into a markdown render silently does nothing.
+  defp token_markdown(_token, %{state: :private}), do: "private item 🔒"
 
   defp token_markdown(token, _), do: "#{prefix(token)}#{escape_md(token.label)}"
 

--- a/lib/phoenix_kit/mentions/access_request.ex
+++ b/lib/phoenix_kit/mentions/access_request.ex
@@ -1,0 +1,72 @@
+defmodule PhoenixKit.Mentions.AccessRequest do
+  @moduledoc """
+  Someone asking to be let in to a record a mention pointed them at.
+
+  A `#` link to something the reader cannot open tells them it exists and
+  nothing else. That is only useful if there is a next step, so the redacted
+  chip offers one: ask the people who own it.
+
+  `status` is a string sentinel per the workspace's soft-delete convention.
+  A `pending` request is unique per (requester, resource) — asking twice is
+  the same ask — but the index is partial, so a denied request never blocks
+  asking again when circumstances change.
+  """
+  use Ecto.Schema
+  use PhoenixKit.SchemaPrefix
+  import Ecto.Changeset
+
+  @primary_key {:uuid, UUIDv7, autogenerate: true}
+  @foreign_key_type UUIDv7
+
+  @statuses ~w(pending granted denied cancelled)
+
+  @type t :: %__MODULE__{
+          uuid: UUIDv7.t() | nil,
+          requester_uuid: UUIDv7.t() | nil,
+          resource_type: String.t() | nil,
+          resource_uuid: UUIDv7.t() | nil,
+          source_type: String.t() | nil,
+          source_uuid: UUIDv7.t() | nil,
+          note: String.t() | nil,
+          status: String.t() | nil,
+          decided_by_uuid: UUIDv7.t() | nil,
+          decided_at: DateTime.t() | nil,
+          inserted_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+
+  schema "phoenix_kit_access_requests" do
+    field(:requester_uuid, UUIDv7)
+    field(:resource_type, :string)
+    field(:resource_uuid, UUIDv7)
+    field(:source_type, :string)
+    field(:source_uuid, UUIDv7)
+    field(:note, :string)
+    field(:status, :string, default: "pending")
+    field(:decided_by_uuid, UUIDv7)
+    field(:decided_at, :utc_datetime)
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @required ~w(requester_uuid resource_type resource_uuid)a
+  @optional ~w(source_type source_uuid note status decided_by_uuid decided_at)a
+
+  @spec changeset(t(), map()) :: Ecto.Changeset.t()
+  def changeset(request, attrs) do
+    request
+    |> cast(attrs, @required ++ @optional)
+    |> validate_required(@required)
+    |> validate_inclusion(:status, @statuses)
+    # The note is shown to whoever decides. Capped because it lands in a
+    # notification body, not a document.
+    |> validate_length(:note, max: 500)
+    |> unique_constraint([:requester_uuid, :resource_type, :resource_uuid],
+      name: :phoenix_kit_access_requests_open_index,
+      message: "already requested"
+    )
+  end
+
+  @spec statuses() :: [String.t()]
+  def statuses, do: @statuses
+end

--- a/lib/phoenix_kit/mentions/access_requests.ex
+++ b/lib/phoenix_kit/mentions/access_requests.ex
@@ -1,0 +1,184 @@
+defmodule PhoenixKit.Mentions.AccessRequests do
+  @moduledoc """
+  Asking to be let in to a record you were pointed at but cannot open.
+
+  A redacted mention says "there is something here you can't see". That is
+  only worth showing if there is a next step, and this is the next step: the
+  reader asks, the people who own the record decide.
+
+  Delivery reuses the activity → notification bridge, so a request arrives
+  wherever the recipient already reads things — inbox, email, Telegram —
+  with no new plumbing. Deciding is deliberately NOT automated: granting
+  access means writing to whatever the owning module calls membership, and
+  core has no business guessing that. The module handles the decision and
+  calls `grant/2` or `deny/2` to close the loop.
+  """
+
+  import Ecto.Query
+
+  require Logger
+
+  alias PhoenixKit.Activity
+  alias PhoenixKit.Mentions.AccessRequest
+  alias PhoenixKit.RepoHelper
+
+  defp repo, do: RepoHelper.repo()
+
+  @doc """
+  Records a request, or returns the one already open.
+
+  Asking twice is the same ask — the partial unique index enforces it, and
+  this returns `{:ok, existing}` rather than an error so the UI can say "already
+  asked" without a special case.
+  """
+  @spec request(String.t(), String.t(), String.t(), keyword()) ::
+          {:ok, AccessRequest.t()} | {:error, term()}
+  def request(resource_type, resource_uuid, requester_uuid, opts \\ []) do
+    attrs = %{
+      resource_type: resource_type,
+      resource_uuid: resource_uuid,
+      requester_uuid: requester_uuid,
+      source_type: Keyword.get(opts, :source_type),
+      source_uuid: Keyword.get(opts, :source_uuid),
+      note: Keyword.get(opts, :note)
+    }
+
+    %AccessRequest{}
+    |> AccessRequest.changeset(attrs)
+    |> repo().insert()
+    |> case do
+      {:ok, request} ->
+        notify_deciders(request, opts)
+        {:ok, request}
+
+      {:error, changeset} ->
+        # The open-request index tripped: they already asked. Hand back the
+        # existing row so the caller can report state rather than failure.
+        case get_open(resource_type, resource_uuid, requester_uuid) do
+          %AccessRequest{} = existing -> {:ok, existing}
+          nil -> {:error, changeset}
+        end
+    end
+  end
+
+  @doc "The open request from this person for this record, if any."
+  @spec get_open(String.t(), String.t(), String.t()) :: AccessRequest.t() | nil
+  def get_open(resource_type, resource_uuid, requester_uuid) do
+    from(r in AccessRequest,
+      where:
+        r.resource_type == ^resource_type and r.resource_uuid == ^resource_uuid and
+          r.requester_uuid == ^requester_uuid and r.status == "pending"
+    )
+    |> repo().one()
+  rescue
+    _ -> nil
+  end
+
+  @doc "Open requests for a record — the owner's queue."
+  @spec list_pending(String.t(), String.t()) :: [AccessRequest.t()]
+  def list_pending(resource_type, resource_uuid) do
+    from(r in AccessRequest,
+      where:
+        r.resource_type == ^resource_type and r.resource_uuid == ^resource_uuid and
+          r.status == "pending",
+      order_by: [asc: r.inserted_at]
+    )
+    |> repo().all()
+  rescue
+    _ -> []
+  end
+
+  @doc "Every open request across all records — the admin queue."
+  @spec list_all_pending(keyword()) :: [AccessRequest.t()]
+  def list_all_pending(opts \\ []) do
+    limit = Keyword.get(opts, :limit, 100)
+
+    from(r in AccessRequest,
+      where: r.status == "pending",
+      order_by: [desc: r.inserted_at],
+      limit: ^limit
+    )
+    |> repo().all()
+  rescue
+    _ -> []
+  end
+
+  @doc """
+  Closes a request as granted.
+
+  Does NOT itself give anyone access: the owning module knows what its own
+  membership means and does that part. This records the decision and tells
+  the requester.
+  """
+  @spec grant(AccessRequest.t(), String.t() | nil) :: {:ok, AccessRequest.t()} | {:error, term()}
+  def grant(request, decided_by_uuid), do: decide(request, "granted", decided_by_uuid)
+
+  @doc "Closes a request as denied, and tells the requester."
+  @spec deny(AccessRequest.t(), String.t() | nil) :: {:ok, AccessRequest.t()} | {:error, term()}
+  def deny(request, decided_by_uuid), do: decide(request, "denied", decided_by_uuid)
+
+  @doc "The requester withdrawing their own ask."
+  @spec cancel(AccessRequest.t()) :: {:ok, AccessRequest.t()} | {:error, term()}
+  def cancel(request), do: decide(request, "cancelled", nil, notify: false)
+
+  defp decide(request, status, decided_by_uuid, opts \\ []) do
+    request
+    |> AccessRequest.changeset(%{
+      status: status,
+      decided_by_uuid: decided_by_uuid,
+      decided_at: DateTime.utc_now() |> DateTime.truncate(:second)
+    })
+    |> repo().update()
+    |> case do
+      {:ok, updated} ->
+        if Keyword.get(opts, :notify, true), do: notify_requester(updated)
+        {:ok, updated}
+
+      other ->
+        other
+    end
+  end
+
+  # Who decides is the owning module's business. Until a module says
+  # otherwise the request is logged with no target, which puts it in the
+  # activity feed and the admin queue without pretending to know an owner.
+  defp notify_deciders(request, opts) do
+    Activity.log(%{
+      action: "access_request.created",
+      module: "mentions",
+      mode: "manual",
+      actor_uuid: request.requester_uuid,
+      resource_type: request.resource_type,
+      resource_uuid: request.resource_uuid,
+      target_uuid: Keyword.get(opts, :notify_uuid),
+      metadata: %{
+        "notification_text" => "Someone asked for access to a record you own",
+        "request_uuid" => request.uuid
+      }
+    })
+  rescue
+    e -> Logger.warning("[AccessRequests] notify failed: #{Exception.message(e)}")
+  catch
+    :exit, _ -> :ok
+  end
+
+  defp notify_requester(request) do
+    Activity.log(%{
+      action: "access_request.#{request.status}",
+      module: "mentions",
+      mode: "manual",
+      actor_uuid: request.decided_by_uuid,
+      resource_type: request.resource_type,
+      resource_uuid: request.resource_uuid,
+      target_uuid: request.requester_uuid,
+      metadata: %{
+        "notification_text" => "Your access request was #{request.status}",
+        "request_uuid" => request.uuid
+      }
+    })
+  rescue
+    e -> Logger.warning("[AccessRequests] notify failed: #{Exception.message(e)}")
+  catch
+    :exit, _ -> :ok
+  end
+end

--- a/lib/phoenix_kit/mentions/live.ex
+++ b/lib/phoenix_kit/mentions/live.ex
@@ -1,0 +1,235 @@
+defmodule PhoenixKit.Mentions.Live do
+  @moduledoc """
+  Everything a LiveView needs to let people WRITE mentions and act on them:
+
+      use PhoenixKit.Mentions.Live
+
+  That injects the typeahead's search handler and the access-request
+  events. In the template, swap a textarea for `<.mention_input>` and drop
+  the dialog somewhere:
+
+      <.mention_input field={@form[:description]} label="Description" />
+      <.access_request_dialog request={@pk_access_request} />
+
+  Reading mentions needs none of this — `<.mention_text>` is a plain
+  function component. This module is only for the two INTERACTIVE halves,
+  which is why it is opt-in per LiveView rather than global.
+
+  Injected clauses follow the MediaBrowser embed precedent: a host adds one
+  `use` instead of copying four handlers and getting one subtly wrong.
+  Every one of them degrades rather than crashes — a click with no dialog
+  rendered, or a search with the feature switched off, is a no-op.
+  """
+
+  # Fully-qualified inside the quote on purpose: this expands in the
+  # CALLER's module, where an alias defined here does not exist.
+  # credo:disable-for-this-file Credo.Check.Design.AliasUsage
+  defmacro __using__(_opts) do
+    quote do
+      import PhoenixKit.Mentions.Live, only: [access_request_dialog: 1, mention_input: 1]
+
+      @impl true
+      def handle_event("pk_mention_search", params, socket) do
+        {:reply, PhoenixKit.Mentions.Live.search_reply(socket, params), socket}
+      end
+
+      @impl true
+      def handle_event("pk_request_access", %{"type" => type, "uuid" => uuid}, socket) do
+        {:noreply,
+         Phoenix.Component.assign(socket, :pk_access_request, %{
+           type: type,
+           uuid: uuid,
+           note: "",
+           state: :open
+         })}
+      end
+
+      def handle_event("pk_access_request_close", _params, socket) do
+        {:noreply, Phoenix.Component.assign(socket, :pk_access_request, nil)}
+      end
+
+      def handle_event("pk_access_request_submit", params, socket) do
+        {:noreply, PhoenixKit.Mentions.Live.submit(socket, params)}
+      end
+    end
+  end
+
+  use Phoenix.Component
+  use Gettext, backend: PhoenixKitWeb.Gettext
+
+  alias Phoenix.HTML.Form
+  alias PhoenixKit.Mentions
+  alias PhoenixKit.Mentions.AccessRequests
+
+  @doc false
+  def submit(socket, params) do
+    request = socket.assigns[:pk_access_request]
+
+    user_uuid =
+      get_in(socket.assigns, [:phoenix_kit_current_scope, Access.key(:user), Access.key(:uuid)])
+
+    cond do
+      is_nil(request) ->
+        socket
+
+      is_nil(user_uuid) ->
+        Phoenix.LiveView.put_flash(socket, :error, gettext("Sign in to request access."))
+
+      true ->
+        case AccessRequests.request(request.type, request.uuid, user_uuid,
+               note: params["note"],
+               source_type: socket.assigns[:pk_access_source_type],
+               source_uuid: socket.assigns[:pk_access_source_uuid]
+             ) do
+          {:ok, _} ->
+            socket
+            |> Phoenix.Component.assign(:pk_access_request, nil)
+            |> Phoenix.LiveView.put_flash(:info, gettext("Access requested."))
+
+          {:error, _} ->
+            Phoenix.LiveView.put_flash(socket, :error, gettext("Could not send that request."))
+        end
+    end
+  end
+
+  @doc false
+  # The typeahead's server half. Replies rather than assigns: the results
+  # belong to one keystroke in one field, and putting them in assigns would
+  # re-render the whole form on every character.
+  def search_reply(socket, params) do
+    kind = if params["kind"] == "user", do: :user, else: :resource
+    query = params["query"] || ""
+
+    results =
+      Mentions.search(kind, query, user_uuid: current_user_uuid(socket))
+      |> Enum.map(fn r ->
+        %{
+          kind: Kernel.to_string(r[:kind] || :resource),
+          type: r[:type],
+          uuid: r[:uuid],
+          title: r[:title],
+          subtitle: r[:subtitle]
+        }
+      end)
+
+    # `seq` is echoed back untouched so the client can drop replies for a
+    # query the user has already typed past.
+    %{results: results, seq: params["seq"]}
+  end
+
+  defp current_user_uuid(socket) do
+    get_in(socket.assigns, [:phoenix_kit_current_scope, Access.key(:user), Access.key(:uuid)])
+  end
+
+  attr :field, Phoenix.HTML.FormField, default: nil
+  attr :label, :string, default: nil
+  attr :id, :string, default: nil
+  attr :name, :string, default: nil
+  attr :value, :string, default: nil
+  attr :rows, :integer, default: 4
+  attr :class, :any, default: nil
+  attr :placeholder, :string, default: nil
+  attr :rest, :global, include: ~w(required maxlength phx-debounce)
+
+  @doc """
+  A textarea that offers `@` and `#` as you type.
+
+  Identical to a plain textarea in every other way, and identical to one
+  entirely when JavaScript is off — the hook is the only difference, and
+  what it inserts is text the field could have held anyway. That is the
+  whole reason the token format is what it is.
+  """
+  def mention_input(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:resolved_id, fn ->
+        assigns[:id] || (assigns[:field] && assigns.field.id) || "pk-mention-input"
+      end)
+      |> assign_new(:resolved_name, fn ->
+        assigns[:name] || (assigns[:field] && assigns.field.name)
+      end)
+      |> assign_new(:resolved_value, fn ->
+        assigns[:value] ||
+          (assigns[:field] && Form.normalize_value("textarea", assigns.field.value))
+      end)
+
+    ~H"""
+    <div class="form-control flex flex-col gap-1">
+      <label :if={@label} for={@resolved_id} class="label">
+        <span class="label-text font-semibold">{@label}</span>
+      </label>
+      <textarea
+        id={@resolved_id}
+        name={@resolved_name}
+        rows={@rows}
+        phx-hook="MentionInput"
+        placeholder={@placeholder}
+        class={["textarea textarea-bordered w-full", @class]}
+        {@rest}
+      >{@resolved_value}</textarea>
+      <p class="text-xs opacity-50">
+        {gettext("Type @ to mention someone, # to link a record.")}
+      </p>
+    </div>
+    """
+  end
+
+  attr :request, :any, default: nil
+
+  @doc """
+  The "ask for access" dialog. Renders nothing until a redacted mention is
+  clicked.
+
+  Deliberately says nothing about WHAT is being requested beyond its kind —
+  the whole point of the redaction is that the reader does not learn the
+  title, and a dialog headed with it would undo that in the one place they
+  are most likely to read.
+  """
+  def access_request_dialog(assigns) do
+    ~H"""
+    <dialog :if={@request} open class="modal modal-open">
+      <div class="modal-box max-w-md">
+        <h3 class="text-lg font-bold">{gettext("Request access")}</h3>
+        <p class="mt-1 text-sm opacity-70">
+          {gettext(
+            "You don't have access to this %{kind}. Ask the people who own it, and say why if it helps.",
+            kind: @request.type
+          )}
+        </p>
+
+        <form phx-submit="pk_access_request_submit" class="mt-4 flex flex-col gap-3">
+          <label class="form-control">
+            <span class="label-text text-xs opacity-70 mb-1">{gettext("Note (optional)")}</span>
+            <textarea
+              name="note"
+              rows="3"
+              maxlength="500"
+              class="textarea textarea-bordered"
+              placeholder={gettext("What do you need it for?")}
+            ></textarea>
+          </label>
+
+          <div class="modal-action">
+            <button type="button" phx-click="pk_access_request_close" class="btn btn-ghost btn-sm">
+              {gettext("Cancel")}
+            </button>
+            <button
+              type="submit"
+              class="btn btn-primary btn-sm"
+              phx-disable-with={gettext("Sending…")}
+            >
+              {gettext("Send request")}
+            </button>
+          </div>
+        </form>
+      </div>
+      <button
+        type="button"
+        phx-click="pk_access_request_close"
+        class="modal-backdrop"
+        aria-label={gettext("Close")}
+      ></button>
+    </dialog>
+    """
+  end
+end

--- a/lib/phoenix_kit/mentions/live.ex
+++ b/lib/phoenix_kit/mentions/live.ex
@@ -100,21 +100,56 @@ defmodule PhoenixKit.Mentions.Live do
     kind = if params["kind"] == "user", do: :user, else: :resource
     query = params["query"] || ""
 
+    # The SCOPE, not just the uuid. A handler asks `Authz.admin_all?` (or
+    # its own equivalent), which only answers for a scope — pass a bare
+    # uuid and a site admin silently gets the membership-only list, so
+    # every project they don't personally belong to vanishes from their
+    # own typeahead.
     results =
-      Mentions.search(kind, query, user_uuid: current_user_uuid(socket))
+      Mentions.search(kind, query,
+        scope: socket.assigns[:phoenix_kit_current_scope],
+        user_uuid: current_user_uuid(socket)
+      )
       |> Enum.map(fn r ->
+        kind = if r[:kind] == :user, do: :user, else: :resource
+
         %{
-          kind: Kernel.to_string(r[:kind] || :resource),
+          kind: Kernel.to_string(kind),
           type: r[:type],
           uuid: r[:uuid],
           title: r[:title],
-          subtitle: r[:subtitle]
+          subtitle: r[:subtitle],
+          # The finished token, built and validated HERE. The client used
+          # to assemble it by concatenation, which silently produced
+          # something unparseable whenever a record's own name contained a
+          # `|` or `]` — "Q3 | Launch" stored a broken token that no
+          # renderer would ever link and no index would ever record.
+          token: build_token(kind, r)
         }
       end)
+      |> Enum.filter(& &1.token)
 
     # `seq` is echoed back untouched so the client can drop replies for a
     # query the user has already typed past.
     %{results: results, seq: params["seq"]}
+  end
+
+  # Falls back to a sanitised label rather than dropping the result: a
+  # record whose name happens to contain a delimiter should still be
+  # mentionable, just under a name the grammar can hold.
+  defp build_token(kind, r) do
+    case Mentions.Token.to_string(kind, r[:type], r[:uuid], r[:title]) do
+      {:ok, token} ->
+        token
+
+      :error ->
+        cleaned = r[:title] |> Kernel.to_string() |> String.replace(["|", "]"], " ")
+
+        case Mentions.Token.to_string(kind, r[:type], r[:uuid], cleaned) do
+          {:ok, token} -> token
+          :error -> nil
+        end
+    end
   end
 
   defp current_user_uuid(socket) do

--- a/lib/phoenix_kit/mentions/mention.ex
+++ b/lib/phoenix_kit/mentions/mention.ex
@@ -1,0 +1,78 @@
+defmodule PhoenixKit.Mentions.Mention do
+  @moduledoc """
+  One `@` ping or `#` record link, indexed.
+
+  The canonical mention is the token inside the text — see
+  `PhoenixKit.Mentions.Token` for why. This row is a rebuilt-on-save cache
+  of the current head of one field, and exists to answer two questions the
+  text cannot answer cheaply:
+
+    * **what links here** — every record pointing at this one, without
+      scanning every body in every module;
+    * **what is new** — so re-saving a comment doesn't re-notify everyone
+      already mentioned in it.
+
+  Neither side carries a foreign key: both point into ~28 optional
+  packages' tables. `actor_uuid` does, because users are core's.
+  """
+  use Ecto.Schema
+  use PhoenixKit.SchemaPrefix
+  import Ecto.Changeset
+
+  alias PhoenixKit.Mentions.Token
+
+  @primary_key {:uuid, UUIDv7, autogenerate: true}
+  @foreign_key_type UUIDv7
+
+  @kinds ~w(user resource)
+
+  @type t :: %__MODULE__{
+          uuid: UUIDv7.t() | nil,
+          source_type: String.t() | nil,
+          source_uuid: UUIDv7.t() | nil,
+          source_field: String.t() | nil,
+          kind: String.t() | nil,
+          target_type: String.t() | nil,
+          target_uuid: UUIDv7.t() | nil,
+          label: String.t() | nil,
+          actor_uuid: UUIDv7.t() | nil,
+          notified_at: DateTime.t() | nil,
+          inserted_at: DateTime.t() | nil
+        }
+
+  schema "phoenix_kit_mentions" do
+    field(:source_type, :string)
+    field(:source_uuid, UUIDv7)
+    field(:source_field, :string, default: "body")
+    field(:kind, :string)
+    field(:target_type, :string)
+    field(:target_uuid, UUIDv7)
+    field(:label, :string)
+    field(:actor_uuid, UUIDv7)
+    field(:notified_at, :utc_datetime)
+
+    timestamps(type: :utc_datetime, updated_at: false)
+  end
+
+  @required ~w(source_type source_uuid source_field kind target_type target_uuid)a
+  @optional ~w(label actor_uuid notified_at)a
+
+  @spec changeset(t(), map()) :: Ecto.Changeset.t()
+  def changeset(mention, attrs) do
+    mention
+    |> cast(attrs, @required ++ @optional)
+    |> validate_required(@required)
+    |> validate_inclusion(:kind, @kinds)
+    |> validate_length(:label, max: Token.max_label_length())
+    |> unique_constraint([:source_type, :source_uuid, :source_field, :target_type, :target_uuid],
+      name: :phoenix_kit_mentions_unique_index
+    )
+    # The actor can be deleted between opening the form and saving it. That
+    # should cost the attribution, not the save.
+    |> foreign_key_constraint(:actor_uuid)
+  end
+
+  @doc "The two mention kinds: an `@` ping and a `#` record link."
+  @spec kinds() :: [String.t()]
+  def kinds, do: @kinds
+end

--- a/lib/phoenix_kit/mentions/token.ex
+++ b/lib/phoenix_kit/mentions/token.ex
@@ -1,0 +1,186 @@
+defmodule PhoenixKit.Mentions.Token do
+  @moduledoc """
+  The stored form of a mention, and the only thing that turns free text into
+  a link.
+
+  Two shapes, both closed and both carrying their own label:
+
+      @[user:018e3c4a-9f6b-7890-abcd-ef1234567890|Alice Smith]
+      #[project:018e3c4a-9f6b-7890-abcd-ef1234567890|Q3 Launch]
+
+  ## Why the label lives in the text
+
+  The token is self-contained on purpose. Text gets copied between records,
+  exported, kept in edit history, and read by people with JavaScript off —
+  and a module can be uninstalled entirely. A bare foreign key survives none
+  of that; this survives all of it, degrading to something a human can still
+  read. It also keeps full-text search working: searching "Alice" finds the
+  comment, because "Alice" is literally in the column.
+
+  The label is a SNAPSHOT of what the author saw when they picked. It is not
+  the display title — `PhoenixKit.Mentions` re-resolves that per viewer at
+  render, and deliberately never shows a refreshed title to someone who
+  cannot open the record.
+
+  ## What is NOT a mention
+
+  A bare `@alice` or `#launch` is ordinary prose and is never linked. Only
+  the closed form above counts, which is what makes escaping mostly a
+  non-problem: a token needs the trigger, a known type, a syntactically valid
+  UUID, a `|`, a label and a `]`, so typing one by accident is not a thing
+  that happens.
+
+  Two deliberate consequences:
+
+    * Publishing's `#hashtag` feature is untouched — the trigger character is
+      shared, the stored form is not.
+    * An unfinished token (someone typing, or a truncated paste) stays plain
+      text rather than becoming a broken link.
+
+  For the rare case of writing a complete-looking token that should NOT
+  link, prefix it with a backslash: `\\@[user:…|Alice]`. `render/2` strips the
+  backslash and leaves the rest as text.
+  """
+
+  @typedoc "`:user` for an `@` ping, `:resource` for a `#` record link."
+  @type kind :: :user | :resource
+
+  @type t :: %__MODULE__{
+          kind: kind(),
+          type: String.t(),
+          uuid: String.t(),
+          label: String.t(),
+          raw: String.t()
+        }
+
+  defstruct [:kind, :type, :uuid, :label, :raw]
+
+  # A resource type is the same namespace `ResourceLinks` uses. The label
+  # stops at the first `]` — labels containing a raw `]` or `|` are refused
+  # at insert time rather than escaped, because the picker is the only thing
+  # that produces tokens and it can simply not produce those.
+  @uuid "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+  @label "[^\\]|]{1,120}"
+
+  @pattern ~r/(?<esc>\\?)(?<trigger>[@#])\[(?<type>[a-z][a-z0-9_]*):(?<uuid>#{@uuid})\|(?<label>#{@label})\]/
+
+  @max_label 120
+
+  @doc "The regex that recognises a token. Exposed so consumers can reuse it."
+  @spec pattern() :: Regex.t()
+  def pattern, do: @pattern
+
+  @doc "Longest label a token may carry."
+  @spec max_label_length() :: pos_integer()
+  def max_label_length, do: @max_label
+
+  @doc """
+  Every mention in `text`, in order, ignoring backslash-escaped ones.
+
+  Returns `[]` for nil or non-binary input so callers can pipe a possibly
+  empty field straight in.
+  """
+  @spec parse(String.t() | nil) :: [t()]
+  def parse(text) when is_binary(text) do
+    @pattern
+    |> Regex.scan(text, capture: :all_names)
+    |> Enum.flat_map(fn captures ->
+      # capture: :all_names returns groups sorted by name — esc, label, trigger,
+      # type, uuid. Zip rather than index so a renamed group can't silently
+      # shift the meaning of every field.
+      case Enum.zip(~w(esc label trigger type uuid), captures) |> Map.new() do
+        %{"esc" => "\\"} ->
+          []
+
+        %{"trigger" => t, "type" => type, "uuid" => uuid, "label" => label} ->
+          [build(t, type, uuid, label)]
+      end
+    end)
+  end
+
+  def parse(_), do: []
+
+  @doc """
+  Builds the stored form. Returns `:error` when the label can't be
+  represented — the picker should then pick a different label rather than
+  the caller escaping anything.
+  """
+  @spec to_string(kind(), String.t(), String.t(), String.t()) :: {:ok, String.t()} | :error
+  def to_string(kind, type, uuid, label) do
+    label = label |> Kernel.to_string() |> String.trim() |> String.slice(0, @max_label)
+    trigger = if kind == :user, do: "@", else: "#"
+
+    cond do
+      label == "" -> :error
+      String.contains?(label, ["]", "|"]) -> :error
+      not Regex.match?(~r/\A#{@uuid}\z/, Kernel.to_string(uuid)) -> :error
+      not Regex.match?(~r/\A[a-z][a-z0-9_]*\z/, Kernel.to_string(type)) -> :error
+      true -> {:ok, "#{trigger}[#{type}:#{uuid}|#{label}]"}
+    end
+  end
+
+  @doc """
+  Splits `text` into a list of plain strings and `t()` structs, in order.
+
+  This is what a renderer walks: everything that isn't a mention comes back
+  as a binary to be escaped and printed as-is, and an escaped token comes
+  back as text with its backslash removed.
+  """
+  @spec split(String.t() | nil) :: [String.t() | t()]
+  def split(text) when is_binary(text) do
+    @pattern
+    |> Regex.split(text, include_captures: true, trim: false)
+    |> Enum.flat_map(&split_piece/1)
+  end
+
+  def split(_), do: []
+
+  defp split_piece("") do
+    []
+  end
+
+  defp split_piece(piece) do
+    case Regex.run(@pattern, piece, capture: :all_names) do
+      nil ->
+        [piece]
+
+      captures ->
+        case Enum.zip(~w(esc label trigger type uuid), captures) |> Map.new() do
+          # Escaped: the author wants the characters, not a link.
+          %{"esc" => "\\"} ->
+            [String.replace_prefix(piece, "\\", "")]
+
+          %{"trigger" => t, "type" => type, "uuid" => uuid, "label" => label} ->
+            [build(t, type, uuid, label)]
+        end
+    end
+  end
+
+  defp build(trigger, type, uuid, label) do
+    kind = if trigger == "@", do: :user, else: :resource
+
+    %__MODULE__{
+      kind: kind,
+      type: type,
+      uuid: String.downcase(uuid),
+      label: label,
+      raw: "#{trigger}[#{type}:#{uuid}|#{label}]"
+    }
+  end
+
+  @doc """
+  The text with every mention replaced by its label — what a plain-text
+  channel (an email digest, a search index, a notification preview) should
+  show instead of raw tokens.
+  """
+  @spec to_plain_text(String.t() | nil) :: String.t()
+  def to_plain_text(text) do
+    text
+    |> split()
+    |> Enum.map_join(fn
+      %__MODULE__{kind: :user, label: label} -> "@" <> label
+      %__MODULE__{label: label} -> label
+      piece -> piece
+    end)
+  end
+end

--- a/lib/phoenix_kit/mentions/users.ex
+++ b/lib/phoenix_kit/mentions/users.ex
@@ -1,0 +1,140 @@
+defmodule PhoenixKit.Mentions.Users do
+  @moduledoc """
+  The `@` side of mentions: finding a person to ping.
+
+  Separate from the `#` fan-out because a ping is always a person, and
+  people are core's — there is no module to ask and no permission model to
+  federate. What there IS is a decision about who may be pinged at all, and
+  the rule shipped here is deliberately narrow:
+
+    * only **active, confirmed** accounts (a pending invite cannot be
+      pinged into existence, and a deactivated account is not a colleague);
+    * only accounts that can reach the admin area at all, since every
+      surface a mention currently appears on lives there — pinging a
+      customer about an internal note would be the leak, not the feature.
+
+  Matching is on username, then name, then email — email last and only on a
+  prefix, so the typeahead cannot be used to confirm whether an address has
+  an account by pasting it in.
+  """
+
+  import Ecto.Query
+
+  alias PhoenixKit.RepoHelper
+  alias PhoenixKit.Users.Auth.{Scope, User}
+
+  @default_limit 8
+
+  # How many rows to pull per requested result before the in-memory
+  # permission filter. Bounded so a site with thousands of non-admin
+  # accounts can't turn one keystroke into a full scan.
+  @overfetch 8
+
+  defp repo, do: RepoHelper.repo()
+
+  @doc """
+  People matching `query`, shaped for the typeahead.
+
+  An empty query returns a short list of candidates rather than nothing:
+  opening the picker with `@` and seeing who is around beats a blank box.
+  """
+  @spec search(String.t(), keyword()) :: [map()]
+  def search(query, opts \\ []) do
+    limit = Keyword.get(opts, :limit, @default_limit)
+
+    User
+    # Confirmation is a column, so it belongs in the query. The admin-area
+    # check is not — it walks roles and permissions per user.
+    |> where([u], u.is_active == true and not is_nil(u.confirmed_at))
+    |> maybe_match(String.trim(query))
+    |> order_by([u], asc: u.username, asc: u.email)
+    # Over-fetch, because the remaining filter runs in memory: taking
+    # `limit` rows first and filtering after returns an EMPTY list whenever
+    # the first N happen to be non-admins, which looks exactly like "nobody
+    # matches" and is how this was first written.
+    |> limit(^(limit * @overfetch))
+    |> repo().all()
+    |> Enum.filter(&pingable?/1)
+    |> Enum.take(limit)
+    |> Enum.map(&to_result/1)
+  end
+
+  defp maybe_match(queryable, ""), do: queryable
+
+  defp maybe_match(queryable, query) do
+    contains = "%#{escape_like(query)}%"
+    prefix = "#{escape_like(query)}%"
+
+    where(
+      queryable,
+      [u],
+      ilike(u.username, ^contains) or ilike(u.first_name, ^contains) or
+        ilike(u.last_name, ^contains) or ilike(u.email, ^prefix)
+    )
+  end
+
+  # `%` and `_` in user input are wildcards to LIKE. Without escaping, a
+  # single `%` matches every account in the system.
+  defp escape_like(value) do
+    value
+    |> String.replace("\\", "\\\\")
+    |> String.replace("%", "\\%")
+    |> String.replace("_", "\\_")
+  end
+
+  # Confirmation is the line between "this address was typed into a form"
+  # and "a person holds this account".
+  defp pingable?(%User{confirmed_at: nil}), do: false
+
+  defp pingable?(%User{} = user) do
+    user
+    |> Scope.for_user()
+    |> Scope.can_access_admin_area?()
+  rescue
+    _ -> false
+  catch
+    :exit, _ -> false
+  end
+
+  defp to_result(%User{} = user) do
+    %{
+      kind: :user,
+      type: "user",
+      uuid: user.uuid,
+      title: display_name(user),
+      subtitle: user.email
+    }
+  end
+
+  @doc """
+  The label a mention of this user carries — what the author saw when they
+  picked, and the fallback when the account is later deleted.
+  """
+  @spec display_name(User.t()) :: String.t()
+  def display_name(%User{} = user) do
+    full = [user.first_name, user.last_name] |> Enum.reject(&(&1 in [nil, ""])) |> Enum.join(" ")
+
+    cond do
+      full != "" -> full
+      is_binary(user.username) and user.username != "" -> user.username
+      true -> user.email |> to_string() |> String.split("@") |> List.first()
+    end
+  end
+
+  @doc """
+  Resolves mentioned user uuids to `%{uuid => %{title, path}}` — the
+  `resolve_comment_resources/1` shape, so `@` mentions render through the
+  same `ResourceLinks` path `#` does.
+  """
+  @spec resolve(list()) :: map()
+  def resolve(uuids) do
+    User
+    |> where([u], u.uuid in ^uuids)
+    |> repo().all()
+    |> Map.new(fn user ->
+      {user.uuid, %{title: display_name(user), full_title: display_name(user), path: nil}}
+    end)
+  rescue
+    _ -> %{}
+  end
+end

--- a/lib/phoenix_kit/mentions/users.ex
+++ b/lib/phoenix_kit/mentions/users.ex
@@ -102,7 +102,10 @@ defmodule PhoenixKit.Mentions.Users do
       type: "user",
       uuid: user.uuid,
       title: display_name(user),
-      subtitle: user.email
+      # NOT the email. The title deliberately degrades to a local part, and
+      # printing the full address underneath it gives back exactly what that
+      # was protecting — in a menu, next to a name, ready to copy.
+      subtitle: nil
     }
   end
 
@@ -111,15 +114,7 @@ defmodule PhoenixKit.Mentions.Users do
   picked, and the fallback when the account is later deleted.
   """
   @spec display_name(User.t()) :: String.t()
-  def display_name(%User{} = user) do
-    full = [user.first_name, user.last_name] |> Enum.reject(&(&1 in [nil, ""])) |> Enum.join(" ")
-
-    cond do
-      full != "" -> full
-      is_binary(user.username) and user.username != "" -> user.username
-      true -> user.email |> to_string() |> String.split("@") |> List.first()
-    end
-  end
+  def display_name(%User{} = user), do: User.display_name(user)
 
   @doc """
   Resolves mentioned user uuids to `%{uuid => %{title, path}}` — the

--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -7,8 +7,17 @@ defmodule PhoenixKit.Migrations.Postgres do
 
   ## Migration Versions
 
+  ### V165 - Cross-module mentions and access requests ⚡ LATEST
+
+  Adds `phoenix_kit_mentions` (the reverse index for `@`/`#` tokens — the
+  canonical mention lives in the text, this answers "what links here" and
+  gives notification fan-out something to diff) and
+  `phoenix_kit_access_requests` (asking the owner for access to a record a
+  mention pointed at but the reader cannot open). Neither target carries a
+  foreign key: both point into ~28 optional packages' tables.
+
   ### V164 - Repair the V56/V57 flush-order bug's fallout, and converge two
-  ### prefix-unsafe historical shapes ⚡ LATEST
+  ### prefix-unsafe historical shapes
   - Also folds in what an earlier draft carried as a separate V164: V68
     (partial `idx_publishing_posts_group_slug`) and V65 (the
     `phoenix_kit_subscription_plans_slug_uidx` -> `..._types_slug_uidx`
@@ -432,7 +441,7 @@ defmodule PhoenixKit.Migrations.Postgres do
   alias PhoenixKit.Migrations.Repair.Environment
 
   @initial_version 135
-  @current_version 164
+  @current_version 165
   @default_prefix "public"
 
   # The frozen pre-squash bridge: the last 1.7.x release, which still carries

--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -7,7 +7,22 @@ defmodule PhoenixKit.Migrations.Postgres do
 
   ## Migration Versions
 
-  ### V165 - Cross-module mentions and access requests ⚡ LATEST
+  ### V166 - Frozen comment attribution ⚡ LATEST
+
+  Adds `author_display_name`, `attribution_mode`, `attributed_project_uuid`
+  and `attributed_label` to `phoenix_kit_comments`. A name resolved at
+  render time rewrites history — someone leaves or fills in a profile and
+  every comment they wrote is silently re-signed — so what the reader was
+  shown is pinned at write. The same applies to speaking on a project's
+  behalf, which is a choice made at the time and not a fact recomputed from
+  current membership. `user_uuid` is never cleared: posting as the project
+  changes what the PUBLIC sees and nothing else, so moderation and audit
+  keep their actor.
+
+  Existing rows are left NULL rather than backfilled — inventing a display
+  history we do not have would be worse than resolving those rows live.
+
+  ### V165 - Cross-module mentions and access requests
 
   Adds `phoenix_kit_mentions` (the reverse index for `@`/`#` tokens — the
   canonical mention lives in the text, this answers "what links here" and
@@ -441,7 +456,7 @@ defmodule PhoenixKit.Migrations.Postgres do
   alias PhoenixKit.Migrations.Repair.Environment
 
   @initial_version 135
-  @current_version 165
+  @current_version 166
   @default_prefix "public"
 
   # The frozen pre-squash bridge: the last 1.7.x release, which still carries

--- a/lib/phoenix_kit/migrations/postgres/v165.ex
+++ b/lib/phoenix_kit/migrations/postgres/v165.ex
@@ -1,0 +1,157 @@
+defmodule PhoenixKit.Migrations.Postgres.V165 do
+  @moduledoc """
+  V165: cross-module mentions and access requests.
+
+  ## `phoenix_kit_mentions`
+
+  The reverse index for `@`/`#` mentions. The canonical mention lives in the
+  text itself as a token, which is what survives copy-paste, edit history,
+  no-JS reading and a module being uninstalled. This table answers the
+  question the text cannot: **what links here** — and gives notification
+  fan-out something to diff against without re-scanning every body.
+
+  It is a CACHE of the current head of each field, rebuilt from the tokens
+  on every durable save. It is deliberately not versioned: history lives in
+  the text.
+
+  No foreign key on `target_uuid`: it points into ~28 optional packages'
+  tables, most of which may not be installed. The source side is the same —
+  a comment, a task description, a note. Orphans are expected and handled at
+  read time, where a target that no longer resolves renders as plain text
+  rather than a link.
+
+  ## `phoenix_kit_access_requests`
+
+  When a mention points at something the reader cannot open, the reader is
+  told it exists but not what it is — and can ask for access. That request
+  needs somewhere to live so the owner can act on it and so the same person
+  cannot spam the same record.
+
+  `status` is a string sentinel (`pending` / `granted` / `denied` /
+  `cancelled`), matching the workspace's soft-delete convention rather than
+  a boolean pair.
+  """
+
+  use Ecto.Migration
+
+  alias PhoenixKit.Migrations.Postgres.Helpers
+
+  def up(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+    schema = schema_name(prefix)
+
+    Helpers.ensure_uuid_v7_function(prefix)
+    uuid_default = Helpers.uuid_v7_call(prefix)
+
+    execute("""
+    CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_mentions (
+      uuid UUID PRIMARY KEY DEFAULT #{uuid_default},
+      -- What CONTAINS the mention. Free-form type + uuid for the same
+      -- reason the target is: the container may be any module's record.
+      source_type TEXT NOT NULL,
+      source_uuid UUID NOT NULL,
+      -- Which field of that record. A task with a description AND a
+      -- summary needs two independent sets of mentions, and re-saving one
+      -- must not wipe the other's rows.
+      source_field TEXT NOT NULL DEFAULT 'body',
+      -- What is MENTIONED. `kind` distinguishes an @ping from a # link so
+      -- notification fan-out doesn't have to special-case the type name.
+      kind TEXT NOT NULL,
+      target_type TEXT NOT NULL,
+      target_uuid UUID NOT NULL,
+      -- The label the author saw when they picked. Kept so "what links
+      -- here" can render without resolving, and so a deleted target still
+      -- has a human name in the reverse index.
+      label TEXT,
+      actor_uuid UUID REFERENCES #{p}phoenix_kit_users(uuid) ON DELETE SET NULL,
+      -- Set once the @ping has been delivered, so re-saving the same text
+      -- never notifies twice. NULL for # links, which don't notify.
+      notified_at TIMESTAMPTZ,
+      inserted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      CONSTRAINT phoenix_kit_mentions_kind_check CHECK (kind IN ('user', 'resource'))
+    )
+    """)
+
+    # One row per (source field, target). Mentioning the same person twice in
+    # one comment is one mention, which is also what stops a double @ from
+    # sending two notifications.
+    execute("""
+    CREATE UNIQUE INDEX IF NOT EXISTS phoenix_kit_mentions_unique_index
+      ON #{p}phoenix_kit_mentions (source_type, source_uuid, source_field, target_type, target_uuid)
+    """)
+
+    # "What links here" — the whole point of the table.
+    execute("""
+    CREATE INDEX IF NOT EXISTS phoenix_kit_mentions_target_index
+      ON #{p}phoenix_kit_mentions (target_type, target_uuid)
+    """)
+
+    # The re-sync path deletes and re-inserts by source field.
+    execute("""
+    CREATE INDEX IF NOT EXISTS phoenix_kit_mentions_source_index
+      ON #{p}phoenix_kit_mentions (source_type, source_uuid, source_field)
+    """)
+
+    # Pending @pings awaiting delivery.
+    execute("""
+    CREATE INDEX IF NOT EXISTS phoenix_kit_mentions_pending_index
+      ON #{p}phoenix_kit_mentions (kind, notified_at) WHERE (notified_at IS NULL)
+    """)
+
+    execute("""
+    CREATE TABLE IF NOT EXISTS #{p}phoenix_kit_access_requests (
+      uuid UUID PRIMARY KEY DEFAULT #{uuid_default},
+      requester_uuid UUID NOT NULL REFERENCES #{p}phoenix_kit_users(uuid) ON DELETE CASCADE,
+      resource_type TEXT NOT NULL,
+      resource_uuid UUID NOT NULL,
+      -- Where they hit the wall, so the owner can see the context that
+      -- prompted the ask rather than a bare "someone wants in".
+      source_type TEXT,
+      source_uuid UUID,
+      note TEXT,
+      status TEXT NOT NULL DEFAULT 'pending',
+      decided_by_uuid UUID REFERENCES #{p}phoenix_kit_users(uuid) ON DELETE SET NULL,
+      decided_at TIMESTAMPTZ,
+      inserted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      CONSTRAINT phoenix_kit_access_requests_status_check
+        CHECK (status IN ('pending', 'granted', 'denied', 'cancelled'))
+    )
+    """)
+
+    # One OPEN request per person per resource: asking twice is the same ask,
+    # and without this the owner's queue fills with duplicates from anyone
+    # who clicks the button repeatedly. Partial, so a denied request doesn't
+    # block asking again later when circumstances change.
+    execute("""
+    CREATE UNIQUE INDEX IF NOT EXISTS phoenix_kit_access_requests_open_index
+      ON #{p}phoenix_kit_access_requests (requester_uuid, resource_type, resource_uuid)
+      WHERE (status = 'pending')
+    """)
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS phoenix_kit_access_requests_resource_index
+      ON #{p}phoenix_kit_access_requests (resource_type, resource_uuid, status)
+    """)
+
+    _ = schema
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '163'")
+  end
+
+  def down(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    execute("DROP TABLE IF EXISTS #{p}phoenix_kit_access_requests")
+    execute("DROP TABLE IF EXISTS #{p}phoenix_kit_mentions")
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '164'")
+  end
+
+  defp schema_name("public"), do: "public"
+  defp schema_name(prefix), do: prefix
+
+  defp prefix_str("public"), do: "public."
+  defp prefix_str(prefix), do: "#{prefix}."
+end

--- a/lib/phoenix_kit/migrations/postgres/v166.ex
+++ b/lib/phoenix_kit/migrations/postgres/v166.ex
@@ -1,0 +1,120 @@
+defmodule PhoenixKit.Migrations.Postgres.V166 do
+  @moduledoc """
+  V166: frozen comment attribution — who a comment is FROM, at the time.
+
+  Two problems, one row.
+
+  ## The name has to be frozen
+
+  A comment header used to render `user.email`, which on a public issue
+  board published a full address next to every remark. Replacing it with a
+  live name chain fixes the address but not the deeper issue: a name
+  resolved at RENDER time rewrites history. Someone leaves, is renamed, or
+  finally fills in their profile, and every comment they ever wrote is
+  silently re-signed. `author_display_name` records what the world was
+  shown when the comment was made.
+
+  Null for every existing row, on purpose: a backfill would invent a
+  history we do not have, so old rows keep resolving live and only new ones
+  are pinned.
+
+  ## Speaking for the project
+
+  Someone answering on their employer's public board may be speaking as
+  themselves or on behalf of the project, and those are different acts. The
+  choice is stored, not recomputed: recomputing means a membership change
+  retroactively alters who said what — and worse, un-masks somebody who
+  deliberately posted under the project's name.
+
+  **`user_uuid` is never cleared.** Posting as the project changes what the
+  PUBLIC sees, and nothing else: internally the actual author stays on the
+  row, so moderation, audit and "who actually said this" keep working. A
+  shared voice with no accountable person behind it is how this feature
+  goes wrong.
+
+  `attributed_label` is frozen alongside `attributed_project_uuid` for the
+  same reason prices are snapshotted on orders: the project may be renamed
+  or deleted, and the comment should still say what it said.
+
+  No FK on `attributed_project_uuid` — projects live in an optional
+  package, exactly like the mention targets in V163.
+  """
+
+  use Ecto.Migration
+
+  def up(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    execute("""
+    ALTER TABLE #{p}phoenix_kit_comments
+      -- What the reader was shown. NULL on historical rows, which keep
+      -- resolving live; only rows written from here on are pinned.
+      ADD COLUMN IF NOT EXISTS author_display_name TEXT,
+      -- 'personal' | 'project'. NULL reads as 'personal' so nothing needs
+      -- a backfill and no existing comment changes meaning.
+      ADD COLUMN IF NOT EXISTS attribution_mode TEXT,
+      -- The project spoken for, and the name it had at the time.
+      ADD COLUMN IF NOT EXISTS attributed_project_uuid UUID,
+      ADD COLUMN IF NOT EXISTS attributed_label TEXT
+    """)
+
+    # Only two values are meaningful, and a typo'd third would render as an
+    # unhandled state on a public page. Cheaper to refuse it here.
+    execute("""
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint c
+        JOIN pg_class t ON t.oid = c.conrelid
+        JOIN pg_namespace n ON n.oid = t.relnamespace
+        WHERE c.conname = 'phoenix_kit_comments_attribution_mode_check'
+          AND t.relname = 'phoenix_kit_comments'
+          AND n.nspname = '#{schema_name(prefix)}'
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_comments
+          ADD CONSTRAINT phoenix_kit_comments_attribution_mode_check
+          CHECK (attribution_mode IS NULL OR attribution_mode IN ('personal', 'project'));
+      END IF;
+    END $$;
+    """)
+
+    # Every comment a project has spoken through, for the moderation view
+    # that has to answer "what have we said publicly, and who wrote it".
+    execute("""
+    CREATE INDEX IF NOT EXISTS phoenix_kit_comments_attributed_project_idx
+      ON #{p}phoenix_kit_comments (attributed_project_uuid)
+      WHERE attributed_project_uuid IS NOT NULL
+    """)
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '166'")
+  end
+
+  def down(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    execute("DROP INDEX IF EXISTS #{p}phoenix_kit_comments_attributed_project_idx")
+
+    execute("""
+    ALTER TABLE #{p}phoenix_kit_comments
+      DROP CONSTRAINT IF EXISTS phoenix_kit_comments_attribution_mode_check
+    """)
+
+    execute("""
+    ALTER TABLE #{p}phoenix_kit_comments
+      DROP COLUMN IF EXISTS attributed_label,
+      DROP COLUMN IF EXISTS attributed_project_uuid,
+      DROP COLUMN IF EXISTS attribution_mode,
+      DROP COLUMN IF EXISTS author_display_name
+    """)
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '165'")
+  end
+
+  defp schema_name("public"), do: "public"
+  defp schema_name(prefix), do: prefix
+
+  defp prefix_str("public"), do: "public."
+  defp prefix_str(prefix), do: "#{prefix}."
+end

--- a/lib/phoenix_kit/module.ex
+++ b/lib/phoenix_kit/module.ex
@@ -154,6 +154,15 @@ defmodule PhoenixKit.Module do
   @callback user_dashboard_tabs() :: [PhoenixKit.Dashboard.Tab.t()]
   @callback children() :: [Supervisor.child_spec() | module() | {module(), term()}]
   @callback route_module() :: module() | nil
+
+  @doc """
+  Lifecycle hook: called for every discovered module BEFORE a user row is
+  deleted (while the user's related rows — memberships, assignments —
+  still exist). Modules use it for remediation the DB cascades can't do:
+  succession, audit trails, orphan warnings. Best-effort — a raising
+  hook is logged and never aborts the deletion.
+  """
+  @callback before_user_delete(user_uuid :: String.t()) :: any()
   @callback version() :: String.t()
   @callback migration_module() :: module() | nil
   @callback required_modules() :: [String.t()]
@@ -500,6 +509,7 @@ defmodule PhoenixKit.Module do
     integration_providers: 0,
     notification_types: 0,
     notification_channels: 0,
+    before_user_delete: 1,
     resource_links: 0,
     css_sources: 0,
     js_sources: 0,

--- a/lib/phoenix_kit/notifications/notifications.ex
+++ b/lib/phoenix_kit/notifications/notifications.ex
@@ -58,6 +58,29 @@ defmodule PhoenixKit.Notifications do
       {:ok, :skipped}
   end
 
+  @doc """
+  Fans ONE committed activity entry out to MANY users' notification
+  rules — the multi-recipient counterpart to `maybe_create_from_activity/1`
+  for events whose audience is a set (project members, watchers) rather
+  than a single `target_uuid`.
+
+  Each recipient is evaluated independently through the SAME machinery
+  (prefs, per-channel routing, digest cadences, self-action skip) by
+  re-routing a copy of the entry with that recipient as target — WITHOUT
+  inserting additional activity rows, so the feed keeps one canonical
+  entry while deliveries still key on its committed uuid.
+
+  Returns the per-recipient results in order.
+  """
+  @spec fan_out_from_activity(Entry.t(), [String.t()]) :: [
+          {:ok, Notification.t() | :skipped} | {:error, term()}
+        ]
+  def fan_out_from_activity(%Entry{} = entry, user_uuids) when is_list(user_uuids) do
+    user_uuids
+    |> Enum.uniq()
+    |> Enum.map(&maybe_create_from_activity(%{entry | target_uuid: &1}))
+  end
+
   # Model B — the in-app inbox and external channels are INDEPENDENT
   # destinations. Create the inbox row iff the user wants it in-app AND in-app is
   # on the "immediate" cadence (a digest cadence skips the per-event row — the

--- a/lib/phoenix_kit/settings/settings.ex
+++ b/lib/phoenix_kit/settings/settings.ex
@@ -136,6 +136,10 @@ defmodule PhoenixKit.Settings do
       "magic_link_registration_enabled" => "true",
       "qr_login_enabled" => "false",
       "new_login_alert_enabled" => "false",
+      # Cross-module @ mentions and # record links. On by default: the
+      # feature is inert until someone actually types a trigger, and
+      # everything it stores degrades to plain text when it is off.
+      "mentions_enabled" => "true",
       "new_user_default_role" => "User",
       "new_user_default_status" => "true",
       "week_start_day" => "1",

--- a/lib/phoenix_kit/settings/settings.ex
+++ b/lib/phoenix_kit/settings/settings.ex
@@ -140,6 +140,10 @@ defmodule PhoenixKit.Settings do
       # feature is inert until someone actually types a trigger, and
       # everything it stores degrades to plain text when it is off.
       "mentions_enabled" => "true",
+      # Extra-security mode: withhold the TITLE of a mention the reader
+      # can't open. Off by default — a record's name is rarely the secret,
+      # the access is — and worth turning on where the name itself is.
+      "mentions_redact_titles" => "false",
       "new_user_default_role" => "User",
       "new_user_default_status" => "true",
       "week_start_day" => "1",

--- a/lib/phoenix_kit/users/auth.ex
+++ b/lib/phoenix_kit/users/auth.ex
@@ -2681,6 +2681,12 @@ defmodule PhoenixKit.Users.Auth do
       # user's related rows (memberships, assignments) still exist —
       # remediation the DB cascades can't do (ownership succession,
       # orphan audit trails). Best-effort: a raising hook never aborts.
+      # Hooks run OUTSIDE the delete transaction, deliberately: a hook's
+      # own writes (succession promotions, audit rows) must survive even
+      # if they use a different repo/pool. Accepted tradeoff: if the
+      # delete itself then fails, hook side-effects have already
+      # committed (e.g. an extra owner) — rare, admin-recoverable, and
+      # preferable to hooks silently vanishing with a rollback.
       run_before_user_delete_hooks(user.uuid)
 
       do_delete_user(user, opts, current_user)
@@ -2723,9 +2729,14 @@ defmodule PhoenixKit.Users.Auth do
               "before_user_delete hook #{inspect(module)} failed: #{Exception.message(e)}"
             )
         catch
-          :exit, reason ->
+          # `kind, reason` (not just :exit) — a hook that THROWS must not
+          # abort the deletion either.
+          kind, reason ->
             require Logger
-            Logger.error("before_user_delete hook #{inspect(module)} exited: #{inspect(reason)}")
+
+            Logger.error(
+              "before_user_delete hook #{inspect(module)} #{kind}: #{inspect(reason)}"
+            )
         end
       end
     end)

--- a/lib/phoenix_kit/users/auth.ex
+++ b/lib/phoenix_kit/users/auth.ex
@@ -2676,8 +2676,19 @@ defmodule PhoenixKit.Users.Auth do
   def delete_user(%User{} = user, opts \\ %{}) do
     current_user = Map.get(opts, :current_user)
 
-    with :ok <- validate_can_delete_user(user, current_user),
-         {:ok, result} <- execute_user_deletion(user, opts) do
+    with :ok <- validate_can_delete_user(user, current_user) do
+      # Module lifecycle hooks run BEFORE the row delete, while the
+      # user's related rows (memberships, assignments) still exist —
+      # remediation the DB cascades can't do (ownership succession,
+      # orphan audit trails). Best-effort: a raising hook never aborts.
+      run_before_user_delete_hooks(user.uuid)
+
+      do_delete_user(user, opts, current_user)
+    end
+  end
+
+  defp do_delete_user(user, opts, current_user) do
+    with {:ok, result} <- execute_user_deletion(user, opts) do
       PhoenixKit.Activity.log(%{
         action: "user.deleted",
         module: "users",
@@ -2690,9 +2701,36 @@ defmodule PhoenixKit.Users.Auth do
       })
 
       {:ok, result}
-    else
-      {:error, reason} -> {:error, reason}
     end
+  end
+
+  @doc """
+  Runs every discovered module's optional `before_user_delete/1` hook.
+  Public with an injectable module list so the dispatch is testable;
+  production callers use the discovered default.
+  """
+  def run_before_user_delete_hooks(user_uuid, modules \\ nil) do
+    (modules || PhoenixKit.ModuleRegistry.all_modules())
+    |> Enum.each(fn module ->
+      if Code.ensure_loaded?(module) and function_exported?(module, :before_user_delete, 1) do
+        try do
+          module.before_user_delete(user_uuid)
+        rescue
+          e ->
+            require Logger
+
+            Logger.error(
+              "before_user_delete hook #{inspect(module)} failed: #{Exception.message(e)}"
+            )
+        catch
+          :exit, reason ->
+            require Logger
+            Logger.error("before_user_delete hook #{inspect(module)} exited: #{inspect(reason)}")
+        end
+      end
+    end)
+
+    :ok
   end
 
   @doc """

--- a/lib/phoenix_kit/users/auth.ex
+++ b/lib/phoenix_kit/users/auth.ex
@@ -2734,9 +2734,7 @@ defmodule PhoenixKit.Users.Auth do
           kind, reason ->
             require Logger
 
-            Logger.error(
-              "before_user_delete hook #{inspect(module)} #{kind}: #{inspect(reason)}"
-            )
+            Logger.error("before_user_delete hook #{inspect(module)} #{kind}: #{inspect(reason)}")
         end
       end
     end)

--- a/lib/phoenix_kit/users/auth/user.ex
+++ b/lib/phoenix_kit/users/auth/user.ex
@@ -615,6 +615,85 @@ defmodule PhoenixKit.Users.Auth.User do
   def excluded_fields, do: @excluded_fields
 
   @doc """
+  What to call this person when showing them TO OTHER PEOPLE.
+
+  The one canonical answer. Before this existed there were half a dozen
+  private copies, several of which ended `|| user.email` — which is how a
+  public issue board came to print commenters' full addresses next to their
+  words, indexed and scrapeable.
+
+  The chain, first non-blank wins:
+
+      organization account's name    (an org has no first/last)
+      first + last name
+      username
+      the local part of the email    (before the "@")
+      "User"
+
+  **Never the full email.** The local part is not anonymity —
+  `john.smith@…` still reads as "john.smith" — but it carries no domain, is
+  not directly mailable, and is not harvestable as an address.
+
+  Every rung is trimmed and rejected when blank: `full_name/1` happily
+  returns `""` for a first name of `"   "`, and an unguarded chain stops
+  dead on it.
+
+  Only fields the USER wrote about themselves. A name recorded by somebody
+  else — `phoenix_kit_staff`'s HR record, a CRM contact label — must never
+  reach this, whatever its quality: the people with no name set are exactly
+  the ones who are pseudonymous by choice or inertia, and publishing an
+  HR-entered legal name on their behalf is not ours to do.
+
+  For "does this person have a real name at all", keep using `full_name/1`
+  — it still answers `nil`, and that question is still worth asking.
+
+  ## Examples
+
+      iex> display_name(%User{first_name: "John", last_name: "Doe"})
+      "John Doe"
+
+      iex> display_name(%User{first_name: nil, username: "jdoe"})
+      "jdoe"
+
+      iex> display_name(%User{first_name: nil, username: nil, email: "j@x.com"})
+      "j"
+  """
+  @spec display_name(t() | nil) :: String.t()
+  def display_name(%__MODULE__{} = user) do
+    first_present([
+      full_name(user),
+      user.username,
+      email_local_part(user.email)
+    ]) || "User"
+  end
+
+  # A deleted or unloaded association. Callers that can say something better
+  # ("Former user") should; this keeps a nil from reaching a template raw.
+  def display_name(_), do: "User"
+
+  defp first_present(candidates) do
+    Enum.find_value(candidates, fn
+      value when is_binary(value) ->
+        case String.trim(value) do
+          "" -> nil
+          trimmed -> trimmed
+        end
+
+      _ ->
+        nil
+    end)
+  end
+
+  defp email_local_part(email) when is_binary(email) do
+    case String.split(email, "@") do
+      [local | _] -> local
+      _ -> nil
+    end
+  end
+
+  defp email_local_part(_), do: nil
+
+  @doc """
   Gets the user's full name by combining first and last name.
 
   ## Examples

--- a/lib/phoenix_kit/users/comment_resources.ex
+++ b/lib/phoenix_kit/users/comment_resources.ex
@@ -43,13 +43,11 @@ defmodule PhoenixKit.Users.CommentResources do
     _ -> %{}
   end
 
-  # Prefer the user's name; fall back to their email so the chip is never blank.
-  defp display_name(user) do
-    case User.full_name(user) do
-      name when is_binary(name) and name != "" -> name
-      _ -> user.email
-    end
-  end
+  # This module is the registered `ResourceLinks` handler for the "user"
+  # type, so it names every `@` mention everywhere — including public issue
+  # boards. The old `|| user.email` fallback therefore published a full
+  # address for any commenter who had not set a name.
+  defp display_name(user), do: User.display_name(user)
 
   # Same avatar precedence the `user_avatar` component uses: an uploaded avatar
   # (storage thumbnail), then an OAuth avatar URL, else none (chip shows a badge).

--- a/lib/phoenix_kit_web/components/core/accordion.ex
+++ b/lib/phoenix_kit_web/components/core/accordion.ex
@@ -58,7 +58,13 @@ defmodule PhoenixKitWeb.Components.Core.Accordion do
       phx-mounted={JS.ignore_attributes(cue_owned_attributes(@cue))}
       class={["collapse collapse-arrow border border-base-200 bg-base-100", @class]}
     >
-      <summary class={["collapse-title text-sm font-semibold", @title_class]}>
+      <%!-- Opening a cued region is the reader SEEING it, which is what
+           resets its baseline server-side. Alongside the native toggle,
+           not instead of it. --%>
+      <summary
+        class={["collapse-title text-sm font-semibold", @title_class]}
+        phx-click={@cue && JS.push(ChangeCue.seen_event(), value: %{"region" => @id})}
+      >
         {render_slot(@title)}
         <ChangeCue.change_marker :if={@cue} label={@cue_label} />
       </summary>

--- a/lib/phoenix_kit_web/components/core/accordion.ex
+++ b/lib/phoenix_kit_web/components/core/accordion.ex
@@ -19,6 +19,12 @@ defmodule PhoenixKitWeb.Components.Core.Accordion do
       </button>
 
   Works without JavaScript (native `<details>` on dead renders).
+
+  Closing a section near the bottom of a long page would shrink the document
+  out from under the reader and jump the viewport upward; the collapse scroll
+  keeper in `priv/static/assets/phoenix_kit.js` holds the page height instead,
+  so the reader stays put. It keys off `class="collapse"` on the `<details>`,
+  which this component always emits.
   """
 
   use Phoenix.Component

--- a/lib/phoenix_kit_web/components/core/accordion.ex
+++ b/lib/phoenix_kit_web/components/core/accordion.ex
@@ -3,52 +3,30 @@ defmodule PhoenixKitWeb.Components.Core.Accordion do
   Collapsible content section on the native `<details>` element + daisyUI
   `collapse` styling.
 
-  Rewritten 2026-08-06: the previous version emitted literal `\#{...}`
-  class text (string interpolation inside a plain HEEx attribute never
-  runs) and depended on `.accordion-*` CSS no host defines — it could
-  not have worked anywhere.
+  The browser owns the open/closed state: the summary click toggles
+  natively (instant, no round trip) and daisyUI 5 animates the reveal
+  via its `::details-content` height transition. `JS.ignore_attributes`
+  marks `open` as client-owned on mount, so LiveView patches never
+  reset a section the user toggled — the historic "accordion slams
+  shut on the next update" morphdom bug.
 
-  ## Two modes
+  `open` sets only the INITIAL state (server changes to it after mount
+  are ignored by design). To open a section from elsewhere in the page,
+  set the attribute client-side:
 
-  - **Uncontrolled** (default): the browser toggles the section — fine on
-    dead renders and static pages. In a connected LiveView any patch
-    resets the element to the server-rendered state (morphdom re-applies
-    the missing `open` attribute), so a section the user opened slams
-    shut on the next update.
-  - **Server-tracked** (recommended in LiveViews): pass `open` +
-    `toggle_event` (+ `toggle_value`). The summary click still toggles
-    natively — instant, no round-trip flicker — and the event mirrors the
-    state into an assign so re-renders agree with what the user sees:
+      <button type="button" phx-click={JS.set_attribute({"open", ""}, to: "#advanced")}>
+        Show advanced settings
+      </button>
 
-        <.accordion
-          id="advanced"
-          open={@open_sections["advanced"]}
-          toggle_event="toggle_section"
-          toggle_value="advanced"
-        >
-          <:title>Advanced</:title>
-          <:content>…</:content>
-        </.accordion>
-
-        def handle_event("toggle_section", %{"key" => key}, socket) do
-          open = socket.assigns.open_sections
-          {:noreply,
-           assign(socket, open_sections: Map.put(open, key, not Map.get(open, key, false)))}
-        end
-
-  Works without JavaScript in both modes (native `<details>`).
+  Works without JavaScript (native `<details>` on dead renders).
   """
 
   use Phoenix.Component
 
+  alias Phoenix.LiveView.JS
+
   attr :id, :string, required: true
-  attr :open, :boolean, default: false
-
-  attr :toggle_event, :string,
-    default: nil,
-    doc: "phx-click on the summary; sends %{\"key\" => toggle_value}"
-
-  attr :toggle_value, :string, default: nil
+  attr :open, :boolean, default: false, doc: "initial state only — client-owned after mount"
   attr :class, :any, default: nil, doc: "extra classes on the <details>"
   attr :title_class, :any, default: nil, doc: "extra classes on the summary"
 
@@ -60,13 +38,10 @@ defmodule PhoenixKitWeb.Components.Core.Accordion do
     <details
       id={@id}
       open={@open}
+      phx-mounted={JS.ignore_attributes(["open"])}
       class={["collapse collapse-arrow border border-base-200 bg-base-100", @class]}
     >
-      <summary
-        class={["collapse-title text-sm font-semibold", @title_class]}
-        phx-click={@toggle_event}
-        phx-value-key={@toggle_value}
-      >
+      <summary class={["collapse-title text-sm font-semibold", @title_class]}>
         {render_slot(@title)}
       </summary>
       <div class="collapse-content">

--- a/lib/phoenix_kit_web/components/core/accordion.ex
+++ b/lib/phoenix_kit_web/components/core/accordion.ex
@@ -1,74 +1,78 @@
 defmodule PhoenixKitWeb.Components.Core.Accordion do
   @moduledoc """
-  Accordion Component for collapsible content sections.
+  Collapsible content section on the native `<details>` element + daisyUI
+  `collapse` styling.
 
-  A versatile accordion component that allows users to expand/collapse
-  content sections, perfect for organizing advanced settings and options.
+  Rewritten 2026-08-06: the previous version emitted literal `\#{...}`
+  class text (string interpolation inside a plain HEEx attribute never
+  runs) and depended on `.accordion-*` CSS no host defines — it could
+  not have worked anywhere.
 
-  ## Features
+  ## Two modes
 
-  - Smooth animations and transitions
-  - Multiple accordion items in a single component
-  - Custom icons and styling
-  - Keyboard navigation support
-  - Controlled and uncontrolled modes
+  - **Uncontrolled** (default): the browser toggles the section — fine on
+    dead renders and static pages. In a connected LiveView any patch
+    resets the element to the server-rendered state (morphdom re-applies
+    the missing `open` attribute), so a section the user opened slams
+    shut on the next update.
+  - **Server-tracked** (recommended in LiveViews): pass `open` +
+    `toggle_event` (+ `toggle_value`). The summary click still toggles
+    natively — instant, no round-trip flicker — and the event mirrors the
+    state into an assign so re-renders agree with what the user sees:
 
-  ## Usage
+        <.accordion
+          id="advanced"
+          open={@open_sections["advanced"]}
+          toggle_event="toggle_section"
+          toggle_value="advanced"
+        >
+          <:title>Advanced</:title>
+          <:content>…</:content>
+        </.accordion>
 
-      <.accordion id="advanced-settings">
-        <:title>Advanced AWS Settings</:title>
-        <:content>
-          Your advanced settings content here...
-        </:content>
-      </.accordion>
+        def handle_event("toggle_section", %{"key" => key}, socket) do
+          open = socket.assigns.open_sections
+          {:noreply,
+           assign(socket, open_sections: Map.put(open, key, not Map.get(open, key, false)))}
+        end
+
+  Works without JavaScript in both modes (native `<details>`).
   """
 
   use Phoenix.Component
 
   attr :id, :string, required: true
   attr :open, :boolean, default: false
-  attr :class, :string, default: ""
+
+  attr :toggle_event, :string,
+    default: nil,
+    doc: "phx-click on the summary; sends %{\"key\" => toggle_value}"
+
+  attr :toggle_value, :string, default: nil
+  attr :class, :any, default: nil, doc: "extra classes on the <details>"
+  attr :title_class, :any, default: nil, doc: "extra classes on the summary"
 
   slot :title, required: true
   slot :content, required: true
 
   def accordion(assigns) do
     ~H"""
-    <div class="accordion #{open_class(@open)} #{sanitize_class(@class)}" id={@id}>
-      <input
-        type="checkbox"
-        class="accordion-toggle"
-        id={@id <> "-toggle"}
-        checked={@open}
-      />
-      <label
-        class="accordion-title cursor-pointer flex items-center justify-between p-4 bg-base-200 hover:bg-base-300 transition-colors duration-200"
-        for={@id <> "-toggle"}
+    <details
+      id={@id}
+      open={@open}
+      class={["collapse collapse-arrow border border-base-200 bg-base-100", @class]}
+    >
+      <summary
+        class={["collapse-title text-sm font-semibold", @title_class]}
+        phx-click={@toggle_event}
+        phx-value-key={@toggle_value}
       >
         {render_slot(@title)}
-        <div class="flex items-center gap-2">
-          <%!-- Chevron icon --%>
-          <svg
-            class="w-4 h-4 transition-transform duration-200 accordion-icon"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M19 9l-7 7-7-7"
-            />
-          </svg>
-        </div>
-      </label>
-      <div class="accordion-content overflow-hidden transition-all duration-300 ease-in-out">
-        <div class="p-4 bg-base-100 border-t border-base-200">
-          {render_slot(@content)}
-        </div>
+      </summary>
+      <div class="collapse-content">
+        {render_slot(@content)}
       </div>
-    </div>
+    </details>
     """
   end
 end

--- a/lib/phoenix_kit_web/components/core/accordion.ex
+++ b/lib/phoenix_kit_web/components/core/accordion.ex
@@ -30,11 +30,21 @@ defmodule PhoenixKitWeb.Components.Core.Accordion do
   use Phoenix.Component
 
   alias Phoenix.LiveView.JS
+  alias PhoenixKitWeb.Components.Core.ChangeCue
 
   attr :id, :string, required: true
   attr :open, :boolean, default: false, doc: "initial state only — client-owned after mount"
   attr :class, :any, default: nil, doc: "extra classes on the <details>"
   attr :title_class, :any, default: nil, doc: "extra classes on the summary"
+
+  attr :cue, :boolean,
+    default: false,
+    doc:
+      "opt into `PhoenixKitWeb.Components.Core.ChangeCue`: the section can be highlighted when " <>
+        "something inside it changes while the reader is elsewhere, and carries a quiet marker " <>
+        "until they open it"
+
+  attr :cue_label, :string, default: nil, doc: "wording for that marker (default \"Updated\")"
 
   slot :title, required: true
   slot :content, required: true
@@ -44,11 +54,13 @@ defmodule PhoenixKitWeb.Components.Core.Accordion do
     <details
       id={@id}
       open={@open}
-      phx-mounted={JS.ignore_attributes(["open"])}
+      data-change-region={@cue && @id}
+      phx-mounted={JS.ignore_attributes(cue_owned_attributes(@cue))}
       class={["collapse collapse-arrow border border-base-200 bg-base-100", @class]}
     >
       <summary class={["collapse-title text-sm font-semibold", @title_class]}>
         {render_slot(@title)}
+        <ChangeCue.change_marker :if={@cue} label={@cue_label} />
       </summary>
       <div class="collapse-content">
         {render_slot(@content)}
@@ -56,4 +68,10 @@ defmodule PhoenixKitWeb.Components.Core.Accordion do
     </details>
     """
   end
+
+  # `data-changed` is set by the client and must survive patches for the
+  # same reason `open` must: the server has no idea the reader hasn't
+  # looked yet, and morphdom would drop the marker on the next keystroke.
+  defp cue_owned_attributes(true), do: ["open", "data-changed"]
+  defp cue_owned_attributes(_), do: ["open"]
 end

--- a/lib/phoenix_kit_web/components/core/change_cue.ex
+++ b/lib/phoenix_kit_web/components/core/change_cue.ex
@@ -1,0 +1,109 @@
+defmodule PhoenixKitWeb.Components.Core.ChangeCue do
+  @moduledoc """
+  Tells the reader that a choice they just made changed something they
+  can't currently see.
+
+  Long forms hide detail behind collapsed sections, and a choice in one
+  place often rewrites another: picking a preset rewrites a checklist,
+  enabling an extension adds a permission row. The change is real,
+  correct, and invisible — it lands inside something nobody is looking at.
+
+  Deliberately NOT called "flash": Phoenix already has flash messages,
+  and the capability is "something over here changed", not an animation.
+
+  ## Using it
+
+  Mark the regions that can be cued — `<.accordion cue>` does this, or add
+  `data-change-region` to any container yourself — give the things inside
+  stable DOM ids, and push the ids that changed:
+
+      # in the LiveView, after working out what actually changed
+      {:noreply, ChangeCue.push(socket, ["ext-row-files", "authz-row-upload_files"],
+        announce: gettext("Permissions updated"))}
+
+  The server says WHAT changed. The client decides how to show it, because
+  only the client knows what is on screen:
+
+    * the region is open → the changed rows highlight;
+    * the region is closed → the region highlights AND keeps a quiet
+      "changed" marker. Opening it replays the row highlights and clears
+      the marker.
+
+  The marker is what makes this survive reality: a highlight that plays
+  while the reader is scrolled elsewhere is simply lost, and a timer that
+  forgets after N seconds turns "what changed here?" into a race. The
+  marker persists until the region is opened.
+
+  ## What it will not do
+
+  Scroll the page, open a section, move focus, or raise a toast. A cue
+  that moves the page under someone mid-form is worse than no cue.
+
+  ## Accessibility
+
+  A pulse tells a screen-reader user nothing, so a closed-region cue also
+  writes to a polite live region — the region's own words (`:announce`),
+  once per push, coalesced. Never assertive, never per-row, and never
+  repeated when the deferred highlights replay.
+
+  `prefers-reduced-motion` keeps the outline and the marker, drops the
+  pulse.
+  """
+
+  use Phoenix.Component
+
+  @event "pk:change-cue"
+
+  @doc """
+  Cues the elements whose ids are given.
+
+  Options:
+
+    * `:announce` — what a screen reader should hear when the change lands
+      in a CLOSED region. Say the result ("Permissions updated"), not the
+      mechanics. Omit it and nothing is announced.
+
+  A push with no ids is a no-op, so callers can pipe an empty diff through
+  without a conditional.
+  """
+  @spec push(Phoenix.LiveView.Socket.t(), [String.t()], keyword()) ::
+          Phoenix.LiveView.Socket.t()
+  def push(socket, ids, opts \\ [])
+
+  def push(socket, [], _opts), do: socket
+
+  def push(socket, ids, opts) when is_list(ids) do
+    payload = %{targets: Enum.uniq(ids)}
+
+    payload =
+      case Keyword.get(opts, :announce) do
+        text when is_binary(text) and text != "" -> Map.put(payload, :announce, text)
+        _ -> payload
+      end
+
+    Phoenix.LiveView.push_event(socket, @event, payload)
+  end
+
+  @doc "The client event name, exposed so consumers can assert on it."
+  @spec event() :: String.t()
+  def event, do: @event
+
+  @doc """
+  The marker shown on a closed region that changed while it was closed.
+
+  Rendered inside the region's own summary by `<.accordion cue>`; it stays
+  hidden until the client sets `data-changed` on the region, and the CSS
+  lives in the same stylesheet as the highlight so a consumer adds nothing.
+  """
+  attr :label, :string, default: nil
+
+  def change_marker(assigns) do
+    assigns = assign_new(assigns, :label, fn -> "Updated" end)
+
+    ~H"""
+    <span data-change-marker class="badge badge-primary badge-sm ml-2 hidden">
+      {@label}
+    </span>
+    """
+  end
+end

--- a/lib/phoenix_kit_web/components/core/change_cue.ex
+++ b/lib/phoenix_kit_web/components/core/change_cue.ex
@@ -53,9 +53,28 @@ defmodule PhoenixKitWeb.Components.Core.ChangeCue do
   use Phoenix.Component
 
   @event "pk:change-cue"
+  @seen_event "pk_cue_seen"
 
   @doc """
   Cues the elements whose ids are given.
+
+  Two forms:
+
+      # ids alone — the client finds each one's region itself
+      ChangeCue.push(socket, ["ext-row-files"])
+
+      # grouped by the region that CONTAINS them
+      ChangeCue.push(socket, %{"create-people" => ["authz-row-comment"]})
+
+  Group them when a change can make the element **disappear**. A row that
+  was removed cannot be found, and neither can the region around it, so a
+  plain id yields no cue at all — precisely when something visibly
+  vanished and the reader most needs telling. With a region named, the
+  client falls back to cueing that.
+
+  This is not the server deciding how to show the change: the client still
+  chooses rows-versus-region from what is actually on screen. The region
+  is provenance the DOM can no longer answer for itself.
 
   Options:
 
@@ -63,17 +82,34 @@ defmodule PhoenixKitWeb.Components.Core.ChangeCue do
       in a CLOSED region. Say the result ("Permissions updated"), not the
       mechanics. Omit it and nothing is announced.
 
-  A push with no ids is a no-op, so callers can pipe an empty diff through
-  without a conditional.
+  A push with nothing in it is a no-op, so callers can pipe an empty diff
+  through without a conditional.
   """
-  @spec push(Phoenix.LiveView.Socket.t(), [String.t()], keyword()) ::
+  @spec push(Phoenix.LiveView.Socket.t(), [String.t()] | %{String.t() => [String.t()]}, keyword()) ::
           Phoenix.LiveView.Socket.t()
   def push(socket, ids, opts \\ [])
 
   def push(socket, [], _opts), do: socket
 
+  def push(socket, ids, _opts) when is_map(ids) and map_size(ids) == 0, do: socket
+
+  def push(socket, ids, opts) when is_map(ids) do
+    ids
+    |> Enum.flat_map(fn {region, target_ids} ->
+      Enum.map(target_ids, &%{id: &1, region: region})
+    end)
+    |> do_push(socket, opts)
+  end
+
   def push(socket, ids, opts) when is_list(ids) do
-    payload = %{targets: Enum.uniq(ids)}
+    ids
+    |> Enum.map(&%{id: &1})
+    |> do_push(socket, opts)
+  end
+
+  defp do_push(targets, socket, opts) do
+    targets = Enum.uniq_by(targets, & &1.id)
+    payload = %{targets: targets}
 
     payload =
       case Keyword.get(opts, :announce) do
@@ -81,12 +117,47 @@ defmodule PhoenixKitWeb.Components.Core.ChangeCue do
         _ -> payload
       end
 
-    Phoenix.LiveView.push_event(socket, @event, payload)
+    if targets == [] do
+      socket
+    else
+      Phoenix.LiveView.push_event(socket, @event, payload)
+    end
   end
 
   @doc "The client event name, exposed so consumers can assert on it."
   @spec event() :: String.t()
   def event, do: @event
+
+  @doc """
+  The event a cued region pushes when the reader OPENS it, carrying
+  `%{"region" => id}`.
+
+  Handle it and reset that region's baseline:
+
+      def handle_event(ChangeCue.seen_event(), %{"region" => region}, socket) do
+        {:noreply, mark_region_seen(socket, region)}
+      end
+
+  Without it a marker means "something happened", which accumulates into a
+  lie: flip a preset back and forth and every section ends up marked even
+  though nothing differs from where you started. Diff against what the
+  reader last SAW, and returning to the original state clears the marks by
+  itself.
+  """
+  @spec seen_event() :: String.t()
+  def seen_event, do: @seen_event
+
+  @doc """
+  Tells the client a region has nothing to show any more — its state went
+  back to what the reader last saw. Clears the marker and any rows queued
+  for replay.
+  """
+  @spec clear(Phoenix.LiveView.Socket.t(), [String.t()]) :: Phoenix.LiveView.Socket.t()
+  def clear(socket, []), do: socket
+
+  def clear(socket, regions) when is_list(regions) do
+    Phoenix.LiveView.push_event(socket, @event, %{targets: [], clear: regions})
+  end
 
   @doc """
   The marker shown on a closed region that changed while it was closed.

--- a/lib/phoenix_kit_web/components/core/file_upload.ex
+++ b/lib/phoenix_kit_web/components/core/file_upload.ex
@@ -34,6 +34,13 @@ defmodule PhoenixKitWeb.Components.Core.FileUpload do
     default: nil,
     doc: "List of file IDs from last upload (for external use)"
 
+  attr :standalone, :boolean,
+    default: true,
+    doc:
+      "wrap the drop zone in its own `<form>`. Set FALSE when embedding inside another form — " <>
+        "HTML forbids nested forms and the browser closes the outer one at the inner tag, " <>
+        "silently pushing every later field out of the host form"
+
   attr :variant, :string,
     default: "full",
     doc: "Display variant - 'full' for drag-drop zone, 'button' for simple button only"
@@ -48,40 +55,19 @@ defmodule PhoenixKitWeb.Components.Core.FileUpload do
   defp full_upload(assigns) do
     ~H"""
     <div class="space-y-4">
-      <form phx-change="validate" id={"upload-form-" <> @upload.ref}>
-        <%!-- Drag and Drop Zone --%>
-        <div
-          class="border-2 border-dashed border-base-300 rounded-lg p-8 text-center transition-colors cursor-pointer hover:border-primary hover:bg-primary/5"
-          phx-drop-target={@upload.ref}
-          id={"drop-zone-" <> @upload.ref}
-        >
-          <label for={@upload.ref} class="cursor-pointer block">
-            <div class="flex flex-col items-center gap-2">
-              <.icon name={@icon} class="w-8 h-8 text-primary" />
-              <div>
-                <p class="font-semibold text-base-content">Drag files here or click to browse</p>
-                <p class="text-sm text-base-content/70 mt-1">
-                  <%= if @accept_description do %>
-                    {@accept_description}
-                  <% else %>
-                    Drop your files to upload
-                  <% end %>
-                </p>
-              </div>
-            </div>
-          </label>
-          <.live_file_input upload={@upload} class="hidden" />
-        </div>
-
-        <%!-- File Type and Size Info --%>
-        <%= if @accept_description != nil or @max_size_description != nil do %>
-          <p class="text-sm text-base-content/70 text-center">
-            <%= if @max_size_description do %>
-              Maximum file size: {@max_size_description}
-            <% end %>
-          </p>
-        <% end %>
+      <%!-- STANDALONE wraps the drop zone in its own form so `phx-change`
+           has something to hang on. Embedded, it must not: nested `<form>`
+           elements are invalid HTML, and the browser resolves that by
+           closing the OUTER form at the inner tag — which silently moves
+           every field after this point, including the host's submit
+           button and any hidden anti-spam field, outside the form that was
+           supposed to carry them. Nothing looks wrong; the host form just
+           stops containing half of itself. --%>
+      <form :if={@standalone} phx-change="validate" id={"upload-form-" <> @upload.ref}>
+        <.drop_zone {assigns} />
       </form>
+
+      <.drop_zone :if={not @standalone} {assigns} />
 
       <%!-- Active Uploads --%>
       <%= if length(@upload.entries) > 0 do %>
@@ -119,6 +105,44 @@ defmodule PhoenixKitWeb.Components.Core.FileUpload do
         </div>
       <% end %>
     </div>
+    """
+  end
+
+  # The drop zone itself, shared by both wrappings so they cannot drift.
+  defp drop_zone(assigns) do
+    ~H"""
+    <%!-- Drag and Drop Zone --%>
+    <div
+      class="border-2 border-dashed border-base-300 rounded-lg p-8 text-center transition-colors cursor-pointer hover:border-primary hover:bg-primary/5"
+      phx-drop-target={@upload.ref}
+      id={"drop-zone-" <> @upload.ref}
+    >
+      <label for={@upload.ref} class="cursor-pointer block">
+        <div class="flex flex-col items-center gap-2">
+          <.icon name={@icon} class="w-8 h-8 text-primary" />
+          <div>
+            <p class="font-semibold text-base-content">Drag files here or click to browse</p>
+            <p class="text-sm text-base-content/70 mt-1">
+              <%= if @accept_description do %>
+                {@accept_description}
+              <% else %>
+                Drop your files to upload
+              <% end %>
+            </p>
+          </div>
+        </div>
+      </label>
+      <.live_file_input upload={@upload} class="hidden" />
+    </div>
+
+    <%!-- File Type and Size Info --%>
+    <%= if @accept_description != nil or @max_size_description != nil do %>
+      <p class="text-sm text-base-content/70 text-center">
+        <%= if @max_size_description do %>
+          Maximum file size: {@max_size_description}
+        <% end %>
+      </p>
+    <% end %>
     """
   end
 

--- a/lib/phoenix_kit_web/components/core/mention_text.ex
+++ b/lib/phoenix_kit_web/components/core/mention_text.ex
@@ -16,16 +16,15 @@ defmodule PhoenixKitWeb.Components.Core.MentionText do
       the label the author saw, unlinked. This is the case that justifies
       keeping the label in the text at all.
 
-    * **a redacted chip** — it exists and they may not see it. They are told
-      that much and nothing more: no title, no uuid in the markup, no href.
-      Clicking asks the owners for access.
+    * **the title plus a lock** — it exists and they may not open it. The
+      sentence still reads as the thing it names; the lock says it isn't
+      theirs, and clicking asks the owners for access. No link.
 
-  The third case is a deliberate product choice, and it has a cost worth
-  knowing: showing "you don't have access to this" reveals that *something*
-  is there. That is the Discord model, chosen because the alternative —
-  silently dropping the mention — leaves a sentence with a hole in it and no
-  way to act. What is never revealed is the title, and a refreshed title is
-  never shown to someone who cannot open the record.
+  The third case shows a LIVE title by default, on the view that a record's
+  name is rarely the secret — the access is. Installs where the name IS
+  sensitive turn on `mentions_redact_titles`, and a forbidden mention then
+  falls back to the label the author stored, so a record renamed after the
+  fact never shows its new name to someone who cannot open it.
 
   ## Wiring the request-access click
 
@@ -123,8 +122,15 @@ defmodule PhoenixKitWeb.Components.Core.MentionText do
     """
   end
 
-  defp piece(%{piece: {%Token{} = token, %{state: :forbidden}}} = assigns) do
-    assigns = assign(assigns, token: token)
+  # The title, plus a lock. The sentence stays readable — a mention blanked
+  # to "No access" leaves a hole where a noun should be — and the lock says
+  # plainly that this one isn't yours to open. No href: knowing what it is
+  # called is not the same as being let in.
+  #
+  # `title` comes from the context, which falls back to the author's stored
+  # label when the record is gone or the install has redaction turned on.
+  defp piece(%{piece: {%Token{} = token, %{state: :forbidden} = info}} = assigns) do
+    assigns = assign(assigns, token: token, label: info[:title] || token.label)
 
     ~H"""
     <button
@@ -133,17 +139,19 @@ defmodule PhoenixKitWeb.Components.Core.MentionText do
       phx-click="pk_request_access"
       phx-value-type={@token.type}
       phx-value-uuid={@token.uuid}
-      class="badge badge-ghost badge-sm gap-1 align-baseline cursor-pointer"
-    >
-      <.icon name="hero-lock-closed" class="w-3 h-3" />
-      {gettext("No access")}
-    </button><span
+      title={gettext("You don't have access — click to request it")}
+      class="inline-flex items-baseline gap-0.5 cursor-pointer opacity-70 hover:opacity-100 underline decoration-dotted underline-offset-2"
+    >{prefix_for(@token)}{@label}<.icon
+      name="hero-lock-closed"
+      class="w-3 h-3 shrink-0 self-center"
+    /></button><span
       :if={not @allow_request}
-      class="badge badge-ghost badge-sm gap-1 align-baseline"
-    >
-      <.icon name="hero-lock-closed" class="w-3 h-3" />
-      {gettext("No access")}
-    </span>
+      title={gettext("You don't have access to this")}
+      class="inline-flex items-baseline gap-0.5 opacity-70"
+    >{prefix_for(@token)}{@label}<.icon
+      name="hero-lock-closed"
+      class="w-3 h-3 shrink-0 self-center"
+    /></span>
     """
   end
 

--- a/lib/phoenix_kit_web/components/core/mention_text.ex
+++ b/lib/phoenix_kit_web/components/core/mention_text.ex
@@ -1,0 +1,160 @@
+defmodule PhoenixKitWeb.Components.Core.MentionText do
+  @moduledoc """
+  Renders free text that may contain `@` and `#` mentions, resolved for the
+  person looking at it.
+
+      <.mention_text text={@comment.content} scope={@phoenix_kit_current_scope} />
+
+  Each mention becomes one of three things, and which one is a permission
+  decision made per viewer, at render:
+
+    * **a link** — they may open it, so they get the live title and a real
+      deep-link. The title is re-resolved rather than taken from the text,
+      so a renamed record reads correctly.
+
+    * **plain text** — it is gone, or its module was uninstalled. They get
+      the label the author saw, unlinked. This is the case that justifies
+      keeping the label in the text at all.
+
+    * **a redacted chip** — it exists and they may not see it. They are told
+      that much and nothing more: no title, no uuid in the markup, no href.
+      Clicking asks the owners for access.
+
+  The third case is a deliberate product choice, and it has a cost worth
+  knowing: showing "you don't have access to this" reveals that *something*
+  is there. That is the Discord model, chosen because the alternative —
+  silently dropping the mention — leaves a sentence with a hole in it and no
+  way to act. What is never revealed is the title, and a refreshed title is
+  never shown to someone who cannot open the record.
+
+  ## Wiring the request-access click
+
+  The chip pushes `"pk_request_access"` with `type` and `uuid`. Handle it
+  yourself, or get the handler and the dialog for free:
+
+      use PhoenixKit.Mentions.RequestAccess
+
+  Without either, the click is inert — the chip still renders and still
+  tells the reader why they cannot see the thing.
+
+  ## No JavaScript
+
+  Everything here is server-rendered. The typeahead that *inserts* mentions
+  is a progressive enhancement; reading them has never needed JS.
+  """
+  use Phoenix.Component
+  use Gettext, backend: PhoenixKitWeb.Gettext
+
+  import PhoenixKitWeb.Components.Core.Icon, only: [icon: 1]
+
+  alias PhoenixKit.Mentions
+  alias PhoenixKit.Mentions.Token
+  alias PhoenixKit.Utils.Routes
+
+  attr :text, :string, default: nil
+  attr :scope, :any, default: nil, doc: "the viewer — decides what resolves"
+  attr :class, :any, default: nil
+
+  attr :allow_request, :boolean,
+    default: true,
+    doc: "offer \"ask for access\" on a redacted mention"
+
+  attr :rest, :global
+
+  def mention_text(assigns) do
+    assigns =
+      assign_new(assigns, :pieces, fn ->
+        %{text: text, scope: scope} = assigns
+        context = Mentions.context(text, user_uuid: user_uuid(scope), scope: scope)
+
+        text
+        |> Token.split()
+        |> Enum.map(fn
+          %Token{} = token ->
+            {token, Map.get(context, {token.type, token.uuid}, %{state: :missing})}
+
+          piece ->
+            piece
+        end)
+      end)
+
+    ~H"""
+    <span class={@class} {@rest}><%= for piece <- @pieces do %>
+      <.piece
+        piece={piece}
+        allow_request={@allow_request}
+      />
+    <% end %></span>
+    """
+  end
+
+  # One rendered fragment: either a run of ordinary text or a resolved
+  # mention. Kept as its own component so the three mention states are
+  # readable side by side rather than nested in a comprehension.
+  attr :piece, :any, required: true
+  attr :allow_request, :boolean, required: true
+
+  defp piece(%{piece: text} = assigns) when is_binary(text) do
+    ~H"{@piece}"
+  end
+
+  defp piece(%{piece: {%Token{} = token, %{state: :ok} = info}} = assigns) do
+    assigns = assign(assigns, token: token, info: info)
+
+    ~H"""
+    <.link
+      :if={@info[:path]}
+      navigate={href(@info)}
+      class="link link-primary font-medium no-underline hover:underline"
+    >{prefix_for(@token)}{@info[:title]}</.link><span
+      :if={is_nil(@info[:path])}
+      class="font-medium"
+    >{prefix_for(@token)}{@info[:title]}</span>
+    """
+  end
+
+  # Deleted, or the module that owned it is no longer installed. The
+  # author's words survive; the link does not.
+  defp piece(%{piece: {%Token{} = token, %{state: :missing}}} = assigns) do
+    assigns = assign(assigns, token: token)
+
+    ~H"""
+    <span class="opacity-70" title={gettext("No longer available")}>{prefix_for(@token)}{@token.label}</span>
+    """
+  end
+
+  defp piece(%{piece: {%Token{} = token, %{state: :forbidden}}} = assigns) do
+    assigns = assign(assigns, token: token)
+
+    ~H"""
+    <button
+      :if={@allow_request}
+      type="button"
+      phx-click="pk_request_access"
+      phx-value-type={@token.type}
+      phx-value-uuid={@token.uuid}
+      class="badge badge-ghost badge-sm gap-1 align-baseline cursor-pointer"
+    >
+      <.icon name="hero-lock-closed" class="w-3 h-3" />
+      {gettext("No access")}
+    </button><span
+      :if={not @allow_request}
+      class="badge badge-ghost badge-sm gap-1 align-baseline"
+    >
+      <.icon name="hero-lock-closed" class="w-3 h-3" />
+      {gettext("No access")}
+    </span>
+    """
+  end
+
+  # An `@` keeps its sigil so a ping reads as a ping; a `#` does not,
+  # because the record's own title is the better label in a sentence.
+  defp prefix_for(%Token{kind: :user}), do: "@"
+  defp prefix_for(_), do: ""
+
+  defp href(%{path: path, prefixed: false}), do: path
+  defp href(%{path: path}), do: Routes.path(path)
+
+  defp user_uuid(%{user: %{uuid: uuid}}), do: uuid
+  defp user_uuid(_), do: nil
+end

--- a/lib/phoenix_kit_web/components/core/mention_text.ex
+++ b/lib/phoenix_kit_web/components/core/mention_text.ex
@@ -58,13 +58,28 @@ defmodule PhoenixKitWeb.Components.Core.MentionText do
     default: true,
     doc: "offer \"ask for access\" on a redacted mention"
 
+  attr :withhold_titles, :boolean,
+    default: false,
+    doc: """
+    For PUBLIC surfaces. A mention the viewer may not see renders with no
+    title and no stored label at all, rather than the usual name-plus-lock.
+    Independent of the `mentions_redact_titles` setting, which is a
+    judgement about internal readers and says nothing about the open web.
+    """
+
   attr :rest, :global
 
   def mention_text(assigns) do
     assigns =
       assign_new(assigns, :pieces, fn ->
         %{text: text, scope: scope} = assigns
-        context = Mentions.context(text, user_uuid: user_uuid(scope), scope: scope)
+
+        context =
+          Mentions.context(text,
+            user_uuid: user_uuid(scope),
+            scope: scope,
+            withhold_titles: assigns.withhold_titles
+          )
 
         text
         |> Token.split()
@@ -119,6 +134,20 @@ defmodule PhoenixKitWeb.Components.Core.MentionText do
 
     ~H"""
     <span class="opacity-70" title={gettext("No longer available")}>{prefix_for(@token)}{@token.label}</span>
+    """
+  end
+
+  # A public surface asked us to withhold, and this one points outside what
+  # the page may show. No title, no label, no link — the reader learns that
+  # something is referenced and nothing about what it is. The sentence keeps
+  # its noun slot, which is why this is not simply deleted: "blocked by" with
+  # nothing after it reads as a bug.
+  defp piece(%{piece: {%Token{}, %{state: :private}}} = assigns) do
+    ~H"""
+    <span
+      title={gettext("Not shown on this page")}
+      class="inline-flex items-baseline gap-0.5 opacity-60"
+    >{gettext("private item")}<.icon name="hero-lock-closed" class="w-3 h-3 shrink-0 self-center" /></span>
     """
   end
 

--- a/lib/phoenix_kit_web/components/core/sortable.ex
+++ b/lib/phoenix_kit_web/components/core/sortable.ex
@@ -79,9 +79,9 @@ defmodule PhoenixKitWeb.Components.Core.Sortable do
       id={@id}
       phx-hook={if @enabled, do: "SortableGrid"}
       data-sortable={if @enabled, do: "true"}
-      data-sortable-event={@event}
-      data-sortable-items=".sortable-item"
-      data-sortable-handle=".pk-drag-handle"
+      data-sortable-event={if @enabled, do: @event}
+      data-sortable-items={if @enabled, do: ".sortable-item"}
+      data-sortable-handle={if @enabled, do: ".pk-drag-handle"}
       {@rest}
     >
       {render_slot(@inner_block)}

--- a/lib/phoenix_kit_web/components/core/textarea.ex
+++ b/lib/phoenix_kit_web/components/core/textarea.ex
@@ -3,6 +3,7 @@ defmodule PhoenixKitWeb.Components.Core.Textarea do
   Provides a default textarea UI component.
   """
   use Phoenix.Component
+  use Gettext, backend: PhoenixKitWeb.Gettext
 
   import PhoenixKitWeb.Components.Core.FormFieldLabel, only: [label: 1]
   import PhoenixKitWeb.Components.Core.FormFieldError, only: [error: 1]
@@ -21,6 +22,13 @@ defmodule PhoenixKitWeb.Components.Core.Textarea do
     default: nil,
     doc:
       "extra classes merged onto the `<textarea>` element (e.g. `textarea-sm`, `min-h-[12rem]`)"
+
+  attr :mentions, :boolean,
+    default: false,
+    doc:
+      "offer `@` people and `#` records as the user types. Needs " <>
+        "`use PhoenixKit.Mentions.Live` on the LiveView for the search handler; " <>
+        "without JavaScript the field behaves exactly as it does today"
 
   attr :rest, :global,
     include: ~w(autocomplete cols maxlength disabled placeholder readonly required rows)
@@ -52,6 +60,7 @@ defmodule PhoenixKitWeb.Components.Core.Textarea do
       <textarea
         id={@id}
         name={@name}
+        phx-hook={@mentions && "MentionInput"}
         class={[
           "textarea min-h-[6rem] w-full focus:textarea-primary",
           @errors != [] && "textarea-error",
@@ -59,6 +68,10 @@ defmodule PhoenixKitWeb.Components.Core.Textarea do
         ]}
         {@rest}
       ><%= Phoenix.HTML.Form.normalize_value("textarea", @value) %></textarea>
+
+      <p :if={@mentions} class="mt-1 text-xs opacity-50">
+        {gettext("Type @ to mention someone, # to link a record.")}
+      </p>
 
       <.error :for={msg <- @errors}>{msg}</.error>
     </div>

--- a/lib/phoenix_kit_web/components/core/textarea.ex
+++ b/lib/phoenix_kit_web/components/core/textarea.ex
@@ -46,6 +46,11 @@ defmodule PhoenixKitWeb.Components.Core.Textarea do
   end
 
   def textarea(assigns) do
+    # The site switch, checked at render: with mentions off the field is an
+    # ordinary textarea again — no hook, no hint promising a feature that
+    # would silently return nothing.
+    assigns = assign(assigns, :mentions, assigns.mentions and PhoenixKit.Mentions.enabled?())
+
     ~H"""
     <div phx-feedback-for={@name}>
       <%!-- Required marker, kept in sync with `<.input>`. --%>

--- a/lib/phoenix_kit_web/components/layout_wrapper.ex
+++ b/lib/phoenix_kit_web/components/layout_wrapper.ex
@@ -553,6 +553,24 @@ defmodule PhoenixKitWeb.Components.LayoutWrapper do
                 <div class="flex-1">
                   {render_slot(@original_inner_block)}
                 </div>
+
+                <%!-- Where the collapse scroll keeper (phoenix_kit.js) parks the
+                     height it holds when a section closes near the page bottom.
+                     It belongs INSIDE the content column: the sidebar is a
+                     sticky grid item, so it only extends into the held space if
+                     the grid row grows — padding the document below <main>
+                     instead leaves the sidebar and the page background cut off
+                     at the old bottom edge. Server-rendered so morphdom keeps
+                     it, with `style` handed to the client so the height it sets
+                     survives patches. --%>
+                <div
+                  id="pk-collapse-pad"
+                  data-pk-collapse-pad
+                  aria-hidden="true"
+                  class="shrink-0"
+                  phx-mounted={Phoenix.LiveView.JS.ignore_attributes(["style"])}
+                >
+                </div>
               </div>
 
               <%!-- Desktop/Mobile Sidebar. lg:[scrollbar-gutter:stable]: the sidebar is

--- a/lib/phoenix_kit_web/components/media_browser.ex
+++ b/lib/phoenix_kit_web/components/media_browser.ex
@@ -2912,7 +2912,7 @@ defmodule PhoenixKitWeb.Components.MediaBrowser do
 
   # Display label for a creator — full name, falling back to email.
   defp creator_label(nil), do: nil
-  defp creator_label(user), do: User.full_name(user) || user.email
+  defp creator_label(user), do: User.display_name(user)
 
   # Display URL for a folder header image (cover or logo) by file uuid, or nil.
   # Loads the referenced file and enriches it for its signed URLs.

--- a/lib/phoenix_kit_web/components/multilang_form.ex
+++ b/lib/phoenix_kit_web/components/multilang_form.ex
@@ -840,6 +840,13 @@ defmodule PhoenixKitWeb.Components.MultilangForm do
   attr :title, :string, default: nil
   attr :hint, :string, default: nil
   attr :secondary_hint, :string, default: nil
+
+  attr :mentions, :boolean,
+    default: false,
+    doc:
+      "offer `@` people and `#` records while typing (textarea only). Needs " <>
+        "`use PhoenixKit.Mentions.Live` on the LiveView"
+
   attr :secondary_name, :string, default: nil
   attr :lang_data_key, :string, default: nil
   slot :label_extra
@@ -850,6 +857,16 @@ defmodule PhoenixKitWeb.Components.MultilangForm do
       if is_map(assigns.lang_data), do: assigns, else: assign(assigns, :lang_data, %{})
 
     is_primary = !assigns.multilang_enabled || assigns.current_lang == assigns.primary_language
+
+    # Opt-in AND site-enabled AND a textarea: the typeahead has nowhere to
+    # go in a single-line input, and a hint promising a feature that is
+    # switched off is worse than no hint.
+    assigns =
+      assign(
+        assigns,
+        :mentions_on,
+        assigns.mentions and assigns.type == "textarea" and PhoenixKit.Mentions.enabled?()
+      )
 
     # Resolve the lang_data lookup key: custom or default "_field_name"
     data_key = assigns.lang_data_key || "_#{assigns.field_name}"
@@ -920,6 +937,7 @@ defmodule PhoenixKitWeb.Components.MultilangForm do
             class={@input_class}
             rows={@rows}
             phx-debounce="300"
+            phx-hook={@mentions_on && "MentionInput"}
             required={@required}
             disabled={@disabled}
           >{@primary_value}</textarea>
@@ -931,9 +949,13 @@ defmodule PhoenixKitWeb.Components.MultilangForm do
             rows={@rows}
             placeholder={@primary_value}
             phx-debounce="300"
+            phx-hook={@mentions_on && "MentionInput"}
             disabled={@disabled}
           >{@lang_value || ""}</textarea>
         <% end %>
+        <p :if={@mentions_on} class="mt-1 text-xs opacity-50">
+          {gettext("Type @ to mention someone, # to link a record.")}
+        </p>
       <% else %>
         <%= if @is_primary do %>
           <input

--- a/lib/phoenix_kit_web/endpoint.ex
+++ b/lib/phoenix_kit_web/endpoint.ex
@@ -11,7 +11,7 @@ defmodule PhoenixKitWeb.Endpoint do
   ]
 
   socket "/live", Phoenix.LiveView.Socket,
-    websocket: [connect_info: [session: @session_options]],
+    websocket: [connect_info: [:peer_data, session: @session_options]],
     longpoll: false
 
   # Serve at "/" the static files from "priv/static" directory.

--- a/lib/phoenix_kit_web/integration.ex
+++ b/lib/phoenix_kit_web/integration.ex
@@ -609,6 +609,14 @@ defmodule PhoenixKitWeb.Integration do
         authenticated_live_routes()
       end
 
+    # Auto-discovered user-dashboard pages: any external module tab from
+    # `user_dashboard_tabs/0` that carries a `live_view` gets its route
+    # generated here (mirrors `compile_module_admin_routes/0`; the
+    # `:user_dashboard` context in `tab_callback_context/1` was dormant
+    # until this). Tabs without `live_view` — the hardcoded module blocks
+    # above — are untouched.
+    user_tab_routes = compile_module_user_routes(__CALLER__.module)
+
     quote do
       # Core dashboard routes (conditional on config)
       if unquote(PhoenixKit.Config.user_dashboard_enabled?()) do
@@ -628,7 +636,26 @@ defmodule PhoenixKitWeb.Integration do
       # Module user pages (full module names — no PhoenixKitWeb alias)
       scope "/", alias: false do
         unquote(module_routes)
+        unquote_splicing(user_tab_routes)
       end
+    end
+  end
+
+  # Auto-discover user-dashboard routes from external modules'
+  # `user_dashboard_tabs/0` (tabs with a `live_view` field). Skipped for
+  # PhoenixKit's own dev/test router, where parent modules don't exist.
+  @doc false
+  def compile_module_user_routes(caller_module) do
+    if caller_module == PhoenixKitWeb.Router do
+      []
+    else
+      PhoenixKit.ModuleDiscovery.discover_external_modules()
+      |> Enum.flat_map(fn mod ->
+        case Code.ensure_compiled(mod) do
+          {:module, _} -> collect_module_tabs(mod, :user_dashboard_tabs)
+          _ -> []
+        end
+      end)
     end
   end
 

--- a/lib/phoenix_kit_web/live/settings.html.heex
+++ b/lib/phoenix_kit_web/live/settings.html.heex
@@ -440,8 +440,25 @@
                   )}
                 </span>
               </div>
+              <.checkbox
+                name="settings[mentions_redact_titles]"
+                checked={@settings["mentions_redact_titles"] == "true"}
+                label={gettext("Hide titles of records the reader can't open")}
+                wrapper_class="mb-3"
+              />
+              <div class="label">
+                <span class="label-text-alt text-xs text-base-content/50">
+                  {gettext(
+                    "By default a mention shows what it names even to someone without access, with a lock icon and no link. Turn this on where the name itself is sensitive; they then see the name as it was when it was written, not its current one."
+                  )}
+                </span>
+              </div>
               <.unsaved_hint
-                dirty={@settings["mentions_enabled"] != @saved_settings["mentions_enabled"]}
+                dirty={
+                  @settings["mentions_enabled"] != @saved_settings["mentions_enabled"] or
+                    @settings["mentions_redact_titles"] !=
+                      @saved_settings["mentions_redact_titles"]
+                }
                 saved={
                   if(@saved_settings["mentions_enabled"] == "true",
                     do: gettext("On"),

--- a/lib/phoenix_kit_web/live/settings.html.heex
+++ b/lib/phoenix_kit_web/live/settings.html.heex
@@ -424,6 +424,32 @@
                 }
               />
             </div>
+
+            <%!-- Mentions --%>
+            <div class="form-control w-full">
+              <.checkbox
+                name="settings[mentions_enabled]"
+                checked={@settings["mentions_enabled"] == "true"}
+                label={gettext("Mentions and record links")}
+                wrapper_class="mb-3"
+              />
+              <div class="label">
+                <span class="label-text-alt text-xs text-base-content/50">
+                  {gettext(
+                    "Lets people type @ to mention someone and # to link a record, anywhere they can write free text. Turning it off stops the suggestions; mentions already written stay readable as plain text."
+                  )}
+                </span>
+              </div>
+              <.unsaved_hint
+                dirty={@settings["mentions_enabled"] != @saved_settings["mentions_enabled"]}
+                saved={
+                  if(@saved_settings["mentions_enabled"] == "true",
+                    do: gettext("On"),
+                    else: gettext("Off")
+                  )
+                }
+              />
+            </div>
           </div>
 
           <.section_header icon="hero-clock" title={gettext("Date & Time")} />

--- a/priv/static/assets/phoenix_kit.js
+++ b/priv/static/assets/phoenix_kit.js
@@ -5664,6 +5664,161 @@ if (typeof window.Chart === "undefined") {
   };
 })();
 
+// ---------------------------------------------------------------------------
+// Collapse scroll keeper. Closing an expanded <details class="collapse"> near
+// the bottom of the page shrinks the document; the browser clamps the scroll
+// position to the new maximum and the viewport jumps upward under the reader.
+// Just before the collapse, pad the document with a body spacer so it cannot
+// become shorter than the reader's current position — they stay put, looking
+// at the now-closed section, with blank space below the fold. Every pixel
+// they then scroll up releases a pixel of that spacer (height leaving from
+// entirely below the viewport is invisible), so the page works its way back
+// to its natural length without ever moving underfoot.
+//
+// Two deliberate choices, both learned from getting it wrong first:
+//
+//   * Measured on the summary ACTIVATION, not the `toggle` event. By the time
+//     `toggle` fires the element may already be collapsed — no animation
+//     under prefers-reduced-motion — leaving nothing to measure, and that is
+//     exactly the case where the jump is most jarring.
+//   * Released against the READER'S SCROLLING, not the live document height.
+//     Mid-collapse the document still contains the content that is on its way
+//     out, so height-based math reads the spacer as unnecessary and hands it
+//     back before the shrink lands — the clamp then happens anyway. Scroll
+//     distance is exact and needs no animation-timing machinery.
+//
+// Only the window-scrolled case is handled: the spacer lives on document.body,
+// safely OUTSIDE the LiveView container (morphdom never touches it). Inside an
+// inner scroll container a body spacer is useless and an injected child would
+// be discarded on the next patch, so those bail out to the browser default.
+(function() {
+  if (typeof window === "undefined" || typeof document === "undefined") return;
+
+  // Extra spacer height so (scrollTop + viewport) still fits inside the
+  // document after `shrink` px of content collapses away. `docHeight`
+  // includes any existing spacer, so the result stacks on top of it.
+  // Pure — unit-tested in test/js/collapse_space.test.cjs.
+  function extraSpaceNeeded(scrollTop, viewport, docHeight, shrink) {
+    var overshoot = scrollTop + viewport - (docHeight - shrink);
+    return overshoot > 0 ? Math.ceil(overshoot) : 0;
+  }
+
+  // Height the spacer still needs once the reader has scrolled up away from
+  // the position it was installed to protect. `highestTop` is the smallest
+  // scrollTop seen since it was installed, so scrolling back down cannot
+  // re-claim space that was already given up — the page only ever gets
+  // shorter, and only from below the fold.
+  function spacerAfterScrollUp(installedHeight, installedTop, highestTop) {
+    var released = Math.max(0, installedTop - highestTop);
+    return Math.max(0, installedHeight - released);
+  }
+
+  if (typeof module === "object" && module.exports) {
+    module.exports.extraSpaceNeeded = extraSpaceNeeded;
+    module.exports.spacerAfterScrollUp = spacerAfterScrollUp;
+  }
+
+  var spacer = null;
+  var installedHeight = 0;
+  var installedTop = 0;
+  var highestTop = 0;
+
+  function scrollTopNow() {
+    return (document.scrollingElement || document.documentElement).scrollTop;
+  }
+
+  function metrics() {
+    var el = document.scrollingElement || document.documentElement;
+    return { top: el.scrollTop, view: window.innerHeight, height: el.scrollHeight };
+  }
+
+  function insideInnerScroller(el) {
+    var node = el.parentElement;
+    while (node && node !== document.body) {
+      var oy = window.getComputedStyle(node).overflowY;
+      if (oy === "auto" || oy === "scroll") return true;
+      node = node.parentElement;
+    }
+    return false;
+  }
+
+  function releaseSpacer() {
+    if (!spacer) return;
+    spacer.remove();
+    spacer = null;
+    installedHeight = 0;
+    window.removeEventListener("scroll", onScroll);
+  }
+
+  function onScroll() {
+    if (!spacer) return;
+    var top = scrollTopNow();
+    if (top < highestTop) highestTop = top;
+    var next = spacerAfterScrollUp(installedHeight, installedTop, highestTop);
+    if (next <= 0) releaseSpacer();
+    else spacer.style.height = next + "px";
+  }
+
+  function hold(shrink) {
+    var m = metrics();
+    var extra = extraSpaceNeeded(m.top, m.view, m.height, shrink);
+    if (extra <= 0) return;
+
+    if (!spacer) {
+      spacer = document.createElement("div");
+      spacer.setAttribute("data-pk-collapse-spacer", "");
+      spacer.setAttribute("aria-hidden", "true");
+      spacer.style.width = "100%";
+      spacer.style.flex = "0 0 auto";
+      spacer.style.pointerEvents = "none";
+      document.body.appendChild(spacer);
+      window.addEventListener("scroll", onScroll, { passive: true });
+    }
+
+    // A second close stacks onto whatever is left and re-anchors: from here
+    // on, this is the position being protected.
+    installedHeight = spacer.offsetHeight + extra;
+    installedTop = m.top;
+    highestTop = m.top;
+    spacer.style.height = installedHeight + "px";
+  }
+
+  // Runs BEFORE the default action toggles the element, so the height read
+  // here is the full expanded one that is about to disappear.
+  function onSummaryActivate(e) {
+    var target = e.target;
+    if (!target || !target.closest) return;
+
+    var summary = target.closest("summary");
+    if (!summary) return;
+
+    var details = summary.closest("details");
+    if (!details || !details.classList.contains("collapse")) return;
+    if (!details.open) return; // opening: the document only grows
+    if (insideInnerScroller(details)) return;
+
+    var shrink = details.offsetHeight - summary.offsetHeight;
+    if (isFinite(shrink) && shrink > 0) hold(shrink);
+  }
+
+  document.addEventListener("click", onSummaryActivate, true);
+  document.addEventListener(
+    "keydown",
+    function(e) {
+      if (e.key === "Enter" || e.key === " " || e.key === "Spacebar") {
+        onSummaryActivate(e);
+      }
+    },
+    true
+  );
+
+  // Live navigation swaps the page content and resets the scroll position;
+  // whatever the old page was holding open is meaningless now.
+  window.addEventListener("phx:page-loading-stop", function() {
+    if (spacer && scrollTopNow() <= 0) releaseSpacer();
+  });
+})();
+
 (function() {
   if (typeof window === "undefined") return;
   window.PhoenixKitHooks = window.PhoenixKitHooks || {};

--- a/priv/static/assets/phoenix_kit.js
+++ b/priv/static/assets/phoenix_kit.js
@@ -5844,24 +5844,43 @@ if (typeof window.Chart === "undefined") {
 
 // ---------------------------------------------------------------------------
 // Section flash. When a click in one place changes something in ANOTHER —
-// picking a starting point that rewrites the capability checklists, enabling
-// an extension that adds a permission row — the change is real but silent:
-// it happens inside a collapsed section the reader isn't looking at. A brief
-// highlight on the affected section says "that click landed here" without
-// opening anything or moving the page.
+// picking a starting point that rewrites a capability checklist, enabling an
+// extension that adds a permission row — the change is real but silent: it
+// lands inside a section the reader isn't looking at. A brief highlight says
+// "that click landed here" without opening anything or moving the page.
 //
-// Server side: push_event(socket, "pk-flash", %{ids: ["section-a", ...]}).
+// Server side:
+//
+//     push_event(socket, "pk-flash", %{
+//       sections: [%{id: "create-people", targets: ["authz-row-comment"]}]
+//     })
+//
 // LiveView dispatches pushed events on `window` as `phx:<name>`, so this
 // needs no hook and no per-element wiring.
 //
-// Honors prefers-reduced-motion: those readers get the same outline, held
-// briefly, without the pulse.
+// Granularity follows what the reader can actually see:
+//
+//   * Section OPEN — flash the changed ROWS. Highlighting the whole section
+//     when its contents are visible says "something in here" to someone who
+//     is already looking at it.
+//   * Section CLOSED — flash the section itself, and REMEMBER the rows. If
+//     they open it within `PENDING_MS`, the rows flash then. Otherwise the
+//     answer to "what changed?" dies with the highlight, which is the one
+//     question the flash provokes.
+//
+// A change touching more rows than `MAX_TARGETS` flashes the section instead:
+// past a handful, individual highlights read as strobing rather than as
+// information.
+//
+// Honors prefers-reduced-motion: same outline, no pulse.
 (function() {
   if (typeof window === "undefined" || typeof document === "undefined") return;
 
   var STYLE_ID = "pk-flash-style";
   var CLASS = "pk-flash";
   var DURATION = 1400;
+  var PENDING_MS = 10000;
+  var MAX_TARGETS = 6;
 
   function ensureStyle() {
     if (document.getElementById(STYLE_ID)) return;
@@ -5877,6 +5896,7 @@ if (typeof window.Chart === "undefined") {
       "." + CLASS + " {" +
       "  animation: pk-flash-pulse 1.4s ease-out 1;" +
       "  border-color: var(--pk-flash-border, oklch(0.7 0.15 250 / 0.6));" +
+      "  border-radius: 0.5rem;" +
       "}" +
       "@media (prefers-reduced-motion: reduce) {" +
       "  ." + CLASS + " { animation: none; }" +
@@ -5885,13 +5905,12 @@ if (typeof window.Chart === "undefined") {
     document.head.appendChild(style);
   }
 
-  function flash(id) {
-    var el = document.getElementById(id);
+  function flash(el) {
     if (!el) return;
 
-    // Restart the animation when the same section flashes twice in a row:
-    // re-adding a class the element already has does nothing, so a rapid
-    // second change would look like nothing happened.
+    // Restart the animation when the same element flashes twice in a row:
+    // re-adding a class it already has does nothing, so a rapid second
+    // change would look like nothing happened.
     el.classList.remove(CLASS);
     void el.offsetWidth;
     el.classList.add(CLASS);
@@ -5902,12 +5921,76 @@ if (typeof window.Chart === "undefined") {
     }, DURATION);
   }
 
+  function flashIds(ids) {
+    ids.forEach(function(id) {
+      flash(document.getElementById(id));
+    });
+  }
+
+  // A <details> is the only thing here that can hide its own contents; any
+  // other container is treated as visible.
+  function collapsed(el) {
+    return el.tagName === "DETAILS" && !el.open;
+  }
+
+  function apply(section) {
+    var el = document.getElementById(section.id);
+    if (!el) return;
+
+    var targets = (section.targets || []).filter(function(id) {
+      return document.getElementById(id);
+    });
+
+    if (!targets.length || targets.length > MAX_TARGETS) {
+      flash(el);
+      return;
+    }
+
+    if (collapsed(el)) {
+      flash(el);
+      el.__pkPendingFlash = { targets: targets, until: Date.now() + PENDING_MS };
+    } else {
+      delete el.__pkPendingFlash;
+      flashIds(targets);
+    }
+  }
+
+  // Opening a section within the window answers "what changed in here?".
+  // Capture phase: `toggle` doesn't bubble.
+  document.addEventListener(
+    "toggle",
+    function(e) {
+      var el = e.target;
+      if (!el || el.tagName !== "DETAILS" || !el.open) return;
+
+      var pending = el.__pkPendingFlash;
+      if (!pending) return;
+
+      delete el.__pkPendingFlash;
+      if (Date.now() > pending.until) return;
+
+      ensureStyle();
+      // Let the reveal start before highlighting inside it, or the flash
+      // plays against content that is still zero-height.
+      window.setTimeout(function() {
+        flashIds(pending.targets);
+      }, 120);
+    },
+    true
+  );
+
   window.addEventListener("phx:pk-flash", function(event) {
-    var ids = (event.detail && event.detail.ids) || [];
-    if (!ids.length) return;
+    var detail = event.detail || {};
+    // `ids` is the whole-section form; `sections` carries row targets.
+    var sections =
+      detail.sections || (detail.ids || []).map(function(id) {
+        return { id: id, targets: [] };
+      });
+
+    if (!sections.length) return;
 
     ensureStyle();
-    ids.forEach(flash);
+    sections.forEach(apply);
   });
 })();
 

--- a/priv/static/assets/phoenix_kit.js
+++ b/priv/static/assets/phoenix_kit.js
@@ -6153,3 +6153,206 @@ if (typeof window.Chart === "undefined") {
   adopt(window.TesseraHooks);
   adopt(window.EtcherHooks);
 })();
+
+// ---------------------------------------------------------------------------
+// MentionInput — @ pings and # record links in any plain textarea.
+//
+// The surface this has to reach is ~70 ordinary `<textarea>` fields, not a
+// rich editor, so this attaches to the field itself and owns nothing else.
+// It watches for a trigger character at a word boundary, tracks the query
+// the user types after it, asks the server, and renders a small list
+// anchored under the caret.
+//
+// The server decides WHAT can be inserted; this decides only where the menu
+// sits and when it closes. Everything it inserts is a complete token, so a
+// half-typed mention is always just text.
+//
+// State is per-hook-instance, never global: several LiveViews can share a
+// page, and two textareas on one page must not fight over one menu.
+// ---------------------------------------------------------------------------
+(function() {
+  if (typeof window === "undefined") return;
+  window.PhoenixKitHooks = window.PhoenixKitHooks || {};
+
+  // A trigger only counts at the start of a word. Without this, an email
+  // address turns the rest of the line into a search box.
+  function triggerAt(value, caret) {
+    var i = caret - 1;
+    while (i >= 0) {
+      var ch = value[i];
+      if (ch === "@" || ch === "#") {
+        var before = i === 0 ? " " : value[i - 1];
+        if (/[\s(\[]/.test(before) || i === 0) {
+          return { char: ch, start: i, query: value.slice(i + 1, caret) };
+        }
+        return null;
+      }
+      // A query is one short run of ordinary characters. Newlines and the
+      // token's own delimiters end it, so an unclosed menu can't swallow a
+      // paragraph.
+      if (/[\n\r\]|]/.test(ch)) return null;
+      if (caret - i > 40) return null;
+      i--;
+    }
+    return null;
+  }
+
+  window.PhoenixKitHooks.MentionInput = {
+    mounted: function() {
+      var self = this;
+      this.el.setAttribute("autocomplete", "off");
+      this.active = null;
+      this.results = [];
+      this.cursor = 0;
+      this.seq = 0;
+
+      this.menu = document.createElement("ul");
+      this.menu.className =
+        "pk-mention-menu menu menu-sm bg-base-100 rounded-box shadow-lg border border-base-300 " +
+        "absolute z-[9999] hidden max-h-64 overflow-y-auto w-72 p-1";
+      this.menu.setAttribute("role", "listbox");
+      document.body.appendChild(this.menu);
+
+      this.close = function() {
+        self.active = null;
+        self.results = [];
+        self.cursor = 0;
+        self.menu.classList.add("hidden");
+      };
+
+      this.render = function() {
+        if (!self.active || !self.results.length) {
+          self.menu.classList.add("hidden");
+          return;
+        }
+        self.menu.innerHTML = "";
+        self.results.forEach(function(r, idx) {
+          var li = document.createElement("li");
+          var a = document.createElement("a");
+          a.className = idx === self.cursor ? "active" : "";
+          a.setAttribute("role", "option");
+          var title = document.createElement("span");
+          title.className = "font-medium truncate";
+          title.textContent = r.title;
+          a.appendChild(title);
+          if (r.subtitle) {
+            var sub = document.createElement("span");
+            sub.className = "text-xs opacity-60 truncate";
+            sub.textContent = r.subtitle;
+            a.appendChild(sub);
+          }
+          // mousedown, not click: click fires after blur, and blur has
+          // already closed the menu by then.
+          a.addEventListener("mousedown", function(e) {
+            e.preventDefault();
+            self.choose(idx);
+          });
+          li.appendChild(a);
+          self.menu.appendChild(li);
+        });
+        self.position();
+        self.menu.classList.remove("hidden");
+      };
+
+      // Anchored to the field rather than the caret: measuring a caret
+      // inside a textarea needs a mirror element, and being a few lines off
+      // is a much smaller problem than a menu that drifts as the text
+      // reflows.
+      this.position = function() {
+        var rect = self.el.getBoundingClientRect();
+        var top = rect.bottom + window.scrollY + 4;
+        var left = rect.left + window.scrollX;
+        var maxLeft = window.scrollX + document.documentElement.clientWidth - self.menu.offsetWidth - 8;
+        self.menu.style.top = top + "px";
+        self.menu.style.left = Math.max(8, Math.min(left, maxLeft)) + "px";
+      };
+
+      this.choose = function(idx) {
+        var r = self.results[idx];
+        if (!r || !self.active) return;
+        var value = self.el.value;
+        var before = value.slice(0, self.active.start);
+        var after = value.slice(self.el.selectionStart);
+        var trigger = r.kind === "user" ? "@" : "#";
+        var token = trigger + "[" + r.type + ":" + r.uuid + "|" + r.title + "]";
+        self.el.value = before + token + " " + after;
+        var caret = (before + token + " ").length;
+        self.el.setSelectionRange(caret, caret);
+        self.close();
+        // The field is inside a phx-change form; without this the server
+        // never sees the inserted token and the next save writes the old
+        // text back over it.
+        self.el.dispatchEvent(new Event("input", { bubbles: true }));
+        self.el.focus();
+      };
+
+      this.search = function() {
+        var caret = self.el.selectionStart;
+        var found = triggerAt(self.el.value, caret);
+        if (!found) {
+          self.close();
+          return;
+        }
+        self.active = found;
+        self.seq += 1;
+        var seq = self.seq;
+        self.pushEvent(
+          "pk_mention_search",
+          { kind: found.char === "@" ? "user" : "resource", query: found.query, seq: seq },
+          function(reply) {
+            // Out-of-order replies: the user kept typing while this one was
+            // in flight, so its results describe a query that no longer
+            // exists. Dropping them stops the list flickering backwards.
+            if (!reply || reply.seq !== self.seq) return;
+            self.results = reply.results || [];
+            self.cursor = 0;
+            self.render();
+          }
+        );
+      };
+
+      this.onInput = function() { self.search(); };
+
+      this.onKeyDown = function(e) {
+        if (!self.active || !self.results.length) {
+          if (e.key === "Escape") self.close();
+          return;
+        }
+        if (e.key === "ArrowDown") {
+          e.preventDefault();
+          self.cursor = (self.cursor + 1) % self.results.length;
+          self.render();
+        } else if (e.key === "ArrowUp") {
+          e.preventDefault();
+          self.cursor = (self.cursor - 1 + self.results.length) % self.results.length;
+          self.render();
+        } else if (e.key === "Enter" || e.key === "Tab") {
+          e.preventDefault();
+          self.choose(self.cursor);
+        } else if (e.key === "Escape") {
+          e.preventDefault();
+          self.close();
+        }
+      };
+
+      this.onBlur = function() { window.setTimeout(self.close, 120); };
+
+      this.el.addEventListener("input", this.onInput);
+      this.el.addEventListener("click", this.onInput);
+      this.el.addEventListener("keydown", this.onKeyDown);
+      this.el.addEventListener("blur", this.onBlur);
+      this.repositionHandler = function() { if (self.active) self.position(); };
+      window.addEventListener("scroll", this.repositionHandler, true);
+      window.addEventListener("resize", this.repositionHandler);
+    },
+
+    destroyed: function() {
+      // The menu lives on document.body, so it outlives the hook's element
+      // unless it is taken down explicitly — a LiveView patch that replaces
+      // the textarea would otherwise leave an orphan floating over the page.
+      if (this.menu && this.menu.parentNode) this.menu.parentNode.removeChild(this.menu);
+      window.removeEventListener("scroll", this.repositionHandler, true);
+      window.removeEventListener("resize", this.repositionHandler);
+    }
+  };
+})();

--- a/priv/static/assets/phoenix_kit.js
+++ b/priv/static/assets/phoenix_kit.js
@@ -5842,6 +5842,75 @@ if (typeof window.Chart === "undefined") {
   });
 })();
 
+// ---------------------------------------------------------------------------
+// Section flash. When a click in one place changes something in ANOTHER —
+// picking a starting point that rewrites the capability checklists, enabling
+// an extension that adds a permission row — the change is real but silent:
+// it happens inside a collapsed section the reader isn't looking at. A brief
+// highlight on the affected section says "that click landed here" without
+// opening anything or moving the page.
+//
+// Server side: push_event(socket, "pk-flash", %{ids: ["section-a", ...]}).
+// LiveView dispatches pushed events on `window` as `phx:<name>`, so this
+// needs no hook and no per-element wiring.
+//
+// Honors prefers-reduced-motion: those readers get the same outline, held
+// briefly, without the pulse.
+(function() {
+  if (typeof window === "undefined" || typeof document === "undefined") return;
+
+  var STYLE_ID = "pk-flash-style";
+  var CLASS = "pk-flash";
+  var DURATION = 1400;
+
+  function ensureStyle() {
+    if (document.getElementById(STYLE_ID)) return;
+
+    var style = document.createElement("style");
+    style.id = STYLE_ID;
+    style.textContent =
+      "@keyframes pk-flash-pulse {" +
+      "  0% { box-shadow: 0 0 0 0 var(--pk-flash-color, oklch(0.7 0.15 250 / 0.55)); }" +
+      "  70% { box-shadow: 0 0 0 6px var(--pk-flash-color, oklch(0.7 0.15 250 / 0)); }" +
+      "  100% { box-shadow: 0 0 0 0 var(--pk-flash-color, oklch(0.7 0.15 250 / 0)); }" +
+      "}" +
+      "." + CLASS + " {" +
+      "  animation: pk-flash-pulse 1.4s ease-out 1;" +
+      "  border-color: var(--pk-flash-border, oklch(0.7 0.15 250 / 0.6));" +
+      "}" +
+      "@media (prefers-reduced-motion: reduce) {" +
+      "  ." + CLASS + " { animation: none; }" +
+      "}";
+
+    document.head.appendChild(style);
+  }
+
+  function flash(id) {
+    var el = document.getElementById(id);
+    if (!el) return;
+
+    // Restart the animation when the same section flashes twice in a row:
+    // re-adding a class the element already has does nothing, so a rapid
+    // second change would look like nothing happened.
+    el.classList.remove(CLASS);
+    void el.offsetWidth;
+    el.classList.add(CLASS);
+
+    window.clearTimeout(el.__pkFlashTimer);
+    el.__pkFlashTimer = window.setTimeout(function() {
+      el.classList.remove(CLASS);
+    }, DURATION);
+  }
+
+  window.addEventListener("phx:pk-flash", function(event) {
+    var ids = (event.detail && event.detail.ids) || [];
+    if (!ids.length) return;
+
+    ensureStyle();
+    ids.forEach(flash);
+  });
+})();
+
 (function() {
   if (typeof window === "undefined") return;
   window.PhoenixKitHooks = window.PhoenixKitHooks || {};

--- a/priv/static/assets/phoenix_kit.js
+++ b/priv/static/assets/phoenix_kit.js
@@ -6273,8 +6273,11 @@ if (typeof window.Chart === "undefined") {
         var value = self.el.value;
         var before = value.slice(0, self.active.start);
         var after = value.slice(self.el.selectionStart);
-        var trigger = r.kind === "user" ? "@" : "#";
-        var token = trigger + "[" + r.type + ":" + r.uuid + "|" + r.title + "]";
+        // The server sends the finished token: building it here by
+        // concatenation produced something unparseable whenever a
+        // record's own name contained a `|` or a `]`.
+        var token = r.token;
+        if (!token) return;
         self.el.value = before + token + " " + after;
         var caret = (before + token + " ").length;
         self.el.setSelectionRange(caret, caret);

--- a/priv/static/assets/phoenix_kit.js
+++ b/priv/static/assets/phoenix_kit.js
@@ -5687,10 +5687,13 @@ if (typeof window.Chart === "undefined") {
 //     back before the shrink lands — the clamp then happens anyway. Scroll
 //     distance is exact and needs no animation-timing machinery.
 //
-// Only the window-scrolled case is handled: the spacer lives on document.body,
-// safely OUTSIDE the LiveView container (morphdom never touches it). Inside an
-// inner scroll container a body spacer is useless and an injected child would
-// be discarded on the next patch, so those bail out to the browser default.
+// The held height goes on the layout's [data-pk-collapse-pad] element when one
+// is present (PhoenixKit's admin layout marks its content column), so sticky
+// sidebars and page backgrounds extend through the blank area; otherwise a
+// body-level div is injected, which holds the position just as well but leaves
+// the blank area outside any app chrome. Only the window-scrolled case is
+// handled: inside an inner scroll container neither helps, so those bail out
+// to the browser default.
 (function() {
   if (typeof window === "undefined" || typeof document === "undefined") return;
 
@@ -5719,6 +5722,7 @@ if (typeof window.Chart === "undefined") {
   }
 
   var spacer = null;
+  var injected = false;
   var installedHeight = 0;
   var installedTop = 0;
   var highestTop = 0;
@@ -5742,9 +5746,37 @@ if (typeof window.Chart === "undefined") {
     return false;
   }
 
+  // The element that carries the held height. A layout that marks its content
+  // column with data-pk-collapse-pad gets the space INSIDE its own chrome, so
+  // sticky sidebars and page backgrounds extend through it; anything else
+  // falls back to a body-level div, which holds the scroll position just as
+  // well but leaves the blank area outside the app's layout.
+  function ensureSpacer() {
+    if (spacer && spacer.isConnected) return spacer;
+
+    var pad = document.querySelector("[data-pk-collapse-pad]");
+    if (pad) {
+      spacer = pad;
+      injected = false;
+    } else {
+      spacer = document.createElement("div");
+      spacer.setAttribute("data-pk-collapse-spacer", "");
+      spacer.setAttribute("aria-hidden", "true");
+      spacer.style.width = "100%";
+      spacer.style.flex = "0 0 auto";
+      spacer.style.pointerEvents = "none";
+      document.body.appendChild(spacer);
+      injected = true;
+    }
+
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return spacer;
+  }
+
   function releaseSpacer() {
     if (!spacer) return;
-    spacer.remove();
+    if (injected) spacer.remove();
+    else spacer.style.height = "";
     spacer = null;
     installedHeight = 0;
     window.removeEventListener("scroll", onScroll);
@@ -5764,16 +5796,7 @@ if (typeof window.Chart === "undefined") {
     var extra = extraSpaceNeeded(m.top, m.view, m.height, shrink);
     if (extra <= 0) return;
 
-    if (!spacer) {
-      spacer = document.createElement("div");
-      spacer.setAttribute("data-pk-collapse-spacer", "");
-      spacer.setAttribute("aria-hidden", "true");
-      spacer.style.width = "100%";
-      spacer.style.flex = "0 0 auto";
-      spacer.style.pointerEvents = "none";
-      document.body.appendChild(spacer);
-      window.addEventListener("scroll", onScroll, { passive: true });
-    }
+    ensureSpacer();
 
     // A second close stacks onto whatever is left and re-anchors: from here
     // on, this is the position being protected.

--- a/priv/static/assets/phoenix_kit.js
+++ b/priv/static/assets/phoenix_kit.js
@@ -5942,6 +5942,62 @@ if (typeof window.Chart === "undefined") {
     live.textContent = text;
   }
 
+  function onScreen(el) {
+    var r = el.getBoundingClientRect();
+    return r.bottom > 0 && r.top < (window.innerHeight || 0);
+  }
+
+  // Opening a long section puts most of it below the fold, so a highlight
+  // down there plays to nobody — the reader opens it, sees nothing, and
+  // the cue has cost them a click and told them less than nothing. Cue
+  // what is on screen now, and watch the rest until they scroll to it.
+  function replay(ids) {
+    var waiting = [];
+
+    ids.forEach(function(id) {
+      var el = document.getElementById(id);
+      if (!el) return;
+
+      if (onScreen(el)) {
+        cue(el);
+      } else {
+        waiting.push(el);
+      }
+    });
+
+    if (!waiting.length || typeof IntersectionObserver === "undefined") return;
+
+    var observer = new IntersectionObserver(
+      function(entries) {
+        entries.forEach(function(entry) {
+          if (!entry.isIntersecting) return;
+          cue(entry.target);
+          observer.unobserve(entry.target);
+        });
+      },
+      { threshold: 0.5 }
+    );
+
+    waiting.forEach(function(el) {
+      observer.observe(el);
+    });
+
+    // Don't watch forever: a section left open and never scrolled to
+    // shouldn't hold observers for the life of the page.
+    window.setTimeout(function() {
+      observer.disconnect();
+    }, 30000);
+  }
+
+  // One utterance per pushed change, however many regions it touched, and
+  // only for changes the reader cannot see: an open region announces
+  // itself by being visible.
+  function announceOnce(payload) {
+    if (payload.__announced) return;
+    payload.__announced = true;
+    announce(payload.announce);
+  }
+
   function markRegion(region, ids) {
     region.setAttribute("data-changed", "");
 
@@ -5959,17 +6015,32 @@ if (typeof window.Chart === "undefined") {
   }
 
   function apply(payload) {
-    var ids = payload.targets || [];
-    if (!ids.length) return;
+    var targets = (payload.targets || []).map(function(t) {
+      // Ids alone are still accepted; the grouped form carries a fallback
+      // region for targets that may not exist any more.
+      return typeof t === "string" ? { id: t } : t;
+    });
+
+    if (!targets.length) return;
 
     ensureStyle();
 
     var byRegion = new Map();
     var loose = [];
+    // Regions whose change REMOVED the element. There is nothing left to
+    // highlight, so the region itself carries the news — and nothing is
+    // queued for replay, because a missing id will still be missing when
+    // they open it.
+    var vanished = new Set();
 
-    ids.forEach(function(id) {
-      var el = document.getElementById(id);
-      if (!el) return;
+    targets.forEach(function(target) {
+      var el = document.getElementById(target.id);
+
+      if (!el) {
+        var anchor = target.region && document.getElementById(target.region);
+        if (anchor) vanished.add(anchor);
+        return;
+      }
 
       var region = el.closest(REGION);
 
@@ -5979,12 +6050,23 @@ if (typeof window.Chart === "undefined") {
       }
 
       if (!byRegion.has(region)) byRegion.set(region, []);
-      byRegion.get(region).push(id);
+      byRegion.get(region).push(target.id);
     });
 
     loose.forEach(cue);
 
-    var announced = false;
+    vanished.forEach(function(region) {
+      // Don't double-cue a region that also has surviving targets — those
+      // are handled below, and a row highlight says more than a region one.
+      if (byRegion.has(region)) return;
+
+      cue(region);
+
+      if (region.tagName === "DETAILS" && !region.open) {
+        region.setAttribute("data-changed", "");
+        announceOnce(payload);
+      }
+    });
 
     byRegion.forEach(function(regionIds, region) {
       var closed = region.tagName === "DETAILS" && !region.open;
@@ -5992,14 +6074,7 @@ if (typeof window.Chart === "undefined") {
       if (closed) {
         cue(region);
         markRegion(region, regionIds);
-
-        // Announce once per push, and only for a change the reader cannot
-        // see — an open region announces itself by being visible.
-        if (!announced) {
-          announce(payload.announce);
-          announced = true;
-        }
-
+        announceOnce(payload);
         return;
       }
 
@@ -6037,16 +6112,27 @@ if (typeof window.Chart === "undefined") {
       // that is still zero-height. Deliberately silent for screen readers:
       // the change was already announced when it landed.
       window.setTimeout(function() {
-        ids.slice(0, MAX_TARGETS).forEach(function(id) {
-          cue(document.getElementById(id));
-        });
-      }, 120);
+        replay(ids.slice(0, MAX_TARGETS));
+      }, 160);
     },
     true
   );
 
+  function clearRegions(ids) {
+    ids.forEach(function(id) {
+      var region = document.getElementById(id);
+      if (region) region.removeAttribute("data-changed");
+      delete pending[id];
+    });
+  }
+
   window.addEventListener("phx:pk:change-cue", function(event) {
-    apply(event.detail || {});
+    var detail = event.detail || {};
+    // A region whose state went back to what the reader last saw has
+    // nothing to show. Without this, flipping a choice back and forth
+    // leaves every section marked.
+    if (detail.clear) clearRegions(detail.clear);
+    apply(detail);
   });
 })();
 

--- a/priv/static/assets/phoenix_kit.js
+++ b/priv/static/assets/phoenix_kit.js
@@ -5843,44 +5843,41 @@ if (typeof window.Chart === "undefined") {
 })();
 
 // ---------------------------------------------------------------------------
-// Section flash. When a click in one place changes something in ANOTHER —
-// picking a starting point that rewrites a capability checklist, enabling an
-// extension that adds a permission row — the change is real but silent: it
-// lands inside a section the reader isn't looking at. A brief highlight says
-// "that click landed here" without opening anything or moving the page.
+// Change cue — "that choice changed something you can't see".
+// Server side: PhoenixKitWeb.Components.Core.ChangeCue.push/3, whose
+// moduledoc is the reference. This is the client half.
 //
-// Server side:
+// The server sends only WHAT changed (element ids). It cannot decide how to
+// show it, because it doesn't know what's on screen: whether a <details> is
+// open is client state, and so is the scroll position. So the client
+// resolves each id, walks up to its [data-change-region], and picks:
 //
-//     push_event(socket, "pk-flash", %{
-//       sections: [%{id: "create-people", targets: ["authz-row-comment"]}]
-//     })
+//   * region open   -> highlight the changed rows. Highlighting the whole
+//     region tells someone already reading it nothing.
+//   * region closed -> highlight the region and MARK it. Opening it replays
+//     the row highlights and clears the mark.
 //
-// LiveView dispatches pushed events on `window` as `phx:<name>`, so this
-// needs no hook and no per-element wiring.
+// The mark, not a timer, is what makes this survive reality. A highlight
+// that plays while the reader is scrolled away is simply lost, and an
+// N-second memory turns "what changed in here?" into a race against a
+// stopwatch. The mark waits.
 //
-// Granularity follows what the reader can actually see:
-//
-//   * Section OPEN — flash the changed ROWS. Highlighting the whole section
-//     when its contents are visible says "something in here" to someone who
-//     is already looking at it.
-//   * Section CLOSED — flash the section itself, and REMEMBER the rows. If
-//     they open it within `PENDING_MS`, the rows flash then. Otherwise the
-//     answer to "what changed?" dies with the highlight, which is the one
-//     question the flash provokes.
-//
-// A change touching more rows than `MAX_TARGETS` flashes the section instead:
-// past a handful, individual highlights read as strobing rather than as
-// information.
-//
-// Honors prefers-reduced-motion: same outline, no pulse.
+// Won't scroll, open anything, or move focus.
 (function() {
   if (typeof window === "undefined" || typeof document === "undefined") return;
 
-  var STYLE_ID = "pk-flash-style";
-  var CLASS = "pk-flash";
+  var STYLE_ID = "pk-change-cue-style";
+  var CLASS = "pk-cued";
+  var REGION = "[data-change-region]";
   var DURATION = 1400;
-  var PENDING_MS = 10000;
   var MAX_TARGETS = 6;
+  var ANNOUNCE_GAP = 1000;
+
+  // Pending rows per region id. Kept off the DOM node: LiveView can replace
+  // an element between the change and the reader opening it, and state on
+  // the old node would go with it.
+  var pending = {};
+  var lastAnnounce = 0;
 
   function ensureStyle() {
     if (document.getElementById(STYLE_ID)) return;
@@ -5888,109 +5885,168 @@ if (typeof window.Chart === "undefined") {
     var style = document.createElement("style");
     style.id = STYLE_ID;
     style.textContent =
-      "@keyframes pk-flash-pulse {" +
-      "  0% { box-shadow: 0 0 0 0 var(--pk-flash-color, oklch(0.7 0.15 250 / 0.55)); }" +
-      "  70% { box-shadow: 0 0 0 6px var(--pk-flash-color, oklch(0.7 0.15 250 / 0)); }" +
-      "  100% { box-shadow: 0 0 0 0 var(--pk-flash-color, oklch(0.7 0.15 250 / 0)); }" +
+      "@keyframes pk-cue-pulse {" +
+      "  0% { box-shadow: 0 0 0 0 var(--pk-cue-color, oklch(0.7 0.15 250 / 0.55)); }" +
+      "  70% { box-shadow: 0 0 0 6px var(--pk-cue-color, oklch(0.7 0.15 250 / 0)); }" +
+      "  100% { box-shadow: 0 0 0 0 var(--pk-cue-color, oklch(0.7 0.15 250 / 0)); }" +
       "}" +
       "." + CLASS + " {" +
-      "  animation: pk-flash-pulse 1.4s ease-out 1;" +
-      "  border-color: var(--pk-flash-border, oklch(0.7 0.15 250 / 0.6));" +
+      "  animation: pk-cue-pulse 1.4s ease-out 1;" +
       "  border-radius: 0.5rem;" +
       "}" +
+      // The marker rides the region's own state, so it survives patches
+      // (the region declares data-changed client-owned) and needs no
+      // server round-trip to clear.
+      "[data-change-region][data-changed] [data-change-marker] { display: inline-flex; }" +
       "@media (prefers-reduced-motion: reduce) {" +
-      "  ." + CLASS + " { animation: none; }" +
+      "  ." + CLASS + " { animation: none; outline: 2px solid var(--pk-cue-color, currentColor); }" +
       "}";
 
     document.head.appendChild(style);
   }
 
-  function flash(el) {
+  function cue(el) {
     if (!el) return;
 
-    // Restart the animation when the same element flashes twice in a row:
-    // re-adding a class it already has does nothing, so a rapid second
-    // change would look like nothing happened.
+    // Restart rather than re-add: a class an element already has changes
+    // nothing, so a rapid second change would look like nothing happened.
     el.classList.remove(CLASS);
     void el.offsetWidth;
     el.classList.add(CLASS);
 
-    window.clearTimeout(el.__pkFlashTimer);
-    el.__pkFlashTimer = window.setTimeout(function() {
+    window.clearTimeout(el.__pkCueTimer);
+    el.__pkCueTimer = window.setTimeout(function() {
       el.classList.remove(CLASS);
     }, DURATION);
   }
 
-  function flashIds(ids) {
+  function announce(text) {
+    if (!text) return;
+
+    var now = Date.now();
+    if (now - lastAnnounce < ANNOUNCE_GAP) return;
+    lastAnnounce = now;
+
+    var live = document.getElementById("pk-change-cue-status");
+
+    if (!live) {
+      live = document.createElement("div");
+      live.id = "pk-change-cue-status";
+      live.setAttribute("role", "status");
+      live.setAttribute("aria-live", "polite");
+      live.setAttribute("aria-atomic", "true");
+      live.className = "sr-only";
+      document.body.appendChild(live);
+    }
+
+    live.textContent = text;
+  }
+
+  function markRegion(region, ids) {
+    region.setAttribute("data-changed", "");
+
+    var key = region.getAttribute("data-change-region") || region.id;
+    if (!key) return;
+
+    var held = pending[key] || [];
+    // Union: a second change while still closed adds to the answer rather
+    // than replacing it.
     ids.forEach(function(id) {
-      flash(document.getElementById(id));
+      if (held.indexOf(id) === -1) held.push(id);
+    });
+
+    pending[key] = held;
+  }
+
+  function apply(payload) {
+    var ids = payload.targets || [];
+    if (!ids.length) return;
+
+    ensureStyle();
+
+    var byRegion = new Map();
+    var loose = [];
+
+    ids.forEach(function(id) {
+      var el = document.getElementById(id);
+      if (!el) return;
+
+      var region = el.closest(REGION);
+
+      if (!region) {
+        loose.push(el);
+        return;
+      }
+
+      if (!byRegion.has(region)) byRegion.set(region, []);
+      byRegion.get(region).push(id);
+    });
+
+    loose.forEach(cue);
+
+    var announced = false;
+
+    byRegion.forEach(function(regionIds, region) {
+      var closed = region.tagName === "DETAILS" && !region.open;
+
+      if (closed) {
+        cue(region);
+        markRegion(region, regionIds);
+
+        // Announce once per push, and only for a change the reader cannot
+        // see — an open region announces itself by being visible.
+        if (!announced) {
+          announce(payload.announce);
+          announced = true;
+        }
+
+        return;
+      }
+
+      // Past a handful, individual highlights read as strobing rather than
+      // as information.
+      if (regionIds.length > MAX_TARGETS) {
+        cue(region);
+      } else {
+        regionIds.forEach(function(id) {
+          cue(document.getElementById(id));
+        });
+      }
     });
   }
 
-  // A <details> is the only thing here that can hide its own contents; any
-  // other container is treated as visible.
-  function collapsed(el) {
-    return el.tagName === "DETAILS" && !el.open;
-  }
-
-  function apply(section) {
-    var el = document.getElementById(section.id);
-    if (!el) return;
-
-    var targets = (section.targets || []).filter(function(id) {
-      return document.getElementById(id);
-    });
-
-    if (!targets.length || targets.length > MAX_TARGETS) {
-      flash(el);
-      return;
-    }
-
-    if (collapsed(el)) {
-      flash(el);
-      el.__pkPendingFlash = { targets: targets, until: Date.now() + PENDING_MS };
-    } else {
-      delete el.__pkPendingFlash;
-      flashIds(targets);
-    }
-  }
-
-  // Opening a section within the window answers "what changed in here?".
+  // Opening a marked region answers the question the mark raised.
   // Capture phase: `toggle` doesn't bubble.
   document.addEventListener(
     "toggle",
     function(e) {
-      var el = e.target;
-      if (!el || el.tagName !== "DETAILS" || !el.open) return;
+      var region = e.target;
+      if (!region || region.tagName !== "DETAILS" || !region.open) return;
+      if (!region.hasAttribute("data-changed")) return;
 
-      var pending = el.__pkPendingFlash;
-      if (!pending) return;
+      var key = region.getAttribute("data-change-region") || region.id;
+      var ids = (key && pending[key]) || [];
 
-      delete el.__pkPendingFlash;
-      if (Date.now() > pending.until) return;
+      region.removeAttribute("data-changed");
+      if (key) delete pending[key];
+      if (!ids.length) return;
 
       ensureStyle();
-      // Let the reveal start before highlighting inside it, or the flash
-      // plays against content that is still zero-height.
+
+      // Let the reveal start first, or the highlight plays against content
+      // that is still zero-height. Deliberately silent for screen readers:
+      // the change was already announced when it landed.
       window.setTimeout(function() {
-        flashIds(pending.targets);
+        ids.slice(0, MAX_TARGETS).forEach(function(id) {
+          cue(document.getElementById(id));
+        });
       }, 120);
     },
     true
   );
 
-  window.addEventListener("phx:pk-flash", function(event) {
-    var detail = event.detail || {};
-    // `ids` is the whole-section form; `sections` carries row targets.
-    var sections =
-      detail.sections || (detail.ids || []).map(function(id) {
-        return { id: id, targets: [] };
-      });
-
-    if (!sections.length) return;
-
-    ensureStyle();
-    sections.forEach(apply);
+  window.addEventListener("phx:pk:change-cue", function(event) {
+    apply(event.detail || {});
   });
 })();
 

--- a/test/js/collapse_space.test.cjs
+++ b/test/js/collapse_space.test.cjs
@@ -1,0 +1,131 @@
+"use strict";
+
+// Unit tests for the pure sizing math behind the collapse scroll keeper in
+// priv/static/assets/phoenix_kit.js — the body spacer that stops the page
+// from getting shorter than the viewer's scroll position when a
+// <details class="collapse"> closes. The bundle is browser code (IIFEs that
+// assign onto `window`), so stub the globals it touches at load time; the
+// DOM-using parts themselves are not invoked here.
+//
+// Run: mix test.js  (node --test needs the explicit file on Node 25)
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const noop = () => {};
+
+function stubElement() {
+  return {
+    style: {},
+    dataset: {},
+    classList: { add: noop, remove: noop, toggle: noop, contains: () => false },
+    setAttribute: noop,
+    getAttribute: () => null,
+    removeAttribute: noop,
+    appendChild: noop,
+    remove: noop,
+    addEventListener: noop,
+    removeEventListener: noop,
+    querySelector: () => null,
+    querySelectorAll: () => [],
+  };
+}
+
+global.document = {
+  documentElement: stubElement(),
+  head: stubElement(),
+  body: stubElement(),
+  createElement: stubElement,
+  createTextNode: () => ({}),
+  getElementById: () => null,
+  querySelector: () => null,
+  querySelectorAll: () => [],
+  addEventListener: noop,
+  removeEventListener: noop,
+  readyState: "complete",
+};
+
+const storage = {
+  getItem: () => null,
+  setItem: noop,
+  removeItem: noop,
+  key: () => null,
+  length: 0,
+};
+
+global.window = {
+  PhoenixKitHooks: {},
+  addEventListener: noop,
+  removeEventListener: noop,
+  matchMedia: () => ({ matches: false, addEventListener: noop, removeEventListener: noop }),
+  localStorage: storage,
+  sessionStorage: storage,
+  location: { href: "http://localhost/", reload: noop },
+  navigator: { userAgent: "node" },
+  document: global.document,
+  setTimeout,
+  clearTimeout,
+};
+
+global.localStorage = storage;
+global.sessionStorage = storage;
+
+const {
+  extraSpaceNeeded,
+  spacerAfterScrollUp,
+} = require("../../priv/static/assets/phoenix_kit.js");
+
+// Scenario used throughout: 1000px viewport. Sizes are px.
+
+test("extraSpaceNeeded: viewer near the bottom gets exactly the clamped-off height", () => {
+  // Document 3200 tall, scrolled to 2000 → viewing 2000..3000. Collapsing
+  // 1200px leaves a 2000-tall document; 3000 - 2000 = 1000px would clamp.
+  assert.equal(extraSpaceNeeded(2000, 1000, 3200, 1200), 1000);
+});
+
+test("extraSpaceNeeded: viewer high up needs nothing", () => {
+  // Viewing 0..1000 of 3200; even after -1200 the document (2000) still
+  // contains the viewport.
+  assert.equal(extraSpaceNeeded(0, 1000, 3200, 1200), 0);
+});
+
+test("extraSpaceNeeded: exact fit is not an overshoot", () => {
+  // Viewing 1000..2000; post-collapse height is exactly 2000.
+  assert.equal(extraSpaceNeeded(1000, 1000, 3200, 1200), 0);
+});
+
+test("extraSpaceNeeded: fractional overshoot rounds up, never leaving a sub-pixel clamp", () => {
+  assert.equal(extraSpaceNeeded(1000.5, 1000, 3200, 1200), 1);
+});
+
+test("spacerAfterScrollUp: still at the anchor, the whole spacer is needed", () => {
+  // Installed 800px of space at scrollTop 2000; reader has not moved.
+  assert.equal(spacerAfterScrollUp(800, 2000, 2000), 800);
+});
+
+test("spacerAfterScrollUp: scrolling up releases exactly the distance travelled", () => {
+  // Up 300px → 300px of blank space is now fully below the fold.
+  assert.equal(spacerAfterScrollUp(800, 2000, 1700), 500);
+});
+
+test("spacerAfterScrollUp: scrolling past the whole spacer clears it", () => {
+  assert.equal(spacerAfterScrollUp(800, 2000, 1100), 0);
+  assert.equal(spacerAfterScrollUp(800, 2000, 0), 0);
+});
+
+test("spacerAfterScrollUp: down-then-back-up does not re-claim released space", () => {
+  // highestTop is the HIGHEST point reached (smallest scrollTop), so a detour
+  // downward cannot hand back space the page already gave up. Reader went up
+  // 300 (highestTop 1700) then back down to 1900 — still 500.
+  assert.equal(spacerAfterScrollUp(800, 2000, 1700), 500);
+});
+
+test("spacerAfterScrollUp: scrolling DOWN from the anchor never grows the spacer", () => {
+  // Scrolling into the blank area must not feed it — that would be an
+  // endless runway of empty page.
+  assert.equal(spacerAfterScrollUp(800, 2000, 2000), 800);
+});
+
+test("spacerAfterScrollUp: never negative", () => {
+  assert.equal(spacerAfterScrollUp(0, 2000, 2000), 0);
+});

--- a/test/phoenix_kit/mentions_redaction_test.exs
+++ b/test/phoenix_kit/mentions_redaction_test.exs
@@ -1,0 +1,42 @@
+defmodule PhoenixKit.MentionsRedactionTest do
+  @moduledoc """
+  The extra-security mode, in its own file and NOT async.
+
+  It flips a real site setting, and settings are ETS-cached rather than
+  transactional — a value written inside a sandbox transaction survives the
+  rollback in the cache and would leak into whatever async test ran next.
+  """
+  use PhoenixKit.DataCase, async: false
+
+  alias PhoenixKit.Mentions
+  alias PhoenixKit.Settings
+
+  @uuid "018e3c4a-9f6b-7890-abcd-ef1234567890"
+
+  defp set_redaction(value) do
+    {:ok, _} = Settings.update_setting("mentions_redact_titles", value)
+    :ok
+  end
+
+  test "off by default: a record's name is rarely the secret, the access is" do
+    set_redaction("false")
+    refute Mentions.redact_titles?()
+  end
+
+  test "on, a forbidden mention shows the label the author stored" do
+    set_redaction("true")
+
+    try do
+      assert Mentions.redact_titles?()
+
+      # `post` is registered but declares no visibility check, so it is
+      # forbidden for everyone. With redaction on, nothing is resolved for
+      # it — the title can only be the author's stored label.
+      assert %{state: :forbidden, title: "Name At Write Time"} =
+               Mentions.context("see #[post:#{@uuid}|Name At Write Time]")
+               |> Map.fetch!({"post", @uuid})
+    after
+      set_redaction("false")
+    end
+  end
+end

--- a/test/phoenix_kit/mentions_redaction_test.exs
+++ b/test/phoenix_kit/mentions_redaction_test.exs
@@ -10,6 +10,7 @@ defmodule PhoenixKit.MentionsRedactionTest do
 
   alias PhoenixKit.Mentions
   alias PhoenixKit.Settings
+  alias PhoenixKit.Users.Auth
 
   @uuid "018e3c4a-9f6b-7890-abcd-ef1234567890"
 
@@ -37,6 +38,81 @@ defmodule PhoenixKit.MentionsRedactionTest do
                |> Map.fetch!({"post", @uuid})
     after
       set_redaction("false")
+    end
+  end
+
+  describe "withhold_titles: the public-surface floor" do
+    test "a forbidden mention gives up its title AND the stored label" do
+      # The setting is OFF — the ordinary internal judgement, and the one
+      # this install actually runs with. A public page must still be able
+      # to withhold on its own account, because the two audiences share one
+      # renderer and only one of them is the open web.
+      set_redaction("false")
+
+      assert %{state: :forbidden, title: "Name At Write Time"} =
+               Mentions.context("see #[post:#{@uuid}|Name At Write Time]")
+               |> Map.fetch!({"post", @uuid})
+
+      assert %{state: :private} =
+               Mentions.context("see #[post:#{@uuid}|Name At Write Time]",
+                 withhold_titles: true
+               )
+               |> Map.fetch!({"post", @uuid})
+    end
+
+    test "markdown honours the withheld state instead of printing the label" do
+      set_redaction("false")
+
+      md = Mentions.to_markdown("see #[post:#{@uuid}|Leak Me]", withhold_titles: true)
+
+      # The catch-all clause used to swallow `:private` and emit
+      # `token.label`, so passing the flag into a markdown render was a
+      # silent no-op — the HEEx component withheld and the comment bodies
+      # right next to it did not.
+      refute md =~ "Leak Me"
+      assert md =~ "private item"
+    end
+
+    test "a user mention loses its admin link when withheld" do
+      set_redaction("false")
+
+      # A REAL user: a made-up uuid resolves to `:missing`, which has no
+      # `:path` either and would have passed this test for entirely the
+      # wrong reason.
+      {:ok, user} =
+        Auth.register_user(%{
+          email: "mention-link-#{System.unique_integer([:positive])}@example.com",
+          password: "ValidPassword123!"
+        })
+
+      text = "ping @[user:#{user.uuid}|Alice]"
+
+      # `user` is a public type, so it is always allowed — and its resolved
+      # path is an /admin/users/view URL. Linking that from a public page
+      # hands an anonymous reader an admin route and a user uuid.
+      open = Mentions.context(text) |> Map.fetch!({"user", user.uuid})
+      assert %{state: :ok} = open
+      assert is_binary(open[:path]), "baseline changed — this test no longer proves anything"
+
+      withheld = Mentions.context(text, withhold_titles: true) |> Map.fetch!({"user", user.uuid})
+
+      assert %{state: :ok} = withheld
+      refute Map.has_key?(withheld, :path), "a public surface linked into the admin app"
+    end
+
+    test "the withheld state carries no title key at all" do
+      set_redaction("false")
+
+      state =
+        Mentions.context("see #[post:#{@uuid}|Leak Me]", withhold_titles: true)
+        |> Map.fetch!({"post", @uuid})
+
+      # Not `title: nil` — absent. A renderer doing `info[:title] ||
+      # token.label` would otherwise fall straight back to the label, which
+      # is the record's name as of writing and exactly what withholding was
+      # for.
+      refute Map.has_key?(state, :title)
+      refute state |> inspect() |> String.contains?("Leak Me")
     end
   end
 end

--- a/test/phoenix_kit/mentions_test.exs
+++ b/test/phoenix_kit/mentions_test.exs
@@ -166,4 +166,36 @@ defmodule PhoenixKit.MentionsTest do
       assert Mentions.context(nil) == %{}
     end
   end
+
+  describe "visible/3 fails closed" do
+    # A token can be typed by hand into any textarea, so a type whose
+    # module declares no visibility check must not render live. Most
+    # registered types (posts, files, CRM contacts, integrations) declare
+    # none, and treating that silence as consent showed their titles and
+    # working links to any reader handed a uuid.
+
+    test "a registered type with no visibility check is redacted" do
+      # `post` is registered by core and implements no check.
+      assert Mentions.visible("post", [@uuid], []) == []
+
+      assert %{{"post", @uuid} => %{state: :forbidden}} =
+               Mentions.context("see #[post:#{@uuid}|Some Post]")
+    end
+
+    test "people stay visible — a name is not a secret here" do
+      # The @ typeahead already lists every pingable account to anyone in
+      # the admin area, so gating mentions of them protects nothing and
+      # would break every ping.
+      assert Mentions.visible("user", [@uuid], []) == [@uuid]
+    end
+
+    test "a type nobody registered renders as the author's words" do
+      # Nothing can resolve it, so there is no title to leak; the reader
+      # should get the sentence, not a lock icon.
+      assert Mentions.visible("nonesuch", [@uuid], []) == [@uuid]
+
+      assert %{{"nonesuch", @uuid} => %{state: :missing}} =
+               Mentions.context("see #[nonesuch:#{@uuid}|Some Thing]")
+    end
+  end
 end

--- a/test/phoenix_kit/mentions_test.exs
+++ b/test/phoenix_kit/mentions_test.exs
@@ -174,12 +174,24 @@ defmodule PhoenixKit.MentionsTest do
     # none, and treating that silence as consent showed their titles and
     # working links to any reader handed a uuid.
 
-    test "a registered type with no visibility check is redacted" do
+    test "a registered type with no visibility check is not openable" do
       # `post` is registered by core and implements no check.
       assert Mentions.visible("post", [@uuid], []) == []
 
       assert %{{"post", @uuid} => %{state: :forbidden}} =
                Mentions.context("see #[post:#{@uuid}|Some Post]")
+    end
+
+    test "a forbidden mention still carries a title to render" do
+      # The reader learns what it is called and that it isn't theirs — the
+      # sentence has to read as the thing it names. What they don't get is
+      # a link.
+      ctx = Mentions.context("see #[post:#{@uuid}|Some Post]")
+      info = Map.fetch!(ctx, {"post", @uuid})
+
+      assert info.state == :forbidden
+      assert info.title == "Some Post"
+      refute Map.has_key?(info, :path)
     end
 
     test "people stay visible — a name is not a secret here" do

--- a/test/phoenix_kit/mentions_test.exs
+++ b/test/phoenix_kit/mentions_test.exs
@@ -1,0 +1,169 @@
+defmodule PhoenixKit.MentionsTest do
+  @moduledoc """
+  The token grammar and the index/notify lifecycle.
+
+  The grammar tests are the load-bearing ones: the format is what every
+  other half depends on, and getting it wrong silently turns prose into
+  links or links into prose.
+  """
+  use PhoenixKit.DataCase, async: true
+
+  alias PhoenixKit.Mentions
+  alias PhoenixKit.Mentions.Token
+
+  @uuid "018e3c4a-9f6b-7890-abcd-ef1234567890"
+  @other "018e3c4a-9f6b-7890-abcd-ef1234567891"
+
+  describe "Token.parse/1" do
+    test "finds both kinds and keeps their labels" do
+      text = "Hi @[user:#{@uuid}|Alice Smith], see #[project:#{@other}|Q3 Launch]"
+
+      assert [user, project] = Token.parse(text)
+      assert user.kind == :user
+      assert user.type == "user"
+      assert user.label == "Alice Smith"
+      assert project.kind == :resource
+      assert project.type == "project"
+      assert project.label == "Q3 Launch"
+    end
+
+    test "bare @name and #tag are prose, not mentions" do
+      # Publishing's hashtags share the trigger character; only the closed
+      # form is a mention, which is what keeps the two from colliding.
+      assert Token.parse("ping @alice about #launch and email a@b.com") == []
+    end
+
+    test "a backslash escapes a complete token" do
+      assert Token.parse("literally \\@[user:#{@uuid}|Alice]") == []
+    end
+
+    test "an incomplete token stays text" do
+      # Mid-typing, or a truncated paste. Neither should become a link.
+      assert Token.parse("@[user:#{@uuid}|Alice") == []
+      assert Token.parse("@[user:not-a-uuid|Alice]") == []
+      assert Token.parse("@[user:#{@uuid}|]") == []
+    end
+
+    test "nil and non-binaries yield nothing rather than raising" do
+      assert Token.parse(nil) == []
+      assert Token.parse(123) == []
+    end
+  end
+
+  describe "Token.to_string/4" do
+    test "builds the canonical form" do
+      assert {:ok, token} = Token.to_string(:resource, "project", @uuid, "Q3 Launch")
+      assert token == "#[project:#{@uuid}|Q3 Launch]"
+      assert [parsed] = Token.parse(token)
+      assert parsed.uuid == @uuid
+    end
+
+    test "refuses a label that would break the grammar" do
+      # The picker is the only thing that builds tokens, so it can simply
+      # not produce these rather than the format carrying escape rules.
+      assert Token.to_string(:user, "user", @uuid, "bad|label") == :error
+      assert Token.to_string(:user, "user", @uuid, "bad]label") == :error
+      assert Token.to_string(:user, "user", @uuid, "   ") == :error
+    end
+
+    test "refuses a bad uuid or type" do
+      assert Token.to_string(:user, "user", "nope", "Alice") == :error
+      assert Token.to_string(:user, "Bad Type", @uuid, "Alice") == :error
+    end
+  end
+
+  describe "Token.split/1" do
+    test "keeps the surrounding text in order" do
+      text = "a @[user:#{@uuid}|Alice] b"
+      assert [before, %Token{} = token, rest] = Token.split(text)
+      assert before == "a "
+      assert token.label == "Alice"
+      assert rest == " b"
+    end
+
+    test "an escaped token comes back as text with the backslash gone" do
+      assert ["@[user:#{@uuid}|Alice]"] == Token.split("\\@[user:#{@uuid}|Alice]")
+    end
+  end
+
+  describe "Token.to_plain_text/1" do
+    test "reduces mentions to readable words" do
+      text = "Hi @[user:#{@uuid}|Alice], see #[project:#{@other}|Q3 Launch]"
+      assert Token.to_plain_text(text) == "Hi @Alice, see Q3 Launch"
+    end
+  end
+
+  describe "sync/4" do
+    setup do
+      {:ok, source: Ecto.UUID.generate()}
+    end
+
+    test "indexes what the text mentions", %{source: source} do
+      text = "see #[project:#{@uuid}|Q3] and #[project:#{@other}|Q4]"
+
+      assert {:ok, new} = Mentions.sync("comment", source, text)
+      assert length(new) == 2
+      assert length(Mentions.list_for_source("comment", source)) == 2
+    end
+
+    test "re-saving the same text reports nothing new", %{source: source} do
+      text = "see #[project:#{@uuid}|Q3]"
+
+      assert {:ok, [_]} = Mentions.sync("comment", source, text)
+      assert {:ok, []} = Mentions.sync("comment", source, text)
+    end
+
+    test "removing a mention removes its row", %{source: source} do
+      assert {:ok, [_]} = Mentions.sync("comment", source, "#[project:#{@uuid}|Q3]")
+      assert {:ok, []} = Mentions.sync("comment", source, "nothing here now")
+      assert Mentions.list_for_source("comment", source) == []
+    end
+
+    test "the same target twice in one field is one mention", %{source: source} do
+      text = "#[project:#{@uuid}|Q3] and again #[project:#{@uuid}|Q3]"
+
+      assert {:ok, [_only_one]} = Mentions.sync("comment", source, text)
+    end
+
+    test "fields are independent", %{source: source} do
+      # A record with a description AND a summary must not have one field's
+      # save wipe the other's mentions.
+      assert {:ok, [_]} =
+               Mentions.sync("task", source, "#[project:#{@uuid}|Q3]", field: "description")
+
+      assert {:ok, [_]} =
+               Mentions.sync("task", source, "#[project:#{@other}|Q4]", field: "summary")
+
+      assert length(Mentions.list_for_source("task", source, "description")) == 1
+      assert length(Mentions.list_for_source("task", source, "summary")) == 1
+    end
+
+    test "backlinks find the source", %{source: source} do
+      assert {:ok, _} = Mentions.sync("comment", source, "#[project:#{@uuid}|Q3]")
+
+      assert [backlink] = Mentions.list_backlinks("project", @uuid)
+      assert backlink.source_uuid == source
+      assert backlink.label == "Q3"
+    end
+
+    test "empty text is not an error", %{source: source} do
+      assert {:ok, []} = Mentions.sync("comment", source, nil)
+      assert {:ok, []} = Mentions.sync("comment", source, "")
+    end
+  end
+
+  describe "context/2" do
+    test "an unresolvable type is missing, not forbidden" do
+      # No handler for "nonesuch": nothing can resolve it, but nothing is
+      # hiding it either — the reader should get the author's words.
+      text = "see #[nonesuch:#{@uuid}|Some Thing]"
+
+      assert %{{"nonesuch", @uuid} => %{state: :missing}} = Mentions.context(text)
+    end
+
+    test "text without mentions costs nothing" do
+      assert Mentions.context("just words") == %{}
+      assert Mentions.context(nil) == %{}
+    end
+  end
+end

--- a/test/phoenix_kit/mentions_test.exs
+++ b/test/phoenix_kit/mentions_test.exs
@@ -198,4 +198,27 @@ defmodule PhoenixKit.MentionsTest do
                Mentions.context("see #[nonesuch:#{@uuid}|Some Thing]")
     end
   end
+
+  describe "a crafted record title cannot forge a second mention" do
+    test "a title carrying token syntax is neutralised, not concatenated" do
+      # The attack: name a record `x] @[user:<ceo>|see this`. If the client
+      # concatenated that into grammar, picking it from the typeahead would
+      # insert TWO valid tokens and ping the CEO as the victim, with the
+      # tail invisible once rendered. The token is built server-side and
+      # the grammar refuses those characters in a label.
+      ceo = "018e3c4a-9f6b-7890-abcd-ef1234567899"
+      hostile = "x] @[user:#{ceo}|see this"
+
+      assert Token.to_string(:resource, "project", @uuid, hostile) == :error
+
+      # And the sanitising fallback the picker uses keeps it to one token.
+      cleaned = String.replace(hostile, ["|", "]"], " ")
+      assert {:ok, token} = Token.to_string(:resource, "project", @uuid, cleaned)
+
+      assert [only_one] = Token.parse(token)
+      assert only_one.type == "project"
+      assert only_one.uuid == @uuid
+      refute Enum.any?(Token.parse(token), &(&1.uuid == ceo))
+    end
+  end
 end

--- a/test/phoenix_kit/modules/storage/image_processor_sanitize_test.exs
+++ b/test/phoenix_kit/modules/storage/image_processor_sanitize_test.exs
@@ -1,0 +1,80 @@
+defmodule PhoenixKit.Modules.Storage.ImageProcessorSanitizeTest do
+  @moduledoc """
+  `sanitize/3` is what makes accepting an upload from a stranger
+  defensible: what gets stored is this encoder's output, not the
+  uploader's bytes.
+
+  Skipped when ImageMagick isn't on the machine — and the skip is safe,
+  because the function fails CLOSED without it (see the last test).
+  """
+  use ExUnit.Case, async: true
+
+  alias PhoenixKit.Modules.Storage.ImageProcessor
+
+  @moduletag :tmp_dir
+
+  defp imagemagick? do
+    match?({_, 0}, System.cmd("identify", ["-version"], stderr_to_stdout: true))
+  rescue
+    _ -> false
+  end
+
+  defp png(path) do
+    {_, 0} = System.cmd("convert", ["-size", "80x40", "xc:skyblue", path], stderr_to_stdout: true)
+    path
+  end
+
+  describe "re-encoding" do
+    @describetag :integration
+
+    test "a payload appended to a valid image does not survive", %{tmp_dir: dir} do
+      if imagemagick?() do
+        # The polyglot: a real PNG with executable text glued on. Byte
+        # inspection is a losing game; decoding to pixels and writing a
+        # fresh file is not.
+        src = png(Path.join(dir, "poly.png"))
+        File.write!(src, "\n<script>alert(1)</script>NEEDLE", [:append])
+        assert File.read!(src) =~ "NEEDLE"
+
+        out = Path.join(dir, "clean.jpg")
+        assert {:ok, ^out} = ImageProcessor.sanitize(src, out)
+
+        cleaned = File.read!(out)
+        refute cleaned =~ "NEEDLE"
+        refute cleaned =~ "<script>"
+      end
+    end
+
+    test "something that isn't an image is refused whatever it's called", %{tmp_dir: dir} do
+      src = Path.join(dir, "totally.png")
+      File.write!(src, "#!/bin/sh\nrm -rf /\n")
+
+      assert {:error, _} = ImageProcessor.sanitize(src, Path.join(dir, "out.jpg"))
+    end
+
+    test "an oversized image is scaled down, not stored at full size", %{tmp_dir: dir} do
+      if imagemagick?() do
+        src = Path.join(dir, "big.png")
+
+        {_, 0} =
+          System.cmd("convert", ["-size", "4000x100", "xc:red", src], stderr_to_stdout: true)
+
+        out = Path.join(dir, "small.jpg")
+        assert {:ok, _} = ImageProcessor.sanitize(src, out, max_edge: 500)
+        assert {:ok, {width, _height}} = ImageProcessor.extract_dimensions(out)
+        assert width <= 500
+      end
+    end
+  end
+
+  test "a missing binary fails closed rather than passing bytes through", %{tmp_dir: dir} do
+    # The whole design rests on never storing the uploader's bytes, so the
+    # failure mode when the tool is absent must be refusal — not a silent
+    # copy. `sanitize/3` returns an error tuple and never raises.
+    src = Path.join(dir, "x.png")
+    File.write!(src, "not an image")
+
+    assert {:error, _} = ImageProcessor.sanitize(src, Path.join(dir, "y.jpg"))
+    refute File.exists?(Path.join(dir, "y.jpg"))
+  end
+end

--- a/test/phoenix_kit/modules/storage/image_processor_sanitize_test.exs
+++ b/test/phoenix_kit/modules/storage/image_processor_sanitize_test.exs
@@ -77,4 +77,24 @@ defmodule PhoenixKit.Modules.Storage.ImageProcessorSanitizeTest do
     assert {:error, _} = ImageProcessor.sanitize(src, Path.join(dir, "y.jpg"))
     refute File.exists?(Path.join(dir, "y.jpg"))
   end
+
+  describe "not trusting the host's configuration" do
+    test "the format must be on the allowlist, not merely readable", %{tmp_dir: dir} do
+      # policy.xml is what actually disables ImageMagick's dangerous
+      # coders, and it belongs to whoever installed the binary. This code
+      # cannot assume it was configured, so it names the format it decodes
+      # and refuses anything outside a short list.
+      src = Path.join(dir, "x.gif")
+      File.write!(src, "GIF89a<svg xmlns=\"http://www.w3.org/2000/svg\" onload=\"alert(1)\"/>")
+
+      assert {:error, _} = ImageProcessor.sanitize(src, Path.join(dir, "out.jpg"))
+    end
+
+    test "a real image still passes", %{tmp_dir: dir} do
+      if imagemagick?() do
+        src = png(Path.join(dir, "fine.png"))
+        assert {:ok, _} = ImageProcessor.sanitize(src, Path.join(dir, "fine.jpg"))
+      end
+    end
+  end
 end

--- a/test/phoenix_kit/notifications/fan_out_test.exs
+++ b/test/phoenix_kit/notifications/fan_out_test.exs
@@ -1,0 +1,73 @@
+defmodule PhoenixKit.Notifications.FanOutTest do
+  use PhoenixKit.DataCase, async: false
+
+  alias PhoenixKit.Activity.Entry
+  alias PhoenixKit.Notifications
+  alias PhoenixKit.Settings
+  alias PhoenixKit.Users.Auth
+
+  defp user do
+    {:ok, u} =
+      Auth.register_user(%{
+        email: "fanout-#{System.unique_integer([:positive])}@example.com",
+        password: "ValidPassword123!"
+      })
+
+    u
+  end
+
+  defp committed_entry(actor_uuid) do
+    # A CORE-registered action: type resolution needs the owning module's
+    # notification_types in the registry, and only core's own are present
+    # in this suite.
+    {:ok, entry} =
+      PhoenixKit.Activity.log(%{
+        action: "comment.replied",
+        module: "comments",
+        actor_uuid: actor_uuid,
+        resource_type: "project",
+        resource_uuid: Ecto.UUID.generate(),
+        metadata: %{"title" => "Standup"}
+      })
+
+    entry
+  end
+
+  test "fans one committed entry out per recipient, skipping the actor, no extra feed rows" do
+    Settings.update_boolean_setting("notifications_enabled", true)
+
+    actor = user()
+    [a, b] = [user(), user()]
+    entry = committed_entry(actor.uuid)
+
+    before_entries = PhoenixKit.RepoHelper.repo().aggregate(Entry, :count)
+
+    results =
+      Notifications.fan_out_from_activity(entry, [a.uuid, b.uuid, actor.uuid, a.uuid])
+
+    # Deduped recipients: a, b, actor → actor self-skips.
+    assert length(results) == 3
+    assert Enum.count(results, &match?({:ok, %Notifications.Notification{}}, &1)) == 2
+    assert {:ok, :skipped} in results
+
+    # The feed kept exactly the one canonical entry.
+    assert PhoenixKit.RepoHelper.repo().aggregate(Entry, :count) == before_entries
+  end
+
+  test "recipients' prefs are honored per user" do
+    Settings.update_boolean_setting("notifications_enabled", true)
+
+    muted = user()
+
+    {:ok, muted} =
+      Auth.update_user_custom_fields(muted, %{
+        "notification_preferences" => %{"comments" => false}
+      })
+
+    open = user()
+    entry = committed_entry(user().uuid)
+
+    results = Notifications.fan_out_from_activity(entry, [muted.uuid, open.uuid])
+    assert [{:ok, :skipped}, {:ok, %Notifications.Notification{}}] = results
+  end
+end

--- a/test/phoenix_kit/user_display_name_test.exs
+++ b/test/phoenix_kit/user_display_name_test.exs
@@ -1,0 +1,87 @@
+defmodule PhoenixKit.UserDisplayNameTest do
+  @moduledoc """
+  The one canonical answer to "what do we call this person in front of
+  other people". Before it existed there were half a dozen private copies,
+  several ending `|| user.email` — which is how a public issue board came
+  to print commenters' full addresses next to their words.
+  """
+  use ExUnit.Case, async: true
+
+  alias PhoenixKit.Users.Auth.User
+
+  describe "the chain, in order" do
+    test "an organization is its own name" do
+      assert User.display_name(%User{
+               account_type: "organization",
+               organization_name: "Ratelia OU",
+               first_name: "Ignore",
+               last_name: "Me"
+             }) == "Ratelia OU"
+    end
+
+    test "a person is their name" do
+      assert User.display_name(%User{first_name: "John", last_name: "Doe"}) == "John Doe"
+      assert User.display_name(%User{first_name: "John"}) == "John"
+      assert User.display_name(%User{last_name: "Doe"}) == "Doe"
+    end
+
+    test "falls to username, then to the local part" do
+      assert User.display_name(%User{username: "jdoe", email: "j.doe@example.com"}) == "jdoe"
+      assert User.display_name(%User{email: "j.doe@example.com"}) == "j.doe"
+    end
+
+    test "never blank, never nil, even for an empty struct" do
+      assert User.display_name(%User{}) == "User"
+      assert User.display_name(nil) == "User"
+    end
+  end
+
+  describe "the blank rungs that broke the old copies" do
+    test "whitespace-only names do not win" do
+      # `full_name/1` returns "" (not nil) for "   ", so an unguarded chain
+      # stops dead on it and renders an empty header.
+      assert User.display_name(%User{first_name: "   ", username: "jdoe"}) == "jdoe"
+      assert User.display_name(%User{first_name: " ", last_name: " ", email: "a@b.com"}) == "a"
+    end
+
+    test "a whitespace-only username does not win" do
+      assert User.display_name(%User{username: "   ", email: "a@b.com"}) == "a"
+    end
+
+    test "an organization with no name falls through rather than rendering blank" do
+      assert User.display_name(%User{
+               account_type: "organization",
+               organization_name: nil,
+               username: "acme"
+             }) == "acme"
+    end
+  end
+
+  describe "the invariant that matters" do
+    test "the result is never the full address" do
+      # NOT "contains no @" — names are free text, so someone can set
+      # first_name to "a@b.com" and defeat that. What must hold is that we
+      # never hand back the address itself.
+      for user <- [
+            %User{email: "someone@example.com"},
+            %User{email: "someone@example.com", username: "  "},
+            %User{email: "someone@example.com", first_name: "", last_name: nil},
+            %User{email: "someone@example.com", account_type: "organization"}
+          ] do
+        refute User.display_name(user) == user.email
+      end
+    end
+
+    test "when the email is the only source, only the local part survives" do
+      name = User.display_name(%User{email: "john.smith@corp.example.com"})
+
+      assert name == "john.smith"
+      refute name =~ "corp.example.com"
+    end
+
+    test "a pathological address still yields something renderable" do
+      assert User.display_name(%User{email: "@nolocal.com"}) == "User"
+      assert User.display_name(%User{email: ""}) == "User"
+    end
+  end
+end

--- a/test/phoenix_kit/users/before_user_delete_hooks_test.exs
+++ b/test/phoenix_kit/users/before_user_delete_hooks_test.exs
@@ -1,0 +1,31 @@
+defmodule PhoenixKit.Users.BeforeUserDeleteHooksTest do
+  use ExUnit.Case, async: true
+
+  alias PhoenixKit.Users.Auth
+
+  defmodule GoodHook do
+    def before_user_delete(uuid), do: send(self(), {:hooked, __MODULE__, uuid})
+  end
+
+  defmodule RaisingHook do
+    def before_user_delete(_uuid), do: raise("boom")
+  end
+
+  defmodule NoHook do
+  end
+
+  import ExUnit.CaptureLog
+
+  test "dispatches to modules exporting the hook; a raiser never aborts" do
+    uuid = Ecto.UUID.generate()
+
+    log =
+      capture_log(fn ->
+        assert :ok =
+                 Auth.run_before_user_delete_hooks(uuid, [GoodHook, RaisingHook, NoHook])
+      end)
+
+    assert_received {:hooked, GoodHook, ^uuid}
+    assert log =~ "RaisingHook failed: boom"
+  end
+end

--- a/test/phoenix_kit/users/comment_resources_test.exs
+++ b/test/phoenix_kit/users/comment_resources_test.exs
@@ -10,7 +10,14 @@ defmodule PhoenixKit.Users.CommentResourcesTest do
 
     result = CommentResources.resolve_comment_resources([user.uuid])
 
-    assert %{title: "moderate-me@example.com", path: path} = result[user.uuid]
+    # This module is the registered handler for the "user" type, so it names
+    # every `@` mention there is — public issue boards included. It used to
+    # answer with the full address, and this test pinned that. The title is
+    # now the auto-generated username; what matters is that the address
+    # itself never comes back.
+    assert %{title: title, path: path} = result[user.uuid]
+    refute title == user.email
+    refute title =~ "@"
     # Raw path — comments applies Routes.path/1 when rendering the chip.
     assert path == "/admin/users/view/#{user.uuid}"
     # No avatar configured → no thumbnail key (chip falls back to a badge).

--- a/test/phoenix_kit_web/components/core/mention_text_test.exs
+++ b/test/phoenix_kit_web/components/core/mention_text_test.exs
@@ -1,0 +1,69 @@
+defmodule PhoenixKitWeb.Components.Core.MentionTextTest do
+  @moduledoc """
+  The renderer's job is a permission decision, and its input is attacker
+  controlled: a token can be TYPED by hand into any textarea, so the label
+  is not "whatever the picker produced" — it is whatever anyone can write.
+  """
+  use PhoenixKit.DataCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias PhoenixKitWeb.Components.Core.MentionText
+
+  @uuid "018e3c4a-9f6b-7890-abcd-ef1234567890"
+
+  defp render_text(text, opts \\ []) do
+    render_component(&MentionText.mention_text/1,
+      text: text,
+      scope: Keyword.get(opts, :scope),
+      allow_request: Keyword.get(opts, :allow_request, true)
+    )
+  end
+
+  describe "escaping" do
+    test "a hand-typed label cannot inject markup" do
+      html = render_text("see #[project:#{@uuid}|<script>alert(1)</script>]")
+
+      refute html =~ "<script>"
+      assert html =~ "&lt;script&gt;"
+    end
+
+    test "an event-handler payload cannot break out of an attribute" do
+      # A quote-and-attribute breakout, built without sigils so the test
+      # source itself stays readable.
+      payload = "see #[project:" <> @uuid <> "|" <> ~s(" onmouseover="alert\(1\)) <> "]"
+      html = render_text(payload)
+
+      # The payload survives as TEXT — what matters is that its quotes are
+      # entity-escaped, so it can never close an attribute and start a new
+      # one. Asserting the substring is absent would be wrong: the words
+      # are allowed to appear, the syntax is not.
+      refute html =~ ~s(onmouseover="alert)
+      assert html =~ "&quot;"
+    end
+
+    test "ordinary text around a mention is escaped too" do
+      html = render_text("<b>hi</b> #[project:#{@uuid}|Q3]")
+
+      refute html =~ "<b>hi</b>"
+      assert html =~ "&lt;b&gt;"
+    end
+  end
+
+  describe "the three states" do
+    test "an unresolvable type shows the author's words, unlinked" do
+      html = render_text("see #[nonesuch:#{@uuid}|Some Thing]")
+
+      assert html =~ "Some Thing"
+      refute html =~ "<a"
+    end
+
+    test "text with no mentions renders unchanged" do
+      assert render_text("just words") =~ "just words"
+    end
+
+    test "nil text is not a crash" do
+      assert is_binary(render_text(nil))
+    end
+  end
+end

--- a/test/phoenix_kit_web/components/core/mention_text_test.exs
+++ b/test/phoenix_kit_web/components/core/mention_text_test.exs
@@ -66,4 +66,31 @@ defmodule PhoenixKitWeb.Components.Core.MentionTextTest do
       assert is_binary(render_text(nil))
     end
   end
+
+  describe "a mention the reader can't open" do
+    test "shows what it is called, with a lock and no link" do
+      # `post` is registered but declares no visibility check, so it
+      # resolves as forbidden for everyone.
+      html = render_text("blocked on #[post:#{@uuid}|Q3 Launch]")
+
+      assert html =~ "Q3 Launch", "the sentence has to read as the thing it names"
+      assert html =~ "hero-lock-closed"
+      refute html =~ "<a", "knowing its name is not the same as being let in"
+    end
+
+    test "clicking it asks for access" do
+      html = render_text("blocked on #[post:#{@uuid}|Q3 Launch]")
+
+      assert html =~ "pk_request_access"
+      assert html =~ @uuid
+    end
+
+    test "with requests turned off it is inert but still readable" do
+      html = render_text("blocked on #[post:#{@uuid}|Q3 Launch]", allow_request: false)
+
+      assert html =~ "Q3 Launch"
+      assert html =~ "hero-lock-closed"
+      refute html =~ "pk_request_access"
+    end
+  end
 end

--- a/test/phoenix_kit_web/components/core/sortable_test.exs
+++ b/test/phoenix_kit_web/components/core/sortable_test.exs
@@ -47,11 +47,15 @@ defmodule PhoenixKitWeb.Components.Core.SortableTest do
         """)
 
       refute result =~ ~s(phx-hook="SortableGrid")
-      # Implementation renders the attribute name with an empty value
-      # rather than omitting the attribute, because `if @enabled, do: ...`
-      # in HEEx evaluates to `nil` when false. Both states tell the hook
-      # "not me" identically — pin the practical outcome (no hook attached).
       refute result =~ ~s(data-sortable="true")
+      # A disabled tbody carries NO sortable attrs at all: the inert
+      # `data-sortable-handle=".pk-drag-handle"` used to render even when
+      # disabled, which broke consumers' honest `refute =~ "pk-drag-handle"`
+      # assertions (phoenix_kit_projects' DnD-truncation test) and shipped
+      # meaningless attributes to the client.
+      refute result =~ "data-sortable-event"
+      refute result =~ "data-sortable-items"
+      refute result =~ "pk-drag-handle"
     end
 
     test "extra attrs pass through via :rest" do


### PR DESCRIPTION
Cross-module `@`/`#` mentions, one canonical display name, and the plumbing two
modules needed to stop leaking email addresses onto public pages.

Rebased onto `upstream/main` today. **Both of this branch's migrations were
renumbered during that rebase** — see "Migration chain" below.

## What's here

**Mentions (V165)** — `@[user:uuid|Label]` / `#[type:uuid|Label]` tokens that
survive markdown, sanitisation and copy-paste, a typeahead any textarea can
opt into (`use PhoenixKit.Mentions.Live`), a reverse index for "what links
here", and access requests for a record the reader can see named but not open.
Visibility is federated to whichever module owns the type and **fails closed**:
a type that declares no check resolves to nothing rather than everything.

**`User.display_name/1`** — one answer to "what do we call this person in
front of other people": organisation name → first+last → username → the local
part of the email → `"User"`. Never the full address.

This replaced four private copies, two of which ended `|| user.email`. One of
them, `Users.CommentResources`, is the registered `ResourceLinks` handler for
the `"user"` type — so it names *every* `@` mention there is, and a public
issue board was rendering commenters' full addresses next to their words:

```
%{state: :ok, title: "nameless-5954@example.com"}
```

Only fields the user wrote about themselves feed it. A name recorded by
somebody else — an HR record, a CRM label — never reaches it.

**`withhold_titles`** (V166 adjacent) — `mentions_redact_titles` is off by
default, which is the right call for internal readers and says nothing about
the open web. Both audiences share one renderer, so a public surface can now
withhold on its own account: an out-of-scope mention renders with no title
*and* no fallback to the author's stored label (the label is the record's name
as of writing — the same leak, one revision staler).

**Frozen comment attribution (V166)** — `author_display_name`,
`attribution_mode`, `attributed_project_uuid`, `attributed_label` on
`phoenix_kit_comments`. A name resolved at render time rewrites history:
someone leaves or fills in a profile and every comment they ever wrote is
silently re-signed. `user_uuid` is never cleared — posting under a project's
name changes what the public sees and nothing else, so moderation and audit
keep their actor.

**Upload sanitiser** — `ImageProcessor.sanitize/3` re-encodes rather than
re-serving: coder forced from the sniffed type, `-strip`, resource `-limit`s,
and a 40 MP cap *before* `convert` is invoked (`-resize` bounds the output; the
decoder still rasterises the input in full, so a 5 MB PNG declaring
50000×50000 is ~10 GB before a pixel is written).

**Smaller fixes** — `file_upload` wrapped itself in a `<form>` unconditionally,
so any host embedding it got nested forms and the browser silently moved every
field after that point *out* of the outer form. Orphan detection learned about
JSONB-referenced attachments, which it would otherwise have collected as
unreferenced while they were live on a public page.

## Migration chain

This branch originally used **V163** and **V164**. Upstream claimed both while
it was local (UUID primary-key integrity; the V56/V57 flush-order repair), so
the rebase renumbered them to **V165** (mentions) and **V166** (attribution),
including their `down/1` markers. `release_check` confirms the result:

```
PASS current_version/0 == v166.ex
PASS min(vNN.ex on disk) == initial_version/0 (V135)
PASS V135..V166 contiguous (32 versions), every module loadable
```

## ⚠️ The manifest is stale, deliberately

`ExpectedSchema.chain_hash/0` no longer matches, so these two fail:

- `check_manifest_chain_hash/0`
- `check_migration_sync/0` (only on the hash assertion — floor, contiguity and
  loadability all pass, as above)

Per `dev_docs/squash/README.md`, this is expected and **not** something to fix
in this PR:

> A migration PR may land with a stale manifest; the `chain_hash` assertion in
> `release_check` and its plain-unit-test twin are the release-time gate —
> regeneration must happen before publish.

Regeneration has to run from a **pre-squash checkout** (on the squashed branch
the generator is self-referential and drops pre-floor drift), and
`restamp_chain_hash.exs` is explicitly the wrong tool here — it would make the
hash pass over a manifest that has no knowledge of these objects, hiding the
drift the hash exists to detect. Hand-merging the manifest is forbidden by the
same policy. So: **regenerate before publishing**, please.

## Tests

`3259 tests, 2 failures` — the two above.

Run with `--max-cases 4`. At full concurrency the integration suite produces
`deadlock_detected` failures in a different handful of tests each run; the same
happens on a clean `upstream/main` worktree, so it is pre-existing and
unrelated to this branch.

`mix precommit` exits 0.
