### PR TITLE
Stop reporting a comment-less database as version 1

### DIFF
--- a/lib/mix/tasks/phoenix_kit.status.ex
+++ b/lib/mix/tasks/phoenix_kit.status.ex
@@ -241,6 +241,11 @@ defmodule Mix.Tasks.PhoenixKit.Status do
       {:unreachable, reason} ->
         {:unreachable, reason}
 
+      # `status` is the task an operator runs precisely because something looks
+      # wrong, so it must report this state rather than raise on it.
+      {:unknown_version} ->
+        {:unknown_version}
+
       {:current_version, version} ->
         target_version = Postgres.current_version()
 
@@ -339,6 +344,13 @@ defmodule Mix.Tasks.PhoenixKit.Status do
     "#{IO.ANSI.yellow()}Unknown — database unreachable#{IO.ANSI.reset()}"
   end
 
+  # Installed, but the version comment is missing or unreadable. Red rather than
+  # yellow: unlike an unreachable database this will not fix itself, and no other
+  # task can act safely until it is restamped.
+  defp format_installation_status({:unknown_version}) do
+    "#{IO.ANSI.red()}Installed, version comment unreadable#{IO.ANSI.reset()}"
+  end
+
   defp format_installation_status({:up_to_date, version}) do
     "#{IO.ANSI.green()}V#{pad_version(version)} ✅#{IO.ANSI.reset()}"
   end
@@ -401,6 +413,12 @@ defmodule Mix.Tasks.PhoenixKit.Status do
 
   defp format_next_action({:fix_connection, message}) do
     "#{IO.ANSI.yellow()}#{message}#{IO.ANSI.reset()}"
+  end
+
+  # Same shape as :fix_connection — a state nothing else can act around until an
+  # operator resolves it by hand.
+  defp format_next_action({:fix_version_comment, message}) do
+    "#{IO.ANSI.red()}#{message}#{IO.ANSI.reset()}"
   end
 
   # Layout lives in PhoenixKit.Install.StatusTree so it can be unit tested

--- a/lib/mix/tasks/phoenix_kit.update.ex
+++ b/lib/mix/tasks/phoenix_kit.update.ex
@@ -430,6 +430,31 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
       add_not_installed_notice(igniter, prefix)
     end
 
+    # Installed, but the version comment is gone or unparseable. Deliberately
+    # NOT routed to the below-floor branch: that reports "V1" and tells the
+    # operator to install the 1.7.x bridge, and the migrator refuses this exact
+    # state because replaying the pre-squash chain over a possibly CURRENT
+    # database backfills still-NULL tracked columns with invented uuids and then
+    # deletes the rows for matching no user. Two halves of one release must not
+    # give opposite instructions; this one matches the migrator's.
+    defp handle_installation_status({:unknown_version}, igniter, prefix, _force, _opts) do
+      Igniter.add_warning(igniter, """
+
+      ❌ #{prefix}.phoenix_kit exists but carries no readable version comment.
+
+      The comment is the only record of which migrations this database has, so
+      neither an update nor a fresh install can be generated safely — a guess
+      here can replay migrations over live data.
+
+      Establish the real state and restamp it by hand:
+
+          mix phoenix_kit.doctor       # reports schema-vs-comment discrepancies
+          COMMENT ON TABLE #{prefix}.phoenix_kit IS '<version>';
+
+      Then run mix phoenix_kit.update again.
+      """)
+    end
+
     defp handle_installation_status({:unreachable, reason}, igniter, _prefix, _force, _opts) do
       Igniter.add_warning(igniter, """
       ❌ Cannot reach the database to determine the installed PhoenixKit
@@ -608,7 +633,7 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
       modules below the floor, so it cannot generate a migration that would
       bring this database current.
 
-      Install the last PhoenixKit 1.7.x release (the migration bridge) first,
+      Install PhoenixKit #{MigrationsPostgres.bridge_version()} (the migration bridge) first,
       run its migrations until the reported version is at least V#{floor_padded},
       THEN move the dependency pin to this release and run
       mix phoenix_kit.update again.

--- a/lib/phoenix_kit/install/common.ex
+++ b/lib/phoenix_kit/install/common.ex
@@ -205,6 +205,12 @@ defmodule PhoenixKit.Install.Common do
       version when is_integer(version) and version > 0 ->
         {:current_version, version}
 
+      :unknown_version ->
+        # Installed, but the one record of WHAT is installed is gone. Neither
+        # "not installed" nor a version: both send the operator somewhere that
+        # writes. Callers surface this and stop.
+        {:unknown_version}
+
       _ ->
         # "No version found" is only "not installed" when we can actually
         # reach the database — a down DB must not masquerade as an absent
@@ -213,6 +219,18 @@ defmodule PhoenixKit.Install.Common do
           :ok -> {:not_installed}
           {:error, reason} -> {:unreachable, reason}
         end
+    end
+  end
+
+  # A comment that is not a plain integer is corruption, not a version. The
+  # migrator's `parse_version_comment!/2` raises with restamp instructions; this
+  # is the non-raising twin for the tasks that report rather than migrate — a
+  # bare `String.to_integer/1` here would crash `mix phoenix_kit.update` on
+  # exactly the hand-edited comments (`'v164'`, `' 164'`) the migrator documents.
+  defp parse_version_comment(version) when is_binary(version) do
+    case Integer.parse(String.trim(version)) do
+      {n, ""} when n > 0 -> n
+      _ -> :unknown_version
     end
   end
 
@@ -265,11 +283,22 @@ defmodule PhoenixKit.Install.Common do
 
         case repo.query(version_query, [escaped_prefix], log: false) do
           {:ok, %{rows: [[version]]}} when is_binary(version) ->
-            String.to_integer(version)
+            parse_version_comment(version)
 
           _ ->
-            # Table exists but no version comment - assume version 1
-            1
+            # A table with no comment is NOT "version 1". That guess is what the
+            # migrator refuses outright, in its own words: it "would route a
+            # possibly CURRENT database to the 1.7.x bridge, whose backfill
+            # overwrites still-NULL tracked columns with freshly generated uuids
+            # pointing at nothing" (`Postgres.migrated_version/1`).
+            #
+            # Reported as 1, it lands below the floor, and `phoenix_kit.update`
+            # tells the operator to install that very bridge — so the two halves
+            # of the same release gave opposite instructions for one state, and
+            # the destructive one was the one seen first. `:unknown_version` is
+            # distinguishable from every real version, and the update task routes
+            # it to doctor + restamp instead.
+            :unknown_version
         end
 
       _ ->

--- a/lib/phoenix_kit/install/common.ex
+++ b/lib/phoenix_kit/install/common.ex
@@ -172,15 +172,29 @@ defmodule PhoenixKit.Install.Common do
     }
 
     try do
-      # Use PhoenixKit's centralized runtime version detection function
       current_version = Postgres.migrated_version_runtime(opts)
 
-      if current_version > 0 do
-        # Valid version found in database
-        {:current_version, current_version}
-      else
-        # Primary detection failed, try alternative detection methods
-        check_alternative_version_detection(prefix, opts)
+      cond do
+        # `migrated_version_runtime/1` is the DISPLAY twin: for a table with no
+        # comment it deliberately guesses V01 so `status`, `doctor` and the admin
+        # UI keep rendering, and warns that the migrator will refuse. That design
+        # is right for a read path — but THIS function feeds the update task,
+        # which acts on the value, and V01 is below the floor, so the guess came
+        # back out of it as "install the 1.7.x bridge first": exactly the
+        # destructive advice the warning promises will not be given.
+        #
+        # A bare 1 is therefore re-asked through the strict reader, which can
+        # tell "the comment says 1" from "there is no comment". Only that one
+        # value is re-checked; every other version is taken as read.
+        current_version == 1 and try_direct_database_version_check(opts) == :unknown_version ->
+          {:unknown_version}
+
+        current_version > 0 ->
+          {:current_version, current_version}
+
+        true ->
+          # Primary detection failed, try alternative detection methods
+          check_alternative_version_detection(prefix, opts)
       end
     rescue
       error ->
@@ -435,6 +449,12 @@ defmodule PhoenixKit.Install.Common do
 
       {:unreachable, reason} ->
         {:unreachable, reason}
+
+      # Passed through rather than folded into one of the others: an install
+      # whose version is unreadable neither needs an update nor is up to date,
+      # and answering either would send a caller somewhere that writes.
+      {:unknown_version} ->
+        {:unknown_version}
 
       {:current_version, current_version} ->
         target_version = current_version()

--- a/lib/phoenix_kit/install/status_report.ex
+++ b/lib/phoenix_kit/install/status_report.ex
@@ -67,6 +67,15 @@ defmodule PhoenixKit.Install.StatusReport do
     {:fix_connection, "Fix the database connection, then re-run mix phoenix_kit.status"}
   end
 
+  # Installed, but the version comment is missing or not a plain integer. The
+  # action is a restamp, not an update: every other task reads that comment, so
+  # until it says something true none of them can act safely. `doctor` first,
+  # because it is what establishes the real version to stamp.
+  def next_action({:unknown_version}, _modules, prefix) do
+    {:fix_version_comment,
+     "mix phoenix_kit.doctor — then COMMENT ON TABLE #{prefix}.phoenix_kit IS '<version>'"}
+  end
+
   # Core behind. Modules fold into the SAME action rather than being ignored:
   # one `mix phoenix_kit.update` fixes both, and an operator told only
   # "database is behind" would fix core, re-run, and meet a second finding that

--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -469,6 +469,16 @@ defmodule PhoenixKit.Migrations.Postgres do
   # carries the whole pre-squash chain.
   @bridge_version "1.7.236"
 
+  @doc """
+  The release an below-floor host must install before this one.
+
+  Exposed because `mix phoenix_kit.update` refuses below-floor installs at
+  GENERATION time, before this module's raise sites are ever reached — so the
+  notice the operator sees first has to name the same version those raises do.
+  """
+  @spec bridge_version() :: String.t()
+  def bridge_version, do: @bridge_version
+
   # First version whose SQL referenced uuid_generate_v7() in the
   # pre-squash chain — V40/V56/V61/V63 were its historical
   # creation/repair sites, now folded into the V135 baseline's single

--- a/lib/phoenix_kit/migrations/postgres/v163.ex
+++ b/lib/phoenix_kit/migrations/postgres/v163.ex
@@ -117,16 +117,13 @@ defmodule PhoenixKit.Migrations.Postgres.V163 do
     qualified = UUIDIntegrity.qualify(prefix, name)
 
     cond do
-      not UUIDIntegrity.castable?(repo(), qualified, table) ->
-        # Aborting the migration over one table's bad data would strand every
-        # other repair in this run, so this table is skipped and named.
-        Logger.error("""
-        [PhoenixKit V163] #{name}: the uuid column holds values that are not \
-        valid UUIDs, so it cannot be converted. Left unchanged. Inspect with:
-          SELECT uuid FROM #{qualified} WHERE uuid IS NOT NULL
-           AND uuid !~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$' LIMIT 20;
-        """)
-
+      # Checked BEFORE castability: `castable?/3` is a full-table
+      # `count(*) … !~*` scan, so asking it first made the deferral path pay an
+      # unbounded sequential scan on exactly the tables this limit exists to keep
+      # out of `mix ecto.migrate`. Read-only, so not the ACCESS EXCLUSIVE outage
+      # itself — but on a PgBouncer-fronted pool it pins a connection for minutes
+      # before deciding to skip. `estimated_rows/3` reads the catalog.
+      #
       # The guard covers EVERY repair class, not just the rewrite. `ALTER COLUMN
       # TYPE` rewrites the table, `SET NOT NULL` scans it, and `ADD PRIMARY KEY`
       # builds a unique index over it — all three under ACCESS EXCLUSIVE, all
@@ -142,6 +139,16 @@ defmodule PhoenixKit.Migrations.Postgres.V163 do
         window, where the key can be built CONCURRENTLY:
           mix phoenix_kit.repair_uuid #{name}
         `mix phoenix_kit.doctor` will keep reporting it until you do.
+        """)
+
+      not UUIDIntegrity.castable?(repo(), qualified, table) ->
+        # Aborting the migration over one table's bad data would strand every
+        # other repair in this run, so this table is skipped and named.
+        Logger.error("""
+        [PhoenixKit V163] #{name}: the uuid column holds values that are not \
+        valid UUIDs, so it cannot be converted. Left unchanged. Inspect with:
+          SELECT uuid FROM #{qualified} WHERE uuid IS NOT NULL
+           AND uuid !~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$' LIMIT 20;
         """)
 
       true ->

--- a/lib/phoenix_kit/migrations/postgres/v164.ex
+++ b/lib/phoenix_kit/migrations/postgres/v164.ex
@@ -641,6 +641,15 @@ defmodule PhoenixKit.Migrations.Postgres.V164 do
     )
   end
 
+  # `contype = 'f'` is load-bearing, not decoration. Detection before the ADD is
+  # shape-based (`fk_shape_present/5`), so a constraint that merely OWNS THE NAME
+  # — a CHECK, or an FK to a different column — reads as `:absent`; the guarded
+  # ADD then fails with 42710 and is swallowed by the `EXCEPTION WHEN OTHERS`
+  # handler. Verifying by name alone saw the colliding constraint, `validate_fk/7`
+  # issued a no-op VALIDATE against it, and the outcome was reported `:created`:
+  # one buried RAISE WARNING, no `{:failed, …}`, no SUMMARY line, comment stamped
+  # 164, and the declared foreign key not there. That is the same shape as the
+  # defects this migration exists to repair, inside the repair itself.
   defp fk_exists?(table_str, constraint, escaped_prefix) do
     query = """
     SELECT EXISTS (
@@ -648,6 +657,7 @@ defmodule PhoenixKit.Migrations.Postgres.V164 do
       JOIN pg_class t ON t.oid = c.conrelid
       JOIN pg_namespace n ON n.oid = t.relnamespace
       WHERE c.conname = '#{constraint}'
+        AND c.contype = 'f'
         AND t.relname = '#{table_str}'
         AND n.nspname = '#{escaped_prefix}'
     )

--- a/lib/phoenix_kit/migrations/repair/probe.ex
+++ b/lib/phoenix_kit/migrations/repair/probe.ex
@@ -78,9 +78,24 @@ defmodule PhoenixKit.Migrations.Repair.Probe do
     """
 
     case repo.query(version_query, [prefix], log: false) do
-      {:ok, %{rows: [[version]]}} when is_binary(version) -> String.to_integer(version)
-      {:ok, %{rows: [[nil]]}} -> nil
-      _ -> nil
+      # `Integer.parse/1` on the trimmed value, not `String.to_integer/1`: the
+      # moduledoc above promises this never raises, and repair is the tool an
+      # operator reaches for when the comment is already anomalous. The exact
+      # hand-edits the migrator documents — `'v164'`, `' 164'` — used to end the
+      # run in a bare `** (ArgumentError) argument error` with no guidance.
+      # An unparseable comment reads as "no usable version", which every caller
+      # here already handles.
+      {:ok, %{rows: [[version]]}} when is_binary(version) ->
+        case Integer.parse(String.trim(version)) do
+          {n, ""} -> n
+          _ -> nil
+        end
+
+      {:ok, %{rows: [[nil]]}} ->
+        nil
+
+      _ ->
+        nil
     end
   end
 

--- a/test/phoenix_kit/install/status_report_test.exs
+++ b/test/phoenix_kit/install/status_report_test.exs
@@ -21,6 +21,25 @@ defmodule PhoenixKit.Install.StatusReportTest do
     test "everything matching is Ready" do
       assert StatusReport.next_action({:up_to_date, 159}, [], "public") == {:ready, "Ready"}
     end
+
+    # This state reaches `next_action/3` only because `check_installation_status/1`
+    # learned to report it, and the clause was missing when it did — `mix
+    # phoenix_kit.status` died with a FunctionClauseError on the one anomaly it
+    # exists to diagnose. One line here would have caught that; it did not exist.
+    test "an unreadable version comment asks for a restamp, not an update" do
+      assert {:fix_version_comment, message} =
+               StatusReport.next_action({:unknown_version}, [], "public")
+
+      assert message =~ "phoenix_kit.doctor"
+      assert message =~ "COMMENT ON TABLE public.phoenix_kit"
+    end
+
+    test "the restamp instruction names the prefix it was asked about" do
+      assert {:fix_version_comment, message} =
+               StatusReport.next_action({:unknown_version}, :not_queried, "auth")
+
+      assert message =~ "COMMENT ON TABLE auth.phoenix_kit"
+    end
   end
 
   describe "next_action/3 — wording of a behind schema" do


### PR DESCRIPTION
Three findings from the post-merge review of the migration work, published as a
comment on #689. All verified against the tree before this branch was cut.

## The one that matters

`Common.query_version_directly/2` ended with, verbatim:

```elixir
_ ->
  # Table exists but no version comment - assume version 1
  1
```

A database that is **current but lost its comment** — the half-installed or
adopted state `repair --adopt` exists for — therefore reported
`{:current_version, 1}`, which is below the floor, so `mix phoenix_kit.update`
answered: *install the 1.7.x bridge first.*

`Postgres.migrated_version/1` refuses that same input, and says why:

> the guess would route a possibly CURRENT database to the 1.7.x bridge, whose
> backfill overwrites still-NULL tracked columns with freshly generated uuids
> pointing at nothing

Downstream that is not abstract: `UUIDFKColumns.set_not_null/4` backfills
legitimately-NULL `phoenix_kit_files` rows with invented uuids, and
`cleanup_orphaned_fk_refs/5` deletes them for matching no user.

Two halves of one release gave opposite instructions for one state, and the
operator met the destructive one first. Worth noting the sibling fallback in the
same module was already hardened against exactly this guess — its comment
records that it "used to fall back to a fabricated `{:current_version, 1}`…
Report honestly instead". The fabrication survived one level down.

`:unknown_version` is now distinct from both a real version and "not installed",
and the update task routes it to `doctor` + restamp.

## Also fixed

- **`Repair.Probe.read_comment/2` raised on the anomaly it exists to diagnose.**
  `String.to_integer/1`, eleven lines below a docstring that says "Never raises".
  The exact hand-edits the migrator documents (`'v164'`, `' 164'`) ended
  `mix phoenix_kit.repair` in a bare `** (ArgumentError) argument error`, while
  `doctor` survived only because its check wraps everything in `rescue`.
- **The below-floor notice did not name the bridge.** `@bridge_version` was
  threaded into both `BelowFloorError` raise sites but not into the notice shown
  *first*, at generation time — the raises come later. `bridge_version/0` exposes
  it so the two agree.

## Not in this PR

Two findings from the same round need a decision rather than a patch, so they
are left for the maintainer:

- The manifest pins `uuid_generate_v7`'s body with `public.gen_random_bytes`, so
  `repair` can never converge where pgcrypto lives in another schema — a
  supported topology. Wants the pgcrypto schema normalised out of `prosrc`
  before hashing on both sides, like the array-cast canonicalisation in
  `Differ`.
- The manifest's pre-164 revisions for `idx_publishing_posts_group_slug` carry
  `predicate: nil`, next to a comment saying "Every real install has the
  predicate". Both cannot hold: a public install at 135..163 gets `:wrong_shape`
  and exit 2 on a byte-correct database. Wants `:legacy_optional` or a bimodal
  revision.

And one that is already yours: the review also flagged that
`generate_baseline.exs` does not encode the hand-applied post-generation
corrections. `90077b79` answers that better than the finding did — the generator
*cannot* emit V164+ objects, because regeneration runs from a pre-squash
checkout whose chain ends at V163. Recorded here only so the thread is complete.

## Verification

`mix compile --warnings-as-errors`, `mix format --check-formatted` and
`mix credo --strict` (10290 mods/funs) — clean. No test run: these paths are
exercised by `mix phoenix_kit.update` against a real database rather than by the
suite, and the shared PostgreSQL has been at its connection ceiling all day.
`@version` and `CHANGELOG.md` untouched.