### PR TITLE
Close the remaining review findings from the #694 round

### DIFF
--- a/lib/mix/tasks/phoenix_kit.repair_uuid.ex
+++ b/lib/mix/tasks/phoenix_kit.repair_uuid.ex
@@ -93,11 +93,21 @@ defmodule Mix.Tasks.PhoenixKit.RepairUuid do
     if UUIDIntegrity.castable?(repo, qualified, table) do
       rows = UUIDIntegrity.estimated_rows(repo, prefix, name)
 
+      # `:unknown` is said out loud rather than printed as a number. This task
+      # is the maintenance-window path the migration defers TO, so the operator
+      # deciding whether they have a window needs to know the size is a guess
+      # nobody has ever taken — not read "~0 rows" and size the window for it.
+      size =
+        case rows do
+          :unknown -> "size unknown — never analyzed"
+          n -> "~#{n} rows"
+        end
+
       Mix.shell().info([
         :cyan,
         "\n#{name}",
         :reset,
-        " (~#{rows} rows) #{UUIDIntegrity.describe(table)}"
+        " (#{size}) #{UUIDIntegrity.describe(table)}"
       ])
 
       announce_duplicates(repo, qualified, table)

--- a/lib/mix/tasks/phoenix_kit.status.ex
+++ b/lib/mix/tasks/phoenix_kit.status.ex
@@ -482,6 +482,16 @@ defmodule Mix.Tasks.PhoenixKit.Status do
       {:unreachable, reason} ->
         IO.puts("  Database unreachable: #{inspect(reason)}")
 
+      # The non-verbose path reports this state; without a clause here the
+      # SAME run crashed with CaseClauseError the moment `--verbose` was added
+      # to it — after printing a correct tree, which is the worst place to die.
+      {:unknown_version} ->
+        IO.puts("  Current version: unreadable — the table exists but its")
+        IO.puts("  version comment is missing or is not a plain integer.")
+        IO.puts("  Establish the real state and restamp it by hand:")
+        IO.puts("    mix phoenix_kit.doctor")
+        IO.puts("    COMMENT ON TABLE #{prefix}.phoenix_kit IS '<version>';")
+
       {:up_to_date, version} ->
         IO.puts("  Current version: V#{pad_version(version)}")
         IO.puts("  Target version: V#{pad_version(Postgres.current_version())}")

--- a/lib/phoenix_kit/migrations/postgres/v163.ex
+++ b/lib/phoenix_kit/migrations/postgres/v163.ex
@@ -131,13 +131,17 @@ defmodule PhoenixKit.Migrations.Postgres.V163 do
       # table that prompted this work is an events table, and had it been uuid-
       # typed-but-keyless it would have taken an index build over every row
       # during `mix ecto.migrate` — exactly the outage this limit exists to stop.
-      UUIDIntegrity.estimated_rows(repo(), prefix, name) > limit ->
+      too_big_or_unmeasured?(UUIDIntegrity.estimated_rows(repo(), prefix, name), limit) ->
         Logger.warning("""
         [PhoenixKit V163] #{name}: #{UUIDIntegrity.describe(table)} — but the \
-        table holds more than #{limit} rows. Skipped: the repair takes an ACCESS \
-        EXCLUSIVE lock for a full pass over the table. Run this in a maintenance \
-        window, where the key can be built CONCURRENTLY:
+        table is over #{limit} rows, or has never been analyzed so its size is \
+        unknown. Skipped: the repair takes an ACCESS EXCLUSIVE lock for a full \
+        pass over the table. Run this in a maintenance window, where the key can \
+        be built CONCURRENTLY:
           mix phoenix_kit.repair_uuid #{name}
+        That command reports the row count, and refuses with the offending values \
+        if the column holds anything that is not a valid UUID — fix those first if \
+        it does, because no repair can convert them.
         `mix phoenix_kit.doctor` will keep reporting it until you do.
         """)
 
@@ -156,6 +160,15 @@ defmodule PhoenixKit.Migrations.Postgres.V163 do
         run_isolated(qualified, prefix, table)
     end
   end
+
+  # `:unknown` defers, exactly as an over-limit count does. The guard exists to
+  # keep an unbounded ACCESS EXCLUSIVE pass out of `mix ecto.migrate`, and "we
+  # never measured this table" is not evidence that the pass is bounded. The
+  # cost of being wrong is asymmetric: deferring leaves the table unrepaired and
+  # loudly reported by `doctor`, while proceeding can lock a large table for the
+  # length of a deploy.
+  defp too_big_or_unmeasured?(:unknown, _limit), do: true
+  defp too_big_or_unmeasured?(rows, limit) when is_integer(rows), do: rows > limit
 
   # Deleting rows is the only destructive thing V163 does, so it is never
   # silent — an operator reading the deploy log sees the count before the

--- a/lib/phoenix_kit/migrations/postgres/v164.ex
+++ b/lib/phoenix_kit/migrations/postgres/v164.ex
@@ -510,12 +510,41 @@ defmodule PhoenixKit.Migrations.Postgres.V164 do
     # this whole migration exists to repair.
     flush()
 
-    if fk_exists?(table_str, constraint, escaped_prefix) do
-      validate_fk(table_str, uuid_fk, ref_table, ref_col, constraint, prefix, escaped_prefix)
-    else
-      {:failed,
-       "#{constraint} on #{table_str}.#{uuid_fk} could not be created — see the RAISE WARNING " <>
-         "above for the PostgreSQL error and SQLSTATE"}
+    # Verified by SHAPE, through the same probe the pre-ADD detection uses. A
+    # name lookup — with or without `contype = 'f'` — answers "something owns
+    # this name", which is a different question: an FK of the right name on the
+    # WRONG column is a real foreign key, so a type filter still matches it, and
+    # the run then reports `:created` for a constraint that does not exist.
+    # Demonstrated on PG 17.4 against this migration's own queries.
+    #
+    # Wrapped, because `fk_shape_present/5` RAISES on a failed probe. That is
+    # right before the ADD — guessing `:absent` there would mean trying to
+    # create a constraint that already exists — but inheriting it here would be
+    # a regression against the `fk_exists?/3` this replaced, which returned
+    # false and let the run finish. This migration has no `rescue` and no
+    # `run_isolated/3`: one flaky catalog read on one of ~70 constraints would
+    # abort mid-run with the earlier repairs already auto-committed
+    # (`@disable_ddl_transaction`) and the `COMMENT … IS '164'` at the tail of
+    # `up/1` never reached — so the whole version replays next time. Post-ADD a
+    # wrong guess only mislabels one outcome, and the summary is where it belongs.
+    probe =
+      try do
+        fk_shape_present(table_str, uuid_fk, ref_table, ref_col, escaped_prefix)
+      rescue
+        e -> {:probe_failed, Exception.message(e)}
+      end
+
+    case probe do
+      {:probe_failed, reason} ->
+        {:failed, "#{constraint} on #{table_str}.#{uuid_fk} could not be verified — #{reason}"}
+
+      :absent ->
+        {:failed,
+         "#{constraint} on #{table_str}.#{uuid_fk} could not be created — see the RAISE WARNING " <>
+           "above for the PostgreSQL error and SQLSTATE"}
+
+      _present ->
+        validate_fk(table_str, uuid_fk, ref_table, ref_col, constraint, prefix, escaped_prefix)
     end
   end
 
@@ -641,34 +670,14 @@ defmodule PhoenixKit.Migrations.Postgres.V164 do
     )
   end
 
-  # `contype = 'f'` is load-bearing, not decoration. Detection before the ADD is
-  # shape-based (`fk_shape_present/5`), so a constraint that merely OWNS THE NAME
-  # — a CHECK, or an FK to a different column — reads as `:absent`; the guarded
-  # ADD then fails with 42710 and is swallowed by the `EXCEPTION WHEN OTHERS`
-  # handler. Verifying by name alone saw the colliding constraint, `validate_fk/7`
-  # issued a no-op VALIDATE against it, and the outcome was reported `:created`:
-  # one buried RAISE WARNING, no `{:failed, …}`, no SUMMARY line, comment stamped
-  # 164, and the declared foreign key not there. That is the same shape as the
-  # defects this migration exists to repair, inside the repair itself.
-  defp fk_exists?(table_str, constraint, escaped_prefix) do
-    query = """
-    SELECT EXISTS (
-      SELECT 1 FROM pg_constraint c
-      JOIN pg_class t ON t.oid = c.conrelid
-      JOIN pg_namespace n ON n.oid = t.relnamespace
-      WHERE c.conname = '#{constraint}'
-        AND c.contype = 'f'
-        AND t.relname = '#{table_str}'
-        AND n.nspname = '#{escaped_prefix}'
-    )
-    """
-
-    case repo().query(query, [], log: false) do
-      {:ok, %{rows: [[true]]}} -> true
-      _ -> false
-    end
-  end
-
+  # Name-only on purpose, and safe only because of where it sits: every caller
+  # reaches it through `fk_shape_present/5`, which has already established that
+  # the constraint of this name on this table is a single-column foreign key on
+  # the expected column pointing at the expected reference. This asks the one
+  # remaining question — is it validated — about a constraint whose shape is
+  # already known. Do not call it from anywhere that has not passed that gate;
+  # the name alone has already produced one `:created` for a foreign key that
+  # did not exist.
   defp fk_validated?(table_str, constraint, escaped_prefix) do
     query = """
     SELECT convalidated FROM pg_constraint c
@@ -799,12 +808,23 @@ defmodule PhoenixKit.Migrations.Postgres.V164 do
   # `'<table>'::regclass` cast in an immediate check (CLAUDE.md's V146
   # 25P02 trap: it raises when the relation doesn't exist yet and aborts
   # the whole transaction).
+  # Anchored on the SHAPE, not just the name. Read by name alone, a constraint
+  # that merely owns `fk_comments_user_uuid` — a CHECK, or a foreign key on a
+  # different column — answered for the real one: a `confdeltype` of 'n' from an
+  # impostor reads as "already SET NULL, nothing to do", so `repair_comments_fk/2`
+  # returns [] and the actual missing FK is never created. Same
+  # name-versus-shape confusion that produced the defect this whole version
+  # repairs, so the column and referenced side are pinned here too.
   defp comments_fk_on_delete(escaped_prefix) do
     query = """
     SELECT c.confdeltype FROM pg_constraint c
     JOIN pg_class t ON t.oid = c.conrelid
     JOIN pg_namespace n ON n.oid = t.relnamespace
+    JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = c.conkey[1]
     WHERE c.conname = '#{@comments_constraint}'
+      AND c.contype = 'f'
+      AND array_length(c.conkey, 1) = 1
+      AND a.attname = 'user_uuid'
       AND t.relname = '#{@comments_table}'
       AND n.nspname = '#{escaped_prefix}'
     """

--- a/lib/phoenix_kit/migrations/repair.ex
+++ b/lib/phoenix_kit/migrations/repair.ex
@@ -86,6 +86,7 @@ defmodule PhoenixKit.Migrations.Repair do
           :not_generated
           | {:not_installed, prefix :: String.t()}
           | {:below_floor, comment :: pos_integer(), floor :: pos_integer()}
+          | {:comment_unreadable, term()}
           | {:above_current, comment :: pos_integer(), current :: pos_integer()}
           | {:pooled_connection, String.t()}
           | {:concurrent_migration, before :: term(), after_ :: term()}
@@ -114,6 +115,15 @@ defmodule PhoenixKit.Migrations.Repair do
     "DB is at version #{comment}, below this release's floor (#{floor}). Repair is a " <>
       "completeness tool, not a migration bridge — install the last 1.x bridge release, " <>
       "run mix phoenix_kit.update to reach the floor, then upgrade to this release."
+  end
+
+  def error_message({:comment_unreadable, _comment}) do
+    "PhoenixKit tables exist and the version comment is present but is not a plain " <>
+      "version number, so nothing can tell which migrations this database has. Repair " <>
+      "will not guess and --adopt will not overwrite it: whatever is written there is " <>
+      "the only record of what the last person believed. Read it, establish the real " <>
+      "state with mix phoenix_kit.doctor, then restamp by hand: " <>
+      "COMMENT ON TABLE <prefix>.phoenix_kit IS '<version>';"
   end
 
   def error_message({:above_current, comment, current}) do
@@ -206,6 +216,14 @@ defmodule PhoenixKit.Migrations.Repair do
 
       :adopt_required ->
         run_adopt_branch(ctx, comment1, skip_validate?)
+
+      # Never routed to `run_adopt_branch/3`, even with `--adopt`. That path
+      # stamps the floor version over whatever the comment holds, and here the
+      # comment holds something an operator wrote. Overwriting it destroys the
+      # only evidence of what they believed the database was, in the one state
+      # where that belief is the most useful thing in the room.
+      :comment_unreadable ->
+        {:error, {:comment_unreadable, comment1}}
 
       {:in_range, comment} ->
         run_in_range_branch(ctx, comment1, comment, skip_validate?)

--- a/lib/phoenix_kit/migrations/repair/comment_policy.ex
+++ b/lib/phoenix_kit/migrations/repair/comment_policy.ex
@@ -45,6 +45,7 @@ defmodule PhoenixKit.Migrations.Repair.CommentPolicy do
           :not_installed
           | {:below_floor, pos_integer()}
           | :adopt_required
+          | :comment_unreadable
           | {:in_range, pos_integer()}
           | {:above_current, pos_integer()}
 
@@ -72,6 +73,16 @@ defmodule PhoenixKit.Migrations.Repair.CommentPolicy do
   @spec classify(raw_comment(), floor :: pos_integer(), current :: pos_integer()) :: branch()
   def classify(:absent, _floor, _current), do: :not_installed
   def classify(nil, _floor, _current), do: :adopt_required
+
+  # Deliberately NOT folded into `:adopt_required`. Both mean "no usable
+  # version", but they are different facts about the database and the operator
+  # needs the difference: `nil` means there is nothing there, while
+  # `:unparseable` means someone wrote something and it is still readable. The
+  # `--adopt` path stamps the floor version over the comment, so collapsing the
+  # two silently destroyed the only record of what that person believed — and
+  # `adopt_required_message/0` told them the comment was "missing" while it sat
+  # in the table saying `v164`.
+  def classify(:unparseable, _floor, _current), do: :comment_unreadable
   def classify(0, _floor, _current), do: :adopt_required
 
   def classify(comment, floor, _current)

--- a/lib/phoenix_kit/migrations/repair/probe.ex
+++ b/lib/phoenix_kit/migrations/repair/probe.ex
@@ -34,7 +34,7 @@ defmodule PhoenixKit.Migrations.Repair.Probe do
   alias PhoenixKit.Migrations.ExpectedSchema.Object
 
   @typedoc "`:absent` (table missing), `nil` (table exists, no comment), or the numeric comment."
-  @type raw_comment :: :absent | nil | non_neg_integer()
+  @type raw_comment :: :absent | nil | :unparseable | non_neg_integer()
 
   @typedoc "One schema's structural snapshot — mirrors `PhoenixKit.Squash.Generate.Catalog.snapshot/2`'s shape, minus seeds (see moduledoc \"Seeds\" note on `PhoenixKit.Migrations.Repair.Differ`)."
   @type snapshot :: %{
@@ -86,9 +86,13 @@ defmodule PhoenixKit.Migrations.Repair.Probe do
       # An unparseable comment reads as "no usable version", which every caller
       # here already handles.
       {:ok, %{rows: [[version]]}} when is_binary(version) ->
+        # `n > 0` matters as much as the parse. `CommentPolicy.classify/3` has
+        # no clause for a non-positive version, so `' -5 '` would parse cleanly
+        # here and raise one call later — and the trim this fix added is what
+        # widened the set of inputs that get that far.
         case Integer.parse(String.trim(version)) do
-          {n, ""} -> n
-          _ -> nil
+          {n, ""} when n > 0 -> n
+          _ -> :unparseable
         end
 
       {:ok, %{rows: [[nil]]}} ->

--- a/lib/phoenix_kit/migrations/uuid_integrity.ex
+++ b/lib/phoenix_kit/migrations/uuid_integrity.ex
@@ -157,25 +157,39 @@ defmodule PhoenixKit.Migrations.UUIDIntegrity do
   Estimated row count, from the planner's statistics rather than a count(*).
 
   A sequential scan to decide whether to avoid an expensive operation is
-  self-defeating. `reltuples` of -1 means "never analyzed" and is reported as 0,
-  so an un-analyzed table is repaired rather than skipped — being wrong in that
-  direction leaves the table correct.
+  self-defeating, so this reads the planner's `reltuples`.
+
+  Returns `:unknown` when the table has never been vacuumed or analyzed
+  (`reltuples = -1` on PostgreSQL >= 14) or the catalog read fails. That used to
+  be reported as `0` on the reasoning that "being wrong in that direction leaves
+  the table correct" — true of the outcome, false of the cost, which is the only
+  thing the caller is asking about. A freshly restored 200k-row table read as
+  zero and took `ACCESS EXCLUSIVE` for a full rewrite mid-deploy, which is the
+  exact event the size limit exists to prevent.
   """
+  @spec estimated_rows(Ecto.Repo.t(), String.t(), String.t()) :: non_neg_integer() | :unknown
   def estimated_rows(repo, prefix, name) do
     # A name-based pg_class + pg_namespace JOIN, never `'schema.table'::regclass`:
     # regclass RAISES when the relation does not exist, which inside a migration
     # aborts the surrounding transaction and takes every other repair with it.
     # This is the chain's documented prefix-safety rule.
+    # `reltuples = -1` is PostgreSQL >= 14 for "never vacuumed or analyzed" — a
+    # table from `pg_restore`, `CREATE TABLE AS`, logical replication, or with
+    # autovacuum off. Collapsing that to 0 answered "small enough, proceed" for a
+    # table nobody had ever measured, which is precisely the input the size guard
+    # exists to stop: a 200k-row table read as 0 and took ACCESS EXCLUSIVE for a
+    # full rewrite mid-deploy. `:unknown` is the honest answer, and callers
+    # decide — the guard defers, the interactive task says so out loud.
     sql = """
-    SELECT COALESCE(NULLIF(c.reltuples, -1), 0)::bigint
+    SELECT c.reltuples::bigint
     FROM pg_class c
     JOIN pg_namespace n ON n.oid = c.relnamespace
     WHERE c.relname = $1 AND n.nspname = $2
     """
 
     case repo.query(sql, [name, prefix], log: false) do
-      {:ok, %{rows: [[n]]}} -> n
-      _ -> 0
+      {:ok, %{rows: [[n]]}} when is_integer(n) and n >= 0 -> n
+      _ -> :unknown
     end
   end
 


### PR DESCRIPTION
#694 merged at its third commit; the work after that never reached main. This is
that remainder, rebuilt onto current main.

**Dropped deliberately:** my version of the comment-less guard. `80fc6784`
replaced it with a better one — mine required a positive "there is no comment"
and fell through to the destructive branch on any failure to answer, while
`comment_literally_says_one?/1` requires a positive "the comment reads 1" and
treats everything else as unknown. That is the right direction and it is already
in main.

## Still live on main

**`mix phoenix_kit.status --verbose` crashes.** The non-verbose path reports the
unreadable-comment state correctly; `show_installation_diagnostics/2` has no
clause for it, so the run dies with `CaseClauseError` right after printing a
correct tree. This is the clause a previous commit message claimed and did not
contain.

## Introduced by #694 and fixed here

**A flaky FK probe aborted the entire chain run.** Moving V164's post-ADD check
to `fk_shape_present/5` was right for correctness and wrong for failure mode:
that probe raises, while the `fk_exists?/3` it replaced returned false. V164 has
no `rescue` and no `run_isolated/3` equivalent, so one failed catalog read on one
of ~70 constraints aborted mid-run — earlier repairs already auto-committed under
`@disable_ddl_transaction`, `COMMENT … IS '164'` never reached, whole version
replays next time. A probe failure is now a `{:failed, …}` entry in the summary.

## Pre-existing, found by the same review

- **`comments_fk_on_delete/1` matched by name alone.** A CHECK, or an FK on a
  different column, owning `fk_comments_user_uuid` answered for the real one — a
  `confdeltype` of `'n'` from an impostor reads as "already SET NULL", so
  `repair_comments_fk/2` returns `[]` and the genuinely missing FK is never
  created. Now anchored on `contype`, arity and column. `fk_validated?/3` stays
  name-only and now documents why: every caller reaches it through the shape gate.
- **`Repair.Probe` collapsed a corrupt comment into "absent".** Both returned
  `nil`, so `adopt_required_message/0` said the comment was "missing" while the
  table held `v164`, and `--adopt` stamped the floor over it — destroying the only
  record of what the last operator believed, in the state where that belief is the
  most useful thing available. A fourth value, `:unparseable`, maps to its own
  `:comment_unreadable` branch that refuses rather than adopting.
- **`estimated_rows/3` reported a never-analyzed table as 0 rows.** PostgreSQL
  ≥ 14 leaves `reltuples = -1` until the first vacuum or analyze — `pg_restore`,
  `CREATE TABLE AS`, logical replication, autovacuum off. Measured: 200k rows read
  as zero, so the size guard passed and V163 would take `ACCESS EXCLUSIVE` for a
  full rewrite on exactly the table the limit exists to protect. It now returns
  `:unknown`, V163 defers on it, and `mix phoenix_kit.repair_uuid` prints
  "size unknown — never analyzed" instead of "~0 rows" to whoever is sizing the
  maintenance window.
- **V163's deferral text named a remedy that cannot work** on a table that is
  also uncastable — since the reorder, such a table takes that branch.

## Verification

`test/phoenix_kit` — 1153 tests, 38 doctests, 0 failures (359 excluded: the
integration half, no database reachable). `mix format --check-formatted`,
`mix compile --warnings-as-errors`, `mix credo --strict` (10297 mods/funs) clean.

⚠️ `mix dialyzer` halts on this branch, on two `LocaleSlug` warnings in
`lib/phoenix_kit/utils/slug.ex` — a file this branch does not touch, with no
entry in `.dialyzer_ignore.exs`. Pre-existing, so `mix quality` / `precommit`
fail here for a reason unrelated to this PR; worth someone's attention
separately.

`@version` and `CHANGELOG.md` untouched.