### PR TITLE
Refuse a malformed actor in the two siblings of the credential guard

### DIFF
--- a/lib/phoenix_kit/users/auth.ex
+++ b/lib/phoenix_kit/users/auth.ex
@@ -1342,6 +1342,16 @@ defmodule PhoenixKit.Users.Auth do
   @doc """
   Toggles user confirmation status (admin function).
 
+  ## Authorization
+
+  Pass `actor: %User{}` and the RANK rule is enforced here, in the context —
+  the actor must outrank the target (`can_manage_user_status?/2`). Do that from
+  every request-driven path.
+
+  Omitting `:actor` is the system path and performs NO authorization, matching
+  `update_user_status/3`. An `:actor` that is PRESENT but is not a `%User{}` is
+  refused rather than read as absent.
+
   ## Examples
 
       iex> toggle_user_confirmation(confirmed_user)
@@ -1349,6 +1359,9 @@ defmodule PhoenixKit.Users.Auth do
 
       iex> toggle_user_confirmation(unconfirmed_user)
       {:ok, %User{confirmed_at: ~N[2023-01-01 12:00:00]}}
+
+      iex> toggle_user_confirmation(owner, actor: admin)
+      {:error, :insufficient_permissions}
   """
   def toggle_user_confirmation(user, opts \\ [])
 
@@ -1364,8 +1377,22 @@ defmodule PhoenixKit.Users.Auth do
           do: do_toggle_user_confirmation(user),
           else: {:error, :insufficient_permissions}
 
-      _system ->
+      # Only an ABSENT actor is the system path — seeds, migrations and mix
+      # tasks pass no opts at all. A value that is present but not a `%User{}`
+      # (a map decoded from JSON by a host controller, a bare uuid string) is a
+      # caller that meant to supply an actor and got the shape wrong; treating
+      # that as "no actor" would hand it the unchecked path. Fails closed for
+      # the same reason `admin_update_user_password/3` does, and it matters most
+      # here: the unchecked path can clear `confirmed_at`.
+      nil ->
         do_toggle_user_confirmation(user)
+
+      _malformed ->
+        Logger.warning(
+          "PhoenixKit: refused a confirmation toggle for #{target_label(user)} — :actor was present but not a %User{}"
+        )
+
+        {:error, :insufficient_permissions}
     end
   end
 
@@ -2237,7 +2264,9 @@ defmodule PhoenixKit.Users.Auth do
 
   Omitting `:actor` means "system-initiated" and performs NO authorization —
   correct for `PhoenixKit.Users.Referrals` expiring an account, wrong for
-  anything a user asked for.
+  anything a user asked for. An `:actor` that is PRESENT but is not a `%User{}`
+  is refused rather than read as absent: it is a caller that meant to supply an
+  actor and got the shape wrong.
 
   ## Parameters
 
@@ -2267,8 +2296,22 @@ defmodule PhoenixKit.Users.Auth do
           {:error, :insufficient_permissions}
         end
 
-      _system ->
+      # Only an ABSENT actor is the system path — `PhoenixKit.Users.Referrals`
+      # expires an account with no `:actor` at all, as do seeds and mix tasks. A
+      # value that is present but not a `%User{}` (a map decoded from JSON by a
+      # host controller, a bare uuid string) is a caller that meant to supply an
+      # actor and got the shape wrong; treating that as "no actor" would hand it
+      # the unchecked path. Fails closed, matching
+      # `admin_update_user_password/3`.
+      nil ->
         do_update_user_status_with_owner_guard(user, attrs)
+
+      _malformed ->
+        Logger.warning(
+          "PhoenixKit: refused a status write for #{target_label(user)} — :actor was present but not a %User{}"
+        )
+
+        {:error, :insufficient_permissions}
     end
   end
 

--- a/test/integration/users/security_authority_test.exs
+++ b/test/integration/users/security_authority_test.exs
@@ -47,6 +47,10 @@ defmodule PhoenixKit.Integration.Users.SecurityAuthorityTest do
   # was actually stored, so a guard that refuses only after writing still fails.
   defp password_hash(user), do: Repo.get!(Auth.User, user.uuid).hashed_password
 
+  # Same reason, for the confirmation toggle: the refusal has to be visible in
+  # the row, not merely in the return value.
+  defp confirmed_at(user), do: Repo.get!(Auth.User, user.uuid).confirmed_at
+
   # The actor this whole series exists to stop: a role that holds the `users`
   # permission — which is what admits it to the user pages — and no staff role.
   #
@@ -210,6 +214,25 @@ defmodule PhoenixKit.Integration.Users.SecurityAuthorityTest do
       assert {:ok, updated} = Auth.update_user_status(target, %{"is_active" => false})
       refute updated.is_active
     end
+
+    test "a present but malformed actor is refused rather than taking the system path" do
+      # The system path exists for callers that pass no `:actor` at all —
+      # `PhoenixKit.Users.Referrals` expiring an account, plus seeds and mix
+      # tasks. A value that is present but not a `%User{}` (a map decoded from
+      # JSON by a host application's controller, a bare uuid string) is a caller
+      # that meant to supply an actor and got the shape wrong, and reading that
+      # as "no actor" hands it the unchecked path. Same table of shapes as the
+      # `admin_update_user_password/3` test below, because it is the same rule.
+      target = plain_user()
+
+      for malformed <- [%{"uuid" => Ecto.UUID.generate()}, "some-uuid-string", false, 42] do
+        assert {:error, :insufficient_permissions} =
+                 Auth.update_user_status(target, %{"is_active" => false}, actor: malformed),
+               "a #{inspect(malformed)} actor took the unchecked path"
+      end
+
+      assert Repo.get!(Auth.User, target.uuid).is_active
+    end
   end
 
   describe "admin_update_user_password/3 enforces rank in the context" do
@@ -329,6 +352,91 @@ defmodule PhoenixKit.Integration.Users.SecurityAuthorityTest do
                Auth.admin_update_user_password(target, %{password: "NewPassword123!"})
 
       refute password_hash(target) == before
+    end
+  end
+
+  describe "toggle_user_confirmation/2 enforces rank in the context" do
+    # The third function offered from the same pages, to the same holders of the
+    # `users` permission, and until now the least covered: it had no test of the
+    # rank rule at all. Unconfirming is the sharper half of the toggle —
+    # `require_email_confirmation` is honoured at eleven gates, so clearing
+    # `confirmed_at` locks the target out of every protected page. That is the
+    # same denial of service `update_user_status/3` closes, against the same
+    # accounts that are meant to outrank the actor.
+    #
+    # Each assertion re-reads `confirmed_at` from the database rather than
+    # trusting the return value: a guard that refuses after writing would still
+    # satisfy the tuple.
+    test "an Admin may not unconfirm an Owner — the lockout this closes" do
+      owner = owner_user()
+
+      assert {:error, :insufficient_permissions} =
+               Auth.toggle_user_confirmation(owner, actor: admin_user())
+
+      assert confirmed_at(owner)
+    end
+
+    test "an Admin may not unconfirm another Admin" do
+      target = admin_user()
+
+      assert {:error, :insufficient_permissions} =
+               Auth.toggle_user_confirmation(target, actor: admin_user())
+
+      assert confirmed_at(target)
+    end
+
+    test "a non-staff actor holding only a permission is refused" do
+      target = plain_user()
+
+      assert {:error, :insufficient_permissions} =
+               Auth.toggle_user_confirmation(target, actor: users_permission_holder())
+
+      assert confirmed_at(target)
+    end
+
+    test "your own confirmation is not yours to toggle" do
+      # `can_manage_user_status?/2` is the shared predicate, and it refuses self
+      # where the credential rule allows it. Inherited here on purpose: locking
+      # yourself out of every gated page is the same accident, not a routine one.
+      actor = admin_user()
+
+      assert {:error, :insufficient_permissions} =
+               Auth.toggle_user_confirmation(actor, actor: actor)
+
+      assert confirmed_at(actor)
+    end
+
+    test "an in-rank actor may toggle in both directions" do
+      target = plain_user()
+      admin = admin_user()
+
+      assert {:ok, unconfirmed} = Auth.toggle_user_confirmation(target, actor: admin)
+      refute unconfirmed.confirmed_at
+      refute confirmed_at(target)
+
+      assert {:ok, reconfirmed} = Auth.toggle_user_confirmation(unconfirmed, actor: admin)
+      assert reconfirmed.confirmed_at
+      assert confirmed_at(target)
+    end
+
+    test "a present but malformed actor is refused rather than taking the system path" do
+      target = plain_user()
+
+      for malformed <- [%{"uuid" => Ecto.UUID.generate()}, "some-uuid-string", false, 42] do
+        assert {:error, :insufficient_permissions} =
+                 Auth.toggle_user_confirmation(target, actor: malformed),
+               "a #{inspect(malformed)} actor took the unchecked path"
+      end
+
+      assert confirmed_at(target)
+    end
+
+    test "omitting the actor is the system path and still writes" do
+      target = plain_user()
+
+      assert {:ok, updated} = Auth.toggle_user_confirmation(target)
+      refute updated.confirmed_at
+      refute confirmed_at(target)
     end
   end
 

--- a/test/integration/users/user_form_authority_test.exs
+++ b/test/integration/users/user_form_authority_test.exs
@@ -41,6 +41,15 @@ defmodule PhoenixKit.Integration.Users.UserFormAuthorityTest do
     Repo.get!(Auth.User, user.uuid)
   end
 
+  # A value that is hostile AND schema-valid for its field. Both halves matter:
+  # hostile so the assertion means something, valid so the changeset is not
+  # rejected for a reason that has nothing to do with the filter under test. A
+  # value that fails validation makes the test pass no matter what the filter
+  # does, which is exactly how this test spent its life proving nothing.
+  defp poison_for(:email), do: "attacker@example.com"
+  defp poison_for(:user_timezone), do: "0"
+  defp poison_for(field), do: "attacker-#{field}"
+
   setup do
     {:ok, seed} = Auth.register_user(%{email: unique_email(), password: "ValidPassword123!"})
     {:ok, _} = Auth.admin_confirm_user(seed)
@@ -145,6 +154,13 @@ defmodule PhoenixKit.Integration.Users.UserFormAuthorityTest do
       after_submit = Repo.get!(Auth.User, target.uuid)
       assert after_submit.hashed_password == before.hashed_password
       assert after_submit.email == before.email
+
+      # The other half of "refuses cleanly": only the credential fields are
+      # dropped. Asserting the two unchanged fields alone is satisfied just as
+      # well by a regression that abandons the whole write — the crash this test
+      # was written for did exactly that, half-way through — so pin that the
+      # non-credential field this submission carried did land.
+      assert after_submit.first_name == "Renamed"
     end
 
     test "every field the context routes into the schema is dropped, not just the two",
@@ -159,18 +175,29 @@ defmodule PhoenixKit.Integration.Users.UserFormAuthorityTest do
 
       {:ok, view, _html} = live(conn, Routes.path("/admin/users/edit/#{owner.uuid}"))
 
-      poisoned =
-        Map.new(Auth.updatable_profile_fields(), fn field ->
-          {Atom.to_string(field), "attacker-#{field}"}
-        end)
-
-      render_submit(view, "save_user", %{
-        "user" => %{"first_name" => "Harmless", "custom_fields" => poisoned}
-      })
-
-      after_submit = Repo.get!(Auth.User, owner.uuid)
-
+      # ONE poisoned field per submission, not all five in one payload.
+      #
+      # The all-at-once form was vacuous and had never once exercised the bypass
+      # it is named after. `Auth.update_user_fields/2` routes every schema field
+      # it recognises into a SINGLE `profile_changeset`, and the generated value
+      # for `user_timezone` — "attacker-user_timezone" — fails that field's
+      # format validation. One invalid member made the whole changeset invalid,
+      # so nothing was written whether the filter ran or not, and the assertion
+      # loop compared an untouched row to itself. Verified: with
+      # `drop_schema_identity_fields/2` deleted, the old form still passed.
+      #
+      # Per-field submission is also what keeps this honest as the list grows: a
+      # sixth field with its own validator would silently re-vacuum a shared
+      # payload, and nothing would say so.
       for field <- Auth.updatable_profile_fields() do
+        {:ok, view, _html} = live(conn, Routes.path("/admin/users/edit/#{owner.uuid}"))
+
+        render_submit(view, "save_user", %{
+          "user" => %{"custom_fields" => %{Atom.to_string(field) => poison_for(field)}}
+        })
+
+        after_submit = Repo.get!(Auth.User, owner.uuid)
+
         assert Map.get(after_submit, field) == Map.get(owner, field),
                "#{field} reached the schema through custom_fields"
       end


### PR DESCRIPTION
Follow-up to the post-merge review of #691, which found the actor-shape hole
closed for `admin_update_user_password/3` still open in its two siblings.

## The hole

`update_user_status/3` and `toggle_user_confirmation/2` both ended in:

```elixir
_system ->
  do_...(user)   # unchecked write
```

That branch exists for callers with no actor — seeds, mix tasks, and
`Users.Referrals`, which expires an account deliberately without one. It also
swallowed every **malformed** actor: `%{"uuid" => …}` decoded from JSON by a host
controller, a bare uuid string, `false`, `42`. Each took the unchecked path.

`toggle_user_confirmation/2` is the serious one — its unchecked path reaches
`admin_unconfirm_user/1`, clearing `confirmed_at` and locking the target out of
every confirmation-gated page. `update_user_status/3` is the same shape with a
reversible effect.

Neither is reachable from core: every LiveView caller passes a real `%User{}`.
This is host-facing surface, and the same authority-bypass class the series set
out to close.

## What changed

Both now use the three-branch shape from `admin_update_user_password/3`,
including the refusal log. Consistency between the three was the goal — three
functions with one stated rule and three different behaviours is the next bug.

An explicit `actor: nil` still takes the system path, identically in all three:
`Keyword.get`/`Map.get` cannot distinguish it from an absent key. Making it fail
closed is a decision for all three at once and is left out of this PR.

## Tests, and an honest accounting of them

The two malformed-actor tests are the ones that carry the fix — verified by
reverting `auth.ex` and re-running: exactly those two go red.

The six new `toggle_user_confirmation/2` tests **survive that revert**. They are
characterization coverage for a rule that had none — `toggle_user_confirmation`
appeared zero times in this file before — and they are described that way rather
than counted as regression detection.

## A vacuous test, fixed

`user_form_authority_test.exs`'s drift pin had been red on `main`, and underneath
that it was proving nothing.

It submitted `"first_name" => "Harmless"` as harness scaffolding while asserting
`first_name` was unchanged — an Admin editing an Owner may legitimately set it,
so the test failed on its own input. Removing that exposed the real problem: it
poisoned all five identity fields in **one** payload, `Auth.update_user_fields/2`
routes them into a **single** `profile_changeset`, and the generated
`"attacker-user_timezone"` fails that field's format validation. One invalid
member invalidated the whole changeset, so nothing was written whether the filter
ran or not.

Confirmed by deleting the `drop_schema_identity_fields/2` call and watching the
test still pass. It now submits one poisoned-but-schema-valid field per
submission, so no single value can abort the others, and it goes red when the
filter is removed.

Worth noting for the next reader: the "sixth field added to
`updatable_profile_fields/0` and forgotten in the filter" drift this test names
is structurally impossible — the filter is derived from that list, not a copy of
it. What it actually pins is that nobody replaces the derived list with a
hardcoded one.

## Verification

`test/integration/users` — **383 tests, 0 failures**, no `excluded` count.
`mix format --check-formatted`, `mix compile --warnings-as-errors`,
`mix credo --strict` (10298 mods/funs) clean.

`@version` and `CHANGELOG.md` untouched.