### PR TITLE
Sort a user's notifications unseen first

### DIFF
--- a/lib/phoenix_kit/notifications/notifications.ex
+++ b/lib/phoenix_kit/notifications/notifications.ex
@@ -406,7 +406,8 @@ defmodule PhoenixKit.Notifications do
   # ── Reads ────────────────────────────────────────────────────────────
 
   @doc """
-  Returns `{notifications, total_count}` for the given user, newest first.
+  Returns `{notifications, total_count}` for the given user — unseen first,
+  then newest first within each group.
 
   Options:
     * `:page` (default 1) / `:per_page` (default 25)
@@ -430,7 +431,7 @@ defmodule PhoenixKit.Notifications do
 
     rows =
       base_query
-      |> order_by([n], desc: n.inserted_at)
+      |> order_unseen_first()
       |> limit(^per_page)
       |> offset(^((page - 1) * per_page))
       |> repo().all()
@@ -439,10 +440,35 @@ defmodule PhoenixKit.Notifications do
     {rows, total}
   end
 
+  # Unseen first, then newest first inside each group.
+  #
+  # Newest-first alone interleaves the two: read one notification and it stays
+  # where it was, so anything you haven't looked at yet ends up scattered among
+  # things you have. On an inbox of any size that means scrolling the whole
+  # list to find what you missed — the one question a notification centre
+  # exists to answer at a glance.
+  #
+  # Ordering by seen-ness pulls everything outstanding to the top and keeps it
+  # there until you deal with it, which is also why "seen" is only ever set by
+  # an explicit action: nothing moves while you are looking at it.
+  #
+  # `IS NOT NULL` rather than `is_nil(...)` inverted, because false sorts
+  # before true — so unseen (NULL `seen_at`, hence false) comes first without
+  # a negation to read past.
+  defp order_unseen_first(query) do
+    order_by(query, [n], asc: fragment("? IS NOT NULL", n.seen_at), desc: n.inserted_at)
+  end
+
   @doc """
   Returns `{notifications, total_count}` across ALL users, newest first, for the
   admin overview. Recipient and activity(+actor) are preloaded so the admin
   table can show who each notification is for and what it's about.
+
+  Deliberately plain newest-first, unlike the per-user reads: "seen" belongs to
+  the recipient, and an admin scanning everybody's notifications is reading a
+  chronological record, not working through their own inbox. Sorting a shared
+  audit feed by whether somebody else has read each row would reorder it
+  differently for no one's benefit.
 
   Options: `:page` (default 1) / `:per_page` (default 25).
   """
@@ -466,14 +492,20 @@ defmodule PhoenixKit.Notifications do
   end
 
   @doc """
-  Returns the N most-recent undismissed notifications for a user.
+  Returns the N most-recent undismissed notifications for a user, unseen
+  first.
 
   Drives the bell dropdown. Activity (and actor) are preloaded.
+
+  Unseen first matters more here than in the full list: the dropdown shows a
+  handful, so with a plain newest-first order a notification you had already
+  read could push an unread one off the bottom entirely — the badge counts it,
+  and opening the bell doesn't show it.
   """
   def recent_for_user(user_uuid, limit \\ 10) when is_binary(user_uuid) do
     Notification
     |> where([n], n.recipient_uuid == ^user_uuid and is_nil(n.dismissed_at))
-    |> order_by([n], desc: n.inserted_at)
+    |> order_unseen_first()
     |> limit(^limit)
     |> repo().all()
     |> repo().preload(activity: [:actor])

--- a/test/integration/notifications/ordering_test.exs
+++ b/test/integration/notifications/ordering_test.exs
@@ -1,0 +1,137 @@
+defmodule PhoenixKit.Integration.Notifications.OrderingTest do
+  @moduledoc """
+  Unseen first, then newest first within each group.
+
+  Newest-first alone interleaves the two: reading a notification leaves it
+  where it was, so anything still outstanding ends up scattered among things
+  already dealt with. On an inbox of any size that means scrolling the whole
+  list to find what was missed — the one question a notification centre exists
+  to answer at a glance.
+
+  Ordering is a promise the UI makes, so it is pinned against the database
+  rather than against a sort function: this is what a host embedding the bell
+  actually gets.
+  """
+  use PhoenixKit.DataCase, async: true
+
+  alias PhoenixKit.Activity
+  alias PhoenixKit.Notifications
+  alias PhoenixKit.Users.Auth
+
+  defp create_user do
+    {:ok, user} =
+      Auth.register_user(%{
+        email: "notif_order_#{System.unique_integer([:positive])}@example.com",
+        password: "ValidPassword123!"
+      })
+
+    user
+  end
+
+  # One notification for `target`, labelled so order is readable in a failure.
+  # The actor differs from the target so the activity hook fans it out.
+  defp notify(target, actor, label) do
+    Activity.log(%{
+      action: "demo.notification",
+      module: "demo",
+      mode: "manual",
+      actor_uuid: actor.uuid,
+      resource_type: "demo",
+      target_uuid: target.uuid,
+      metadata: %{"notification_text" => label}
+    })
+
+    # `inserted_at` has second granularity in this schema, so several created
+    # inside one second would tie and leave the newest-first half of the order
+    # unprovable. Waiting is the honest way to get distinct timestamps.
+    Process.sleep(1_100)
+
+    {rows, _} = Notifications.list_for_user(target.uuid)
+    Enum.find(rows, &(text(&1) == label))
+  end
+
+  defp text(notification), do: get_in(notification.activity.metadata, ["notification_text"])
+
+  defp labels(target) do
+    {rows, _} = Notifications.list_for_user(target.uuid)
+    Enum.map(rows, &text/1)
+  end
+
+  defp bell_labels(target, limit) do
+    target.uuid |> Notifications.recent_for_user(limit) |> Enum.map(&text/1)
+  end
+
+  describe "list_for_user/2" do
+    @tag timeout: 120_000
+    test "an unseen older notification outranks a seen newer one" do
+      target = create_user()
+      actor = create_user()
+
+      notify(target, actor, "old")
+      newer = notify(target, actor, "new")
+
+      # Newest first while both are unseen.
+      assert labels(target) == ["new", "old"]
+
+      # Reading the newer one sends it below the older one still outstanding —
+      # the whole point. Before this, "new" stayed on top and "old" sat under
+      # something already handled.
+      {:ok, _} = Notifications.mark_seen(target.uuid, newer.uuid)
+
+      assert labels(target) == ["old", "new"]
+    end
+
+    @tag timeout: 120_000
+    test "newest first still holds within each group" do
+      target = create_user()
+      actor = create_user()
+
+      notify(target, actor, "a")
+      notify(target, actor, "b")
+      c = notify(target, actor, "c")
+      d = notify(target, actor, "d")
+
+      # The two NEWEST are the ones read. Marking the two oldest instead would
+      # leave both orderings agreeing on d, c, b, a, and prove nothing.
+      {:ok, _} = Notifications.mark_seen(target.uuid, c.uuid)
+      {:ok, _} = Notifications.mark_seen(target.uuid, d.uuid)
+
+      # Unseen b, a (newest first) — then seen d, c (newest first). Plain
+      # newest-first would say d, c, b, a.
+      assert labels(target) == ["b", "a", "d", "c"]
+    end
+
+    @tag timeout: 120_000
+    test "all seen falls back to plain newest first" do
+      target = create_user()
+      actor = create_user()
+
+      first = notify(target, actor, "first")
+      second = notify(target, actor, "second")
+
+      {:ok, _} = Notifications.mark_seen(target.uuid, first.uuid)
+      {:ok, _} = Notifications.mark_seen(target.uuid, second.uuid)
+
+      assert labels(target) == ["second", "first"]
+    end
+  end
+
+  describe "recent_for_user/2" do
+    @tag timeout: 120_000
+    test "an unread notification is not pushed off the end by a read one" do
+      # The dropdown shows a handful, so this is worse here than in the full
+      # list: with plain newest-first the badge counts something the bell
+      # cannot show, because a notification already read took its place.
+      target = create_user()
+      actor = create_user()
+
+      notify(target, actor, "unread")
+      read = notify(target, actor, "read")
+
+      {:ok, _} = Notifications.mark_seen(target.uuid, read.uuid)
+
+      assert bell_labels(target, 1) == ["unread"]
+      assert Notifications.count_unread(target.uuid) == 1
+    end
+  end
+end


### PR DESCRIPTION
The notification centre sorts newest first, which interleaves read and unread.
Opening a notification leaves it exactly where it was, so anything still
outstanding ends up scattered among things already dealt with — read a new
arrival and the older unread one is now sitting underneath it.

On an inbox of any size that means scrolling up and down hunting for what was
missed, which is the one question a notification centre exists to answer at a
glance.

## The change

Unseen sort above seen; newest first within each group. Reading something drops
it below whatever is still outstanding, so the unread block stays contiguous at
the top.

```elixir
order_by(query, [n], asc: fragment("? IS NOT NULL", n.seen_at), desc: n.inserted_at)
```

`IS NOT NULL` rather than an inverted `is_nil`, because false sorts before true
— unseen comes first without a negation to read past.

Applies to `list_for_user/2` and `recent_for_user/2`.

## Why it matters more in the bell

The dropdown shows ten. With plain newest-first, a notification already read
could push an unread one off the bottom entirely — so the badge counts something
opening the bell doesn't show. There's a test for exactly that.

## Nothing shuffles while you're looking at it

"Seen" is only ever set by an explicit action, and on that click the bell either
navigates away or refreshes — so the reorder lands on the *next* look rather
than under the cursor. No change was needed there; worth stating because the
opposite would be worse than the bug.

## Deliberately unchanged

`admin_list/1` stays plain newest-first. "Seen" belongs to the recipient, and an
admin scanning everybody's notifications is reading a chronological record, not
working through their own inbox — sorting a shared audit feed by whether someone
else has read each row reorders it differently for nobody's benefit. Recorded in
the doc so the inconsistency doesn't look like an oversight.

## Testing

Four integration tests, pinned against the database rather than a sort function,
since ordering is a promise the UI makes and this is what a host embedding the
bell actually gets:

- an unseen older notification outranks a seen newer one
- newest-first still holds *within* each group
- all-seen falls back to plain newest-first
- an unread notification is not pushed off the end of the bell by a read one

Mutation-tested: reverting to plain newest-first fails three of the four. The
fourth is the all-seen fallback, which correctly shouldn't change either way.

One note on the second test — my first version marked the two *oldest* as read,
where both orderings agree on the result and it proved nothing. It now marks the
two newest, so the expectation (`b, a, d, c`) differs from what newest-first
would give (`d, c, b, a`).

45 notification tests and 101 LiveView tests pass; `credo --strict` clean;
compiles with `--warnings-as-errors`.

## One thing worth a look separately

`n_recipient_inbox_index` is `(recipient_uuid, inserted_at DESC) WHERE
dismissed_at IS NULL`. It still serves the fetch, but the new sort key isn't in
it, so ordering happens in memory. Irrelevant at inbox sizes — retention prunes
at 90 days by default — but if these ever grow large the index wants
`(recipient_uuid, (seen_at IS NOT NULL), inserted_at DESC)`. Not added here:
that's a migration, and the chain isn't mine to extend on a whim.

No version bump or CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NTj7hm3fpCTcFvKLRtgppW
