### PR TITLE
Warn when a module's JS hooks will never be loaded

### DIFF
--- a/lib/mix/tasks/compile.phoenix_kit_js_sources.ex
+++ b/lib/mix/tasks/compile.phoenix_kit_js_sources.ex
@@ -2,9 +2,7 @@ defmodule Mix.Tasks.Compile.PhoenixKitJsSources do
   @moduledoc """
   Mix compiler that vendors PhoenixKit's JS hooks into the host app.
 
-  A LiveView JS hook must be present in the host's single `LiveSocket` at
-  construction time — a nested LiveView cannot register one at runtime. This
-  compiler keeps two vendored files current on **every** `mix compile`:
+  This compiler keeps two vendored files current on **every** `mix compile`:
 
   1. `priv/static/assets/vendor/phoenix_kit.js` — a straight copy of
      PhoenixKit's own core hooks file. Previously this was only copied once,
@@ -43,6 +41,30 @@ defmodule Mix.Tasks.Compile.PhoenixKitJsSources do
   Failures are loud: a missing core JS file (corrupted/incomplete dependency
   fetch) or a declared module bundle that can't be resolved raises a compile
   error rather than silently shipping "unknown hook" console errors.
+
+  ## This is a fast path, not the only way
+
+  It used to be the only way, on the reasoning that a hook had to be in the
+  host's single `LiveSocket` at construction time because a nested LiveView
+  could not register one at runtime. That stopped being true in LiveView 1.1:
+  `getHookDefinition/1` resolves a hook name when its element mounts, and falls
+  back to a `script[data-phx-runtime-hook="Name"]` in the document whose
+  `window.phx_hook_<Name>()` returns the callbacks. LiveView re-creates such a
+  script when a patch adds it, so it works on a page delivered over the socket
+  as well as in the first HTML.
+
+  A module can therefore ship its hooks itself and ask nothing of the host —
+  `phoenix_kit_boards` does, after two releases where `js_sources/0` alone
+  silently delivered nothing to hosts that bundle dependency JS their own way.
+  The host's own registration still wins (`getHookDefinition` checks
+  `liveSocket.hooks` first), so the two never collide and this compiler stays
+  the cheaper path where it is set up.
+
+  What it must not be is a *silent* requirement. `PhoenixKitWeb.Integration`
+  warns at compile time when installed modules declare `js_sources/0` and this
+  compiler is absent from the host's `:compilers` — the state where those
+  modules' hooks are never delivered, no error appears anywhere, and only the
+  feature is missing.
   """
 
   use Mix.Task.Compiler

--- a/lib/phoenix_kit_web/integration.ex
+++ b/lib/phoenix_kit_web/integration.ex
@@ -1148,6 +1148,89 @@ defmodule PhoenixKitWeb.Integration do
     end
   end
 
+  @doc false
+  # Warn when installed modules ship JS hooks the host will never load.
+  #
+  # A module declares its hook bundle with `js_sources/0`, and the ONLY thing
+  # that consumes that declaration is the `:phoenix_kit_js_sources` compiler.
+  # A host without it in `:compilers` gets nothing: no vendored bundle, no
+  # error, no warning — `window.PhoenixKitHooks` simply never gains those
+  # hooks, while the module's templates go on rendering `phx-hook="..."` names
+  # the LiveSocket has never heard of.
+  #
+  # That failure is the worst available shape. The page renders, the module
+  # looks installed, and only the half of the feature that needed JS is
+  # missing — so it reads as "this module is broken" rather than "its JS never
+  # loaded". `phoenix_kit_boards` shipped that state twice before anyone
+  # traced it, and a host running the CSS compiler but not the JS one (an easy
+  # asymmetry to end up with) hits it without ever having made a decision.
+  #
+  # Cheap to detect and worth saying out loud: if any module declares a bundle
+  # and the compiler is absent, name the modules and the one line that fixes
+  # it. Silence here has cost more than a warning ever will.
+  def warn_missing_js_compiler do
+    warn_missing_js_compiler(modules_declaring_js_sources(), js_compiler_configured?())
+  end
+
+  @doc false
+  # Split from the discovery so the decision can be tested for what it is: a
+  # question about two facts. Reaching it through the real dep tree would mean
+  # the interesting branch only runs on a host that happens to be misconfigured
+  # — i.e. never, in this library's own suite.
+  def warn_missing_js_compiler(modules, compiler_configured?)
+
+  def warn_missing_js_compiler([], _compiler_configured?), do: :ok
+  def warn_missing_js_compiler(_modules, true), do: :ok
+
+  def warn_missing_js_compiler(modules, false) do
+    IO.warn("""
+    PhoenixKit: these modules ship JavaScript hooks that will not be loaded:
+
+      #{Enum.map_join(modules, "\n  ", &inspect/1)}
+
+    They declare `js_sources/0`, which only the `:phoenix_kit_js_sources`
+    compiler consumes, and it is not in this app's `:compilers`. Their hooks
+    will be missing from `window.PhoenixKitHooks` with no further error —
+    their pages will render and the parts that need JavaScript will not work.
+
+    Add it to mix.exs:
+
+        compilers: [:phoenix_kit_js_sources, :phoenix_live_view] ++ Mix.compilers()
+
+    and make sure the root layout loads the vendored bundles before app.js:
+
+        <script src={~p"/assets/vendor/phoenix_kit.js"}></script>
+        <script src={~p"/assets/vendor/phoenix_kit_modules.js"}></script>
+    """)
+
+    :ok
+  end
+
+  defp modules_declaring_js_sources do
+    PhoenixKit.ModuleDiscovery.discover_external_modules()
+    |> Enum.filter(fn mod ->
+      Code.ensure_loaded?(mod) and function_exported?(mod, :js_sources, 0) and
+        mod.js_sources() != []
+    end)
+  rescue
+    # Discovery reaches into the dep tree; a warning is never worth failing a
+    # host's compile over.
+    _ -> []
+  end
+
+  # Mix is present while the host's router compiles, which is when this runs.
+  # Guarded anyway: releases and escripts can evaluate code with Mix unloaded,
+  # and there is nothing to warn about there — the compile already happened.
+  defp js_compiler_configured? do
+    if Code.ensure_loaded?(Mix.Project) and function_exported?(Mix.Project, :config, 0) do
+      :phoenix_kit_js_sources in (Mix.Project.config()[:compilers] || [])
+    else
+      true
+    end
+  rescue
+    _ -> true
+  end
+
   # Compile public routes from external route modules.
   # Each module should implement public_routes/1 (receives url_prefix).
   @doc false
@@ -1392,6 +1475,10 @@ defmodule PhoenixKitWeb.Integration do
     # here would be silently ignored (it was, for months). Which locales
     # are actually accepted is decided at runtime by the locale
     # validation plug; see `build_live_surface/5`.
+
+    # Every host compiles this macro, which makes it the one place that can
+    # see a host-side integration gap the compiler itself cannot report.
+    warn_missing_js_compiler()
 
     # External route modules with public/non-admin routes
     external_public_routes = compile_external_public_routes(url_prefix)

--- a/test/phoenix_kit_web/js_compiler_warning_test.exs
+++ b/test/phoenix_kit_web/js_compiler_warning_test.exs
@@ -1,0 +1,80 @@
+defmodule PhoenixKitWeb.JsCompilerWarningTest do
+  @moduledoc """
+  The warning that fires when installed modules ship JS hooks the host will
+  never load.
+
+  A module declares its bundle with `js_sources/0`, and the only thing that
+  consumes that declaration is the `:phoenix_kit_js_sources` compiler. Without
+  it in the host's `:compilers` the hooks are simply absent — no error
+  anywhere, the module's pages render, and only the half that needed
+  JavaScript is missing, so it reads as a broken module rather than as JS that
+  never loaded. `phoenix_kit_boards` shipped exactly that state twice before
+  anyone traced it.
+
+  Two things are worth pinning, and they pull against each other: it has to
+  speak up in that state, and stay silent in every other. A warning that fires
+  on correctly-configured hosts gets muted, which puts everyone back where
+  they started.
+  """
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureIO
+
+  alias PhoenixKitWeb.Integration
+
+  defp warning(modules, compiler_configured?) do
+    capture_io(:stderr, fn ->
+      assert Integration.warn_missing_js_compiler(modules, compiler_configured?) == :ok
+    end)
+  end
+
+  describe "the host is missing the compiler" do
+    test "names the modules whose hooks will not load" do
+      output = warning([SomeModule.WithHooks, Another.Module], false)
+
+      assert output =~ "will not be loaded"
+      assert output =~ "SomeModule.WithHooks"
+      assert output =~ "Another.Module"
+    end
+
+    test "says what to do about it" do
+      # A warning naming a problem and not its fix is a warning people learn
+      # to scroll past.
+      output = warning([SomeModule.WithHooks], false)
+
+      assert output =~ ":phoenix_kit_js_sources"
+      assert output =~ "compilers:"
+      assert output =~ "vendor/phoenix_kit_modules.js"
+    end
+
+    test "says what the failure looks like, because it looks like nothing" do
+      # The reason this is worth a warning at all: there is no error to find
+      # later. Someone reading it should recognise the symptom they will hit.
+      output = warning([SomeModule.WithHooks], false)
+
+      assert output =~ "no further error"
+    end
+  end
+
+  describe "silence" do
+    test "when the compiler is configured" do
+      refute warning([SomeModule.WithHooks], true) =~ "will not be loaded"
+    end
+
+    test "when nothing declares a bundle" do
+      # A host with no JS-bearing modules has nothing to be warned about,
+      # compiler or not.
+      assert warning([], false) == ""
+      assert warning([], true) == ""
+    end
+  end
+
+  describe "discovery" do
+    test "never fails the host's compile" do
+      # This runs while the host's router compiles. Whatever module discovery
+      # finds, or fails to find, a warning is not worth taking a build down
+      # for.
+      assert Integration.warn_missing_js_compiler() == :ok
+    end
+  end
+end


### PR DESCRIPTION
From the integration report, item #7 — the one the boards 0.3.0 and 0.4.0
incidents were both symptoms of.

## The trap

A module declares its hook bundle with `js_sources/0`. The only thing that
consumes that declaration is the `:phoenix_kit_js_sources` compiler. A host
without it in `:compilers` gets **nothing** — no vendored bundle, no error, no
warning. `window.PhoenixKitHooks` never gains those hooks, while the module's
templates go on rendering `phx-hook="..."` names the LiveSocket has never heard
of.

That is the worst shape a failure can take. The page renders, the module looks
installed, and only the half that needed JavaScript is missing — so it reads as
"this module is broken" rather than "its JS never loaded". `phoenix_kit_boards`
shipped exactly that state twice before anyone traced it, and a host running the
**CSS** compiler but not the JS one (the reporter's app, and an easy asymmetry to
end up with) lands there without ever having made a decision.

## The warning

`phoenix_kit_routes()` runs while the host's router compiles, which is the one
place that can see both facts: what is installed, and what is in `:compilers`.
When any installed module declares a bundle and the compiler is absent, it names
the modules and the line that fixes it.

Silent when the compiler is present, and silent when nothing declares a bundle.
That restraint is the point — a warning that fires on correctly-configured hosts
is one people learn to scroll past, which is how we got here.

Verified against a real host both ways:

```
=== compiler PRESENT (expect silence) ===
0
=== compiler REMOVED (expect the warning) ===
warning: PhoenixKit: these modules ship JavaScript hooks that will not be loaded:

  PhoenixKitBoards
  PhoenixKitReferrals
```

It can never fail a host's compile: discovery is rescued, and the Mix lookup is
guarded for contexts where Mix isn't loaded.

## The stale rationale

The compiler's moduledoc opened with:

> A LiveView JS hook must be present in the host's single `LiveSocket` at
> construction time — a nested LiveView cannot register one at runtime.

Not true since LiveView 1.1. `getHookDefinition/1` resolves a hook name when its
element mounts and falls back to a `script[data-phx-runtime-hook="Name"]` in the
document; LiveView re-creates such a script when a patch adds it, so it works for
a page delivered over the socket too. (Verified against the 1.2.x source while
building the boards fix, not taken on trust.)

So a module *can* deliver its own hooks and ask nothing of the host — which is
what `phoenix_kit_boards` does now. Leaving the old reasoning in place tells the
next module author that host wiring is unavoidable when it isn't. Rewritten to
say what the compiler actually is: the cheaper path where it's set up, not the
only one.

## Testing

Six tests on the decision itself. The first version reached it through real
module discovery, which meant the interesting branch only ran on a host that
happened to be misconfigured — i.e. never, in this library's own suite. Split
into a two-argument form so both branches are exercised directly.

Both directions mutation-tested: silencing the warning fails three tests,
removing the "configured" guard fails one. (My first attempt at the former was
invalid Elixir and only produced a compile error, so it proved nothing — redone.)

705 web tests pass, `credo --strict` clean, compiles with `--warnings-as-errors`.

## Scope

Only #7 (plus its moduledoc). On the rest of the report, three corrections worth
recording:

- **#1 and #2 are not core.** Comments is a separate package,
  `phoenix_kit_comments` (0.2.13). The resource model and the zero-width-space
  GIF placeholder both live there.
- **#4 already exists.** `Auth.merge_user_custom_fields/3` does the atomic
  `COALESCE(?, '{}'::jsonb) || ?` merge the report asks for, and its docstring
  says to reach for it whenever the intent is "add/update these keys, leave
  everything else as any concurrent writer left it". There is a
  `delete_user_custom_field/3` too. The host's 13 call sites are calling the
  wrong function — a real race in that app, a discoverability problem here. A
  one-key `put_user_custom_field/3` convenience would be a fair addition.
- #3, #5, #6, #8 and the rest of #9 are untouched and still stand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NTj7hm3fpCTcFvKLRtgppW
