### PR TITLE
Let notifications collapse repeat events onto one row

### DIFF
--- a/lib/phoenix_kit/notifications/events.ex
+++ b/lib/phoenix_kit/notifications/events.ex
@@ -8,6 +8,8 @@ defmodule PhoenixKit.Notifications.Events do
   Events sent to these topics:
 
     * `{:notification_created, %Notification{}}`
+    * `{:notification_updated, %Notification{}}` — an existing row refreshed by
+      `upsert_inapp/3` rather than a new one added
     * `{:notification_seen, %Notification{}}`
     * `{:notification_dismissed, %Notification{}}`
   """

--- a/lib/phoenix_kit/notifications/notifications.ex
+++ b/lib/phoenix_kit/notifications/notifications.ex
@@ -34,6 +34,7 @@ defmodule PhoenixKit.Notifications do
   alias PhoenixKit.Notifications.Types
   alias PhoenixKit.Settings
   alias PhoenixKit.Users.Auth
+  alias PhoenixKit.Utils.Date, as: UtilsDate
 
   # ── Creation ─────────────────────────────────────────────────────────
 
@@ -280,6 +281,10 @@ defmodule PhoenixKit.Notifications do
       |> put_meta("notification_text", display[:text])
       |> put_meta("notification_icon", display[:icon])
       |> put_meta("notification_link", display[:link])
+      # What `upsert_inapp/3` later collapses on, and anything else the caller
+      # wants to carry. Both are dropped silently without this.
+      |> put_meta("dedupe_key", display[:dedupe_key])
+      |> Map.merge(display[:metadata] || %{})
 
     %Notification{}
     |> Notification.changeset(%{
@@ -297,6 +302,106 @@ defmodule PhoenixKit.Notifications do
       {:error, %Ecto.Changeset{} = cs} ->
         Logger.warning("Notifications.create_inapp failed: #{inspect(cs.errors)}")
         {:error, cs}
+    end
+  end
+
+  @doc """
+  Post an in-app notification, or refresh the one already standing for the
+  same `key`.
+
+  This is the GitHub-style collapsing entry — "3 new comments on earlier
+  chapters" — where a second event should update the row a user has not dealt
+  with yet rather than add another beside it.
+
+  Doing that without an API meant reaching past it: querying
+  `PhoenixKit.Notifications.Notification` directly, `update_all`-ing the row,
+  and then re-broadcasting `:notification_created` by hand, because the only
+  broadcast fired on insert. One host that tried it with a schemaless write
+  stringified `metadata` into the jsonb column and 500'd that user's bell.
+
+  ## What counts as "already standing"
+
+  An undismissed, **unseen** notification for the same recipient carrying the
+  same key. Once someone has read it, the next event is news again and gets
+  its own row — collapsing into something already read would hide it, and the
+  unseen-first ordering exists precisely so unread work stays visible.
+
+  ## Refreshing
+
+  `display` replaces the text/icon/link, and `inserted_at` moves to now so the
+  refreshed entry sorts as new. Any other metadata keys the caller passes are
+  merged, leaving keys it doesn't mention alone.
+
+      iex> upsert_inapp(user_uuid, "comments:chapter:42", %{text: "3 new comments"})
+      {:ok, %Notification{}}
+
+  Broadcasts either way — `{:notification_created, n}` for a new row,
+  `{:notification_updated, n}` for a refresh — so a bell that is already open
+  reflects it without the caller broadcasting anything itself.
+  """
+  @spec upsert_inapp(String.t(), String.t(), map()) ::
+          {:ok, Notification.t()} | {:error, term()}
+  def upsert_inapp(recipient_uuid, key, display)
+      when is_binary(recipient_uuid) and is_binary(key) and is_map(display) do
+    case find_collapsible(recipient_uuid, key) do
+      nil -> create_inapp(recipient_uuid, Map.put(display, :dedupe_key, key))
+      existing -> refresh_inapp(existing, display)
+    end
+  end
+
+  # Only unseen rows collapse — see the moduledoc above for why. Newest first
+  # so a duplicate key (possible if one was seen and a later one wasn't) folds
+  # into the one the user still has outstanding.
+  defp find_collapsible(recipient_uuid, key) do
+    Notification
+    |> where([n], n.recipient_uuid == ^recipient_uuid)
+    |> where([n], is_nil(n.dismissed_at) and is_nil(n.seen_at))
+    |> where([n], fragment("?->>'dedupe_key' = ?", n.metadata, ^key))
+    |> order_by([n], desc: n.inserted_at)
+    |> limit(1)
+    |> repo().one()
+  rescue
+    # A read that fails is not a reason to drop the notification — fall
+    # through and post a new one.
+    _ -> nil
+  end
+
+  defp refresh_inapp(%Notification{} = notification, display) do
+    patch =
+      %{}
+      |> put_meta("notification_text", display[:text])
+      |> put_meta("notification_icon", display[:icon])
+      |> put_meta("notification_link", display[:link])
+      |> Map.merge(display[:metadata] || %{})
+
+    now = UtilsDate.utc_now()
+
+    query =
+      from(n in Notification,
+        where: n.uuid == ^notification.uuid,
+        update: [
+          set: [
+            # Merged, not replaced: the caller is saying what changed, and the
+            # dedupe key it collapsed on lives in here too.
+            metadata: fragment("COALESCE(?, '{}'::jsonb) || ?", n.metadata, type(^patch, :map)),
+            # Moves to now so a refreshed entry sorts as new rather than
+            # staying wherever the first event of the run left it.
+            inserted_at: ^now
+          ]
+        ],
+        select: n
+      )
+
+    case repo().update_all(query, []) do
+      {1, [updated]} ->
+        updated = %{updated | activity: nil}
+        Events.broadcast(updated.recipient_uuid, {:notification_updated, updated})
+        {:ok, updated}
+
+      _ ->
+        # Dismissed or pruned between the read and the write — post a fresh
+        # one rather than losing the event.
+        create_inapp(notification.recipient_uuid, display)
     end
   end
 

--- a/lib/phoenix_kit_web/live/notifications_bell.ex
+++ b/lib/phoenix_kit_web/live/notifications_bell.ex
@@ -91,6 +91,7 @@ defmodule PhoenixKitWeb.Live.NotificationsBell do
   def handle_info({event, _payload}, socket)
       when event in [
              :notification_created,
+             :notification_updated,
              :notification_seen,
              :notification_dismissed,
              :notifications_bulk_updated

--- a/test/integration/notifications/upsert_test.exs
+++ b/test/integration/notifications/upsert_test.exs
@@ -1,0 +1,125 @@
+defmodule PhoenixKit.Integration.Notifications.UpsertTest do
+  @moduledoc """
+  Collapsing repeat events onto one notification — "3 new comments on earlier
+  chapters" rather than three rows.
+
+  The interesting rule is when it must NOT collapse. Folding into something
+  the user has already read would hide the new event behind a row they have
+  dismissed from their attention, which is exactly what the unseen-first
+  ordering exists to prevent.
+  """
+  use PhoenixKit.DataCase, async: true
+
+  alias PhoenixKit.Notifications
+  alias PhoenixKit.Notifications.Events
+  alias PhoenixKit.Users.Auth
+
+  defp create_user do
+    {:ok, user} =
+      Auth.register_user(%{
+        email: "notif_upsert_#{System.unique_integer([:positive])}@example.com",
+        password: "ValidPassword123!"
+      })
+
+    user
+  end
+
+  defp texts(user) do
+    {rows, _} = Notifications.list_for_user(user.uuid)
+    Enum.map(rows, &get_in(&1.metadata, ["notification_text"]))
+  end
+
+  describe "upsert_inapp/3" do
+    test "a repeat event refreshes the standing row instead of adding one" do
+      user = create_user()
+
+      {:ok, _} = Notifications.upsert_inapp(user.uuid, "comments:42", %{text: "1 new comment"})
+      {:ok, _} = Notifications.upsert_inapp(user.uuid, "comments:42", %{text: "2 new comments"})
+      {:ok, _} = Notifications.upsert_inapp(user.uuid, "comments:42", %{text: "3 new comments"})
+
+      assert texts(user) == ["3 new comments"]
+      assert Notifications.count_unread(user.uuid) == 1
+    end
+
+    test "a different key gets its own row" do
+      user = create_user()
+
+      {:ok, _} = Notifications.upsert_inapp(user.uuid, "comments:1", %{text: "chapter one"})
+      {:ok, _} = Notifications.upsert_inapp(user.uuid, "comments:2", %{text: "chapter two"})
+
+      assert length(texts(user)) == 2
+    end
+
+    test "a different user's notification is never collapsed into" do
+      a = create_user()
+      b = create_user()
+
+      {:ok, _} = Notifications.upsert_inapp(a.uuid, "comments:42", %{text: "for a"})
+      {:ok, _} = Notifications.upsert_inapp(b.uuid, "comments:42", %{text: "for b"})
+
+      assert texts(a) == ["for a"]
+      assert texts(b) == ["for b"]
+    end
+
+    test "once read, the next event is news again" do
+      # The rule that matters. Collapsing into a row the user has already read
+      # would hide the new event inside something they have finished with, and
+      # the unread count would not move.
+      user = create_user()
+
+      {:ok, first} = Notifications.upsert_inapp(user.uuid, "comments:42", %{text: "1 new"})
+      {:ok, _} = Notifications.mark_seen(user.uuid, first.uuid)
+
+      {:ok, second} = Notifications.upsert_inapp(user.uuid, "comments:42", %{text: "1 more"})
+
+      refute second.uuid == first.uuid
+      assert Notifications.count_unread(user.uuid) == 1
+      assert length(texts(user)) == 2
+    end
+
+    test "a dismissed row is not resurrected" do
+      user = create_user()
+
+      {:ok, first} = Notifications.upsert_inapp(user.uuid, "comments:42", %{text: "1 new"})
+      {:ok, _} = Notifications.dismiss(user.uuid, first.uuid)
+
+      {:ok, second} = Notifications.upsert_inapp(user.uuid, "comments:42", %{text: "1 more"})
+
+      refute second.uuid == first.uuid
+    end
+
+    test "extra metadata is merged, not replaced" do
+      user = create_user()
+
+      {:ok, _} =
+        Notifications.upsert_inapp(user.uuid, "k", %{
+          text: "first",
+          metadata: %{"chapter" => "12", "keep" => "me"}
+        })
+
+      {:ok, updated} =
+        Notifications.upsert_inapp(user.uuid, "k", %{
+          text: "second",
+          metadata: %{"chapter" => "13"}
+        })
+
+      assert updated.metadata["chapter"] == "13"
+      assert updated.metadata["keep"] == "me", "unmentioned keys must survive the patch"
+      assert updated.metadata["dedupe_key"] == "k", "the key it collapsed on must survive too"
+      assert updated.metadata["notification_text"] == "second"
+    end
+
+    test "broadcasts both ways, so an open bell keeps up" do
+      # Without this the host had to re-broadcast by hand, because the only
+      # broadcast fired on insert.
+      user = create_user()
+      Events.subscribe(user.uuid)
+
+      {:ok, _} = Notifications.upsert_inapp(user.uuid, "k", %{text: "first"})
+      assert_receive {:notification_created, _}
+
+      {:ok, _} = Notifications.upsert_inapp(user.uuid, "k", %{text: "second"})
+      assert_receive {:notification_updated, %{metadata: %{"notification_text" => "second"}}}
+    end
+  end
+end


### PR DESCRIPTION
From the integration report, item #3.

## The gap

"3 new comments on earlier chapters" is what every mature product does with a
run of related events, and there was no way to say it. `create_inapp/2` only
ever inserts, and the only broadcast fired on insert.

So a host that wanted collapsing reached past the API: queried the
`Notification` schema directly, `update_all`ed the row, then re-broadcast
`:notification_created` by hand. One that tried it with a *schemaless* write
stringified `metadata` into the jsonb column and 500'd that user's bell — which
is the cost of leaving a schema as the only way to do something.

## `upsert_inapp/3`

Takes a key: refresh the row already standing for it, or post a new one.

```elixir
upsert_inapp(user_uuid, "comments:chapter:42", %{text: "3 new comments"})
```

Text, icon and link are replaced; other metadata keys are **merged**, so keys
the caller doesn't mention survive. `inserted_at` moves to now, so a refreshed
entry sorts as new.

## The rule worth stating: only unseen rows collapse

Folding a new event into something the user has already read would hide it
inside a row they've finished with, and the unread count wouldn't move. That's
the same reasoning as the unseen-first ordering in #702. Once read, the next
event is news again and gets its own row.

Dismissed rows are never resurrected either, and a row that vanishes between the
read and the write posts a fresh one rather than losing the event.

## Broadcasting

`{:notification_created, n}` for a new row, `{:notification_updated, n}` for a
refresh — so an already-open bell reflects it without the caller broadcasting
anything. `NotificationsBell` handles the new event; `Events`' docs list it.

## Testing

Seven integration tests, including the three refusals (seen, dismissed, other
user) and the merge-not-replace behaviour.

Two mutations checked: collapsing into read rows fails the suite; replacing
metadata instead of merging fails it twice.

Writing them caught two real errors before this went anywhere — `updated_at`
isn't a column on this schema, and the row-count guard on `update_all` was the
only thing standing between a dismissed notification and resurrection.

149 notification + LiveView tests pass, `credo --strict` clean, compiles with
`--warnings-as-errors`. No version bump or CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NTj7hm3fpCTcFvKLRtgppW
