### PR TITLE
Make the fingerprint log mean something

### DIFF
--- a/lib/phoenix_kit/users/auth.ex
+++ b/lib/phoenix_kit/users/auth.ex
@@ -1166,13 +1166,26 @@ defmodule PhoenixKit.Users.Auth do
           SessionFingerprint.verify_fingerprint(
             conn,
             token_record.ip_address,
-            token_record.user_agent_hash
+            token_record.user_agent_hash,
+            session: session_label(token)
           )
       end
     else
       :ok
     end
   end
+
+  # A short, stable label for one session, so fingerprint lines can be
+  # correlated to each other and to a row in the sessions UI.
+  #
+  # Hashed and truncated because the raw token is a bearer credential and must
+  # never reach a log file — 8 hex characters is plenty to group a handful of
+  # lines by, and useless to anyone who steals the log.
+  defp session_label(token) when is_binary(token) do
+    :sha256 |> :crypto.hash(token) |> Base.encode16(case: :lower) |> binary_part(0, 8)
+  end
+
+  defp session_label(_), do: "unknown"
 
   @doc """
   Ensures the user is active by checking the is_active field.

--- a/lib/phoenix_kit/utils/session_fingerprint.ex
+++ b/lib/phoenix_kit/utils/session_fingerprint.ex
@@ -141,7 +141,7 @@ defmodule PhoenixKit.Utils.SessionFingerprint do
       {:warning, :ip_mismatch}
 
   """
-  def verify_fingerprint(conn, stored_ip, stored_ua_hash) do
+  def verify_fingerprint(conn, stored_ip, stored_ua_hash, opts \\ []) do
     # Backward compatibility: if no fingerprint was stored, allow access
     if is_nil(stored_ip) and is_nil(stored_ua_hash) do
       :ok
@@ -152,36 +152,48 @@ defmodule PhoenixKit.Utils.SessionFingerprint do
       ip_matches? = is_nil(stored_ip) or stored_ip == current_ip
       ua_matches? = is_nil(stored_ua_hash) or stored_ua_hash == current_ua_hash
 
+      # Correlation, so a line names WHICH session it is about. Without it a
+      # log full of these says only that something, somewhere, changed — and
+      # the raw token must never be written down, so a truncated hash it is.
+      session = Keyword.get(opts, :session, "unknown")
+
       case {ip_matches?, ua_matches?} do
         {true, true} ->
           :ok
 
         {false, true} ->
-          Logger.warning("""
-          PhoenixKit: Session IP mismatch detected
-            Stored IP: #{stored_ip}
-            Current IP: #{current_ip}
-            User Agent matches: yes
-          """)
+          Logger.warning(
+            "PhoenixKit: session #{session} changed IP (#{stored_ip} -> #{current_ip}), " <>
+              "same browser"
+          )
 
           {:warning, :ip_mismatch}
 
         {true, false} ->
-          Logger.warning("""
-          PhoenixKit: Session User-Agent mismatch detected
-            IP matches: yes
-            User Agent changed
-          """)
+          # Info, not warning. Browsers rewrite their user agent on every
+          # update — roughly monthly, for every user — so this fires in
+          # numbers no one can read, for a thing that is almost never an
+          # attack and never acted on. At warning level it was the bulk of a
+          # 765-line log, which is how the lines that DO matter got lost.
+          Logger.info("PhoenixKit: session #{session} changed user agent, same IP")
 
           {:warning, :user_agent_mismatch}
 
         {false, false} ->
-          Logger.error("""
-          PhoenixKit: Session fingerprint mismatch - possible hijacking attempt
-            Stored IP: #{stored_ip}
-            Current IP: #{current_ip}
-            User Agent also changed
-          """)
+          # The level follows what actually happens. In strict mode this
+          # denies the request, which is an error; otherwise the request is
+          # allowed and this is a warning. Logging "possible hijacking
+          # attempt" at :error and then serving the request anyway is what
+          # teaches people that :error means nothing here.
+          message =
+            "PhoenixKit: session #{session} changed BOTH IP (#{stored_ip} -> #{current_ip}) " <>
+              "and user agent"
+
+          if strict_mode?() do
+            Logger.error(message <> " — access denied (strict mode)")
+          else
+            Logger.warning(message <> " — allowed (strict mode off)")
+          end
 
           {:error, :fingerprint_mismatch}
       end

--- a/lib/phoenix_kit_web/users/auth.ex
+++ b/lib/phoenix_kit_web/users/auth.ex
@@ -415,20 +415,15 @@ defmodule PhoenixKitWeb.Users.Auth do
           :ok ->
             true
 
-          {:warning, reason} ->
-            # Log warning but allow access (IP/UA can legitimately change)
-            Logger.warning("PhoenixKit: Session fingerprint warning: #{reason} for token")
-
-            # In non-strict mode, allow access despite warning
+          # Deliberately silent. `verify_fingerprint/4` has already logged
+          # what changed, for which session, at a level that matches whether
+          # the request is about to be refused — a second line here said only
+          # "for token", naming neither, and doubled the volume of the noisiest
+          # thing in the log.
+          {:warning, _reason} ->
             not SessionFingerprint.strict_mode?()
 
           {:error, :fingerprint_mismatch} ->
-            # Both IP and UA changed - likely hijacking
-            Logger.error(
-              "PhoenixKit: Session fingerprint mismatch detected - possible hijacking attempt"
-            )
-
-            # Strict mode: deny access; non-strict: log but allow
             not SessionFingerprint.strict_mode?()
 
           {:error, :token_not_found} ->

--- a/test/phoenix_kit/utils/session_fingerprint_logging_test.exs
+++ b/test/phoenix_kit/utils/session_fingerprint_logging_test.exs
@@ -1,0 +1,122 @@
+defmodule PhoenixKit.Utils.SessionFingerprintLoggingTest do
+  @moduledoc """
+  What the fingerprint check writes to the log.
+
+  One reporting app carried **765** `user_agent_mismatch` warnings, plus
+  `[error] ... possible hijacking attempt` lines after which — in non-strict
+  mode — the request was served anyway. Two lines per request, per-request and
+  unthrottled, naming neither the user nor the session.
+
+  That is worse than logging nothing: an error that takes no action and names
+  no one teaches people the log is noise, and the lines that would have
+  mattered go with it. So the levels have to mean something, and each line has
+  to say which session it is about.
+  """
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  alias PhoenixKit.Utils.SessionFingerprint
+
+  @stored_ip "203.0.113.7"
+  @other_ip "198.51.100.9"
+
+  setup do
+    # This suite runs at `level: :warning`, which is the point — the
+    # user-agent line is demoted precisely so a normally-configured app never
+    # sees it. Lowered here so the assertions can tell "logged at info" apart
+    # from "not logged", which are the same thing from the outside.
+    previous = Logger.level()
+    Logger.configure(level: :info)
+    on_exit(fn -> Logger.configure(level: previous) end)
+    :ok
+  end
+
+  defp conn(ip, user_agent) do
+    :get
+    |> Plug.Test.conn("/")
+    |> Plug.Conn.put_req_header("x-forwarded-for", ip)
+    |> Plug.Conn.put_req_header("user-agent", user_agent)
+  end
+
+  defp stored_ua_hash(user_agent),
+    do: SessionFingerprint.hash_user_agent(conn(@stored_ip, user_agent))
+
+  defp verify(conn, opts \\ []) do
+    stored = stored_ua_hash("Mozilla/5.0 original")
+
+    capture_log([level: :info], fn ->
+      SessionFingerprint.verify_fingerprint(conn, @stored_ip, stored, opts)
+    end)
+  end
+
+  describe "a browser that updated itself" do
+    test "is not a warning" do
+      # Browsers rewrite their user agent roughly monthly, for every user. At
+      # warning level this was the bulk of the log, for something that is
+      # almost never an attack and is never acted on.
+      log = verify(conn(@stored_ip, "Mozilla/5.0 updated"))
+
+      refute log =~ "[warning]"
+      refute log =~ "[error]"
+      assert log =~ "changed user agent"
+    end
+  end
+
+  describe "a session that moved" do
+    test "IP change stays a warning" do
+      log = verify(conn(@other_ip, "Mozilla/5.0 original"))
+
+      assert log =~ "[warning]"
+      assert log =~ "changed IP"
+    end
+  end
+
+  describe "both changed" do
+    setup do
+      original = Application.get_env(:phoenix_kit, :session_fingerprint_strict)
+      on_exit(fn -> Application.put_env(:phoenix_kit, :session_fingerprint_strict, original) end)
+      :ok
+    end
+
+    test "is an error only when it actually denies the request" do
+      # Strict mode refuses the request, so :error is the truth.
+      Application.put_env(:phoenix_kit, :session_fingerprint_strict, true)
+      log = verify(conn(@other_ip, "Mozilla/5.0 different"))
+
+      assert log =~ "[error]"
+      assert log =~ "denied"
+    end
+
+    test "is a warning when the request is served anyway" do
+      # This is the line that trained people to ignore the log: "possible
+      # hijacking attempt", logged at :error, followed by serving the request.
+      Application.put_env(:phoenix_kit, :session_fingerprint_strict, false)
+      log = verify(conn(@other_ip, "Mozilla/5.0 different"))
+
+      refute log =~ "[error]"
+      assert log =~ "[warning]"
+      assert log =~ "allowed"
+    end
+  end
+
+  describe "correlation" do
+    test "every line names the session it is about" do
+      for c <- [conn(@other_ip, "Mozilla/5.0 original"), conn(@stored_ip, "Mozilla/5.0 new")] do
+        assert verify(c, session: "a1b2c3d4") =~ "a1b2c3d4"
+      end
+    end
+
+    test "a caller that gives no label still logs" do
+      # Degrades to an unlabelled line rather than crashing the request it was
+      # only ever meant to describe.
+      assert verify(conn(@other_ip, "Mozilla/5.0 original")) =~ "changed IP"
+    end
+  end
+
+  describe "a matching fingerprint" do
+    test "says nothing at all" do
+      assert verify(conn(@stored_ip, "Mozilla/5.0 original")) == ""
+    end
+  end
+end


### PR DESCRIPTION
From the integration report, item #5.

## What the log looked like

One app carried **765** `user_agent_mismatch` warnings in a single log, plus
`[error] ... possible hijacking attempt` lines after which — in non-strict mode
— the request was served anyway.

Per-request, unthrottled, naming neither the user nor the session. And
**doubled**: `verify_fingerprint/3` logged, then `PhoenixKitWeb.Users.Auth`
logged again with a line that said only `"for token"` and named no token.

That is worse than logging nothing. An error that takes no action and
identifies no one teaches people the log is noise — and the lines that would
have mattered go out with it.

## Three changes, all about making the level and the content honest

**A user-agent change with the same IP is `:info`.** Browsers rewrite their UA
on every update, roughly monthly, for every user. At warning level this was the
bulk of the volume, for something that is almost never an attack and is never
acted on. A normally-configured app stops seeing it entirely.

**Both-changed picks its level from what actually happens** — `:error` when
strict mode denies the request, `:warning` when the request is served. Logging
"possible hijacking attempt" at `:error` and then serving the request is
precisely what trains people that `:error` means nothing here.

**Every line names its session** — a truncated SHA-256 of the token. The raw
token is a bearer credential and must never reach a log; eight hex characters
is enough to group a handful of lines and useless to anyone who steals the
file.

The duplicate log in the web caller is gone. The surviving line already says
what changed, for which session, at the right level.

## Testing

Seven tests on what actually reaches the log, including the two cases the
report is about: a UA-only change must not be a warning, and both-changed must
not be an `:error` when the request is allowed anyway.

Both mutation-tested: restoring the UA warning fails the suite; always logging
`:error` fails it twice.

Worth noting the suite has to lower `Logger.level` itself — it runs at
`:warning`, which is the whole point of the demotion, and from the outside
"logged at info" and "not logged" are the same thing. That's in the setup with
a restore.

256 fingerprint + auth tests pass, `credo --strict` clean, compiles with
`--warnings-as-errors`.

## Not done

The report's fourth suggestion — surfacing genuine both-changed mismatches as
an admin-visible security event in the sessions UI — is a feature, not a
logging fix, and wants its own design. Left for that.

No version bump or CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NTj7hm3fpCTcFvKLRtgppW
