### PR TITLE
integrations: GitHub and Amazon Bedrock providers

### DIFF
--- a/lib/phoenix_kit/integrations/integrations.ex
+++ b/lib/phoenix_kit/integrations/integrations.ex
@@ -1072,6 +1072,9 @@ defmodule PhoenixKit.Integrations do
   defp do_validate(%{auth_type: :api_key, validation: %{strategy: :brevo_api}}, data),
     do: Validators.brevo_api(data)
 
+  defp do_validate(%{auth_type: :api_key, validation: %{strategy: :amazon_bedrock}}, data),
+    do: Validators.amazon_bedrock(data)
+
   defp do_validate(%{auth_type: :bot_token, validation: %{strategy: :telegram}}, data),
     do: Validators.telegram(data)
 

--- a/lib/phoenix_kit/integrations/providers.ex
+++ b/lib/phoenix_kit/integrations/providers.ex
@@ -185,10 +185,12 @@ defmodule PhoenixKit.Integrations.Providers do
       deepseek(),
       xai(),
       elevenlabs(),
+      amazon_bedrock(),
       aws_ses(),
       smtp(),
       brevo_api(),
-      telegram()
+      telegram(),
+      github()
     ]
   end
 
@@ -676,6 +678,122 @@ defmodule PhoenixKit.Integrations.Providers do
             gettext(
               "The free tier includes a monthly character quota; paid plans raise the quota and unlock commercial use and additional voices."
             )
+        }
+      ]
+    }
+  end
+
+  # Bedrock's OpenAI-compatible chat endpoint is regional, but the registry
+  # `base_url` is static — the default below matches our primary region, and
+  # the AI endpoint form lets the operator override `base_url` per endpoint.
+  # Auth is a long-term Bedrock API key (plain Bearer, no SigV4) — the same
+  # header the OpenAI-compatible runtime endpoint accepts, so one credential
+  # serves both the validation probe and real completions.
+  defp amazon_bedrock do
+    %{
+      key: "amazon_bedrock",
+      scopes: [:system, :personal],
+      name: gettext("Amazon Bedrock"),
+      description:
+        gettext("AWS Bedrock LLMs (Anthropic, Meta, Amazon Nova…) via a Bedrock API key"),
+      icon: "hero-sparkles",
+      auth_type: :api_key,
+      oauth_config: nil,
+      base_url: "https://bedrock-runtime.eu-central-1.amazonaws.com/openai/v1",
+      # Region-aware — checked against the Bedrock control plane itself
+      # (ListFoundationModels), see PhoenixKit.Integrations.Validators.
+      validation: %{strategy: :amazon_bedrock},
+      setup_fields: [
+        %{
+          key: "api_key",
+          label: gettext("Bedrock API key"),
+          type: :password,
+          required: true,
+          placeholder: "ABSK…",
+          help: gettext("AWS console → Amazon Bedrock → API keys (long-term key)"),
+          options: nil
+        },
+        %{
+          key: "aws_region",
+          label: gettext("Region"),
+          type: :text,
+          required: true,
+          placeholder: "eu-central-1",
+          help: nil,
+          options: nil
+        }
+      ],
+      capabilities: [:ai_completions],
+      instructions: [
+        %{
+          title: gettext("Create a Bedrock API key"),
+          steps: [
+            {gettext(
+               "In the AWS console open **Amazon Bedrock → API keys** and generate a long-term key (or IAM → your user → Security credentials → Bedrock API keys)"
+             ), nil},
+            {gettext("Copy the key (shown once) and paste it into the form above"), nil}
+          ]
+        },
+        %{
+          title: gettext("Enable model access"),
+          steps: [
+            {gettext(
+               "In Bedrock → Model access enable the models you plan to call — a key with no enabled models validates but cannot complete"
+             ), nil},
+            {gettext(
+               "Pick the region where access was granted; the AI endpoint's base URL must use the same region"
+             ), nil}
+          ]
+        }
+      ]
+    }
+  end
+
+  # A read-only token for GitHub API consumers (e.g. org-statistics dashboard
+  # widgets). GraphQL requires authentication even for public data, so the
+  # least-privilege credential is a fine-grained PAT with public-repo
+  # read-only access.
+  defp github do
+    %{
+      key: "github",
+      scopes: [:system, :personal],
+      name: gettext("GitHub"),
+      description:
+        gettext("GitHub API token — org statistics, repositories (read-only is enough)"),
+      icon: "hero-code-bracket-square",
+      auth_type: :api_key,
+      oauth_config: nil,
+      # 200 with a valid token, 401 otherwise; standard Bearer auth.
+      validation: %{
+        url: "https://api.github.com/rate_limit",
+        method: :get,
+        auth_header: "Authorization",
+        auth_prefix: "Bearer "
+      },
+      setup_fields: [
+        %{
+          key: "api_key",
+          label: gettext("Personal access token"),
+          type: :password,
+          required: true,
+          placeholder: "github_pat_… / ghp_…",
+          help: gettext("github.com/settings/personal-access-tokens — fine-grained, read-only"),
+          options: nil
+        }
+      ],
+      capabilities: [:github_api],
+      instructions: [
+        %{
+          title: gettext("Create a token"),
+          steps: [
+            {gettext(
+               "Go to [Fine-grained tokens](https://github.com/settings/personal-access-tokens) and click **Generate new token**"
+             ), nil},
+            {gettext(
+               "Repository access: **Public repositories (read-only)** — no extra permissions needed for public-org statistics"
+             ), nil},
+            {gettext("Copy the token and paste it into the form above"), nil}
+          ]
         }
       ]
     }

--- a/lib/phoenix_kit/integrations/providers.ex
+++ b/lib/phoenix_kit/integrations/providers.ex
@@ -695,7 +695,9 @@ defmodule PhoenixKit.Integrations.Providers do
       scopes: [:system, :personal],
       name: gettext("Amazon Bedrock"),
       description:
-        gettext("AWS Bedrock LLMs (Anthropic, Meta, Amazon Nova…) via a Bedrock API key"),
+        gettext(
+          "AWS Bedrock LLMs via a Bedrock API key (OpenAI-compatible endpoint: gpt-oss models; the rest via native Converse)"
+        ),
       icon: "hero-sparkles",
       auth_type: :api_key,
       oauth_config: nil,
@@ -759,7 +761,7 @@ defmodule PhoenixKit.Integrations.Providers do
                "The OpenAI-compatible endpoint (`…/openai/v1`) currently serves only the `openai.gpt-oss-*` models — Anthropic and the other Bedrock models answer on the native Converse API with the same key"
              ), nil},
             {gettext(
-               "Create an AI endpoint (Admin → AI → Endpoints) pointing at this connection with a `gpt-oss` model to complete through Bedrock"
+               "In the AI module, create an endpoint pointing at this connection with a `gpt-oss` model and a base URL in the SAME region as this key"
              ), nil}
           ]
         }

--- a/lib/phoenix_kit/integrations/providers.ex
+++ b/lib/phoenix_kit/integrations/providers.ex
@@ -729,19 +729,37 @@ defmodule PhoenixKit.Integrations.Providers do
           title: gettext("Create a Bedrock API key"),
           steps: [
             {gettext(
-               "In the AWS console open **Amazon Bedrock → API keys** and generate a long-term key (or IAM → your user → Security credentials → Bedrock API keys)"
+               "Open the [Bedrock console → API keys](https://console.aws.amazon.com/bedrock/home#/api-keys) and generate a **long-term** key (docs: [Bedrock API keys](https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys.html))"
              ), nil},
-            {gettext("Copy the key (shown once) and paste it into the form above"), nil}
-          ]
+            {gettext(
+               "Or attach one to an existing IAM user: [IAM console](https://console.aws.amazon.com/iam/home#/users) → user → Security credentials → Bedrock API keys"
+             ), nil},
+            {gettext("Copy the key (shown once, `ABSK…`) and paste it into the form above"), nil}
+          ],
+          note:
+            gettext(
+              "The key's IAM identity must allow the `bedrock:CallWithBearerToken` action — without it every Bearer call answers 403 even when invoke permissions are in place."
+            )
         },
         %{
           title: gettext("Enable model access"),
           steps: [
             {gettext(
-               "In Bedrock → Model access enable the models you plan to call — a key with no enabled models validates but cannot complete"
+               "In [Bedrock → Model access](https://console.aws.amazon.com/bedrock/home#/modelaccess) enable the models you plan to call — a key with no enabled models validates but cannot complete"
              ), nil},
             {gettext(
                "Pick the region where access was granted; the AI endpoint's base URL must use the same region"
+             ), nil}
+          ]
+        },
+        %{
+          title: gettext("Use it from the AI module"),
+          steps: [
+            {gettext(
+               "The OpenAI-compatible endpoint (`…/openai/v1`) currently serves only the `openai.gpt-oss-*` models — Anthropic and the other Bedrock models answer on the native Converse API with the same key"
+             ), nil},
+            {gettext(
+               "Create an AI endpoint (Admin → AI → Endpoints) pointing at this connection with a `gpt-oss` model to complete through Bedrock"
              ), nil}
           ]
         }
@@ -845,7 +863,35 @@ defmodule PhoenixKit.Integrations.Providers do
           options: nil
         }
       ],
-      capabilities: [:email_send]
+      capabilities: [:email_send],
+      instructions: [
+        %{
+          title: gettext("Create an IAM user with SES access"),
+          steps: [
+            {gettext(
+               "In the [IAM console](https://console.aws.amazon.com/iam/home#/users) create a user for programmatic access and attach an SES policy (least privilege: `ses:SendEmail`/`ses:SendRawEmail`; docs: [SES setup](https://docs.aws.amazon.com/ses/latest/dg/setting-up.html))"
+             ), nil},
+            {gettext(
+               "Create an access key for that user (Security credentials → Create access key) and paste the ID and secret above"
+             ), nil}
+          ]
+        },
+        %{
+          title: gettext("Verify a sender in SES"),
+          steps: [
+            {gettext(
+               "In the [SES console](https://console.aws.amazon.com/ses/home#/identities) verify your domain or sender address — SES refuses to send from unverified identities"
+             ), nil},
+            {gettext(
+               "New accounts start in the SES sandbox (verified recipients only) — [request production access](https://docs.aws.amazon.com/ses/latest/dg/request-production-access.html) before real sending"
+             ), nil}
+          ],
+          note:
+            gettext(
+              "This connection stores the credential. The full sending pipeline — configuration set, SNS topic, SQS event queue, delivery tracking — is configured in Admin → Settings → Emails, which can select this connection as its credential source."
+            )
+        }
+      ]
     }
   end
 

--- a/lib/phoenix_kit/integrations/validators.ex
+++ b/lib/phoenix_kit/integrations/validators.ex
@@ -67,6 +67,62 @@ defmodule PhoenixKit.Integrations.Validators do
   end
 
   @doc """
+  Validates an Amazon Bedrock API key against the Bedrock control plane.
+
+  Lists foundation models in the configured region — the cheapest call that
+  proves both the key and the region at once. Bedrock long-term API keys
+  authenticate with a plain Bearer header (no SigV4), the same header the
+  OpenAI-compatible runtime endpoint accepts, so a green check here means the
+  AI module's completions path can authenticate too.
+  """
+  @spec amazon_bedrock(map()) :: :ok | {:ok, String.t()} | {:error, String.t()}
+  def amazon_bedrock(data) do
+    region = data["aws_region"]
+
+    cond do
+      blank?(data["api_key"]) ->
+        {:error, gettext("No credentials configured")}
+
+      blank?(region) ->
+        {:error, gettext("Region is required")}
+
+      # A malformed region would send the probe to a non-AWS hostname.
+      not Regex.match?(~r/^[a-z]{2}(-[a-z]+)+-\d$/, region) ->
+        {:error, gettext("Invalid region format (expected e.g. eu-central-1)")}
+
+      true ->
+        request_bedrock_models(region, data["api_key"])
+    end
+  end
+
+  defp request_bedrock_models(region, api_key) do
+    case Req.get("https://bedrock.#{region}.amazonaws.com/foundation-models",
+           headers: [{"authorization", "Bearer " <> api_key}],
+           receive_timeout: @http_timeout
+         ) do
+      {:ok, %{status: 200, body: %{"modelSummaries" => models}}} when is_list(models) ->
+        {:ok,
+         gettext("%{count} foundation models visible in %{region}",
+           count: length(models),
+           region: region
+         )}
+
+      {:ok, %{status: 200}} ->
+        :ok
+
+      {:ok, %{status: status}} when status in [401, 403] ->
+        {:error, gettext("Invalid credentials")}
+
+      {:ok, %{status: status}} ->
+        {:error, gettext("Bedrock error %{status}", status: status)}
+
+      {:error, reason} ->
+        Logger.warning("Bedrock connection check failed: #{inspect(reason)}")
+        {:error, gettext("Could not reach Bedrock in %{region}", region: region)}
+    end
+  end
+
+  @doc """
   Validates an SMTP relay by opening a real session and authenticating.
 
   The connection options come from `PhoenixKit.Mailer.SmtpTransport.config/1`, so

--- a/lib/phoenix_kit/integrations/validators.ex
+++ b/lib/phoenix_kit/integrations/validators.ex
@@ -63,41 +63,81 @@ defmodule PhoenixKit.Integrations.Validators do
         {:error, gettext("Region is required")}
 
       true ->
-        Probe.run(fn ->
-          # The send-quota probe stays the AUTH VERDICT — its transient-
-          # signature retry logic is what keeps good keys from being called
-          # invalid. The CredentialsVerifier sweep (the same one the Emails
-          # settings page runs) only enriches a passing verdict with the
-          # account identity and per-service permissions.
-          case request_send_quota(region, data) do
-            :ok -> {:ok, aws_note(region, data, nil)}
-            {:ok, quota_note} -> {:ok, aws_note(region, data, quota_note)}
-            error -> error
-          end
-        end)
+        # The send-quota probe stays the AUTH VERDICT — its transient-
+        # signature retry logic is what keeps good keys from being called
+        # invalid. The CredentialsVerifier sweep (the same one the Emails
+        # settings page runs) runs AFTERWARDS in its own probe and is
+        # strictly additive: a passing verdict may gain account identity
+        # and permission context, but enrichment failing, exiting, or
+        # timing out can never downgrade the verdict itself.
+        case Probe.run(fn -> request_send_quota(region, data) end) do
+          :ok -> ok_with_note(region, data, nil)
+          {:ok, quota_note} -> ok_with_note(region, data, quota_note)
+          error -> error
+        end
     end
   end
 
-  defp aws_note(region, data, quota_note) do
-    ak = data["access_key"]
-    sk = data["secret_key"]
+  defp ok_with_note(region, data, quota_note) do
+    case enrich_note(region, data, quota_note) do
+      nil -> :ok
+      note -> {:ok, note}
+    end
+  end
 
-    identity =
-      case CredentialsVerifier.verify_credentials(ak, sk, region) do
-        {:ok, %{account_id: id}} -> gettext("Account %{id}", id: id)
-        _ -> nil
-      end
+  defp enrich_note(region, data, quota_note) do
+    # The probe contract carries strings, so the note is assembled inside the
+    # closure; :ok = "nothing to add", any probe failure = keep the quota note.
+    result =
+      Probe.run(fn ->
+        identity =
+          case CredentialsVerifier.verify_credentials(
+                 data["access_key"],
+                 data["secret_key"],
+                 region
+               ) do
+            {:ok, %{account_id: id}} -> gettext("Account %{id}", id: id)
+            _ -> nil
+          end
+
+        perms =
+          case CredentialsVerifier.check_permissions(
+                 data["access_key"],
+                 data["secret_key"],
+                 region
+               ) do
+            {:ok, perms} -> perms
+            _ -> nil
+          end
+
+        case aws_note(identity, perms, quota_note) do
+          nil -> :ok
+          note -> {:ok, note}
+        end
+      end)
+
+    case result do
+      {:ok, note} -> note
+      :ok -> nil
+      _ -> quota_note
+    end
+  end
+
+  @doc false
+  # Pure note assembly, public for tests. Only GRANTED management APIs are
+  # listed — a least-privilege ses:SendEmail-only key (which the verdict
+  # deliberately passes) must not read as "SES denied" here, so denied
+  # services are omitted rather than dashed out.
+  def aws_note(identity, perms, quota_note) do
+    granted =
+      for {key, label} <- [ses: "SES", sqs: "SQS", sns: "SNS"],
+          is_map(perms) and perms[key] |> Map.values() |> Enum.any?(&(&1 == :granted)),
+          do: label
 
     services =
-      case CredentialsVerifier.check_permissions(ak, sk, region) do
-        {:ok, perms} ->
-          Enum.map_join([ses: "SES", sqs: "SQS", sns: "SNS"], " · ", fn {key, label} ->
-            granted? = perms[key] |> Map.values() |> Enum.any?(&(&1 == :granted))
-            "#{label} #{if granted?, do: "✓", else: "—"}"
-          end)
-
-        _ ->
-          nil
+      case granted do
+        [] -> nil
+        list -> gettext("management API: %{services}", services: Enum.join(list, ", "))
       end
 
     [identity, services, quota_note]
@@ -115,12 +155,13 @@ defmodule PhoenixKit.Integrations.Validators do
   Lists foundation models in the configured region — the cheapest call that
   proves both the key and the region at once. Bedrock long-term API keys
   authenticate with a plain Bearer header (no SigV4), the same header the
-  OpenAI-compatible runtime endpoint accepts, so a green check here means the
-  AI module's completions path can authenticate too.
+  OpenAI-compatible runtime endpoint accepts — a green check proves the
+  completions path can authenticate IN THIS REGION; an AI endpoint must
+  point its base URL at the same region for that guarantee to carry over.
   """
   @spec amazon_bedrock(map()) :: :ok | {:ok, String.t()} | {:error, String.t()}
   def amazon_bedrock(data) do
-    region = data["aws_region"]
+    region = String.trim(data["aws_region"] || "")
 
     cond do
       blank?(data["api_key"]) ->
@@ -130,31 +171,49 @@ defmodule PhoenixKit.Integrations.Validators do
         {:error, gettext("Region is required")}
 
       # A malformed region would send the probe to a non-AWS hostname.
-      not Regex.match?(~r/^[a-z]{2}(-[a-z]+)+-\d$/, region) ->
+      not valid_aws_region?(region) ->
         {:error, gettext("Invalid region format (expected e.g. eu-central-1)")}
 
       true ->
-        request_bedrock_models(region, data["api_key"])
+        Probe.run(fn -> request_bedrock_models(region, data["api_key"]) end)
     end
   end
 
+  @doc false
+  # Pure, public for tests. The prefix is 2-4 letters (us-east-1 …
+  # eusc-de-east-1), the suffix a small number.
+  def valid_aws_region?(region) when is_binary(region) do
+    Regex.match?(~r/^[a-z]{2,4}(-[a-z]+)+-\d{1,2}$/, region)
+  end
+
+  def valid_aws_region?(_), do: false
+
   defp request_bedrock_models(region, api_key) do
+    # retry: false — the outer Probe deadline is the only clock here; Req's
+    # default transient retries would sleep through most of it.
     case Req.get("https://bedrock.#{region}.amazonaws.com/foundation-models",
            headers: [{"authorization", "Bearer " <> api_key}],
-           receive_timeout: @http_timeout
+           receive_timeout: @http_timeout,
+           retry: false
          ) do
       {:ok, %{status: 200, body: %{"modelSummaries" => models}}} when is_list(models) ->
-        {:ok,
-         gettext("%{count} foundation models visible in %{region}",
-           count: length(models),
-           region: region
-         )}
+        {:ok, bedrock_models_note(length(models), region)}
 
       {:ok, %{status: 200}} ->
         :ok
 
-      {:ok, %{status: status}} when status in [401, 403] ->
+      {:ok, %{status: 401}} ->
         {:error, gettext("Invalid credentials")}
+
+      # The most likely 403 is a key whose IAM identity lacks
+      # bedrock:CallWithBearerToken (or ListFoundationModels) — the key
+      # itself authenticated, so "invalid credentials" would send the
+      # operator off to reissue a perfectly good key.
+      {:ok, %{status: 403}} ->
+        {:error,
+         gettext(
+           "Key authenticated but not authorised — allow bedrock:CallWithBearerToken (and ListFoundationModels) on its IAM identity"
+         )}
 
       {:ok, %{status: status}} ->
         {:error, gettext("Bedrock error %{status}", status: status)}
@@ -163,6 +222,16 @@ defmodule PhoenixKit.Integrations.Validators do
         Logger.warning("Bedrock connection check failed: #{inspect(reason)}")
         {:error, gettext("Could not reach Bedrock in %{region}", region: region)}
     end
+  end
+
+  @doc false
+  # Pure, public for tests. Sidesteps plural forms; the count is the region's
+  # whole catalog, not the models this account may invoke — say so.
+  def bedrock_models_note(count, region) do
+    gettext("Model catalog in %{region}: %{count} (grants are configured separately)",
+      count: count,
+      region: region
+    )
   end
 
   @doc """

--- a/lib/phoenix_kit/integrations/validators.ex
+++ b/lib/phoenix_kit/integrations/validators.ex
@@ -131,7 +131,8 @@ defmodule PhoenixKit.Integrations.Validators do
   def aws_note(identity, perms, quota_note) do
     granted =
       for {key, label} <- [ses: "SES", sqs: "SQS", sns: "SNS"],
-          is_map(perms) and perms[key] |> Map.values() |> Enum.any?(&(&1 == :granted)),
+          is_map(perms),
+          perms |> Map.get(key, %{}) |> Map.values() |> Enum.any?(&(&1 == :granted)),
           do: label
 
     services =
@@ -162,9 +163,10 @@ defmodule PhoenixKit.Integrations.Validators do
   @spec amazon_bedrock(map()) :: :ok | {:ok, String.t()} | {:error, String.t()}
   def amazon_bedrock(data) do
     region = String.trim(data["aws_region"] || "")
+    api_key = String.trim(data["api_key"] || "")
 
     cond do
-      blank?(data["api_key"]) ->
+      blank?(api_key) ->
         {:error, gettext("No credentials configured")}
 
       blank?(region) ->
@@ -175,7 +177,7 @@ defmodule PhoenixKit.Integrations.Validators do
         {:error, gettext("Invalid region format (expected e.g. eu-central-1)")}
 
       true ->
-        Probe.run(fn -> request_bedrock_models(region, data["api_key"]) end)
+        Probe.run(fn -> request_bedrock_models(region, api_key) end)
     end
   end
 
@@ -191,7 +193,7 @@ defmodule PhoenixKit.Integrations.Validators do
   defp request_bedrock_models(region, api_key) do
     # retry: false — the outer Probe deadline is the only clock here; Req's
     # default transient retries would sleep through most of it.
-    case Req.get("https://bedrock.#{region}.amazonaws.com/foundation-models",
+    case Req.get("#{bedrock_host(region)}/foundation-models",
            headers: [{"authorization", "Bearer " <> api_key}],
            receive_timeout: @http_timeout,
            retry: false
@@ -212,7 +214,8 @@ defmodule PhoenixKit.Integrations.Validators do
       {:ok, %{status: 403}} ->
         {:error,
          gettext(
-           "Key authenticated but not authorised — allow bedrock:CallWithBearerToken (and ListFoundationModels) on its IAM identity"
+           "Key authenticated but not authorised in %{region} — allow bedrock:CallWithBearerToken (and ListFoundationModels) on its IAM identity, or check the key was issued for this region",
+           region: region
          )}
 
       {:ok, %{status: status}} ->
@@ -223,6 +226,12 @@ defmodule PhoenixKit.Integrations.Validators do
         {:error, gettext("Could not reach Bedrock in %{region}", region: region)}
     end
   end
+
+  @doc false
+  # The China partition answers on .amazonaws.com.cn — the global host does not
+  # resolve there at all, which would surface as "could not reach Bedrock".
+  def bedrock_host("cn-" <> _ = region), do: "https://bedrock.#{region}.amazonaws.com.cn"
+  def bedrock_host(region), do: "https://bedrock.#{region}.amazonaws.com"
 
   @doc false
   # Pure, public for tests. Sidesteps plural forms; the count is the region's

--- a/lib/phoenix_kit/integrations/validators.ex
+++ b/lib/phoenix_kit/integrations/validators.ex
@@ -28,6 +28,7 @@ defmodule PhoenixKit.Integrations.Validators do
 
   require Logger
 
+  alias PhoenixKit.AWS.CredentialsVerifier
   alias PhoenixKit.Integrations.Probe
   alias PhoenixKit.Mailer.SmtpTransport
   alias PhoenixKit.Utils.Number
@@ -62,7 +63,49 @@ defmodule PhoenixKit.Integrations.Validators do
         {:error, gettext("Region is required")}
 
       true ->
-        Probe.run(fn -> request_send_quota(region, data) end)
+        Probe.run(fn ->
+          # The send-quota probe stays the AUTH VERDICT — its transient-
+          # signature retry logic is what keeps good keys from being called
+          # invalid. The CredentialsVerifier sweep (the same one the Emails
+          # settings page runs) only enriches a passing verdict with the
+          # account identity and per-service permissions.
+          case request_send_quota(region, data) do
+            :ok -> {:ok, aws_note(region, data, nil)}
+            {:ok, quota_note} -> {:ok, aws_note(region, data, quota_note)}
+            error -> error
+          end
+        end)
+    end
+  end
+
+  defp aws_note(region, data, quota_note) do
+    ak = data["access_key"]
+    sk = data["secret_key"]
+
+    identity =
+      case CredentialsVerifier.verify_credentials(ak, sk, region) do
+        {:ok, %{account_id: id}} -> gettext("Account %{id}", id: id)
+        _ -> nil
+      end
+
+    services =
+      case CredentialsVerifier.check_permissions(ak, sk, region) do
+        {:ok, perms} ->
+          Enum.map_join([ses: "SES", sqs: "SQS", sns: "SNS"], " · ", fn {key, label} ->
+            granted? = perms[key] |> Map.values() |> Enum.any?(&(&1 == :granted))
+            "#{label} #{if granted?, do: "✓", else: "—"}"
+          end)
+
+        _ ->
+          nil
+      end
+
+    [identity, services, quota_note]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join(" · ")
+    |> case do
+      "" -> nil
+      note -> note
     end
   end
 

--- a/lib/phoenix_kit_web/live/settings/integrations.html.heex
+++ b/lib/phoenix_kit_web/live/settings/integrations.html.heex
@@ -14,6 +14,7 @@
     <div :if={@connections != []}>
       <.table_default
         id="integrations-table"
+        variant="zebra"
         toggleable
         items={@connections}
         card_title={fn conn -> conn.provider.name end}

--- a/test/phoenix_kit/integrations/validators_test.exs
+++ b/test/phoenix_kit/integrations/validators_test.exs
@@ -324,6 +324,72 @@ defmodule PhoenixKit.Integrations.ValidatorsTest do
   # Answers the given results in order. A plain closure beats a mocking library here:
   # the thing under test is "how many times is AWS asked, and what is done with each
   # answer", which is exactly what a queue makes visible.
+
+  describe "amazon_bedrock/1 refuses to guess" do
+    test "missing key and missing region are reported without a network round trip" do
+      assert {:error, _} = Validators.amazon_bedrock(%{"aws_region" => "eu-central-1"})
+      assert {:error, message} = Validators.amazon_bedrock(%{"api_key" => "ABSK_T"})
+      assert message =~ "Region"
+    end
+
+    test "a malformed region is rejected before it becomes a hostname" do
+      for bad <- ["eu central", "EU-CENTRAL-1", "bedrock.evil.example/", "eu-central-"] do
+        creds = %{"api_key" => "ABSK_T", "aws_region" => bad}
+        assert {:error, message} = Validators.amazon_bedrock(creds)
+        assert message =~ "region format"
+      end
+    end
+
+    test "real region shapes pass the format guard, including 4-letter sovereign prefixes" do
+      for good <- [
+            "us-east-1",
+            "ap-southeast-3",
+            "il-central-1",
+            "us-gov-west-1",
+            "eusc-de-east-1"
+          ] do
+        assert Validators.valid_aws_region?(good), good
+      end
+
+      for bad <- ["", "eu central", "EU-CENTRAL-1", "bedrock.evil.example/", "eu-central-", nil] do
+        refute Validators.valid_aws_region?(bad), inspect(bad)
+      end
+    end
+  end
+
+  describe "aws_note/3 assembles the enrichment note additively" do
+    test "lists only GRANTED management APIs — a send-only key shows no denied dashes" do
+      perms = %{
+        ses: %{"ListConfigurationSets" => :denied},
+        sqs: %{"ListQueues" => :denied},
+        sns: %{"ListTopics" => :denied}
+      }
+
+      assert Validators.aws_note("Account 1", perms, nil) == "Account 1"
+    end
+
+    test "grants surface by service name" do
+      perms = %{
+        ses: %{"ListConfigurationSets" => :granted},
+        sqs: %{"ListQueues" => :granted},
+        sns: %{"ListTopics" => :denied}
+      }
+
+      note = Validators.aws_note("Account 1", perms, "Quota: 1/200")
+      assert note =~ "SES, SQS"
+      refute note =~ "SNS"
+      assert note =~ "Quota: 1/200"
+    end
+
+    test "nothing to say means nil, so the verdict stays a bare :ok" do
+      assert Validators.aws_note(nil, nil, nil) == nil
+    end
+
+    test "a missing permissions sweep keeps identity and quota" do
+      assert Validators.aws_note("Account 1", nil, "Q") == "Account 1 · Q"
+    end
+  end
+
   defp stub(results) do
     {:ok, agent} = Agent.start_link(fn -> results end)
     on_exit(fn -> if Process.alive?(agent), do: Agent.stop(agent) end)

--- a/test/phoenix_kit/integrations/validators_test.exs
+++ b/test/phoenix_kit/integrations/validators_test.exs
@@ -388,6 +388,19 @@ defmodule PhoenixKit.Integrations.ValidatorsTest do
     test "a missing permissions sweep keeps identity and quota" do
       assert Validators.aws_note("Account 1", nil, "Q") == "Account 1 · Q"
     end
+
+    test "a partial permissions map is read, not crashed on" do
+      assert Validators.aws_note(nil, %{ses: %{"ListConfigurationSets" => :granted}}, nil) =~
+               "SES"
+    end
+  end
+
+  describe "bedrock_host/1 follows the partition" do
+    test "the China partition gets its own suffix" do
+      assert Validators.bedrock_host("cn-north-1") =~ ".amazonaws.com.cn"
+      assert Validators.bedrock_host("eu-central-1") =~ ".amazonaws.com"
+      refute Validators.bedrock_host("eu-central-1") =~ ".cn"
+    end
   end
 
   defp stub(results) do


### PR DESCRIPTION
Two new built-in integration providers, and richer validation notes for the AWS ones.

## GitHub (`github`, api_key)

A read-only token for GitHub API consumers — org-statistics dashboard widgets and the like. GraphQL requires authentication even for public data, so the least-privilege credential is a fine-grained PAT with public-repo read-only access. Validated with the generic Bearer GET against `/rate_limit`. Instructions walk through fine-grained token creation.

## Amazon Bedrock (`amazon_bedrock`, api_key)

Long-term Bedrock API keys (plain Bearer, no SigV4) plus a region field. Validation is a new `:amazon_bedrock` strategy: `ListFoundationModels` in the configured region — the cheapest call that proves the key, the region, and the `bedrock:CallWithBearerToken` permission at once. It is the same auth header the OpenAI-compatible runtime endpoint accepts, so a green check means the AI completions path can authenticate too.

Declares `:ai_completions` with the primary region as the default `base_url`; other regions override `base_url` per AI endpoint. Two field-tested caveats are spelled out in the card instructions:

- the key's IAM identity must allow `bedrock:CallWithBearerToken` — without it every Bearer call answers 403 even when invoke permissions are in place;
- the OpenAI-compatible endpoint (`…/openai/v1`) currently serves only the `openai.gpt-oss-*` models — Anthropic and the rest answer on the native Converse API with the same key.

## aws_ses Test enrichment

The Test verdict stays the retry-confirmed send-quota probe (its transient-signature logic is what keeps good keys from being called invalid). A passing check now also reports the account id and per-service permissions (SES/SQS/SNS) via `PhoenixKit.AWS.CredentialsVerifier` — the same sweep the Emails settings page runs — so "Test connection" says whose key it is and what it may do. The SES and Bedrock cards gain step-by-step instructions with console/docs links, and the SES one cross-references Admin → Settings → Emails as the home of the delivery pipeline.

Also: the connections table gets the `zebra` variant like every other admin list.

## Verified

Live on a host app: GitHub connection validates and feeds the dashboard widgets; Bedrock connection validates ("38 foundation models visible in eu-central-1") and completes end-to-end through phoenix_kit_ai 0.19.0 against `openai.gpt-oss-20b-1:0` (and through native Converse with the same key). Pre-commit gate (compile --warnings-as-errors, format, credo --strict, sobelow) green on both commits.
