### PR TITLE
Add locale and priority options to the country selects

### DIFF
--- a/lib/phoenix_kit/utils/country_data.ex
+++ b/lib/phoenix_kit/utils/country_data.ex
@@ -466,24 +466,34 @@ defmodule PhoenixKit.Utils.CountryData do
   def get_currency_code(_), do: nil
 
   @doc """
-  Get country name.
+  Get country name in the active locale.
+
+  Takes the same `:locale` option as `countries_for_select/1` and falls back
+  to the English name when that locale has no translation for the country.
 
   ## Examples
 
-      iex> CountryData.get_country_name("EE")
+      iex> CountryData.get_country_name("EE", locale: "en")
       "Estonia"
+
+      iex> CountryData.get_country_name("EE", locale: "ru")
+      "Эстония"
 
       iex> CountryData.get_country_name("XX")
       nil
   """
-  def get_country_name(country_code) when is_binary(country_code) do
+  def get_country_name(country_code, opts \\ [])
+
+  def get_country_name(country_code, opts) when is_binary(country_code) do
+    locale = opts |> Keyword.get(:locale, active_locale()) |> normalize_locale()
+
     case get_country(country_code) do
-      %{name: name} -> name
+      %{} = country -> translated_name(country, locale)
       _ -> nil
     end
   end
 
-  def get_country_name(_), do: nil
+  def get_country_name(_, _), do: nil
 
   @doc """
   Get country flag (emoji).

--- a/lib/phoenix_kit/utils/country_data.ex
+++ b/lib/phoenix_kit/utils/country_data.ex
@@ -289,17 +289,45 @@ defmodule PhoenixKit.Utils.CountryData do
   Returns list of tuples {display_name, alpha2_code} for use
   in Phoenix form selects, sorted by the country name in the active locale.
 
+  Names come from `BeamLabCountries.Translations`, not the country struct's
+  `:name` field — the two differ even in English, for 20 of the 250
+  countries (as of beamlab_countries 1.1.0). For example: GB "United
+  Kingdom of Great Britain and Northern Ireland" -> "United Kingdom", US
+  "United States of America" -> "United States", CZ "Czech Republic" ->
+  "Czechia", TR "Turkey" -> "Türkiye", KP "Korea (Democratic People's
+  Republic of)" -> "North Korea" (which also moves its place in the sorted
+  list, from the K's to the N's). A host that never passes `:locale` still
+  gets different strings, and a different order, than a version of this
+  function that read `.name` directly.
+
+  Sorting folds accented letters to their base form before comparing (e.g.
+  "ü" sorts with "u"), which is a deliberate approximation, not proper
+  collation — the BEAM has no ICU. It is correct for most Latin-script
+  locales, but wrong for locales that give diacritics their own place in
+  the alphabet: in Estonian, Ü belongs at the very end (after W, Õ, Ä, Ö),
+  and in Swedish, Å, Ä, Ö belong after Z; folding moves those names out of
+  that position instead of leaving them there. A host that needs strict
+  local collation should sort the returned list itself.
+
   ## Options
 
     * `:locale` — locale for the country names. Defaults to the active
-      `PhoenixKitWeb.Gettext` locale, reduced to its base code. Locales
-      `BeamLabCountries` ships no translations for fall back to English, so a
-      host only ever loses the translation, never the entry.
+      `PhoenixKitWeb.Gettext` locale, reduced to its base code (`"ru-RU"`
+      normalizes to `"ru"`). `BeamLabCountries` 1.1.0 ships translations for
+      `ar`, `de`, `en`, `es`, `fr`, `it`, `ja`, `ko`, `nl`, `pl`, `pt`, `ru`,
+      `sv`, `uk`, `zh` (`BeamLabCountries.Translations.supported_locales/0`);
+      any other locale falls back to the country's English name, and so
+      does an unsupported *value* such as an atom (`locale: :ru`) — a host
+      only ever loses the translation, never the entry.
 
     * `:priority` — alpha-2 codes pinned to the top of the list, in the order
       given; everything else follows alphabetically. Defaults to
       `config :phoenix_kit, :country_select_priority`, so a host that serves
       one region can put its own countries first without touching call sites.
+      A non-list value is treated as `[]`.
+
+  `opts` itself must be a keyword list — a map or a bare string raises
+  `FunctionClauseError` naming this function rather than `Keyword`.
 
   ## Examples
 
@@ -311,17 +339,13 @@ defmodule PhoenixKit.Utils.CountryData do
       ...> |> Enum.take(2)
       [{"🇪🇪 Эстония", "EE"}, {"🇫🇮 Финляндия", "FI"}]
   """
-  def countries_for_select(opts \\ []) do
+  def countries_for_select(opts \\ []) when is_list(opts) do
     locale = opts |> Keyword.get(:locale, active_locale()) |> normalize_locale()
     priority = opts |> Keyword.get(:priority, configured_priority()) |> normalize_priority()
 
-    entries = Enum.map(BeamLabCountries.all(), &select_entry(&1, locale))
+    {pinned, rest} = locale |> sorted_entries(:all) |> split_priority(priority)
 
-    {pinned, rest} = split_priority(entries, priority)
-
-    Enum.map(pinned ++ sort_by_name(rest), fn {_name, display_name, code} ->
-      {display_name, code}
-    end)
+    Enum.map(pinned ++ rest, fn {_name, display_name, code} -> {display_name, code} end)
   end
 
   @doc """
@@ -355,18 +379,16 @@ defmodule PhoenixKit.Utils.CountryData do
   Get list of EU countries for select dropdown.
 
   Takes the same `:locale` and `:priority` options as
-  `countries_for_select/1`.
+  `countries_for_select/1`, including its fallback, leniency, and sorting
+  caveats.
   """
-  def eu_countries_for_select(opts \\ []) do
+  def eu_countries_for_select(opts \\ []) when is_list(opts) do
     locale = opts |> Keyword.get(:locale, active_locale()) |> normalize_locale()
     priority = opts |> Keyword.get(:priority, configured_priority()) |> normalize_priority()
 
-    entries = Enum.map(eu_countries(), &select_entry(&1, locale))
-    {pinned, rest} = split_priority(entries, priority)
+    {pinned, rest} = locale |> sorted_entries(:eu) |> split_priority(priority)
 
-    Enum.map(pinned ++ sort_by_name(rest), fn {_name, display_name, code} ->
-      {display_name, code}
-    end)
+    Enum.map(pinned ++ rest, fn {_name, display_name, code} -> {display_name, code} end)
   end
 
   # {sortable_name, display_name, alpha2} for one country in `locale`.
@@ -394,8 +416,46 @@ defmodule PhoenixKit.Utils.CountryData do
     end
   end
 
+  # Localized, alphabetically-sorted {sortable_name, display_name, alpha2}
+  # entries for `source` (:all or :eu), memoized in :persistent_term per
+  # locale — countries_for_select/1 runs in LiveView mount twice per
+  # connection, and rebuilding + sort-keying ~250 translated names on every
+  # call was measured as the expensive part (the translation lookup itself
+  # is cheap). Keyed by locale *and* source so the EU subset can never
+  # collide with the full list. A cache miss computes once and stores;
+  # realistic callers only ever use the handful of locales this host's
+  # Gettext config and BeamLabCountries between them support, so the number
+  # of distinct writes is bounded. Priority pinning is deliberately *not*
+  # part of the cache key — split_priority/2 below is cheap (one pass over
+  # already-sorted input) and runs on every call, so
+  # `:country_select_priority` changes take effect immediately without
+  # invalidating anything.
+  defp sorted_entries(locale, source) do
+    key = {__MODULE__, :sorted_entries, source, locale}
+
+    case :persistent_term.get(key, :not_cached) do
+      :not_cached ->
+        entries =
+          source
+          |> countries_for_source()
+          |> Enum.map(&select_entry(&1, locale))
+          |> sort_by_name()
+
+        :persistent_term.put(key, entries)
+        entries
+
+      entries ->
+        entries
+    end
+  end
+
+  defp countries_for_source(:all), do: BeamLabCountries.all()
+  defp countries_for_source(:eu), do: eu_countries()
+
   # Pull the priority codes out in the order they were given; the remainder
-  # keeps its original order for the caller to sort.
+  # keeps its incoming order. Callers now pass the already-sorted output of
+  # sorted_entries/2, so that incoming order is alphabetical — no further
+  # sort needed.
   defp split_priority(entries, []), do: {[], entries}
 
   defp split_priority(entries, priority) do
@@ -408,9 +468,17 @@ defmodule PhoenixKit.Utils.CountryData do
     {pinned, rest}
   end
 
-  # Case- and diacritic-insensitive sort. Without ICU collation the byte order
-  # would exile every accented name past "Z" — "Ühendkuningriik" after
-  # "Zimbabwe" — which reads as a bug in any locale that uses them.
+  # Deliberate approximation, not proper collation: folding diacritics to
+  # their base letter before comparing is correct for locales that treat
+  # accented letters as variants of the base letter — most Latin-script
+  # locales (French, German, Spanish, Italian, Dutch, Polish, Portuguese,
+  # ...) — but wrong for locales that give diacritics their own position in
+  # the alphabet. Estonian sorts Ü at the very end, after W, Õ, Ä, Ö;
+  # Swedish sorts Å, Ä, Ö after Z. Folding pulls "Ühendkuningriik" into the U
+  # block and "Åland" between "Azerbajdzjan" and "Bahamas" instead of
+  # leaving them at the end, which is where correct collation puts them in
+  # those locales. Proper per-locale collation would need ICU, which the
+  # BEAM does not ship.
   defp sort_by_name(entries) do
     Enum.sort_by(entries, fn {name, _display, _code} ->
       name |> String.downcase() |> :unicode.characters_to_nfd_binary()
@@ -468,8 +536,13 @@ defmodule PhoenixKit.Utils.CountryData do
   @doc """
   Get country name in the active locale.
 
-  Takes the same `:locale` option as `countries_for_select/1` and falls back
+  Takes the same `:locale` option as `countries_for_select/1` — including
+  its supported-locale set and its fallback/leniency rules — and falls back
   to the English name when that locale has no translation for the country.
+
+  `opts` must be a keyword list. `get_country_name("EE", "ru")` is a
+  realistic slip (the option is `:locale`), and raises
+  `FunctionClauseError` naming this function rather than `Keyword`.
 
   ## Examples
 
@@ -484,7 +557,7 @@ defmodule PhoenixKit.Utils.CountryData do
   """
   def get_country_name(country_code, opts \\ [])
 
-  def get_country_name(country_code, opts) when is_binary(country_code) do
+  def get_country_name(country_code, opts) when is_binary(country_code) and is_list(opts) do
     locale = opts |> Keyword.get(:locale, active_locale()) |> normalize_locale()
 
     case get_country(country_code) do
@@ -493,7 +566,7 @@ defmodule PhoenixKit.Utils.CountryData do
     end
   end
 
-  def get_country_name(_, _), do: nil
+  def get_country_name(country_code, _opts) when not is_binary(country_code), do: nil
 
   @doc """
   Get country flag (emoji).

--- a/lib/phoenix_kit/utils/country_data.ex
+++ b/lib/phoenix_kit/utils/country_data.ex
@@ -287,25 +287,40 @@ defmodule PhoenixKit.Utils.CountryData do
   Get list of countries for select dropdown.
 
   Returns list of tuples {display_name, alpha2_code} for use
-  in Phoenix form selects.
+  in Phoenix form selects, sorted by the country name in the active locale.
+
+  ## Options
+
+    * `:locale` — locale for the country names. Defaults to the active
+      `PhoenixKitWeb.Gettext` locale, reduced to its base code. Locales
+      `BeamLabCountries` ships no translations for fall back to English, so a
+      host only ever loses the translation, never the entry.
+
+    * `:priority` — alpha-2 codes pinned to the top of the list, in the order
+      given; everything else follows alphabetically. Defaults to
+      `config :phoenix_kit, :country_select_priority`, so a host that serves
+      one region can put its own countries first without touching call sites.
 
   ## Examples
 
-      iex> countries = CountryData.countries_for_select()
+      iex> countries = CountryData.countries_for_select(locale: "en")
       iex> {"🇦🇫 Afghanistan", "AF"} in countries
       true
-  """
-  def countries_for_select do
-    list_countries()
-    |> Enum.map(fn c ->
-      display_name =
-        case c.flag do
-          nil -> c.name
-          "" -> c.name
-          flag -> flag <> " " <> c.name
-        end
 
-      {display_name, c.alpha2}
+      iex> CountryData.countries_for_select(locale: "ru", priority: ["EE", "FI"])
+      ...> |> Enum.take(2)
+      [{"🇪🇪 Эстония", "EE"}, {"🇫🇮 Финляндия", "FI"}]
+  """
+  def countries_for_select(opts \\ []) do
+    locale = opts |> Keyword.get(:locale, active_locale()) |> normalize_locale()
+    priority = opts |> Keyword.get(:priority, configured_priority()) |> normalize_priority()
+
+    entries = Enum.map(BeamLabCountries.all(), &select_entry(&1, locale))
+
+    {pinned, rest} = split_priority(entries, priority)
+
+    Enum.map(pinned ++ sort_by_name(rest), fn {_name, display_name, code} ->
+      {display_name, code}
     end)
   end
 
@@ -338,21 +353,94 @@ defmodule PhoenixKit.Utils.CountryData do
 
   @doc """
   Get list of EU countries for select dropdown.
-  """
-  def eu_countries_for_select do
-    eu_countries()
-    |> Enum.sort_by(& &1.name)
-    |> Enum.map(fn c ->
-      display_name =
-        case c.flag do
-          nil -> c.name
-          "" -> c.name
-          flag -> flag <> " " <> c.name
-        end
 
-      {display_name, c.alpha2}
+  Takes the same `:locale` and `:priority` options as
+  `countries_for_select/1`.
+  """
+  def eu_countries_for_select(opts \\ []) do
+    locale = opts |> Keyword.get(:locale, active_locale()) |> normalize_locale()
+    priority = opts |> Keyword.get(:priority, configured_priority()) |> normalize_priority()
+
+    entries = Enum.map(eu_countries(), &select_entry(&1, locale))
+    {pinned, rest} = split_priority(entries, priority)
+
+    Enum.map(pinned ++ sort_by_name(rest), fn {_name, display_name, code} ->
+      {display_name, code}
     end)
   end
+
+  # {sortable_name, display_name, alpha2} for one country in `locale`.
+  defp select_entry(country, locale) do
+    name = translated_name(country, locale)
+
+    display_name =
+      case country.flag do
+        nil -> name
+        "" -> name
+        flag -> flag <> " " <> name
+      end
+
+    {name, display_name, country.alpha2}
+  end
+
+  defp translated_name(country, locale) do
+    with true <- is_binary(locale),
+         true <- BeamLabCountries.Translations.locale_supported?(locale),
+         name when is_binary(name) <-
+           BeamLabCountries.Translations.get_name(country.alpha2, locale) do
+      name
+    else
+      _ -> country.name
+    end
+  end
+
+  # Pull the priority codes out in the order they were given; the remainder
+  # keeps its original order for the caller to sort.
+  defp split_priority(entries, []), do: {[], entries}
+
+  defp split_priority(entries, priority) do
+    index = Map.new(entries, fn {_name, _display, code} = entry -> {code, entry} end)
+
+    pinned_codes = Enum.filter(priority, &Map.has_key?(index, &1))
+    pinned = Enum.map(pinned_codes, &Map.fetch!(index, &1))
+    rest = Enum.reject(entries, fn {_name, _display, code} -> code in pinned_codes end)
+
+    {pinned, rest}
+  end
+
+  # Case- and diacritic-insensitive sort. Without ICU collation the byte order
+  # would exile every accented name past "Z" — "Ühendkuningriik" after
+  # "Zimbabwe" — which reads as a bug in any locale that uses them.
+  defp sort_by_name(entries) do
+    Enum.sort_by(entries, fn {name, _display, _code} ->
+      name |> String.downcase() |> :unicode.characters_to_nfd_binary()
+    end)
+  end
+
+  defp active_locale do
+    Gettext.get_locale(PhoenixKitWeb.Gettext)
+  end
+
+  defp normalize_locale(nil), do: nil
+
+  defp normalize_locale(locale) when is_binary(locale) do
+    locale |> String.split(["-", "_"]) |> hd() |> String.downcase()
+  end
+
+  defp normalize_locale(_), do: nil
+
+  defp configured_priority do
+    Application.get_env(:phoenix_kit, :country_select_priority, [])
+  end
+
+  defp normalize_priority(codes) when is_list(codes) do
+    codes
+    |> Enum.filter(&is_binary/1)
+    |> Enum.map(&String.upcase/1)
+    |> Enum.uniq()
+  end
+
+  defp normalize_priority(_), do: []
 
   @doc """
   Get country currency code.

--- a/lib/phoenix_kit/utils/country_data.ex
+++ b/lib/phoenix_kit/utils/country_data.ex
@@ -588,11 +588,11 @@ defmodule PhoenixKit.Utils.CountryData do
 
   Returns that country first, then its nearest neighbours by great-circle
   distance between country centroids — so a host in Estonia is offered
-  Latvia, Finland, Lithuania and Sweden, one in Germany gets Luxembourg,
+  Latvia, Åland, Finland and Lithuania, one in Germany gets Luxembourg,
   the Netherlands, Czechia and Belgium, and one in Singapore gets Malaysia,
-  Indonesia and Cambodia. The point is that it is derived from the host's
-  own data rather than from a constant baked in by whoever wrote the
-  library.
+  Indonesia, Cambodia and Brunei. The point is that it is derived from the
+  host's own data rather than from a constant baked in by whoever wrote
+  the library.
 
   This is a *suggestion* for the settings UI to offer, never applied on its
   own: nothing is pinned until an operator stores a list. The result can
@@ -619,7 +619,7 @@ defmodule PhoenixKit.Utils.CountryData do
   def suggested_priority(country_code, opts \\ [])
 
   def suggested_priority(country_code, opts) when is_binary(country_code) and is_list(opts) do
-    limit = Keyword.get(opts, :limit, 4)
+    limit = opts |> Keyword.get(:limit, 4) |> normalize_limit()
 
     case get_country(country_code) do
       %{geo: %{latitude: lat, longitude: lon}} = origin when is_number(lat) and is_number(lon) ->
@@ -634,6 +634,13 @@ defmodule PhoenixKit.Utils.CountryData do
   end
 
   def suggested_priority(_, _), do: []
+
+  # A non-integer `:limit` (nil, a string, a float — Erlang term ordering
+  # makes all of those `> 0`, so a guard alone won't stop them) falls back
+  # to the same default `suggested_priority/2` uses when `:limit` is
+  # omitted, rather than reaching `Enum.take/2` and raising.
+  defp normalize_limit(limit) when is_integer(limit), do: limit
+  defp normalize_limit(_), do: 4
 
   defp nearest_codes(origin, limit) when limit > 0 do
     BeamLabCountries.all()

--- a/lib/phoenix_kit/utils/country_data.ex
+++ b/lib/phoenix_kit/utils/country_data.ex
@@ -321,10 +321,13 @@ defmodule PhoenixKit.Utils.CountryData do
       only ever loses the translation, never the entry.
 
     * `:priority` — alpha-2 codes pinned to the top of the list, in the order
-      given; everything else follows alphabetically. Defaults to
-      `config :phoenix_kit, :country_select_priority`, so a host that serves
-      one region can put its own countries first without touching call sites.
-      A non-list value is treated as `[]`.
+      given; everything else follows alphabetically. A non-list value is
+      treated as `[]`. The default comes from, in order: the
+      `country_select_priority` setting (Admin → Settings → Organization,
+      where an operator can reorder the dropdown without a deploy), then
+      `config :phoenix_kit, :country_select_priority` when that setting is
+      blank or unset. A host that serves one region can therefore put its own
+      countries first without touching any call site.
 
   `opts` itself must be a keyword list — a map or a bare string raises
   `FunctionClauseError` naming this function rather than `Keyword`.
@@ -497,9 +500,75 @@ defmodule PhoenixKit.Utils.CountryData do
 
   defp normalize_locale(_), do: nil
 
+  # The admin-editable setting wins over the compile-time config, so an
+  # operator can reorder the dropdown without a deploy. A missing or blank
+  # setting means "not configured" and falls through to the config, which
+  # keeps every host that never opens the settings page working as before.
+  #
+  # Read through the cache: this runs on the hot path, and `get_setting_cached/2`
+  # is consulted before the update-mode short-circuit, so a primed key resolves
+  # without a database at all. A settings read can raise on an unowned checkout
+  # AND exit on a dead pool, so both are caught — the country list must not
+  # depend on the database being up.
   defp configured_priority do
-    Application.get_env(:phoenix_kit, :country_select_priority, [])
+    case setting_priority() do
+      [] -> Application.get_env(:phoenix_kit, :country_select_priority, [])
+      codes -> codes
+    end
   end
+
+  defp setting_priority do
+    "country_select_priority"
+    |> Settings.get_setting_cached("")
+    |> parse_priority()
+  rescue
+    _ -> []
+  catch
+    :exit, _ -> []
+  end
+
+  @doc """
+  Split an operator-entered priority string into alpha-2 codes.
+
+  Accepts the separators a human actually types — commas, spaces, semicolons,
+  newlines — so `"EE, FI"`, `"ee fi"` and `"EE;FI"` all parse. Unknown codes
+  are kept here and dropped later by the same normalization every caller of
+  `:priority` goes through; use `known_country_codes/1` to report them.
+
+  ## Examples
+
+      iex> CountryData.parse_priority("EE, FI ; lv")
+      ["EE", "FI", "LV"]
+
+      iex> CountryData.parse_priority("")
+      []
+  """
+  def parse_priority(value) when is_binary(value) do
+    value
+    |> String.split([",", ";", " ", "\n", "\t"], trim: true)
+    |> Enum.map(&(&1 |> String.trim() |> String.upcase()))
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.uniq()
+  end
+
+  def parse_priority(_), do: []
+
+  @doc """
+  Keep only the codes that name a real country, in the order given.
+
+  The counterpart of `parse_priority/1` for a settings form: it tells the
+  operator which of the codes they typed will actually pin something.
+
+  ## Examples
+
+      iex> CountryData.known_country_codes(["EE", "ZZ", "FI"])
+      ["EE", "FI"]
+  """
+  def known_country_codes(codes) when is_list(codes) do
+    Enum.filter(codes, fn code -> is_binary(code) and get_country(code) != nil end)
+  end
+
+  def known_country_codes(_), do: []
 
   defp normalize_priority(codes) when is_list(codes) do
     codes

--- a/lib/phoenix_kit/utils/country_data.ex
+++ b/lib/phoenix_kit/utils/country_data.ex
@@ -34,8 +34,6 @@ defmodule PhoenixKit.Utils.CountryData do
   alias PhoenixKit.Settings
   alias PhoenixKitBilling.IbanData
 
-  @none_priority "none"
-
   @doc """
   Get all countries sorted by name.
 
@@ -324,18 +322,15 @@ defmodule PhoenixKit.Utils.CountryData do
 
     * `:priority` — alpha-2 codes pinned to the top of the list, in the order
       given; everything else follows alphabetically. A non-list value is
-      treated as `[]`. The default comes from, in order: the
-      `country_select_priority` setting (Admin → Settings → Organization,
-      where an operator can reorder the dropdown without a deploy), then
-      `config :phoenix_kit, :country_select_priority` when that setting is
-      blank or unset. A stored value of `"none"` (case-insensitive, trimmed
-      — see `none_priority?/1`) is an explicit sentinel meaning "pin
-      nothing"; it is honoured over the config, which is the only way an
-      operator can disable pinning on a host that has the config set
-      without a deploy — a blank/absent setting can't be told apart from
-      "not configured" and falls back to the config just the same. A host
-      that serves one region can therefore put its own countries first
-      without touching any call site.
+      treated as `[]`. The default is the `country_select_priority` setting
+      (Admin → Settings → Organization), and nothing else: **there is no
+      compile-time config**, deliberately. A default baked into the library
+      would pin whatever countries its author serves, so every other host
+      would install it and find the dropdown already reordered before anyone
+      chose anything. Until an operator stores a list, nothing is pinned and
+      the order is plain alphabetical; `suggested_priority/2` is what the
+      settings UI offers them as a starting point, derived from their own
+      country rather than from a constant.
 
   `opts` itself must be a keyword list — a map or a bare string raises
   `FunctionClauseError` naming this function rather than `Keyword`.
@@ -521,35 +516,25 @@ defmodule PhoenixKit.Utils.CountryData do
     end
   end
 
-  # The admin-editable setting wins over the compile-time config, so an
-  # operator can reorder the dropdown without a deploy. A blank or absent
-  # setting means "not configured" and falls through to the config, which
-  # keeps every host that never opens the settings page working as before.
-  # A stored value of `"none"` (see `none_priority?/1`) is an explicit
-  # sentinel meaning "pin nothing", honoured over the config — the only way
-  # an operator can disable pinning on a host that has the config set,
-  # since a blank/absent setting can't be told apart from "not configured"
-  # at the settings layer.
+  # The stored setting is the ONLY source. There is deliberately no
+  # compile-time config fallback: a default baked into the library would
+  # pin whatever countries its author happens to serve, and every other
+  # host installs it to find a list already filtered before anyone chose
+  # anything. Nothing is pinned until an operator says so — see
+  # `suggested_priority/2` for how the settings UI proposes a starting
+  # list from the organization's own country instead of from a constant.
   #
   # Read through the cache: this runs on the hot path, and
   # `get_setting_cached/2` is consulted before the update-mode
   # short-circuit, so a primed key resolves without a database at all.
   # `Settings.get_setting_cached/2` — and the `get_setting/2` it falls back
   # to on a cache error — already rescue AND catch `:exit` internally, so
-  # the country list degrading to the config when the database is
-  # unreachable is handled entirely by the Settings layer, not by this
-  # function.
+  # an unreachable database degrades to "nothing pinned" rather than
+  # raising, without this function handling anything itself.
   defp configured_priority do
-    raw = Settings.get_setting_cached("country_select_priority", "")
-
-    if none_priority?(raw) do
-      []
-    else
-      case parse_priority(raw) do
-        [] -> Application.get_env(:phoenix_kit, :country_select_priority, [])
-        codes -> codes
-      end
-    end
+    "country_select_priority"
+    |> Settings.get_setting_cached("")
+    |> parse_priority()
   end
 
   @doc """
@@ -599,47 +584,95 @@ defmodule PhoenixKit.Utils.CountryData do
   def known_country_codes(_), do: []
 
   @doc """
-  The sentinel value for the `country_select_priority` setting that means
-  "pin nothing", honoured over `config :phoenix_kit,
-  :country_select_priority` by `countries_for_select/1` and
-  `eu_countries_for_select/1` (see `configured_priority/0`). A caller that
-  writes the setting (the Organization settings form) should store this
-  exact value rather than hardcoding the literal string, so the write side
-  and `none_priority?/1` never drift apart.
+  Suggest a starting priority list for a host based in `country_code`.
+
+  Returns that country first, then its nearest neighbours by great-circle
+  distance between country centroids — so a host in Estonia is offered
+  Latvia, Finland, Lithuania and Sweden, one in Germany gets Luxembourg,
+  the Netherlands, Czechia and Belgium, and one in Singapore gets Malaysia,
+  Indonesia and Cambodia. The point is that it is derived from the host's
+  own data rather than from a constant baked in by whoever wrote the
+  library.
+
+  This is a *suggestion* for the settings UI to offer, never applied on its
+  own: nothing is pinned until an operator stores a list. The result can
+  include dependent territories (Åland is the second-nearest thing to
+  Estonia) — the data has no "sovereign state" flag — so the operator is
+  expected to prune it.
+
+  Dissolved countries are excluded. Countries with no coordinates cannot be
+  ranked and are skipped.
+
+  ## Options
+
+    * `:limit` — how many neighbours to add after the country itself.
+      Defaults to 4.
 
   ## Examples
 
-      iex> CountryData.none_priority_value()
-      "none"
+      iex> CountryData.suggested_priority("EE", limit: 2)
+      ["EE", "LV", "AX"]
+
+      iex> CountryData.suggested_priority("XX")
+      []
   """
-  def none_priority_value, do: @none_priority
+  def suggested_priority(country_code, opts \\ [])
 
-  @doc """
-  True if `value`, trimmed and downcased, is the `"none"` sentinel.
+  def suggested_priority(country_code, opts) when is_binary(country_code) and is_list(opts) do
+    limit = Keyword.get(opts, :limit, 4)
 
-  This is the only way to disable country-priority pinning on a host that
-  has `config :phoenix_kit, :country_select_priority` set: a blank or
-  absent setting can't be told apart from "not configured"
-  (`Settings.get_setting_cached/2` returns the default for both) and falls
-  back to the config either way, so an operator needs an explicit value
-  that means "pin nothing" instead.
+    case get_country(country_code) do
+      %{geo: %{latitude: lat, longitude: lon}} = origin when is_number(lat) and is_number(lon) ->
+        [origin.alpha2 | nearest_codes(origin, limit)]
 
-  ## Examples
+      %{} = origin ->
+        [origin.alpha2]
 
-      iex> CountryData.none_priority?("none")
-      true
-
-      iex> CountryData.none_priority?(" NONE ")
-      true
-
-      iex> CountryData.none_priority?("EE")
-      false
-  """
-  def none_priority?(value) when is_binary(value) do
-    value |> String.trim() |> String.downcase() == @none_priority
+      _ ->
+        []
+    end
   end
 
-  def none_priority?(_), do: false
+  def suggested_priority(_, _), do: []
+
+  defp nearest_codes(origin, limit) when limit > 0 do
+    BeamLabCountries.all()
+    |> Enum.filter(&rankable_neighbour?(&1, origin))
+    |> Enum.sort_by(&distance_km(origin, &1))
+    |> Enum.take(limit)
+    |> Enum.map(& &1.alpha2)
+  end
+
+  defp nearest_codes(_origin, _limit), do: []
+
+  defp rankable_neighbour?(
+         %{alpha2: code, dissolved_on: nil, geo: %{latitude: lat, longitude: lon}},
+         origin
+       )
+       when is_number(lat) and is_number(lon),
+       do: code != origin.alpha2
+
+  defp rankable_neighbour?(_, _), do: false
+
+  # Haversine over the country centroids the dataset carries. Centroids are a
+  # coarse proxy for "neighbouring" — a large country's centroid can sit far
+  # from the border it shares with the origin — but the dataset has no border
+  # list, and the result only has to be a plausible starting point an operator
+  # then edits.
+  defp distance_km(a, b) do
+    lat1 = deg_to_rad(a.geo.latitude)
+    lat2 = deg_to_rad(b.geo.latitude)
+    dlat = lat2 - lat1
+    dlon = deg_to_rad(b.geo.longitude - a.geo.longitude)
+
+    h =
+      :math.pow(:math.sin(dlat / 2), 2) +
+        :math.cos(lat1) * :math.cos(lat2) * :math.pow(:math.sin(dlon / 2), 2)
+
+    6371 * 2 * :math.asin(min(1.0, :math.sqrt(h)))
+  end
+
+  defp deg_to_rad(degrees), do: degrees * :math.pi() / 180
 
   defp normalize_priority(codes) when is_list(codes) do
     codes

--- a/lib/phoenix_kit/utils/country_data.ex
+++ b/lib/phoenix_kit/utils/country_data.ex
@@ -34,6 +34,8 @@ defmodule PhoenixKit.Utils.CountryData do
   alias PhoenixKit.Settings
   alias PhoenixKitBilling.IbanData
 
+  @none_priority "none"
+
   @doc """
   Get all countries sorted by name.
 
@@ -326,8 +328,14 @@ defmodule PhoenixKit.Utils.CountryData do
       `country_select_priority` setting (Admin → Settings → Organization,
       where an operator can reorder the dropdown without a deploy), then
       `config :phoenix_kit, :country_select_priority` when that setting is
-      blank or unset. A host that serves one region can therefore put its own
-      countries first without touching any call site.
+      blank or unset. A stored value of `"none"` (case-insensitive, trimmed
+      — see `none_priority?/1`) is an explicit sentinel meaning "pin
+      nothing"; it is honoured over the config, which is the only way an
+      operator can disable pinning on a host that has the config set
+      without a deploy — a blank/absent setting can't be told apart from
+      "not configured" and falls back to the config just the same. A host
+      that serves one region can therefore put its own countries first
+      without touching any call site.
 
   `opts` itself must be a keyword list — a map or a bare string raises
   `FunctionClauseError` naming this function rather than `Keyword`.
@@ -343,8 +351,8 @@ defmodule PhoenixKit.Utils.CountryData do
       [{"🇪🇪 Эстония", "EE"}, {"🇫🇮 Финляндия", "FI"}]
   """
   def countries_for_select(opts \\ []) when is_list(opts) do
-    locale = opts |> Keyword.get(:locale, active_locale()) |> normalize_locale()
-    priority = opts |> Keyword.get(:priority, configured_priority()) |> normalize_priority()
+    locale = opts |> fetch_opt(:locale, &active_locale/0) |> normalize_locale()
+    priority = opts |> fetch_opt(:priority, &configured_priority/0) |> normalize_priority()
 
     {pinned, rest} = locale |> sorted_entries(:all) |> split_priority(priority)
 
@@ -386,8 +394,8 @@ defmodule PhoenixKit.Utils.CountryData do
   caveats.
   """
   def eu_countries_for_select(opts \\ []) when is_list(opts) do
-    locale = opts |> Keyword.get(:locale, active_locale()) |> normalize_locale()
-    priority = opts |> Keyword.get(:priority, configured_priority()) |> normalize_priority()
+    locale = opts |> fetch_opt(:locale, &active_locale/0) |> normalize_locale()
+    priority = opts |> fetch_opt(:priority, &configured_priority/0) |> normalize_priority()
 
     {pinned, rest} = locale |> sorted_entries(:eu) |> split_priority(priority)
 
@@ -500,31 +508,48 @@ defmodule PhoenixKit.Utils.CountryData do
 
   defp normalize_locale(_), do: nil
 
-  # The admin-editable setting wins over the compile-time config, so an
-  # operator can reorder the dropdown without a deploy. A missing or blank
-  # setting means "not configured" and falls through to the config, which
-  # keeps every host that never opens the settings page working as before.
-  #
-  # Read through the cache: this runs on the hot path, and `get_setting_cached/2`
-  # is consulted before the update-mode short-circuit, so a primed key resolves
-  # without a database at all. A settings read can raise on an unowned checkout
-  # AND exit on a dead pool, so both are caught — the country list must not
-  # depend on the database being up.
-  defp configured_priority do
-    case setting_priority() do
-      [] -> Application.get_env(:phoenix_kit, :country_select_priority, [])
-      codes -> codes
+  # Keyword.get(opts, key, default) evaluates `default` eagerly even when
+  # `opts` already has `key` — cheap when the default is a literal, but here
+  # the defaults are a Gettext lookup and a settings-cache read (which can
+  # fall through to a database query on a cold key), and the result would be
+  # thrown away whenever the caller passed an explicit value. Only compute
+  # the default in the :error branch.
+  defp fetch_opt(opts, key, default_fun) do
+    case Keyword.fetch(opts, key) do
+      {:ok, value} -> value
+      :error -> default_fun.()
     end
   end
 
-  defp setting_priority do
-    "country_select_priority"
-    |> Settings.get_setting_cached("")
-    |> parse_priority()
-  rescue
-    _ -> []
-  catch
-    :exit, _ -> []
+  # The admin-editable setting wins over the compile-time config, so an
+  # operator can reorder the dropdown without a deploy. A blank or absent
+  # setting means "not configured" and falls through to the config, which
+  # keeps every host that never opens the settings page working as before.
+  # A stored value of `"none"` (see `none_priority?/1`) is an explicit
+  # sentinel meaning "pin nothing", honoured over the config — the only way
+  # an operator can disable pinning on a host that has the config set,
+  # since a blank/absent setting can't be told apart from "not configured"
+  # at the settings layer.
+  #
+  # Read through the cache: this runs on the hot path, and
+  # `get_setting_cached/2` is consulted before the update-mode
+  # short-circuit, so a primed key resolves without a database at all.
+  # `Settings.get_setting_cached/2` — and the `get_setting/2` it falls back
+  # to on a cache error — already rescue AND catch `:exit` internally, so
+  # the country list degrading to the config when the database is
+  # unreachable is handled entirely by the Settings layer, not by this
+  # function.
+  defp configured_priority do
+    raw = Settings.get_setting_cached("country_select_priority", "")
+
+    if none_priority?(raw) do
+      []
+    else
+      case parse_priority(raw) do
+        [] -> Application.get_env(:phoenix_kit, :country_select_priority, [])
+        codes -> codes
+      end
+    end
   end
 
   @doc """
@@ -532,8 +557,11 @@ defmodule PhoenixKit.Utils.CountryData do
 
   Accepts the separators a human actually types — commas, spaces, semicolons,
   newlines — so `"EE, FI"`, `"ee fi"` and `"EE;FI"` all parse. Unknown codes
-  are kept here and dropped later by the same normalization every caller of
-  `:priority` goes through; use `known_country_codes/1` to report them.
+  are kept here, not dropped — `normalize_priority/1` only filters
+  non-binaries, upcases, and dedupes. They are dropped later, when
+  `split_priority/2` looks each one up against the real country list and
+  finds no match; use `known_country_codes/1` to report them to the
+  operator before that happens.
 
   ## Examples
 
@@ -569,6 +597,49 @@ defmodule PhoenixKit.Utils.CountryData do
   end
 
   def known_country_codes(_), do: []
+
+  @doc """
+  The sentinel value for the `country_select_priority` setting that means
+  "pin nothing", honoured over `config :phoenix_kit,
+  :country_select_priority` by `countries_for_select/1` and
+  `eu_countries_for_select/1` (see `configured_priority/0`). A caller that
+  writes the setting (the Organization settings form) should store this
+  exact value rather than hardcoding the literal string, so the write side
+  and `none_priority?/1` never drift apart.
+
+  ## Examples
+
+      iex> CountryData.none_priority_value()
+      "none"
+  """
+  def none_priority_value, do: @none_priority
+
+  @doc """
+  True if `value`, trimmed and downcased, is the `"none"` sentinel.
+
+  This is the only way to disable country-priority pinning on a host that
+  has `config :phoenix_kit, :country_select_priority` set: a blank or
+  absent setting can't be told apart from "not configured"
+  (`Settings.get_setting_cached/2` returns the default for both) and falls
+  back to the config either way, so an operator needs an explicit value
+  that means "pin nothing" instead.
+
+  ## Examples
+
+      iex> CountryData.none_priority?("none")
+      true
+
+      iex> CountryData.none_priority?(" NONE ")
+      true
+
+      iex> CountryData.none_priority?("EE")
+      false
+  """
+  def none_priority?(value) when is_binary(value) do
+    value |> String.trim() |> String.downcase() == @none_priority
+  end
+
+  def none_priority?(_), do: false
 
   defp normalize_priority(codes) when is_list(codes) do
     codes
@@ -627,7 +698,7 @@ defmodule PhoenixKit.Utils.CountryData do
   def get_country_name(country_code, opts \\ [])
 
   def get_country_name(country_code, opts) when is_binary(country_code) and is_list(opts) do
-    locale = opts |> Keyword.get(:locale, active_locale()) |> normalize_locale()
+    locale = opts |> fetch_opt(:locale, &active_locale/0) |> normalize_locale()
 
     case get_country(country_code) do
       %{} = country -> translated_name(country, locale)

--- a/lib/phoenix_kit_web/live/settings/organization.ex
+++ b/lib/phoenix_kit_web/live/settings/organization.ex
@@ -118,10 +118,16 @@ defmodule PhoenixKitWeb.Live.Settings.Organization do
   end
 
   defp main_country_rows(codes) do
-    Enum.map(codes, fn code ->
+    last = length(codes) - 1
+
+    codes
+    |> Enum.with_index()
+    |> Enum.map(fn {code, index} ->
       %{
         code: code,
-        label: CountryData.get_flag(code) <> " " <> CountryData.get_country_name(code)
+        label: CountryData.get_flag(code) <> " " <> CountryData.get_country_name(code),
+        first?: index == 0,
+        last?: index == last
       }
     end)
   end
@@ -176,12 +182,20 @@ defmodule PhoenixKitWeb.Live.Settings.Organization do
         if rate != 0 and rate != current_rate, do: rate
       end
 
+    # The main-countries suggestion is derived from the company country too,
+    # so it goes stale the same way the tax rate would if left alone: an
+    # unsaved country pick must not leave the previous country's neighbours
+    # on screen.
+    suggestion =
+      main_country_suggestion(country_code, MapSet.new(socket.assigns.main_countries))
+
     {:noreply,
      socket
      |> assign(:company_country, country_code)
      |> assign(:subdivision_label, get_subdivision_label(country_code))
      |> assign(:eu_country, eu_country?(country_code))
-     |> assign(:suggested_tax_rate, suggested_rate)}
+     |> assign(:suggested_tax_rate, suggested_rate)
+     |> assign(:main_country_suggestion, suggestion)}
   end
 
   def handle_event("save_company", params, socket) do
@@ -207,7 +221,7 @@ defmodule PhoenixKitWeb.Live.Settings.Organization do
   # The main-countries card writes on every action rather than behind a save
   # button: each click is already a deliberate edit, and there is no second
   # field whose validation could hold the list hostage.
-  def handle_event("add_main_country", %{"code" => code}, socket) do
+  def handle_event("add_main_country", %{"code" => code}, socket) when is_binary(code) do
     {:noreply, put_main_countries(socket, socket.assigns.main_countries ++ [code])}
   end
 
@@ -218,16 +232,32 @@ defmodule PhoenixKitWeb.Live.Settings.Organization do
      put_main_countries(socket, Enum.reject(socket.assigns.main_countries, &(&1 == code)))}
   end
 
+  def handle_event("remove_main_country", _params, socket), do: {:noreply, socket}
+
   # SortableGrid pushes the full order on drop, so the list is taken as given
   # rather than diffed — but only codes that were already pinned are honoured,
   # so a forged payload can neither add a country nor drop one silently.
-  def handle_event("reorder_main_countries", %{"ordered_ids" => ordered}, socket) do
+  def handle_event("reorder_main_countries", %{"ordered_ids" => ordered}, socket)
+      when is_list(ordered) do
     current = socket.assigns.main_countries
     reordered = Enum.filter(ordered, &(&1 in current))
     codes = reordered ++ (current -- reordered)
 
     {:noreply, put_main_countries(socket, codes)}
   end
+
+  def handle_event("reorder_main_countries", _params, socket), do: {:noreply, socket}
+
+  # Restored alongside drag: SortableJS is a CDN fetch that a strict CSP or
+  # an offline deploy can block, and dragging itself has no keyboard path —
+  # without these buttons a keyboard/screen-reader operator could not
+  # reorder at all.
+  def handle_event("move_main_country", %{"code" => code, "direction" => direction}, socket)
+      when is_binary(code) and direction in ["up", "down"] do
+    {:noreply, put_main_countries(socket, move(socket.assigns.main_countries, code, direction))}
+  end
+
+  def handle_event("move_main_country", _params, socket), do: {:noreply, socket}
 
   def handle_event("apply_main_country_suggestion", _params, socket) do
     suggested = Enum.map(socket.assigns.main_country_suggestion, & &1.code)
@@ -442,13 +472,52 @@ defmodule PhoenixKitWeb.Live.Settings.Organization do
       |> Enum.uniq()
       |> CountryData.known_country_codes()
 
-    case Settings.update_setting("country_select_priority", Enum.join(codes, ", ")) do
-      {:ok, _setting} ->
-        assign_main_countries(socket, codes, socket.assigns.company_country)
+    if codes == socket.assigns.main_countries do
+      # Nothing actually changed (e.g. "Add" with an empty selection, or
+      # removing/reordering into the same set) — don't write an identical
+      # value and don't broadcast a no-op.
+      socket
+    else
+      case Settings.update_setting("country_select_priority", Enum.join(codes, ", ")) do
+        {:ok, _setting} ->
+          # Broadcast to all admin sessions, same mechanism the other cards
+          # use. `handle_info` only calls `load_settings/1` — it never
+          # broadcasts itself — so the acting session's own bounce-back
+          # cannot loop; it just reloads with the value already written.
+          broadcast_settings_change(:main_countries_updated)
 
-      {:error, _changeset} ->
-        put_flash(socket, :error, gettext("Main countries could not be saved"))
+          socket
+          # The Company card's country <.select> is computed once in
+          # `load_settings/1`; without recomputing it here it keeps
+          # offering the pre-pin alphabetical order until the next reload.
+          |> assign(:countries, CountryData.countries_for_select())
+          |> assign_main_countries(codes, socket.assigns.company_country)
+
+        {:error, _changeset} ->
+          put_flash(socket, :error, gettext("Main countries could not be saved"))
+      end
     end
+  end
+
+  defp move(codes, code, direction) do
+    case Enum.find_index(codes, &(&1 == code)) do
+      nil -> codes
+      index -> swap(codes, index, target_index(index, direction, length(codes)))
+    end
+  end
+
+  defp target_index(index, "up", _length), do: max(index - 1, 0)
+  defp target_index(index, "down", length), do: min(index + 1, length - 1)
+  defp target_index(index, _direction, _length), do: index
+
+  defp swap(codes, index, index), do: codes
+
+  defp swap(codes, from, to) do
+    moved = Enum.at(codes, from)
+
+    codes
+    |> List.delete_at(from)
+    |> List.insert_at(to, moved)
   end
 
   defp save_bank_details(params, iban, swift) do

--- a/lib/phoenix_kit_web/live/settings/organization.ex
+++ b/lib/phoenix_kit_web/live/settings/organization.ex
@@ -84,7 +84,7 @@ defmodule PhoenixKitWeb.Live.Settings.Organization do
     |> assign(:countries, CountryData.countries_for_select())
     |> assign(:subdivision_label, get_subdivision_label(country))
     |> assign(:eu_country, eu_country?(country))
-    |> assign(:country_priority, Settings.get_setting("country_select_priority", ""))
+    |> assign(:country_priority, Settings.get_setting_cached("country_select_priority", ""))
   end
 
   defp assign_tax_settings(socket, _company_info) do
@@ -136,21 +136,29 @@ defmodule PhoenixKitWeb.Live.Settings.Organization do
   def handle_event("save_company", params, socket) do
     data = extract_company_data(params)
 
-    case validate_company_data(data) do
-      [] ->
-        save_company_info(data, params)
+    # The country-priority list is an independent setting from the rest of
+    # the company form — it must persist whether or not the company data
+    # below validates, so it is saved unconditionally here rather than from
+    # inside the `[] ->` branch.
+    priority_result = save_country_priority(params["country_priority"])
 
-        # Broadcast to all admin sessions
-        broadcast_settings_change(:company_info_updated)
+    socket =
+      case validate_company_data(data) do
+        [] ->
+          save_company_info(data, params)
 
-        {:noreply,
-         socket
-         |> load_settings()
-         |> put_flash(:info, gettext("Organization information saved"))}
+          # Broadcast to all admin sessions
+          broadcast_settings_change(:company_info_updated)
 
-      errors ->
-        {:noreply, put_flash(socket, :error, Enum.join(errors, ". "))}
-    end
+          socket
+          |> load_settings()
+          |> put_flash(:info, gettext("Organization information saved"))
+
+        errors ->
+          put_flash(socket, :error, Enum.join(errors, ". "))
+      end
+
+    {:noreply, put_country_priority_flash(socket, priority_result)}
   end
 
   def handle_event("save_tax", params, socket) do
@@ -345,20 +353,76 @@ defmodule PhoenixKitWeb.Live.Settings.Organization do
       })
 
     Settings.update_json_setting("company_info", company_info)
-    save_country_priority(params["country_priority"])
   end
 
   # Stored normalized — upper-cased, deduplicated, unknown codes dropped — so
   # what the operator sees after saving is exactly what the dropdown will do.
   # Blank clears the setting, which hands the default back to
-  # `config :phoenix_kit, :country_select_priority`.
+  # `config :phoenix_kit, :country_select_priority`. Typing the literal word
+  # "none" (case-insensitive, trimmed — `CountryData.none_priority?/1`)
+  # stores the sentinel `CountryData.configured_priority/0` honours over
+  # that config, so it must be checked BEFORE `known_country_codes/1` runs —
+  # "none" is not a real country code and would otherwise be silently
+  # dropped just like any other unknown one, storing blank instead of the
+  # sentinel and leaving pinning impossible to turn off.
+  #
+  # Returns `{:ok, %{kept: [...], rejected: [...]}}` — the codes actually
+  # stored and the ones the operator typed that name no real country, for
+  # the caller to report — or `{:error, changeset}` if the write itself
+  # failed (e.g. over the settings value's 1000-character cap).
   defp save_country_priority(value) do
-    codes =
-      value
-      |> CountryData.parse_priority()
-      |> CountryData.known_country_codes()
+    trimmed = (value || "") |> String.trim()
 
-    Settings.update_setting("country_select_priority", Enum.join(codes, ", "))
+    if CountryData.none_priority?(trimmed) do
+      write_country_priority(CountryData.none_priority_value(), %{kept: [], rejected: []})
+    else
+      typed = CountryData.parse_priority(trimmed)
+      known = CountryData.known_country_codes(typed)
+      rejected = typed -- known
+
+      write_country_priority(Enum.join(known, ", "), %{kept: known, rejected: rejected})
+    end
+  end
+
+  defp write_country_priority(stored_value, outcome) do
+    case Settings.update_setting("country_select_priority", stored_value) do
+      {:ok, _setting} -> {:ok, outcome}
+      {:error, changeset} -> {:error, changeset}
+    end
+  end
+
+  # A partial drop still saved something, so it rides alongside whatever
+  # flash the company-info save already produced. A total drop (something
+  # was typed, nothing survived) gets the same treatment — it must not be
+  # silently folded into an unqualified "saved" flash — but says so plainly
+  # rather than implying a partial success. Both are :error, matching this
+  # LiveView's only two flash kinds; company_info's own flash is untouched
+  # either way.
+  defp put_country_priority_flash(socket, {:ok, %{rejected: []}}), do: socket
+
+  defp put_country_priority_flash(socket, {:ok, %{kept: [], rejected: rejected}}) do
+    put_flash(
+      socket,
+      :error,
+      gettext(
+        "None of the preferred-country codes you entered are valid, so preferred countries was cleared: %{codes}",
+        codes: Enum.join(rejected, ", ")
+      )
+    )
+  end
+
+  defp put_country_priority_flash(socket, {:ok, %{rejected: rejected}}) do
+    put_flash(
+      socket,
+      :error,
+      gettext("Preferred countries saved, but ignored unrecognized code(s): %{codes}",
+        codes: Enum.join(rejected, ", ")
+      )
+    )
+  end
+
+  defp put_country_priority_flash(socket, {:error, _changeset}) do
+    put_flash(socket, :error, gettext("Preferred countries could not be saved"))
   end
 
   defp save_bank_details(params, iban, swift) do

--- a/lib/phoenix_kit_web/live/settings/organization.ex
+++ b/lib/phoenix_kit_web/live/settings/organization.ex
@@ -84,7 +84,61 @@ defmodule PhoenixKitWeb.Live.Settings.Organization do
     |> assign(:countries, CountryData.countries_for_select())
     |> assign(:subdivision_label, get_subdivision_label(country))
     |> assign(:eu_country, eu_country?(country))
-    |> assign(:country_priority, Settings.get_setting_cached("country_select_priority", ""))
+    |> assign_main_countries(stored_main_countries(), country)
+  end
+
+  defp stored_main_countries do
+    "country_select_priority"
+    |> Settings.get_setting_cached("")
+    |> CountryData.parse_priority()
+    |> CountryData.known_country_codes()
+  end
+
+  # Everything the card renders is precomputed here rather than called from
+  # the template: a `defp` invoked from HEEX cannot be verified by the
+  # compiler. `:main_country_suggestion` is what the host's own country
+  # proposes and is deliberately empty once every suggested code is already
+  # in the list — there is nothing left to offer.
+  defp assign_main_countries(socket, codes, country) do
+    chosen = MapSet.new(codes)
+
+    socket
+    |> assign(:main_countries, codes)
+    |> assign(:main_country_rows, main_country_rows(codes))
+    |> assign(
+      :main_country_options,
+      Enum.reject(CountryData.countries_for_select(), fn {_label, code} ->
+        MapSet.member?(chosen, code)
+      end)
+    )
+    |> assign(:main_country_suggestion, main_country_suggestion(country, chosen))
+  end
+
+  defp main_country_rows(codes) do
+    last = length(codes) - 1
+
+    codes
+    |> Enum.with_index()
+    |> Enum.map(fn {code, index} ->
+      %{
+        code: code,
+        label: CountryData.get_flag(code) <> " " <> CountryData.get_country_name(code),
+        first?: index == 0,
+        last?: index == last
+      }
+    end)
+  end
+
+  defp main_country_suggestion(country, chosen) do
+    country
+    |> CountryData.suggested_priority()
+    |> Enum.reject(&MapSet.member?(chosen, &1))
+    |> Enum.map(fn code ->
+      %{
+        code: code,
+        label: CountryData.get_flag(code) <> " " <> CountryData.get_country_name(code)
+      }
+    end)
   end
 
   defp assign_tax_settings(socket, _company_info) do
@@ -136,29 +190,45 @@ defmodule PhoenixKitWeb.Live.Settings.Organization do
   def handle_event("save_company", params, socket) do
     data = extract_company_data(params)
 
-    # The country-priority list is an independent setting from the rest of
-    # the company form — it must persist whether or not the company data
-    # below validates, so it is saved unconditionally here rather than from
-    # inside the `[] ->` branch.
-    priority_result = save_country_priority(params["country_priority"])
+    case validate_company_data(data) do
+      [] ->
+        save_company_info(data, params)
 
-    socket =
-      case validate_company_data(data) do
-        [] ->
-          save_company_info(data, params)
+        # Broadcast to all admin sessions
+        broadcast_settings_change(:company_info_updated)
 
-          # Broadcast to all admin sessions
-          broadcast_settings_change(:company_info_updated)
+        {:noreply,
+         socket
+         |> load_settings()
+         |> put_flash(:info, gettext("Organization information saved"))}
 
-          socket
-          |> load_settings()
-          |> put_flash(:info, gettext("Organization information saved"))
+      errors ->
+        {:noreply, put_flash(socket, :error, Enum.join(errors, ". "))}
+    end
+  end
 
-        errors ->
-          put_flash(socket, :error, Enum.join(errors, ". "))
-      end
+  # The main-countries card writes on every action rather than behind a save
+  # button: each click is already a deliberate edit, and there is no second
+  # field whose validation could hold the list hostage.
+  def handle_event("add_main_country", %{"code" => code}, socket) do
+    {:noreply, put_main_countries(socket, socket.assigns.main_countries ++ [code])}
+  end
 
-    {:noreply, put_country_priority_flash(socket, priority_result)}
+  def handle_event("add_main_country", _params, socket), do: {:noreply, socket}
+
+  def handle_event("remove_main_country", %{"code" => code}, socket) do
+    {:noreply,
+     put_main_countries(socket, Enum.reject(socket.assigns.main_countries, &(&1 == code)))}
+  end
+
+  def handle_event("move_main_country", %{"code" => code, "direction" => direction}, socket) do
+    {:noreply, put_main_countries(socket, move(socket.assigns.main_countries, code, direction))}
+  end
+
+  def handle_event("apply_main_country_suggestion", _params, socket) do
+    suggested = Enum.map(socket.assigns.main_country_suggestion, & &1.code)
+
+    {:noreply, put_main_countries(socket, socket.assigns.main_countries ++ suggested)}
   end
 
   def handle_event("save_tax", params, socket) do
@@ -355,74 +425,47 @@ defmodule PhoenixKitWeb.Live.Settings.Organization do
     Settings.update_json_setting("company_info", company_info)
   end
 
-  # Stored normalized — upper-cased, deduplicated, unknown codes dropped — so
-  # what the operator sees after saving is exactly what the dropdown will do.
-  # Blank clears the setting, which hands the default back to
-  # `config :phoenix_kit, :country_select_priority`. Typing the literal word
-  # "none" (case-insensitive, trimmed — `CountryData.none_priority?/1`)
-  # stores the sentinel `CountryData.configured_priority/0` honours over
-  # that config, so it must be checked BEFORE `known_country_codes/1` runs —
-  # "none" is not a real country code and would otherwise be silently
-  # dropped just like any other unknown one, storing blank instead of the
-  # sentinel and leaving pinning impossible to turn off.
-  #
-  # Returns `{:ok, %{kept: [...], rejected: [...]}}` — the codes actually
-  # stored and the ones the operator typed that name no real country, for
-  # the caller to report — or `{:error, changeset}` if the write itself
-  # failed (e.g. over the settings value's 1000-character cap).
-  defp save_country_priority(value) do
-    trimmed = (value || "") |> String.trim()
+  # Only real, deduplicated country codes ever reach the setting: the card
+  # offers a picker over the country list, so there is no free text to
+  # sanitize, and `known_country_codes/1` is the belt-and-braces guard on a
+  # forged phx-value. An empty list means nothing is pinned and every country
+  # list is plain alphabetical — the setting is the only source, there is no
+  # config underneath it.
+  defp put_main_countries(socket, codes) do
+    codes =
+      codes
+      |> Enum.map(&String.upcase/1)
+      |> Enum.uniq()
+      |> CountryData.known_country_codes()
 
-    if CountryData.none_priority?(trimmed) do
-      write_country_priority(CountryData.none_priority_value(), %{kept: [], rejected: []})
-    else
-      typed = CountryData.parse_priority(trimmed)
-      known = CountryData.known_country_codes(typed)
-      rejected = typed -- known
+    case Settings.update_setting("country_select_priority", Enum.join(codes, ", ")) do
+      {:ok, _setting} ->
+        assign_main_countries(socket, codes, socket.assigns.company_country)
 
-      write_country_priority(Enum.join(known, ", "), %{kept: known, rejected: rejected})
+      {:error, _changeset} ->
+        put_flash(socket, :error, gettext("Main countries could not be saved"))
     end
   end
 
-  defp write_country_priority(stored_value, outcome) do
-    case Settings.update_setting("country_select_priority", stored_value) do
-      {:ok, _setting} -> {:ok, outcome}
-      {:error, changeset} -> {:error, changeset}
+  defp move(codes, code, direction) do
+    case Enum.find_index(codes, &(&1 == code)) do
+      nil -> codes
+      index -> swap(codes, index, target_index(index, direction, length(codes)))
     end
   end
 
-  # A partial drop still saved something, so it rides alongside whatever
-  # flash the company-info save already produced. A total drop (something
-  # was typed, nothing survived) gets the same treatment — it must not be
-  # silently folded into an unqualified "saved" flash — but says so plainly
-  # rather than implying a partial success. Both are :error, matching this
-  # LiveView's only two flash kinds; company_info's own flash is untouched
-  # either way.
-  defp put_country_priority_flash(socket, {:ok, %{rejected: []}}), do: socket
+  defp target_index(index, "up", _length), do: max(index - 1, 0)
+  defp target_index(index, "down", length), do: min(index + 1, length - 1)
+  defp target_index(index, _direction, _length), do: index
 
-  defp put_country_priority_flash(socket, {:ok, %{kept: [], rejected: rejected}}) do
-    put_flash(
-      socket,
-      :error,
-      gettext(
-        "None of the preferred-country codes you entered are valid, so preferred countries was cleared: %{codes}",
-        codes: Enum.join(rejected, ", ")
-      )
-    )
-  end
+  defp swap(codes, index, index), do: codes
 
-  defp put_country_priority_flash(socket, {:ok, %{rejected: rejected}}) do
-    put_flash(
-      socket,
-      :error,
-      gettext("Preferred countries saved, but ignored unrecognized code(s): %{codes}",
-        codes: Enum.join(rejected, ", ")
-      )
-    )
-  end
+  defp swap(codes, from, to) do
+    moved = Enum.at(codes, from)
 
-  defp put_country_priority_flash(socket, {:error, _changeset}) do
-    put_flash(socket, :error, gettext("Preferred countries could not be saved"))
+    codes
+    |> List.delete_at(from)
+    |> List.insert_at(to, moved)
   end
 
   defp save_bank_details(params, iban, swift) do

--- a/lib/phoenix_kit_web/live/settings/organization.ex
+++ b/lib/phoenix_kit_web/live/settings/organization.ex
@@ -107,7 +107,10 @@ defmodule PhoenixKitWeb.Live.Settings.Organization do
     |> assign(:main_country_rows, main_country_rows(codes))
     |> assign(
       :main_country_options,
-      Enum.reject(CountryData.countries_for_select(), fn {_label, code} ->
+      # `priority: []` on purpose: the picker is where you go to CHANGE the
+      # pinned set, so it must not itself be reordered by it — otherwise the
+      # first thing the dropdown offers is whatever is already pinned.
+      Enum.reject(CountryData.countries_for_select(priority: []), fn {_label, code} ->
         MapSet.member?(chosen, code)
       end)
     )
@@ -115,16 +118,10 @@ defmodule PhoenixKitWeb.Live.Settings.Organization do
   end
 
   defp main_country_rows(codes) do
-    last = length(codes) - 1
-
-    codes
-    |> Enum.with_index()
-    |> Enum.map(fn {code, index} ->
+    Enum.map(codes, fn code ->
       %{
         code: code,
-        label: CountryData.get_flag(code) <> " " <> CountryData.get_country_name(code),
-        first?: index == 0,
-        last?: index == last
+        label: CountryData.get_flag(code) <> " " <> CountryData.get_country_name(code)
       }
     end)
   end
@@ -221,8 +218,15 @@ defmodule PhoenixKitWeb.Live.Settings.Organization do
      put_main_countries(socket, Enum.reject(socket.assigns.main_countries, &(&1 == code)))}
   end
 
-  def handle_event("move_main_country", %{"code" => code, "direction" => direction}, socket) do
-    {:noreply, put_main_countries(socket, move(socket.assigns.main_countries, code, direction))}
+  # SortableGrid pushes the full order on drop, so the list is taken as given
+  # rather than diffed — but only codes that were already pinned are honoured,
+  # so a forged payload can neither add a country nor drop one silently.
+  def handle_event("reorder_main_countries", %{"ordered_ids" => ordered}, socket) do
+    current = socket.assigns.main_countries
+    reordered = Enum.filter(ordered, &(&1 in current))
+    codes = reordered ++ (current -- reordered)
+
+    {:noreply, put_main_countries(socket, codes)}
   end
 
   def handle_event("apply_main_country_suggestion", _params, socket) do
@@ -445,27 +449,6 @@ defmodule PhoenixKitWeb.Live.Settings.Organization do
       {:error, _changeset} ->
         put_flash(socket, :error, gettext("Main countries could not be saved"))
     end
-  end
-
-  defp move(codes, code, direction) do
-    case Enum.find_index(codes, &(&1 == code)) do
-      nil -> codes
-      index -> swap(codes, index, target_index(index, direction, length(codes)))
-    end
-  end
-
-  defp target_index(index, "up", _length), do: max(index - 1, 0)
-  defp target_index(index, "down", length), do: min(index + 1, length - 1)
-  defp target_index(index, _direction, _length), do: index
-
-  defp swap(codes, index, index), do: codes
-
-  defp swap(codes, from, to) do
-    moved = Enum.at(codes, from)
-
-    codes
-    |> List.delete_at(from)
-    |> List.insert_at(to, moved)
   end
 
   defp save_bank_details(params, iban, swift) do

--- a/lib/phoenix_kit_web/live/settings/organization.ex
+++ b/lib/phoenix_kit_web/live/settings/organization.ex
@@ -84,6 +84,7 @@ defmodule PhoenixKitWeb.Live.Settings.Organization do
     |> assign(:countries, CountryData.countries_for_select())
     |> assign(:subdivision_label, get_subdivision_label(country))
     |> assign(:eu_country, eu_country?(country))
+    |> assign(:country_priority, Settings.get_setting("country_select_priority", ""))
   end
 
   defp assign_tax_settings(socket, _company_info) do
@@ -344,6 +345,20 @@ defmodule PhoenixKitWeb.Live.Settings.Organization do
       })
 
     Settings.update_json_setting("company_info", company_info)
+    save_country_priority(params["country_priority"])
+  end
+
+  # Stored normalized — upper-cased, deduplicated, unknown codes dropped — so
+  # what the operator sees after saving is exactly what the dropdown will do.
+  # Blank clears the setting, which hands the default back to
+  # `config :phoenix_kit, :country_select_priority`.
+  defp save_country_priority(value) do
+    codes =
+      value
+      |> CountryData.parse_priority()
+      |> CountryData.known_country_codes()
+
+    Settings.update_setting("country_select_priority", Enum.join(codes, ", "))
   end
 
   defp save_bank_details(params, iban, swift) do

--- a/lib/phoenix_kit_web/live/settings/organization.html.heex
+++ b/lib/phoenix_kit_web/live/settings/organization.html.heex
@@ -60,7 +60,7 @@
               <label class="label">
                 <span class="label-text-alt">
                   {gettext(
-                    "Two-letter country codes, in the order they should appear at the top of every country dropdown. Unknown codes are dropped on save. Leave empty to use the application config."
+                    "Two-letter country codes, in the order they should appear at the top of every country dropdown. Unknown codes are dropped on save. Leave empty to use the application config, or enter \"none\" to disable pinning entirely."
                   )}
                 </span>
               </label>

--- a/lib/phoenix_kit_web/live/settings/organization.html.heex
+++ b/lib/phoenix_kit_web/live/settings/organization.html.heex
@@ -10,154 +10,154 @@
 >
   <div class="px-4 py-6">
     <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
-      <%!-- Company Information --%>
-      <div class="card bg-base-100 shadow-xl">
-        <div class="card-body gap-0.5">
-          <h2 class="card-title">
-            <.icon name="hero-building-office-2" class="w-5 h-5" />
-            {gettext("Company Information")}
-          </h2>
-          <p class="text-sm text-base-content/60 flex-none">
-            {gettext("Used in legal documents and invoices")}
-          </p>
-
-          <form phx-submit="save_company" class="space-y-4">
-            <%!-- Row: Company Name + Country --%>
-            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-              <div class="form-control">
-                <.input
-                  type="text"
-                  name="company_name"
-                  value={@company_name}
-                  label={gettext("Company Name")}
-                  placeholder={gettext("Your Company Name")}
-                  required
-                />
-              </div>
-
-              <div class="form-control">
-                <.select
-                  name="company_country"
-                  value={@company_country}
-                  phx-change="country_changed"
-                  required
-                  label={gettext("Country")}
-                  prompt={gettext("Select country...")}
-                  options={@countries}
-                />
-              </div>
-            </div>
-
-            <div class="divider text-xs">{gettext("Address")}</div>
-
-            <%!-- Row: Street Address --%>
-            <div class="form-control">
-              <.input
-                type="text"
-                name="company_address_line1"
-                value={@company_address_line1}
-                label={gettext("Street Address")}
-                placeholder={gettext("123 Business Street")}
-                required
-              />
-            </div>
-
-            <%!-- Row: Address Line 2 --%>
-            <div class="form-control">
-              <.input
-                type="text"
-                name="company_address_line2"
-                value={@company_address_line2}
-                label={gettext("Address Line 2")}
-                placeholder={gettext("Suite, Floor, Building (optional)")}
-              />
-            </div>
-
-            <%!-- Row: City + State/Province + Postal Code --%>
-            <div class="grid grid-cols-3 gap-4">
-              <div class="form-control">
-                <.input
-                  type="text"
-                  name="company_city"
-                  value={@company_city}
-                  label={gettext("City")}
-                  placeholder={gettext("City")}
-                  required
-                />
-              </div>
-
-              <div class="form-control">
-                <.input
-                  type="text"
-                  name="company_state"
-                  value={@company_state}
-                  label={@subdivision_label}
-                  placeholder={gettext("(optional)")}
-                />
-              </div>
-
-              <div class="form-control">
-                <.input
-                  type="text"
-                  name="company_postal_code"
-                  value={@company_postal_code}
-                  label={gettext("Postal Code")}
-                  placeholder="10115"
-                  class="font-mono"
-                />
-              </div>
-            </div>
-
-            <div class="divider text-xs">{gettext("Tax & Registration")}</div>
-
-            <%!-- Row: VAT Number + Registration Number --%>
-            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-              <div class="form-control">
-                <.input
-                  type="text"
-                  name="company_vat"
-                  value={@company_vat}
-                  label={gettext("VAT Number")}
-                  placeholder={
-                    if @eu_country, do: "#{@company_country}123456789", else: gettext("Tax ID")
-                  }
-                  required
-                  class="font-mono"
-                />
-                <%= if @eu_country do %>
-                  <label class="label">
-                    <span class="label-text-alt text-info">
-                      <.icon name="hero-information-circle" class="w-4 h-4 inline" />
-                      {gettext("EU format: %{country}123456789", country: @company_country)}
-                    </span>
-                  </label>
-                <% end %>
-              </div>
-
-              <div class="form-control">
-                <.input
-                  type="text"
-                  name="company_registration"
-                  value={@company_registration}
-                  label={gettext("Registration Number")}
-                  placeholder={gettext("Business reg. number (optional)")}
-                  class="font-mono"
-                />
-              </div>
-            </div>
-
-            <div class="card-actions justify-end mt-4">
-              <button type="submit" class="btn btn-primary">
-                <.icon name="hero-check" class="w-4 h-4" />
-                {gettext("Save Company Info")}
-              </button>
-            </div>
-          </form>
-        </div>
-      </div>
-
-      <%!-- Right column: Main countries + Bank + Tax + Site URL stacked --%>
+      <%!-- Left column: Company + Main countries stacked --%>
       <div class="space-y-6">
+        <%!-- Company Information --%>
+        <div class="card bg-base-100 shadow-xl">
+          <div class="card-body gap-0.5">
+            <h2 class="card-title">
+              <.icon name="hero-building-office-2" class="w-5 h-5" />
+              {gettext("Company Information")}
+            </h2>
+            <p class="text-sm text-base-content/60 flex-none">
+              {gettext("Used in legal documents and invoices")}
+            </p>
+
+            <form phx-submit="save_company" class="space-y-4">
+              <%!-- Row: Company Name + Country --%>
+              <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div class="form-control">
+                  <.input
+                    type="text"
+                    name="company_name"
+                    value={@company_name}
+                    label={gettext("Company Name")}
+                    placeholder={gettext("Your Company Name")}
+                    required
+                  />
+                </div>
+
+                <div class="form-control">
+                  <.select
+                    name="company_country"
+                    value={@company_country}
+                    phx-change="country_changed"
+                    required
+                    label={gettext("Country")}
+                    prompt={gettext("Select country...")}
+                    options={@countries}
+                  />
+                </div>
+              </div>
+
+              <div class="divider text-xs">{gettext("Address")}</div>
+
+              <%!-- Row: Street Address --%>
+              <div class="form-control">
+                <.input
+                  type="text"
+                  name="company_address_line1"
+                  value={@company_address_line1}
+                  label={gettext("Street Address")}
+                  placeholder={gettext("123 Business Street")}
+                  required
+                />
+              </div>
+
+              <%!-- Row: Address Line 2 --%>
+              <div class="form-control">
+                <.input
+                  type="text"
+                  name="company_address_line2"
+                  value={@company_address_line2}
+                  label={gettext("Address Line 2")}
+                  placeholder={gettext("Suite, Floor, Building (optional)")}
+                />
+              </div>
+
+              <%!-- Row: City + State/Province + Postal Code --%>
+              <div class="grid grid-cols-3 gap-4">
+                <div class="form-control">
+                  <.input
+                    type="text"
+                    name="company_city"
+                    value={@company_city}
+                    label={gettext("City")}
+                    placeholder={gettext("City")}
+                    required
+                  />
+                </div>
+
+                <div class="form-control">
+                  <.input
+                    type="text"
+                    name="company_state"
+                    value={@company_state}
+                    label={@subdivision_label}
+                    placeholder={gettext("(optional)")}
+                  />
+                </div>
+
+                <div class="form-control">
+                  <.input
+                    type="text"
+                    name="company_postal_code"
+                    value={@company_postal_code}
+                    label={gettext("Postal Code")}
+                    placeholder="10115"
+                    class="font-mono"
+                  />
+                </div>
+              </div>
+
+              <div class="divider text-xs">{gettext("Tax & Registration")}</div>
+
+              <%!-- Row: VAT Number + Registration Number --%>
+              <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div class="form-control">
+                  <.input
+                    type="text"
+                    name="company_vat"
+                    value={@company_vat}
+                    label={gettext("VAT Number")}
+                    placeholder={
+                      if @eu_country, do: "#{@company_country}123456789", else: gettext("Tax ID")
+                    }
+                    required
+                    class="font-mono"
+                  />
+                  <%= if @eu_country do %>
+                    <label class="label">
+                      <span class="label-text-alt text-info">
+                        <.icon name="hero-information-circle" class="w-4 h-4 inline" />
+                        {gettext("EU format: %{country}123456789", country: @company_country)}
+                      </span>
+                    </label>
+                  <% end %>
+                </div>
+
+                <div class="form-control">
+                  <.input
+                    type="text"
+                    name="company_registration"
+                    value={@company_registration}
+                    label={gettext("Registration Number")}
+                    placeholder={gettext("Business reg. number (optional)")}
+                    class="font-mono"
+                  />
+                </div>
+              </div>
+
+              <div class="card-actions justify-end mt-4">
+                <button type="submit" class="btn btn-primary">
+                  <.icon name="hero-check" class="w-4 h-4" />
+                  {gettext("Save Company Info")}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+
         <%!-- Main countries --%>
         <div class="card bg-base-100 shadow-xl">
           <div class="card-body">
@@ -166,7 +166,7 @@
               {gettext("Main countries")}
             </h2>
             <p class="text-sm text-base-content/60">
-              {gettext("Shown at the top of every country list, in this order")}
+              {gettext("Shown at the top of every country list. Drag to reorder.")}
             </p>
 
             <%= if @main_country_rows == [] do %>
@@ -174,37 +174,23 @@
                 {gettext("Nothing chosen yet — country lists are plain alphabetical.")}
               </p>
             <% else %>
-              <ul class="mt-4 divide-y divide-base-200">
-                <li
-                  :for={row <- @main_country_rows}
-                  class="flex items-center gap-1 py-2"
-                >
+              <.draggable_list
+                id="main-countries"
+                items={@main_country_rows}
+                item_id={& &1.code}
+                on_reorder="reorder_main_countries"
+                layout={:list}
+                gap="gap-1"
+                class="mt-4"
+                sortable_handle=".pk-drag-handle"
+                item_class="flex items-center gap-2 py-2 px-1 rounded-lg hover:bg-base-200"
+              >
+                <:item :let={row}>
+                  <.icon
+                    name="hero-bars-3"
+                    class="pk-drag-handle w-4 h-4 shrink-0 text-base-content/40 cursor-grab active:cursor-grabbing"
+                  />
                   <span class="grow truncate">{row.label}</span>
-
-                  <button
-                    type="button"
-                    phx-click="move_main_country"
-                    phx-value-code={row.code}
-                    phx-value-direction="up"
-                    class="btn btn-ghost btn-xs"
-                    disabled={row.first?}
-                    aria-label={gettext("Move up")}
-                  >
-                    <.icon name="hero-chevron-up" class="w-4 h-4" />
-                  </button>
-
-                  <button
-                    type="button"
-                    phx-click="move_main_country"
-                    phx-value-code={row.code}
-                    phx-value-direction="down"
-                    class="btn btn-ghost btn-xs"
-                    disabled={row.last?}
-                    aria-label={gettext("Move down")}
-                  >
-                    <.icon name="hero-chevron-down" class="w-4 h-4" />
-                  </button>
-
                   <button
                     type="button"
                     phx-click="remove_main_country"
@@ -214,8 +200,8 @@
                   >
                     <.icon name="hero-x-mark" class="w-4 h-4" />
                   </button>
-                </li>
-              </ul>
+                </:item>
+              </.draggable_list>
             <% end %>
 
             <%= if @main_country_suggestion != [] do %>
@@ -228,11 +214,7 @@
                       end)
                   )}
                 </span>
-                <button
-                  type="button"
-                  phx-click="apply_main_country_suggestion"
-                  class="btn btn-sm"
-                >
+                <button type="button" phx-click="apply_main_country_suggestion" class="btn btn-sm">
                   <.icon name="hero-plus" class="w-4 h-4" />
                   {gettext("Add these")}
                 </button>
@@ -245,12 +227,16 @@
               class="flex items-end gap-2 mt-4"
             >
               <div class="grow">
-                <.select
+                <%!-- The id carries the current count so the picker remounts
+                     (and clears its own selection) after every add. --%>
+                <.live_component
+                  module={PhoenixKitWeb.Live.Components.SearchableSelect}
+                  id={"main-country-picker-#{length(@main_country_rows)}"}
                   name="code"
                   value=""
                   options={@main_country_options}
-                  prompt={gettext("Select country...")}
                   label={gettext("Add a country")}
+                  placeholder={gettext("Search countries...")}
                 />
               </div>
               <button type="submit" class="btn btn-primary">
@@ -260,7 +246,10 @@
             </form>
           </div>
         </div>
+      </div>
 
+      <%!-- Right column: Bank + Tax + Site URL stacked --%>
+      <div class="space-y-6">
         <%!-- Bank Details --%>
         <div class="card bg-base-100 shadow-xl">
           <div class="card-body">

--- a/lib/phoenix_kit_web/live/settings/organization.html.heex
+++ b/lib/phoenix_kit_web/live/settings/organization.html.heex
@@ -193,6 +193,28 @@
                   <span class="grow truncate">{row.label}</span>
                   <button
                     type="button"
+                    phx-click="move_main_country"
+                    phx-value-code={row.code}
+                    phx-value-direction="up"
+                    class="btn btn-ghost btn-xs"
+                    disabled={row.first?}
+                    aria-label={gettext("Move up")}
+                  >
+                    <.icon name="hero-chevron-up" class="w-4 h-4" />
+                  </button>
+                  <button
+                    type="button"
+                    phx-click="move_main_country"
+                    phx-value-code={row.code}
+                    phx-value-direction="down"
+                    class="btn btn-ghost btn-xs"
+                    disabled={row.last?}
+                    aria-label={gettext("Move down")}
+                  >
+                    <.icon name="hero-chevron-down" class="w-4 h-4" />
+                  </button>
+                  <button
+                    type="button"
                     phx-click="remove_main_country"
                     phx-value-code={row.code}
                     class="btn btn-ghost btn-xs text-error"

--- a/lib/phoenix_kit_web/live/settings/organization.html.heex
+++ b/lib/phoenix_kit_web/live/settings/organization.html.heex
@@ -48,24 +48,6 @@
               </div>
             </div>
 
-            <%!-- Row: countries pinned to the top of every country dropdown --%>
-            <div class="form-control">
-              <.input
-                type="text"
-                name="country_priority"
-                value={@country_priority}
-                label={gettext("Preferred countries")}
-                placeholder="EE, FI, LV, LT, SE"
-              />
-              <label class="label">
-                <span class="label-text-alt">
-                  {gettext(
-                    "Two-letter country codes, in the order they should appear at the top of every country dropdown. Unknown codes are dropped on save. Leave empty to use the application config, or enter \"none\" to disable pinning entirely."
-                  )}
-                </span>
-              </label>
-            </div>
-
             <div class="divider text-xs">{gettext("Address")}</div>
 
             <%!-- Row: Street Address --%>
@@ -174,8 +156,111 @@
         </div>
       </div>
 
-      <%!-- Right column: Bank + Tax + Site URL stacked --%>
+      <%!-- Right column: Main countries + Bank + Tax + Site URL stacked --%>
       <div class="space-y-6">
+        <%!-- Main countries --%>
+        <div class="card bg-base-100 shadow-xl">
+          <div class="card-body">
+            <h2 class="card-title">
+              <.icon name="hero-map-pin" class="w-5 h-5" />
+              {gettext("Main countries")}
+            </h2>
+            <p class="text-sm text-base-content/60">
+              {gettext("Shown at the top of every country list, in this order")}
+            </p>
+
+            <%= if @main_country_rows == [] do %>
+              <p class="text-sm text-base-content/50 mt-4">
+                {gettext("Nothing chosen yet — country lists are plain alphabetical.")}
+              </p>
+            <% else %>
+              <ul class="mt-4 divide-y divide-base-200">
+                <li
+                  :for={row <- @main_country_rows}
+                  class="flex items-center gap-1 py-2"
+                >
+                  <span class="grow truncate">{row.label}</span>
+
+                  <button
+                    type="button"
+                    phx-click="move_main_country"
+                    phx-value-code={row.code}
+                    phx-value-direction="up"
+                    class="btn btn-ghost btn-xs"
+                    disabled={row.first?}
+                    aria-label={gettext("Move up")}
+                  >
+                    <.icon name="hero-chevron-up" class="w-4 h-4" />
+                  </button>
+
+                  <button
+                    type="button"
+                    phx-click="move_main_country"
+                    phx-value-code={row.code}
+                    phx-value-direction="down"
+                    class="btn btn-ghost btn-xs"
+                    disabled={row.last?}
+                    aria-label={gettext("Move down")}
+                  >
+                    <.icon name="hero-chevron-down" class="w-4 h-4" />
+                  </button>
+
+                  <button
+                    type="button"
+                    phx-click="remove_main_country"
+                    phx-value-code={row.code}
+                    class="btn btn-ghost btn-xs text-error"
+                    aria-label={gettext("Remove")}
+                  >
+                    <.icon name="hero-x-mark" class="w-4 h-4" />
+                  </button>
+                </li>
+              </ul>
+            <% end %>
+
+            <%= if @main_country_suggestion != [] do %>
+              <div class="alert alert-info mt-4 flex-col items-start gap-2">
+                <span class="text-sm">
+                  {gettext("Based on your country: %{countries}",
+                    countries:
+                      Enum.map_join(@main_country_suggestion, ", ", fn suggested ->
+                        suggested.label
+                      end)
+                  )}
+                </span>
+                <button
+                  type="button"
+                  phx-click="apply_main_country_suggestion"
+                  class="btn btn-sm"
+                >
+                  <.icon name="hero-plus" class="w-4 h-4" />
+                  {gettext("Add these")}
+                </button>
+              </div>
+            <% end %>
+
+            <form
+              id="main-countries-add"
+              phx-submit="add_main_country"
+              class="flex items-end gap-2 mt-4"
+            >
+              <div class="grow">
+                <.select
+                  name="code"
+                  value=""
+                  options={@main_country_options}
+                  prompt={gettext("Select country...")}
+                  label={gettext("Add a country")}
+                />
+              </div>
+              <button type="submit" class="btn btn-primary">
+                <.icon name="hero-plus" class="w-4 h-4" />
+                {gettext("Add")}
+              </button>
+            </form>
+          </div>
+        </div>
+
         <%!-- Bank Details --%>
         <div class="card bg-base-100 shadow-xl">
           <div class="card-body">

--- a/lib/phoenix_kit_web/live/settings/organization.html.heex
+++ b/lib/phoenix_kit_web/live/settings/organization.html.heex
@@ -48,6 +48,24 @@
               </div>
             </div>
 
+            <%!-- Row: countries pinned to the top of every country dropdown --%>
+            <div class="form-control">
+              <.input
+                type="text"
+                name="country_priority"
+                value={@country_priority}
+                label={gettext("Preferred countries")}
+                placeholder="EE, FI, LV, LT, SE"
+              />
+              <label class="label">
+                <span class="label-text-alt">
+                  {gettext(
+                    "Two-letter country codes, in the order they should appear at the top of every country dropdown. Unknown codes are dropped on save. Leave empty to use the application config."
+                  )}
+                </span>
+              </label>
+            </div>
+
             <div class="divider text-xs">{gettext("Address")}</div>
 
             <%!-- Row: Street Address --%>

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -12179,9 +12179,54 @@ msgstr ""
 msgid "Where PhoenixKit sends visitors who are not signed in. Empty = the sign-in page."
 msgstr ""
 
+#: lib/phoenix_kit_web/live/settings/organization.html.heex:139
+#, elixir-autogen, elixir-format
+msgid "Add a country"
+msgstr ""
+
+#: lib/phoenix_kit_web/live/settings/organization.html.heex:127
+#, elixir-autogen, elixir-format
+msgid "Add these"
+msgstr ""
+
+#: lib/phoenix_kit_web/live/settings/organization.html.heex:113
+#, elixir-autogen, elixir-format
+msgid "Based on your country: %{countries}"
+msgstr ""
+
+#: lib/phoenix_kit_web/live/settings/organization.html.heex:167
+#, elixir-autogen, elixir-format
+msgid "Main countries"
+msgstr ""
+
+#: lib/phoenix_kit_web/live/settings/organization.ex:445
+#, elixir-autogen, elixir-format
+msgid "Main countries could not be saved"
+msgstr ""
+
+#: lib/phoenix_kit_web/live/settings/organization.html.heex:96
+#, elixir-autogen, elixir-format
+msgid "Move down"
+msgstr ""
+
+#: lib/phoenix_kit_web/live/settings/organization.html.heex:84
+#, elixir-autogen, elixir-format
+msgid "Move up"
+msgstr ""
+
+#: lib/phoenix_kit_web/live/settings/organization.html.heex:65
+#, elixir-autogen, elixir-format
+msgid "Nothing chosen yet — country lists are plain alphabetical."
+msgstr ""
+
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:350
 #, elixir-autogen, elixir-format
 msgid "Require the provider to confirm the email address"
+msgstr ""
+
+#: lib/phoenix_kit_web/live/settings/organization.html.heex:60
+#, elixir-autogen, elixir-format
+msgid "Shown at the top of every country list, in this order"
 msgstr ""
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:354

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -12224,9 +12224,14 @@ msgstr ""
 msgid "Require the provider to confirm the email address"
 msgstr ""
 
+#: lib/phoenix_kit_web/live/settings/organization.html.heex:229
+#, elixir-autogen, elixir-format
+msgid "Search countries..."
+msgstr ""
+
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:60
 #, elixir-autogen, elixir-format
-msgid "Shown at the top of every country list, in this order"
+msgid "Shown at the top of every country list. Drag to reorder."
 msgstr ""
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:354

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -12225,10 +12225,15 @@ msgstr "Nothing chosen yet — country lists are plain alphabetical."
 msgid "Require the provider to confirm the email address"
 msgstr ""
 
+#: lib/phoenix_kit_web/live/settings/organization.html.heex:229
+#, elixir-autogen, elixir-format
+msgid "Search countries..."
+msgstr "Search countries..."
+
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:60
 #, elixir-autogen, elixir-format
-msgid "Shown at the top of every country list, in this order"
-msgstr "Shown at the top of every country list, in this order"
+msgid "Shown at the top of every country list. Drag to reorder."
+msgstr "Shown at the top of every country list. Drag to reorder."
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:354
 #, elixir-autogen, elixir-format

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -12180,10 +12180,55 @@ msgstr ""
 msgid "Where PhoenixKit sends visitors who are not signed in. Empty = the sign-in page."
 msgstr ""
 
+#: lib/phoenix_kit_web/live/settings/organization.html.heex:139
+#, elixir-autogen, elixir-format
+msgid "Add a country"
+msgstr "Add a country"
+
+#: lib/phoenix_kit_web/live/settings/organization.html.heex:127
+#, elixir-autogen, elixir-format
+msgid "Add these"
+msgstr "Add these"
+
+#: lib/phoenix_kit_web/live/settings/organization.html.heex:113
+#, elixir-autogen, elixir-format
+msgid "Based on your country: %{countries}"
+msgstr "Based on your country: %{countries}"
+
+#: lib/phoenix_kit_web/live/settings/organization.html.heex:167
+#, elixir-autogen, elixir-format
+msgid "Main countries"
+msgstr "Main countries"
+
+#: lib/phoenix_kit_web/live/settings/organization.ex:445
+#, elixir-autogen, elixir-format
+msgid "Main countries could not be saved"
+msgstr "Main countries could not be saved"
+
+#: lib/phoenix_kit_web/live/settings/organization.html.heex:96
+#, elixir-autogen, elixir-format
+msgid "Move down"
+msgstr "Move down"
+
+#: lib/phoenix_kit_web/live/settings/organization.html.heex:84
+#, elixir-autogen, elixir-format
+msgid "Move up"
+msgstr "Move up"
+
+#: lib/phoenix_kit_web/live/settings/organization.html.heex:65
+#, elixir-autogen, elixir-format
+msgid "Nothing chosen yet — country lists are plain alphabetical."
+msgstr "Nothing chosen yet — country lists are plain alphabetical."
+
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:350
 #, elixir-autogen, elixir-format
 msgid "Require the provider to confirm the email address"
 msgstr ""
+
+#: lib/phoenix_kit_web/live/settings/organization.html.heex:60
+#, elixir-autogen, elixir-format
+msgid "Shown at the top of every country list, in this order"
+msgstr "Shown at the top of every country list, in this order"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:354
 #, elixir-autogen, elixir-format

--- a/priv/gettext/et/LC_MESSAGES/default.po
+++ b/priv/gettext/et/LC_MESSAGES/default.po
@@ -12242,10 +12242,15 @@ msgstr "Midagi pole veel valitud — riikide loendid on tähestikulises järjeko
 msgid "Require the provider to confirm the email address"
 msgstr "Nõua, et teenusepakkuja kinnitaks e-posti aadressi"
 
+#: lib/phoenix_kit_web/live/settings/organization.html.heex:229
+#, elixir-autogen, elixir-format
+msgid "Search countries..."
+msgstr "Otsi riike..."
+
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:60
 #, elixir-autogen, elixir-format
-msgid "Shown at the top of every country list, in this order"
-msgstr "Kuvatakse iga riikide loendi alguses, selles järjekorras"
+msgid "Shown at the top of every country list. Drag to reorder."
+msgstr "Kuvatakse iga riikide loendi alguses. Järjekorra muutmiseks lohista."
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:354
 #, elixir-autogen, elixir-format

--- a/priv/gettext/et/LC_MESSAGES/default.po
+++ b/priv/gettext/et/LC_MESSAGES/default.po
@@ -12197,10 +12197,55 @@ msgstr "Avaleht"
 msgid "Where PhoenixKit sends visitors who are not signed in. Empty = the sign-in page."
 msgstr "Kuhu PhoenixKit suunab sisse logimata külastajad. Tühi = sisselogimisleht."
 
+#: lib/phoenix_kit_web/live/settings/organization.html.heex:139
+#, elixir-autogen, elixir-format
+msgid "Add a country"
+msgstr "Lisa riik"
+
+#: lib/phoenix_kit_web/live/settings/organization.html.heex:127
+#, elixir-autogen, elixir-format
+msgid "Add these"
+msgstr "Lisa need"
+
+#: lib/phoenix_kit_web/live/settings/organization.html.heex:113
+#, elixir-autogen, elixir-format
+msgid "Based on your country: %{countries}"
+msgstr "Sinu riigi põhjal: %{countries}"
+
+#: lib/phoenix_kit_web/live/settings/organization.html.heex:167
+#, elixir-autogen, elixir-format
+msgid "Main countries"
+msgstr "Põhiriigid"
+
+#: lib/phoenix_kit_web/live/settings/organization.ex:445
+#, elixir-autogen, elixir-format
+msgid "Main countries could not be saved"
+msgstr "Põhiriike ei õnnestunud salvestada"
+
+#: lib/phoenix_kit_web/live/settings/organization.html.heex:96
+#, elixir-autogen, elixir-format
+msgid "Move down"
+msgstr "Liiguta alla"
+
+#: lib/phoenix_kit_web/live/settings/organization.html.heex:84
+#, elixir-autogen, elixir-format
+msgid "Move up"
+msgstr "Liiguta üles"
+
+#: lib/phoenix_kit_web/live/settings/organization.html.heex:65
+#, elixir-autogen, elixir-format
+msgid "Nothing chosen yet — country lists are plain alphabetical."
+msgstr "Midagi pole veel valitud — riikide loendid on tähestikulises järjekorras."
+
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:350
 #, elixir-autogen, elixir-format
 msgid "Require the provider to confirm the email address"
 msgstr "Nõua, et teenusepakkuja kinnitaks e-posti aadressi"
+
+#: lib/phoenix_kit_web/live/settings/organization.html.heex:60
+#, elixir-autogen, elixir-format
+msgid "Shown at the top of every country list, in this order"
+msgstr "Kuvatakse iga riikide loendi alguses, selles järjekorras"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:354
 #, elixir-autogen, elixir-format

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -12220,10 +12220,55 @@ msgstr "Главная страница"
 msgid "Where PhoenixKit sends visitors who are not signed in. Empty = the sign-in page."
 msgstr "Куда PhoenixKit направляет посетителей, не выполнивших вход. Пусто = страница входа."
 
+#: lib/phoenix_kit_web/live/settings/organization.html.heex:139
+#, elixir-autogen, elixir-format
+msgid "Add a country"
+msgstr "Добавить страну"
+
+#: lib/phoenix_kit_web/live/settings/organization.html.heex:127
+#, elixir-autogen, elixir-format
+msgid "Add these"
+msgstr "Добавить их"
+
+#: lib/phoenix_kit_web/live/settings/organization.html.heex:113
+#, elixir-autogen, elixir-format
+msgid "Based on your country: %{countries}"
+msgstr "Исходя из вашей страны: %{countries}"
+
+#: lib/phoenix_kit_web/live/settings/organization.html.heex:167
+#, elixir-autogen, elixir-format
+msgid "Main countries"
+msgstr "Основные страны"
+
+#: lib/phoenix_kit_web/live/settings/organization.ex:445
+#, elixir-autogen, elixir-format
+msgid "Main countries could not be saved"
+msgstr "Не удалось сохранить основные страны"
+
+#: lib/phoenix_kit_web/live/settings/organization.html.heex:96
+#, elixir-autogen, elixir-format
+msgid "Move down"
+msgstr "Переместить вниз"
+
+#: lib/phoenix_kit_web/live/settings/organization.html.heex:84
+#, elixir-autogen, elixir-format
+msgid "Move up"
+msgstr "Переместить вверх"
+
+#: lib/phoenix_kit_web/live/settings/organization.html.heex:65
+#, elixir-autogen, elixir-format
+msgid "Nothing chosen yet — country lists are plain alphabetical."
+msgstr "Пока ничего не выбрано — списки стран идут по алфавиту."
+
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:350
 #, elixir-autogen, elixir-format
 msgid "Require the provider to confirm the email address"
 msgstr "Требовать подтверждение адреса электронной почты от провайдера"
+
+#: lib/phoenix_kit_web/live/settings/organization.html.heex:60
+#, elixir-autogen, elixir-format
+msgid "Shown at the top of every country list, in this order"
+msgstr "Показываются в начале каждого списка стран, в этом порядке"
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:354
 #, elixir-autogen, elixir-format

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -12265,10 +12265,15 @@ msgstr "Пока ничего не выбрано — списки стран и
 msgid "Require the provider to confirm the email address"
 msgstr "Требовать подтверждение адреса электронной почты от провайдера"
 
+#: lib/phoenix_kit_web/live/settings/organization.html.heex:229
+#, elixir-autogen, elixir-format
+msgid "Search countries..."
+msgstr "Поиск стран..."
+
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:60
 #, elixir-autogen, elixir-format
-msgid "Shown at the top of every country list, in this order"
-msgstr "Показываются в начале каждого списка стран, в этом порядке"
+msgid "Shown at the top of every country list. Drag to reorder."
+msgstr "Показываются в начале каждого списка стран. Порядок меняется перетаскиванием."
 
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:354
 #, elixir-autogen, elixir-format

--- a/test/integration/phoenix_kit_web/live/settings/organization_main_countries_test.exs
+++ b/test/integration/phoenix_kit_web/live/settings/organization_main_countries_test.exs
@@ -1,0 +1,275 @@
+defmodule PhoenixKitWeb.Live.Settings.OrganizationMainCountriesTest do
+  use PhoenixKitWeb.ConnCase, async: false
+
+  alias PhoenixKit.Settings
+  alias PhoenixKit.Utils.Routes
+
+  # Sets up the organization settings the "Main countries" card reads from,
+  # logs in a fresh admin, and mounts the page. Each call is self-contained
+  # (its own admin + conn) so a test can mount two independent sessions to
+  # exercise the PubSub broadcast between them.
+  defp mount_organization(opts) do
+    country = Keyword.get(opts, :country, "EE")
+    main_countries = Keyword.get(opts, :main_countries, "")
+
+    Settings.update_json_setting("company_info", %{"name" => "Acme OÜ", "country" => country})
+    Settings.update_setting("country_select_priority", main_countries)
+
+    {admin, _token} = create_admin_user()
+    conn = log_in_user(build_conn(), admin)
+    {:ok, lv, html} = live(conn, Routes.path("/admin/settings/organization"))
+    {lv, html}
+  end
+
+  defp stored_priority, do: Settings.get_setting("country_select_priority")
+
+  # Country names appear twice on this page — once in the always-present
+  # 250-country <select>, once (maybe) in the "Based on your country"
+  # suggestion — so a bare `html =~ "Finland"` proves nothing either way.
+  # This pulls just the suggestion sentence's interpolated country list.
+  defp suggested_countries_text(html) do
+    case Regex.run(~r/Based on your country: ([^<]*)/, html) do
+      [_, text] -> text
+      nil -> ""
+    end
+  end
+
+  # ===================================
+  # FIX 1 & FIX 2 — forged payloads must never crash a handler
+  # ===================================
+
+  describe "forged payloads never crash the handlers" do
+    test "add_main_country ignores a non-binary code" do
+      {lv, _html} = mount_organization(main_countries: "EE")
+
+      for bad_code <- [42, ["EE"], %{}] do
+        render_hook(lv, "add_main_country", %{"code" => bad_code})
+      end
+
+      assert stored_priority() == "EE"
+    end
+
+    test "add_main_country with no code param is a no-op" do
+      {lv, _html} = mount_organization(main_countries: "EE")
+
+      render_hook(lv, "add_main_country", %{})
+
+      assert stored_priority() == "EE"
+    end
+
+    test "reorder_main_countries ignores a non-list ordered_ids" do
+      {lv, _html} = mount_organization(main_countries: "EE, FI")
+
+      for bad_ordered <- ["SE", nil, 1, %{}] do
+        render_hook(lv, "reorder_main_countries", %{"ordered_ids" => bad_ordered})
+      end
+
+      assert stored_priority() == "EE, FI"
+    end
+
+    test "reorder_main_countries with no ordered_ids param is a no-op" do
+      {lv, _html} = mount_organization(main_countries: "EE, FI")
+
+      render_hook(lv, "reorder_main_countries", %{})
+
+      assert stored_priority() == "EE, FI"
+    end
+
+    test "remove_main_country with no code param is a no-op" do
+      {lv, _html} = mount_organization(main_countries: "EE, FI")
+
+      render_hook(lv, "remove_main_country", %{})
+
+      assert stored_priority() == "EE, FI"
+    end
+
+    test "move_main_country ignores a malformed payload" do
+      {lv, _html} = mount_organization(main_countries: "EE, FI")
+
+      for bad_payload <- [
+            %{"code" => 42, "direction" => "up"},
+            %{"code" => "EE", "direction" => "sideways"},
+            %{"code" => "EE"},
+            %{}
+          ] do
+        render_hook(lv, "move_main_country", bad_payload)
+      end
+
+      assert stored_priority() == "EE, FI"
+    end
+  end
+
+  # ===================================
+  # reorder_main_countries — only ever reorders the pinned set
+  # ===================================
+
+  describe "reorder_main_countries only ever reorders the pinned set" do
+    test "an unrecognized id in the payload is not added" do
+      {lv, _html} = mount_organization(main_countries: "EE, FI, LV")
+
+      render_hook(lv, "reorder_main_countries", %{"ordered_ids" => ["ZZ", "LV", "EE", "FI"]})
+
+      assert stored_priority() == "LV, EE, FI"
+    end
+
+    test "an omitted id is re-appended rather than dropped" do
+      {lv, _html} = mount_organization(main_countries: "EE, FI, LV")
+
+      render_hook(lv, "reorder_main_countries", %{"ordered_ids" => ["LV"]})
+
+      assert stored_priority() == "LV, EE, FI"
+    end
+
+    test "a duplicated id in the payload does not duplicate the stored list" do
+      {lv, _html} = mount_organization(main_countries: "EE, FI, LV")
+
+      render_hook(lv, "reorder_main_countries", %{"ordered_ids" => ["LV", "LV", "EE", "FI"]})
+
+      assert stored_priority() == "LV, EE, FI"
+    end
+  end
+
+  # ===================================
+  # add_main_country — dedupe, unknown codes, empty selection (FIX 8)
+  # ===================================
+
+  describe "add_main_country" do
+    test "adding a code that is already pinned changes nothing" do
+      {lv, _html} = mount_organization(main_countries: "EE, FI")
+
+      render_hook(lv, "add_main_country", %{"code" => "ee"})
+
+      assert stored_priority() == "EE, FI"
+    end
+
+    test "adding a code that names no country is dropped" do
+      {lv, _html} = mount_organization(main_countries: "EE")
+
+      render_hook(lv, "add_main_country", %{"code" => "ZZ"})
+
+      assert stored_priority() == "EE"
+    end
+
+    test "adding a new known code appends it" do
+      {lv, _html} = mount_organization(main_countries: "EE")
+
+      render_hook(lv, "add_main_country", %{"code" => "fi"})
+
+      assert stored_priority() == "EE, FI"
+    end
+
+    # FIX 8: pressing "Add" with nothing selected must not rewrite the
+    # (identical) setting.
+    test "an empty code is a no-op" do
+      {lv, _html} = mount_organization(main_countries: "EE")
+
+      render_hook(lv, "add_main_country", %{"code" => ""})
+
+      assert stored_priority() == "EE"
+    end
+  end
+
+  # ===================================
+  # FIX 5 — move_main_country: up/down, clamped at the ends
+  # ===================================
+
+  describe "move_main_country" do
+    test "moves a row up and stops at the top" do
+      {lv, _html} = mount_organization(main_countries: "EE, FI, LV")
+
+      render_hook(lv, "move_main_country", %{"code" => "LV", "direction" => "up"})
+      assert stored_priority() == "EE, LV, FI"
+
+      render_hook(lv, "move_main_country", %{"code" => "EE", "direction" => "up"})
+      assert stored_priority() == "EE, LV, FI"
+    end
+
+    test "moves a row down and stops at the bottom" do
+      {lv, _html} = mount_organization(main_countries: "EE, FI, LV")
+
+      render_hook(lv, "move_main_country", %{"code" => "EE", "direction" => "down"})
+      assert stored_priority() == "FI, EE, LV"
+
+      render_hook(lv, "move_main_country", %{"code" => "LV", "direction" => "down"})
+      assert stored_priority() == "FI, EE, LV"
+    end
+  end
+
+  describe "move_main_country buttons in the rendered card" do
+    test "carry the reused Move up/Move down aria-labels and are disabled at the ends" do
+      {_lv, html} = mount_organization(main_countries: "EE, FI, LV")
+      doc = Floki.parse_document!(html)
+
+      up_first = Floki.find(doc, ~s(button[phx-value-code="EE"][phx-value-direction="up"]))
+      down_first = Floki.find(doc, ~s(button[phx-value-code="EE"][phx-value-direction="down"]))
+      up_last = Floki.find(doc, ~s(button[phx-value-code="LV"][phx-value-direction="up"]))
+      down_last = Floki.find(doc, ~s(button[phx-value-code="LV"][phx-value-direction="down"]))
+
+      assert Floki.attribute(up_first, "aria-label") == ["Move up"]
+      assert Floki.attribute(down_first, "aria-label") == ["Move down"]
+
+      # First row: can't move up, can move down.
+      assert Floki.attribute(up_first, "disabled") != []
+      assert Floki.attribute(down_first, "disabled") == []
+
+      # Last row: can move up, can't move down.
+      assert Floki.attribute(up_last, "disabled") == []
+      assert Floki.attribute(down_last, "disabled") != []
+    end
+  end
+
+  # ===================================
+  # FIX 3 — the Company card's country <select> must refresh too
+  # ===================================
+
+  test "adding a main country refreshes the Company card's country select" do
+    {lv, html} = mount_organization(main_countries: "")
+
+    {af_before, _len} = :binary.match(html, ~s(value="AF"))
+    {ee_before, _len} = :binary.match(html, ~s(value="EE"))
+    assert af_before < ee_before
+
+    html = render_hook(lv, "add_main_country", %{"code" => "EE"})
+
+    {ee_after, _len} = :binary.match(html, ~s(value="EE"))
+    {af_after, _len} = :binary.match(html, ~s(value="AF"))
+    assert ee_after < af_after
+  end
+
+  # ===================================
+  # FIX 4 — main-country actions broadcast to other admin sessions
+  # ===================================
+
+  test "an add action broadcasts to a second admin session" do
+    {lv_a, _html_a} = mount_organization(main_countries: "EE")
+    {lv_b, html_b} = mount_organization(main_countries: "EE")
+
+    # `phx-value-code="FI"` only appears on a pinned row's move/remove
+    # buttons — unlike the country name, it can't also come from the
+    # always-present 250-country <select> or the suggestion sentence.
+    refute html_b =~ ~s(phx-value-code="FI")
+
+    render_hook(lv_a, "add_main_country", %{"code" => "FI"})
+
+    assert render(lv_b) =~ ~s(phx-value-code="FI")
+  end
+
+  # ===================================
+  # FIX 9 — country_changed must recompute the suggestion, unsaved
+  # ===================================
+
+  test "country_changed recomputes the suggestion without persisting the country" do
+    {lv, html} = mount_organization(country: "EE", main_countries: "")
+
+    assert suggested_countries_text(html) =~ "Latvia"
+    refute suggested_countries_text(html) =~ "Luxembourg"
+
+    html = render_hook(lv, "country_changed", %{"company_country" => "DE"})
+
+    assert suggested_countries_text(html) =~ "Luxembourg"
+    refute suggested_countries_text(html) =~ "Latvia"
+
+    # Only the in-memory suggestion moved — nothing was saved.
+    assert Settings.get_json_setting("company_info")["country"] == "EE"
+  end
+end

--- a/test/phoenix_kit/utils/country_data_test.exs
+++ b/test/phoenix_kit/utils/country_data_test.exs
@@ -1,0 +1,104 @@
+defmodule PhoenixKit.Utils.CountryDataTest do
+  use ExUnit.Case, async: false
+
+  # No `doctest` here: this module's examples are written against the bare
+  # `CountryData.` alias, which a doctest has no way to resolve.
+
+  alias PhoenixKit.Utils.CountryData
+
+  setup do
+    previous = Application.get_env(:phoenix_kit, :country_select_priority)
+    on_exit(fn -> restore(:country_select_priority, previous) end)
+    :ok
+  end
+
+  defp restore(key, nil), do: Application.delete_env(:phoenix_kit, key)
+  defp restore(key, value), do: Application.put_env(:phoenix_kit, key, value)
+
+  defp by_code(entries), do: Map.new(entries, fn {display, code} -> {code, display} end)
+
+  # The display name carries a flag emoji, which sorts by country code rather
+  # than by name — compare the names the sort actually keys on.
+  defp without_flag(display), do: display |> String.split(" ", parts: 2) |> List.last()
+
+  describe "countries_for_select/1 locale" do
+    test "translates names into the requested locale" do
+      names = by_code(CountryData.countries_for_select(locale: "ru"))
+      assert names["EE"] == "🇪🇪 Эстония"
+      assert names["DE"] == "🇩🇪 Германия"
+    end
+
+    test "falls back to English for a locale with no translations" do
+      names = by_code(CountryData.countries_for_select(locale: "xx"))
+      assert names["EE"] == "🇪🇪 Estonia"
+    end
+
+    test "reduces a dialect to its base code" do
+      assert CountryData.countries_for_select(locale: "ru-RU") ==
+               CountryData.countries_for_select(locale: "ru")
+    end
+
+    test "keeps every country regardless of locale" do
+      assert length(CountryData.countries_for_select(locale: "ru")) ==
+               length(CountryData.countries_for_select(locale: "en"))
+    end
+  end
+
+  describe "countries_for_select/1 priority" do
+    test "pins the given codes to the top, in the order given" do
+      result = CountryData.countries_for_select(locale: "en", priority: ["EE", "FI", "LV"])
+
+      assert Enum.take(result, 3) == [
+               {"🇪🇪 Estonia", "EE"},
+               {"🇫🇮 Finland", "FI"},
+               {"🇱🇻 Latvia", "LV"}
+             ]
+    end
+
+    test "lists each pinned country exactly once" do
+      codes =
+        CountryData.countries_for_select(locale: "en", priority: ["EE", "FI"])
+        |> Enum.map(&elem(&1, 1))
+
+      assert Enum.count(codes, &(&1 == "EE")) == 1
+      assert length(codes) == length(Enum.uniq(codes))
+    end
+
+    test "ignores unknown codes and normalizes case" do
+      result = CountryData.countries_for_select(locale: "en", priority: ["zz", "ee"])
+      assert hd(result) == {"🇪🇪 Estonia", "EE"}
+    end
+
+    test "defaults to the configured priority" do
+      Application.put_env(:phoenix_kit, :country_select_priority, ["FI"])
+      assert hd(CountryData.countries_for_select(locale: "en")) == {"🇫🇮 Finland", "FI"}
+    end
+
+    test "sorts the unpinned remainder alphabetically, accents folded" do
+      names =
+        CountryData.countries_for_select(locale: "en", priority: [])
+        |> Enum.map(&without_flag(elem(&1, 0)))
+
+      assert names == Enum.sort_by(names, &:unicode.characters_to_nfd_binary(String.downcase(&1)))
+    end
+
+    test "sorts by the localized name, not the English one" do
+      names =
+        CountryData.countries_for_select(locale: "ru", priority: [])
+        |> Enum.map(&without_flag(elem(&1, 0)))
+
+      assert "Австралия" in names
+
+      assert Enum.find_index(names, &(&1 == "Австралия")) <
+               Enum.find_index(names, &(&1 == "Швеция"))
+    end
+  end
+
+  describe "eu_countries_for_select/1" do
+    test "translates and pins like countries_for_select/1" do
+      result = CountryData.eu_countries_for_select(locale: "ru", priority: ["EE"])
+      assert hd(result) == {"🇪🇪 Эстония", "EE"}
+      assert length(result) == 27
+    end
+  end
+end

--- a/test/phoenix_kit/utils/country_data_test.exs
+++ b/test/phoenix_kit/utils/country_data_test.exs
@@ -4,6 +4,7 @@ defmodule PhoenixKit.Utils.CountryDataTest do
   # No `doctest` here: this module's examples are written against the bare
   # `CountryData.` alias, which a doctest has no way to resolve.
 
+  alias Ecto.Adapters.SQL.Sandbox
   alias PhoenixKit.Utils.CountryData
 
   setup do
@@ -120,7 +121,21 @@ defmodule PhoenixKit.Utils.CountryDataTest do
     # The settings cache is consulted before the update-mode short-circuit, so
     # priming it exercises the real read path with no database involved. The
     # cache is a globally named process, hence async: false for the file.
+    #
+    # A cache MISS still falls through to `PhoenixKit.Settings`: with no
+    # database `test_helper.exs` short-circuits that read to the default, but
+    # when a database IS reachable it becomes a real query from a process
+    # that owns no sandbox connection — an OwnershipError, not a miss.
+    # Checking out here (copied from `safe_destination_settings_test.exs`,
+    # which recorded the same failure on its first run against a database)
+    # makes the file behave the same either way. Every test below primes the
+    # key it reads except the "absent key" one, which is exactly why this
+    # guard is needed at the describe level rather than per-test.
     setup do
+      if Application.get_env(:phoenix_kit, :test_repo_available, false) do
+        :ok = Sandbox.checkout(PhoenixKit.Test.Repo)
+      end
+
       start_supervised!({PhoenixKit.Cache.Registry, []})
       start_supervised!({PhoenixKit.Cache, name: :settings})
       :ok
@@ -146,12 +161,40 @@ defmodule PhoenixKit.Utils.CountryDataTest do
       assert hd(CountryData.countries_for_select(locale: "en")) == {"🇫🇮 Finland", "FI"}
     end
 
+    test "an absent setting (never primed) falls back to the config" do
+      Application.put_env(:phoenix_kit, :country_select_priority, ["FI"])
+      # No put_priority_setting call: nothing was ever written for this key,
+      # simulating a host that never opened the settings page — as distinct
+      # from "a blank setting" above, which IS a written, empty row.
+
+      assert hd(CountryData.countries_for_select(locale: "en")) == {"🇫🇮 Finland", "FI"}
+    end
+
     test "an explicit :priority still overrides both" do
       Application.put_env(:phoenix_kit, :country_select_priority, ["FI"])
       put_priority_setting("EE")
 
       assert hd(CountryData.countries_for_select(locale: "en", priority: ["LV"])) ==
                {"🇱🇻 Latvia", "LV"}
+    end
+
+    test "a stored \"none\" sentinel beats the config" do
+      Application.put_env(:phoenix_kit, :country_select_priority, ["FI"])
+      put_priority_setting(CountryData.none_priority_value())
+
+      assert CountryData.countries_for_select(locale: "en") ==
+               CountryData.countries_for_select(locale: "en", priority: [])
+    end
+
+    test "the stored sentinel is recognized case-insensitively and trimmed" do
+      Application.put_env(:phoenix_kit, :country_select_priority, ["FI"])
+      unpinned = CountryData.countries_for_select(locale: "en", priority: [])
+
+      for stored <- ["NONE", "None", " none ", "\tnone\n"] do
+        put_priority_setting(stored)
+
+        assert CountryData.countries_for_select(locale: "en") == unpinned
+      end
     end
   end
 
@@ -167,6 +210,51 @@ defmodule PhoenixKit.Utils.CountryDataTest do
     test "drops codes that name no country" do
       assert CountryData.known_country_codes(["EE", "ZZ", "FI"]) == ["EE", "FI"]
       assert CountryData.known_country_codes(["", nil, :ee]) == []
+    end
+
+    test "a fully-rejected input keeps the unknown codes for reporting, but pins nothing" do
+      # The scenario the settings form's flash has to report: every code the
+      # operator typed is unknown, so nothing survives to be stored.
+      typed = CountryData.parse_priority("Estonia, USA, Suomi")
+      assert typed == ["ESTONIA", "USA", "SUOMI"]
+      assert CountryData.known_country_codes(typed) == []
+    end
+  end
+
+  describe "none_priority?/1 and none_priority_value/0" do
+    test "recognizes the sentinel case-insensitively and trimmed" do
+      assert CountryData.none_priority?("none")
+      assert CountryData.none_priority?("NONE")
+      assert CountryData.none_priority?("None")
+      assert CountryData.none_priority?(" none ")
+      assert CountryData.none_priority?("\tnone\n")
+    end
+
+    test "rejects everything else, including near-misses" do
+      refute CountryData.none_priority?("EE")
+      refute CountryData.none_priority?("")
+      refute CountryData.none_priority?("none, EE")
+      refute CountryData.none_priority?("noneEE")
+      refute CountryData.none_priority?(nil)
+      refute CountryData.none_priority?(:none)
+    end
+
+    test "the canonical value round-trips through the check" do
+      assert CountryData.none_priority_value() == "none"
+      assert CountryData.none_priority?(CountryData.none_priority_value())
+    end
+
+    test "the sentinel is not a real country code, so known_country_codes/1 would drop it" do
+      # This is why the settings form must check `none_priority?/1` BEFORE
+      # running the typed value through `parse_priority/1` and
+      # `known_country_codes/1`: without that check, "none" is just another
+      # unrecognized code and gets silently dropped like any other, storing
+      # blank instead of the sentinel.
+      refute CountryData.exists?(CountryData.none_priority_value())
+
+      assert CountryData.none_priority_value()
+             |> CountryData.parse_priority()
+             |> CountryData.known_country_codes() == []
     end
   end
 

--- a/test/phoenix_kit/utils/country_data_test.exs
+++ b/test/phoenix_kit/utils/country_data_test.exs
@@ -39,8 +39,16 @@ defmodule PhoenixKit.Utils.CountryDataTest do
     end
 
     test "keeps every country regardless of locale" do
-      assert length(CountryData.countries_for_select(locale: "ru")) ==
-               length(CountryData.countries_for_select(locale: "en"))
+      # Same country *codes*, not just the same count — a locale-dependent
+      # filter bug could drop one country and pick up another while leaving
+      # the length unchanged at 250.
+      codes = fn locale ->
+        CountryData.countries_for_select(locale: locale)
+        |> Enum.map(&elem(&1, 1))
+        |> MapSet.new()
+      end
+
+      assert codes.("ru") == codes.("en")
     end
   end
 
@@ -79,7 +87,21 @@ defmodule PhoenixKit.Utils.CountryDataTest do
         CountryData.countries_for_select(locale: "en", priority: [])
         |> Enum.map(&without_flag(elem(&1, 0)))
 
-      assert names == Enum.sort_by(names, &:unicode.characters_to_nfd_binary(String.downcase(&1)))
+      index = fn name -> Enum.find_index(names, &(&1 == name)) end
+
+      # Literal neighbours from the real sorted (English) output, so that
+      # changing the sort key breaks this test — unlike the previous version,
+      # which re-derived the same NFD-fold-and-downcase key the implementation
+      # uses and therefore could never fail. Folding places each accented name
+      # next to its unaccented neighbours instead of exiling it past "Z".
+      assert index.("Azerbaijan") < index.("Åland Islands")
+      assert index.("Åland Islands") < index.("Bahamas")
+
+      assert index.("Costa Rica") < index.("Côte d'Ivoire")
+      assert index.("Côte d'Ivoire") < index.("Croatia")
+
+      assert index.("Tuvalu") < index.("Türkiye")
+      assert index.("Türkiye") < index.("Uganda")
     end
 
     test "sorts by the localized name, not the English one" do
@@ -110,6 +132,7 @@ defmodule PhoenixKit.Utils.CountryDataTest do
     end
 
     test "keeps its one-argument shape for existing callers" do
+      assert Code.ensure_loaded?(CountryData)
       assert function_exported?(CountryData, :get_country_name, 1)
       assert is_binary(CountryData.get_country_name("EE"))
     end
@@ -120,6 +143,33 @@ defmodule PhoenixKit.Utils.CountryDataTest do
       result = CountryData.eu_countries_for_select(locale: "ru", priority: ["EE"])
       assert hd(result) == {"🇪🇪 Эстония", "EE"}
       assert length(result) == 27
+    end
+  end
+
+  describe "zero-arity contract" do
+    test "countries_for_select/0 and eu_countries_for_select/0 stay exported" do
+      # phoenix_kit_billing's core_compat lists
+      # {CountryData, :countries_for_select, 0} as an unguarded runtime call
+      # (lib/phoenix_kit_billing/core_compat.ex) — a regression here breaks
+      # billing at boot. eu_countries_for_select/0 isn't in that list today,
+      # but it shares the same `opts \\ []` contract, so it's asserted here
+      # too rather than leaving it uncovered.
+      #
+      # function_exported?/3 answers false for a module that hasn't been
+      # loaded yet, regardless of what it defines, so ensure_loaded? first.
+      assert Code.ensure_loaded?(CountryData)
+      assert function_exported?(CountryData, :countries_for_select, 0)
+      assert function_exported?(CountryData, :eu_countries_for_select, 0)
+    end
+
+    test "countries_for_select/0 uses the active Gettext locale when :locale is omitted" do
+      previous = Gettext.get_locale(PhoenixKitWeb.Gettext)
+      on_exit(fn -> Gettext.put_locale(PhoenixKitWeb.Gettext, previous) end)
+
+      Gettext.put_locale(PhoenixKitWeb.Gettext, "ru")
+
+      names = by_code(CountryData.countries_for_select())
+      assert names["EE"] == "🇪🇪 Эстония"
     end
   end
 end

--- a/test/phoenix_kit/utils/country_data_test.exs
+++ b/test/phoenix_kit/utils/country_data_test.exs
@@ -78,9 +78,13 @@ defmodule PhoenixKit.Utils.CountryDataTest do
       assert hd(result) == {"🇪🇪 Estonia", "EE"}
     end
 
-    test "defaults to the configured priority" do
+    test "pins nothing when no priority is given or stored" do
+      # There is no compile-time config underneath the setting, so an
+      # untouched install must be plain alphabetical. Setting the old config
+      # key must have no effect whatsoever.
       Application.put_env(:phoenix_kit, :country_select_priority, ["FI"])
-      assert hd(CountryData.countries_for_select(locale: "en")) == {"🇫🇮 Finland", "FI"}
+
+      assert hd(CountryData.countries_for_select(locale: "en")) == {"🇦🇫 Afghanistan", "AF"}
     end
 
     test "sorts the unpinned remainder alphabetically, accents folded" do
@@ -144,57 +148,47 @@ defmodule PhoenixKit.Utils.CountryDataTest do
     defp put_priority_setting(value),
       do: PhoenixKit.Cache.put(:settings, "country_select_priority", value)
 
-    test "the setting wins over the config" do
-      Application.put_env(:phoenix_kit, :country_select_priority, ["FI"])
+    test "the stored setting pins the countries" do
       put_priority_setting("EE, LV")
 
       assert CountryData.countries_for_select(locale: "en") |> Enum.take(2) == [
-               {"🇪🇪 Estonia", "EE"},
-               {"🇱🇻 Latvia", "LV"}
+               {"\u{1F1EA}\u{1F1EA} Estonia", "EE"},
+               {"\u{1F1F1}\u{1F1FB} Latvia", "LV"}
              ]
     end
 
-    test "a blank setting falls back to the config" do
-      Application.put_env(:phoenix_kit, :country_select_priority, ["FI"])
+    test "a blank setting pins nothing" do
       put_priority_setting("")
 
-      assert hd(CountryData.countries_for_select(locale: "en")) == {"🇫🇮 Finland", "FI"}
+      assert hd(CountryData.countries_for_select(locale: "en")) ==
+               {"\u{1F1E6}\u{1F1EB} Afghanistan", "AF"}
     end
 
-    test "an absent setting (never primed) falls back to the config" do
-      Application.put_env(:phoenix_kit, :country_select_priority, ["FI"])
-      # No put_priority_setting call: nothing was ever written for this key,
-      # simulating a host that never opened the settings page — as distinct
-      # from "a blank setting" above, which IS a written, empty row.
-
-      assert hd(CountryData.countries_for_select(locale: "en")) == {"🇫🇮 Finland", "FI"}
+    test "an absent setting pins nothing" do
+      # No put_priority_setting call: a host that never opened the settings
+      # page. Nothing is pinned — there is no config underneath to inherit.
+      assert hd(CountryData.countries_for_select(locale: "en")) ==
+               {"\u{1F1E6}\u{1F1EB} Afghanistan", "AF"}
     end
 
-    test "an explicit :priority still overrides both" do
+    test "the old config key is ignored entirely" do
       Application.put_env(:phoenix_kit, :country_select_priority, ["FI"])
       put_priority_setting("EE")
 
+      assert hd(CountryData.countries_for_select(locale: "en")) ==
+               {"\u{1F1EA}\u{1F1EA} Estonia", "EE"}
+
+      put_priority_setting("")
+
+      assert hd(CountryData.countries_for_select(locale: "en")) ==
+               {"\u{1F1E6}\u{1F1EB} Afghanistan", "AF"}
+    end
+
+    test "an explicit :priority overrides the setting" do
+      put_priority_setting("EE")
+
       assert hd(CountryData.countries_for_select(locale: "en", priority: ["LV"])) ==
-               {"🇱🇻 Latvia", "LV"}
-    end
-
-    test "a stored \"none\" sentinel beats the config" do
-      Application.put_env(:phoenix_kit, :country_select_priority, ["FI"])
-      put_priority_setting(CountryData.none_priority_value())
-
-      assert CountryData.countries_for_select(locale: "en") ==
-               CountryData.countries_for_select(locale: "en", priority: [])
-    end
-
-    test "the stored sentinel is recognized case-insensitively and trimmed" do
-      Application.put_env(:phoenix_kit, :country_select_priority, ["FI"])
-      unpinned = CountryData.countries_for_select(locale: "en", priority: [])
-
-      for stored <- ["NONE", "None", " none ", "\tnone\n"] do
-        put_priority_setting(stored)
-
-        assert CountryData.countries_for_select(locale: "en") == unpinned
-      end
+               {"\u{1F1F1}\u{1F1FB} Latvia", "LV"}
     end
   end
 
@@ -221,40 +215,46 @@ defmodule PhoenixKit.Utils.CountryDataTest do
     end
   end
 
-  describe "none_priority?/1 and none_priority_value/0" do
-    test "recognizes the sentinel case-insensitively and trimmed" do
-      assert CountryData.none_priority?("none")
-      assert CountryData.none_priority?("NONE")
-      assert CountryData.none_priority?("None")
-      assert CountryData.none_priority?(" none ")
-      assert CountryData.none_priority?("\tnone\n")
+  describe "suggested_priority/2" do
+    test "puts the host's own country first, then its nearest neighbours" do
+      assert ["EE" | neighbours] = CountryData.suggested_priority("EE", limit: 4)
+      assert "LV" in neighbours
+      assert "FI" in neighbours
+      assert length(neighbours) == 4
     end
 
-    test "rejects everything else, including near-misses" do
-      refute CountryData.none_priority?("EE")
-      refute CountryData.none_priority?("")
-      refute CountryData.none_priority?("none, EE")
-      refute CountryData.none_priority?("noneEE")
-      refute CountryData.none_priority?(nil)
-      refute CountryData.none_priority?(:none)
+    test "works anywhere, not just where the library was written" do
+      # The point of deriving this from the data rather than from a constant:
+      # a host in Germany or Singapore must get ITS neighbours.
+      assert ["DE" | de] = CountryData.suggested_priority("DE", limit: 3)
+      assert "NL" in de or "LU" in de
+
+      assert ["SG" | sg] = CountryData.suggested_priority("SG", limit: 3)
+      assert "MY" in sg
+      refute "EE" in sg
     end
 
-    test "the canonical value round-trips through the check" do
-      assert CountryData.none_priority_value() == "none"
-      assert CountryData.none_priority?(CountryData.none_priority_value())
+    test "never repeats the origin country" do
+      codes = CountryData.suggested_priority("EE", limit: 6)
+      assert Enum.count(codes, &(&1 == "EE")) == 1
+      assert codes == Enum.uniq(codes)
     end
 
-    test "the sentinel is not a real country code, so known_country_codes/1 would drop it" do
-      # This is why the settings form must check `none_priority?/1` BEFORE
-      # running the typed value through `parse_priority/1` and
-      # `known_country_codes/1`: without that check, "none" is just another
-      # unrecognized code and gets silently dropped like any other, storing
-      # blank instead of the sentinel.
-      refute CountryData.exists?(CountryData.none_priority_value())
+    test "honours :limit, including zero" do
+      assert length(CountryData.suggested_priority("EE", limit: 0)) == 1
+      assert length(CountryData.suggested_priority("EE", limit: 1)) == 2
+      assert length(CountryData.suggested_priority("EE")) == 5
+    end
 
-      assert CountryData.none_priority_value()
-             |> CountryData.parse_priority()
-             |> CountryData.known_country_codes() == []
+    test "answers [] for a code that names no country" do
+      assert CountryData.suggested_priority("XX") == []
+      assert CountryData.suggested_priority(nil) == []
+      assert CountryData.suggested_priority(123) == []
+    end
+
+    test "returns codes that are all real countries" do
+      codes = CountryData.suggested_priority("EE", limit: 8)
+      assert CountryData.known_country_codes(codes) == codes
     end
   end
 

--- a/test/phoenix_kit/utils/country_data_test.exs
+++ b/test/phoenix_kit/utils/country_data_test.exs
@@ -116,6 +116,60 @@ defmodule PhoenixKit.Utils.CountryDataTest do
     end
   end
 
+  describe "countries_for_select/1 priority from settings" do
+    # The settings cache is consulted before the update-mode short-circuit, so
+    # priming it exercises the real read path with no database involved. The
+    # cache is a globally named process, hence async: false for the file.
+    setup do
+      start_supervised!({PhoenixKit.Cache.Registry, []})
+      start_supervised!({PhoenixKit.Cache, name: :settings})
+      :ok
+    end
+
+    defp put_priority_setting(value),
+      do: PhoenixKit.Cache.put(:settings, "country_select_priority", value)
+
+    test "the setting wins over the config" do
+      Application.put_env(:phoenix_kit, :country_select_priority, ["FI"])
+      put_priority_setting("EE, LV")
+
+      assert CountryData.countries_for_select(locale: "en") |> Enum.take(2) == [
+               {"🇪🇪 Estonia", "EE"},
+               {"🇱🇻 Latvia", "LV"}
+             ]
+    end
+
+    test "a blank setting falls back to the config" do
+      Application.put_env(:phoenix_kit, :country_select_priority, ["FI"])
+      put_priority_setting("")
+
+      assert hd(CountryData.countries_for_select(locale: "en")) == {"🇫🇮 Finland", "FI"}
+    end
+
+    test "an explicit :priority still overrides both" do
+      Application.put_env(:phoenix_kit, :country_select_priority, ["FI"])
+      put_priority_setting("EE")
+
+      assert hd(CountryData.countries_for_select(locale: "en", priority: ["LV"])) ==
+               {"🇱🇻 Latvia", "LV"}
+    end
+  end
+
+  describe "parse_priority/1 and known_country_codes/1" do
+    test "parses the separators an operator actually types" do
+      assert CountryData.parse_priority("EE, FI ; lv") == ["EE", "FI", "LV"]
+      assert CountryData.parse_priority("ee\nfi") == ["EE", "FI"]
+      assert CountryData.parse_priority("EE, EE") == ["EE"]
+      assert CountryData.parse_priority("") == []
+      assert CountryData.parse_priority(nil) == []
+    end
+
+    test "drops codes that name no country" do
+      assert CountryData.known_country_codes(["EE", "ZZ", "FI"]) == ["EE", "FI"]
+      assert CountryData.known_country_codes(["", nil, :ee]) == []
+    end
+  end
+
   describe "get_country_name/2" do
     test "translates into the requested locale" do
       assert CountryData.get_country_name("EE", locale: "ru") == "Эстония"

--- a/test/phoenix_kit/utils/country_data_test.exs
+++ b/test/phoenix_kit/utils/country_data_test.exs
@@ -246,6 +246,14 @@ defmodule PhoenixKit.Utils.CountryDataTest do
       assert length(CountryData.suggested_priority("EE")) == 5
     end
 
+    test "falls back to the default instead of raising on a non-integer :limit" do
+      default = CountryData.suggested_priority("EE")
+
+      assert CountryData.suggested_priority("EE", limit: nil) == default
+      assert CountryData.suggested_priority("EE", limit: "4") == default
+      assert CountryData.suggested_priority("EE", limit: 2.5) == default
+    end
+
     test "answers [] for a code that names no country" do
       assert CountryData.suggested_priority("XX") == []
       assert CountryData.suggested_priority(nil) == []

--- a/test/phoenix_kit/utils/country_data_test.exs
+++ b/test/phoenix_kit/utils/country_data_test.exs
@@ -94,6 +94,27 @@ defmodule PhoenixKit.Utils.CountryDataTest do
     end
   end
 
+  describe "get_country_name/2" do
+    test "translates into the requested locale" do
+      assert CountryData.get_country_name("EE", locale: "ru") == "Эстония"
+      assert CountryData.get_country_name("EE", locale: "en") == "Estonia"
+    end
+
+    test "falls back to the English name for an untranslated locale" do
+      assert CountryData.get_country_name("EE", locale: "xx") == "Estonia"
+    end
+
+    test "still answers nil for an unknown country" do
+      assert CountryData.get_country_name("XX") == nil
+      assert CountryData.get_country_name(nil) == nil
+    end
+
+    test "keeps its one-argument shape for existing callers" do
+      assert function_exported?(CountryData, :get_country_name, 1)
+      assert is_binary(CountryData.get_country_name("EE"))
+    end
+  end
+
   describe "eu_countries_for_select/1" do
     test "translates and pins like countries_for_select/1" do
       result = CountryData.eu_countries_for_select(locale: "ru", priority: ["EE"])


### PR DESCRIPTION
## Problem

`CountryData.countries_for_select/0` returns all 250 countries as English names in one flat alphabetical list. Two consequences for a non-English host:

- The dropdown is English on a fully translated page — an Estonian admin picks **Estonia**, not **Eesti**.
- Their own country is buried: `Estonia` sits between `Eritrea` and `Eswatini`, 60-odd rows down, and the countries they actually invoice are scattered across the list.

`beamlab_countries` has carried per-locale country names all along (`BeamLabCountries.Translations`); nothing in core used them.

## Change

`countries_for_select/1` and `eu_countries_for_select/1` take two options:

- **`:locale`** — country names in that locale, defaulting to the active `PhoenixKitWeb.Gettext` locale (dialects reduce to their base: `ru-RU` → `ru`). A locale with no translation data falls back to the English name **per country**, so a host only ever loses the translation, never the entry.
- **`:priority`** — alpha-2 codes pinned to the top in the order given, defaulting to `config :phoenix_kit, :country_select_priority`. A host that serves one region configures it once instead of patching call sites.

Sorting moves from the English name to the localized one, with accents folded through NFD — plain byte order exiles every accented name past `Z` (`Ühendkuningriik` after `Zimbabwe`), which reads as a bug in any locale that uses them.

```elixir
config :phoenix_kit, :country_select_priority, ~w(EE FI LV LT SE)

CountryData.countries_for_select(locale: "et") |> Enum.take(3)
# [{"🇪🇪 Eesti", "EE"}, {"🇫🇮 Soome", "FI"}, {"🇱🇻 Läti", "LV"}]
```

Both functions keep working with no arguments, so every existing caller — including `phoenix_kit_billing`'s `core_compat` MFA list, which probes `{CountryData, :countries_for_select, 0}` — is unaffected.

## Verification

New `test/phoenix_kit/utils/country_data_test.exs` (11 tests, the module had none): translation, dialect reduction, unknown-locale fallback, no country lost, pin order, no duplicate pinned entry, unknown/lower-case codes in `:priority`, the config default, and that the tail is sorted by the localized name.

```
$ mix test test/phoenix_kit/utils/country_data_test.exs
11 tests, 0 failures

$ mix format --check-formatted && mix credo --strict lib/phoenix_kit/utils/country_data.ex
(clean, no issues)
```

Also exercised end-to-end in a host app (Andi): the order form's country select renders `Eesti / Soome / Läti / Leedu / Rootsi` first, then the rest alphabetically, in `et`, `ru` and `en`.

## Notes

- No `doctest` was added: this module's existing examples are written against the bare `CountryData.` alias, which doctests cannot resolve. The new examples follow the same house style, so they are documentation only.
- Estonian names need `beamlab_countries` with an `et` locale (BeamLabEU/beamlab_countries#9). Without it, `et` simply falls back to English — this PR does not depend on it.
- `CHANGELOG.md` and `@version` are left to the maintainer.