### PR TITLE
Point the editor bundle at the leaf release we actually resolve

### DIFF
--- a/priv/static/assets/phoenix_kit.js
+++ b/priv/static/assets/phoenix_kit.js
@@ -3962,13 +3962,19 @@ if (typeof window.Chart === "undefined") {
   // ============================================================================
   // LEAF EDITOR (loaded from CDN)
   //
-  // Auto-loads Leaf editor JS from CDN when the hook mounts.
-  // The Elixir LiveComponent comes from the {:leaf, "~> 0.3"} hex dependency.
-  // Keep this pin in lockstep with the resolved hex version in mix.lock.
+  // Auto-loads Leaf editor JS from CDN when the hook mounts, so a page with
+  // no editor on it pays nothing.
+  //
+  // The Elixir LiveComponent comes from the :leaf hex dependency, and this
+  // tag has to name the same release: almost everything leaf adds is a
+  // server<->client contract, and a bundle left behind still renders an
+  // identical editor while quietly not implementing what the server now
+  // expects. test/phoenix_kit_web/leaf_bundle_pin_test.exs holds the two
+  // together, because the comment that used to ask for it did not.
   // ============================================================================
 
   (function() {
-    var LEAF_CDN = "https://cdn.jsdelivr.net/gh/alexdont/leaf@v0.3.2/priv/static/assets/leaf.js";
+    var LEAF_CDN = "https://cdn.jsdelivr.net/gh/alexdont/leaf@v0.5.1/priv/static/assets/leaf.js";
     var leafLoading = false;
     var leafCallbacks = [];
 

--- a/test/phoenix_kit_web/leaf_bundle_pin_test.exs
+++ b/test/phoenix_kit_web/leaf_bundle_pin_test.exs
@@ -1,0 +1,61 @@
+defmodule PhoenixKitWeb.LeafBundlePinTest do
+  @moduledoc """
+  The editor's JavaScript is fetched from a CDN tag; its Elixir half comes
+  from hex. Nothing makes the two agree except the string in `phoenix_kit.js`.
+
+  They drifted two minor versions apart — hex resolved leaf 0.5.1 while the
+  tag still served v0.3.2 — and nothing said so. Almost everything leaf adds
+  is a server<->client contract, so a stale bundle renders an identical
+  editor and just stops implementing what the server now expects: no
+  `{:leaf_flushed, ...}` reply for a host awaiting a save before it
+  navigates, no dirty re-baseline, atomic blocks with no styling.
+
+  Leaf carries its own guard against exactly this — it renders
+  `data-leaf-js-version` and the bundle warns when the two disagree — but a
+  bundle old enough to matter predates the guard and cannot fire it. That is
+  the shape of the problem: the further behind the pin falls, the quieter it
+  gets. So the check belongs here, where the pin is written.
+  """
+  use ExUnit.Case, async: true
+
+  @bundle Path.join(__DIR__, "../../priv/static/assets/phoenix_kit.js")
+  @pin ~r{cdn\.jsdelivr\.net/gh/alexdont/leaf@([^/]+)/priv/static/assets/leaf\.js}
+
+  defp pins do
+    @bundle |> File.read!() |> then(&Regex.scan(@pin, &1)) |> Enum.map(fn [_, tag] -> tag end)
+  end
+
+  test "the CDN tag names the leaf release that hex resolved" do
+    resolved = to_string(Application.spec(:leaf, :vsn))
+
+    assert [tag] = pins()
+
+    assert tag == "v#{resolved}",
+           """
+           The leaf editor bundle is pinned to #{tag}, but this project resolves \
+           leaf #{resolved}.
+
+           Update LEAF_CDN in priv/static/assets/phoenix_kit.js to \
+           v#{resolved}. A mismatch is silent: the editor renders normally and \
+           quietly stops honouring the parts of the API the server has moved on to.
+           """
+  end
+
+  test "there is one pin to keep in step" do
+    # A second copy of the URL is a second thing to remember, and the one that
+    # gets forgotten is by definition the one no test named.
+    assert length(pins()) == 1,
+           "expected exactly one leaf CDN pin, found #{length(pins())}"
+  end
+
+  test "the loader still keys off the version the bundle publishes" do
+    # `window.LeafHooks.version` is what leaf's own stale-bundle warning
+    # compares against `data-leaf-js-version`. Fetching a bundle that predates
+    # it disables that warning, which is why this test exists rather than
+    # relying on the console.
+    js = File.read!(@bundle)
+
+    assert js =~ "window.LeafHooks && window.LeafHooks.Leaf",
+           "the lazy loader no longer probes LeafHooks; the pin check may be guarding nothing"
+  end
+end


### PR DESCRIPTION
Hex resolves **leaf 0.5.1**. The CDN tag in `phoenix_kit.js` still served
**v0.3.2** — 1,966 lines of server↔client contract behind — and nothing said so.

The comment directly above the pin asked for lockstep, and named
`{:leaf, "~> 0.3"}` while `mix.exs:183` had already moved to
`~> 0.4.1 or ~> 0.5`. A comment is not a mechanism.

## Why it stayed quiet

Almost everything leaf adds is a contract between the component and the bundle,
so a stale copy renders an **identical** editor and simply stops implementing
what the server now expects:

- no `{:leaf_flushed, …}` reply, so a host awaiting a save before it navigates
  waits forever
- no dirty re-baseline
- atomic preserved blocks with no styling for their preview

Leaf ships a guard against exactly this — it renders `data-leaf-js-version`, and
the bundle warns on mismatch. But the guard arrived in **0.4.0**. v0.3.2
publishes no `window.LeafHooks.version` and has no `_warnStaleBundle`, so the
further behind the pin fell, the less able it was to say so. That asymmetry is
why the check belongs next to where the pin is written rather than in the
console.

## Verified before pinning

```
v0.3.2   http=200  bytes=434,922
v0.5.1   http=200  bytes=509,747
md5(cdn v0.5.1) == md5(git show v0.5.1:priv/static/assets/leaf.js)
         462aab9116d91998bc7e3f3d8eff93aa
```

The tag resolves and is byte-identical to the leaf checkout.

## Nothing else in core needs to catch up

Checked rather than assumed:

- `CommentsForwarding` forwards `{:leaf_changed, _}` only, and no call site
  passes a flush `ref` — the new `{:leaf_flushed, …}` reply is unreachable from
  here, so the 0.5.1 addition is inert for us.
- `Settings.get_editor_mode/0` returns `:hybrid | :visual | :markdown | :html`,
  which still matches the component's accepted set exactly.
- The 0.5.1 note about a denied mode's fallback changing needs a `deny:` list;
  core passes none.

## The test

`test/phoenix_kit_web/leaf_bundle_pin_test.exs` compares the pin against
`Application.spec(:leaf, :vsn)`, so the lock is the source of truth and the two
cannot drift again silently. It also asserts there is exactly **one** pin (a
second copy is a second thing to remember, and the forgotten one is by
definition the one no test named) and that the lazy loader still probes
`LeafHooks`, so the check can't end up guarding a mechanism that moved.

Three mutations checked — pin falls behind the lock, a second pin appears,
the loader stops probing `LeafHooks` — each failing with a message naming the
real problem.

## Rollout note

Hosts pick this up on `mix phoenix_kit.update`, which re-copies the bundle into
their vendor directory. Until they run it they keep loading v0.3.2.

## Gates

`mix precommit` exits 0 (credo `--strict`: 10,422 mods/funs, no issues; dialyzer
clean; 31 JS tests). Full suite **3,364 tests, 0 failures**, with the database
reachable — 1,329 integration tests actually ran rather than being silently
excluded.

No `@version` or CHANGELOG changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NTj7hm3fpCTcFvKLRtgppW
