### PR TITLE
Fix the scheduled-jobs sweep dying at :debug, add the missing queue on upgrade, and catch the general case in doctor

### DIFF
--- a/lib/mix/tasks/phoenix_kit.doctor.ex
+++ b/lib/mix/tasks/phoenix_kit.doctor.ex
@@ -43,14 +43,15 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
    13. **Lock Conflicts** — Any blocked or long-running queries?
    14. **Orphaned Connections** — Idle-in-transaction or stuck connections
    15. **Oban Configuration** — Queues and plugins that consume pool connections
-   16. **PhoenixKit Supervisor** — What's running (update_mode vs full)?
-   17. **Child Start Order** — Does the Repo start before PhoenixKit/Oban in application.ex?
-   18. **Update Mode** — Is update_mode active?
-   19. **daisyUI Version** — Is the host's vendored daisyUI recent enough?
-   20. **User Dashboard (deprecated)** — Is the host still on the retired dashboard?
-   21. **Sitemap Discoverability** — Is the sitemap actually reachable?
-   22. **Demo Auth Pages** — Are the demo auth routes still exposed?
-   23. **Manifest Repair (dry-run)** — `PhoenixKit.Migrations.Repair.verify/1`
+   16. **Oban Cron Queues** — Does every crontab worker have its queue configured?
+   17. **PhoenixKit Supervisor** — What's running (update_mode vs full)?
+   18. **Child Start Order** — Does the Repo start before PhoenixKit/Oban in application.ex?
+   19. **Update Mode** — Is update_mode active?
+   20. **daisyUI Version** — Is the host's vendored daisyUI recent enough?
+   21. **User Dashboard (deprecated)** — Is the host still on the retired dashboard?
+   22. **Sitemap Discoverability** — Is the sitemap actually reachable?
+   23. **Demo Auth Pages** — Are the demo auth routes still exposed?
+   24. **Manifest Repair (dry-run)** — `PhoenixKit.Migrations.Repair.verify/1`
        runs read-only against the generated
        `PhoenixKit.Migrations.ExpectedSchema` manifest as an additional,
        non-fatal check (never `:fail`). Passes and says so if the manifest
@@ -119,6 +120,7 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
       run_check("Lock Conflicts", fn -> check_lock_conflicts() end),
       run_check("Orphaned Connections", fn -> check_orphaned_connections() end),
       run_check("Oban Configuration", fn -> check_oban_config(oban_config) end),
+      run_check("Oban Cron Queues", fn -> check_cron_queues(oban_config) end),
       run_check("PhoenixKit Supervisor", fn -> check_supervisor_state() end),
       run_check("Child Start Order", fn -> check_child_order() end),
       run_check("Update Mode", fn -> check_update_mode() end),
@@ -905,6 +907,150 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
       _ -> nil
     end)
   end
+
+  # A cron entry inserts a job whether or not anything is configured to run it,
+  # and Oban only fetches for queues this node lists in `queues:`. So a crontab
+  # worker whose queue is missing produces one job per tick that stays
+  # :available forever — Pruner deletes terminal states only, so nothing ever
+  # clears them.
+  #
+  # PhoenixKit shipped exactly this between 2025-12-28 and 1.7.63: the
+  # ProcessScheduledJobsWorker entry went into the generated config without its
+  # :scheduled_jobs queue. Hosts installed in that window are still affected,
+  # because the installer's *upgrade* path only ever added the entry — one such
+  # host was found with 21,337 orphaned rows and climbing at ~1,440/day.
+  #
+  # Checking the whole crontab rather than that one worker is the point: the
+  # next instance of this mistake is then a warning on the next doctor run
+  # instead of something a host has to discover by reading its own oban_jobs
+  # table.
+  @doc """
+  Reports crontab entries whose queue this node does not run.
+
+  Public so it can be unit-tested directly against config keyword lists, for
+  the same reason as `exit_code/1`: it is the pure decision inside a task whose
+  `run/1` needs a live app and a database.
+  """
+  @spec check_cron_queues(keyword() | nil | term()) :: {:pass | :warn, String.t()}
+  def check_cron_queues(nil), do: {:pass, "Oban not configured"}
+
+  def check_cron_queues(config) when is_list(config) do
+    raw_queues = Keyword.get(config, :queues, [])
+    raw_plugins = Keyword.get(config, :plugins, [])
+    queues = normalize_oban_list(raw_queues)
+
+    cond do
+      # `testing: :inline | :manual` makes Oban itself overwrite both plugins
+      # and queues with [] (Oban.Config.normalize_opts/1), so no cron ever
+      # fires and nothing can accumulate. Reading the host's declared values
+      # and warning would describe a config Oban is not going to use.
+      Keyword.get(config, :testing, :disabled) in [:inline, :manual] ->
+        {:pass, "Oban is in testing mode — it runs no queues and no plugins."}
+
+      # `plugins: false` is Oban's documented way to turn plugins off
+      # wholesale: no Cron, so no entries to check.
+      raw_plugins == false ->
+        {:pass, "Oban plugins are disabled on this node (plugins: false)."}
+
+      # Oban documents an empty list and `false` as the same thing — "prevents
+      # any queues from starting on init". A web-only node says one or the
+      # other, and there every entry would look orphaned, so the honest answer
+      # is "not applicable" rather than a warning per crontab line.
+      raw_queues == false or queues == [] ->
+        {:pass, "Oban runs no queues on this node — jobs are executed elsewhere."}
+
+      true ->
+        config
+        |> crontab_entries()
+        |> check_entry_queues(queues)
+    end
+  end
+
+  def check_cron_queues(_other), do: {:pass, "Oban configured (non-keyword config)"}
+
+  # `flat_map` rather than "find the Cron plugin", and the top-level key as
+  # well as the plugin: Oban still accepts `crontab:` directly on the Oban
+  # config and promotes it into a Cron plugin itself
+  # (`Oban.Config.crontab_to_plugin/1`). A host using that form has entries the
+  # plugins list never mentions, and stopping at the first Cron plugin would
+  # have missed them entirely — reporting a clean bill of health on precisely
+  # the config this check exists to catch.
+  defp crontab_entries(config) do
+    plugin_entries =
+      config
+      |> Keyword.get(:plugins, [])
+      |> normalize_oban_list()
+      |> Enum.flat_map(fn
+        {Oban.Plugins.Cron, opts} when is_list(opts) -> Keyword.get(opts, :crontab, [])
+        _ -> []
+      end)
+
+    plugin_entries ++ Keyword.get(config, :crontab, [])
+  end
+
+  defp check_entry_queues([], _queues),
+    do: {:pass, "No Oban.Plugins.Cron crontab entries to check."}
+
+  defp check_entry_queues(entries, queues) do
+    configured = MapSet.new(Keyword.keys(queues), &to_string/1)
+
+    orphans =
+      for entry <- entries,
+          {:ok, worker, queue} <- [entry_queue(entry)],
+          not MapSet.member?(configured, queue),
+          uniq: true,
+          do: {worker, queue}
+
+    case orphans do
+      [] ->
+        {:pass, "#{length(entries)} crontab entries, every queue configured."}
+
+      orphans ->
+        detail =
+          Enum.map_join(orphans, ", ", fn {worker, queue} ->
+            "#{inspect(worker)} → #{queue}"
+          end)
+
+        {:warn,
+         "#{length(entries)} crontab entries. These fire into queues this node does not run, so " <>
+           "each tick inserts a job nothing will execute and Pruner never clears it (terminal " <>
+           "states only): #{detail}. Add the queue to `queues:` in config.exs, or drop the " <>
+           "crontab entry — `mix phoenix_kit.update` adds the ones PhoenixKit ships. Check what " <>
+           "has already collected first (`SELECT count(*) FROM oban_jobs WHERE state = " <>
+           "'available'`): configuring the queue releases the whole backlog at once, and for " <>
+           "ProcessScheduledJobsWorker that first sweep publishes every overdue scheduled post " <>
+           "and sends every overdue broadcast. `Oban.cancel_all_jobs/1` over the queue clears " <>
+           "them without running them."}
+    end
+  end
+
+  # Mirrors Oban.Plugins.Cron.build_changeset/4: the entry's own opts win over
+  # the worker's, and a worker declaring no queue falls back to Oban.Job's
+  # "default". (Cron uses Worker.merge_opts/2, whose only special case is
+  # :unique — for :queue it is a plain Keyword.merge.)
+  #
+  # Queues compare as strings because Oban accepts either form — `queue: :foo`
+  # in a worker and `foo: 10` in `queues:` are the same queue — and it avoids
+  # minting atoms from config while checking it.
+  defp entry_queue({expr, worker}), do: entry_queue({expr, worker, []})
+
+  defp entry_queue({_expr, worker, opts}) when is_atom(worker) and is_list(opts) do
+    # A crontab may name a worker from a dependency that is not loaded in the
+    # doctor's VM. Skipping is right: we cannot read its queue, and guessing
+    # would report a host as broken for a module we simply failed to load.
+    if Code.ensure_loaded?(worker) and function_exported?(worker, :__opts__, 0) do
+      queue =
+        worker.__opts__()
+        |> Keyword.merge(opts)
+        |> Keyword.get(:queue, :default)
+
+      {:ok, worker, to_string(queue)}
+    else
+      :skip
+    end
+  end
+
+  defp entry_queue(_other), do: :skip
 
   defp check_supervisor_state do
     case Process.whereis(PhoenixKit.Supervisor) do

--- a/lib/phoenix_kit/install/oban_config.ex
+++ b/lib/phoenix_kit/install/oban_config.ex
@@ -25,6 +25,8 @@ if Code.ensure_loaded?(Igniter) do
     @dialyzer {:nowarn_function, ensure_newsletters_delivery_queue: 2}
     @dialyzer {:nowarn_function, ensure_catalogue_pdf_queue: 2}
     @dialyzer {:nowarn_function, ensure_notifications_queue: 2}
+    @dialyzer {:nowarn_function, ensure_scheduled_jobs_queue: 2}
+    @dialyzer {:nowarn_function, insert_scheduled_jobs_queue: 2}
     @dialyzer {:nowarn_function, ensure_cron_plugin: 2}
     @dialyzer {:nowarn_function, ensure_digest_cron_entries: 2}
     @dialyzer {:nowarn_function, add_digest_entries_to_crontab: 3}
@@ -305,6 +307,7 @@ if Code.ensure_loaded?(Igniter) do
         |> ensure_newsletters_delivery_queue(app_name)
         |> ensure_catalogue_pdf_queue(app_name)
         |> ensure_notifications_queue(app_name)
+        |> ensure_scheduled_jobs_queue(app_name)
         |> ensure_cron_plugin(app_name)
         |> ensure_digest_cron_entries(app_name)
         |> ensure_worker_cron_entries(app_name)
@@ -595,6 +598,131 @@ if Code.ensure_loaded?(Igniter) do
             content
         end
       end
+    end
+
+    # The one queue a host can be missing through no fault of its own.
+    #
+    # The ProcessScheduledJobsWorker crontab entry entered the generated config
+    # on 2025-12-28 without the queue it runs in; the fresh-install block gained
+    # `scheduled_jobs: 1` on 2026-03-05, released in 1.7.63. Every host that
+    # installed in between got a per-minute cron entry firing into a queue
+    # nothing runs, and no upgrade repaired it, because this is the upgrade path
+    # and it had no helper for that queue — the other six queues did. One such
+    # host was found 15 days in with 21,337 jobs stuck in :available, growing at
+    # ~1,440/day, because Pruner only deletes terminal states.
+    #
+    @doc """
+    Ensures the `scheduled_jobs` queue exists in a host's existing Oban config.
+
+    Public for the same reason as `ensure_worker_cron_entries/2`: so it can be
+    unit-tested directly against content strings.
+    """
+    @spec ensure_scheduled_jobs_queue(String.t(), atom() | String.t()) :: String.t()
+    def ensure_scheduled_jobs_queue(content, app_name) do
+      if scheduled_jobs_queue_configured?(content) do
+        Mix.shell().info("  ℹ️  scheduled_jobs queue already configured")
+        content
+      else
+        Mix.shell().info("  ➕ Adding scheduled_jobs queue to Oban configuration...")
+        insert_scheduled_jobs_queue(content, app_name)
+      end
+    end
+
+    # Comment lines go before the check, for the same reason
+    # `oban_block_missing_prefix?/1` strips them and with a sharper edge here:
+    # the failure path below prints "Please manually add: scheduled_jobs: 1",
+    # so the exact line a host pastes in as a reminder-to-self is what would
+    # otherwise convince the next run the queue is already there — leaving it
+    # broken forever, quietly.
+    #
+    # `[` is accepted next to a bare integer because `scheduled_jobs: [limit: 1]`
+    # is the same queue in Oban's keyword form. Missing it would append a second
+    # entry, and a duplicate key is not a compile error: it survives into
+    # `Oban.Config.normalize_queues/1`, and `Oban.Midwife` asserts `{:ok, _}` on
+    # start_queue, so the second start returns `{:error, {:already_started, _}}`
+    # and the host does not boot.
+    defp scheduled_jobs_queue_configured?(content) do
+      Regex.match?(~r/^\s*scheduled_jobs:\s*(?:\d+|\[)/m, strip_comment_lines(content))
+    end
+
+    # Two ways string surgery on a queues list goes wrong, both already paid for
+    # elsewhere in this file:
+    #
+    #   * stopping at a nested list's bracket rather than the queues list's own
+    #     — `default: [limit: 10]` is legal, and inserting there produces an
+    #     option Oban rejects at boot. `ensure_lifeline_plugin/2` documents the
+    #     fix: anchor the closing `]` to the keyword's own indentation with a
+    #     backreference, which nested entries are always indented past.
+    #
+    #   * running out of this app's Oban block entirely. An Oban block with no
+    #     `queues:` at all let a lazy `.*?` walk into the next `config` entry
+    #     and add the queue to an unrelated application. The block is bounded
+    #     here by the next top-level `config`/`import_config`, the same boundary
+    #     `oban_block_missing_prefix?/1` uses.
+    #
+    # An empty `queues: []` deliberately finds no match and takes the manual
+    # path: Oban documents an empty list as equivalent to `false` — "prevents
+    # any queues from starting on init" — so a node that says it runs no queues
+    # should not silently be given one.
+    defp insert_scheduled_jobs_queue(content, app_name) do
+      case Regex.run(
+             ~r/(^config\s+:#{app_name},\s+Oban\b(?:(?!\n(?:config\s|import_config\s)).)*?\n([ \t]+)queues:\s*\[\n)(.*?)(\n\2\])/ms,
+             content,
+             capture: :all
+           ) do
+        [full_match, queues_open, indent, queues_content, queues_close] ->
+          Mix.shell().info("  ✓ Found queues block, adding scheduled_jobs queue")
+
+          updated_queues =
+            queues_open <> add_queue_entry(queues_content, indent <> "  ") <> queues_close
+
+          String.replace(content, full_match, updated_queues, global: false)
+
+        nil ->
+          Mix.shell().error(
+            "  ⚠️  Could not parse queues block for :#{app_name} - skipping scheduled_jobs queue update"
+          )
+
+          Mix.shell().error("     Please manually add: scheduled_jobs: 1")
+          content
+      end
+    end
+
+    # The entry goes after the last line carrying code, not at the end of the
+    # block. A queues list can end in comment lines, and appending the
+    # separating comma there puts it inside the comment — which leaves the
+    # previous entry and the new one with nothing between them, and a
+    # config.exs that no longer parses.
+    defp add_queue_entry(queues_content, entry_indent) do
+      entry = entry_indent <> "scheduled_jobs: 1"
+      lines = String.split(queues_content, "\n")
+
+      case last_code_line_index(lines) do
+        nil when queues_content == "" ->
+          entry
+
+        nil ->
+          queues_content <> "\n" <> entry
+
+        index ->
+          lines
+          |> List.update_at(index, fn line ->
+            if String.ends_with?(String.trim(line), ","), do: line, else: line <> ","
+          end)
+          |> List.insert_at(index + 1, entry)
+          |> Enum.join("\n")
+      end
+    end
+
+    defp last_code_line_index(lines) do
+      lines
+      |> Enum.with_index()
+      |> Enum.reverse()
+      |> Enum.find_value(fn {line, index} ->
+        trimmed = String.trim(line)
+
+        if trimmed != "" and not String.starts_with?(trimmed, "#"), do: index
+      end)
     end
 
     # Ensure Pruner has max_age configured for 30-day retention

--- a/lib/phoenix_kit/install/oban_config.ex
+++ b/lib/phoenix_kit/install/oban_config.ex
@@ -882,20 +882,59 @@ if Code.ensure_loaded?(Igniter) do
       end
     end
 
-    # Ensure cron plugin exists in the plugins list
-    defp ensure_cron_plugin(content, app_name) do
+    # Any module path ending in the old worker's name. The replacement used to
+    # be the literal "PhoenixKit.Posts.Workers.PublishScheduledPostsJob", a
+    # module that exists in no repo — the real one is
+    # `PhoenixKitPosts.Workers.PublishScheduledPostsJob`. So the Case 1 guard
+    # matched, `String.replace/3` found nothing, and the branch returned the
+    # content untouched while printing "🔄 Replacing…". Being `cond`'s first
+    # clause, it also shadowed Cases 2-4, so the core worker was never added
+    # either: an upgrading host kept the old posts worker, gained nothing, and
+    # was told the opposite. That is why hosts are found running both cron
+    # entries, which is what makes the posts sweep race itself on a single node.
+    @old_posts_worker ~r/[A-Za-z0-9_.]*\bPublishScheduledPostsJob\b/
+    @new_worker "PhoenixKit.ScheduledJobs.Workers.ProcessScheduledJobsWorker"
+
+    @doc """
+    Ensures the crontab schedules `ProcessScheduledJobsWorker`.
+
+    Public for the same reason as `ensure_worker_cron_entries/2`: so it can be
+    unit-tested directly against content strings.
+    """
+    @spec ensure_cron_plugin(String.t(), atom() | String.t()) :: String.t()
+    def ensure_cron_plugin(content, app_name) do
       cond do
-        # Case 1: Old worker exists - REPLACE it with new worker
-        String.contains?(content, "PublishScheduledPostsJob") ->
+        # Case 1: the old worker is scheduled and the core worker is not.
+        # Rename it in place — the core worker's catch-up already calls
+        # PhoenixKitPosts.process_scheduled_posts/0, so it subsumes the entry.
+        Regex.match?(@old_posts_worker, content) and
+            not String.contains?(content, "ProcessScheduledJobsWorker") ->
           Mix.shell().info(
             "  🔄 Replacing PublishScheduledPostsJob with ProcessScheduledJobsWorker..."
           )
 
-          String.replace(
-            content,
-            "PhoenixKit.Posts.Workers.PublishScheduledPostsJob",
-            "PhoenixKit.ScheduledJobs.Workers.ProcessScheduledJobsWorker"
+          Regex.replace(@old_posts_worker, content, @new_worker)
+
+        # Case 1b: both are scheduled. Rewriting the old entry would leave two
+        # identical crontab lines, so say what is there and change nothing —
+        # the two are independently cronned callers of the same sweep, and
+        # which one to drop is the host's decision, not ours.
+        Regex.match?(@old_posts_worker, content) ->
+          Mix.shell().error(
+            "  ⚠️  Both PublishScheduledPostsJob and ProcessScheduledJobsWorker are in the crontab"
           )
+
+          Mix.shell().error(
+            "     They run the same posts sweep from different queues, so scheduled posts can be"
+          )
+
+          Mix.shell().error(
+            "     published twice. Remove the PublishScheduledPostsJob entry — the core worker"
+          )
+
+          Mix.shell().error("     already covers it via catchup_scheduled_posts/0.")
+
+          content
 
         # Case 2: Cron plugin exists with new worker - already configured
         String.contains?(content, "Oban.Plugins.Cron") and

--- a/lib/phoenix_kit/scheduled_jobs/workers/process_scheduled_jobs_worker.ex
+++ b/lib/phoenix_kit/scheduled_jobs/workers/process_scheduled_jobs_worker.ex
@@ -43,19 +43,14 @@ defmodule PhoenixKit.ScheduledJobs.Workers.ProcessScheduledJobsWorker do
 
   @impl Oban.Worker
   def perform(%Oban.Job{args: _args}) do
-    pending_jobs = ScheduledJobs.get_pending_jobs()
-    pending_count = length(pending_jobs)
-
-    if pending_count > 0 do
-      Logger.info("ProcessScheduledJobsWorker: Found #{pending_count} pending job(s) to process")
-
-      Enum.each(pending_jobs, fn job ->
-        Logger.debug(
-          "ProcessScheduledJobsWorker: Job #{job.id} - type=#{job.job_type}, resource=#{job.resource_type}/#{job.resource_uuid}, scheduled_at=#{job.scheduled_at}"
-        )
-      end)
-    end
-
+    # This used to announce the work before doing it, by running
+    # get_pending_jobs/0 a second time purely to log a count that the
+    # completion line below already reports — and logging `job.id`, a field
+    # ScheduledJob does not have: its key is `:uuid`. Logger.debug defers
+    # evaluation, so at :info the interpolation never ran and the mistake was
+    # invisible. At :debug it raised KeyError, and with max_attempts: 1 the
+    # sweep was discarded rather than retried, so a host with debug logging
+    # and one pending job simply never published anything.
     {:ok, stats} = ScheduledJobs.process_pending_jobs()
 
     if stats.executed > 0 or stats.failed > 0 do

--- a/test/integration/scheduled_jobs/process_scheduled_jobs_worker_test.exs
+++ b/test/integration/scheduled_jobs/process_scheduled_jobs_worker_test.exs
@@ -1,0 +1,74 @@
+defmodule PhoenixKit.Integration.ScheduledJobs.ProcessScheduledJobsWorkerTest do
+  use PhoenixKit.DataCase, async: false
+
+  alias PhoenixKit.ScheduledJobs.ScheduledJob
+  alias PhoenixKit.ScheduledJobs.Workers.ProcessScheduledJobsWorker
+
+  defmodule Handler do
+    @moduledoc false
+    @behaviour PhoenixKit.ScheduledJobs.Handler
+
+    @impl true
+    def job_type, do: "test_job"
+
+    @impl true
+    def resource_type, do: "test_resource"
+
+    @impl true
+    def execute(_resource_uuid, _args), do: :ok
+  end
+
+  setup do
+    level = Logger.level()
+    on_exit(fn -> Logger.configure(level: level) end)
+    :ok
+  end
+
+  # Inserted rather than scheduled: create_changeset/2 requires a future
+  # scheduled_at, and a job the sweep will pick up has to already be due.
+  defp due_job! do
+    Repo.insert!(%ScheduledJob{
+      job_type: "test_job",
+      # to_string/1, not inspect/1: execute_job/1 resolves this with
+      # String.to_existing_atom, so it needs the "Elixir."-prefixed form that
+      # schedule_job/5 writes.
+      handler_module: to_string(Handler),
+      resource_type: "test_resource",
+      resource_uuid: Ecto.UUID.generate(),
+      scheduled_at:
+        DateTime.utc_now() |> DateTime.add(-60, :second) |> DateTime.truncate(:second),
+      status: "pending"
+    })
+  end
+
+  describe "perform/1 with work waiting" do
+    test "runs at :debug — the level that used to kill the sweep" do
+      # Regression: perform/1 logged `job.id`, but ScheduledJob's key is
+      # `:uuid`. Logger.debug defers evaluation, so at :info the mistake was
+      # invisible; at :debug it raised KeyError before any work happened, and
+      # max_attempts: 1 discarded the sweep rather than retrying it — so a host
+      # on debug logging published nothing, silently, for as long as it ran.
+      job = due_job!()
+      Logger.configure(level: :debug)
+
+      assert :ok = ProcessScheduledJobsWorker.perform(%Oban.Job{args: %{}})
+
+      assert Repo.get(ScheduledJob, job.uuid).status == "executed"
+    end
+
+    test "runs at :info too" do
+      job = due_job!()
+      Logger.configure(level: :info)
+
+      assert :ok = ProcessScheduledJobsWorker.perform(%Oban.Job{args: %{}})
+
+      assert Repo.get(ScheduledJob, job.uuid).status == "executed"
+    end
+
+    test "runs at :debug with nothing pending" do
+      Logger.configure(level: :debug)
+
+      assert :ok = ProcessScheduledJobsWorker.perform(%Oban.Job{args: %{}})
+    end
+  end
+end

--- a/test/mix/tasks/phoenix_kit_doctor_test.exs
+++ b/test/mix/tasks/phoenix_kit_doctor_test.exs
@@ -57,4 +57,208 @@ defmodule Mix.Tasks.PhoenixKit.DoctorTest do
              ]) == 1
     end
   end
+
+  defmodule ScheduledWorker do
+    use Oban.Worker, queue: :scheduled_jobs
+
+    @impl Oban.Worker
+    def perform(_job), do: :ok
+  end
+
+  defmodule DefaultQueueWorker do
+    # No `queue:` — Oban.Job's own "default" applies.
+    use Oban.Worker
+
+    @impl Oban.Worker
+    def perform(_job), do: :ok
+  end
+
+  describe "check_cron_queues/1 — a crontab entry with no queue to run it" do
+    test "warns when a crontab worker's queue is not configured" do
+      # PhoenixKit's own 2025-12-28 → 1.7.63 bug, reproduced: the entry fires
+      # every minute, the queue it declares is absent, so each tick inserts a
+      # job that stays :available forever.
+      config = [
+        queues: [default: 10],
+        plugins: [{Oban.Plugins.Cron, crontab: [{"* * * * *", ScheduledWorker}]}]
+      ]
+
+      assert {:warn, message} = DoctorTask.check_cron_queues(config)
+      assert message =~ "ScheduledWorker"
+      assert message =~ "scheduled_jobs"
+    end
+
+    test "passes once the queue is configured" do
+      config = [
+        queues: [default: 10, scheduled_jobs: 1],
+        plugins: [{Oban.Plugins.Cron, crontab: [{"* * * * *", ScheduledWorker}]}]
+      ]
+
+      assert {:pass, _} = DoctorTask.check_cron_queues(config)
+    end
+
+    test "a worker declaring no queue is checked against 'default', not skipped" do
+      assert {:warn, message} =
+               DoctorTask.check_cron_queues(
+                 queues: [emails: 10],
+                 plugins: [{Oban.Plugins.Cron, crontab: [{"0 3 * * *", DefaultQueueWorker}]}]
+               )
+
+      assert message =~ "default"
+
+      assert {:pass, _} =
+               DoctorTask.check_cron_queues(
+                 queues: [default: 10],
+                 plugins: [{Oban.Plugins.Cron, crontab: [{"0 3 * * *", DefaultQueueWorker}]}]
+               )
+    end
+
+    test "an entry's own queue opt overrides the worker's, as Oban resolves it" do
+      # Cron merges the entry's opts over `worker.__opts__()`, so a worker
+      # declaring an unconfigured queue is fine when the entry redirects it —
+      # and reporting it would be a false positive.
+      assert {:pass, _} =
+               DoctorTask.check_cron_queues(
+                 queues: [default: 10],
+                 plugins: [
+                   {Oban.Plugins.Cron, crontab: [{"* * * * *", ScheduledWorker, queue: :default}]}
+                 ]
+               )
+    end
+
+    test "queues: false is a node that runs no jobs, not a misconfiguration" do
+      # Web-only and test nodes turn queues off wholesale; every entry would
+      # look orphaned. Warning there is a false positive by construction.
+      assert {:pass, message} =
+               DoctorTask.check_cron_queues(
+                 queues: false,
+                 plugins: [{Oban.Plugins.Cron, crontab: [{"* * * * *", ScheduledWorker}]}]
+               )
+
+      assert message =~ "runs no queues"
+    end
+
+    test "plugins: false means there is no cron to check" do
+      assert {:pass, message} =
+               DoctorTask.check_cron_queues(queues: [default: 10], plugins: false)
+
+      assert message =~ "plugins: false"
+    end
+
+    test "a module that is not an Oban worker is skipped rather than reported" do
+      # A crontab can name something doctor's VM cannot load. Guessing would
+      # report a healthy host as broken over a module we merely failed to
+      # resolve.
+      assert {:pass, _} =
+               DoctorTask.check_cron_queues(
+                 queues: [default: 10],
+                 plugins: [{Oban.Plugins.Cron, crontab: [{"* * * * *", NoSuchWorker.Nowhere}]}]
+               )
+    end
+
+    test "no Cron plugin, no crontab, and no Oban config at all are all clean" do
+      assert {:pass, _} = DoctorTask.check_cron_queues(queues: [default: 10], plugins: [])
+      assert {:pass, _} = DoctorTask.check_cron_queues(nil)
+
+      assert {:pass, _} =
+               DoctorTask.check_cron_queues(
+                 queues: [default: 10],
+                 plugins: [{Oban.Plugins.Cron, crontab: []}]
+               )
+    end
+
+    test "a top-level crontab: key is checked, not just the Cron plugin" do
+      # Oban still accepts `crontab:` directly on the Oban config and promotes
+      # it into a Cron plugin itself (Oban.Config.crontab_to_plugin/1). Reading
+      # only `plugins:` reported a clean bill of health on exactly the config
+      # this check exists to catch.
+      assert {:warn, message} =
+               DoctorTask.check_cron_queues(
+                 queues: [default: 10],
+                 crontab: [{"* * * * *", ScheduledWorker}]
+               )
+
+      assert message =~ "ScheduledWorker"
+    end
+
+    test "entries from a second Cron plugin are not lost" do
+      assert {:warn, message} =
+               DoctorTask.check_cron_queues(
+                 queues: [default: 10],
+                 plugins: [
+                   {Oban.Plugins.Cron, crontab: []},
+                   {Oban.Plugins.Cron, crontab: [{"* * * * *", ScheduledWorker}]}
+                 ]
+               )
+
+      assert message =~ "ScheduledWorker"
+    end
+
+    test "an empty queues list reads the same as queues: false" do
+      # Oban's own docs: "Using an empty list or `false` prevents any queues
+      # from starting on init." Treating them differently warned on one
+      # spelling of a deliberate web-only node and passed the other.
+      assert {:pass, message} =
+               DoctorTask.check_cron_queues(
+                 queues: [],
+                 plugins: [{Oban.Plugins.Cron, crontab: [{"* * * * *", ScheduledWorker}]}]
+               )
+
+      assert message =~ "runs no queues"
+    end
+
+    test "testing mode is not a misconfiguration" do
+      # `testing: :inline | :manual` makes Oban overwrite queues and plugins
+      # with [] itself, so no cron fires and nothing can accumulate.
+      for mode <- [:inline, :manual] do
+        assert {:pass, message} =
+                 DoctorTask.check_cron_queues(
+                   testing: mode,
+                   queues: [default: 10],
+                   plugins: [{Oban.Plugins.Cron, crontab: [{"* * * * *", ScheduledWorker}]}]
+                 )
+
+        assert message =~ "testing mode"
+      end
+
+      # :disabled is the real default and must still be checked.
+      assert {:warn, _} =
+               DoctorTask.check_cron_queues(
+                 testing: :disabled,
+                 queues: [default: 10],
+                 plugins: [{Oban.Plugins.Cron, crontab: [{"* * * * *", ScheduledWorker}]}]
+               )
+    end
+
+    test "the warning says what configuring the queue will release" do
+      # Draining is not free: the first sweep publishes every overdue
+      # scheduled post and sends every overdue broadcast. A host that reads
+      # only "add the queue" gets that as a surprise.
+      assert {:warn, message} =
+               DoctorTask.check_cron_queues(
+                 queues: [default: 10],
+                 plugins: [{Oban.Plugins.Cron, crontab: [{"* * * * *", ScheduledWorker}]}]
+               )
+
+      assert message =~ "backlog"
+      assert message =~ "cancel_all_jobs"
+    end
+
+    test "every offending worker is named, not just the first" do
+      assert {:warn, message} =
+               DoctorTask.check_cron_queues(
+                 queues: [emails: 10],
+                 plugins: [
+                   {Oban.Plugins.Cron,
+                    crontab: [
+                      {"* * * * *", ScheduledWorker},
+                      {"0 3 * * *", DefaultQueueWorker}
+                    ]}
+                 ]
+               )
+
+      assert message =~ "ScheduledWorker"
+      assert message =~ "DefaultQueueWorker"
+    end
+  end
 end

--- a/test/phoenix_kit/install/oban_config_test.exs
+++ b/test/phoenix_kit/install/oban_config_test.exs
@@ -403,6 +403,60 @@ defmodule PhoenixKit.Install.ObanConfigTest do
     end
   end
 
+  describe "ensure_cron_plugin/2 — migrating off the old posts worker" do
+    defp crontab_with(worker) do
+      """
+      config :my_app, Oban,
+        repo: MyApp.Repo,
+        queues: [default: 10],
+        plugins: [
+          {Oban.Plugins.Cron,
+           crontab: [
+             {"* * * * *", #{worker}}
+           ]}
+        ]
+      """
+    end
+
+    test "renames the real module, which the old literal never matched" do
+      # The replacement was "PhoenixKit.Posts.Workers.PublishScheduledPostsJob",
+      # a module in no repo; the real one is PhoenixKitPosts.Workers.…. The
+      # guard matched, the replace found nothing, and because this is cond's
+      # first clause it shadowed every later case — so the core worker was
+      # never added either.
+      content = crontab_with("PhoenixKitPosts.Workers.PublishScheduledPostsJob")
+      updated = ObanConfig.ensure_cron_plugin(content, "my_app")
+
+      refute updated =~ "PublishScheduledPostsJob"
+      assert updated =~ "PhoenixKit.ScheduledJobs.Workers.ProcessScheduledJobsWorker"
+      assert {:ok, _} = Code.string_to_quoted(updated)
+    end
+
+    test "leaves a host that already has both alone rather than duplicating" do
+      # Rewriting here would produce two identical crontab lines.
+      content = """
+      config :my_app, Oban,
+        repo: MyApp.Repo,
+        queues: [default: 10],
+        plugins: [
+          {Oban.Plugins.Cron,
+           crontab: [
+             {"* * * * *", PhoenixKitPosts.Workers.PublishScheduledPostsJob},
+             {"* * * * *", PhoenixKit.ScheduledJobs.Workers.ProcessScheduledJobsWorker}
+           ]}
+        ]
+      """
+
+      assert ObanConfig.ensure_cron_plugin(content, "my_app") == content
+    end
+
+    test "a host already on the core worker is untouched" do
+      content = crontab_with("PhoenixKit.ScheduledJobs.Workers.ProcessScheduledJobsWorker")
+
+      assert ObanConfig.ensure_cron_plugin(content, "my_app") == content
+    end
+  end
+
   describe "ensure_scheduled_jobs_queue/2" do
     # The exact shape a host installed between 2025-12-28 and 1.7.63 still has:
     # the per-minute cron entry present, the queue it fires into absent.

--- a/test/phoenix_kit/install/oban_config_test.exs
+++ b/test/phoenix_kit/install/oban_config_test.exs
@@ -403,6 +403,175 @@ defmodule PhoenixKit.Install.ObanConfigTest do
     end
   end
 
+  describe "ensure_scheduled_jobs_queue/2" do
+    # The exact shape a host installed between 2025-12-28 and 1.7.63 still has:
+    # the per-minute cron entry present, the queue it fires into absent.
+    @queueless_host """
+    config :my_app, Oban,
+      repo: MyApp.Repo,
+      queues: [
+        default: 10,
+        emails: 50
+      ],
+      plugins: [
+        {Oban.Plugins.Pruner, max_age: 60 * 60 * 24 * 30},
+        {Oban.Plugins.Cron,
+         crontab: [
+           {"* * * * *", PhoenixKit.ScheduledJobs.Workers.ProcessScheduledJobsWorker}
+         ]}
+      ]
+    """
+
+    test "adds the queue to a host whose crontab fires into it but never ran it" do
+      updated = ObanConfig.ensure_scheduled_jobs_queue(@queueless_host, "my_app")
+
+      assert updated =~ ~r/scheduled_jobs:\s*1/
+      assert {:ok, _} = Code.string_to_quoted(updated)
+    end
+
+    test "the crontab's worker reference alone does not count as the queue" do
+      # The regression that made this helper necessary: the entry naming
+      # PhoenixKit.ScheduledJobs.Workers.ProcessScheduledJobsWorker is already
+      # in the file. A looser check would read that as "configured" and leave
+      # the host exactly as broken as it was, silently.
+      refute @queueless_host =~ ~r/scheduled_jobs:\s*\d+/
+
+      assert ObanConfig.ensure_scheduled_jobs_queue(@queueless_host, "my_app") !=
+               @queueless_host
+    end
+
+    test "leaves an already-configured queue alone" do
+      configured = """
+      config :my_app, Oban,
+        repo: MyApp.Repo,
+        queues: [
+          default: 10,
+          scheduled_jobs: 1
+        ]
+      """
+
+      assert ObanConfig.ensure_scheduled_jobs_queue(configured, "my_app") == configured
+    end
+
+    test "does not double up when run twice" do
+      once = ObanConfig.ensure_scheduled_jobs_queue(@queueless_host, "my_app")
+      twice = ObanConfig.ensure_scheduled_jobs_queue(once, "my_app")
+
+      assert once == twice
+      assert length(Regex.scan(~r/scheduled_jobs:\s*\d+/, twice)) == 1
+    end
+
+    test "a queues block that already ends in a comma does not gain a second one" do
+      trailing = """
+      config :my_app, Oban,
+        repo: MyApp.Repo,
+        queues: [
+          default: 10,
+        ]
+      """
+
+      updated = ObanConfig.ensure_scheduled_jobs_queue(trailing, "my_app")
+
+      refute updated =~ ",,"
+      assert {:ok, _} = Code.string_to_quoted(updated)
+    end
+
+    test "leaves content untouched when there is no queues block to parse" do
+      no_queues = "config :my_app, Oban, repo: MyApp.Repo\n"
+
+      assert ObanConfig.ensure_scheduled_jobs_queue(no_queues, "my_app") == no_queues
+    end
+
+    test "a commented-out entry does not count as configured" do
+      # The nastiest shape available, because this function's own failure path
+      # prints "Please manually add: scheduled_jobs: 1" — so the line a host
+      # pastes in to remind itself is exactly what a whole-file match would
+      # read as "already done", leaving it broken with no output saying so.
+      commented = """
+      config :my_app, Oban,
+        queues: [
+          default: 10
+          # scheduled_jobs: 1
+        ]
+      """
+
+      updated = ObanConfig.ensure_scheduled_jobs_queue(commented, "my_app")
+
+      refute updated == commented
+      assert updated =~ ~r/^\s*scheduled_jobs: 1/m
+      assert {:ok, _} = Code.string_to_quoted(updated)
+    end
+
+    test "the keyword form of the queue counts as configured" do
+      # `scheduled_jobs: [limit: 1]` is the same queue. Appending a second
+      # entry gives the config a duplicate key, which parses — so nothing here
+      # would notice — and then Oban.Midwife's `{:ok, _} = start_queue(...)`
+      # raises on the second start and the host does not boot.
+      keyword_form = """
+      config :my_app, Oban,
+        queues: [
+          default: 10,
+          scheduled_jobs: [limit: 1]
+        ]
+      """
+
+      assert ObanConfig.ensure_scheduled_jobs_queue(keyword_form, "my_app") == keyword_form
+    end
+
+    test "never writes the queue into a neighbouring application's config" do
+      # An Oban block with no `queues:` of its own used to let the scan run
+      # past the end of the block and add the queue to whatever came next.
+      other_app = """
+      config :my_app, Oban,
+        repo: MyApp.Repo
+
+      config :other_app, OtherThing,
+        queues: [
+          alpha: 5
+        ]
+      """
+
+      assert ObanConfig.ensure_scheduled_jobs_queue(other_app, "my_app") == other_app
+    end
+
+    test "an entry with nested options keeps the insert at the outer level" do
+      # `default: [limit: 10]` is legal. Stopping at the first `]` would put
+      # the queue inside it, producing an option Oban rejects at boot — and
+      # the result parses, so only reading it catches the mistake.
+      nested = """
+      config :my_app, Oban,
+        queues: [
+          default: [
+            limit: 10
+          ],
+          emails: 50
+        ]
+      """
+
+      updated = ObanConfig.ensure_scheduled_jobs_queue(nested, "my_app")
+
+      assert {:ok, _} = Code.string_to_quoted(updated)
+
+      # Indentation is the tell: a sibling of `emails:` (4 spaces) is in the
+      # queues list; a sibling of `limit:` (6) is inside `default:`.
+      assert updated =~ ~r/^    emails: 50,\n    scheduled_jobs: 1$/m
+      assert updated =~ "default: [\n      limit: 10\n    ],"
+    end
+
+    test "an empty queues list is left alone rather than given a queue" do
+      # Oban documents `[]` as equivalent to `false` — "prevents any queues
+      # from starting on init". A node that says it runs nothing should not be
+      # handed a queue, and the old scan corrupted these anyway: `queues: []`
+      # ran on into the plugins block, and `queues: [\n]` wrote `queues: [,`.
+      for empty <- [
+            "config :my_app, Oban,\n  queues: [],\n  plugins: [\n    {Oban.Plugins.Pruner, max_age: 60}\n  ]\n",
+            "config :my_app, Oban,\n  queues: [\n  ]\n"
+          ] do
+        assert ObanConfig.ensure_scheduled_jobs_queue(empty, "my_app") == empty
+      end
+    end
+  end
+
   defp oban_worker?(module) do
     Code.ensure_loaded?(module) and
       function_exported?(module, :timeout, 1) and


### PR DESCRIPTION
Three fixes around the scheduled-jobs sweep. The first is a live outage; the other two are the config bug that started the investigation and a check so the class doesn't recur.

## 1. The sweep dies before doing any work, at `:debug`

`ProcessScheduledJobsWorker.perform/1` opened by announcing the work — running `get_pending_jobs/0` a second time purely to log a count, then logging one line per job using **`job.id`**. `ScheduledJob` has no `:id`; its key is `:uuid`.

`Logger.debug` defers evaluation, so at `:info` the interpolation never ran and the mistake stayed invisible. At `:debug` it raises `KeyError` **before** reaching `process_pending_jobs/0`, and the worker is `max_attempts: 1`, so Oban discards the sweep rather than retrying it.

**A host running debug logging with anything pending publishes nothing at all**, for as long as it runs, leaving only a discarded job behind.

The block is deleted rather than corrected: the count it logged is already covered by the completion line below it, and computing it cost a duplicate query of the same rows every minute. The regression test drives `perform/1` at `:debug` with a due job — the fatal combination.

## 2. Upgrading never added the `scheduled_jobs` queue

A cron entry inserts a job whether or not anything is configured to run it, and Oban only fetches for queues the node lists in `queues:`. A crontab worker whose queue is missing produces **one job per tick that stays `available` forever** — Pruner deletes terminal states only.

| When | What |
|---|---|
| 2025-12-28 (`6d34615a`) | `ProcessScheduledJobsWorker` crontab entry added — **without** the `:scheduled_jobs` queue it declares |
| 2026-03-05 00:19 UTC | **1.7.62 published** — still missing the queue |
| 2026-03-05 16:50 UTC (`22e2c492`) | Queue added to the fresh-install block |
| 2026-03-07 00:01 UTC | **1.7.63 published** with the fix |

**No upgrade repaired hosts installed in that window.** `update_existing_oban_config/3` — which `mix phoenix_kit.update` calls at `phoenix_kit.update.ex:385` — had an `ensure_*_queue` helper for six queues and none for this one. A host was found 15 days in with **21,337 jobs stuck in `available`**, growing ~1,440/day, having gone 1.7.62 → 1.7.214 → 1.7.225 without ever receiving the queue.

`ensure_scheduled_jobs_queue/2` fills the gap, and deliberately does not copy its siblings' regexes — review found six ways those misread a config, all reproduced before fixing:

- a commented-out `# scheduled_jobs: 1` satisfied the guard — badly, since the failure path prints that exact line for a host to paste in
- the keyword form `scheduled_jobs: [limit: 1]` was missed and duplicated. That parses, survives `normalize_queues/1`, then trips `Oban.Midwife`'s `{:ok, _} = start_queue(...)` — the host does not boot
- the insert could land inside a nested queue option, inside `plugins:`, or in a **neighbouring application's config**
- `queues: [\n]` produced `queues: [,`
- a list ending in a comment line took the separating comma *into* the comment

The block is now bounded by the next top-level `config`/`import_config`, and the closing bracket anchored to the `queues:` keyword's own indentation — the technique `ensure_lifeline_plugin/2` documents at `oban_config.ex:735`, having learned it the same way.

## 3. `mix phoenix_kit.doctor` — "Oban Cron Queues"

Repairing one queue fixes the instance; checking that *every* crontab worker has a queue to run in fixes the class, and reaches hosts that never re-run the installer. It resolves queues as Oban does (`Cron.build_changeset/4` merges the entry's opts over `worker.__opts__()`, falling back to Job's `"default"`), reads the top-level `crontab:` key since `Oban.Config.crontab_to_plugin/1` still promotes it, and stays quiet where a warning would be wrong: `queues: false`, `queues: []` and `testing: :inline | :manual` all mean this node runs no jobs.

Its warning says what taking the advice will do: configuring the queue releases the whole backlog at once, and that first sweep publishes every overdue scheduled post.

## Verification

- `mix precommit` → exit 0
- `mix test` against a real PostgreSQL → **3,389 tests, 0 failures, nothing excluded**
- 26 new tests, including a reproduction of every corruption case above

## Deliberately not in this PR

**`unique:` on `ProcessScheduledJobsWorker`** — investigated and deferred on evidence:

- `period: 60` **does not work**: Oban measures from `inserted_at`, so a worker cron'd every 60s falls outside the previous tick's window and still accumulates one row per minute (verified with `period: 1` and a 1.1s sleep).
- `states: :incomplete` works but adds a **permanent silent stall**: Lifeline is not an Oban default (`Oban.Config` ships `plugins: []`), it arrives only via our installer, while `unique:` would arrive via a plain `mix deps.update`. One OOM on a Lifeline-less host leaves an `executing` orphan nothing ever clears.
- `states: [:available, :scheduled]` avoids the stall but emits an unsuppressable `IO.warn` on every build of the dep (`job.ex:848` exempts only `[:scheduled]`).

**No atomic claim in `process_pending_jobs/0`** — `get_pending_jobs/1` is a plain `SELECT` and `execute_job/1` runs the handler before `mark_executed`, so overlapping sweeps double-execute. `handler_module` is a string resolved at runtime and the `Handler` behaviour is public, so this is real exposure for host-written handlers. Fixing it properly means an advisory lock at the `perform/1` boundary (session-level, gated on the existing `Environment.pooled?/2` — this repo already documents at `migrations/postgres.ex:1090` why the session form needs `try/after`), which deserves its own PR.

Also out of scope: `Igniter.Project.Config.configure/5` in place of the shared regex pattern, single-line `queues: [default: 10]` (still takes the manual-fix path, as with the six siblings), and counting `available` rows in doctor (kept `check_cron_queues/1` pure and unit-testable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)