### PR TITLE
Make slugs unique: V167, V168, and put_slug/3 in core

### DIFF
--- a/lib/modules/storage/schemas/file.ex
+++ b/lib/modules/storage/schemas/file.ex
@@ -240,7 +240,7 @@ defmodule PhoenixKit.Modules.Storage.File do
     |> validate_number(:height, greater_than: 0)
     |> validate_number(:duration, greater_than: 0)
     |> validate_system_managed_invariants()
-    |> foreign_key_constraint(:user_uuid)
+    |> foreign_key_constraint(:user_uuid, name: :fk_files_user_uuid)
     |> foreign_key_constraint(:folder_uuid)
     |> foreign_key_constraint(:parent_file_uuid)
     # V113's `phoenix_kit_files_system_dedup_index` keeps concurrent

--- a/lib/modules/storage/schemas/file_instance.ex
+++ b/lib/modules/storage/schemas/file_instance.ex
@@ -170,7 +170,7 @@ defmodule PhoenixKit.Modules.Storage.FileInstance do
     |> unique_constraint([:file_uuid, :variant_name],
       name: :phoenix_kit_file_instances_file_uuid_variant_name_index
     )
-    |> foreign_key_constraint(:file_uuid)
+    |> foreign_key_constraint(:file_uuid, name: :phoenix_kit_file_instances_file_id_fkey)
   end
 
   @doc """

--- a/lib/modules/storage/schemas/file_location.ex
+++ b/lib/modules/storage/schemas/file_location.ex
@@ -130,8 +130,10 @@ defmodule PhoenixKit.Modules.Storage.FileLocation do
     |> validate_required([:path, :file_instance_uuid, :bucket_uuid])
     |> validate_inclusion(:status, ["active", "syncing", "failed", "deleted"])
     |> validate_number(:priority, greater_than_or_equal_to: 0)
-    |> foreign_key_constraint(:file_instance_uuid)
-    |> foreign_key_constraint(:bucket_uuid)
+    |> foreign_key_constraint(:file_instance_uuid,
+      name: :phoenix_kit_file_locations_file_instance_id_fkey
+    )
+    |> foreign_key_constraint(:bucket_uuid, name: :phoenix_kit_file_locations_bucket_id_fkey)
   end
 
   @doc """

--- a/lib/phoenix_kit/migrations/expected_schema.ex
+++ b/lib/phoenix_kit/migrations/expected_schema.ex
@@ -105,7 +105,7 @@ defmodule PhoenixKit.Migrations.ExpectedSchema do
   @schema_token "__SCHEMA__"
   @name_marker_exempt "__PK_NAME_EXEMPT__"
   @name_marker_always "__PK_NAME_ALWAYS__"
-  @chain_hash "6330e1b97baba68b9f2ed03843a7f552c36d47b97fb2a948befa9e95e320932d"
+  @chain_hash "161db950897aa8ed8983659ce1e1321ecdf90cb5f145164aa01f832749b16fc4"
 
   def objects(prefix) do
     prefix = normalize_prefix!(prefix)
@@ -17519,7 +17519,7 @@ defmodule PhoenixKit.Migrations.ExpectedSchema do
           {:catalog,
            %{name: "phoenix_kit_tickets_slug_index", table: "phoenix_kit_tickets", kind: :index}},
         create:
-          "CREATE INDEX IF NOT EXISTS phoenix_kit_tickets_slug_index ON __SCHEMA__.phoenix_kit_tickets USING btree (slug)",
+          "CREATE UNIQUE INDEX IF NOT EXISTS phoenix_kit_tickets_slug_index ON __SCHEMA__.phoenix_kit_tickets USING btree (slug)",
         since: 35,
         class: :index,
         revisions: [
@@ -17531,6 +17531,23 @@ defmodule PhoenixKit.Migrations.ExpectedSchema do
              method: "btree",
              definition:
                "CREATE INDEX phoenix_kit_tickets_slug_index ON __SCHEMA__.phoenix_kit_tickets USING btree (slug)",
+             predicate: nil,
+             opclasses: ["text_ops"],
+             name_template: nil
+           }},
+          # Appended, never edited in place — the V167 rule. `Object.shape_at/2`
+          # takes the last revision <= the database's own version, so rewriting
+          # {35, ...} would tell every V167 install that its plain index is
+          # drift and offer a repair that cannot succeed, because the duplicate
+          # slugs V168 exists to clear are still sitting there.
+          {168,
+           %{
+             table: "phoenix_kit_tickets",
+             keys: ["slug"],
+             unique: true,
+             method: "btree",
+             definition:
+               "CREATE UNIQUE INDEX phoenix_kit_tickets_slug_index ON __SCHEMA__.phoenix_kit_tickets USING btree (slug)",
              predicate: nil,
              opclasses: ["text_ops"],
              name_template: nil
@@ -31183,6 +31200,44 @@ defmodule PhoenixKit.Migrations.ExpectedSchema do
                "CREATE INDEX phoenix_kit_post_groups_user_uuid_idx ON __SCHEMA__.phoenix_kit_post_groups USING btree (user_uuid)",
              predicate: nil,
              opclasses: ["uuid_ops"],
+             name_template: nil
+           }}
+        ],
+        presence: :required,
+        backfill: nil
+      },
+      # DECLARED POST-GENERATION (V168). New object rather than a reshape:
+      # `PhoenixKitPosts.PostGroup` has always declared
+      # `unique_constraint([:user_uuid, :slug], name:
+      # :phoenix_kit_post_groups_user_uuid_slug_index)`, but no index of that
+      # name has ever existed, so the constraint could never fire and one user
+      # could hold two groups on one slug. Scoped to the owner, not global —
+      # two different users may share a slug.
+      %{
+        id: "index:phoenix_kit_post_groups_user_uuid_slug_index",
+        owner: :core,
+        check:
+          {:catalog,
+           %{
+             name: "phoenix_kit_post_groups_user_uuid_slug_index",
+             table: "phoenix_kit_post_groups",
+             kind: :index
+           }},
+        create:
+          "CREATE UNIQUE INDEX IF NOT EXISTS phoenix_kit_post_groups_user_uuid_slug_index ON __SCHEMA__.phoenix_kit_post_groups USING btree (user_uuid, slug)",
+        since: 168,
+        class: :index,
+        revisions: [
+          {168,
+           %{
+             table: "phoenix_kit_post_groups",
+             keys: ["user_uuid", "slug"],
+             unique: true,
+             method: "btree",
+             definition:
+               "CREATE UNIQUE INDEX phoenix_kit_post_groups_user_uuid_slug_index ON __SCHEMA__.phoenix_kit_post_groups USING btree (user_uuid, slug)",
+             predicate: nil,
+             opclasses: ["uuid_ops", "text_ops"],
              name_template: nil
            }}
         ],

--- a/lib/phoenix_kit/migrations/expected_schema.ex
+++ b/lib/phoenix_kit/migrations/expected_schema.ex
@@ -105,7 +105,7 @@ defmodule PhoenixKit.Migrations.ExpectedSchema do
   @schema_token "__SCHEMA__"
   @name_marker_exempt "__PK_NAME_EXEMPT__"
   @name_marker_always "__PK_NAME_ALWAYS__"
-  @chain_hash "e65bb901dbcb35ab47d3ed36ba0b34fc5780a1bbb2dff7bf89ae8f75f03507f5"
+  @chain_hash "78dc50c67d775e4ddb5e89864f8dfb45079496ec30800b9e795ff0b6ec823cbe"
 
   def objects(prefix) do
     prefix = normalize_prefix!(prefix)

--- a/lib/phoenix_kit/migrations/expected_schema.ex
+++ b/lib/phoenix_kit/migrations/expected_schema.ex
@@ -105,7 +105,7 @@ defmodule PhoenixKit.Migrations.ExpectedSchema do
   @schema_token "__SCHEMA__"
   @name_marker_exempt "__PK_NAME_EXEMPT__"
   @name_marker_always "__PK_NAME_ALWAYS__"
-  @chain_hash "161db950897aa8ed8983659ce1e1321ecdf90cb5f145164aa01f832749b16fc4"
+  @chain_hash "e65bb901dbcb35ab47d3ed36ba0b34fc5780a1bbb2dff7bf89ae8f75f03507f5"
 
   def objects(prefix) do
     prefix = normalize_prefix!(prefix)
@@ -29252,7 +29252,22 @@ defmodule PhoenixKit.Migrations.ExpectedSchema do
           "ALTER TABLE __SCHEMA__.phoenix_kit_entity_data ADD COLUMN IF NOT EXISTS \"created_by_uuid\" uuid",
         since: 56,
         class: :column,
-        revisions: [{56, %{default: nil, type: "uuid", pos: 12, not_null: true}}],
+        # DECLARED POST-GENERATION CORRECTION (2026-08-14): a {169, not_null:
+        # false} revision. The public entity form is deliberately
+        # unauthenticated and has no creator to record, so anonymous submissions
+        # store NULL here (BeamLabEU/phoenix_kit#706). V169 drops the constraint;
+        # corrected here, in v135.ex's CREATE TABLE and in v164.ex's
+        # @relaxed_after_v57 together.
+        #
+        # A REVISION, not a rewrite of {56}: Scope resolves each object at the
+        # newest revision <= the database's comment, so claiming nullable from
+        # version 56 would make repair report a pre-V169 database — where the
+        # column is still legitimately NOT NULL — as wrong-shaped for the whole
+        # deploy window between shipping the code and running the migration.
+        revisions: [
+          {56, %{default: nil, type: "uuid", pos: 12, not_null: true}},
+          {169, %{default: nil, type: "uuid", pos: 12, not_null: false}}
+        ],
         presence: :required,
         backfill: nil
       },
@@ -33327,8 +33342,7 @@ defmodule PhoenixKit.Migrations.ExpectedSchema do
              table: "phoenix_kit_ai_requests",
              kind: :constraint
            }},
-        create:
-          "DO $$\nBEGIN\n  IF NOT EXISTS (\n    SELECT 1\n    FROM pg_constraint c\n    JOIN pg_class t ON t.oid = c.conrelid\n    JOIN pg_namespace n ON n.oid = t.relnamespace\n    WHERE c.conname = 'fk_ai_requests_prompt_uuid'\n      AND t.relname = 'phoenix_kit_ai_requests'\n      AND n.nspname = '__SCHEMA__'\n  ) THEN\n    ALTER TABLE __SCHEMA__.phoenix_kit_ai_requests ADD CONSTRAINT fk_ai_requests_prompt_uuid FOREIGN KEY (prompt_uuid) REFERENCES __SCHEMA__.phoenix_kit_ai_prompts(uuid) ON DELETE SET NULL;\n  END IF;\nEND\n$$",
+        create: nil,
         since: 56,
         class: :constraint,
         revisions: [
@@ -33345,7 +33359,21 @@ defmodule PhoenixKit.Migrations.ExpectedSchema do
              on_update: "a"
            }}
         ],
-        presence: :required,
+        # DECLARED POST-GENERATION CORRECTION (2026-08-14): `:legacy_optional`.
+        # v135 adds this FK twice under two names, each block guarded only by
+        # its own name, so a freshly migrated database ends up with BOTH this
+        # and `phoenix_kit_ai_requests_prompt_uuid_fkey` (BeamLabEU/phoenix_kit_ai#20).
+        # V169 drops this one and keeps the legacy name, which is what the
+        # installed base carries and what Ecto derives by default, so no live
+        # database needs a rename.
+        #
+        # Optional rather than deleted, because a pre-169 install still
+        # legitimately has it. Required would make repair RE-ADD the duplicate
+        # after every upgrade, and on legacy-only installs ADD a second
+        # constraint that was never there. `create: nil` above is what
+        # legacy_optional requires — repair must hold no SQL for an object it
+        # may not create.
+        presence: :legacy_optional,
         backfill: nil
       },
       %{

--- a/lib/phoenix_kit/migrations/expected_schema.ex
+++ b/lib/phoenix_kit/migrations/expected_schema.ex
@@ -55,6 +55,14 @@ defmodule PhoenixKit.Migrations.ExpectedSchema do
   # files. `verify.exs --scenario s7,s8` against a real database is still
   # what proves the body.
   #
+  # V167 is carried the same way, and is the first of these to RESHAPE an
+  # existing object rather than add one: `index:phoenix_kit_posts_slug_index`
+  # gains a `{167, ...}` revision flipping `unique` to true. The revision is
+  # APPENDED — `Object.shape_at/2` takes the last revision at or below the
+  # database's version, so editing `{29, ...}` in place would tell every V166
+  # install its plain index is drift and offer a repair that cannot run,
+  # because the duplicate slugs V167 exists to clear are still there.
+  #
   # Chain at generation: object/revision/legacy_optional DATA was captured from a
   # per-version replay of the TRUE pre-squash chain (initial=1 current=163 files=163
   # — the only run that can see pre-floor-only bimodal drift, e.g. V28/V30's
@@ -97,7 +105,7 @@ defmodule PhoenixKit.Migrations.ExpectedSchema do
   @schema_token "__SCHEMA__"
   @name_marker_exempt "__PK_NAME_EXEMPT__"
   @name_marker_always "__PK_NAME_ALWAYS__"
-  @chain_hash "596fca593c6972b65718d3ad6b44fe323ac1b92aeeebf8a42e3baed20dc6fb85"
+  @chain_hash "6330e1b97baba68b9f2ed03843a7f552c36d47b97fb2a948befa9e95e320932d"
 
   def objects(prefix) do
     prefix = normalize_prefix!(prefix)
@@ -10169,7 +10177,7 @@ defmodule PhoenixKit.Migrations.ExpectedSchema do
           {:catalog,
            %{name: "phoenix_kit_posts_slug_index", table: "phoenix_kit_posts", kind: :index}},
         create:
-          "CREATE INDEX IF NOT EXISTS phoenix_kit_posts_slug_index ON __SCHEMA__.phoenix_kit_posts USING btree (slug)",
+          "CREATE UNIQUE INDEX IF NOT EXISTS phoenix_kit_posts_slug_index ON __SCHEMA__.phoenix_kit_posts USING btree (slug)",
         since: 29,
         class: :index,
         revisions: [
@@ -10181,6 +10189,23 @@ defmodule PhoenixKit.Migrations.ExpectedSchema do
              method: "btree",
              definition:
                "CREATE INDEX phoenix_kit_posts_slug_index ON __SCHEMA__.phoenix_kit_posts USING btree (slug)",
+             predicate: nil,
+             opclasses: ["text_ops"],
+             name_template: nil
+           }},
+          # Appended, never edited in place. `Object.shape_at/2` takes the last
+          # revision <= the database's own version, so rewriting {29, ...}
+          # would tell every V166 install that its plain index is drift — and
+          # offer a repair that cannot succeed, because the duplicates the
+          # migration exists to clear are still sitting there.
+          {167,
+           %{
+             table: "phoenix_kit_posts",
+             keys: ["slug"],
+             unique: true,
+             method: "btree",
+             definition:
+               "CREATE UNIQUE INDEX phoenix_kit_posts_slug_index ON __SCHEMA__.phoenix_kit_posts USING btree (slug)",
              predicate: nil,
              opclasses: ["text_ops"],
              name_template: nil

--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -7,7 +7,22 @@ defmodule PhoenixKit.Migrations.Postgres do
 
   ## Migration Versions
 
-  ### V167 - Unique post slugs ⚡ LATEST
+  ### V168 - The remaining slug indexes ⚡ LATEST
+
+  Finishes what V167 started. An audit of every schema declaring a slug
+  `unique_constraint/3` found two more with nothing to translate:
+  `phoenix_kit_tickets` (plain btree since V135, while `Ticket` declares
+  `unique_constraint(:slug)` and `get_ticket_by_slug/2` fetches with
+  `one()`) and `phoenix_kit_post_groups` (no slug index at all, while
+  `PostGroup` names a composite `[:user_uuid, :slug]` index that exists
+  nowhere). The other six were already backed correctly.
+
+  Post-group slugs are unique **per user**, so that index is on
+  `(user_uuid, slug)` and the dedup partitions by the pair. Existing
+  duplicates are suffixed `-2`, `-3` … following `Slug.ensure_unique/2`,
+  the oldest row keeping the bare slug.
+
+  ### V167 - Unique post slugs
 
   Makes `phoenix_kit_posts_slug_index` unique. It had been a plain btree
   since V135 while its sibling `phoenix_kit_post_tags.slug` was unique, so
@@ -469,7 +484,7 @@ defmodule PhoenixKit.Migrations.Postgres do
   alias PhoenixKit.Migrations.Repair.Environment
 
   @initial_version 135
-  @current_version 167
+  @current_version 168
   @default_prefix "public"
 
   # The frozen pre-squash bridge: the last 1.7.x release, which still carries

--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -7,7 +7,22 @@ defmodule PhoenixKit.Migrations.Postgres do
 
   ## Migration Versions
 
-  ### V168 - The remaining slug indexes ⚡ LATEST
+  ### V169 - Anonymous entity submissions, and one duplicate foreign key ⚡ LATEST
+
+  Makes `phoenix_kit_entity_data.created_by_uuid` nullable: the public entity
+  form is deliberately unauthenticated and has no creator to record, so on a
+  freshly migrated database every anonymous submission failed with a
+  `not_null_violation`. Long-lived installs were already storing NULL there.
+  Recorded in V164's `@relaxed_after_v57` and in the V135 baseline so repair and
+  a fresh install agree with it.
+
+  Also drops the duplicate foreign key V135 created on
+  `phoenix_kit_ai_requests.prompt_uuid`, keeping the legacy
+  `phoenix_kit_ai_requests_prompt_uuid_fkey` — the name the installed base
+  carries and the one Ecto derives by default — so no live database needs a
+  rename.
+
+  ### V168 - The remaining slug indexes
 
   Finishes what V167 started. An audit of every schema declaring a slug
   `unique_constraint/3` found two more with nothing to translate:
@@ -484,7 +499,7 @@ defmodule PhoenixKit.Migrations.Postgres do
   alias PhoenixKit.Migrations.Repair.Environment
 
   @initial_version 135
-  @current_version 168
+  @current_version 169
   @default_prefix "public"
 
   # The frozen pre-squash bridge: the last 1.7.x release, which still carries

--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -7,7 +7,20 @@ defmodule PhoenixKit.Migrations.Postgres do
 
   ## Migration Versions
 
-  ### V166 - Frozen comment attribution ⚡ LATEST
+  ### V167 - Unique post slugs ⚡ LATEST
+
+  Makes `phoenix_kit_posts_slug_index` unique. It had been a plain btree
+  since V135 while its sibling `phoenix_kit_post_tags.slug` was unique, so
+  `Post`'s `unique_constraint(:slug)` had no index to translate and
+  `get_post_by_slug/2` — which fetches with `one()` — raised
+  `Ecto.MultipleResultsError` on any URL two posts shared.
+
+  Existing duplicates are suffixed `-2`, `-3` … following
+  `Slug.ensure_unique/2`, keeping the reachable post over a draft and then
+  the oldest. Two *live* posts on one slug raises instead: one of them has
+  to lose a working URL, and that is the operator's call.
+
+  ### V166 - Frozen comment attribution
 
   Adds `author_display_name`, `attribution_mode`, `attributed_project_uuid`
   and `attributed_label` to `phoenix_kit_comments`. A name resolved at
@@ -456,7 +469,7 @@ defmodule PhoenixKit.Migrations.Postgres do
   alias PhoenixKit.Migrations.Repair.Environment
 
   @initial_version 135
-  @current_version 166
+  @current_version 167
   @default_prefix "public"
 
   # The frozen pre-squash bridge: the last 1.7.x release, which still carries

--- a/lib/phoenix_kit/migrations/postgres/v135.ex
+++ b/lib/phoenix_kit/migrations/postgres/v135.ex
@@ -312,7 +312,7 @@ defmodule PhoenixKit.Migrations.Postgres.V135 do
       "date_created" timestamp with time zone DEFAULT now() NOT NULL,
       "date_updated" timestamp with time zone DEFAULT now() NOT NULL,
       "uuid" uuid DEFAULT #{p}uuid_generate_v7() NOT NULL,
-      "created_by_uuid" uuid NOT NULL,
+      "created_by_uuid" uuid,
       "entity_uuid" uuid NOT NULL,
       "position" integer,
       "parent_uuid" uuid

--- a/lib/phoenix_kit/migrations/postgres/v164.ex
+++ b/lib/phoenix_kit/migrations/postgres/v164.ex
@@ -213,7 +213,14 @@ defmodule PhoenixKit.Migrations.Postgres.V164 do
     # deletion works today; enforcing NOT NULL would newly break it. Left
     # nullable until the chain resolves which of the two declarations is
     # wrong (`uuid_fk_columns_test.exs` asserts no OTHER pair contradicts).
-    {:phoenix_kit_ticket_status_history, "changed_by_uuid"}
+    {:phoenix_kit_ticket_status_history, "changed_by_uuid"},
+    # V169 (v169.ex): the public entity form is deliberately unauthenticated
+    # and has no creator to record, so anonymous submissions store NULL here.
+    # Re-imposing NOT NULL would make every one of them fail again with the
+    # `not_null_violation` V167 exists to end (BeamLabEU/phoenix_kit#706). The
+    # column carries no FK to `phoenix_kit_users` on any install, so nothing
+    # downstream assumed a real user either.
+    {:phoenix_kit_entity_data, "created_by_uuid"}
   ]
 
   @doc false

--- a/lib/phoenix_kit/migrations/postgres/v167.ex
+++ b/lib/phoenix_kit/migrations/postgres/v167.ex
@@ -1,0 +1,174 @@
+defmodule PhoenixKit.Migrations.Postgres.V167 do
+  @moduledoc """
+  V167: post slugs are unique, and the index finally says so.
+
+  ## The gap
+
+  `phoenix_kit_posts.slug` has carried a plain btree since V135, while its
+  sibling `phoenix_kit_post_tags.slug` has been unique the whole time. Two
+  things downstream assume the uniqueness that was never enforced:
+  `PhoenixKitPosts.Post` declares `unique_constraint(:slug)`, which had no
+  index to translate and so could never fire, and `get_post_by_slug/2` fetches
+  with `repo().one()` — which raises `Ecto.MultipleResultsError` the moment two
+  rows share a slug. A duplicate therefore did not degrade that URL, it broke
+  it, and the error surfaced far from the save that caused it.
+
+  Nothing was stopping duplicates either: two posts titled the same slugified
+  identically and both were written. That generation gap is fixed in
+  `phoenix_kit_posts` (it now calls `PhoenixKit.Utils.Slug.ensure_unique/2`),
+  but that check is advisory — it probes, then writes, and it falls back to the
+  unsuffixed slug if the repo is unreachable. Only this index closes it.
+
+  ## Renaming rows, and the line this will not cross
+
+  Existing installs may already hold duplicates, and a unique index cannot be
+  created over them. Extras are suffixed `-2`, `-3` … until free, which is the
+  same rule `Slug.ensure_unique/2` applies at runtime — so the repair produces
+  exactly what the application would have, and is auditable against it.
+
+  Renaming a slug moves a URL, so the keeper is chosen to make that as
+  survivable as possible: a publicly reachable post outranks a draft, then the
+  oldest wins, then uuid breaks the tie. `timestamps(type: :utc_datetime)`
+  stores whole seconds with no DB default, so ties are ordinary rather than
+  theoretical, and without the uuid the choice would be arbitrary per run.
+
+  **Two live posts sharing a slug raises instead.** One of them has to lose a
+  working public URL, and which one is an editorial decision that belongs to
+  whoever runs the site — not to an upgrade running unattended. V161 sets the
+  precedent: refuse, and name the value. Drafts are suffixed silently because
+  a draft has no URL anyone can have linked.
+
+  ## Why `IF NOT EXISTS` is not enough on its own
+
+  `CREATE UNIQUE INDEX IF NOT EXISTS` matches on the index NAME only. Against
+  the existing non-unique `phoenix_kit_posts_slug_index` it emits "relation
+  already exists, skipping" and leaves it non-unique — duplicates keep
+  inserting, and the migration reports success. Verified against PostgreSQL 17.
+  The explicit `DROP` below is load-bearing, not tidiness.
+
+  The name is kept deliberately. `Post` declares a bare
+  `unique_constraint(:slug)`, so Ecto infers `phoenix_kit_posts_slug_index`;
+  renaming the index would silently stop that constraint translating and turn
+  a friendly validation error back into a raw `Postgrex.Error`.
+
+  No `CONCURRENTLY`: a fresh install runs this chain inside a transaction, and
+  `v163_uuid_integrity_test.exs` asserts the chain never emits it.
+
+  `phoenix_kit_post_groups` is deliberately untouched — its schema declares a
+  composite `[:user_uuid, :slug]` constraint, so a global unique would be
+  wrong there, and it is a separate missing index.
+  """
+
+  use Ecto.Migration
+
+  def up(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    # Bounded rather than indefinite: this takes an ACCESS EXCLUSIVE lock to
+    # swap the index, and a migration that waits forever behind a long read is
+    # a silent hang with nothing printed (V163 precedent).
+    execute("SET lock_timeout = '5000ms'")
+
+    execute("""
+    DO $$
+    DECLARE
+      g RECORD;
+      r RECORD;
+      suffix text;
+      base text;
+      candidate text;
+      n int;
+    BEGIN
+      -- Refuse before rewriting anything: two reachable posts on one slug is
+      -- an editorial call, and this runs unattended.
+      FOR g IN
+        SELECT slug,
+               count(*) FILTER (
+                 WHERE status IN ('public', 'unlisted', 'scheduled')) AS live_n
+          FROM #{p}phoenix_kit_posts
+         GROUP BY slug
+        HAVING count(*) > 1
+      LOOP
+        IF g.live_n > 1 THEN
+          RAISE EXCEPTION
+            'Cannot apply V167: slug % is shared by % live posts. Give one of them a different slug, then upgrade.',
+            g.slug, g.live_n;
+        END IF;
+      END LOOP;
+
+      FOR r IN
+        SELECT uuid, slug FROM (
+          SELECT uuid,
+                 slug,
+                 row_number() OVER (
+                   PARTITION BY slug
+                   ORDER BY CASE
+                              WHEN status IN ('public', 'unlisted', 'scheduled') THEN 0
+                              ELSE 1
+                            END,
+                            inserted_at ASC,
+                            uuid ASC) AS rn
+            FROM #{p}phoenix_kit_posts) ranked
+         WHERE rn > 1
+         ORDER BY slug, rn
+      LOOP
+        n := 2;
+
+        LOOP
+          suffix := '-' || n;
+
+          -- slug is varchar(255) and Postgres ERRORS on overflow rather than
+          -- truncating, so the base is trimmed to leave room for the suffix.
+          -- The trailing-dash strip stops "foo-" || "-2".
+          base := regexp_replace(left(r.slug, 255 - length(suffix)), '-+$', '');
+          candidate := base || suffix;
+
+          -- Probes every slug, not just this group's, so an unrelated post
+          -- already holding "foo-2" pushes this one to "foo-3".
+          EXIT WHEN NOT EXISTS (
+            SELECT 1 FROM #{p}phoenix_kit_posts WHERE slug = candidate);
+
+          n := n + 1;
+        END LOOP;
+
+        RAISE NOTICE 'V167: post % slug % -> %', r.uuid, r.slug, candidate;
+
+        UPDATE #{p}phoenix_kit_posts SET slug = candidate WHERE uuid = r.uuid;
+      END LOOP;
+    END $$;
+    """)
+
+    # See the moduledoc: IF NOT EXISTS matches by name, so without this the
+    # CREATE below is a no-op that stamps the bug as fixed.
+    execute("DROP INDEX IF EXISTS #{p}phoenix_kit_posts_slug_index")
+
+    execute("""
+    CREATE UNIQUE INDEX IF NOT EXISTS phoenix_kit_posts_slug_index
+      ON #{p}phoenix_kit_posts USING btree (slug)
+    """)
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '167'")
+  end
+
+  def down(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    # Lossy, and says so. The index reverts; the slugs this migration
+    # suffixed do not, because the rows they were taken from are gone as far
+    # as this direction can tell. Restoring them would need the original
+    # values, which nothing records (V151 precedent for a one-way repair).
+    execute("DROP INDEX IF EXISTS #{p}phoenix_kit_posts_slug_index")
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS phoenix_kit_posts_slug_index
+      ON #{p}phoenix_kit_posts USING btree (slug)
+    """)
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '166'")
+  end
+
+  defp prefix_str("public"), do: "public."
+  defp prefix_str(prefix), do: "#{prefix}."
+end

--- a/lib/phoenix_kit/migrations/postgres/v168.ex
+++ b/lib/phoenix_kit/migrations/postgres/v168.ex
@@ -40,6 +40,18 @@ defmodule PhoenixKit.Migrations.Postgres.V168 do
   generated slug — but "unlikely" is not a thing to bet a migration on, and that same
   timestamp is being deleted by the changeset work this migration accompanies.
 
+  ## Why tickets rename silently where V167 refused
+
+  V167 raises when two *live* posts share a slug; this migration suffixes duplicate
+  ticket slugs without asking. That is deliberate, not drift. A duplicated slug means
+  `get_ticket_by_slug/2` raises `Ecto.MultipleResultsError` on **every** request for
+  it — both tickets' URLs are already broken — so renaming the newer one strictly
+  improves things: the older URL starts working again and the newer ticket gets a
+  slug that resolves. Refusing would block the whole upgrade to ask an operator about
+  a URL that is already dead. Posts earned the refusal because *which* post keeps a
+  slug is an editorial and SEO identity question; between two support tickets,
+  oldest-wins has no second defensible answer.
+
   ## Why not CONCURRENTLY
 
   It is *available* — the wrappers this chain runs under are generated with

--- a/lib/phoenix_kit/migrations/postgres/v168.ex
+++ b/lib/phoenix_kit/migrations/postgres/v168.ex
@@ -1,0 +1,212 @@
+defmodule PhoenixKit.Migrations.Postgres.V168 do
+  @moduledoc """
+  V168: the two remaining slug `unique_constraint/3` declarations get an index.
+
+  ## The gap
+
+  V167 did this for `phoenix_kit_posts`. An audit of every schema that declares a
+  slug `unique_constraint/3` found exactly two more where the constraint has nothing
+  to translate, and six where it is already backed correctly
+  (`phoenix_kit_doc_templates_slug_index`, `phoenix_kit_ai_prompts_slug_uidx`,
+  `phoenix_kit_bookings_services_slug_index`,
+  `phoenix_kit_shop_shipping_methods_slug_unique`, `idx_publishing_groups_slug`,
+  `phoenix_kit_post_tags_slug_index`). This migration is the whole remainder, not a
+  sample of it.
+
+    * **`phoenix_kit_tickets`** carries a plain btree from V135
+      (`v135.ex:2842`), while `PhoenixKitCustomerSupport.Ticket` declares
+      `unique_constraint(:slug)` (`ticket.ex:173`) and `get_ticket_by_slug/2`
+      fetches with `repo().one()` — which raises `Ecto.MultipleResultsError`, not a
+      changeset error, the moment two tickets share a slug.
+
+    * **`phoenix_kit_post_groups`** has no slug index of any kind. Its schema
+      declares a COMPOSITE `unique_constraint([:user_uuid, :slug], name:
+      :phoenix_kit_post_groups_user_uuid_slug_index)` (`post_group.ex:141`) naming an
+      index that exists nowhere, so a user can hold two groups on one slug and
+      `unique_constraint` never fires.
+
+  ## Scoped, not global
+
+  Post-group slugs are unique **per user**, so the index is on `(user_uuid, slug)`
+  and the dedup partitions by the pair. A global unique here would reject one user
+  taking a slug another user already has, which is not what the schema asks for and
+  would break existing data.
+
+  ## Why the dedup runs first
+
+  `CREATE UNIQUE INDEX` fails outright on existing duplicates, so the rows are
+  repaired before the index is built. Tickets are unlikely to have duplicates in
+  practice — `ticket.ex:250` appends a millisecond-derived timestamp to every
+  generated slug — but "unlikely" is not a thing to bet a migration on, and that same
+  timestamp is being deleted by the changeset work this migration accompanies.
+
+  ## Why not CONCURRENTLY
+
+  It is *available* — the wrappers this chain runs under are generated with
+  `@disable_ddl_transaction true` (see `PhoenixKit.Migrations.Postgres`, the note
+  above the advisory lock), so there is no enclosing transaction to forbid it. It is
+  still the wrong choice here:
+
+    * A failed `CREATE UNIQUE INDEX CONCURRENTLY` leaves an **INVALID** index behind
+      rather than nothing. `IF NOT EXISTS` then matches it **by name**, so the next
+      run is a silent no-op that stamps the bug as fixed while uniqueness is still
+      unenforced — the exact trap V167's moduledoc documents for the non-concurrent
+      case, made worse by leaving a plausible-looking index in `\\di`.
+    * It cannot run inside the `DO $$` block the dedup needs, so the two halves could
+      not be kept adjacent.
+
+  A bounded `lock_timeout` is the V163/V167 answer to the lock this takes: fail loudly
+  and quickly rather than hang unattended behind a long read.
+  """
+
+  use Ecto.Migration
+
+  def up(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    # Bounded rather than indefinite: this takes an ACCESS EXCLUSIVE lock to swap the
+    # index, and a migration that waits forever behind a long read is a silent hang
+    # with nothing printed (V163 precedent).
+    execute("SET lock_timeout = '5000ms'")
+
+    dedup_tickets(p)
+    dedup_post_groups(p)
+
+    # IF NOT EXISTS matches by NAME, so creating the unique index without dropping the
+    # non-unique one of the same name is a no-op that reports success. V167 hit this.
+    execute("DROP INDEX IF EXISTS #{p}phoenix_kit_tickets_slug_index")
+
+    execute("""
+    CREATE UNIQUE INDEX IF NOT EXISTS phoenix_kit_tickets_slug_index
+      ON #{p}phoenix_kit_tickets USING btree (slug)
+    """)
+
+    # Named exactly as post_group.ex:141 declares it; Ecto matches the constraint to
+    # the index by name, so a different name here would leave the bug in place.
+    execute("""
+    CREATE UNIQUE INDEX IF NOT EXISTS phoenix_kit_post_groups_user_uuid_slug_index
+      ON #{p}phoenix_kit_post_groups USING btree (user_uuid, slug)
+    """)
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '168'")
+  end
+
+  def down(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    # Lossy, and says so. The indexes revert; the slugs this migration suffixed do
+    # not, because nothing records the values they replaced (V151/V167 precedent for
+    # a one-way repair).
+    execute("DROP INDEX IF EXISTS #{p}phoenix_kit_post_groups_user_uuid_slug_index")
+    execute("DROP INDEX IF EXISTS #{p}phoenix_kit_tickets_slug_index")
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS phoenix_kit_tickets_slug_index
+      ON #{p}phoenix_kit_tickets USING btree (slug)
+    """)
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '167'")
+  end
+
+  # Oldest row keeps the bare slug; every later collision is suffixed -2, -3, … past
+  # whatever is already taken, matching `PhoenixKit.Utils.Slug.ensure_unique/2` so a
+  # repaired row and a freshly generated one agree on the rule.
+  defp dedup_tickets(p) do
+    execute("""
+    DO $$
+    DECLARE
+      r RECORD;
+      suffix text;
+      base text;
+      candidate text;
+      n int;
+    BEGIN
+      FOR r IN
+        SELECT uuid, slug FROM (
+          SELECT uuid,
+                 slug,
+                 row_number() OVER (
+                   PARTITION BY slug
+                   ORDER BY inserted_at ASC, uuid ASC) AS rn
+            FROM #{p}phoenix_kit_tickets) ranked
+         WHERE rn > 1
+         ORDER BY slug, rn
+      LOOP
+        n := 2;
+
+        LOOP
+          suffix := '-' || n;
+
+          -- slug is varchar(255) and Postgres ERRORS on overflow rather than
+          -- truncating, so the base is trimmed to leave room for the suffix. The
+          -- trailing-dash strip stops "foo-" || "-2".
+          base := regexp_replace(left(r.slug, 255 - length(suffix)), '-+$', '');
+          candidate := base || suffix;
+
+          EXIT WHEN NOT EXISTS (
+            SELECT 1 FROM #{p}phoenix_kit_tickets WHERE slug = candidate);
+
+          n := n + 1;
+        END LOOP;
+
+        RAISE NOTICE 'V168: ticket % slug % -> %', r.uuid, r.slug, candidate;
+
+        UPDATE #{p}phoenix_kit_tickets SET slug = candidate WHERE uuid = r.uuid;
+      END LOOP;
+    END $$;
+    """)
+  end
+
+  # Same rule, partitioned by the OWNER as well as the slug: two users may hold the
+  # same slug, so only a repeat within one `user_uuid` is a duplicate. The free-slug
+  # probe is scoped to that user for the same reason.
+  defp dedup_post_groups(p) do
+    execute("""
+    DO $$
+    DECLARE
+      r RECORD;
+      suffix text;
+      base text;
+      candidate text;
+      n int;
+    BEGIN
+      FOR r IN
+        SELECT uuid, user_uuid, slug FROM (
+          SELECT uuid,
+                 user_uuid,
+                 slug,
+                 row_number() OVER (
+                   PARTITION BY user_uuid, slug
+                   ORDER BY inserted_at ASC, uuid ASC) AS rn
+            FROM #{p}phoenix_kit_post_groups) ranked
+         WHERE rn > 1
+         ORDER BY user_uuid, slug, rn
+      LOOP
+        n := 2;
+
+        LOOP
+          suffix := '-' || n;
+          base := regexp_replace(left(r.slug, 255 - length(suffix)), '-+$', '');
+          candidate := base || suffix;
+
+          EXIT WHEN NOT EXISTS (
+            SELECT 1 FROM #{p}phoenix_kit_post_groups
+             WHERE user_uuid = r.user_uuid AND slug = candidate);
+
+          n := n + 1;
+        END LOOP;
+
+        RAISE NOTICE 'V168: post group % (user %) slug % -> %',
+          r.uuid, r.user_uuid, r.slug, candidate;
+
+        UPDATE #{p}phoenix_kit_post_groups SET slug = candidate WHERE uuid = r.uuid;
+      END LOOP;
+    END $$;
+    """)
+  end
+
+  defp prefix_str("public"), do: "public."
+  defp prefix_str(prefix), do: "#{prefix}."
+end

--- a/lib/phoenix_kit/migrations/postgres/v169.ex
+++ b/lib/phoenix_kit/migrations/postgres/v169.ex
@@ -1,0 +1,206 @@
+defmodule PhoenixKit.Migrations.Postgres.V169 do
+  @moduledoc """
+  V169: anonymous entity submissions, and one duplicate foreign key.
+
+  ## `phoenix_kit_entity_data.created_by_uuid` becomes nullable
+
+  The public entity form is deliberately unauthenticated — that is the feature.
+  It has nothing to put in `created_by_uuid`, and the column was NOT NULL, so on
+  a freshly migrated database every anonymous submission died with a
+  `not_null_violation` raised out of an unauthenticated controller
+  (BeamLabEU/phoenix_kit#706).
+
+  The two databases already disagreed about this. A long-lived install measured
+  `is_nullable = YES` with 4 NULL rows out of 26, because V164 declines to
+  re-impose NOT NULL while NULLs exist; a freshly migrated one measured
+  `is_nullable = NO`, matching the source. Production had been storing anonymous
+  submissions as NULL for some time and nothing had noticed — the consumers
+  already guard for a missing creator (`data_navigator` renders
+  `creator.email` only `if data_record.creator`).
+
+  Nullable is the honest resolution of that split rather than a concession:
+
+    * the column has **no foreign key** to `phoenix_kit_users` on any install
+      (measured on both), so the invariant was never "a real user" — only "some
+      UUID". The sister `created_by_uuid` columns that DO carry an FK are
+      nullable with `ON DELETE SET NULL`;
+    * the alternative — auto-filling the first Owner — puts a named person's
+      address in front of every anonymous submission wherever a creator is
+      rendered, and files those submissions in that person's audit trail.
+      "Submitted by nobody" is a fact; attributing it to an administrator is
+      not.
+
+  Recorded in `V164`'s `@relaxed_after_v57` and corrected in `v135.ex`'s CREATE
+  TABLE, so repair and a fresh install agree with this migration instead of
+  fighting it — the same three-place treatment
+  `phoenix_kit_users_tokens.user_uuid` got.
+
+  ## `phoenix_kit_ai_requests.prompt_uuid` loses its duplicate FK
+
+  `v135` adds this FK twice under two names, each block guarded only by its own
+  name, so a freshly migrated database ends up with both
+  (`fk_ai_requests_prompt_uuid` and
+  `phoenix_kit_ai_requests_prompt_uuid_fkey`) — two identical constraint checks
+  on every insert and update of the row, for no benefit
+  (BeamLabEU/phoenix_kit_ai#20).
+
+  **The legacy `phoenix_kit_ai_requests_prompt_uuid_fkey` is the one kept**, not
+  the `fk_` name core's own `UUIDFKColumns.fk_constraint_name/2` would generate.
+  It is the name the installed base actually carries — measured on two databases
+  that have only that one — so converging on it renames nothing on a live
+  install, and it is what Ecto's default `foreign_key_constraint/2` derives, so a
+  consumer that never passed `:name` keeps working.
+
+  Ordering matters: the survivor is created first when absent, so no install is
+  ever momentarily left with no foreign key on the column.
+  """
+
+  use Ecto.Migration
+
+  def up(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+    schema = schema_name(prefix)
+
+    # Anonymous submissions are a supported flow; see the moduledoc. Idempotent:
+    # DROP NOT NULL on an already-nullable column is a no-op. Guarded on the
+    # table, like the AI block below — an unconditional ALTER is what turns a
+    # partial install into a failed migration.
+    execute("""
+    DO $$
+    BEGIN
+      IF EXISTS (
+        SELECT 1 FROM pg_class t
+        JOIN pg_namespace n ON n.oid = t.relnamespace
+        WHERE t.relname = 'phoenix_kit_entity_data' AND n.nspname = '#{schema}'
+      ) THEN
+        ALTER TABLE #{p}phoenix_kit_entity_data ALTER COLUMN "created_by_uuid" DROP NOT NULL;
+      END IF;
+    END
+    $$
+    """)
+
+    # Converge the duplicated prompt FK onto the legacy name. Create-then-drop,
+    # never drop-then-create: an install carrying only `fk_ai_requests_prompt_uuid`
+    # must not lose referential integrity in between.
+    #
+    # Both statements sit inside ONE table-existence guard. `ALTER TABLE ... DROP
+    # CONSTRAINT IF EXISTS` still requires the TABLE to exist — the `IF EXISTS`
+    # only forgives a missing constraint — so an unguarded drop would raise
+    # `relation does not exist` wherever the AI tables are absent.
+    execute("""
+    DO $$
+    DECLARE
+      survivor_ok boolean;
+    BEGIN
+      IF EXISTS (
+        SELECT 1 FROM pg_class t
+        JOIN pg_namespace n ON n.oid = t.relnamespace
+        WHERE t.relname = 'phoenix_kit_ai_requests' AND n.nspname = '#{schema}'
+      ) THEN
+        -- Shape, not just name. A constraint merely CALLED
+        -- `phoenix_kit_ai_requests_prompt_uuid_fkey` — a CHECK, or a foreign key
+        -- pointing somewhere else — is not the survivor, and treating it as one
+        -- would drop the real `fk_` foreign key and leave the column
+        -- unreferenced. Same reasoning as V164's `fk_shape_present`.
+        SELECT EXISTS (
+          SELECT 1 FROM pg_constraint c
+          JOIN pg_class t ON t.oid = c.conrelid
+          JOIN pg_namespace n ON n.oid = t.relnamespace
+          JOIN pg_class ref ON ref.oid = c.confrelid
+          WHERE c.conname = 'phoenix_kit_ai_requests_prompt_uuid_fkey'
+            AND t.relname = 'phoenix_kit_ai_requests'
+            AND n.nspname = '#{schema}'
+            AND c.contype = 'f'
+            AND ref.relname = 'phoenix_kit_ai_prompts'
+            AND c.conkey = ARRAY[
+              (SELECT a.attnum FROM pg_attribute a
+               WHERE a.attrelid = t.oid AND a.attname = 'prompt_uuid')
+            ]::smallint[]
+        ) INTO survivor_ok;
+
+        IF NOT survivor_ok THEN
+          -- Only safe to create when the name is free. If something else holds
+          -- it, leave BOTH alone and say so rather than dropping a working key.
+          IF EXISTS (
+            SELECT 1 FROM pg_constraint c
+            JOIN pg_class t ON t.oid = c.conrelid
+            JOIN pg_namespace n ON n.oid = t.relnamespace
+            WHERE c.conname = 'phoenix_kit_ai_requests_prompt_uuid_fkey'
+              AND t.relname = 'phoenix_kit_ai_requests'
+              AND n.nspname = '#{schema}'
+          ) THEN
+            RAISE WARNING 'phoenix_kit_ai_requests_prompt_uuid_fkey exists with an unexpected shape; leaving both prompt_uuid constraints untouched';
+          ELSE
+            ALTER TABLE #{p}phoenix_kit_ai_requests
+              ADD CONSTRAINT phoenix_kit_ai_requests_prompt_uuid_fkey
+              FOREIGN KEY (prompt_uuid) REFERENCES #{p}phoenix_kit_ai_prompts(uuid) ON DELETE SET NULL;
+            survivor_ok := true;
+          END IF;
+        END IF;
+
+        -- Never drop the duplicate unless a correctly shaped survivor is in
+        -- place, so the column is never left with no foreign key at all.
+        IF survivor_ok THEN
+          ALTER TABLE #{p}phoenix_kit_ai_requests
+            DROP CONSTRAINT IF EXISTS fk_ai_requests_prompt_uuid;
+        END IF;
+      END IF;
+    END
+    $$
+    """)
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '169'")
+  end
+
+  def down(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    # The de-duplication is deliberately NOT rolled back.
+    #
+    # `up` drops `fk_ai_requests_prompt_uuid` only where it exists, and the two
+    # populations differ: a freshly migrated database had both names, an older
+    # one had only the legacy `_fkey`. Nothing in the schema records which this
+    # install was, so re-adding the `fk_` name here would hand the second group a
+    # constraint they never had — inventing the duplicate on exactly the
+    # databases that never suffered it. Leaving one correct foreign key in place
+    # is a better rollback than restoring a defect.
+    #
+    # The column relaxation below IS reversible, and is what `down` restores.
+
+    # Re-imposing NOT NULL is only possible when nothing relies on the
+    # relaxation. Rolling back after even one anonymous submission would
+    # otherwise abort the whole rollback, so this warns and leaves the column
+    # nullable — the same choice V164 makes for the columns it repairs.
+    execute("""
+    DO $$
+    DECLARE
+      null_rows bigint;
+    BEGIN
+      -- Take the lock the ALTER will need BEFORE counting. Otherwise a
+      -- concurrent insert can add a NULL between the count and the ALTER, and
+      -- the rollback aborts on exactly the case this branch exists to avoid.
+      LOCK TABLE #{p}phoenix_kit_entity_data IN EXCLUSIVE MODE;
+
+      SELECT count(*) INTO null_rows
+      FROM #{p}phoenix_kit_entity_data WHERE created_by_uuid IS NULL;
+
+      IF null_rows = 0 THEN
+        ALTER TABLE #{p}phoenix_kit_entity_data ALTER COLUMN "created_by_uuid" SET NOT NULL;
+      ELSE
+        RAISE WARNING 'phoenix_kit_entity_data.created_by_uuid left nullable: % row(s) have no creator (anonymous public submissions). Resolve them before re-imposing NOT NULL.', null_rows;
+      END IF;
+    END
+    $$
+    """)
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '168'")
+  end
+
+  defp schema_name("public"), do: "public"
+  defp schema_name(prefix), do: prefix
+
+  defp prefix_str("public"), do: "public."
+  defp prefix_str(prefix), do: "#{prefix}."
+end

--- a/lib/phoenix_kit/users/admin_note.ex
+++ b/lib/phoenix_kit/users/admin_note.ex
@@ -59,8 +59,8 @@ defmodule PhoenixKit.Users.AdminNote do
     |> cast(attrs, [:user_uuid, :author_uuid, :content])
     |> validate_required([:user_uuid, :author_uuid, :content])
     |> validate_length(:content, min: 1, max: 10_000)
-    |> foreign_key_constraint(:user_uuid)
-    |> foreign_key_constraint(:author_uuid)
+    |> foreign_key_constraint(:user_uuid, name: :fk_admin_notes_user_uuid)
+    |> foreign_key_constraint(:author_uuid, name: :fk_admin_notes_author_uuid)
   end
 
   @doc """

--- a/lib/phoenix_kit/users/oauth_provider.ex
+++ b/lib/phoenix_kit/users/oauth_provider.ex
@@ -48,7 +48,7 @@ defmodule PhoenixKit.Users.OAuthProvider do
     |> validate_required([:user_uuid, :provider, :provider_uid])
     |> validate_provider()
     |> validate_length(:provider_uid, min: 1, max: 255)
-    |> foreign_key_constraint(:user_uuid)
+    |> foreign_key_constraint(:user_uuid, name: :fk_user_oauth_providers_user_uuid)
     |> unique_constraint([:user_uuid, :provider],
       name: :phoenix_kit_oauth_providers_user_uuid_provider_idx
     )

--- a/lib/phoenix_kit/users/role_assignment.ex
+++ b/lib/phoenix_kit/users/role_assignment.ex
@@ -87,9 +87,9 @@ defmodule PhoenixKit.Users.RoleAssignment do
       name: :phoenix_kit_role_assignments_user_uuid_role_uuid_idx,
       message: "user already has this role"
     )
-    |> foreign_key_constraint(:user_uuid)
-    |> foreign_key_constraint(:role_uuid)
-    |> foreign_key_constraint(:assigned_by_uuid)
+    |> foreign_key_constraint(:user_uuid, name: :fk_user_role_assignments_user_uuid)
+    |> foreign_key_constraint(:role_uuid, name: :fk_user_role_assignments_role_uuid)
+    |> foreign_key_constraint(:assigned_by_uuid, name: :fk_user_role_assignments_assigned_by_uuid)
   end
 
   # Set assigned_at to current time if not provided

--- a/lib/phoenix_kit/users/role_permission.ex
+++ b/lib/phoenix_kit/users/role_permission.ex
@@ -51,6 +51,6 @@ defmodule PhoenixKit.Users.RolePermission do
       name: :phoenix_kit_role_permissions_role_uuid_module_key_idx,
       message: "permission already granted"
     )
-    |> foreign_key_constraint(:role_uuid)
+    |> foreign_key_constraint(:role_uuid, name: :fk_role_permissions_role_uuid)
   end
 end

--- a/lib/phoenix_kit/utils/slug.ex
+++ b/lib/phoenix_kit/utils/slug.ex
@@ -112,25 +112,207 @@ defmodule PhoenixKit.Utils.Slug do
   `ılık` and `ilik` both romanize to `ilik`, and plain English `Café`/`Cafe` collide
   too — so slugs are not identifiers and the suffix here is the answer, not a better
   table.
-  """
-  @spec ensure_unique(String.t(), (String.t() -> boolean())) :: String.t()
-  def ensure_unique("", _exists_fun), do: ""
 
-  def ensure_unique(slug, exists_fun) when is_function(exists_fun, 1) do
+  ## Options
+
+    * `:max_length` — the ceiling the *final* slug must respect, suffix included.
+
+  Without it the suffix is simply appended, which overflows any cap the caller already
+  applied: `slugify(title, max_length: 20)` returns 20 characters and `-2` makes 22.
+  That silently defeats an SEO cap, and against a `varchar(n)` column Postgres raises
+  rather than truncating. Given the option, the base is trimmed to make room —
+  per candidate, since `-10` needs one more character than `-9` — and a trailing
+  separator left by the trim is stripped so the result is never `foo--2`.
+  """
+  @spec ensure_unique(String.t(), (String.t() -> boolean()), keyword()) :: String.t()
+  def ensure_unique(slug, exists_fun, opts \\ [])
+
+  def ensure_unique("", _exists_fun, _opts), do: ""
+
+  def ensure_unique(slug, exists_fun, opts) when is_function(exists_fun, 1) do
     if exists_fun.(slug) do
-      increment_slug(slug, 2, exists_fun)
+      increment_slug(slug, 2, exists_fun, Keyword.get(opts, :max_length))
     else
       slug
     end
   end
 
-  defp increment_slug(base_slug, counter, exists_fun) do
-    candidate = "#{base_slug}-#{counter}"
+  defp increment_slug(base_slug, counter, exists_fun, limit) do
+    suffix = "-#{counter}"
+    candidate = trim_for(base_slug, suffix, limit) <> suffix
 
     if exists_fun.(candidate) do
-      increment_slug(base_slug, counter + 1, exists_fun)
+      increment_slug(base_slug, counter + 1, exists_fun, limit)
     else
       candidate
     end
+  end
+
+  defp trim_for(base, _suffix, nil), do: base
+
+  defp trim_for(base, suffix, limit) do
+    keep = limit - String.length(suffix)
+
+    if String.length(base) <= keep do
+      base
+    else
+      base
+      |> String.slice(0, Kernel.max(keep, 0))
+      |> String.trim_trailing("-")
+    end
+  end
+
+  @doc """
+  Puts a generated, collision-free slug on `changeset`, derived from `source_field`.
+
+  This is the changeset glue that was missing from core, and which 14 hand-rolled
+  `maybe_generate_slug/1` copies across eight sibling packages each got a different
+  subset of right.
+
+  ## The four cases, and why "absent" is not "empty"
+
+  The bug this exists to delete is reading `get_change(:slug)` and treating `nil` as
+  "this record has no slug". It does not mean that — it means *this save did not carry
+  one*, which is true of almost every save. `cast/3` drops a value equal to the data,
+  so an edit form that faithfully re-sends the current slug produces no change at all.
+  Under `get_change/2` that reads as "regenerate from the title", so renaming anything
+  moved its live URL and nothing recorded the old one.
+
+    * an explicit, non-blank slug always wins;
+    * an explicitly blanked slug regenerates (the column is typically `NOT NULL`, so
+      storing the blank is not an option);
+    * **no slug in the changeset means unchanged** — generate only if the stored
+      record has none;
+    * a source that slugifies to `""` leaves the changeset alone rather than writing
+      a blank that the next save would read as "no slug yet" and regenerate forever.
+
+  ## Options
+
+    * `:to` — the slug field. Defaults to `:slug`.
+    * `:scope` — fields the uniqueness is *scoped by*, e.g. `[:user_uuid]` for a
+      per-user slug backed by a composite index. Defaults to `[]` (global).
+    * `:unique` — set `false` to skip the probe entirely. Defaults to `true`.
+    * `:repo` — the repo to probe. Defaults to the configured PhoenixKit repo.
+    * `:queryable` — override the probed source, e.g. to exclude soft-deleted rows:
+      `queryable: from(p in Post, where: is_nil(p.deleted_at))`. Defaults to the
+      changeset's own schema.
+    * `:locale`, `:separator`, `:max_length` — forwarded to `slugify/2`.
+
+  ## Uniqueness here is an allocator, not a guarantee
+
+  The probe runs from inside the changeset, which is unusual but deliberate: it is
+  what `Ecto.Changeset.unsafe_validate_unique/4` does, and the alternative — generate
+  in the schema, uniquify in the context — splits one decision across two modules and
+  is how the copies drifted in the first place.
+
+  It stays advisory. A concurrent insert between the probe and the write still
+  collides, so **every caller must also declare `unique_constraint/3` against an index
+  that actually exists**. This function picks a free-looking suffix; the index is what
+  makes it true.
+
+  ## No repo configured is tolerated; a broken repo is not
+
+  If no repo is configured at all, the uniqueness probe is skipped — the library is
+  usable for pure changeset construction without a database. If a repo *is* configured
+  and the query then fails, the error is allowed to raise. The predecessor in
+  `phoenix_kit_posts` wrapped the whole probe in a bare `rescue _ -> slug`, which
+  cannot tell those apart and answers a transient database fault by writing the
+  unsuffixed slug — reintroducing exactly the duplicate the probe exists to prevent.
+
+  ## Examples
+
+      changeset |> Slug.put_slug(:title)
+      changeset |> Slug.put_slug(:name, scope: [:user_uuid])
+      changeset |> Slug.put_slug(:title, locale: "de", max_length: 60)
+  """
+  @spec put_slug(Ecto.Changeset.t(), atom(), keyword()) :: Ecto.Changeset.t()
+  def put_slug(%Ecto.Changeset{} = changeset, source_field, opts \\ []) do
+    to = Keyword.get(opts, :to, :slug)
+
+    case Ecto.Changeset.fetch_change(changeset, to) do
+      {:ok, slug} when is_binary(slug) and slug != "" ->
+        changeset
+
+      {:ok, _blank} ->
+        changeset
+        |> Ecto.Changeset.delete_change(to)
+        |> generate(source_field, to, opts)
+
+      :error ->
+        if Map.get(changeset.data, to) in [nil, ""] do
+          generate(changeset, source_field, to, opts)
+        else
+          changeset
+        end
+    end
+  end
+
+  defp generate(changeset, source_field, to, opts) do
+    with value when is_binary(value) and value != "" <-
+           Ecto.Changeset.get_field(changeset, source_field),
+         slug when slug != "" <-
+           slugify(value, Keyword.take(opts, [:separator, :locale, :max_length])) do
+      Ecto.Changeset.put_change(changeset, to, unique(changeset, slug, to, opts))
+    else
+      _ -> changeset
+    end
+  end
+
+  defp unique(changeset, slug, to, opts) do
+    repo = Keyword.get_lazy(opts, :repo, fn -> PhoenixKit.Config.get(:repo, nil) end)
+
+    if Keyword.get(opts, :unique, true) and repo do
+      # `:max_length` is forwarded so the suffix respects the same ceiling the base
+      # was cut to, rather than overflowing it by two characters.
+      ensure_unique(slug, taken_fun(changeset, to, repo, opts),
+        max_length: Keyword.get(opts, :max_length)
+      )
+    else
+      slug
+    end
+  end
+
+  defp taken_fun(changeset, to, repo, opts) do
+    import Ecto.Query, only: [where: 3]
+
+    schema = changeset.data.__struct__
+    queryable = Keyword.get(opts, :queryable, schema)
+
+    # Reflection, not an option: every PhoenixKit schema declares
+    # `@primary_key {:uuid, UUIDv7, autogenerate: true}` today, but asking the caller
+    # to restate it is one more thing 14 call sites can each get wrong.
+    base =
+      schema.__schema__(:primary_key)
+      |> Enum.reduce(Ecto.Queryable.to_query(queryable), fn pk, query ->
+        case Map.get(changeset.data, pk) do
+          # An insert has nothing to exclude.
+          nil -> query
+          value -> where(query, [r], field(r, ^pk) != ^value)
+        end
+      end)
+      |> scope_query(changeset, Keyword.get(opts, :scope, []))
+
+    # Honours a schema prefix so a multi-tenant install probes its own rows rather
+    # than "public"'s.
+    prefix = changeset.data.__meta__.prefix
+
+    fn candidate ->
+      base
+      |> where([r], field(r, ^to) == ^candidate)
+      |> repo.exists?(prefix: prefix)
+    end
+  end
+
+  defp scope_query(query, changeset, scope) do
+    import Ecto.Query, only: [where: 3]
+
+    Enum.reduce(scope, query, fn field_name, acc ->
+      # NULL never equals NULL, so an unset scope has to be matched with IS NULL or
+      # the probe silently reports every candidate free.
+      case Ecto.Changeset.get_field(changeset, field_name) do
+        nil -> where(acc, [r], is_nil(field(r, ^field_name)))
+        value -> where(acc, [r], field(r, ^field_name) == ^value)
+      end
+    end)
   end
 end

--- a/test/integration/constraint_declaration_test.exs
+++ b/test/integration/constraint_declaration_test.exs
@@ -1,0 +1,168 @@
+defmodule PhoenixKit.Integration.ConstraintDeclarationTest do
+  @moduledoc """
+  Every constraint a changeset declares must exist in the database under that
+  exact name.
+
+  Ecto matches a constraint by NAME. `foreign_key_constraint(:user_uuid)` with no
+  `:name` expects `<table>_user_uuid_fkey`, but this chain names most of its
+  foreign keys `fk_<table-without-prefix>_<column>` — so the declaration silently
+  matches nothing, and a violation escapes as a raw `Ecto.ConstraintError` (a 500)
+  instead of the changeset error the caller is written to handle.
+
+  Eleven declarations were wrong this way when this test was written, across
+  storage, admin notes, OAuth providers, role assignments and role permissions.
+  A per-site test would have pinned each one; this pins the RULE, so the next
+  schema cannot repeat it.
+
+  Names are read from the live database rather than parsed out of the migration
+  chain, because the chain is what the database is built from but not what it
+  necessarily still holds — a renamed column can leave a constraint carrying its
+  old name (`phoenix_kit_file_instances_file_id_fkey` on a `file_uuid` column is
+  exactly that).
+  """
+  use PhoenixKit.DataCase, async: true
+
+  # Declarations with no backing database object, kept deliberately.
+  #
+  # `phoenix_kit_activities` has no foreign keys on ANY install (verified on a
+  # freshly migrated database and on a long-lived one): activity rows outlive
+  # the users they mention, which is the point of an audit log. The
+  # declarations are inert rather than wrong — Ecto simply never matches them —
+  # and they stay so the changeset already handles it the day an FK is added.
+  @known_unbacked [
+    {"phoenix_kit_activities", "phoenix_kit_activities_actor_uuid_fkey"},
+    {"phoenix_kit_activities", "phoenix_kit_activities_target_uuid_fkey"}
+  ]
+
+  # Ecto's constraint types map onto different catalog objects, and conflating
+  # them lets a wrong declaration pass: a NON-unique index named like a unique
+  # constraint would satisfy a `unique_constraint`, and a CHECK would satisfy a
+  # `foreign_key_constraint`. Keep them apart.
+  defp existing_by_type(repo, schema) do
+    {:ok, %{rows: constraints}} =
+      repo.query(
+        """
+        SELECT t.relname, c.conname, c.contype
+        FROM pg_constraint c
+        JOIN pg_class t ON t.oid = c.conrelid
+        JOIN pg_namespace n ON n.oid = t.relnamespace
+        WHERE n.nspname = $1
+        """,
+        [schema]
+      )
+
+    # A `CREATE UNIQUE INDEX` produces no pg_constraint row, yet Postgres still
+    # reports the INDEX name on violation and Ecto matches on that — so unique
+    # declarations have to be checked against pg_indexes too, or every one of
+    # them reads as broken. Unique indexes only.
+    {:ok, %{rows: unique_indexes}} =
+      repo.query(
+        """
+        SELECT tablename, indexname FROM pg_indexes
+        WHERE schemaname = $1 AND indexdef LIKE 'CREATE UNIQUE INDEX%'
+        """,
+        [schema]
+      )
+
+    Enum.reduce(constraints, %{}, fn [table, name, contype], acc ->
+      type =
+        case contype do
+          "f" -> :foreign_key
+          "u" -> :unique
+          "p" -> :unique
+          "c" -> :check
+          "x" -> :exclusion
+          _ -> :other
+        end
+
+      Map.update(acc, type, MapSet.new([{table, name}]), &MapSet.put(&1, {table, name}))
+    end)
+    |> Map.update(
+      :unique,
+      MapSet.new(unique_indexes, fn [t, i] -> {t, i} end),
+      fn existing ->
+        Enum.reduce(unique_indexes, existing, fn [t, i], acc -> MapSet.put(acc, {t, i}) end)
+      end
+    )
+  end
+
+  defp core_schemas do
+    {:ok, modules} = :application.get_key(:phoenix_kit, :modules)
+
+    modules
+    |> Enum.filter(fn mod ->
+      Code.ensure_loaded?(mod) and function_exported?(mod, :__schema__, 1) and
+        function_exported?(mod, :changeset, 2)
+    end)
+    |> Enum.sort()
+  end
+
+  test "every declared constraint exists in the database under that name" do
+    schema = Application.get_env(:phoenix_kit, :prefix, "public")
+    existing_by_type = existing_by_type(PhoenixKit.Test.Repo, schema)
+    known_unbacked = MapSet.new(@known_unbacked)
+
+    inspected =
+      for mod <- core_schemas(),
+          changeset = safe_changeset(mod),
+          changeset != nil,
+          do: {mod, mod.__schema__(:source), changeset.constraints}
+
+    # A schema whose changeset/2 cannot be built from empty attrs is skipped,
+    # which is a silent hole — assert enough of the tree was actually inspected
+    # that a wholesale skip (a compile change, a renamed callback) cannot pass
+    # this test by inspecting nothing.
+    assert length(inspected) >= 20,
+           "only #{length(inspected)} schema(s) inspected — the discovery or " <>
+             "changeset construction above is broken, so this test proves nothing"
+
+    # Grouped per field, because declaring the SAME field under two names is a
+    # deliberate pattern where the surviving constraint name differs by install
+    # age (phoenix_kit_ai's prompt_uuid). Only one of those can exist on any one
+    # database; the group is satisfied when any declared name is real.
+    missing =
+      for {mod, table, constraints} <- inspected,
+          # `match: :suffix`/`:prefix` declarations are matched by Ecto against a
+          # PART of the reported name, so an exact-name check would misjudge
+          # them. None exist today; skipping keeps this honest if one appears.
+          {{field, type}, declared} <-
+            constraints
+            |> Enum.filter(&(Map.get(&1, :match, :exact) == :exact))
+            |> Enum.group_by(&{&1.field, &1.type}, & &1.constraint),
+          existing = Map.get(existing_by_type, type, MapSet.new()),
+          not Enum.any?(declared, &MapSet.member?(existing, {table, &1})),
+          not Enum.all?(declared, &MapSet.member?(known_unbacked, {table, &1})) do
+        "#{inspect(mod)} declares #{type} on #{table}.#{field} as " <>
+          "#{Enum.map_join(declared, " / ", &inspect/1)}, none of which exists"
+      end
+
+    assert missing == [], """
+    #{length(missing)} constraint declaration(s) match nothing in the database:
+
+    #{Enum.map_join(missing, "\n", &"  - #{&1}")}
+
+    Ecto matches constraints by name. A declaration that names a constraint the
+    chain never created can never fire, so the violation raises
+    Ecto.ConstraintError instead of returning a changeset error. Pass the name
+    the migration actually creates:
+
+        foreign_key_constraint(:user_uuid, name: :fk_files_user_uuid)
+
+    If the object genuinely does not exist on any install and the declaration is
+    deliberate, add it to @known_unbacked with the reason.
+    """
+  end
+
+  # A schema's changeset/2 registers its constraints regardless of whether the
+  # attrs are valid, so empty attrs are enough. Some take different arities or
+  # require a struct shape we cannot guess — skip those rather than fail, since
+  # a skipped schema costs coverage while a crashed one costs the whole test.
+  defp safe_changeset(mod) do
+    struct = struct(mod)
+    mod.changeset(struct, %{})
+  rescue
+    _ -> nil
+  catch
+    _, _ -> nil
+  end
+end

--- a/test/integration/v167_post_slug_uniqueness_test.exs
+++ b/test/integration/v167_post_slug_uniqueness_test.exs
@@ -1,0 +1,267 @@
+defmodule PhoenixKit.Integration.V167PostSlugUniquenessTest do
+  @moduledoc """
+  V167 repairs duplicate post slugs, which a current install can no longer
+  produce — so every test here manufactures the duplicates first.
+
+  Each builds its own scratch table shaped like `phoenix_kit_posts` rather than
+  damaging the real one, so a failure cannot corrupt the schema for whatever
+  runs next. The SQL under test is the migration's, run against that table.
+  """
+  use PhoenixKit.DataCase, async: false
+
+  setup do
+    table = "phoenix_kit_zz_v167_#{System.unique_integer([:positive])}"
+    on_exit(fn -> Repo.query("DROP TABLE IF EXISTS #{table}", []) end)
+
+    Repo.query!("""
+    CREATE TABLE #{table} (
+      uuid uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      slug character varying(255) NOT NULL,
+      status character varying(50) NOT NULL DEFAULT 'draft',
+      inserted_at timestamp(0) without time zone NOT NULL DEFAULT now()
+    )
+    """)
+
+    Repo.query!("CREATE INDEX #{table}_slug_index ON #{table} USING btree (slug)")
+
+    {:ok, table: table}
+  end
+
+  defp insert!(table, slug, status, inserted_at) do
+    %{rows: [[uuid]]} =
+      Repo.query!(
+        "INSERT INTO #{table} (slug, status, inserted_at) VALUES ($1, $2, $3) RETURNING uuid",
+        [slug, status, inserted_at]
+      )
+
+    uuid
+  end
+
+  defp slug_of(table, uuid) do
+    %{rows: [[slug]]} = Repo.query!("SELECT slug FROM #{table} WHERE uuid = $1", [uuid])
+    slug
+  end
+
+  defp at(seconds_ago) do
+    DateTime.utc_now() |> DateTime.add(-seconds_ago, :second) |> DateTime.to_naive()
+  end
+
+  # The migration's repair block, with the table name substituted. Kept in one
+  # place so a change to the migration has to be reflected here to stay green.
+  defp dedupe!(table) do
+    Repo.query!("""
+    DO $$
+    DECLARE
+      g RECORD; r RECORD; suffix text; base text; candidate text; n int;
+    BEGIN
+      FOR g IN
+        SELECT slug, count(*) FILTER (
+                 WHERE status IN ('public', 'unlisted', 'scheduled')) AS live_n
+          FROM #{table} GROUP BY slug HAVING count(*) > 1
+      LOOP
+        IF g.live_n > 1 THEN
+          RAISE EXCEPTION
+            'Cannot apply V167: slug % is shared by % live posts. Give one of them a different slug, then upgrade.',
+            g.slug, g.live_n;
+        END IF;
+      END LOOP;
+
+      FOR r IN
+        SELECT uuid, slug FROM (
+          SELECT uuid, slug, row_number() OVER (
+            PARTITION BY slug
+            ORDER BY CASE WHEN status IN ('public', 'unlisted', 'scheduled')
+                          THEN 0 ELSE 1 END,
+                     inserted_at ASC, uuid ASC) AS rn
+            FROM #{table}) ranked
+         WHERE rn > 1 ORDER BY slug, rn
+      LOOP
+        n := 2;
+        LOOP
+          suffix := '-' || n;
+          base := regexp_replace(left(r.slug, 255 - length(suffix)), '-+$', '');
+          candidate := base || suffix;
+          EXIT WHEN NOT EXISTS (SELECT 1 FROM #{table} WHERE slug = candidate);
+          n := n + 1;
+        END LOOP;
+        UPDATE #{table} SET slug = candidate WHERE uuid = r.uuid;
+      END LOOP;
+    END $$;
+    """)
+  end
+
+  defp swap_index!(table) do
+    Repo.query!("DROP INDEX IF EXISTS #{table}_slug_index")
+
+    Repo.query!(
+      "CREATE UNIQUE INDEX IF NOT EXISTS #{table}_slug_index ON #{table} USING btree (slug)"
+    )
+  end
+
+  describe "de-duplication" do
+    test "the oldest keeps the slug, later ones are suffixed", %{table: t} do
+      a = insert!(t, "foo", "draft", at(300))
+      b = insert!(t, "foo", "draft", at(200))
+      c = insert!(t, "foo", "draft", at(100))
+
+      dedupe!(t)
+
+      assert slug_of(t, a) == "foo"
+      assert slug_of(t, b) == "foo-2"
+      assert slug_of(t, c) == "foo-3"
+    end
+
+    test "a suffix already taken by an unrelated post is skipped", %{table: t} do
+      # The case a naive row_number() suffix gets wrong: "foo-2" exists
+      # already, so the duplicate has to land on "foo-3".
+      a = insert!(t, "foo", "draft", at(300))
+      b = insert!(t, "foo", "draft", at(200))
+      unrelated = insert!(t, "foo-2", "draft", at(250))
+
+      dedupe!(t)
+
+      assert slug_of(t, a) == "foo"
+      assert slug_of(t, b) == "foo-3"
+      assert slug_of(t, unrelated) == "foo-2"
+    end
+
+    test "a reachable post outranks an older draft", %{table: t} do
+      draft = insert!(t, "foo", "draft", at(300))
+      live = insert!(t, "foo", "public", at(100))
+
+      dedupe!(t)
+
+      # The draft is older but has no URL anyone can have linked.
+      assert slug_of(t, live) == "foo"
+      assert slug_of(t, draft) == "foo-2"
+    end
+
+    test "identical timestamps still produce a stable, total order", %{table: t} do
+      # timestamps(type: :utc_datetime) stores whole seconds with no DB
+      # default, so ties are ordinary. Without the uuid tiebreak the winner
+      # would vary per run.
+      same = at(100)
+      a = insert!(t, "foo", "draft", same)
+      b = insert!(t, "foo", "draft", same)
+
+      dedupe!(t)
+
+      [first, second] = Enum.sort([slug_of(t, a), slug_of(t, b)])
+      assert first == "foo"
+      assert second == "foo-2"
+    end
+
+    test "two live posts raise, and nothing is rewritten", %{table: t} do
+      a = insert!(t, "foo", "public", at(300))
+      b = insert!(t, "foo", "unlisted", at(100))
+
+      assert_raise Postgrex.Error, ~r/shared by 2 live posts/, fn -> dedupe!(t) end
+
+      assert slug_of(t, a) == "foo"
+      assert slug_of(t, b) == "foo"
+    end
+
+    test "a 255-character slug is trimmed to fit rather than overflowing", %{table: t} do
+      # varchar(255) ERRORS on overflow, it does not truncate.
+      long = String.duplicate("a", 255)
+      a = insert!(t, long, "draft", at(300))
+      b = insert!(t, long, "draft", at(100))
+
+      dedupe!(t)
+
+      assert slug_of(t, a) == long
+      assert String.length(slug_of(t, b)) == 255
+      assert String.ends_with?(slug_of(t, b), "-2")
+    end
+
+    test "a base ending in a dash does not produce a double dash", %{table: t} do
+      long = String.duplicate("a", 252) <> "-bb"
+      insert!(t, long, "draft", at(300))
+      b = insert!(t, long, "draft", at(100))
+
+      dedupe!(t)
+
+      refute slug_of(t, b) =~ "--"
+    end
+
+    test "case-different slugs are left alone — they do not collide", %{table: t} do
+      a = insert!(t, "Foo", "draft", at(300))
+      b = insert!(t, "foo", "draft", at(100))
+
+      dedupe!(t)
+
+      assert slug_of(t, a) == "Foo"
+      assert slug_of(t, b) == "foo"
+    end
+
+    test "running twice changes nothing the second time", %{table: t} do
+      insert!(t, "foo", "draft", at(300))
+      insert!(t, "foo", "draft", at(100))
+
+      dedupe!(t)
+      %{rows: after_first} = Repo.query!("SELECT uuid, slug FROM #{t} ORDER BY slug")
+
+      dedupe!(t)
+      %{rows: after_second} = Repo.query!("SELECT uuid, slug FROM #{t} ORDER BY slug")
+
+      assert after_first == after_second
+    end
+  end
+
+  describe "the index swap" do
+    test "the unique index is created and then rejects a duplicate", %{table: t} do
+      insert!(t, "foo", "draft", at(300))
+      insert!(t, "foo", "draft", at(100))
+
+      dedupe!(t)
+      swap_index!(t)
+
+      %{rows: [[unique?]]} =
+        Repo.query!(
+          "SELECT indexdef ~ 'UNIQUE' FROM pg_indexes WHERE indexname = $1",
+          ["#{t}_slug_index"]
+        )
+
+      assert unique?
+
+      assert_raise Postgrex.Error, ~r/duplicate key/, fn ->
+        insert!(t, "foo", "draft", at(50))
+      end
+    end
+
+    test "CREATE UNIQUE ... IF NOT EXISTS alone is a silent no-op", %{table: t} do
+      # Matching is by index NAME only. Without the DROP the index stays
+      # non-unique and the migration reports success — which is the whole
+      # reason the DROP is in the migration.
+      Repo.query!("CREATE UNIQUE INDEX IF NOT EXISTS #{t}_slug_index ON #{t} USING btree (slug)")
+
+      %{rows: [[unique?]]} =
+        Repo.query!(
+          "SELECT indexdef ~ 'UNIQUE' FROM pg_indexes WHERE indexname = $1",
+          ["#{t}_slug_index"]
+        )
+
+      refute unique?
+    end
+  end
+
+  describe "the manifest" do
+    test "the shape flips to unique at 167, and is unchanged before it" do
+      alias PhoenixKit.Migrations.ExpectedSchema
+      alias PhoenixKit.Migrations.ExpectedSchema.Object
+
+      object =
+        "public"
+        |> ExpectedSchema.objects()
+        |> Enum.find(&(&1.id == "index:phoenix_kit_posts_slug_index"))
+
+      assert object, "the posts slug index is missing from the manifest"
+
+      # The revision is appended rather than edited: a V166 database must keep
+      # reading its plain index as correct, or doctor reports drift with a
+      # repair that cannot run.
+      refute Object.shape_at(object, 166).unique
+      assert Object.shape_at(object, 167).unique
+    end
+  end
+end

--- a/test/integration/v168_slug_index_test.exs
+++ b/test/integration/v168_slug_index_test.exs
@@ -1,0 +1,270 @@
+defmodule PhoenixKit.Integration.V168SlugIndexTest do
+  @moduledoc """
+  V168 repairs duplicate ticket and post-group slugs before it can build the unique
+  indexes, so every test here manufactures the duplicates first.
+
+  Each builds its own scratch table shaped like the real one rather than damaging it,
+  so a failure cannot corrupt the schema for whatever runs next. The SQL under test is
+  the migration's, run against that table. Same pattern as the V167 test.
+  """
+  use PhoenixKit.DataCase, async: false
+
+  setup do
+    tickets = "phoenix_kit_zz_v168_t_#{System.unique_integer([:positive])}"
+    groups = "phoenix_kit_zz_v168_g_#{System.unique_integer([:positive])}"
+
+    on_exit(fn ->
+      Repo.query("DROP TABLE IF EXISTS #{tickets}", [])
+      Repo.query("DROP TABLE IF EXISTS #{groups}", [])
+    end)
+
+    Repo.query!("""
+    CREATE TABLE #{tickets} (
+      uuid uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      slug character varying(255) NOT NULL,
+      inserted_at timestamptz NOT NULL DEFAULT now()
+    )
+    """)
+
+    Repo.query!("CREATE INDEX #{tickets}_slug_index ON #{tickets} USING btree (slug)")
+
+    Repo.query!("""
+    CREATE TABLE #{groups} (
+      uuid uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      user_uuid uuid NOT NULL,
+      slug character varying(255) NOT NULL,
+      inserted_at timestamptz NOT NULL DEFAULT now()
+    )
+    """)
+
+    {:ok, tickets: tickets, groups: groups}
+  end
+
+  # The migration's ticket dedup, verbatim except for the table name.
+  defp dedup_tickets(table) do
+    Repo.query!("""
+    DO $$
+    DECLARE
+      r RECORD; suffix text; base text; candidate text; n int;
+    BEGIN
+      FOR r IN
+        SELECT uuid, slug FROM (
+          SELECT uuid, slug,
+                 row_number() OVER (
+                   PARTITION BY slug ORDER BY inserted_at ASC, uuid ASC) AS rn
+            FROM #{table}) ranked
+         WHERE rn > 1 ORDER BY slug, rn
+      LOOP
+        n := 2;
+        LOOP
+          suffix := '-' || n;
+          base := regexp_replace(left(r.slug, 255 - length(suffix)), '-+$', '');
+          candidate := base || suffix;
+          EXIT WHEN NOT EXISTS (SELECT 1 FROM #{table} WHERE slug = candidate);
+          n := n + 1;
+        END LOOP;
+        UPDATE #{table} SET slug = candidate WHERE uuid = r.uuid;
+      END LOOP;
+    END $$;
+    """)
+  end
+
+  # The migration's post-group dedup, verbatim except for the table name.
+  defp dedup_groups(table) do
+    Repo.query!("""
+    DO $$
+    DECLARE
+      r RECORD; suffix text; base text; candidate text; n int;
+    BEGIN
+      FOR r IN
+        SELECT uuid, user_uuid, slug FROM (
+          SELECT uuid, user_uuid, slug,
+                 row_number() OVER (
+                   PARTITION BY user_uuid, slug
+                   ORDER BY inserted_at ASC, uuid ASC) AS rn
+            FROM #{table}) ranked
+         WHERE rn > 1 ORDER BY user_uuid, slug, rn
+      LOOP
+        n := 2;
+        LOOP
+          suffix := '-' || n;
+          base := regexp_replace(left(r.slug, 255 - length(suffix)), '-+$', '');
+          candidate := base || suffix;
+          EXIT WHEN NOT EXISTS (
+            SELECT 1 FROM #{table} WHERE user_uuid = r.user_uuid AND slug = candidate);
+          n := n + 1;
+        END LOOP;
+        UPDATE #{table} SET slug = candidate WHERE uuid = r.uuid;
+      END LOOP;
+    END $$;
+    """)
+  end
+
+  defp insert_ticket!(table, slug, inserted_at) do
+    %{rows: [[uuid]]} =
+      Repo.query!(
+        "INSERT INTO #{table} (slug, inserted_at) VALUES ($1, $2) RETURNING uuid",
+        [slug, inserted_at]
+      )
+
+    uuid
+  end
+
+  defp insert_group!(table, user_uuid, slug, inserted_at) do
+    %{rows: [[uuid]]} =
+      Repo.query!(
+        "INSERT INTO #{table} (user_uuid, slug, inserted_at) VALUES ($1, $2, $3) RETURNING uuid",
+        [Ecto.UUID.dump!(user_uuid), slug, inserted_at]
+      )
+
+    uuid
+  end
+
+  defp slug_of(table, uuid) do
+    %{rows: [[slug]]} = Repo.query!("SELECT slug FROM #{table} WHERE uuid = $1", [uuid])
+    slug
+  end
+
+  defp t(offset), do: DateTime.add(~U[2026-01-01 00:00:00Z], offset, :second)
+
+  describe "ticket dedup" do
+    test "the oldest row keeps the bare slug and later ones are suffixed", %{tickets: table} do
+      first = insert_ticket!(table, "broken-login", t(0))
+      second = insert_ticket!(table, "broken-login", t(10))
+      third = insert_ticket!(table, "broken-login", t(20))
+
+      dedup_tickets(table)
+
+      assert slug_of(table, first) == "broken-login"
+      assert slug_of(table, second) == "broken-login-2"
+      assert slug_of(table, third) == "broken-login-3"
+    end
+
+    test "an unrelated row already holding the -2 pushes the duplicate to -3", %{tickets: table} do
+      first = insert_ticket!(table, "printer", t(0))
+      dup = insert_ticket!(table, "printer", t(10))
+      squatter = insert_ticket!(table, "printer-2", t(20))
+
+      dedup_tickets(table)
+
+      assert slug_of(table, first) == "printer"
+      assert slug_of(table, squatter) == "printer-2"
+      assert slug_of(table, dup) == "printer-3"
+    end
+
+    test "a 255-char slug is trimmed to fit its suffix rather than overflowing", %{
+      tickets: table
+    } do
+      long = String.duplicate("a", 255)
+      first = insert_ticket!(table, long, t(0))
+      dup = insert_ticket!(table, long, t(10))
+
+      dedup_tickets(table)
+
+      assert slug_of(table, first) == long
+      repaired = slug_of(table, dup)
+      assert String.length(repaired) <= 255
+      assert String.ends_with?(repaired, "-2")
+    end
+
+    test "a slug ending in a dash does not become a double dash", %{tickets: table} do
+      # left() can cut mid-word and leave a trailing dash; the regexp_replace strips it.
+      long = String.duplicate("ab-", 84) <> "abc"
+      first = insert_ticket!(table, long, t(0))
+      dup = insert_ticket!(table, long, t(10))
+
+      dedup_tickets(table)
+
+      assert slug_of(table, first) == long
+      refute slug_of(table, dup) =~ "--"
+    end
+
+    test "the unique index builds once the duplicates are gone", %{tickets: table} do
+      insert_ticket!(table, "same", t(0))
+      insert_ticket!(table, "same", t(10))
+
+      # Proves the ordering matters: the index cannot be built first.
+      assert_raise Postgrex.Error, fn ->
+        Repo.query!("CREATE UNIQUE INDEX #{table}_u ON #{table} USING btree (slug)")
+      end
+
+      dedup_tickets(table)
+
+      Repo.query!("DROP INDEX IF EXISTS #{table}_slug_index")
+      Repo.query!("CREATE UNIQUE INDEX #{table}_slug_index ON #{table} USING btree (slug)")
+
+      assert_raise Postgrex.Error, fn ->
+        Repo.query!("INSERT INTO #{table} (slug) VALUES ('same')")
+      end
+    end
+  end
+
+  describe "post group dedup is scoped to the owner" do
+    test "two users may hold the same slug and neither is touched", %{groups: table} do
+      alice = Ecto.UUID.generate()
+      bob = Ecto.UUID.generate()
+
+      a = insert_group!(table, alice, "notes", t(0))
+      b = insert_group!(table, bob, "notes", t(10))
+
+      dedup_groups(table)
+
+      assert slug_of(table, a) == "notes"
+      assert slug_of(table, b) == "notes"
+    end
+
+    test "one user holding it twice is repaired", %{groups: table} do
+      alice = Ecto.UUID.generate()
+
+      first = insert_group!(table, alice, "notes", t(0))
+      second = insert_group!(table, alice, "notes", t(10))
+
+      dedup_groups(table)
+
+      assert slug_of(table, first) == "notes"
+      assert slug_of(table, second) == "notes-2"
+    end
+
+    test "the suffix probe is scoped, so another user's -2 does not push it to -3", %{
+      groups: table
+    } do
+      alice = Ecto.UUID.generate()
+      bob = Ecto.UUID.generate()
+
+      insert_group!(table, bob, "notes-2", t(0))
+      first = insert_group!(table, alice, "notes", t(10))
+      second = insert_group!(table, alice, "notes", t(20))
+
+      dedup_groups(table)
+
+      assert slug_of(table, first) == "notes"
+      # Bob's "notes-2" is irrelevant to Alice's namespace.
+      assert slug_of(table, second) == "notes-2"
+    end
+
+    test "the composite unique index builds and then enforces per-user uniqueness", %{
+      groups: table
+    } do
+      alice = Ecto.UUID.generate()
+      bob = Ecto.UUID.generate()
+      insert_group!(table, alice, "notes", t(0))
+      insert_group!(table, alice, "notes", t(10))
+
+      dedup_groups(table)
+
+      Repo.query!("CREATE UNIQUE INDEX #{table}_u ON #{table} USING btree (user_uuid, slug)")
+
+      # Bob may still take the slug Alice holds.
+      Repo.query!("INSERT INTO #{table} (user_uuid, slug) VALUES ($1, 'notes')", [
+        Ecto.UUID.dump!(bob)
+      ])
+
+      # Alice may not take it twice.
+      assert_raise Postgrex.Error, fn ->
+        Repo.query!("INSERT INTO #{table} (user_uuid, slug) VALUES ($1, 'notes')", [
+          Ecto.UUID.dump!(alice)
+        ])
+      end
+    end
+  end
+end

--- a/test/phoenix_kit/migrations/v164_relaxed_columns_test.exs
+++ b/test/phoenix_kit/migrations/v164_relaxed_columns_test.exs
@@ -53,9 +53,14 @@ defmodule PhoenixKit.Migrations.V164RelaxedColumnsTest do
   # "later" relaxation of it.
   @first_version_in_scope 58
 
+  # Identifiers may be double-quoted on either side — the chain writes both
+  # (`ALTER COLUMN "created_by_uuid"` in V167, bare elsewhere), and Postgres
+  # treats them identically. Without the optional quotes this scan silently
+  # skipped a real relaxation, which is precisely the false NEGATIVE the
+  # moduledoc calls the failure mode that matters.
   @inline_pattern ~r/
-    ALTER\s+TABLE\s+\S*?(phoenix_kit_[a-zA-Z0-9_]+)
-    \s+ALTER\s+COLUMN\s+([a-zA-Z_][a-zA-Z0-9_]*)
+    ALTER\s+TABLE\s+\S*?"?(phoenix_kit_[a-zA-Z0-9_]+)"?
+    \s+ALTER\s+COLUMN\s+"?([a-zA-Z_][a-zA-Z0-9_]*)"?
     \s+DROP\s+NOT\s+NULL
   /xi
 

--- a/test/phoenix_kit/utils/slug_put_slug_test.exs
+++ b/test/phoenix_kit/utils/slug_put_slug_test.exs
@@ -1,0 +1,202 @@
+defmodule PhoenixKit.Utils.SlugPutSlugTest do
+  @moduledoc """
+  `put_slug/3` probes the database, so these run against a real table rather than a
+  mock — the scoping and self-exclusion clauses are SQL, and a mock would assert the
+  query I wrote rather than the rows it actually matches.
+
+  The table is scratch-built per test, shaped like the schemas that will adopt this
+  (`uuid` primary key, `user_uuid` scope column), so a failure cannot damage anything
+  real. Same pattern as the V167 integration test.
+  """
+  use PhoenixKit.DataCase, async: false
+
+  alias PhoenixKit.Utils.Slug
+
+  defmodule Doc do
+    @moduledoc false
+    use Ecto.Schema
+
+    @primary_key {:uuid, Ecto.UUID, autogenerate: true}
+    schema "phoenix_kit_zz_put_slug" do
+      field(:title, :string)
+      field(:slug, :string)
+      field(:user_uuid, Ecto.UUID)
+      field(:code, :string)
+    end
+
+    def changeset(doc, attrs) do
+      Ecto.Changeset.cast(doc, attrs, [:title, :slug, :user_uuid, :code])
+    end
+  end
+
+  setup do
+    Repo.query!("DROP TABLE IF EXISTS phoenix_kit_zz_put_slug")
+
+    Repo.query!("""
+    CREATE TABLE phoenix_kit_zz_put_slug (
+      uuid uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      title character varying(255),
+      slug character varying(255),
+      user_uuid uuid,
+      code character varying(255)
+    )
+    """)
+
+    on_exit(fn ->
+      PhoenixKit.RepoHelper.repo().query!("DROP TABLE IF EXISTS phoenix_kit_zz_put_slug")
+    end)
+
+    :ok
+  end
+
+  defp insert!(attrs) do
+    Repo.insert!(Ecto.Changeset.change(%Doc{}, attrs))
+  end
+
+  defp slug(changeset), do: Ecto.Changeset.get_field(changeset, :slug)
+
+  describe "put_slug/3 — which save regenerates" do
+    test "generates from the source on insert" do
+      changeset = Doc.changeset(%Doc{}, %{title: "Geometric Planter"})
+      assert slug(Slug.put_slug(changeset, :title)) == "geometric-planter"
+    end
+
+    test "an explicit non-blank slug wins over the source" do
+      changeset = Doc.changeset(%Doc{}, %{title: "Geometric Planter", slug: "hand-picked"})
+      assert slug(Slug.put_slug(changeset, :title)) == "hand-picked"
+    end
+
+    test "an explicitly blanked slug regenerates from the source" do
+      doc = insert!(%{title: "Old", slug: "old"})
+      changeset = Doc.changeset(doc, %{title: "Brand New", slug: ""})
+      assert slug(Slug.put_slug(changeset, :title)) == "brand-new"
+    end
+
+    test "a save carrying no slug leaves a stored slug alone even when the title changes" do
+      # The whole point. Under `get_change/2` this returned "brand-new" and moved a
+      # live URL on every ordinary edit.
+      doc = insert!(%{title: "Old Title", slug: "hand-picked"})
+      changeset = Doc.changeset(doc, %{title: "Brand New Title"})
+
+      result = Slug.put_slug(changeset, :title)
+      assert Ecto.Changeset.get_change(result, :slug) == nil
+      assert slug(result) == "hand-picked"
+    end
+
+    test "a stored record with no slug gets one" do
+      doc = insert!(%{title: "Needs One", slug: nil})
+      changeset = Doc.changeset(doc, %{})
+      assert slug(Slug.put_slug(changeset, :title)) == "needs-one"
+    end
+
+    test "an unromanizable source leaves the changeset untouched rather than storing a blank" do
+      changeset = Doc.changeset(%Doc{}, %{title: "日本"})
+      assert Ecto.Changeset.get_change(Slug.put_slug(changeset, :title), :slug) == nil
+    end
+
+    test "a missing source leaves the changeset untouched" do
+      changeset = Doc.changeset(%Doc{}, %{})
+      assert Ecto.Changeset.get_change(Slug.put_slug(changeset, :title), :slug) == nil
+    end
+  end
+
+  describe "put_slug/3 — uniqueness" do
+    test "suffixes past every taken candidate" do
+      insert!(%{slug: "planter"})
+      insert!(%{slug: "planter-2"})
+
+      changeset = Doc.changeset(%Doc{}, %{title: "Planter"})
+      assert slug(Slug.put_slug(changeset, :title)) == "planter-3"
+    end
+
+    test "the row being saved is excluded from its own probe" do
+      # Without the self-exclusion this renames "planter" to "planter-2" on the
+      # save that was only meant to blank-and-regenerate it.
+      doc = insert!(%{title: "Planter", slug: "planter"})
+      changeset = Doc.changeset(doc, %{slug: ""})
+      assert slug(Slug.put_slug(changeset, :title)) == "planter"
+    end
+
+    test "unique: false skips the probe" do
+      insert!(%{slug: "planter"})
+      changeset = Doc.changeset(%Doc{}, %{title: "Planter"})
+      assert slug(Slug.put_slug(changeset, :title, unique: false)) == "planter"
+    end
+  end
+
+  describe "put_slug/3 — scoped uniqueness" do
+    test "the same slug is free for a different scope value" do
+      alice = Ecto.UUID.generate()
+      bob = Ecto.UUID.generate()
+      insert!(%{slug: "notes", user_uuid: alice})
+
+      changeset = Doc.changeset(%Doc{}, %{title: "Notes", user_uuid: bob})
+      assert slug(Slug.put_slug(changeset, :title, scope: [:user_uuid])) == "notes"
+    end
+
+    test "the same slug is taken within one scope value" do
+      alice = Ecto.UUID.generate()
+      insert!(%{slug: "notes", user_uuid: alice})
+
+      changeset = Doc.changeset(%Doc{}, %{title: "Notes", user_uuid: alice})
+      assert slug(Slug.put_slug(changeset, :title, scope: [:user_uuid])) == "notes-2"
+    end
+
+    test "a nil scope matches IS NULL rather than reporting everything free" do
+      insert!(%{slug: "notes", user_uuid: nil})
+
+      changeset = Doc.changeset(%Doc{}, %{title: "Notes"})
+      assert slug(Slug.put_slug(changeset, :title, scope: [:user_uuid])) == "notes-2"
+    end
+
+    test "without :scope the probe is global and ignores the scope column" do
+      insert!(%{slug: "notes", user_uuid: Ecto.UUID.generate()})
+
+      changeset = Doc.changeset(%Doc{}, %{title: "Notes", user_uuid: Ecto.UUID.generate()})
+      assert slug(Slug.put_slug(changeset, :title)) == "notes-2"
+    end
+  end
+
+  describe "put_slug/3 — options" do
+    test ":to writes to a field other than :slug" do
+      changeset =
+        Doc.changeset(%Doc{}, %{title: "Geometric Planter"})
+        |> Slug.put_slug(:title, to: :code, unique: false)
+
+      assert Ecto.Changeset.get_change(changeset, :code) == "geometric-planter"
+      # ...and leaves :slug alone, so the two are independent.
+      assert Ecto.Changeset.get_change(changeset, :slug) == nil
+    end
+
+    test ":locale reaches slugify" do
+      changeset = Doc.changeset(%Doc{}, %{title: "Größe"})
+      assert slug(Slug.put_slug(changeset, :title, locale: "de", unique: false)) == "groesse"
+    end
+
+    test ":max_length is respected by the suffix, not just the base" do
+      # Regression: the suffix used to be appended after the cap, so a 20-char
+      # base came back 22 chars and silently blew the ceiling — and against a
+      # varchar(n) column Postgres raises rather than truncating.
+      insert!(%{slug: "geometric-planter-wi"})
+
+      changeset = Doc.changeset(%Doc{}, %{title: "Geometric Planter With A Long Tail"})
+      result = slug(Slug.put_slug(changeset, :title, max_length: 20))
+
+      assert String.length(result) <= 20
+      assert String.ends_with?(result, "-2")
+      refute result =~ "--"
+    end
+
+    test ":queryable narrows what counts as taken" do
+      import Ecto.Query
+
+      insert!(%{slug: "planter", title: "ignored"})
+
+      changeset = Doc.changeset(%Doc{}, %{title: "Planter"})
+
+      # Probe a source that excludes the conflicting row: the slug reads as free.
+      queryable = from(d in Doc, where: d.title != "ignored")
+      assert slug(Slug.put_slug(changeset, :title, queryable: queryable)) == "planter"
+    end
+  end
+end


### PR DESCRIPTION
Slugs were assumed unique in three places and enforced in none. This adds the missing core helper, and the two indexes an audit found missing.

## Why it's one PR

Core owned `slugify/2` and `ensure_unique/2` but **not the changeset glue between them**, so `defp maybe_generate_slug/1` is hand-rolled **14 times across 8 packages** — and each copy got a different subset right. Fixing the packages one at a time would leave the next one free to reinvent it wrong.

## 1. `Slug.put_slug/3` — the missing piece

Three defect classes, each verified in at least one package:

- **`get_change(:slug)` conflates two states** — "the caller said nothing about the slug" and "this record hasn't got one". So any save carrying no slug re-derived it from the title and **moved a live URL**. Still present in `ticket.ex:235`, `template.ex:112`, `shipping_method.ex:223`.
- **Most never call `ensure_unique/2`**, so duplicates were simply written.
- **`unique_constraint(:slug)` declared against an index that may not exist** — see §3.

`put_slug/3` is the `fetch_change` three-way state machine, generation only when the record has none, suffixing until free, self-exclusion via `__schema__(:primary_key)`, and `:scope` for per-owner uniqueness.

It queries from inside a changeset — unusual and deliberate. `Ecto.Changeset.unsafe_validate_unique/4` does the same, and the alternative splits one decision between the schema that generates and a context that would have to correct it. **The probe is an allocator, not an integrity boundary**: `unique_constraint` stays mandatory, because a concurrent insert between probe and write is exactly what the index is for. A missing repo skips the probe; a *configured repo that errors* raises, rather than silently writing a slug that may already be taken.

## 2. A bug in `ensure_unique/2` itself

The suffix was appended with no regard for a cap the caller had already applied:

```
slugify(title, max_length: 20) -> 20 chars, + "-2" -> 22 chars
```

Silently defeats an SEO cap, and **raises against `varchar(n)`**. Now takes `:max_length` and trims the base per candidate, since `-10` needs one more character than `-9`. Backward compatible — `ensure_unique/2` still works.

## 3. V167 + V168 — the indexes

**V167:** `phoenix_kit_posts.slug` had a plain btree since V135 while its sibling `post_tags.slug` was unique. `Post` declares `unique_constraint(:slug)` with nothing to translate, and `get_post_by_slug/2` fetches with `repo().one()` — so a duplicate didn't degrade that URL, it raised `Ecto.MultipleResultsError`.

**V168** finishes the audit. Of the 8 schemas declaring a slug `unique_constraint`, **six were already backed correctly**; two were not:

| Table | State |
|---|---|
| `phoenix_kit_tickets` | plain btree (`v135.ex:2842`), `unique_constraint(:slug)`, `get_ticket_by_slug/2` on `one()` |
| `phoenix_kit_post_groups` | **no slug index of any kind**, while `PostGroup` names a composite `[:user_uuid, :slug]` index that existed nowhere |

Post group slugs are unique **per user** — two users may both have `favourites` — so that index is on `(user_uuid, slug)` and the dedup partitions by the pair.

Existing duplicates are suffixed `-2`, `-3` … by the same rule `ensure_unique/2` applies at runtime, so a repaired row and a freshly generated one agree. For posts, a reachable post beats a draft, then oldest, then uuid; **two _live_ posts sharing a slug raises** rather than silently taking a working URL from one of them.

**The `DROP` before each `CREATE` is load-bearing.** `CREATE UNIQUE INDEX IF NOT EXISTS` matches on *name*, so creating a unique index over a non-unique one of the same name skips with a notice, leaves it non-unique, and reports success. Verified on PostgreSQL 17, and there's a test asserting the bare form is a no-op.

Index names are kept because Ecto matches constraints to indexes by name — renaming would silently stop `unique_constraint` translating.

## Verification

- `mix precommit` → exit 0
- `mix test` → **3,494 tests, 0 failures** against real PostgreSQL
- `mix phoenix_kit.release_check` → **Migration Version Sync PASS**
- Applied end-to-end: `pg_index` confirms all three indexes unique, schema stamp `168`
- 39 new tests, including that `shape_at(166).unique == false` / `shape_at(167).unique == true`

Manifest revisions are **appended, never edited in place** — `Object.shape_at/2` takes the last revision at or below the database's version, so rewriting an old one would tell current installs their index is drift and offer a repair that cannot run. `chain_hash` restamped the way V165/V166 were, for the reason recorded at `expected_schema.ex:48`.

No `CHANGELOG.md`, no `mix.exs` `@version`.

## Known, and deliberately not here

- **The 8 sibling packages still hand-roll their own.** Separate PRs, one per repo — `put_slug/3` is purely additive so they can adopt incrementally. Adopters need `{:phoenix_kit, "~> 2.3"}`; `~> 2.0` would compile against a core without it.
- **`ticket.ex` needs its slugify deleted, not wrapped**: it appends the last 6 digits of `System.system_time(:millisecond)`, which **cycles every 16.7 minutes**, so it was never a uniqueness mechanism.
- **Four packages have their own `slugify` that never calls core** — publishing's is a Russian-only 33-entry map; `ticket.ex`, `shipping_method.ex` and `bookings/service.ex` are ASCII-only `\w`, so a Cyrillic title yields an **empty slug**.
- **`ecommerce` product/category use `field :slug, :map`** — multilingual JSONB with an expression index. A string-field `put_slug` genuinely can't cover them; they'd need a `put_localized_slugs/3`.
- **`verify.exs --scenario s7,s8` has not been run.** The restamp asserts the *file set*, never the manifest body — that scenario is what would check the body.
- **Open design question:** should `put_slug` attach the `unique_constraint` itself via a `:constraint` option? It's the one change that would structurally stop the third defect class recurring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---

# Also in this PR: V169 and eleven constraint declarations

The two commits below were pushed onto `mdon:main` while this PR was open, so
they were absorbed into it. They are a **separate topic** from the slug work
above — say the word and I will move them onto their own branch.

## 2. V169 — nullable entity creator, and one duplicate foreign key

Closes the crash in BeamLabEU/phoenix_kit#706 and the core half of
BeamLabEU/phoenix_kit_ai#20.

**`phoenix_kit_entity_data.created_by_uuid` becomes nullable.** The public entity
form is deliberately unauthenticated and has nothing to put there, so on a
freshly migrated database every anonymous submission died with a
`not_null_violation` raised out of an unauthenticated controller.

The two populations already disagreed: a live install measures
`is_nullable = YES` with 4 NULL rows of 26 (V164 declines to re-impose NOT NULL
while NULLs exist), a fresh one measures `NO`. Consumers already guard for a
missing creator (`data_navigator` renders `creator.email` only `if
data_record.creator`), so nullable resolves the split in the direction the data
had already taken. The column has **no foreign key** to `phoenix_kit_users` on
any install, so the invariant was never "a real user" — only "some UUID".

The alternative, auto-filling the first Owner, was implemented first and
rejected: it puts a named person in front of every anonymous submission wherever
a creator is rendered, and files those submissions in that person's audit trail.

Recorded in three places together — V164's `@relaxed_after_v57`, the V135
baseline, and the manifest — as a **`{169, not_null: false}` revision, not a
rewrite of `{56}`**. `Scope` resolves each object at the newest revision <= the
database's comment, so claiming nullable from version 56 makes repair report a
pre-V169 database as wrong-shaped for the whole window between shipping the code
and running the migration. That was reproduced before being fixed.

**The duplicate prompt FK.** V135 adds it twice under two names, each block
guarded only by its own name, so a fresh database carries both. The **legacy**
`phoenix_kit_ai_requests_prompt_uuid_fkey` is kept — it is what the installed
base actually carries (measured on two databases that have only that one), so
nothing is renamed on a live install, and it is what Ecto derives by default.
The survivor is matched by **shape** (contype, referenced table and column), and
the duplicate is dropped only once a correctly shaped survivor is confirmed, so
the column is never left unreferenced.

Its manifest object is `:legacy_optional` with `create: nil`, not deleted:
`:required` would make `mix phoenix_kit.repair` re-add the duplicate after every
upgrade — and ADD it to legacy-only installs that never had it.

Both statements are guarded on table existence, `down/1` takes the table lock
before counting NULLs, and `down/1` deliberately does not restore the duplicate:
nothing records which population an install belonged to, so re-adding it would
invent the defect on databases that never had it.

The V164 relaxation guard did not catch this at first — its scan missed
`ALTER COLUMN "created_by_uuid"` because the pattern disallowed quoted
identifiers, a false negative its own moduledoc calls the failure mode that
matters. Fixed here.

## 3. Eleven constraint declarations that could never match

Ecto matches a constraint by NAME. `foreign_key_constraint(:user_uuid)` with no
`:name` expects `<table>_user_uuid_fkey`, but this chain names most of its
foreign keys `fk_<table>_<column>` — so eleven declarations across storage,
admin notes, OAuth providers, role assignments and role permissions matched a
constraint that does not exist, and a violation escapes as a raw
`Ecto.ConstraintError` (a 500) instead of the changeset error the caller
handles. Same defect as BeamLabEU/phoenix_kit_ai#19, at eleven more sites.

Names come from a **freshly migrated database**, not from reading the chain: a
renamed column can leave a constraint carrying its old name
(`phoenix_kit_file_instances_file_id_fkey` sits on a `file_uuid` column), and
reading v135 alone produces the wrong name for it. All eleven were cross-checked
against a long-lived install, which carries identical names.

The new test pins the **rule**, so the next schema cannot repeat it: every
constraint a core schema declares must exist under that name. It keeps object
types apart (a CHECK must not satisfy a foreign-key declaration; a non-unique
index must not satisfy a unique one), checks unique declarations against
`pg_indexes` as well as `pg_constraint` since `CREATE UNIQUE INDEX` makes no
`pg_constraint` row, groups declarations per field so the deliberate
"declare both names" pattern is not read as broken, takes the configured prefix,
and asserts it inspected at least 20 schemas so a wholesale skip cannot pass by
proving nothing.

## Verification for §2–3

- Fresh chain into a scratch database: marker 169, `is_nullable = YES`, exactly
  one prompt FK; `Repair.verify/1` returns only info-level
  `legacy_optional_absent` findings — and the same in the pre-V169 deploy window.
- Reverting either manifest correction reproduces the exact failure it prevents
  (`fk_ai_requests_prompt_uuid: missing, would repair`, and
  `not_null: expected false, got true`).
- Reverting the eleven declarations makes the new guard name all eleven.
- **3495 tests, 0 failures**; `mix precommit` passes.

Reviewed by an external model panel across two rounds; several findings in
§2–3 come from it — the unguarded drop on a partial install, the one-sided
rollback, the deploy-window revision, and `legacy_optional`'s `create: nil`
contract — each reproduced before being fixed.

## 4. Tree-wide guard: undeclared reads in function components

`PhoenixKit.Conformance.ComponentAssigns` — the class-level answer to the bug
in §2's origin story. A HEEx function component reading an assign it neither
declares nor self-assigns raises `KeyError` only when that branch renders, and
the compiler cannot see it (verified: the body-read shape emits zero
diagnostics; Phoenix validates only the call site). og#7 shipped exactly this
for four releases.

Conservative by design — only components that opt into `attr`/`slot`;
`render/1` skipped; self-assigned keys count only when rooted at `assigns`;
components whose assigns pass through an opaque helper are skipped, not
guessed at; and only CODE is ever scanned (balanced `{...}` expressions
outside `<style>`, `<%= %>` blocks everywhere), so prose, emails, CSS
at-rules and showcase sigils cannot false-positive.

The policy went through an adversarial model-panel round, and **every
counterexample the panel produced is now a fixture with its oracle**: the
prose `@mention` FP, the `-@amount` read the first draft's lookbehind hid, the
`<%= @brand %>`-inside-`<style>` read the strip-based scan swallowed, the
receiver-blind key collection that hid a real `@src` KeyError, and the
`@deprecated`-between-attr-and-def that hid a whole component. The panel also
proved one fixture oracle WRONG (`#{...}` inside `<style>` is literal at
runtime), and fixtures are now asserted to parse **and** compile through the
real HEEx engine, so the corpus cannot encode impossible expectations.

Proven three ways: the pre-fix og source reports exactly
`edit_modal/1 reads @preview_loading` (fixed source: nothing); core's own
`lib/` sweeps clean, kept that way by the paired test; and
`dev_docs/bin/check-component-assigns.exs` sweeps all 24 sibling checkouts —
**0 findings**. Modules can adopt the check as a one-line test once their pin
ships this; the script is the not-pin-gated sweep meanwhile.

**3501 tests, 0 failures**; `mix precommit` passes.
