### PR TITLE
Fix admin activity crash on map metadata and scope the log to admins

### DIFF
--- a/lib/phoenix_kit/activity/activity.ex
+++ b/lib/phoenix_kit/activity/activity.ex
@@ -28,6 +28,8 @@ defmodule PhoenixKit.Activity do
   alias PhoenixKit.Activity.Entry
   alias PhoenixKit.PubSub.Manager, as: PubSubManager
   alias PhoenixKit.Settings
+  alias PhoenixKit.Users.Auth.Scope
+  alias PhoenixKit.Users.Role
 
   @pubsub_topic "phoenix_kit:activity"
 
@@ -343,12 +345,62 @@ defmodule PhoenixKit.Activity do
     end
   end
 
+  @doc """
+  Whether `scope` may read the WHOLE activity log — every user's actions —
+  rather than only its own.
+
+  Administrators qualify: the Admin or Owner role, or any `"*"` superadmin
+  role. Everyone else (a custom role that merely holds `dashboard`) is scoped
+  to their own actions. The activity LiveViews share this as the single gate
+  for both the list and the single-entry page.
+  """
+  @spec full_log_access?(Scope.t() | nil) :: boolean()
+  def full_log_access?(scope) do
+    Scope.superadmin?(scope) or Scope.owner?(scope) or
+      Scope.has_role?(scope, Role.system_roles().admin)
+  end
+
   @doc "Returns a CSS badge class based on the mode."
   def mode_badge_color("manual"), do: "badge-warning"
   def mode_badge_color("auto"), do: "badge-info"
   def mode_badge_color("cron"), do: "badge-secondary"
   def mode_badge_color("script"), do: "badge-accent"
   def mode_badge_color(_), do: "badge-ghost"
+
+  @doc """
+  Renders an activity-metadata VALUE as human-readable text, tolerant of the
+  shapes host apps store.
+
+  The admin feed and detail page display arbitrary per-module metadata, so this
+  must never raise `Protocol.UndefinedError` (`String.Chars`/`to_string` on a
+  Map): a field-change diff carries a nested `%{"from" => _, "to" => _}` map,
+  which is rendered as `"1 → 2"`; any other map is rendered as
+  `"key: value, ..."`. Legacy entries whose scalar was serialised via `inspect`
+  (`"Decimal.new(\\"1\\")"`) are unwrapped to their inner value so old rows read
+  cleanly instead of leaking Elixir syntax.
+  """
+  def humanize_metadata_value(%{"from" => from, "to" => to}),
+    do: "#{humanize_metadata_value(from)} → #{humanize_metadata_value(to)}"
+
+  def humanize_metadata_value(value) when is_map(value) and not is_struct(value) do
+    Enum.map_join(value, ", ", fn {k, v} -> "#{k}: #{humanize_metadata_value(v)}" end)
+  end
+
+  def humanize_metadata_value(value) when is_list(value),
+    do: Enum.map_join(value, ", ", &humanize_metadata_value/1)
+
+  def humanize_metadata_value(value) when is_binary(value), do: unwrap_inspect_scalar(value)
+  def humanize_metadata_value(nil), do: ""
+  def humanize_metadata_value(value), do: to_string(value)
+
+  # Legacy rows serialised a Decimal via inspect/1 ("Decimal.new(\"1\")"); show
+  # the number instead. Anything that doesn't match is returned unchanged.
+  defp unwrap_inspect_scalar(str) do
+    case Regex.run(~r/^Decimal\.new\("?(-?\d+(?:\.\d+)?)"?\)$/, str) do
+      [_, number] -> number
+      _ -> str
+    end
+  end
 
   # Private
 

--- a/lib/phoenix_kit/activity/activity.ex
+++ b/lib/phoenix_kit/activity/activity.ex
@@ -360,6 +360,27 @@ defmodule PhoenixKit.Activity do
       Scope.has_role?(scope, Role.system_roles().admin)
   end
 
+  @doc """
+  Whether `entry` is `scope`'s OWN activity.
+
+  "Own" is defined by AUTHORSHIP: the scope's user is the entry's `actor_uuid`
+  (the account that performed the action). A record where the user is only the
+  `target_uuid` — someone else acted on or for them — is NOT their own and stays
+  hidden from a non-administrator.
+
+  This is the single definition the audit log enforces in two places, and they
+  must not drift: the list pins `actor_uuid` to the user (`Activity.Index`) and
+  the single-entry page gates on this predicate (`Activity.Show`). If "own" ever
+  needs to include target-side records, change it HERE and switch the list's
+  filter in lock-step — do not fork the rule per view.
+  """
+  @spec own_entry?(Scope.t() | nil, Entry.t()) :: boolean()
+  def own_entry?(%Scope{user: %{uuid: uuid}}, %Entry{actor_uuid: actor_uuid})
+      when is_binary(uuid) and is_binary(actor_uuid),
+      do: actor_uuid == uuid
+
+  def own_entry?(_scope, _entry), do: false
+
   @doc "Returns a CSS badge class based on the mode."
   def mode_badge_color("manual"), do: "badge-warning"
   def mode_badge_color("auto"), do: "badge-info"

--- a/lib/phoenix_kit_web/live/activity/index.ex
+++ b/lib/phoenix_kit_web/live/activity/index.ex
@@ -38,10 +38,19 @@ defmodule PhoenixKitWeb.Live.Activity.Index do
 
       project_title = Settings.get_project_title()
 
+      # The shared audit log is administrators-only: a full-access operator
+      # (Admin/Owner, or any role holding every grantable permission) sees the
+      # whole platform's activity; every other dashboard-holder is scoped to
+      # their OWN actions — enforced here (not just in the UI) so it also holds
+      # for the direct `?actor`-style URL and the per-resource deep link.
+      full_access? = Activity.full_log_access?(scope)
+
       socket =
         socket
         |> assign(:page_title, gettext("Activity"))
         |> assign(:project_title, project_title)
+        |> assign(:full_log_access?, full_access?)
+        |> assign(:scoped_actor_uuid, scoped_actor_uuid(full_access?, scope))
         |> assign(:modules, Activity.list_modules())
         |> assign(:modes, Activity.list_modes())
         |> assign(:action_types, Activity.list_action_types())
@@ -143,6 +152,9 @@ defmodule PhoenixKitWeb.Live.Activity.Index do
         action: socket.assigns.filter_action,
         resource_type: socket.assigns.filter_resource_type,
         resource_uuid: socket.assigns.filter_resource_uuid,
+        # nil for a full-access operator (all actors); the current user's uuid
+        # otherwise — a hard server-side scope to own actions.
+        actor_uuid: socket.assigns.scoped_actor_uuid,
         preload: [:actor, :target]
       )
 
@@ -238,6 +250,13 @@ defmodule PhoenixKitWeb.Live.Activity.Index do
   defp action_badge_color(action), do: Activity.action_badge_color(action)
   defp mode_badge_color(mode), do: Activity.mode_badge_color(mode)
 
+  # Which actor the list is pinned to: nil (unrestricted) for a full-access
+  # operator, else the current user's own uuid. Fail closed — a non-full scope
+  # with no resolvable user sees nothing, never everything.
+  defp scoped_actor_uuid(true, _scope), do: nil
+  defp scoped_actor_uuid(false, %Scope{user: %User{uuid: uuid}}) when is_binary(uuid), do: uuid
+  defp scoped_actor_uuid(false, _scope), do: Ecto.UUID.generate()
+
   # True when any of the four Activity filters is set. Drives both the
   # toolbar Clear-filters button and the filtered empty-state message.
   defp any_filter_active?(assigns) do
@@ -256,8 +275,17 @@ defmodule PhoenixKitWeb.Live.Activity.Index do
     if meta["added"] || meta["removed"] do
       # For role updates, show added/removed summary
       parts = []
-      parts = if meta["added"], do: parts ++ ["added: #{meta["added"]}"], else: parts
-      parts = if meta["removed"], do: parts ++ ["removed: #{meta["removed"]}"], else: parts
+
+      parts =
+        if meta["added"],
+          do: parts ++ ["added: #{Activity.humanize_metadata_value(meta["added"])}"],
+          else: parts
+
+      parts =
+        if meta["removed"],
+          do: parts ++ ["removed: #{Activity.humanize_metadata_value(meta["removed"])}"],
+          else: parts
+
       Enum.join(parts, ", ")
     else
       # For profile updates, extract field names from _from/_to pairs
@@ -282,8 +310,16 @@ defmodule PhoenixKitWeb.Live.Activity.Index do
     |> Map.drop(["method", "actor_role"])
     |> Enum.reject(fn {_k, v} -> v == nil or v == "" end)
     |> case do
-      [] -> nil
-      entries -> Enum.map_join(entries, ", ", fn {k, v} -> "#{k}: #{v}" end)
+      [] ->
+        nil
+
+      entries ->
+        # Values may be nested maps (e.g. a `%{"from" => _, "to" => _}` field
+        # diff) — Activity.humanize_metadata_value/1 renders those as "1 → 2"
+        # rather than raising String.Chars on a Map (the crash this fixes).
+        Enum.map_join(entries, ", ", fn {k, v} ->
+          "#{k}: #{Activity.humanize_metadata_value(v)}"
+        end)
     end
   end
 end

--- a/lib/phoenix_kit_web/live/activity/index.ex
+++ b/lib/phoenix_kit_web/live/activity/index.ex
@@ -251,8 +251,11 @@ defmodule PhoenixKitWeb.Live.Activity.Index do
   defp mode_badge_color(mode), do: Activity.mode_badge_color(mode)
 
   # Which actor the list is pinned to: nil (unrestricted) for a full-access
-  # operator, else the current user's own uuid. Fail closed — a non-full scope
-  # with no resolvable user sees nothing, never everything.
+  # operator, else the current user's own uuid. Pinning `actor_uuid` is what
+  # makes "own" mean AUTHORED-BY — the same definition as Activity.own_entry?/2
+  # that the single-entry page enforces; a record merely targeting the user is
+  # deliberately not shown. Fail closed — a non-full scope with no resolvable
+  # user sees nothing, never everything.
   defp scoped_actor_uuid(true, _scope), do: nil
   defp scoped_actor_uuid(false, %Scope{user: %User{uuid: uuid}}) when is_binary(uuid), do: uuid
   defp scoped_actor_uuid(false, _scope), do: Ecto.UUID.generate()

--- a/lib/phoenix_kit_web/live/activity/show.ex
+++ b/lib/phoenix_kit_web/live/activity/show.ex
@@ -17,35 +17,38 @@ defmodule PhoenixKitWeb.Live.Activity.Show do
     scope = socket.assigns[:phoenix_kit_current_scope]
 
     if scope && Scope.has_module_access?(scope, "dashboard") do
-      case Activity.get_entry(uuid) do
-        nil ->
-          {:ok,
-           socket
-           |> put_flash(:error, gettext("Activity not found"))
-           |> push_navigate(to: Routes.path("/admin/activity"))}
+      entry = Activity.get_entry(uuid)
 
-        entry ->
-          project_title = Settings.get_project_title()
-          resource_user = resolve_resource_user(entry)
+      # A non-administrator may only open their OWN entries. Treat someone
+      # else's as not-found (same response as a missing uuid) so the detail
+      # page never leaks another user's audit record via its direct URL.
+      if is_nil(entry) or not can_view_entry?(scope, entry) do
+        {:ok,
+         socket
+         |> put_flash(:error, gettext("Activity not found"))
+         |> push_navigate(to: Routes.path("/admin/activity"))}
+      else
+        project_title = Settings.get_project_title()
+        resource_user = resolve_resource_user(entry)
 
-          # Resolve deep-links for the resource AND the actor/target (both users),
-          # so the who-did-it / who-it's-for identities are clickable too.
-          links =
-            [entry]
-            |> Enum.concat(user_items(entry))
-            |> PhoenixKit.ResourceLinks.resolve()
+        # Resolve deep-links for the resource AND the actor/target (both users),
+        # so the who-did-it / who-it's-for identities are clickable too.
+        links =
+          [entry]
+          |> Enum.concat(user_items(entry))
+          |> PhoenixKit.ResourceLinks.resolve()
 
-          socket =
-            socket
-            |> assign(:page_title, gettext("Activity Detail"))
-            |> assign(:project_title, project_title)
-            |> assign(:entry, entry)
-            |> assign(:resource_user, resource_user)
-            |> assign(:resource_link, links[{entry.resource_type, entry.resource_uuid}])
-            |> assign(:actor_link, links[{"user", entry.actor_uuid}])
-            |> assign(:target_link, links[{"user", entry.target_uuid}])
+        socket =
+          socket
+          |> assign(:page_title, gettext("Activity Detail"))
+          |> assign(:project_title, project_title)
+          |> assign(:entry, entry)
+          |> assign(:resource_user, resource_user)
+          |> assign(:resource_link, links[{entry.resource_type, entry.resource_uuid}])
+          |> assign(:actor_link, links[{"user", entry.actor_uuid}])
+          |> assign(:target_link, links[{"user", entry.target_uuid}])
 
-          {:ok, socket}
+        {:ok, socket}
       end
     else
       {:ok,
@@ -80,4 +83,17 @@ defmodule PhoenixKitWeb.Live.Activity.Show do
 
   defp mode_badge_color(mode), do: Activity.mode_badge_color(mode)
   defp action_badge_color(action), do: Activity.action_badge_color(action)
+
+  # Administrators — Admin or Owner (or any "*" superadmin role) — may open any
+  # entry; everyone else only their own. Mirrors the list-scoping gate in
+  # Activity.Index — keep the two in lock-step.
+  defp can_view_entry?(scope, entry) do
+    Activity.full_log_access?(scope) or own_entry?(scope, entry)
+  end
+
+  defp own_entry?(%Scope{user: %{uuid: uuid}}, %{actor_uuid: actor_uuid})
+       when is_binary(actor_uuid),
+       do: actor_uuid == uuid
+
+  defp own_entry?(_scope, _entry), do: false
 end

--- a/lib/phoenix_kit_web/live/activity/show.ex
+++ b/lib/phoenix_kit_web/live/activity/show.ex
@@ -88,12 +88,8 @@ defmodule PhoenixKitWeb.Live.Activity.Show do
   # entry; everyone else only their own. Mirrors the list-scoping gate in
   # Activity.Index — keep the two in lock-step.
   defp can_view_entry?(scope, entry) do
-    Activity.full_log_access?(scope) or own_entry?(scope, entry)
+    # "Own" == authored by this user (actor), NOT merely targeted at them —
+    # see Activity.own_entry?/2, the single definition shared with the list.
+    Activity.full_log_access?(scope) or Activity.own_entry?(scope, entry)
   end
-
-  defp own_entry?(%Scope{user: %{uuid: uuid}}, %{actor_uuid: actor_uuid})
-       when is_binary(actor_uuid),
-       do: actor_uuid == uuid
-
-  defp own_entry?(_scope, _entry), do: false
 end

--- a/lib/phoenix_kit_web/live/activity/show.html.heex
+++ b/lib/phoenix_kit_web/live/activity/show.html.heex
@@ -163,7 +163,7 @@
                     {key}
                   </.table_default_cell>
                   <.table_default_cell class="text-sm break-all">
-                    {to_string(value)}
+                    {Activity.humanize_metadata_value(value)}
                   </.table_default_cell>
                 </.table_default_row>
               </.table_default_body>

--- a/test/integration/phoenix_kit_web/live/activity/activity_access_test.exs
+++ b/test/integration/phoenix_kit_web/live/activity/activity_access_test.exs
@@ -1,0 +1,160 @@
+defmodule PhoenixKitWeb.Live.Activity.AccessTest do
+  @moduledoc """
+  The shared audit log at `/admin/activity`.
+
+  Two guarantees pinned here:
+
+    * Render tolerance — a structural change event carries a nested
+      `%{"from" => _, "to" => _}` diff map; the feed used to interpolate it as a
+      scalar and crash the whole page with `Protocol.UndefinedError`
+      (String.Chars for Map). Legacy rows whose scalar was `inspect`-serialised
+      ("Decimal.new(\\"1\\")") must read cleanly too.
+
+    * Authorization — the full log is administrators-only. A non-admin
+      dashboard-holder sees only their OWN actions, in the list AND via a direct
+      entry URL; someone else's entry is treated as not-found.
+  """
+  use PhoenixKitWeb.ConnCase, async: false
+
+  alias PhoenixKit.Activity
+  alias PhoenixKit.Users.Auth
+  alias PhoenixKit.Users.Permissions
+  alias PhoenixKit.Users.Roles
+  alias PhoenixKit.Utils.Routes
+
+  setup do
+    # The first account in a fresh sandbox is auto-promoted to Owner; burn one
+    # so the users built below get exactly the rank each test asks for.
+    {:ok, seed} = Auth.register_user(%{email: unique_email(), password: "ValidPassword123!"})
+    {:ok, _} = Auth.admin_confirm_user(seed)
+    :ok
+  end
+
+  defp unique_email, do: "u#{System.unique_integer([:positive])}@example.com"
+
+  defp confirmed_user do
+    {:ok, user} = Auth.register_user(%{email: unique_email(), password: "ValidPassword123!"})
+    {:ok, user} = Auth.admin_confirm_user(user)
+    Repo.get!(Auth.User, user.uuid)
+  end
+
+  defp admin_user do
+    user = confirmed_user()
+    {:ok, _} = Roles.assign_role(user, "Admin")
+    Repo.get!(Auth.User, user.uuid)
+  end
+
+  # A non-admin who can reach /admin/activity (holds `dashboard`) but does not
+  # hold every permission — so they are scoped to their own actions.
+  defp dashboard_only_user do
+    user = confirmed_user()
+
+    {:ok, role} =
+      Roles.create_role(%{
+        name: "ActivityDashboardOnly#{System.unique_integer([:positive])}",
+        description: "dashboard access, nothing else"
+      })
+
+    {:ok, _} = Permissions.grant_permission(role.uuid, "dashboard")
+    {:ok, _} = Roles.assign_role(user, role.name)
+    Repo.get!(Auth.User, user.uuid)
+  end
+
+  defp log!(actor, action, metadata) do
+    {:ok, entry} =
+      Activity.log(%{
+        action: action,
+        module: "orders",
+        actor_uuid: actor.uuid,
+        resource_type: "order",
+        resource_uuid: Ecto.UUID.generate(),
+        metadata: metadata
+      })
+
+    entry
+  end
+
+  describe "render tolerance" do
+    test "a qty field-change diff renders as 1 → 2 instead of crashing", %{conn: conn} do
+      admin = admin_user()
+
+      log!(admin, "orders.row_updated", %{
+        "item_name" => "Widget",
+        "changes" => %{"qty" => %{"from" => "1", "to" => "2"}}
+      })
+
+      {:ok, _lv, html} = live(log_in_user(conn, admin), Routes.path("/admin/activity"))
+      assert html =~ "1 → 2"
+    end
+
+    test "a legacy inspect-serialised Decimal reads as the bare number", %{conn: conn} do
+      admin = admin_user()
+
+      log!(admin, "orders.row_updated", %{"qty" => "Decimal.new(\"5\")"})
+
+      {:ok, _lv, html} = live(log_in_user(conn, admin), Routes.path("/admin/activity"))
+      assert html =~ "qty: 5"
+      refute html =~ "Decimal.new"
+    end
+  end
+
+  describe "authorization — list" do
+    test "an administrator sees every user's actions", %{conn: conn} do
+      admin = admin_user()
+      other = confirmed_user()
+
+      log!(other, "orders.created", %{"title" => "THEIRS"})
+      log!(admin, "orders.created", %{"title" => "MINE"})
+
+      {:ok, _lv, html} = live(log_in_user(conn, admin), Routes.path("/admin/activity"))
+      assert html =~ "THEIRS"
+      assert html =~ "MINE"
+    end
+
+    test "a dashboard-only user sees only their own actions", %{conn: conn} do
+      user = dashboard_only_user()
+      other = admin_user()
+
+      log!(other, "orders.created", %{"title" => "THEIRS"})
+      log!(user, "orders.created", %{"title" => "MINE"})
+
+      {:ok, _lv, html} = live(log_in_user(conn, user), Routes.path("/admin/activity"))
+      assert html =~ "MINE"
+      refute html =~ "THEIRS"
+    end
+  end
+
+  describe "authorization — single entry (direct URL)" do
+    test "an administrator may open anyone's entry", %{conn: conn} do
+      admin = admin_user()
+      other = confirmed_user()
+      entry = log!(other, "orders.created", %{"title" => "THEIRS"})
+
+      {:ok, _lv, html} =
+        live(log_in_user(conn, admin), Routes.path("/admin/activity/#{entry.uuid}"))
+
+      assert html =~ "THEIRS"
+    end
+
+    test "a dashboard-only user may open their OWN entry", %{conn: conn} do
+      user = dashboard_only_user()
+      entry = log!(user, "orders.created", %{"title" => "MINE"})
+
+      {:ok, _lv, html} =
+        live(log_in_user(conn, user), Routes.path("/admin/activity/#{entry.uuid}"))
+
+      assert html =~ "MINE"
+    end
+
+    test "a dashboard-only user is bounced from someone else's entry", %{conn: conn} do
+      user = dashboard_only_user()
+      other = admin_user()
+      entry = log!(other, "orders.created", %{"title" => "THEIRS"})
+
+      assert {:error, {:live_redirect, %{to: to}}} =
+               live(log_in_user(conn, user), Routes.path("/admin/activity/#{entry.uuid}"))
+
+      assert to =~ "/admin/activity"
+    end
+  end
+end

--- a/test/integration/phoenix_kit_web/live/activity/activity_access_test.exs
+++ b/test/integration/phoenix_kit_web/live/activity/activity_access_test.exs
@@ -74,6 +74,23 @@ defmodule PhoenixKitWeb.Live.Activity.AccessTest do
     entry
   end
 
+  # An action `actor` performed ON/FOR `target` — `target` is the subject, not
+  # the author. Used to pin that "own" is authorship, not being targeted.
+  defp log_targeting!(actor, target, action, metadata) do
+    {:ok, entry} =
+      Activity.log(%{
+        action: action,
+        module: "users",
+        actor_uuid: actor.uuid,
+        target_uuid: target.uuid,
+        resource_type: "user",
+        resource_uuid: target.uuid,
+        metadata: metadata
+      })
+
+    entry
+  end
+
   describe "render tolerance" do
     test "a qty field-change diff renders as 1 → 2 instead of crashing", %{conn: conn} do
       admin = admin_user()
@@ -150,6 +167,35 @@ defmodule PhoenixKitWeb.Live.Activity.AccessTest do
       user = dashboard_only_user()
       other = admin_user()
       entry = log!(other, "orders.created", %{"title" => "THEIRS"})
+
+      assert {:error, {:live_redirect, %{to: to}}} =
+               live(log_in_user(conn, user), Routes.path("/admin/activity/#{entry.uuid}"))
+
+      assert to =~ "/admin/activity"
+    end
+  end
+
+  # "Own" is authorship (actor), not being the subject (target). A record where
+  # the user is only the target must stay hidden from a non-administrator, in
+  # both the list and via the direct URL — the definition Activity.own_entry?/2
+  # fixes for both views.
+  describe "own == actor, not target" do
+    test "a dashboard-only user does NOT see an action merely targeting them", %{conn: conn} do
+      user = dashboard_only_user()
+      other = admin_user()
+
+      log_targeting!(other, user, "users.profile_updated", %{"note" => "TARGETED"})
+      log!(user, "orders.created", %{"title" => "AUTHORED"})
+
+      {:ok, _lv, html} = live(log_in_user(conn, user), Routes.path("/admin/activity"))
+      assert html =~ "AUTHORED"
+      refute html =~ "TARGETED"
+    end
+
+    test "a dashboard-only user is bounced from an entry that only targets them", %{conn: conn} do
+      user = dashboard_only_user()
+      other = admin_user()
+      entry = log_targeting!(other, user, "users.profile_updated", %{"note" => "TARGETED"})
 
       assert {:error, {:live_redirect, %{to: to}}} =
                live(log_in_user(conn, user), Routes.path("/admin/activity/#{entry.uuid}"))

--- a/test/phoenix_kit/activity/humanize_metadata_value_test.exs
+++ b/test/phoenix_kit/activity/humanize_metadata_value_test.exs
@@ -1,0 +1,45 @@
+defmodule PhoenixKit.Activity.HumanizeMetadataValueTest do
+  @moduledoc """
+  The admin activity feed and the single-entry page render arbitrary
+  per-module metadata. A structural change event stores a nested
+  `%{"from" => _, "to" => _}` map; interpolating that as a scalar used to raise
+  `Protocol.UndefinedError` (String.Chars not implemented for Map) and take the
+  whole `/admin/activity` page down. These pin the tolerant rendering.
+  """
+  use ExUnit.Case, async: true
+
+  alias PhoenixKit.Activity
+
+  test "a from/to diff renders as an arrow, never raising on the map" do
+    assert Activity.humanize_metadata_value(%{"from" => "1", "to" => "2"}) == "1 → 2"
+  end
+
+  test "a nested field-change map (the exact crash payload) is readable" do
+    value = %{"qty" => %{"from" => "1", "to" => "2"}}
+    assert Activity.humanize_metadata_value(value) == "qty: 1 → 2"
+  end
+
+  test "legacy inspect-serialised Decimals are unwrapped to the bare number" do
+    assert Activity.humanize_metadata_value("Decimal.new(\"1\")") == "1"
+
+    assert Activity.humanize_metadata_value(%{
+             "from" => "Decimal.new(\"1\")",
+             "to" => "Decimal.new(\"2\")"
+           }) ==
+             "1 → 2"
+  end
+
+  test "plain scalars pass through" do
+    assert Activity.humanize_metadata_value("hello") == "hello"
+    assert Activity.humanize_metadata_value(42) == "42"
+    assert Activity.humanize_metadata_value(nil) == ""
+  end
+
+  test "a generic (non from/to) map renders key: value pairs without raising" do
+    assert Activity.humanize_metadata_value(%{"a" => "1"}) == "a: 1"
+  end
+
+  test "a list renders comma-joined" do
+    assert Activity.humanize_metadata_value(["a", "b"]) == "a, b"
+  end
+end


### PR DESCRIPTION
## Fix /admin/activity crash on map metadata + scope the activity log

Two commits from the LOOP pipeline (contract L023):

**1. Render crash (`836baa02`):** `GET /admin/activity` raised
`Protocol.UndefinedError` («String.Chars not implemented for Map») on entries
whose metadata carries a change-diff map (e.g. `%{"qty" => %{"from" => …,
"to" => …}}`). The renderer now handles map metadata with a human-readable
diff («1 → 2») and tolerates legacy rows that stored `Decimal.new("1")`
inspect-strings. Regression test included.

**2. Access scoping (`128ce85f`):** the full activity log is now admin-only;
a regular user sees only entries where they are the **actor** (author).
Semantics are pinned in `PhoenixKit.Activity.own_entry?/2` (docstring + spec +
guard tests) so index and show can never diverge; direct URLs to other users'
entries are denied; anonymous access is fail-closed.

## Independent review (LOOP checker gate)

Isolated reviewer (GLM-5.2 via Pi, static analysis over the full diff):
**SHIP.** Renderer fix and rights scoping verified; no bypass via
params/sort/export; anonymous fail-closed. The one P1 (pin the "own entry"
semantics) was addressed by `own_entry?/2` + guard tests before this PR.

Tests: core 16/0 new (access LiveView both roles + foreign entry, humanize
unit, activity_filter) + `activity_access_test.exs` 9/0; format/credo clean.
