### PR TITLE
Fix the ten findings from the high-effort review of the recent merges

### DIFF
--- a/lib/phoenix_kit/migrations/expected_schema.ex
+++ b/lib/phoenix_kit/migrations/expected_schema.ex
@@ -105,7 +105,7 @@ defmodule PhoenixKit.Migrations.ExpectedSchema do
   @schema_token "__SCHEMA__"
   @name_marker_exempt "__PK_NAME_EXEMPT__"
   @name_marker_always "__PK_NAME_ALWAYS__"
-  @chain_hash "629c9100db77ab288f622da2afd93ab7c1860ec039c084aad598eb9b8bef7dc7"
+  @chain_hash "afba80ea02c44069735a602444c12d20436d8b17b37fdd8223d6b9285be9c438"
 
   def objects(prefix) do
     prefix = normalize_prefix!(prefix)
@@ -49170,6 +49170,81 @@ defmodule PhoenixKit.Migrations.ExpectedSchema do
                "CREATE INDEX phoenix_kit_notifications_recipient_inbox_index ON __SCHEMA__.phoenix_kit_notifications USING btree (recipient_uuid, inserted_at DESC) WHERE (dismissed_at IS NULL)",
              predicate: "(dismissed_at IS NULL)",
              opclasses: ["uuid_ops", "timestamptz_ops"],
+             name_template: nil
+           }}
+        ],
+        presence: :required,
+        backfill: nil
+      },
+      # DECLARED POST-GENERATION (2026-08-14): V170 adds these two indexes for
+      # the notification-collapsing API — carried the same way the V165..V167
+      # objects are (hand-declared, chain_hash restamped over the shipped
+      # files). Definitions and opclasses were captured from pg_get_indexdef /
+      # pg_index on a live V169 database after creating the indexes, not
+      # hand-derived. `verify.exs --scenario s7,s8` against a real database is
+      # still what proves the body.
+      %{
+        id: "index:phoenix_kit_notifications_dedupe_unseen_idx",
+        owner: :core,
+        check:
+          {:catalog,
+           %{
+             name: "phoenix_kit_notifications_dedupe_unseen_idx",
+             table: "phoenix_kit_notifications",
+             kind: :index
+           }},
+        create:
+          "CREATE UNIQUE INDEX IF NOT EXISTS phoenix_kit_notifications_dedupe_unseen_idx ON __SCHEMA__.phoenix_kit_notifications USING btree (recipient_uuid, ((metadata ->> 'dedupe_key'::text))) WHERE ((seen_at IS NULL) AND (dismissed_at IS NULL) AND ((metadata ->> 'dedupe_key'::text) IS NOT NULL))",
+        since: 170,
+        class: :index,
+        revisions: [
+          {170,
+           %{
+             table: "phoenix_kit_notifications",
+             keys: ["recipient_uuid", "((metadata ->> 'dedupe_key'::text))"],
+             unique: true,
+             method: "btree",
+             definition:
+               "CREATE UNIQUE INDEX phoenix_kit_notifications_dedupe_unseen_idx ON __SCHEMA__.phoenix_kit_notifications USING btree (recipient_uuid, ((metadata ->> 'dedupe_key'::text))) WHERE ((seen_at IS NULL) AND (dismissed_at IS NULL) AND ((metadata ->> 'dedupe_key'::text) IS NOT NULL))",
+             predicate:
+               "((seen_at IS NULL) AND (dismissed_at IS NULL) AND ((metadata ->> 'dedupe_key'::text) IS NOT NULL))",
+             opclasses: ["uuid_ops", "text_ops"],
+             name_template: nil
+           }}
+        ],
+        presence: :required,
+        backfill: nil
+      },
+      %{
+        id: "index:phoenix_kit_notifications_recipient_unseen_first_idx",
+        owner: :core,
+        check:
+          {:catalog,
+           %{
+             name: "phoenix_kit_notifications_recipient_unseen_first_idx",
+             table: "phoenix_kit_notifications",
+             kind: :index
+           }},
+        create:
+          "CREATE INDEX IF NOT EXISTS phoenix_kit_notifications_recipient_unseen_first_idx ON __SCHEMA__.phoenix_kit_notifications USING btree (recipient_uuid, ((seen_at IS NOT NULL)), inserted_at DESC, uuid DESC) WHERE (dismissed_at IS NULL)",
+        since: 170,
+        class: :index,
+        revisions: [
+          {170,
+           %{
+             table: "phoenix_kit_notifications",
+             keys: [
+               "recipient_uuid",
+               "((seen_at IS NOT NULL))",
+               "inserted_at",
+               "uuid"
+             ],
+             unique: false,
+             method: "btree",
+             definition:
+               "CREATE INDEX phoenix_kit_notifications_recipient_unseen_first_idx ON __SCHEMA__.phoenix_kit_notifications USING btree (recipient_uuid, ((seen_at IS NOT NULL)), inserted_at DESC, uuid DESC) WHERE (dismissed_at IS NULL)",
+             predicate: "(dismissed_at IS NULL)",
+             opclasses: ["uuid_ops", "bool_ops", "timestamptz_ops", "uuid_ops"],
              name_template: nil
            }}
         ],

--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -7,7 +7,20 @@ defmodule PhoenixKit.Migrations.Postgres do
 
   ## Migration Versions
 
-  ### V169 - Anonymous entity submissions, and one duplicate foreign key ⚡ LATEST
+  ### V170 - Notification collapsing gets indexes and a uniqueness backstop ⚡ LATEST
+
+  Two indexes for the `upsert_inapp/3` collapsing API. A partial UNIQUE index
+  on `(recipient_uuid, metadata->>'dedupe_key')` over undismissed unseen rows
+  serves the dedupe lookup and turns the find-then-insert race (two workers
+  both inserting the same key) into a constraint the code retries as a
+  collapse; existing duplicate unseen rows are folded — all but the newest per
+  key marked dismissed — before the index is created. A second index on
+  `(recipient_uuid, seen_at IS NOT NULL, inserted_at DESC, uuid DESC)` over
+  undismissed rows matches the unseen-first inbox ordering term-for-term, so
+  the bell and inbox reads come straight off an index again. Rows without a
+  dedupe key are outside both the uniqueness rule and the fold.
+
+  ### V169 - Anonymous entity submissions, and one duplicate foreign key
 
   Makes `phoenix_kit_entity_data.created_by_uuid` nullable: the public entity
   form is deliberately unauthenticated and has no creator to record, so on a
@@ -499,7 +512,7 @@ defmodule PhoenixKit.Migrations.Postgres do
   alias PhoenixKit.Migrations.Repair.Environment
 
   @initial_version 135
-  @current_version 169
+  @current_version 170
   @default_prefix "public"
 
   # The frozen pre-squash bridge: the last 1.7.x release, which still carries

--- a/lib/phoenix_kit/migrations/postgres/v170.ex
+++ b/lib/phoenix_kit/migrations/postgres/v170.ex
@@ -1,0 +1,135 @@
+defmodule PhoenixKit.Migrations.Postgres.V170 do
+  @moduledoc """
+  V170: index support and a uniqueness backstop for notification collapsing.
+
+  `Notifications.upsert_inapp/3` (added alongside the unseen-first inbox
+  ordering) shipped with neither:
+
+    * **The dedupe lookup walked the inbox.** `find_collapsible/2` filters on
+      `metadata->>'dedupe_key'` under recipient + unseen, and the only inbox
+      index — `(recipient_uuid, inserted_at DESC) WHERE dismissed_at IS NULL`
+      (V104, re-created by the V135 squash) — cannot serve either that lookup
+      or the new `(seen_at IS NOT NULL, inserted_at DESC, uuid DESC)` ordering,
+      so every bell mount and every upsert re-sorted or re-walked a
+      recipient's whole undismissed backlog (thousands of rows for a user who
+      never dismisses, multiplied by fan-out on the write path).
+
+    * **The find-then-insert had no backstop.** Two concurrent upserts for the
+      same absent key (parallel Oban workers, two nodes) both read nil and
+      both inserted; the user got two unseen rows for one logical key, pinned
+      to the top by the unseen-first ordering, and later refreshes folded into
+      only one of them — the stale twin sat there until manually dismissed.
+
+  Two indexes fix both:
+
+    * `phoenix_kit_notifications_dedupe_unseen_idx` — partial UNIQUE on
+      `(recipient_uuid, (metadata->>'dedupe_key'))` over undismissed, unseen,
+      keyed rows. Serves `find_collapsible/2`'s exact predicate AND turns the
+      race's second insert into a constraint violation the code retries as a
+      collapse (`Notifications.insert_collapsible/3`). Rows without a dedupe
+      key — every notification the fan-out path creates — are outside the
+      partial predicate and completely unaffected.
+
+    * `phoenix_kit_notifications_recipient_unseen_first_idx` — on
+      `(recipient_uuid, (seen_at IS NOT NULL), inserted_at DESC, uuid DESC)`
+      over undismissed rows, matching `order_unseen_first/1`'s ORDER BY
+      expression term-for-term so the bell's `recent_for_user` and the inbox
+      pages come straight off the index again.
+
+  ## Existing duplicates
+
+  A unique index cannot be created over rows that already violate it, and the
+  raced installs are exactly the ones carrying duplicates. Before creating the
+  index, all but the newest unseen row per `(recipient, key)` — the same
+  "newest wins" choice `find_collapsible/2` makes, `inserted_at` then `uuid`
+  (UUIDv7, time-ordered below the timestamp's granularity) — are marked
+  **dismissed**. Dismissal, not deletion: the rows and their history remain,
+  they simply stop occupying the inbox — which is where the collapsing API
+  would have put them had it won the race in the first place.
+
+  The fold and the index creation share one `SHARE ROW EXCLUSIVE` table lock,
+  so a concurrent insert cannot re-introduce a duplicate in the gap between
+  them and abort the migration.
+  """
+
+  use Ecto.Migration
+
+  def up(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+    schema = schema_name(prefix)
+
+    execute("""
+    DO $$
+    BEGIN
+      -- The table guard exists for the same reason every LOCK TABLE in this
+      -- chain carries one: LOCK has no IF EXISTS form, and a database that
+      -- somehow lacks the table must skip, not abort the whole migration.
+      IF EXISTS (
+        SELECT 1 FROM pg_class t
+        JOIN pg_namespace n ON n.oid = t.relnamespace
+        WHERE t.relname = 'phoenix_kit_notifications' AND n.nspname = '#{schema}'
+      ) AND NOT EXISTS (
+        SELECT 1 FROM pg_indexes
+        WHERE indexname = 'phoenix_kit_notifications_dedupe_unseen_idx'
+          AND schemaname = '#{schema}'
+      ) THEN
+        -- Writes blocked (reads fine) from the duplicate fold through index
+        -- creation, so no new duplicate can slip into the gap and abort us.
+        LOCK TABLE #{p}phoenix_kit_notifications IN SHARE ROW EXCLUSIVE MODE;
+
+        WITH ranked AS (
+          SELECT uuid,
+                 row_number() OVER (
+                   PARTITION BY recipient_uuid, metadata->>'dedupe_key'
+                   ORDER BY inserted_at DESC, uuid DESC
+                 ) AS rn
+          FROM #{p}phoenix_kit_notifications
+          WHERE seen_at IS NULL
+            AND dismissed_at IS NULL
+            AND metadata->>'dedupe_key' IS NOT NULL
+        )
+        UPDATE #{p}phoenix_kit_notifications n
+        SET dismissed_at = now()
+        FROM ranked r
+        WHERE n.uuid = r.uuid AND r.rn > 1;
+
+        CREATE UNIQUE INDEX phoenix_kit_notifications_dedupe_unseen_idx
+        ON #{p}phoenix_kit_notifications (recipient_uuid, (metadata->>'dedupe_key'))
+        WHERE seen_at IS NULL
+          AND dismissed_at IS NULL
+          AND metadata->>'dedupe_key' IS NOT NULL;
+      END IF;
+    END
+    $$
+    """)
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS phoenix_kit_notifications_recipient_unseen_first_idx
+    ON #{p}phoenix_kit_notifications (recipient_uuid, (seen_at IS NOT NULL), inserted_at DESC, uuid DESC)
+    WHERE dismissed_at IS NULL
+    """)
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '170'")
+  end
+
+  def down(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    # The duplicate fold is deliberately not undone: the dismissed twins were
+    # duplicates the collapsing API would never have created, and nothing
+    # records which rows the fold touched versus which the user dismissed.
+    execute("DROP INDEX IF EXISTS #{p}phoenix_kit_notifications_recipient_unseen_first_idx")
+
+    execute("DROP INDEX IF EXISTS #{p}phoenix_kit_notifications_dedupe_unseen_idx")
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '169'")
+  end
+
+  defp schema_name("public"), do: "public"
+  defp schema_name(prefix), do: prefix
+
+  defp prefix_str("public"), do: "public."
+  defp prefix_str(prefix), do: "#{prefix}."
+end

--- a/lib/phoenix_kit/notifications/notifications.ex
+++ b/lib/phoenix_kit/notifications/notifications.ex
@@ -276,15 +276,21 @@ defmodule PhoenixKit.Notifications do
   """
   @spec create_inapp(String.t(), map()) :: {:ok, Notification.t()} | {:error, term()}
   def create_inapp(recipient_uuid, display) when is_binary(recipient_uuid) and is_map(display) do
+    # Caller metadata first, reserved keys on top — the reverse order let a
+    # passed-through `metadata` (say, copied off a prior notification)
+    # silently clobber the `dedupe_key` the upsert had just decided on,
+    # turning collapsing off for that key with nothing logged. A reserved
+    # key is only stamped when the caller supplied the display field, so
+    # setting `notification_text` via metadata alone still works.
     metadata =
-      %{}
+      display[:metadata]
+      |> stringify_keys()
       |> put_meta("notification_text", display[:text])
       |> put_meta("notification_icon", display[:icon])
       |> put_meta("notification_link", display[:link])
-      # What `upsert_inapp/3` later collapses on, and anything else the caller
-      # wants to carry. Both are dropped silently without this.
+      # What `upsert_inapp/3` later collapses on. Dropped silently without
+      # this.
       |> put_meta("dedupe_key", display[:dedupe_key])
-      |> Map.merge(display[:metadata] || %{})
 
     %Notification{}
     |> Notification.changeset(%{
@@ -292,6 +298,9 @@ defmodule PhoenixKit.Notifications do
       activity_uuid: nil,
       metadata: metadata
     })
+    |> Ecto.Changeset.unique_constraint(:metadata,
+      name: :phoenix_kit_notifications_dedupe_unseen_idx
+    )
     |> repo().insert()
     |> case do
       {:ok, notification} ->
@@ -300,8 +309,21 @@ defmodule PhoenixKit.Notifications do
         {:ok, notification}
 
       {:error, %Ecto.Changeset{} = cs} ->
-        Logger.warning("Notifications.create_inapp failed: #{inspect(cs.errors)}")
+        # The dedupe uniqueness trip is an ANTICIPATED outcome — it is how
+        # `insert_collapsible/3` learns it lost the race and should fold —
+        # so it doesn't warrant a warning; everything else does.
+        unless dedupe_conflict?(cs) do
+          Logger.warning("Notifications.create_inapp failed: #{inspect(cs.errors)}")
+        end
+
         {:error, cs}
+    end
+  end
+
+  defp dedupe_conflict?(%Ecto.Changeset{errors: errors}) do
+    case Keyword.get(errors, :metadata) do
+      {_, opts} -> Keyword.get(opts, :constraint) == :unique
+      _ -> false
     end
   end
 
@@ -338,41 +360,86 @@ defmodule PhoenixKit.Notifications do
   Broadcasts either way — `{:notification_created, n}` for a new row,
   `{:notification_updated, n}` for a refresh — so a bell that is already open
   reflects it without the caller broadcasting anything itself.
+
+  Honors the `notifications_enabled` kill switch like `create/1` does,
+  returning `{:ok, :skipped}` when notifications are off — this is a
+  host-facing entry point, not the digest's private lane, and "off" that
+  quietly doesn't apply to the newest creation path isn't off.
   """
   @spec upsert_inapp(String.t(), String.t(), map()) ::
-          {:ok, Notification.t()} | {:error, term()}
+          {:ok, Notification.t()} | {:ok, :skipped} | {:error, term()}
   def upsert_inapp(recipient_uuid, key, display)
       when is_binary(recipient_uuid) and is_binary(key) and is_map(display) do
-    case find_collapsible(recipient_uuid, key) do
-      nil -> create_inapp(recipient_uuid, Map.put(display, :dedupe_key, key))
-      existing -> refresh_inapp(existing, key, display)
+    if enabled?() do
+      case find_collapsible(recipient_uuid, key) do
+        nil -> insert_collapsible(recipient_uuid, key, display)
+        existing -> refresh_inapp(existing, key, display)
+      end
+    else
+      {:ok, :skipped}
+    end
+  end
+
+  # Insert a fresh keyed row — with the concurrency backstop. Two concurrent
+  # upserts for the same absent key (parallel Oban workers, two nodes) both
+  # read nil from `find_collapsible/2`; without the partial unique index
+  # (V170) both inserted, and the user got two unseen rows for one logical
+  # key. The second insert now trips the constraint, and the loser retries
+  # the find — the winner's row is there to collapse onto.
+  defp insert_collapsible(recipient_uuid, key, display) do
+    case create_inapp(recipient_uuid, Map.put(display, :dedupe_key, key)) do
+      {:error, %Ecto.Changeset{errors: errors} = cs} ->
+        if Keyword.has_key?(errors, :metadata) do
+          case find_collapsible(recipient_uuid, key) do
+            nil -> {:error, cs}
+            existing -> refresh_inapp(existing, key, display)
+          end
+        else
+          {:error, cs}
+        end
+
+      other ->
+        other
     end
   end
 
   # Only unseen rows collapse — see the moduledoc above for why. Newest first
-  # so a duplicate key (possible if one was seen and a later one wasn't) folds
-  # into the one the user still has outstanding.
+  # (uuid as the tie-break: UUIDv7 is time-ordered below `inserted_at`'s
+  # second granularity) so a duplicate key folds into the one the user most
+  # recently got.
   defp find_collapsible(recipient_uuid, key) do
     Notification
     |> where([n], n.recipient_uuid == ^recipient_uuid)
     |> where([n], is_nil(n.dismissed_at) and is_nil(n.seen_at))
     |> where([n], fragment("?->>'dedupe_key' = ?", n.metadata, ^key))
-    |> order_by([n], desc: n.inserted_at)
+    |> order_by([n], desc: n.inserted_at, desc: n.uuid)
     |> limit(1)
     |> repo().one()
   rescue
     # A read that fails is not a reason to drop the notification — fall
-    # through and post a new one.
-    _ -> nil
+    # through and post a new one. Logged so a permanent failure (a query or
+    # schema bug turning every call into nil) is diagnosable instead of
+    # silently degrading upsert into insert-always.
+    error ->
+      Logger.warning("Notifications.find_collapsible failed: #{Exception.message(error)}")
+      nil
+  catch
+    # An unreachable DB raises on an unowned checkout but EXITS on a dead
+    # pool — the soft-failure rule needs both.
+    :exit, reason ->
+      Logger.warning("Notifications.find_collapsible exited: #{inspect(reason)}")
+      nil
   end
 
   defp refresh_inapp(%Notification{} = notification, key, display) do
+    # Same order as `create_inapp/2`: caller metadata first, reserved keys
+    # on top, so a passed-through metadata map cannot clobber them.
     patch =
-      %{}
+      display[:metadata]
+      |> stringify_keys()
       |> put_meta("notification_text", display[:text])
       |> put_meta("notification_icon", display[:icon])
       |> put_meta("notification_link", display[:link])
-      |> Map.merge(display[:metadata] || %{})
 
     now = UtilsDate.utc_now()
 
@@ -518,6 +585,17 @@ defmodule PhoenixKit.Notifications do
   defp put_meta(meta, _key, nil), do: meta
   defp put_meta(meta, _key, ""), do: meta
   defp put_meta(meta, key, val), do: Map.put(meta, key, val)
+
+  # Caller metadata arrives with whatever keys the caller typed —
+  # `%{notification_text: ...}` and `%{"notification_text" => ...}` are the
+  # same key once serialized to jsonb, but as an Elixir map they coexist and
+  # which one wins the JSON encoding is adapter-order-dependent. Normalized
+  # here so the reserved-key stamping above has one namespace to win in.
+  defp stringify_keys(nil), do: %{}
+
+  defp stringify_keys(map) when is_map(map) do
+    Map.new(map, fn {k, v} -> {to_string(k), v} end)
+  end
 
   # ── Reads ────────────────────────────────────────────────────────────
 

--- a/lib/phoenix_kit/users/auth.ex
+++ b/lib/phoenix_kit/users/auth.ex
@@ -1178,14 +1178,23 @@ defmodule PhoenixKit.Users.Auth do
   # A short, stable label for one session, so fingerprint lines can be
   # correlated to each other and to a row in the sessions UI.
   #
-  # Hashed and truncated because the raw token is a bearer credential and must
-  # never reach a log file — 8 hex characters is plenty to group a handful of
-  # lines by, and useless to anyone who steals the log.
-  defp session_label(token) when is_binary(token) do
-    :sha256 |> :crypto.hash(token) |> Base.encode16(case: :lower) |> binary_part(0, 8)
+  # THE SAME derivation the sessions UI displays as its token preview —
+  # `encode(substring(token, 1, 4), 'hex')` in `PhoenixKit.Users.Sessions` —
+  # because the label exists to be searched for on that page, and the
+  # previous derivation (truncated sha256) could never match it: an operator
+  # pasting the logged label into the sessions search got zero results every
+  # time. Four of the token's ~32 random bytes in a log is not a usable
+  # credential (the UI already shows admins these same bytes), and 8 hex
+  # characters is plenty to group a handful of lines by.
+  #
+  # Public (@doc false) so the test suite can hold the two derivations
+  # together — they drifted apart silently once already.
+  @doc false
+  def session_label(token) when is_binary(token) and byte_size(token) >= 4 do
+    token |> binary_part(0, 4) |> Base.encode16(case: :lower)
   end
 
-  defp session_label(_), do: "unknown"
+  def session_label(_), do: "unknown"
 
   @doc """
   Ensures the user is active by checking the is_active field.

--- a/lib/phoenix_kit_web/integration.ex
+++ b/lib/phoenix_kit_web/integration.ex
@@ -1169,7 +1169,51 @@ defmodule PhoenixKitWeb.Integration do
   # and the compiler is absent, name the modules and the one line that fixes
   # it. Silence here has cost more than a warning ever will.
   def warn_missing_js_compiler do
-    warn_missing_js_compiler(modules_declaring_js_sources(), js_compiler_configured?())
+    modules = modules_declaring_js_sources()
+
+    # A module PACKAGE compiling its own (test) router is not a host. Its
+    # mix.exs legitimately has no :phoenix_kit_js_sources compiler — the
+    # host it ships to is where that belongs — yet discovery finds the
+    # package's own beams and `Mix.Project.config/0` answers for the
+    # package, so without this check every `mix test` in e.g.
+    # phoenix_kit_boards printed the fix-your-mix.exs warning for a
+    # configuration that was already correct. Recurring false warnings
+    # train exactly the scroll-past behavior this warning exists to fight.
+    # The tell: a host never compiles a js_sources module from its own
+    # source tree; a package always does.
+    if Enum.any?(modules, &compiled_from_current_project?/1) do
+      :ok
+    else
+      warn_missing_js_compiler(modules, js_compiler_configured?())
+    end
+  end
+
+  # Public (@doc false) so the suppression can be tested with real modules:
+  # this library's own modules ARE compiled from the current project when its
+  # suite runs, and dep-compiled modules are not.
+  #
+  # Hex deps compile from `<cwd>/deps/...` — UNDER the project directory —
+  # so "under cwd" alone would call every dep locally compiled and suppress
+  # the warning on exactly the hosts it exists for. Path deps (`../sibling`)
+  # sit outside cwd and were never at risk.
+  @doc false
+  def compiled_from_current_project?(mod) do
+    cwd = File.cwd!()
+
+    case mod.module_info(:compile)[:source] do
+      source when is_list(source) ->
+        path = List.to_string(source)
+
+        String.starts_with?(path, cwd <> "/") and
+          not String.starts_with?(path, cwd <> "/deps/")
+
+      _ ->
+        false
+    end
+  rescue
+    _ -> false
+  catch
+    _kind, _value -> false
   end
 
   @doc false
@@ -1226,6 +1270,12 @@ defmodule PhoenixKitWeb.Integration do
     # Discovery reaches into the dep tree; a warning is never worth failing a
     # host's compile over.
     _ -> []
+  catch
+    # A discovered module's js_sources/0 can throw or exit as well as raise
+    # (a compile-time call into an unstarted process exits) — `rescue` alone
+    # let those escape the macro expansion and abort the host's compile,
+    # which is precisely what the comment above promises cannot happen.
+    _kind, _value -> []
   end
 
   # Mix is present while the host's router compiles, which is when this runs.

--- a/lib/phoenix_kit_web/live/notifications/inbox.ex
+++ b/lib/phoenix_kit_web/live/notifications/inbox.ex
@@ -106,10 +106,14 @@ defmodule PhoenixKitWeb.Live.Notifications.Inbox do
 
   # Live updates: any change to this user's notifications (own action, another
   # tab, the bell, or a new one arriving) reloads the current page.
+  # `:notification_updated` is what `upsert_inapp/3` broadcasts when it
+  # collapses a repeat event onto an existing row — without it here, an open
+  # inbox kept the stale text and position while the bell refreshed.
   @impl true
   def handle_info({event, _payload}, socket)
       when event in [
              :notification_created,
+             :notification_updated,
              :notification_seen,
              :notification_dismissed,
              :notifications_bulk_updated

--- a/lib/phoenix_kit_web/users/auth.ex
+++ b/lib/phoenix_kit_web/users/auth.ex
@@ -407,32 +407,7 @@ defmodule PhoenixKitWeb.Users.Auth do
 
   defp do_fetch_phoenix_kit_current_user(conn) do
     {user_token, conn} = ensure_user_token(conn)
-
-    # Verify session fingerprint if token exists
-    fingerprint_valid? =
-      if user_token do
-        case Auth.verify_session_fingerprint(conn, user_token) do
-          :ok ->
-            true
-
-          # Deliberately silent. `verify_fingerprint/4` has already logged
-          # what changed, for which session, at a level that matches whether
-          # the request is about to be refused — a second line here said only
-          # "for token", naming neither, and doubled the volume of the noisiest
-          # thing in the log.
-          {:warning, _reason} ->
-            not SessionFingerprint.strict_mode?()
-
-          {:error, :fingerprint_mismatch} ->
-            not SessionFingerprint.strict_mode?()
-
-          {:error, :token_not_found} ->
-            # Token expired or invalid
-            false
-        end
-      else
-        true
-      end
+    {conn, fingerprint_valid?} = check_fingerprint_once(conn, user_token)
 
     user =
       if fingerprint_valid? do
@@ -448,6 +423,42 @@ defmodule PhoenixKitWeb.Users.Auth do
     assign(conn, :phoenix_kit_current_user, active_user)
   end
 
+  # Verify the session fingerprint at most ONCE per request, whatever the
+  # pipeline shape. The shipped `:phoenix_kit_admin_only` pipeline runs BOTH
+  # fetch plugs, and each used to verify independently — so every mismatch
+  # was checked twice and `verify_fingerprint/4` logged its line twice. The
+  # first verification's result is cached on the conn and reused.
+  #
+  # No logging here on any branch, deliberately: `verify_fingerprint/4` has
+  # already logged what changed, for which session, at a level that matches
+  # whether the request is about to be refused — extra lines here said only
+  # "for token", naming neither, and doubled (or tripled) the volume of the
+  # noisiest thing in the log.
+  defp check_fingerprint_once(conn, nil), do: {conn, true}
+
+  defp check_fingerprint_once(conn, user_token) do
+    case conn.private[:phoenix_kit_fingerprint_valid] do
+      nil ->
+        result = Auth.verify_session_fingerprint(conn, user_token)
+        valid? = fingerprint_allows_access?(result)
+        {Plug.Conn.put_private(conn, :phoenix_kit_fingerprint_valid, valid?), valid?}
+
+      valid? ->
+        {conn, valid?}
+    end
+  end
+
+  defp fingerprint_allows_access?(:ok), do: true
+
+  defp fingerprint_allows_access?({:warning, _reason}),
+    do: not SessionFingerprint.strict_mode?()
+
+  defp fingerprint_allows_access?({:error, :fingerprint_mismatch}),
+    do: not SessionFingerprint.strict_mode?()
+
+  # Token expired or invalid
+  defp fingerprint_allows_access?({:error, :token_not_found}), do: false
+
   @doc """
   Fetches the current user and creates a scope for authentication context.
 
@@ -462,36 +473,12 @@ defmodule PhoenixKitWeb.Users.Auth do
   def fetch_phoenix_kit_current_scope(conn, _opts) do
     {user_token, conn} = ensure_user_token(conn)
 
-    # Verify session fingerprint if token exists
-    fingerprint_valid? =
-      if user_token do
-        case Auth.verify_session_fingerprint(conn, user_token) do
-          :ok ->
-            true
-
-          {:warning, reason} ->
-            # Log warning but allow access (IP/UA can legitimately change)
-            Logger.warning("PhoenixKit: Session fingerprint warning: #{reason} for token (scope)")
-
-            # In non-strict mode, allow access despite warning
-            not SessionFingerprint.strict_mode?()
-
-          {:error, :fingerprint_mismatch} ->
-            # Both IP and UA changed - likely hijacking
-            Logger.error(
-              "PhoenixKit: Session fingerprint mismatch detected in scope - possible hijacking"
-            )
-
-            # Strict mode: deny access; non-strict: log but allow
-            not SessionFingerprint.strict_mode?()
-
-          {:error, :token_not_found} ->
-            # Token expired or invalid
-            false
-        end
-      else
-        true
-      end
+    # Shares the once-per-request verification (and its no-extra-logging
+    # policy) with `fetch_phoenix_kit_current_user` — this plug used to
+    # carry its own copy of the old logging, so a pipeline running both
+    # plugs logged every mismatch three times, including an `:error`
+    # "possible hijacking" line for requests that were then served.
+    {conn, fingerprint_valid?} = check_fingerprint_once(conn, user_token)
 
     user =
       if fingerprint_valid? do

--- a/test/integration/notifications/upsert_kill_switch_test.exs
+++ b/test/integration/notifications/upsert_kill_switch_test.exs
@@ -1,0 +1,47 @@
+defmodule PhoenixKit.Integration.Notifications.UpsertKillSwitchTest do
+  @moduledoc """
+  `upsert_inapp/3` honors the `notifications_enabled` kill switch.
+
+  It didn't: the function is built on `create_inapp/2`, whose documented
+  kill-switch bypass is justified only for the DigestWorker ("the digest
+  already decided to post") — but `upsert_inapp/3` is a host-facing entry
+  point, so "off" quietly did not apply to the newest creation path.
+
+  `async: false` because the switch is a global setting; the sandbox rolls
+  the write back, and `enabled?/0` reads uncached, so no cache priming or
+  cleanup is needed (same pattern as `FanOutTest`).
+  """
+  use PhoenixKit.DataCase, async: false
+
+  alias PhoenixKit.Notifications
+  alias PhoenixKit.Settings
+  alias PhoenixKit.Users.Auth
+
+  defp create_user do
+    {:ok, user} =
+      Auth.register_user(%{
+        email: "notif_kill_#{System.unique_integer([:positive])}@example.com",
+        password: "ValidPassword123!"
+      })
+
+    user
+  end
+
+  test "upsert_inapp is a no-op while notifications are disabled" do
+    user = create_user()
+    Settings.update_boolean_setting("notifications_enabled", false)
+
+    assert {:ok, :skipped} =
+             Notifications.upsert_inapp(user.uuid, "k", %{text: "should not exist"})
+
+    assert {[], 0} = Notifications.list_for_user(user.uuid)
+  end
+
+  test "and works again the moment they are re-enabled" do
+    user = create_user()
+    Settings.update_boolean_setting("notifications_enabled", true)
+
+    assert {:ok, %Notifications.Notification{}} =
+             Notifications.upsert_inapp(user.uuid, "k", %{text: "posted"})
+  end
+end

--- a/test/integration/notifications/upsert_test.exs
+++ b/test/integration/notifications/upsert_test.exs
@@ -109,6 +109,75 @@ defmodule PhoenixKit.Integration.Notifications.UpsertTest do
       assert updated.metadata["notification_text"] == "second"
     end
 
+    test "caller metadata cannot clobber the dedupe key" do
+      # The reserved keys are stamped AFTER the caller's metadata merges. The
+      # old order let a passed-through metadata map (say, copied off a prior
+      # notification) overwrite the key the upsert had just decided on —
+      # which silently turned collapsing off for that key, with no error.
+      user = create_user()
+
+      {:ok, first} =
+        Notifications.upsert_inapp(user.uuid, "k", %{
+          text: "1 new",
+          metadata: %{"dedupe_key" => "stale", "keep" => "me"}
+        })
+
+      assert first.metadata["dedupe_key"] == "k",
+             "the key the API collapsed on must win over pass-through metadata"
+
+      {:ok, second} = Notifications.upsert_inapp(user.uuid, "k", %{text: "2 new"})
+      assert second.uuid == first.uuid, "collapsing must still work after the attempt"
+      assert second.metadata["keep"] == "me"
+    end
+
+    test "atom-keyed caller metadata lands in the same namespace as the display fields" do
+      # `%{notification_text: ...}` and `%{"notification_text" => ...}` are one
+      # key in jsonb but two in an Elixir map — which one won the JSON encoding
+      # was adapter-order-dependent. Keys are normalized to strings before the
+      # display fields stamp on top.
+      user = create_user()
+
+      {:ok, n} =
+        Notifications.upsert_inapp(user.uuid, "k", %{
+          text: "the real text",
+          metadata: %{notification_text: "the impostor", chapter: "12"}
+        })
+
+      assert n.metadata["notification_text"] == "the real text"
+      assert n.metadata["chapter"] == "12"
+      refute Map.has_key?(n.metadata, :notification_text)
+    end
+
+    test "the unique index turns a raced double-insert into a collapse" do
+      # Two concurrent upserts for the same absent key both read nil from the
+      # find. The loser's insert now trips the V170 partial unique index
+      # instead of standing up a duplicate unseen row, and the public API
+      # retries the find and folds.
+      user = create_user()
+
+      {:ok, first} = Notifications.create_inapp(user.uuid, %{text: "1", dedupe_key: "k"})
+
+      # What the race's loser does: insert without re-checking.
+      assert {:error, %Ecto.Changeset{}} =
+               Notifications.create_inapp(user.uuid, %{text: "2", dedupe_key: "k"}),
+             "a second unseen row for the same key must be refused, not inserted"
+
+      {:ok, updated} = Notifications.upsert_inapp(user.uuid, "k", %{text: "3"})
+      assert updated.uuid == first.uuid
+      assert texts(user) == ["3"]
+    end
+
+    test "unkeyed rows are untouched by the uniqueness rule" do
+      # The index is partial: everything the fan-out path creates carries no
+      # dedupe key and must keep inserting freely.
+      user = create_user()
+
+      {:ok, _} = Notifications.create_inapp(user.uuid, %{text: "a"})
+      {:ok, _} = Notifications.create_inapp(user.uuid, %{text: "b"})
+
+      assert length(texts(user)) == 2
+    end
+
     test "broadcasts both ways, so an open bell keeps up" do
       # Without this the host had to re-broadcast by hand, because the only
       # broadcast fired on insert.

--- a/test/integration/users/fingerprint_once_test.exs
+++ b/test/integration/users/fingerprint_once_test.exs
@@ -1,0 +1,99 @@
+defmodule PhoenixKit.Integration.Users.FingerprintOnceTest do
+  @moduledoc """
+  The session fingerprint is verified at most once per request, and its
+  label matches the sessions UI.
+
+  The shipped `:phoenix_kit_admin_only` pipeline runs BOTH fetch plugs
+  (`fetch_phoenix_kit_current_user` and `fetch_phoenix_kit_current_scope`),
+  and each used to verify — and therefore log — independently: every
+  mismatch was checked twice, logged up to three times, including a leftover
+  `:error` "possible hijacking" line for requests that were then served.
+  Verification now runs once, its verdict cached in `conn.private`, and the
+  second plug reuses it.
+  """
+  use PhoenixKit.DataCase, async: true
+
+  alias PhoenixKit.Users.Auth
+  alias PhoenixKitWeb.Users.Auth, as: AuthPlugs
+
+  defp user_and_token do
+    {:ok, user} =
+      Auth.register_user(%{
+        email: "fp_once_#{System.unique_integer([:positive])}@example.com",
+        password: "ValidPassword123!"
+      })
+
+    {user, Auth.generate_user_session_token(user)}
+  end
+
+  defp conn_with_token(token) do
+    :get
+    |> Plug.Test.conn("/")
+    |> Plug.Test.init_test_session(%{"user_token" => token})
+  end
+
+  describe "the cached verdict is authoritative" do
+    # The proof that verification happens at most once: pre-seed the cache
+    # with the OPPOSITE of what a fresh verification would return. If either
+    # plug re-verified, it would overturn the seeded verdict and load the
+    # user anyway — fingerprinting is off in this suite, so a fresh check
+    # answers :ok.
+    test "a cached denial is honored by both plugs without re-verifying" do
+      {_user, token} = user_and_token()
+
+      conn =
+        token
+        |> conn_with_token()
+        |> Plug.Conn.put_private(:phoenix_kit_fingerprint_valid, false)
+
+      conn = AuthPlugs.fetch_phoenix_kit_current_user(conn, [])
+      assert conn.assigns.phoenix_kit_current_user == nil
+
+      conn = AuthPlugs.fetch_phoenix_kit_current_scope(conn, [])
+      assert conn.assigns.phoenix_kit_current_scope.user == nil
+    end
+
+    test "the first plug caches its verdict for the second" do
+      {user, token} = user_and_token()
+
+      conn = AuthPlugs.fetch_phoenix_kit_current_user(conn_with_token(token), [])
+
+      assert conn.private[:phoenix_kit_fingerprint_valid] == true
+      assert conn.assigns.phoenix_kit_current_user.uuid == user.uuid
+
+      conn = AuthPlugs.fetch_phoenix_kit_current_scope(conn, [])
+      assert conn.assigns.phoenix_kit_current_scope.user.uuid == user.uuid
+    end
+
+    test "a conn with no session token skips the machinery entirely" do
+      conn =
+        :get
+        |> Plug.Test.conn("/")
+        |> Plug.Test.init_test_session(%{})
+        |> AuthPlugs.fetch_phoenix_kit_current_user([])
+
+      assert conn.assigns.phoenix_kit_current_user == nil
+      refute Map.has_key?(conn.private, :phoenix_kit_fingerprint_valid)
+    end
+  end
+
+  describe "session_label/1" do
+    test "matches the sessions UI's token preview, so the correlation works" do
+      # The label exists to be pasted into the sessions page search. The UI
+      # shows `encode(substring(token, 1, 4), 'hex')`; the previous label
+      # (truncated sha256) could never match it — an operator searching for
+      # a logged label got zero results every time.
+      {_user, token} = user_and_token()
+
+      ui_preview = token |> binary_part(0, 4) |> Base.encode16(case: :lower)
+
+      assert Auth.session_label(token) == ui_preview
+      assert String.length(Auth.session_label(token)) == 8
+    end
+
+    test "degrades to a placeholder rather than crashing on junk" do
+      assert Auth.session_label(nil) == "unknown"
+      assert Auth.session_label("ab") == "unknown"
+    end
+  end
+end

--- a/test/phoenix_kit_web/js_compiler_warning_test.exs
+++ b/test/phoenix_kit_web/js_compiler_warning_test.exs
@@ -95,5 +95,50 @@ defmodule PhoenixKitWeb.JsCompilerWarningTest do
       # for.
       assert Integration.warn_missing_js_compiler() == :ok
     end
+
+    test "a throw or exit from a module's js_sources/0 is contained too" do
+      # `rescue` alone let a `throw` or an `exit` (a compile-time call into
+      # an unstarted process exits) escape the macro expansion and abort the
+      # host's compile — precisely what the guarantee above promises cannot
+      # happen. Pinned at the source level because the discovery seam is
+      # private and dep-driven: what matters is that the containment clause
+      # exists next to the rescue.
+      source = File.read!("lib/phoenix_kit_web/integration.ex")
+
+      [_, body] =
+        Regex.run(
+          ~r/defp modules_declaring_js_sources do(.*?)\n  end/s,
+          source
+        )
+
+      assert body =~ "rescue"
+
+      assert body =~ "catch",
+             "modules_declaring_js_sources rescues raises only — a throw/exit " <>
+               "from a discovered module's js_sources/0 fails the host's compile"
+    end
+  end
+
+  describe "a module package compiling its own router" do
+    # `phoenix_kit_boards` running its own test suite expands
+    # `phoenix_kit_routes()`: discovery finds the package's own beam, and
+    # `Mix.Project.config/0` answers for the package — whose mix.exs
+    # legitimately has no `:phoenix_kit_js_sources` compiler, because it is
+    # not a host. Every compile printed the fix-your-mix.exs warning for a
+    # correct configuration. The tell is compile provenance: a host never
+    # compiles a js_sources module from its own source tree; a package
+    # always does.
+    test "its own modules are recognized as locally compiled" do
+      # This library's modules ARE the current project while this suite runs.
+      assert Integration.compiled_from_current_project?(PhoenixKitWeb.Integration)
+    end
+
+    test "dep-compiled modules are not" do
+      refute Integration.compiled_from_current_project?(Phoenix.Router)
+    end
+
+    test "junk never raises out of the provenance check" do
+      refute Integration.compiled_from_current_project?(:not_a_real_module_at_all)
+    end
   end
 end

--- a/test/phoenix_kit_web/live/notifications/inbox_events_test.exs
+++ b/test/phoenix_kit_web/live/notifications/inbox_events_test.exs
@@ -1,0 +1,64 @@
+defmodule PhoenixKitWeb.Live.Notifications.InboxEventsTest do
+  @moduledoc """
+  The inbox reacts to every per-user notification event the library
+  broadcasts.
+
+  Its `handle_info` guards on an explicit whitelist with a silent catch-all
+  below it — the safe shape for a LiveView sharing a topic, and exactly the
+  shape that fails silently when a NEW event is added: `upsert_inapp/3`
+  shipped broadcasting `:notification_updated`, the bell learned it, and the
+  inbox didn't — so an open inbox kept stale text and position while the
+  bell refreshed. Nothing crashed, nothing logged; the message just hit the
+  catch-all.
+
+  Pinned by scraping the broadcast call sites, so the NEXT event added to
+  the library fails this test until the inbox handles it too.
+  """
+  use ExUnit.Case, async: true
+
+  @lib "lib/phoenix_kit"
+  @inbox "lib/phoenix_kit_web/live/notifications/inbox.ex"
+
+  defp broadcast_events do
+    @lib
+    |> Path.join("**/*.ex")
+    |> Path.wildcard()
+    |> Enum.flat_map(fn file ->
+      content = File.read!(file)
+
+      ~r/Events\.broadcast\([^,]+,\s*\{:(\w+)/
+      |> Regex.scan(content)
+      |> Enum.map(fn [_, event] -> String.to_atom(event) end)
+    end)
+    |> Enum.uniq()
+    |> Enum.sort()
+  end
+
+  defp inbox_whitelist do
+    content = File.read!(@inbox)
+
+    [_, guard] = Regex.run(~r/when event in \[([^\]]+)\]/s, content)
+
+    ~r/:(\w+)/
+    |> Regex.scan(guard)
+    |> Enum.map(fn [_, event] -> String.to_atom(event) end)
+    |> Enum.sort()
+  end
+
+  test "every broadcast event is in the inbox whitelist" do
+    events = broadcast_events()
+
+    assert events != [], "found no Events.broadcast call sites — the scrape regex went stale"
+
+    missing = events -- inbox_whitelist()
+
+    assert missing == [],
+           "the inbox silently ignores #{inspect(missing)} — an open inbox will show " <>
+             "stale rows for those events while the bell refreshes"
+  end
+
+  test "the event this pin was written for is broadcast and handled" do
+    assert :notification_updated in broadcast_events()
+    assert :notification_updated in inbox_whitelist()
+  end
+end


### PR DESCRIPTION
A `/code-review high` pass over the recently merged notifications-upsert, fingerprint-logging and js-compiler-warning work (#702–#705) confirmed **ten findings**. This fixes all ten; the two needing schema support ride a new **V170** migration.

## Notifications — V170 + `upsert_inapp` hardening

**Indexes & the race (2 findings).** The dedupe lookup and the new unseen-first ordering had no index support — `recent_for_user` runs on every bell mount and had gone from index-served to fetch-everything-and-top-N-sort. V170 adds:

- a **partial UNIQUE** index on `(recipient_uuid, metadata->>'dedupe_key')` over undismissed *unseen* keyed rows — serves `find_collapsible`'s exact predicate **and** closes the find-then-insert race: two workers inserting the same absent key now trip the constraint, and `insert_collapsible` retries the find and folds. Pre-existing duplicate unseen rows are folded (all but the newest per key marked *dismissed*, not deleted) under the same table lock that creates the index. The anticipated constraint trip isn't logged as a failure; every other insert error still is.
- an index matching `order_unseen_first`'s expression **term-for-term** (`recipient_uuid, seen_at IS NOT NULL, inserted_at DESC, uuid DESC` where undismissed).

Rows without a dedupe key — everything the fan-out path creates — are outside both.

**Kill switch.** `upsert_inapp` now honors `notifications_enabled` like `create/1` (`{:ok, :skipped}`). It's a host-facing entry point; "off" that quietly didn't apply to the newest creation path wasn't off.

**Metadata clobber.** Caller metadata merges FIRST, reserved keys stamp on top — a passed-through metadata map can no longer overwrite `dedupe_key` (silently disabling collapsing) or the display keys. Caller keys are normalized to strings, so `%{notification_text: ...}` can't coexist with the string key and win adapter-order-dependently.

**`find_collapsible`.** Gains the `catch :exit` the project's soft-failure rule requires (a dead pool *exits*, bypassing `rescue` and crashing the caller the comment promised it wouldn't); both clauses log now, so a permanent query bug degrading upsert into insert-always is diagnosable. Also tie-breaks on `uuid` below `inserted_at`'s second granularity.

**Inbox.** `handle_info` whitelist gains `:notification_updated` — the bell had it, the inbox didn't, so an open inbox showed stale rows exactly when upsert refreshed one. A scrape test now holds the whitelist to *every* event the library broadcasts, so the next event added fails the test until the inbox handles it.

## Fingerprint logging

The #705 dedup had only landed in `fetch_phoenix_kit_current_user`; the scope plug still carried the old `"(scope)"` warning and the `:error` "possible hijacking" line for requests that were then served — and the shipped `:phoenix_kit_admin_only` pipeline runs **both** plugs, so one mismatch logged three lines. Verification now runs **at most once per request** (verdict cached in `conn.private`, both plugs share it), no extra logging on any branch. Tested by seeding the cache with the *opposite* verdict and observing both plugs honor it.

`session_label` is now **the same derivation** the sessions UI shows as its token preview (hex of the raw token's first 4 bytes) — the truncated-sha256 label could never match it, so the promised log↔UI correlation failed every time. The two derivations are held together by a test.

## JS-compiler warning

`js_compiler_configured?` read `Mix.Project.config()` of whatever project was compiling, so a module package running its own suite (its test router expands `phoenix_kit_routes()`, discovery finds its own beam) printed the fix-your-mix.exs warning on every compile for a configuration that was already correct. Suppressed when any warned module was **compiled from the current project's own source tree** — excluding `deps/`, which sits *under* cwd; the first cut missed that and the new test caught every hex dep reading as locally compiled before it shipped.

`modules_declaring_js_sources` gains a `catch` clause: a `throw`/`exit` from a discovered module's `js_sources/0` escaped the `rescue` and failed the host's compile — precisely what the adjacent guarantee promises cannot happen.

## Manifest & verification

- The two V170 indexes are hand-declared in `expected_schema.ex` with definitions and opclasses **captured from `pg_get_indexdef` on a live database**, not hand-derived; `chain_hash` restamped over the 36 shipped files — the same treatment (and the same recorded caveat) as the V165–V167 objects.
- The repo's own guards caught two omissions in my first cut of V170 — the unguarded `LOCK TABLE` and the missing version heading — both fixed and covered.
- Full suite: **3,536 tests, 0 failures**, database reachable (integration tests genuinely ran, including the new race-backstop test exercising the live V170 index). `mix precommit` exits 0.

No `@version` or CHANGELOG changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NTj7hm3fpCTcFvKLRtgppW
