### PR TITLE
UploadGuard: native leave-page protection for in-flight uploads

### DIFF
--- a/lib/phoenix_kit_web/components/core/file_upload.ex
+++ b/lib/phoenix_kit_web/components/core/file_upload.ex
@@ -28,7 +28,7 @@ defmodule PhoenixKitWeb.Components.Core.FileUpload do
   alias PhoenixKit.Utils.Format
 
   attr :upload, :any, required: true
-  attr :label, :string, default: "Upload Files"
+  attr :label, :string, default: nil, doc: "Button label; defaults to a translated \"Upload Files\""
   attr :icon, :string, default: "hero-cloud-arrow-up"
   attr :accept_description, :string, default: nil
   attr :max_size_description, :string, default: nil
@@ -87,7 +87,16 @@ defmodule PhoenixKitWeb.Components.Core.FileUpload do
 
   defp full_upload(assigns) do
     ~H"""
-    <div class="space-y-4">
+    <%!-- UploadGuard: while any entry is in flight (data-active), the
+         browser's own beforeunload dialog blocks an accidental refresh /
+         close that would kill the transfer — interrupted LiveView
+         uploads are not resumed. Protection instead of disclaimer prose. --%>
+    <div
+      id={"pk-upload-guard-" <> @upload.ref}
+      phx-hook="UploadGuard"
+      data-active={to_string(@upload.entries != [])}
+      class="space-y-4"
+    >
       <%!-- STANDALONE wraps the drop zone in its own form so `phx-change`
            has something to hang on. Embedded, it must not: nested `<form>`
            elements are invalid HTML, and the browser resolves that by
@@ -130,7 +139,7 @@ defmodule PhoenixKitWeb.Components.Core.FileUpload do
                 phx-click="cancel_upload"
                 phx-value-ref={entry.ref}
                 class="btn btn-xs btn-ghost text-error"
-                title="Cancel upload"
+                title={gettext("Cancel upload")}
               >
                 <.icon name="hero-x-mark" class="w-4 h-4" />
               </button>
@@ -155,12 +164,12 @@ defmodule PhoenixKitWeb.Components.Core.FileUpload do
         <div class="flex flex-col items-center gap-2">
           <.icon name={@icon} class="w-8 h-8 text-primary" />
           <div>
-            <p class="font-semibold text-base-content">Drag files here or click to browse</p>
+            <p class="font-semibold text-base-content">{gettext("Drag files here or click to browse")}</p>
             <p class="text-sm text-base-content/70 mt-1">
               <%= if @accept_description do %>
                 {@accept_description}
               <% else %>
-                Drop your files to upload
+                {gettext("Drop your files to upload")}
               <% end %>
             </p>
           </div>
@@ -173,7 +182,7 @@ defmodule PhoenixKitWeb.Components.Core.FileUpload do
     <%= if @accept_description != nil or @max_size_description != nil do %>
       <p class="text-sm text-base-content/70 text-center">
         <%= if @max_size_description do %>
-          Maximum file size: {@max_size_description}
+          {gettext("Maximum file size: %{size}", size: @max_size_description)}
         <% end %>
       </p>
     <% end %>
@@ -182,13 +191,18 @@ defmodule PhoenixKitWeb.Components.Core.FileUpload do
 
   defp button_upload(assigns) do
     ~H"""
-    <div class="space-y-3">
+    <div
+      id={"pk-upload-guard-btn-" <> @upload.ref}
+      phx-hook="UploadGuard"
+      data-active={to_string(@upload.entries != [])}
+      class="space-y-3"
+    >
       <form phx-change="validate" id={"button-upload-form-" <> @upload.ref}>
         <label
           for={@upload.ref}
           class="btn btn-primary btn-block"
         >
-          <.icon name={@icon} class="w-5 h-5" /> {@label}
+          <.icon name={@icon} class="w-5 h-5" /> {@label || gettext("Upload Files")}
         </label>
         <.live_file_input upload={@upload} class="hidden" />
       </form>
@@ -216,7 +230,7 @@ defmodule PhoenixKitWeb.Components.Core.FileUpload do
                 phx-click="cancel_upload"
                 phx-value-ref={entry.ref}
                 class="btn btn-xs btn-ghost text-error"
-                title="Cancel upload"
+                title={gettext("Cancel upload")}
               >
                 <.icon name="hero-x-mark" class="w-4 h-4" />
               </button>

--- a/lib/phoenix_kit_web/components/core/file_upload.ex
+++ b/lib/phoenix_kit_web/components/core/file_upload.ex
@@ -28,7 +28,11 @@ defmodule PhoenixKitWeb.Components.Core.FileUpload do
   alias PhoenixKit.Utils.Format
 
   attr :upload, :any, required: true
-  attr :label, :string, default: nil, doc: "Button label; defaults to a translated \"Upload Files\""
+
+  attr :label, :string,
+    default: nil,
+    doc: "Button label; defaults to a translated \"Upload Files\""
+
   attr :icon, :string, default: "hero-cloud-arrow-up"
   attr :accept_description, :string, default: nil
   attr :max_size_description, :string, default: nil
@@ -164,7 +168,9 @@ defmodule PhoenixKitWeb.Components.Core.FileUpload do
         <div class="flex flex-col items-center gap-2">
           <.icon name={@icon} class="w-8 h-8 text-primary" />
           <div>
-            <p class="font-semibold text-base-content">{gettext("Drag files here or click to browse")}</p>
+            <p class="font-semibold text-base-content">
+              {gettext("Drag files here or click to browse")}
+            </p>
             <p class="text-sm text-base-content/70 mt-1">
               <%= if @accept_description do %>
                 {@accept_description}

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -12801,3 +12801,12 @@ msgstr "Laden Sie die erste Datei über den Bereich oben hoch"
 #, elixir-autogen, elixir-format
 msgid "left"
 msgstr "verbleibend"
+
+msgid "Upload Files"
+msgstr "Dateien hochladen"
+
+msgid "Drop your files to upload"
+msgstr "Dateien zum Hochladen hier ablegen"
+
+msgid "Maximum file size: %{size}"
+msgstr "Maximale Dateigröße: %{size}"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -12800,3 +12800,12 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "left"
 msgstr ""
+
+msgid "Upload Files"
+msgstr ""
+
+msgid "Drop your files to upload"
+msgstr ""
+
+msgid "Maximum file size: %{size}"
+msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -12801,3 +12801,12 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "left"
 msgstr ""
+
+msgid "Upload Files"
+msgstr ""
+
+msgid "Drop your files to upload"
+msgstr ""
+
+msgid "Maximum file size: %{size}"
+msgstr ""

--- a/priv/gettext/es/LC_MESSAGES/default.po
+++ b/priv/gettext/es/LC_MESSAGES/default.po
@@ -12809,3 +12809,12 @@ msgstr "Sube el primero usando el área de arriba"
 #, elixir-autogen, elixir-format
 msgid "left"
 msgstr "restante"
+
+msgid "Upload Files"
+msgstr "Subir archivos"
+
+msgid "Drop your files to upload"
+msgstr "Suelta tus archivos para subirlos"
+
+msgid "Maximum file size: %{size}"
+msgstr "Tamaño máximo de archivo: %{size}"

--- a/priv/gettext/et/LC_MESSAGES/default.po
+++ b/priv/gettext/et/LC_MESSAGES/default.po
@@ -12818,3 +12818,12 @@ msgstr "Laadi esimene üles ülaloleva ala kaudu"
 #, elixir-autogen, elixir-format
 msgid "left"
 msgstr "jäänud"
+
+msgid "Upload Files"
+msgstr "Laadi failid üles"
+
+msgid "Drop your files to upload"
+msgstr "Lohista failid üleslaadimiseks siia"
+
+msgid "Maximum file size: %{size}"
+msgstr "Maksimaalne failisuurus: %{size}"

--- a/priv/gettext/fr/LC_MESSAGES/default.po
+++ b/priv/gettext/fr/LC_MESSAGES/default.po
@@ -12801,3 +12801,12 @@ msgstr "Téléversez le premier via la zone ci-dessus"
 #, elixir-autogen, elixir-format
 msgid "left"
 msgstr "restant"
+
+msgid "Upload Files"
+msgstr "Téléverser des fichiers"
+
+msgid "Drop your files to upload"
+msgstr "Déposez vos fichiers à téléverser"
+
+msgid "Maximum file size: %{size}"
+msgstr "Taille maximale du fichier : %{size}"

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -12801,3 +12801,12 @@ msgstr "Carica il primo usando l'area qui sopra"
 #, elixir-autogen, elixir-format
 msgid "left"
 msgstr "rimanenti"
+
+msgid "Upload Files"
+msgstr "Carica file"
+
+msgid "Drop your files to upload"
+msgstr "Trascina i file da caricare"
+
+msgid "Maximum file size: %{size}"
+msgstr "Dimensione massima del file: %{size}"

--- a/priv/gettext/pl/LC_MESSAGES/default.po
+++ b/priv/gettext/pl/LC_MESSAGES/default.po
@@ -12829,3 +12829,12 @@ msgstr "Prześlij pierwszy plik w polu powyżej"
 #, elixir-autogen, elixir-format
 msgid "left"
 msgstr "pozostało"
+
+msgid "Upload Files"
+msgstr "Prześlij pliki"
+
+msgid "Drop your files to upload"
+msgstr "Upuść pliki, aby przesłać"
+
+msgid "Maximum file size: %{size}"
+msgstr "Maksymalny rozmiar pliku: %{size}"

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -12841,3 +12841,12 @@ msgstr "Загрузите первый файл через область вы�
 #, elixir-autogen, elixir-format
 msgid "left"
 msgstr "осталось"
+
+msgid "Upload Files"
+msgstr "Загрузить файлы"
+
+msgid "Drop your files to upload"
+msgstr "Перетащите файлы для загрузки"
+
+msgid "Maximum file size: %{size}"
+msgstr "Максимальный размер файла: %{size}"

--- a/priv/static/assets/phoenix_kit.js
+++ b/priv/static/assets/phoenix_kit.js
@@ -6522,3 +6522,38 @@ if (typeof window.Chart === "undefined") {
     module.exports.uploadStatsText = uploadStatsText;
   }
 })();
+
+// ============================================================================
+// UploadGuard - native leave-page guard while uploads are in flight
+// ============================================================================
+//
+// Attached to an upload component's root. The server patches
+// `data-active` ("true" while any upload entry exists); while active, the
+// browser's own beforeunload dialog blocks an accidental refresh / tab
+// close that would kill the transfer (interrupted LiveView uploads are not
+// resumed). This replaces disclaimer prose with actual protection. Note it
+// guards full page unloads only — LiveView patch/navigate stays free.
+(function() {
+  "use strict";
+
+  window.PhoenixKitHooks = window.PhoenixKitHooks || {};
+
+  window.PhoenixKitHooks.UploadGuard = {
+    mounted() {
+      var self = this;
+      this.handler = function(e) {
+        if (self.el.dataset.active === "true") {
+          e.preventDefault();
+          // Chrome requires returnValue to show the dialog; the text is
+          // browser-controlled either way.
+          e.returnValue = "";
+        }
+      };
+      window.addEventListener("beforeunload", this.handler);
+    },
+
+    destroyed() {
+      window.removeEventListener("beforeunload", this.handler);
+    }
+  };
+})();

--- a/test/phoenix_kit_web/components/core/file_upload_test.exs
+++ b/test/phoenix_kit_web/components/core/file_upload_test.exs
@@ -25,6 +25,36 @@ defmodule PhoenixKitWeb.Components.Core.FileUploadTest do
   # entry's size and patches only data-progress; everything else (speed, ETA,
   # the ticking "Processing on server…" phase) is computed in the browser.
   # These pins keep the markup the hook depends on from drifting.
+  # The UploadGuard hook contract: the component root carries the hook and
+  # a data-active flag the server patches — "true" while any entry is in
+  # flight, so the browser's beforeunload dialog blocks an accidental
+  # refresh/close that would kill the transfer.
+  test "file_upload arms the UploadGuard while entries are in flight" do
+    upload = %Phoenix.LiveView.UploadConfig{ref: "phx-upload-1", entries: [entry()]}
+    assigns = %{upload: upload}
+
+    html =
+      render(~H"""
+      <.file_upload upload={@upload} />
+      """)
+
+    assert html =~ ~s(phx-hook="UploadGuard")
+    assert html =~ ~s(id="pk-upload-guard-phx-upload-1")
+    assert html =~ ~s(data-active="true")
+  end
+
+  test "file_upload disarms the UploadGuard with no entries" do
+    upload = %Phoenix.LiveView.UploadConfig{ref: "phx-upload-1", entries: []}
+    assigns = %{upload: upload}
+
+    html =
+      render(~H"""
+      <.file_upload upload={@upload} />
+      """)
+
+    assert html =~ ~s(data-active="false")
+  end
+
   test "upload_entry_stats renders the UploadStats hook contract" do
     assigns = %{entry: entry()}
 


### PR DESCRIPTION
## Summary

Post-#719 batch that missed the morning merge window. One feature:
`file_upload` now protects against the thing consumers used to warn
about in prose.

### UploadGuard

- While any upload entry is in flight, an `UploadGuard` JS hook
  (server-patched `data-active`) arms the browser's own beforeunload
  dialog — an accidental refresh / tab close of a non-resumable
  LiveView upload gets a native confirmation instead of an italic
  disclaimer. Wired into both `file_upload` variants automatically;
  guards full page unloads only (LiveView navigation stays free).
- Contract pinned in the component test (hook + `data-active`
  arm/disarm).

### FileUpload translations

- The component ignored existing translations: "Drag files here or
  click to browse" and "Cancel upload" had msgids (and locale
  catalogs) the markup never called gettext for.
- The label default, "Drop your files to upload", and the max-size
  line were untranslatable — wrapped, with three new msgids added
  across the eight locale catalogs.

## Verification

- `mix precommit` clean; suite 43 doctests + 3686 tests, 0 failures
  (one pre-existing order-dependent flake in the MediaBrowser
  controlled-mode test observed once and green on re-run + isolation)
- Browser-verified on max-dev.don.ee: guard element arms/disarms with
  entries; the catalogue PDF library dropped its disclaimer paragraph
  in the companion PR

## Test plan

- [x] file_upload_test: UploadGuard contract (hook id, data-active
  true/false), UploadStats contract unchanged
- [x] Upstream 2.8.0 merged back cleanly before this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164bhZcmjp9N98XXTtZbrxv