### PR TITLE
Request-scoped default-language override for multi-domain hosts

### DIFF
--- a/lib/modules/languages/languages.ex
+++ b/lib/modules/languages/languages.ex
@@ -100,6 +100,7 @@ defmodule PhoenixKit.Modules.Languages do
 
   alias PhoenixKit.Config
   alias PhoenixKit.Dashboard.Tab
+  alias PhoenixKit.Modules.Languages.DialectMapper
   alias PhoenixKit.Modules.Languages.Language
   alias PhoenixKit.Settings
 
@@ -529,12 +530,59 @@ defmodule PhoenixKit.Modules.Languages do
   """
   def get_default_language do
     if enabled?() do
-      get_languages()
-      |> Enum.find(& &1.is_default)
+      languages = get_languages()
+
+      request_override =
+        case request_default_language() do
+          nil -> nil
+          code -> Enum.find(languages, &request_override_matches?(&1, code))
+        end
+
+      request_override || Enum.find(languages, & &1.is_default)
     else
       nil
     end
   end
+
+  # Only an enabled language can be a request-scoped default; the override
+  # code and the configured code may each be a full locale ("fr-FR") or a
+  # base URL code ("fr") — match on the base either way.
+  defp request_override_matches?(%Language{code: lang_code, is_enabled: enabled?}, code) do
+    enabled? and
+      (lang_code == code or
+         DialectMapper.extract_base(lang_code) == DialectMapper.extract_base(code))
+  end
+
+  @request_default_language_key :phoenix_kit_request_default_language
+
+  @doc """
+  Sets a request/process-scoped default-language override, for multi-domain
+  hosts where each domain has its own canonical language.
+
+  While set, `get_default_language/0` prefers the named language (when it is
+  enabled) over the site-wide `is_default` flag, which every URL generator
+  and content-language lookup in the workspace already delegates to.
+
+  Process-scoped: set it per conn (a Plug) and per LiveView socket (an
+  `on_mount` hook). Spawned tasks and Oban jobs do NOT inherit it. Pass
+  `nil` to clear.
+  """
+  @spec put_request_default_language(String.t() | nil) :: :ok
+  def put_request_default_language(nil) do
+    Process.delete(@request_default_language_key)
+    :ok
+  end
+
+  def put_request_default_language(code) when is_binary(code) do
+    Process.put(@request_default_language_key, code)
+    :ok
+  end
+
+  @doc """
+  Returns the request/process-scoped default-language override, if any.
+  """
+  @spec request_default_language() :: String.t() | nil
+  def request_default_language, do: Process.get(@request_default_language_key)
 
   @doc """
   Returns true when public + admin URLs should omit the locale segment

--- a/lib/phoenix_kit_web/integration.ex
+++ b/lib/phoenix_kit_web/integration.ex
@@ -292,7 +292,11 @@ defmodule PhoenixKitWeb.Integration do
         pipe_through [:browser, :phoenix_kit_auto_setup]
 
         live_session :phoenix_kit_maintenance,
-          on_mount: [{PhoenixKitWeb.Users.Auth, :phoenix_kit_mount_current_scope}] do
+          on_mount:
+            unquote(
+              extra_on_mount() ++
+                [{PhoenixKitWeb.Users.Auth, :phoenix_kit_mount_current_scope}]
+            ) do
           live "/maintenance", Live.Modules.Maintenance.Page, :index
         end
       end
@@ -811,10 +815,14 @@ defmodule PhoenixKitWeb.Integration do
     quote do
       if unquote(PhoenixKit.Config.user_dashboard_enabled?()) do
         live_session unquote(session_name),
-          on_mount: [
-            {PhoenixKitWeb.Users.Auth, :phoenix_kit_ensure_authenticated_scope},
-            {PhoenixKitWeb.Dashboard.ContextProvider, :default}
-          ] do
+          on_mount:
+            unquote(
+              extra_on_mount() ++
+                [
+                  {PhoenixKitWeb.Users.Auth, :phoenix_kit_ensure_authenticated_scope},
+                  {PhoenixKitWeb.Dashboard.ContextProvider, :default}
+                ]
+            ) do
           live "/dashboard", Live.Dashboard.Index, :index
           live "/dashboard/settings", Live.Dashboard.Settings, :edit
 
@@ -1412,7 +1420,8 @@ defmodule PhoenixKitWeb.Integration do
     root_routes = {route_macro, [], [:""]}
 
     quote do
-      live_session unquote(session_name), on_mount: unquote(on_mount) do
+      live_session unquote(session_name),
+        on_mount: unquote(extra_on_mount() ++ on_mount) do
         scope "#{unquote(url_prefix)}/:locale", PhoenixKitWeb do
           pipe_through unquote(pipelines)
           unquote(localized_routes)
@@ -1424,6 +1433,24 @@ defmodule PhoenixKitWeb.Integration do
         end
       end
     end
+  end
+
+  # Extra on_mount hooks the HOST app adds to every PhoenixKit
+  # live_session (e.g., a multi-domain default-language hook):
+  #
+  #     config :phoenix_kit, extra_live_session_on_mount:
+  #       [{MyAppWeb.DomainLanguageHook, :default}]
+  #
+  # PREPENDED, not appended: request-context hooks must run before the auth
+  # hooks, whose {:halt, redirect} paths already resolve locale-prefixed
+  # URLs via Languages.get_default_language/0 — appended hooks would never
+  # run on that path and the redirect would use the site-wide default.
+  # Extra hooks therefore must not assume an authenticated socket.
+  #
+  # Read at router compile time; __mix_recompile__? below invalidates the
+  # host router when this config changes.
+  defp extra_on_mount do
+    Application.get_env(:phoenix_kit, :extra_live_session_on_mount, [])
   end
 
   # Root-level sitemap endpoints, for installs mounted under a prefix. See the
@@ -1627,10 +1654,15 @@ defmodule PhoenixKitWeb.Integration do
       # Recompile router when deps change (mix.lock is updated by mix deps.get)
       @external_resource unquote(mix_lock_path)
 
-      # Precise check: only actually recompile if the set of PhoenixKit modules changed
+      # Precise check: recompile if the set of PhoenixKit modules changed, or
+      # if the host's extra_live_session_on_mount config no longer matches the
+      # value baked in at compile time (plain Application.get_env at macro
+      # expansion is not tracked by the compiler's compile_env mechanism).
       @doc false
       def __mix_recompile__? do
-        unquote(current_hash) != PhoenixKit.ModuleDiscovery.module_hash()
+        unquote(current_hash) != PhoenixKit.ModuleDiscovery.module_hash() or
+          unquote(Macro.escape(extra_on_mount())) !=
+            Application.get_env(:phoenix_kit, :extra_live_session_on_mount, [])
       end
 
       # Compile-time dependency on each route module (see the comment at

--- a/test/integration/languages/request_default_language_test.exs
+++ b/test/integration/languages/request_default_language_test.exs
@@ -1,0 +1,79 @@
+defmodule PhoenixKit.Integration.Languages.RequestDefaultLanguageTest do
+  @moduledoc """
+  Pins the request-scoped default-language override used by multi-domain
+  host apps: `put_request_default_language/1` + its precedence over the
+  site-wide `is_default` flag inside `get_default_language/0`.
+  """
+
+  use PhoenixKit.DataCase, async: false
+
+  alias PhoenixKit.Modules.Languages
+  alias PhoenixKit.Settings
+
+  setup do
+    config = %{
+      "languages" => [
+        %{"code" => "en-US", "name" => "English", "is_default" => true, "is_enabled" => true},
+        %{"code" => "fr-FR", "name" => "French", "is_default" => false, "is_enabled" => true},
+        %{"code" => "de", "name" => "German", "is_default" => false, "is_enabled" => false}
+      ]
+    }
+
+    Settings.update_setting("languages_enabled", "true")
+    Settings.update_json_setting("languages_config", config)
+
+    on_exit(fn ->
+      Languages.put_request_default_language(nil)
+      Settings.update_setting("languages_enabled", "false")
+    end)
+
+    :ok
+  end
+
+  test "without an override the is_default language wins" do
+    assert %{code: "en-US"} = Languages.get_default_language()
+  end
+
+  test "an enabled override (exact code) wins over is_default" do
+    Languages.put_request_default_language("fr-FR")
+    assert %{code: "fr-FR"} = Languages.get_default_language()
+  end
+
+  test "an enabled override matches on base code, both directions" do
+    Languages.put_request_default_language("fr")
+    assert %{code: "fr-FR"} = Languages.get_default_language()
+  end
+
+  test "a disabled override falls back to is_default" do
+    Languages.put_request_default_language("de")
+    assert %{code: "en-US"} = Languages.get_default_language()
+  end
+
+  test "an unknown override falls back to is_default" do
+    Languages.put_request_default_language("xx")
+    assert %{code: "en-US"} = Languages.get_default_language()
+  end
+
+  test "nil clears the override" do
+    Languages.put_request_default_language("fr-FR")
+    Languages.put_request_default_language(nil)
+    assert Languages.request_default_language() == nil
+    assert %{code: "en-US"} = Languages.get_default_language()
+  end
+
+  test "the override is process-scoped" do
+    Languages.put_request_default_language("fr-FR")
+
+    other =
+      Task.async(fn -> Languages.request_default_language() end)
+      |> Task.await()
+
+    assert other == nil
+  end
+
+  test "override has no effect while the Languages module is disabled" do
+    Settings.update_setting("languages_enabled", "false")
+    Languages.put_request_default_language("fr-FR")
+    assert Languages.get_default_language() == nil
+  end
+end


### PR DESCRIPTION
## What

`PhoenixKit.Languages.put_request_default_language/1` + `request_default_language/0` set a process-scoped override; `get_default_language/0` prefers it (enabled languages only, matches full or base code) over the site-wide `is_default` flag. Set per `conn` by a host-app plug, or per LiveView socket by an `on_mount` hook; spawned tasks and Oban jobs do not inherit it (deliberate — they aren't tied to a request).

Also adds `extra_live_session_on_mount` config so a host app can append `on_mount` hooks to every PhoenixKit `live_session` (public/admin surfaces, dashboard, maintenance) without forking the router:

```elixir
config :phoenix_kit, extra_live_session_on_mount: [{MyAppWeb.DomainLanguageHook, :default}]
```

Extra hooks are **prepended**, not appended — an appended hook on a fresh socket runs *after* the auth hooks' `{:halt, redirect}` paths, which already resolve a locale-prefixed URL against the site-wide default before the extra hook gets a chance to set request context. `__mix_recompile__?` also compares the baked-in hook list against the current config, since a plain `Application.get_env` read at macro-expansion time is invisible to the compiler's `compile_env` tracking — a config-only change wouldn't otherwise recompile the host router.

## Why

A single Phoenix app serving multiple public domains (each with its own default language) can't currently show the right default language on a domain without a locale prefix — `is_default` is one flag, site-wide.

## What's tested

- `test/integration/languages/request_default_language_test.exs` — override round-trip, base-code matching against enabled languages.
- Full suite run in isolation on a fresh `upstream/main` checkout (this PR alone, no other unmerged changes): 43 doctests + 3716 tests, 0 failures.
