### PR TITLE
Per-domain sitemap generation, storage, cache and serving

### DIFF
--- a/lib/modules/sitemap/cache.ex
+++ b/lib/modules/sitemap/cache.ex
@@ -127,6 +127,10 @@ defmodule PhoenixKit.Modules.Sitemap.Cache do
     FileStorage.delete()
     FileStorage.delete_all_modules()
 
+    # Domain mode inherits the delete-on-invalidate freshness guarantee:
+    # every generated per-host set goes too (current AND stale hosts).
+    Enum.each(FileStorage.list_domain_hosts(), &FileStorage.delete_domain_files/1)
+
     # Clear generation stats
     Sitemap.clear_generation_stats()
 

--- a/lib/modules/sitemap/domain_mode.ex
+++ b/lib/modules/sitemap/domain_mode.ex
@@ -1,0 +1,236 @@
+defmodule PhoenixKit.Modules.Sitemap.DomainMode do
+  @moduledoc """
+  Multi-domain sitemap post-processing (one domain = one canonical language).
+
+  Activated by a host-app provider:
+
+      config :phoenix_kit, :sitemap_domains_provider, {MyAppWeb.SEO, :sitemap_domains}
+
+  The provider returns `[%{host: "example.fr", language: "fr", primary: false}, ...]`.
+  The result is VALIDATED here — exactly one `primary: true`, every host a
+  distinct language (base-code level), well-formed hosts. Any violation
+  deactivates domain mode (with a warning) rather than silently producing
+  malformed URLs or dropping x-default.
+
+  `rebuild_for_domains/2` regroups the entries the generator already
+  collected across languages: for the domain of language L, every canonical
+  group that HAS an L entry contributes one URL — L's own entry re-hosted on
+  that domain with its locale prefix stripped (L is the default there) —
+  carrying an alternates set computed ONCE per group (identical across all
+  domain files by construction): each group language on its home URL, plus
+  `x-default` for the primary domain's language when the group has it
+  (omitted otherwise — never mislabel another language as x-default).
+
+  Runs inside Oban jobs and unpiped controller requests: language resolution
+  here never consults the request-scoped default-language override — the
+  unprefixed-entry fallback reads the raw `is_default` flag, mirroring the
+  generator's hardened `get_languages/0`.
+
+  NB: the generator's `base_url` (Settings `site_url`) and the provider's
+  primary host are independently-edited settings that must refer to the same
+  site; rel-path extraction below is host-string-agnostic, so a mismatch
+  yields consistent (if unexpected-host) URLs rather than corruption.
+  """
+
+  require Logger
+
+  alias PhoenixKit.Modules.Languages
+  alias PhoenixKit.Modules.Languages.DialectMapper
+  alias PhoenixKit.Modules.Sitemap.UrlEntry
+
+  @host_re ~r/^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/
+  @locale_prefix_re ~r/^\/([a-z]{2,3}(?:-[A-Za-z]{2,4})?)(?:\/|$)/
+
+  @type domain :: %{host: String.t(), language: String.t(), primary: boolean()}
+
+  @doc "Validated provider domains; [] (inactive) on any contract violation."
+  @spec domains() :: [domain()]
+  def domains do
+    case Application.get_env(:phoenix_kit, :sitemap_domains_provider) do
+      {mod, fun} -> mod |> apply(fun, []) |> validate()
+      _ -> []
+    end
+  rescue
+    error ->
+      Logger.warning("[Sitemap] sitemap_domains_provider raised: #{Exception.message(error)}")
+      []
+  end
+
+  @doc false
+  @spec active?() :: boolean()
+  def active?, do: domains() != []
+
+  defp validate(list) when is_list(list) and list != [] do
+    normalized =
+      Enum.map(list, fn %{host: host, language: language} = d ->
+        %{
+          host: host |> to_string() |> String.downcase(),
+          language: DialectMapper.extract_base(to_string(language)),
+          primary: Map.get(d, :primary, false) == true
+        }
+      end)
+
+    cond do
+      Enum.any?(normalized, &(not Regex.match?(@host_re, &1.host))) ->
+        warn_invalid("malformed host")
+
+      Enum.count(normalized, & &1.primary) != 1 ->
+        warn_invalid("exactly one primary domain required")
+
+      normalized |> Enum.map(& &1.language) |> Enum.uniq() |> length() != length(normalized) ->
+        warn_invalid("each host must map a distinct language")
+
+      true ->
+        normalized
+    end
+  rescue
+    error ->
+      Logger.warning("[Sitemap] invalid sitemap_domains_provider data: #{inspect(error)}")
+      []
+  end
+
+  defp validate(_), do: []
+
+  defp warn_invalid(reason) do
+    Logger.warning("[Sitemap] domain mode disabled: #{reason}")
+    []
+  end
+
+  @doc """
+  Regroups collected entries into per-domain URL sets: `%{host => [UrlEntry.t()]}`.
+  """
+  @spec rebuild_for_domains([UrlEntry.t()], String.t()) :: %{String.t() => [UrlEntry.t()]}
+  def rebuild_for_domains(entries, base_url) do
+    case domains() do
+      [] ->
+        %{}
+
+      domains ->
+        default_lang = raw_default_language()
+        enabled_bases = enabled_language_bases()
+        host_by_lang = Map.new(domains, &{&1.language, &1.host})
+        primary = Enum.find(domains, & &1.primary)
+
+        groups =
+          entries
+          |> Enum.group_by(fn e -> e.canonical_path || {:loc, e.loc} end)
+          |> Map.values()
+          |> Enum.map(&group_by_language(&1, base_url, default_lang, enabled_bases))
+
+        Map.new(domains, fn %{host: host, language: lang} ->
+          {host, domain_entries(groups, lang, host_by_lang, primary, base_url)}
+        end)
+    end
+  end
+
+  defp group_by_language(members, base_url, default_lang, enabled_bases) do
+    Map.new(members, fn e -> {entry_language(e, base_url, default_lang, enabled_bases), e} end)
+  end
+
+  defp domain_entries(groups, lang, host_by_lang, primary, base_url) do
+    groups
+    |> Enum.flat_map(fn by_lang ->
+      case by_lang[lang] do
+        nil ->
+          []
+
+        entry ->
+          alternates = group_alternates(by_lang, host_by_lang, primary, base_url)
+
+          [
+            %{
+              entry
+              | loc: home_url(lang, entry, host_by_lang, primary, base_url),
+                alternates: alternates
+            }
+          ]
+      end
+    end)
+    |> Enum.sort_by(& &1.loc)
+  end
+
+  # Computed once per group and reused verbatim for every domain that carries
+  # the group — the spec's "identical hreflang set on every duplicate".
+  defp group_alternates(by_lang, host_by_lang, primary, base_url) do
+    links =
+      by_lang
+      |> Enum.sort_by(fn {lang, _} -> lang end)
+      |> Enum.map(fn {lang, entry} ->
+        %{hreflang: lang, href: home_url(lang, entry, host_by_lang, primary, base_url)}
+      end)
+
+    case by_lang[primary.language] do
+      nil ->
+        links
+
+      primary_entry ->
+        links ++
+          [
+            %{
+              hreflang: "x-default",
+              href: home_url(primary.language, primary_entry, host_by_lang, primary, base_url)
+            }
+          ]
+    end
+  end
+
+  defp home_url(lang, %UrlEntry{loc: loc}, host_by_lang, primary, base_url) do
+    rel = String.replace_prefix(loc, String.trim_trailing(base_url, "/"), "")
+    rel = if String.starts_with?(rel, "/"), do: rel, else: "/" <> rel
+
+    case host_by_lang[lang] do
+      nil -> "https://#{primary.host}#{rel}"
+      host -> "https://#{host}#{strip_own_prefix(rel, lang)}"
+    end
+  end
+
+  defp strip_own_prefix(rel, lang) do
+    case String.split(rel, "/", parts: 3) do
+      ["", ^lang] -> "/"
+      ["", ^lang, rest] -> "/" <> rest
+      _ -> rel
+    end
+  end
+
+  # Language of an entry, from its loc's locale prefix — only when the
+  # segment is a real enabled language (a "/api/..." first segment is not a
+  # locale). Unprefixed entries (home, router-discovery) belong to the site
+  # default. Reads the RAW is_default flag — never the request-scoped
+  # override (Oban/unpiped safe).
+  defp entry_language(%UrlEntry{loc: loc}, base_url, default_lang, enabled_bases) do
+    rel = String.replace_prefix(loc, String.trim_trailing(base_url, "/"), "")
+
+    with [_, code] <- Regex.run(@locale_prefix_re, rel),
+         base = DialectMapper.extract_base(code),
+         true <- base in enabled_bases do
+      base
+    else
+      _ -> default_lang
+    end
+  end
+
+  defp enabled_language_bases do
+    if Languages.enabled?() do
+      Languages.get_enabled_languages()
+      |> Enum.map(&DialectMapper.extract_base(&1.code))
+      |> MapSet.new()
+    else
+      MapSet.new()
+    end
+  rescue
+    _ -> MapSet.new()
+  end
+
+  defp raw_default_language do
+    if Languages.enabled?() do
+      case Enum.find(Languages.get_languages(), & &1.is_default) do
+        %{code: code} -> DialectMapper.extract_base(code)
+        _ -> "en"
+      end
+    else
+      "en"
+    end
+  rescue
+    _ -> "en"
+  end
+end

--- a/lib/modules/sitemap/file_storage.ex
+++ b/lib/modules/sitemap/file_storage.ex
@@ -193,6 +193,72 @@ defmodule PhoenixKit.Modules.Sitemap.FileStorage do
     Path.join(sitemaps_dir(), "#{filename}.xml")
   end
 
+  # ── Multi-domain files (DomainMode) ─────────────────────────────────
+  #
+  # Per-host sitemap sets live under sitemaps/domains/{host}/. Hosts come
+  # exclusively from the validated DomainMode provider list (never raw user
+  # input), and are additionally path-sanitized here as defense in depth.
+
+  @domains_subdir "domains"
+  @domain_host_re ~r/^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/
+
+  @doc "Directory holding all per-domain sitemap sets."
+  @spec domains_dir() :: String.t()
+  def domains_dir, do: Path.join(sitemaps_dir(), @domains_subdir)
+
+  @doc "Full path of one host's sitemap file (filename without .xml)."
+  @spec domain_file_path(String.t(), String.t()) :: {:ok, String.t()} | {:error, :bad_host}
+  def domain_file_path(host, filename \\ "sitemap") do
+    if Regex.match?(@domain_host_re, host) do
+      {:ok, Path.join([domains_dir(), host, "#{filename}.xml"])}
+    else
+      {:error, :bad_host}
+    end
+  end
+
+  @doc "Writes one host's sitemap file."
+  @spec write_domain_sitemap(String.t(), String.t(), String.t()) :: :ok | {:error, term()}
+  def write_domain_sitemap(host, filename, xml_content) when is_binary(xml_content) do
+    with {:ok, path} <- domain_file_path(host, filename),
+         :ok <- ensure_directory_exists(path),
+         :ok <- File.write(path, xml_content) do
+      :ok
+    else
+      error ->
+        Logger.warning(
+          "FileStorage: Failed to write domain sitemap for #{host}: #{inspect(error)}"
+        )
+
+        error
+    end
+  end
+
+  @doc "Deletes one host's entire sitemap directory."
+  @spec delete_domain_files(String.t()) :: :ok
+  def delete_domain_files(host) do
+    with {:ok, path} <- domain_file_path(host) do
+      path |> Path.dirname() |> File.rm_rf()
+    end
+
+    :ok
+  rescue
+    _ -> :ok
+  end
+
+  @doc "Hosts that currently have generated domain sitemap directories."
+  @spec list_domain_hosts() :: [String.t()]
+  def list_domain_hosts do
+    dir = domains_dir()
+
+    if File.dir?(dir) do
+      dir |> File.ls!() |> Enum.filter(&File.dir?(Path.join(dir, &1)))
+    else
+      []
+    end
+  rescue
+    _ -> []
+  end
+
   # ── Legacy / backward-compatible API ───────────────────────────────
 
   @doc """

--- a/lib/modules/sitemap/generator.ex
+++ b/lib/modules/sitemap/generator.ex
@@ -34,6 +34,7 @@ defmodule PhoenixKit.Modules.Sitemap.Generator do
   alias PhoenixKit.Modules.Languages
   alias PhoenixKit.Modules.Sitemap
   alias PhoenixKit.Modules.Sitemap.Cache
+  alias PhoenixKit.Modules.Sitemap.DomainMode
   alias PhoenixKit.Modules.Sitemap.FileStorage
   alias PhoenixKit.Modules.Sitemap.HtmlGenerator
   alias PhoenixKit.Modules.Sitemap.SchedulerWorker
@@ -118,6 +119,15 @@ defmodule PhoenixKit.Modules.Sitemap.Generator do
     FileStorage.save_index(xml)
     FileStorage.delete_all_modules()
 
+    # Domain mode inherits noindex: an empty urlset per mapped host, so
+    # previously-generated real-URL files stop being served the moment
+    # noindex flips on (mirrors delete_all_modules for the legacy set).
+    for %{host: host} <- DomainMode.domains() do
+      FileStorage.write_domain_sitemap(host, "sitemap", xml)
+    end
+
+    cleanup_stale_domain_dirs()
+
     {:ok, %{index_xml: xml, modules: [], total_urls: 0}}
   end
 
@@ -130,6 +140,100 @@ defmodule PhoenixKit.Modules.Sitemap.Generator do
     # An unreachable database RAISES on an unowned checkout but EXITS on a
     # dead pool; rescue alone leaves the exit path unguarded.
     :exit, _ -> false
+  end
+
+  # Multi-domain post-processing (DomainMode): one flat urlset per mapped
+  # host (its language's entries, re-hosted prefix-free, cross-domain
+  # alternates), with the 50k splitter per host. `entries` may be passed in
+  # (flat mode reuses its collection) or nil (index mode — collected here).
+  # Inactive provider ⇒ no-op; stale host dirs are always cleaned up.
+  defp generate_domain_sitemaps(entries, base_url, opts, xsl_style, xsl_enabled) do
+    if DomainMode.active?() do
+      # Index mode re-collects here (flat mode passes its entries through).
+      # Accepted trade-off: one extra collection pass per scheduled/on-demand
+      # generation, in exchange for zero restructuring of the per-module
+      # legacy path. Content changing between the two passes within one run
+      # can skew module stats vs domain files until the next generation.
+      entries =
+        entries || collect_all_entries(Keyword.put(opts, :force, true), get_sources())
+
+      per_host = DomainMode.rebuild_for_domains(entries, base_url)
+
+      for {host, host_entries} <- per_host do
+        write_domain_files(host, host_entries, xsl_style, xsl_enabled)
+      end
+
+      Logger.info("Sitemap: Generated domain sitemaps for #{map_size(per_host)} hosts")
+    end
+
+    cleanup_stale_domain_dirs()
+    :ok
+  end
+
+  defp write_domain_files(host, entries, xsl_style, xsl_enabled) do
+    if length(entries) > @max_urls_per_file do
+      chunks = Enum.chunk_every(entries, @max_urls_per_file)
+
+      filenames =
+        chunks
+        |> Enum.with_index(1)
+        |> Enum.map(fn {chunk, i} ->
+          filename = "sitemap-#{i}"
+          xml = build_urlset_xml(chunk, xsl_style, xsl_enabled)
+          FileStorage.write_domain_sitemap(host, filename, xml)
+          Cache.put({:domain_xml, host, filename}, xml)
+          filename
+        end)
+
+      index_xml = build_domain_index_xml(host, filenames, xsl_style, xsl_enabled)
+      FileStorage.write_domain_sitemap(host, "sitemap", index_xml)
+      Cache.put({:domain_xml, host, "sitemap"}, index_xml)
+    else
+      xml = build_urlset_xml(entries, xsl_style, xsl_enabled)
+      FileStorage.write_domain_sitemap(host, "sitemap", xml)
+      Cache.put({:domain_xml, host, "sitemap"}, xml)
+    end
+  end
+
+  defp build_domain_index_xml(host, filenames, xsl_style, xsl_enabled) do
+    lastmod = DateTime.utc_now() |> DateTime.to_iso8601()
+
+    # Same prefix handling as the legacy generate_index/4 — hosts served
+    # under a non-root url_prefix must reference their chunks there too.
+    prefix =
+      case PhoenixKit.Config.get_url_prefix() do
+        "/" -> ""
+        p -> String.trim_trailing(p, "/")
+      end
+
+    entries_xml =
+      Enum.map_join(filenames, "\n", fn filename ->
+        "  <sitemap>\n    <loc>https://#{host}#{prefix}/sitemaps/#{filename}.xml</loc>\n    <lastmod>#{lastmod}</lastmod>\n  </sitemap>"
+      end)
+
+    [
+      @xml_declaration,
+      build_index_xsl_line(xsl_style, xsl_enabled),
+      @sitemapindex_open,
+      entries_xml,
+      @sitemapindex_close
+    ]
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.join("\n")
+  end
+
+  # Hosts with generated dirs that are no longer in the provider list.
+  defp cleanup_stale_domain_dirs do
+    active_hosts = MapSet.new(DomainMode.domains(), & &1.host)
+
+    for host <- FileStorage.list_domain_hosts(),
+        host not in active_hosts do
+      FileStorage.delete_domain_files(host)
+    end
+
+    :ok
+  rescue
+    _ -> :ok
   end
 
   defp do_generate_index(base_url, opts, sources, xsl_style, xsl_enabled) do
@@ -149,6 +253,8 @@ defmodule PhoenixKit.Modules.Sitemap.Generator do
     # Clean up stale module files from disabled sources
     cleanup_stale_modules(module_infos)
 
+    generate_domain_sitemaps(nil, base_url, opts, xsl_style, xsl_enabled)
+
     total_urls = Enum.reduce(module_infos, 0, fn info, acc -> acc + info.url_count end)
 
     Logger.info(
@@ -163,7 +269,7 @@ defmodule PhoenixKit.Modules.Sitemap.Generator do
      }}
   end
 
-  defp do_generate_flat(_base_url, opts, sources, xsl_style, xsl_enabled) do
+  defp do_generate_flat(base_url, opts, sources, xsl_style, xsl_enabled) do
     Logger.info("Sitemap: Generating flat sitemap from #{length(sources)} sources")
 
     flat_opts = Keyword.put(opts, :force, true)
@@ -173,6 +279,8 @@ defmodule PhoenixKit.Modules.Sitemap.Generator do
 
     # Clean up any leftover per-module files
     FileStorage.delete_all_modules()
+
+    generate_domain_sitemaps(entries, base_url, opts, xsl_style, xsl_enabled)
 
     total_urls = length(entries)
 

--- a/lib/modules/sitemap/web/controller.ex
+++ b/lib/modules/sitemap/web/controller.ex
@@ -23,6 +23,7 @@ defmodule PhoenixKit.Modules.Sitemap.Web.Controller do
   require Logger
 
   alias PhoenixKit.Modules.Sitemap
+  alias PhoenixKit.Modules.Sitemap.DomainMode
   alias PhoenixKit.Modules.Sitemap.FileStorage
   alias PhoenixKit.Modules.Sitemap.Generator
 
@@ -49,10 +50,15 @@ defmodule PhoenixKit.Modules.Sitemap.Web.Controller do
           _ -> get_xsl_style(config)
         end
 
-      if Map.get(params, "format") == "html" do
-        serve_html(conn, config, xsl_style)
-      else
-        serve_index_xml(conn, xsl_style)
+      cond do
+        Map.get(params, "format") == "html" ->
+          serve_html(conn, config, xsl_style)
+
+        domain_host(conn) ->
+          serve_domain_file(conn, domain_host(conn), "sitemap", xsl_style)
+
+        true ->
+          serve_index_xml(conn, xsl_style)
       end
     else
       conn
@@ -68,9 +74,23 @@ defmodule PhoenixKit.Modules.Sitemap.Web.Controller do
   The `.xml` extension is appended automatically.
   """
   def module_sitemap(conn, %{"filename" => raw_filename}) do
+    # Strip .xml extension if provided in URL
+    filename = String.trim_trailing(raw_filename, ".xml")
+
     cond do
       !Sitemap.enabled?() ->
         send_plain_error(conn, 404, "Sitemap not available")
+
+      not Regex.match?(@filename_pattern, filename) ->
+        send_plain_error(conn, 400, "Invalid filename")
+
+      host = domain_host(conn) ->
+        # A mapped host only ever resolves inside its own domain dir (split
+        # chunks like sitemap-2); never the legacy module files. Checked
+        # BEFORE the flat-mode 404 — domain sets are always flat-with-split,
+        # independent of the legacy mode, so a >50k domain's chunk files
+        # must stay reachable even when the site runs in flat mode.
+        serve_domain_file(conn, host, filename, nil)
 
       Sitemap.flat_mode?() ->
         send_plain_error(
@@ -80,14 +100,50 @@ defmodule PhoenixKit.Modules.Sitemap.Web.Controller do
         )
 
       true ->
-        # Strip .xml extension if provided in URL
-        filename = String.trim_trailing(raw_filename, ".xml")
+        serve_module_file(conn, filename)
+    end
+  end
 
-        if Regex.match?(@filename_pattern, filename) do
-          serve_module_file(conn, filename)
-        else
-          send_plain_error(conn, 400, "Invalid filename")
+  # The request host when domain mode is active and the host is mapped.
+  defp domain_host(conn) do
+    case Enum.find(DomainMode.domains(), &(&1.host == String.downcase(conn.host || ""))) do
+      %{host: host} -> host
+      _ -> nil
+    end
+  end
+
+  # Serves one host's domain sitemap file: file if present, else regenerate
+  # everything on demand (same policy as the legacy index path).
+  defp serve_domain_file(conn, host, filename, xsl_style) do
+    with {:ok, path} <- FileStorage.domain_file_path(host, filename),
+         true <- File.exists?(path) do
+      serve_file_with_etag(conn, path, domain_file_stat(path))
+    else
+      _ ->
+        style = xsl_style || get_xsl_style(Sitemap.get_config())
+
+        case Generator.generate_all(base_url: Sitemap.get_base_url(), xsl_style: style) do
+          {:ok, _} ->
+            with {:ok, path} <- FileStorage.domain_file_path(host, filename),
+                 true <- File.exists?(path) do
+              serve_file_with_etag(conn, path, domain_file_stat(path))
+            else
+              _ -> send_plain_error(conn, 404, "Sitemap not found")
+            end
+
+          {:error, _} ->
+            send_plain_error(conn, 500, "Sitemap generation failed")
         end
+    end
+  end
+
+  # generate_etag_from_stat/1 expects the {:ok, mtime, size} shape
+  # (FileStorage.get_file_stat/0's contract) — a raw File.stat result would
+  # silently degrade every domain file to the shared "default" ETag.
+  defp domain_file_stat(path) do
+    case File.stat(path) do
+      {:ok, %{mtime: mtime, size: size}} -> {:ok, mtime, size}
+      _ -> :error
     end
   end
 

--- a/test/integration/sitemap/domain_generation_test.exs
+++ b/test/integration/sitemap/domain_generation_test.exs
@@ -1,0 +1,88 @@
+defmodule PhoenixKit.Integration.Sitemap.DomainGenerationProviderStub do
+  @moduledoc false
+  def domains do
+    [
+      %{host: "gen.example.com", language: "en", primary: true},
+      %{host: "gen.example.fr", language: "fr", primary: false}
+    ]
+  end
+end
+
+defmodule PhoenixKit.Integration.Sitemap.DomainGenerationTest do
+  @moduledoc """
+  End-to-end plumbing of DomainMode through Generator, FileStorage, Cache
+  and the noindex branch: per-host files written, legacy set untouched,
+  invalidate deletes domain files, noindex publishes empty per-host urlsets,
+  stale host dirs cleaned up.
+  """
+  use PhoenixKit.DataCase, async: false
+
+  alias PhoenixKit.Integration.Sitemap.DomainGenerationProviderStub, as: Stub
+  alias PhoenixKit.Modules.Sitemap.Cache
+  alias PhoenixKit.Modules.Sitemap.FileStorage
+  alias PhoenixKit.Modules.Sitemap.Generator
+  alias PhoenixKit.Settings
+
+  @base_url "https://gen.example.com"
+
+  setup do
+    {:ok, _} = Settings.update_boolean_setting("sitemap_enabled", true)
+    {:ok, _} = Settings.update_setting("site_url", @base_url)
+    {:ok, _} = Settings.update_boolean_setting("crawlers_no_index", false)
+
+    Application.put_env(:phoenix_kit, :sitemap_domains_provider, {Stub, :domains})
+
+    on_exit(fn ->
+      Application.delete_env(:phoenix_kit, :sitemap_domains_provider)
+      Enum.each(FileStorage.list_domain_hosts(), &FileStorage.delete_domain_files/1)
+    end)
+
+    :ok
+  end
+
+  test "generation writes per-host files alongside the legacy set" do
+    assert {:ok, _} = Generator.generate_all(base_url: @base_url)
+
+    assert {:ok, com_path} = FileStorage.domain_file_path("gen.example.com")
+    assert {:ok, fr_path} = FileStorage.domain_file_path("gen.example.fr")
+    assert File.exists?(com_path)
+    assert File.exists?(fr_path)
+    assert File.exists?(FileStorage.file_path())
+
+    assert File.read!(com_path) =~ "<urlset"
+  end
+
+  test "invalidate deletes domain files too" do
+    {:ok, _} = Generator.generate_all(base_url: @base_url)
+    assert FileStorage.list_domain_hosts() != []
+
+    Cache.invalidate()
+    assert FileStorage.list_domain_hosts() == []
+  end
+
+  test "noindex publishes empty urlsets per host" do
+    {:ok, _} = Settings.update_boolean_setting("crawlers_no_index", true)
+    assert {:ok, %{total_urls: 0}} = Generator.generate_all(base_url: @base_url)
+
+    {:ok, com_path} = FileStorage.domain_file_path("gen.example.com")
+    xml = File.read!(com_path)
+    assert xml =~ "<urlset"
+    refute xml =~ "<loc>"
+  end
+
+  test "stale host dirs are cleaned up on generation" do
+    FileStorage.write_domain_sitemap("stale.example.org", "sitemap", "<urlset/>")
+    assert "stale.example.org" in FileStorage.list_domain_hosts()
+
+    {:ok, _} = Generator.generate_all(base_url: @base_url)
+    refute "stale.example.org" in FileStorage.list_domain_hosts()
+  end
+
+  test "inactive provider leaves no domain dirs behind" do
+    Application.delete_env(:phoenix_kit, :sitemap_domains_provider)
+    FileStorage.write_domain_sitemap("leftover.example.org", "sitemap", "<urlset/>")
+
+    {:ok, _} = Generator.generate_all(base_url: @base_url)
+    assert FileStorage.list_domain_hosts() == []
+  end
+end

--- a/test/integration/sitemap/domain_mode_test.exs
+++ b/test/integration/sitemap/domain_mode_test.exs
@@ -1,0 +1,157 @@
+defmodule PhoenixKit.Integration.Sitemap.DomainModeProviderStub do
+  @moduledoc false
+  def ok do
+    [
+      %{host: "site.example.com", language: "en", primary: true},
+      %{host: "site.example.fr", language: "fr", primary: false}
+    ]
+  end
+
+  def no_primary, do: Enum.map(ok(), &%{&1 | primary: false})
+  def two_primaries, do: Enum.map(ok(), &%{&1 | primary: true})
+
+  def duplicate_language,
+    do: ok() ++ [%{host: "other.example.fr", language: "fr-FR", primary: false}]
+
+  def raising, do: raise("boom")
+  def empty, do: []
+
+  def malformed_host,
+    do: [%{host: "../etc/passwd", language: "en", primary: true}]
+end
+
+defmodule PhoenixKit.Integration.Sitemap.DomainModeTest do
+  use PhoenixKit.DataCase, async: false
+
+  alias PhoenixKit.Integration.Sitemap.DomainModeProviderStub, as: Stub
+  alias PhoenixKit.Modules.Sitemap.DomainMode
+  alias PhoenixKit.Modules.Sitemap.UrlEntry
+  alias PhoenixKit.Settings
+
+  @base "https://legacy.example.com"
+
+  setup do
+    Settings.update_setting("languages_enabled", "true")
+
+    Settings.update_json_setting("languages_config", %{
+      "languages" => [
+        %{"code" => "en-US", "name" => "English", "is_default" => true, "is_enabled" => true},
+        %{"code" => "fr", "name" => "French", "is_default" => false, "is_enabled" => true},
+        %{"code" => "de", "name" => "German", "is_default" => false, "is_enabled" => true}
+      ]
+    })
+
+    on_exit(fn ->
+      Application.delete_env(:phoenix_kit, :sitemap_domains_provider)
+      Settings.update_setting("languages_enabled", "false")
+    end)
+
+    :ok
+  end
+
+  defp put_provider(fun) do
+    Application.put_env(:phoenix_kit, :sitemap_domains_provider, {Stub, fun})
+  end
+
+  defp entry(loc, canonical_path) do
+    UrlEntry.new(%{loc: @base <> loc, canonical_path: canonical_path, source: :test})
+  end
+
+  describe "domains/0 validation (B1)" do
+    test "valid provider activates" do
+      put_provider(:ok)
+      assert [%{host: "site.example.com", primary: true} | _] = DomainMode.domains()
+      assert DomainMode.active?()
+    end
+
+    test "no primary / two primaries / duplicate language / raising / empty / bad host ⇒ inactive" do
+      for fun <- [
+            :no_primary,
+            :two_primaries,
+            :duplicate_language,
+            :raising,
+            :empty,
+            :malformed_host
+          ] do
+        put_provider(fun)
+        assert DomainMode.domains() == [], "expected inactive for #{fun}"
+      end
+    end
+
+    test "absent provider config ⇒ inactive" do
+      Application.delete_env(:phoenix_kit, :sitemap_domains_provider)
+      refute DomainMode.active?()
+    end
+  end
+
+  describe "rebuild_for_domains/2" do
+    setup do
+      put_provider(:ok)
+      :ok
+    end
+
+    test "fully translated group: membership, re-hosting, identical alternates, x-default" do
+      entries = [
+        entry("/decor/post", "/decor/post"),
+        entry("/fr/decor/le-post", "/decor/post"),
+        entry("/de/decor/der-post", "/decor/post")
+      ]
+
+      result = DomainMode.rebuild_for_domains(entries, @base)
+
+      [en_entry] = result["site.example.com"]
+      [fr_entry] = result["site.example.fr"]
+
+      assert en_entry.loc == "https://site.example.com/decor/post"
+      # fr loses its own prefix on its home domain
+      assert fr_entry.loc == "https://site.example.fr/decor/le-post"
+
+      # identical alternates on both duplicates
+      assert en_entry.alternates == fr_entry.alternates
+
+      hrefs = Map.new(en_entry.alternates, &{&1.hreflang, &1.href})
+      assert hrefs["en"] == "https://site.example.com/decor/post"
+      assert hrefs["fr"] == "https://site.example.fr/decor/le-post"
+      # unmapped language stays prefixed on the primary domain
+      assert hrefs["de"] == "https://site.example.com/de/decor/der-post"
+      assert hrefs["x-default"] == "https://site.example.com/decor/post"
+    end
+
+    test "untranslated group appears only on its language's domain" do
+      entries = [entry("/fr/only-french", "/only-french")]
+      result = DomainMode.rebuild_for_domains(entries, @base)
+
+      assert result["site.example.com"] == []
+      [fr_entry] = result["site.example.fr"]
+      assert fr_entry.loc == "https://site.example.fr/only-french"
+      # no x-default: the primary language has no entry in this group (m2)
+      refute Enum.any?(fr_entry.alternates, &(&1.hreflang == "x-default"))
+    end
+
+    test "canonical_path-less entry forms its own single-language group (m1)" do
+      entries = [
+        %{entry("/some/tool", nil) | canonical_path: nil}
+      ]
+
+      result = DomainMode.rebuild_for_domains(entries, @base)
+
+      # unprefixed ⇒ default language (en) ⇒ primary domain only
+      [en_entry] = result["site.example.com"]
+      assert en_entry.loc == "https://site.example.com/some/tool"
+      assert result["site.example.fr"] == []
+    end
+
+    test "a non-locale first segment is not treated as a language" do
+      entries = [entry("/api/docs", nil)]
+      result = DomainMode.rebuild_for_domains(entries, @base)
+
+      [en_entry] = result["site.example.com"]
+      assert en_entry.loc == "https://site.example.com/api/docs"
+    end
+
+    test "inactive provider yields empty map" do
+      Application.delete_env(:phoenix_kit, :sitemap_domains_provider)
+      assert DomainMode.rebuild_for_domains([entry("/x", "/x")], @base) == %{}
+    end
+  end
+end

--- a/test/integration/sitemap/domain_serving_test.exs
+++ b/test/integration/sitemap/domain_serving_test.exs
@@ -1,0 +1,78 @@
+defmodule PhoenixKit.Integration.Sitemap.DomainServingProviderStub do
+  @moduledoc false
+  def domains do
+    [
+      %{host: "serve.example.com", language: "en", primary: true},
+      %{host: "serve.example.fr", language: "fr", primary: false}
+    ]
+  end
+end
+
+defmodule PhoenixKit.Integration.Sitemap.DomainServingTest do
+  @moduledoc """
+  Controller-level contract of domain mode (plan Task 3): a mapped request
+  host serves its own domain file with its own ETag (304 round-trip), an
+  unmapped host keeps the legacy set, and the >50k chunk path stays
+  reachable regardless of flat mode.
+  """
+  use PhoenixKitWeb.ConnCase, async: false
+
+  alias PhoenixKit.Integration.Sitemap.DomainServingProviderStub, as: Stub
+  alias PhoenixKit.Modules.Sitemap.FileStorage
+  alias PhoenixKit.Modules.Sitemap.Generator
+  alias PhoenixKit.Settings
+
+  @base_url "https://serve.example.com"
+
+  setup do
+    {:ok, _} = Settings.update_boolean_setting("sitemap_enabled", true)
+    {:ok, _} = Settings.update_setting("site_url", @base_url)
+    {:ok, _} = Settings.update_boolean_setting("seo_no_index", false)
+
+    Application.put_env(:phoenix_kit, :sitemap_domains_provider, {Stub, :domains})
+    {:ok, _} = Generator.generate_all(base_url: @base_url)
+
+    on_exit(fn ->
+      Application.delete_env(:phoenix_kit, :sitemap_domains_provider)
+      Enum.each(FileStorage.list_domain_hosts(), &FileStorage.delete_domain_files/1)
+    end)
+
+    :ok
+  end
+
+  test "mapped host serves its domain file; ETags differ per host", %{conn: conn} do
+    com_conn = %{conn | host: "serve.example.com"} |> get("/phoenix_kit/sitemap.xml")
+    fr_conn = %{conn | host: "serve.example.fr"} |> get("/phoenix_kit/sitemap.xml")
+
+    assert response(com_conn, 200) =~ "<urlset"
+    assert response(fr_conn, 200) =~ "<urlset"
+
+    [com_etag] = get_resp_header(com_conn, "etag")
+    [fr_etag] = get_resp_header(fr_conn, "etag")
+    refute com_etag == "\"default\""
+    refute com_etag == fr_etag
+
+    conn304 =
+      %{build_conn() | host: "serve.example.com"}
+      |> put_req_header("if-none-match", com_etag)
+      |> get("/phoenix_kit/sitemap.xml")
+
+    assert conn304.status == 304
+  end
+
+  test "unmapped host keeps the legacy set", %{conn: conn} do
+    legacy = %{conn | host: "unmapped.example.org"} |> get("/phoenix_kit/sitemap.xml")
+    assert response(legacy, 200)
+  end
+
+  test "a mapped host's chunk filename resolves in its domain dir even in flat mode", %{
+    conn: conn
+  } do
+    # Simulate a split: write a chunk file directly; flat mode must not 404 it.
+    :ok = FileStorage.write_domain_sitemap("serve.example.com", "sitemap-2", "<urlset/>")
+    {:ok, _} = Settings.update_boolean_setting("sitemap_router_discovery_enabled", true)
+
+    chunk = %{conn | host: "serve.example.com"} |> get("/phoenix_kit/sitemaps/sitemap-2.xml")
+    assert response(chunk, 200) =~ "<urlset"
+  end
+end


### PR DESCRIPTION
## What

`PhoenixKit.Modules.Sitemap.DomainMode` — a provider-driven mode that regroups sitemap entries per domain for a multi-domain host. The provider is validated (one primary domain, distinct languages, well-formed hosts); a violation deactivates the mode with a warning rather than crashing generation. Each language's own entry is re-hosted prefix-free on its home domain, group alternates are computed once (identical across domain files), and `x-default` comes from the primary domain's language when the group has one. Language extraction verifies the locale segment against enabled languages and never consults a request-scoped default-language override — sitemap generation isn't a request.

`Generator`: after the legacy set (index/flat/noindex branches, unchanged), a `DomainMode`-active run additionally writes one flat urlset per mapped host (50k splitter + per-host sitemapindex when a domain exceeds it), mirrored into ETS; stale host directories are always cleaned up on generation; the noindex branch publishes *empty* per-host urlsets so a stale real-URL file can't outlive a noindex flip. `FileStorage` gets a `sitemaps/domains/{host}/` layout with host sanitation. `Controller`: a request against a mapped host serves that host's own set (same ETag/304 policy, generated on demand); an unmapped host keeps getting the legacy files byte-identically.

Two review follow-ups are included: `generate_etag_from_stat/1` expected `{:ok, mtime, size}` and a raw `File.stat` result fell through to the shared "default" ETag, so every domain file would 304 against every other domain's cached copy; and `module_sitemap` now checks the mapped host *before* the flat-mode 404 branch, since a >50k-URL domain's chunk files are always flat-with-split and must stay reachable regardless of the legacy site's index/flat setting.

## Why

The same multi-domain scenario as the default-language PR: one Phoenix host serving several public domains needs a sitemap per domain, with that domain's own URLs — not one shared sitemap for all of them.

## What's tested

- `test/integration/sitemap/domain_mode_test.exs`, `domain_generation_test.exs`, `domain_serving_test.exs` — provider validation, end-to-end generation/storage/cache/invalidate, per-host ETag/304, unmapped-host legacy behavior, flat-mode chunk serving, stale-host cleanup.
- Full suite run in isolation on a fresh `upstream/main` checkout (this PR alone, no other unmerged changes): 43 doctests + 3724 tests, 0 failures.
