### PR TITLE
Fix domain mode dropping the URLs of languages without a domain

### DIFF
--- a/lib/modules/sitemap/domain_mode.ex
+++ b/lib/modules/sitemap/domain_mode.ex
@@ -21,6 +21,11 @@ defmodule PhoenixKit.Modules.Sitemap.DomainMode do
   `x-default` for the primary domain's language when the group has it
   (omitted otherwise — never mislabel another language as x-default).
 
+  An enabled language that has NO domain of its own keeps its locale prefix
+  and lives on the primary domain, so its URLs are published from the primary
+  domain's file (they are already what this module's alternates point at).
+  Mapped hosts stay strictly single-language.
+
   Runs inside Oban jobs and unpiped controller requests: language resolution
   here never consults the request-scoped default-language override — the
   unprefixed-entry fallback reads the raw `is_default` flag, mirroring the
@@ -117,10 +122,52 @@ defmodule PhoenixKit.Modules.Sitemap.DomainMode do
           |> Map.values()
           |> Enum.map(&group_by_language(&1, base_url, default_lang, enabled_bases))
 
-        Map.new(domains, fn %{host: host, language: lang} ->
-          {host, domain_entries(groups, lang, host_by_lang, primary, base_url)}
+        Map.new(domains, fn %{host: host, language: lang, primary: primary?} ->
+          own = domain_entries(groups, lang, host_by_lang, primary, base_url)
+
+          entries =
+            if primary?,
+              do:
+                Enum.sort_by(
+                  own ++ domainless_entries(groups, host_by_lang, primary, base_url),
+                  & &1.loc
+                ),
+              else: own
+
+          {host, entries}
         end)
     end
+  end
+
+  # An enabled language that has no domain of its own is served with its locale
+  # prefix on the primary domain — that is exactly the URL `home_url/5` already
+  # builds for it, and what every group's alternates already point at. Those
+  # pages need a `<loc>` of their own somewhere, and the primary domain's file
+  # is the only set served from the host they live on.
+  #
+  # Without this, activating domain mode silently DROPS every URL of such a
+  # language: the legacy set that used to carry them is only served to
+  # unmapped hosts, and no mapped host's file admits a foreign language.
+  defp domainless_entries(groups, host_by_lang, primary, base_url) do
+    Enum.flat_map(groups, fn by_lang ->
+      case Enum.reject(by_lang, fn {lang, _} -> Map.has_key?(host_by_lang, lang) end) do
+        [] ->
+          []
+
+        domainless ->
+          # Same alternates as every other duplicate of this group — computed
+          # once here for the same reason `domain_entries/5` computes it once.
+          alternates = group_alternates(by_lang, host_by_lang, primary, base_url)
+
+          Enum.map(domainless, fn {lang, entry} ->
+            %{
+              entry
+              | loc: home_url(lang, entry, host_by_lang, primary, base_url),
+                alternates: alternates
+            }
+          end)
+      end
+    end)
   end
 
   defp group_by_language(members, base_url, default_lang, enabled_bases) do

--- a/test/integration/sitemap/domain_mode_test.exs
+++ b/test/integration/sitemap/domain_mode_test.exs
@@ -7,6 +7,10 @@ defmodule PhoenixKit.Integration.Sitemap.DomainModeProviderStub do
     ]
   end
 
+  # Every enabled language (en, fr, de) has a domain of its own — the shape a
+  # site reaches once it stops leaving languages domainless.
+  def all_mapped, do: ok() ++ [%{host: "site.example.de", language: "de", primary: false}]
+
   def no_primary, do: Enum.map(ok(), &%{&1 | primary: false})
   def two_primaries, do: Enum.map(ok(), &%{&1 | primary: true})
 
@@ -99,7 +103,11 @@ defmodule PhoenixKit.Integration.Sitemap.DomainModeTest do
 
       result = DomainMode.rebuild_for_domains(entries, @base)
 
-      [en_entry] = result["site.example.com"]
+      # de has no domain of its own, so it rides the primary domain, prefixed
+      primary_locs = Enum.map(result["site.example.com"], & &1.loc)
+      assert "https://site.example.com/de/decor/der-post" in primary_locs
+
+      en_entry = Enum.find(result["site.example.com"], &(&1.loc =~ "/decor/post"))
       [fr_entry] = result["site.example.fr"]
 
       assert en_entry.loc == "https://site.example.com/decor/post"
@@ -115,6 +123,57 @@ defmodule PhoenixKit.Integration.Sitemap.DomainModeTest do
       # unmapped language stays prefixed on the primary domain
       assert hrefs["de"] == "https://site.example.com/de/decor/der-post"
       assert hrefs["x-default"] == "https://site.example.com/decor/post"
+    end
+
+    test "a language with no domain is published, prefixed, from the primary domain" do
+      entries = [
+        entry("/decor/post", "/decor/post"),
+        entry("/de/decor/der-post", "/decor/post"),
+        entry("/de/only-german", "/only-german")
+      ]
+
+      result = DomainMode.rebuild_for_domains(entries, @base)
+
+      locs = result["site.example.com"] |> Enum.map(& &1.loc) |> Enum.sort()
+
+      assert locs == [
+               "https://site.example.com/de/decor/der-post",
+               "https://site.example.com/de/only-german",
+               "https://site.example.com/decor/post"
+             ]
+
+      # a domainless language rides the primary host only — never a mapped
+      # sibling's file, which must stay single-language
+      assert result["site.example.fr"] == []
+
+      # and it carries the same group alternates as its translated sibling
+      de = Enum.find(result["site.example.com"], &(&1.loc =~ "/de/decor/"))
+
+      en =
+        Enum.find(result["site.example.com"], &(&1.loc == "https://site.example.com/decor/post"))
+
+      assert de.alternates == en.alternates
+    end
+
+    test "every enabled language mapped ⇒ no domainless entries are added" do
+      put_provider(:all_mapped)
+
+      entries = [
+        entry("/decor/post", "/decor/post"),
+        entry("/fr/decor/le-post", "/decor/post"),
+        entry("/de/decor/der-post", "/decor/post")
+      ]
+
+      result = DomainMode.rebuild_for_domains(entries, @base)
+
+      assert Enum.map(result["site.example.com"], & &1.loc) ==
+               ["https://site.example.com/decor/post"]
+
+      assert Enum.map(result["site.example.fr"], & &1.loc) ==
+               ["https://site.example.fr/decor/le-post"]
+
+      assert Enum.map(result["site.example.de"], & &1.loc) ==
+               ["https://site.example.de/decor/der-post"]
     end
 
     test "untranslated group appears only on its language's domain" do


### PR DESCRIPTION
## What's wrong today

Activating domain mode silently drops every URL of an enabled language that has **no domain of its own**.

Such a language keeps its locale prefix and lives on the primary host — `home_url/5` already builds exactly that URL, and every group's alternates already point at it. But nothing lists it as a `<loc>`:

- a mapped host's file only ever gets entries of *its own* language (`domain_entries/5` takes `by_lang[lang]`, `nil ⇒ []`);
- the legacy set that used to carry those URLs is only served to **unmapped** hosts (`Web.Controller.domain_host/1` → `serve_domain_file/4`), and the primary host is mapped by definition.

So those pages exist, are served, are linked as `hreflang` alternates from every other language — and are advertised by no sitemap a crawler actually fetches.

## What this changes

The primary domain's file additionally carries the entries of enabled languages that have no domain, at the same prefixed URLs the alternates already use, with the group's usual alternates set (identical across duplicates, as before). Mapped hosts stay strictly single-language.

**When every enabled language has a domain, the output is byte-identical to today.** That is the common case and it is pinned by a test.

## What's tested

New and updated tests in `test/integration/sitemap/domain_mode_test.exs`:

- **`a language with no domain is published, prefixed, from the primary domain`** — en (primary) + fr mapped, de enabled but unmapped: the primary's set is exactly its own `/decor/post` plus `/de/decor/der-post` and `/de/only-german`; `site.example.fr` stays empty (a domainless language must not leak into a mapped sibling's file); the de entry carries the same alternates as its en sibling.
- **`every enabled language mapped ⇒ no domainless entries are added`** — new `all_mapped` provider stub (en/fr/de each with a host): every host's set is exactly its own single URL. This is the no-op guarantee for existing multi-domain installs.
- **`fully translated group: …`** (existing test) updated: the primary's set is no longer a single entry, and the assertion now also pins the de URL that appears there. Its existing `hrefs["de"] == "https://site.example.com/de/decor/der-post"` assertion is unchanged — the `<loc>` now agrees with the alternate that was already being published.

Full suite on this branch, from a clean database: **43 doctests + 3747 tests, 0 failures** (103 s). `mix format --check-formatted` clean, `mix credo --strict` clean on the touched file.

## How it was found

On a live 3-domain install (`.com`/`.de`/`.fr`, one language each) whose sitemaps were verified end to end against the running site: per-domain `<loc>`s all on their own host, canonical of the page equal to the `<loc>` in 10/10 sampled URLs, hreflang reciprocity across all groups with 0 non-reciprocal links. That install has a domain for every enabled language, so it is precisely the case this PR leaves untouched — the gap showed up when working through what adding a fourth, domainless language would do.
