### PR TITLE
Skip JSON-pipeline routes in sitemap router discovery

### DIFF
--- a/lib/modules/sitemap/sources/router_discovery.ex
+++ b/lib/modules/sitemap/sources/router_discovery.ex
@@ -48,6 +48,13 @@ defmodule PhoenixKit.Modules.Sitemap.Sources.RouterDiscovery do
 
   Custom pipelines can be added via `sitemap_protected_pipelines` setting.
 
+  Routes served by a JSON pipeline are excluded too, wherever they are
+  mounted — `:api` and `:phoenix_kit_api`. The path patterns above only catch
+  API endpoints that sit under `/api`; a module mounting its own API
+  (`/sync/api/status`) or a host's infrastructure hook outside `/api`
+  (Caddy's on-demand-TLS `/caddy/ask`) escapes them, and the pipeline is the
+  route's own declaration that it does not serve a page.
+
   LiveView routes using authentication `on_mount` hooks are also excluded:
   - `{PhoenixKitWeb.Users.Auth, :phoenix_kit_ensure_authenticated_scope}` - Ensures user is authenticated
   - `{PhoenixKitWeb.Users.Auth, :phoenix_kit_redirect_if_authenticated_scope}` - Redirects if already authenticated
@@ -155,6 +162,18 @@ defmodule PhoenixKit.Modules.Sitemap.Sources.RouterDiscovery do
     :admin_only
   ]
 
+  # Pipelines that answer with JSON rather than pages. A route piped through
+  # one of them is an API endpoint wherever it is mounted, which the path
+  # patterns above only catch when it happens to sit under "/api" — a module
+  # mounting its API under its own prefix ("/sync/api/status", declared
+  # `pipe_through [:phoenix_kit_api]`) or a host's infrastructure endpoint
+  # outside "/api" entirely (Caddy's on-demand-TLS "/caddy/ask" hook,
+  # declared `pipe_through :api`) both slip past them.
+  @default_non_page_pipelines [
+    :api,
+    :phoenix_kit_api
+  ]
+
   # Default on_mount hooks that require authentication (for LiveView routes)
   # Format: {Module, hook_name} - matches against on_mount id tuples
   @default_protected_on_mount_hooks [
@@ -250,6 +269,14 @@ defmodule PhoenixKit.Modules.Sitemap.Sources.RouterDiscovery do
   @spec default_protected_pipelines() :: [atom()]
   def default_protected_pipelines, do: @default_protected_pipelines
 
+  @doc """
+  Returns the pipelines whose routes serve JSON rather than pages.
+
+  Routes piped through any of these are skipped regardless of their path.
+  """
+  @spec default_non_page_pipelines() :: [atom()]
+  def default_non_page_pipelines, do: @default_non_page_pipelines
+
   defp do_collect(opts) do
     base_url = Keyword.get(opts, :base_url)
     exclude_patterns = compile_patterns(effective_exclude_patterns(), "exclude")
@@ -265,20 +292,30 @@ defmodule PhoenixKit.Modules.Sitemap.Sources.RouterDiscovery do
     get_route?(route) and
       not excluded?(route.path, exclude_patterns) and
       included?(route.path, include_only) and
-      not protected_by_route_info?(route) and
+      not excluded_by_route_info?(route) and
       not disabled_module_route?(route.path)
   end
 
-  # Single route_info call checks both pipelines and on_mount hooks
-  defp protected_by_route_info?(route) do
+  # Single route_info call checks pipelines (both auth-protected and
+  # JSON-serving) and on_mount hooks
+  defp excluded_by_route_info?(route) do
     case get_route_info(route.path) do
       nil ->
         false
 
       info ->
-        has_protected_pipeline?(info) or has_protected_on_mount?(info)
+        has_protected_pipeline?(info) or has_non_page_pipeline?(info) or
+          has_protected_on_mount?(info)
     end
   end
+
+  # A JSON pipeline is the route's own declaration that it does not serve a
+  # page — a fact about the route, not a guess from its path.
+  defp has_non_page_pipeline?(%{pipe_through: pipelines}) when is_list(pipelines) do
+    Enum.any?(@default_non_page_pipelines, &(&1 in pipelines))
+  end
+
+  defp has_non_page_pipeline?(_), do: false
 
   # Get route_info once per route (instead of twice)
   defp get_route_info(path) do

--- a/test/integration/sitemap/router_discovery_api_pipeline_test.exs
+++ b/test/integration/sitemap/router_discovery_api_pipeline_test.exs
@@ -1,0 +1,94 @@
+defmodule PhoenixKit.Integration.Sitemap.RouterDiscoveryApiPipelineTest do
+  @moduledoc """
+  Pins that Router Discovery skips routes served by a JSON pipeline.
+
+  Path patterns only catch API endpoints that happen to live under `/api`.
+  Two shapes routinely escape them, and both were found in a live install's
+  sitemap:
+
+    * a module mounting its API under its own prefix — `/sync/api/status`,
+      declared `pipe_through [:phoenix_kit_api]`, which answers
+      `application/json`;
+    * a host's infrastructure endpoint outside `/api` entirely — `/caddy/ask`
+      (Caddy's on-demand-TLS "ask" hook), declared `pipe_through :api`, which
+      answers `404 unknown domain` to a plain GET.
+
+  Neither is a page. The pipeline says so at declaration time, which is a
+  fact about the route rather than a guess about its path.
+  """
+  use PhoenixKit.DataCase, async: false
+
+  alias PhoenixKit.Modules.Sitemap.Sources.RouterDiscovery
+  alias PhoenixKit.Settings
+
+  @base_url "https://example.test"
+
+  defmodule DummyController do
+    @moduledoc false
+    use Phoenix.Controller, formats: []
+
+    def page(conn, _), do: conn
+    def json(conn, _), do: conn
+  end
+
+  defmodule TestRouter do
+    @moduledoc false
+    use Phoenix.Router
+
+    pipeline :browser do
+      plug :accepts, ["html"]
+    end
+
+    pipeline :api do
+      plug :accepts, ["json"]
+    end
+
+    # Core declares this one in `PhoenixKitWeb.Integration`; modules mount
+    # their JSON endpoints through it.
+    pipeline :phoenix_kit_api do
+      plug :accepts, ["json"]
+    end
+
+    scope "/" do
+      pipe_through :browser
+      get "/about", DummyController, :page
+    end
+
+    scope "/caddy" do
+      pipe_through :api
+      get "/ask", DummyController, :json
+    end
+
+    scope "/sync" do
+      pipe_through [:phoenix_kit_api]
+      get "/api/status", DummyController, :json
+    end
+  end
+
+  setup do
+    previous = Application.get_env(:phoenix_kit, :router)
+    Application.put_env(:phoenix_kit, :router, TestRouter)
+    {:ok, _} = Settings.update_boolean_setting("sitemap_router_discovery_enabled", true)
+
+    on_exit(fn ->
+      if previous,
+        do: Application.put_env(:phoenix_kit, :router, previous),
+        else: Application.delete_env(:phoenix_kit, :router)
+    end)
+
+    :ok
+  end
+
+  test "a JSON pipeline keeps a route out of the sitemap, wherever it is mounted" do
+    locs = RouterDiscovery.collect(base_url: @base_url) |> Enum.map(& &1.loc) |> Enum.sort()
+
+    assert locs == ["#{@base_url}/about"]
+  end
+
+  test "default_non_page_pipelines/0 exposes the JSON pipelines it filters on" do
+    defaults = RouterDiscovery.default_non_page_pipelines()
+
+    assert :api in defaults
+    assert :phoenix_kit_api in defaults
+  end
+end


### PR DESCRIPTION
## What's wrong today

Router discovery keeps API endpoints out by path — `"^/api"` among the default exclude patterns. That only catches endpoints mounted at the site root. Two shapes escape it, and both were found in the sitemap of a live install:

| URL | Declared as | What it actually answers |
|---|---|---|
| `/sync/api/status` | `pipe_through [:phoenix_kit_api]` (`phoenix_kit_sync`, `routes.ex:15,53`) | `200 application/json` — `{"enabled":false,...}` |
| `/caddy/ask` | `pipe_through :api` (host router; Caddy on-demand-TLS "ask" hook) | **`404` `unknown domain`** to a plain GET |

Both were verified against the running site, not inferred: content type and status above are from `curl` on the live host. The generated `.com` sitemap listed both — so the site was advertising a JSON endpoint and a hard 404 to crawlers.

Path patterns cannot fix this class: a module mounts its API under its own prefix, and a host's infrastructure endpoint may live anywhere. Every host would have to discover the leak and add its own pattern.

## What this changes

Routes piped through a JSON pipeline — `:api`, `:phoenix_kit_api` — are skipped wherever they are mounted. The pipeline is the route's own declaration that it does not serve a page, which is a fact about the route rather than a guess from its path.

No extra work at collection time: the check rides the single `Phoenix.Router.route_info/4` call that already resolves protected pipelines and `on_mount` hooks (`protected_by_route_info?` → `excluded_by_route_info?`).

Scope is deliberately narrow. Only these two pipeline names, both meaning `plug :accepts, ["json"]` — `:api` is what `mix phx.new` generates and `:phoenix_kit_api` is core's own (`integration.ex:223`). Nothing that serves HTML changes: on the install where this was found, the discovered set goes from `/about`-style pages **plus** those two, to the pages alone.

## What's tested

New `test/integration/sitemap/router_discovery_api_pipeline_test.exs` — a router with `:browser`, `:api` and `:phoenix_kit_api` pipelines reproducing both real shapes (`/caddy/ask` under `:api`, `/sync/api/status` under `[:phoenix_kit_api]`, `/about` under `:browser`):

- **`a JSON pipeline keeps a route out of the sitemap, wherever it is mounted`** — `collect/1` returns exactly `["https://example.test/about"]`. Before the fix this test fails with `left: ["…/about", "…/caddy/ask", "…/sync/api/status"]` — the live symptom, reproduced in the suite.
- **`default_non_page_pipelines/0 exposes the JSON pipelines it filters on`** — parity with the existing `default_protected_pipelines/0` accessor the settings UI reads.

`test/integration/sitemap/router_discovery_validation_test.exs` still green (pattern-validation contract untouched).

Full suite, from a clean database, run four times: **43 doctests + 3747 tests**. Two runs clean; two reported a single failure — the one I captured is `PhoenixKit.Install.CommonUnreachableTest` (`(EXIT) shutdown: "owner … exited"` on a sandbox checkout), which touches nothing in this change and passes 3/3 when run alone. Every sitemap suite is green in every run. `mix format --check-formatted` and `mix credo --strict` clean on the touched file.

## Note on a neighbour, deliberately not changed

`/llms.txt` (mounted by core itself, `integration.ex:335`) is also discovered and listed. It answers `200 text/markdown` — a directive/machine file rather than a page, the same category as `robots.txt`, which the default patterns already exclude with exactly that reasoning. Left alone here because it is a judgement about content policy, not a leaking API endpoint, and it deserves its own decision. Happy to add it if you want the categories consistent.
