### PR TITLE
Give every mapped domain its own static pages in the sitemap (+ review follow-ups)

### DIFF
--- a/lib/modules/sitemap/generator.ex
+++ b/lib/modules/sitemap/generator.ex
@@ -142,6 +142,42 @@ defmodule PhoenixKit.Modules.Sitemap.Generator do
     :exit, _ -> false
   end
 
+  # Static pages (home page, and whatever else a host lists in
+  # `sitemap_static_routes` / `sitemap_custom_urls`) are collected for the site
+  # default language only: in a prefix install a "/fr/..." static page has no
+  # localized route. A language with a domain of its own does serve them — from
+  # its own host, prefix-free — so its copies are collected HERE, for the domain
+  # files alone.
+  #
+  # Deliberately not folded into the shared collection: these entries carry a
+  # locale prefix that only means something to `DomainMode.rebuild_for_domains/2`,
+  # which strips it while re-hosting. In the legacy set (served verbatim to
+  # unmapped hosts) nothing would rewrite them, and `https://<primary>/fr/` is
+  # usually not a page at all.
+  defp domain_static_entries(opts, base_url) do
+    static = PhoenixKit.Modules.Sitemap.Sources.Static
+
+    if static in get_sources() do
+      mapped = MapSet.new(DomainMode.domains(), & &1.language)
+
+      get_languages()
+      |> Enum.reject(& &1.is_default)
+      |> Enum.filter(&MapSet.member?(mapped, &1.code))
+      |> Enum.flat_map(fn %{code: code} ->
+        static.collect(
+          Keyword.merge(opts,
+            base_url: base_url,
+            language: code,
+            is_default_language: false,
+            domain_pass: true
+          )
+        )
+      end)
+    else
+      []
+    end
+  end
+
   # Multi-domain post-processing (DomainMode): one flat urlset per mapped
   # host (its language's entries, re-hosted prefix-free, cross-domain
   # alternates), with the 50k splitter per host. `entries` may be passed in
@@ -164,7 +200,8 @@ defmodule PhoenixKit.Modules.Sitemap.Generator do
       # disabled-module URLs into index mode, which never leaked before.
       entries = entries || collect_all_entries(opts, get_sources())
 
-      per_host = DomainMode.rebuild_for_domains(entries, base_url)
+      per_host =
+        DomainMode.rebuild_for_domains(entries ++ domain_static_entries(opts, base_url), base_url)
 
       for {host, host_entries} <- per_host do
         write_domain_files(host, host_entries, xsl_style, xsl_enabled)

--- a/lib/modules/sitemap/sitemap.ex
+++ b/lib/modules/sitemap/sitemap.ex
@@ -565,11 +565,21 @@ defmodule PhoenixKit.Modules.Sitemap do
   """
   @spec regenerate(any()) :: {:ok, map()} | {:error, any()}
   def regenerate(scope \\ nil) do
-    if enabled?() do
-      Logger.info("Sitemap regeneration triggered by #{inspect(scope)}")
-      Generator.generate_all(base_url: get_base_url())
-    else
-      {:error, :sitemap_disabled}
+    base_url = get_base_url()
+
+    cond do
+      not enabled?() ->
+        {:error, :sitemap_disabled}
+
+      # `get_base_url/0` falls back to "", which `Generator.generate_all/1`
+      # accepts (it only rejects nil) and turns into host-less `<loc>`s. The
+      # scheduler guards this before regenerating; so does this entry point.
+      base_url == "" ->
+        {:error, :base_url_not_configured}
+
+      true ->
+        Logger.info("Sitemap regeneration triggered by #{inspect(scope)}")
+        Generator.generate_all(base_url: base_url)
     end
   end
 

--- a/lib/modules/sitemap/sitemap.ex
+++ b/lib/modules/sitemap/sitemap.ex
@@ -63,11 +63,13 @@ defmodule PhoenixKit.Modules.Sitemap do
 
   ## Usage Examples
 
-      # Check if sitemap module is enabled
-      if PhoenixKit.Modules.Sitemap.enabled?() do
-        # Generate sitemap
-        PhoenixKit.Modules.Sitemap.regenerate(scope)
-      end
+      # Regenerate every sitemap file, inline — this walks every source and
+      # language, so do not call it from a request. From a controller or
+      # LiveView use the queued path instead:
+      PhoenixKit.Modules.Sitemap.Generator.invalidate_and_regenerate()
+
+      # Inline, for a mix task or a worker that wants the result:
+      {:ok, %{total_urls: _}} = PhoenixKit.Modules.Sitemap.regenerate(scope)
 
       # Get configuration
       config = PhoenixKit.Modules.Sitemap.get_config()

--- a/lib/modules/sitemap/sources/router_discovery.ex
+++ b/lib/modules/sitemap/sources/router_discovery.ex
@@ -55,6 +55,15 @@ defmodule PhoenixKit.Modules.Sitemap.Sources.RouterDiscovery do
   (Caddy's on-demand-TLS `/caddy/ask`) escapes them, and the pipeline is the
   route's own declaration that it does not serve a page.
 
+  `sitemap_non_page_pipelines` **replaces** that list (unlike
+  `sitemap_protected_pipelines`, which adds to its defaults): `:api` is a
+  generic name, so a host that serves real pages through a pipeline called
+  `:api` must be able to take it off the list. Saving `[]` turns
+  pipeline-based exclusion off entirely.
+
+      Settings.update_setting("sitemap_non_page_pipelines",
+        JSON.encode!(["phoenix_kit_api"]))
+
   LiveView routes using authentication `on_mount` hooks are also excluded:
   - `{PhoenixKitWeb.Users.Auth, :phoenix_kit_ensure_authenticated_scope}` - Ensures user is authenticated
   - `{PhoenixKitWeb.Users.Auth, :phoenix_kit_redirect_if_authenticated_scope}` - Redirects if already authenticated
@@ -312,10 +321,34 @@ defmodule PhoenixKit.Modules.Sitemap.Sources.RouterDiscovery do
   # A JSON pipeline is the route's own declaration that it does not serve a
   # page — a fact about the route, not a guess from its path.
   defp has_non_page_pipeline?(%{pipe_through: pipelines}) when is_list(pipelines) do
-    Enum.any?(@default_non_page_pipelines, &(&1 in pipelines))
+    Enum.any?(non_page_pipelines(), &(&1 in pipelines))
   end
 
   defp has_non_page_pipeline?(_), do: false
+
+  # `sitemap_non_page_pipelines` REPLACES the defaults rather than adding to
+  # them (the opposite of `sitemap_protected_pipelines`): `:api` is a generic
+  # name, and a host that serves real pages through a pipeline of that name
+  # needs a way to take it OFF the list. Saving `[]` disables pipeline-based
+  # exclusion entirely.
+  defp non_page_pipelines do
+    case Settings.get_setting("sitemap_non_page_pipelines") do
+      nil ->
+        @default_non_page_pipelines
+
+      json_string when is_binary(json_string) ->
+        case JSON.decode(json_string) do
+          {:ok, pipelines} when is_list(pipelines) -> Enum.map(pipelines, &safe_to_atom/1)
+          _ -> @default_non_page_pipelines
+        end
+
+      pipelines when is_list(pipelines) ->
+        Enum.map(pipelines, &safe_to_atom/1)
+
+      _ ->
+        @default_non_page_pipelines
+    end
+  end
 
   # Get route_info once per route (instead of twice)
   defp get_route_info(path) do

--- a/lib/modules/sitemap/sources/static.ex
+++ b/lib/modules/sitemap/sources/static.ex
@@ -108,7 +108,10 @@ defmodule PhoenixKit.Modules.Sitemap.Sources.Static do
   def collect(opts \\ []) do
     is_default = Keyword.get(opts, :is_default_language, true)
     language = Keyword.get(opts, :language)
-    domain_hosted? = domain_hosted_language?(language)
+    # The default language never needs the lookup: it is emitted either way,
+    # and it keeps `skip_language_prefix` regardless. Saves one provider call
+    # per generation pass on every install.
+    domain_hosted? = not is_default and domain_hosted_language?(language)
 
     # Static pages only generate URLs for the default language: in a
     # prefix-based install a "/de/..." static page would 404.

--- a/lib/modules/sitemap/sources/static.ex
+++ b/lib/modules/sitemap/sources/static.ex
@@ -108,10 +108,17 @@ defmodule PhoenixKit.Modules.Sitemap.Sources.Static do
   def collect(opts \\ []) do
     is_default = Keyword.get(opts, :is_default_language, true)
     language = Keyword.get(opts, :language)
-    # The default language never needs the lookup: it is emitted either way,
-    # and it keeps `skip_language_prefix` regardless. Saves one provider call
-    # per generation pass on every install.
-    domain_hosted? = not is_default and domain_hosted_language?(language)
+    # Only the domain pass asks for these: the URL built for a domain-hosted
+    # language is a locale-prefixed INTERMEDIATE that `DomainMode` re-hosts
+    # prefix-free onto that language's domain. It must never reach the legacy
+    # set (which unmapped hosts are served verbatim), where nothing would
+    # rewrite it and `https://<primary>/fr/` is usually not a real page.
+    #
+    # The default language never needs the lookup either: it is emitted either
+    # way and keeps `skip_language_prefix` regardless.
+    domain_hosted? =
+      Keyword.get(opts, :domain_pass, false) and not is_default and
+        domain_hosted_language?(language)
 
     # Static pages only generate URLs for the default language: in a
     # prefix-based install a "/de/..." static page would 404.

--- a/lib/modules/sitemap/sources/static.ex
+++ b/lib/modules/sitemap/sources/static.ex
@@ -52,6 +52,7 @@ defmodule PhoenixKit.Modules.Sitemap.Sources.Static do
   @behaviour PhoenixKit.Modules.Sitemap.Sources.Source
 
   alias PhoenixKit.Modules.Languages
+  alias PhoenixKit.Modules.Sitemap.DomainMode
   alias PhoenixKit.Modules.Sitemap.LocalePath
   alias PhoenixKit.Modules.Sitemap.RouteResolver
   alias PhoenixKit.Modules.Sitemap.UrlEntry
@@ -106,14 +107,21 @@ defmodule PhoenixKit.Modules.Sitemap.Sources.Static do
   @impl true
   def collect(opts \\ []) do
     is_default = Keyword.get(opts, :is_default_language, true)
+    language = Keyword.get(opts, :language)
+    domain_hosted? = domain_hosted_language?(language)
 
-    # Static pages only generate URLs for the default language
-    # Non-default language URLs would lead to 404 errors
-    if is_default do
+    # Static pages only generate URLs for the default language: in a
+    # prefix-based install a "/de/..." static page would 404.
+    #
+    # A language with a domain of its own is the exception — it serves these
+    # pages from that host, prefix-free, so they are real 200s. Without this
+    # every non-primary domain's sitemap loses its own home page while still
+    # listing its products. The prefixed URL built here is what DomainMode
+    # re-hosts onto the language's domain.
+    if is_default or domain_hosted? do
       base_url = Keyword.get(opts, :base_url)
-      language = Keyword.get(opts, :language)
 
-      static_entries = collect_static_routes(base_url, language, is_default)
+      static_entries = collect_static_routes(base_url, language, is_default, domain_hosted?)
       custom_entries = collect_custom_urls(base_url, language, is_default)
 
       (static_entries ++ custom_entries)
@@ -128,9 +136,21 @@ defmodule PhoenixKit.Modules.Sitemap.Sources.Static do
       []
   end
 
-  defp collect_static_routes(base_url, language, is_default) do
+  defp collect_static_routes(base_url, language, is_default, domain_hosted?) do
     get_static_routes_config()
-    |> Enum.map(&build_static_entry(&1, base_url, language, is_default))
+    |> Enum.map(&build_static_entry(&1, base_url, language, is_default, domain_hosted?))
+  end
+
+  # True when `language` has a domain of its own under domain mode. Resolved
+  # once per collect/1 — DomainMode reads (and validates) the host app's
+  # provider on every call.
+  defp domain_hosted_language?(nil), do: false
+
+  defp domain_hosted_language?(language) do
+    base = Languages.DialectMapper.extract_base(language)
+    Enum.any?(DomainMode.domains(), &(&1.language == base))
+  rescue
+    _ -> false
   end
 
   defp collect_custom_urls(base_url, language, is_default) do
@@ -190,12 +210,18 @@ defmodule PhoenixKit.Modules.Sitemap.Sources.Static do
     end
   end
 
-  defp build_static_entry(config, base_url, language, is_default) do
+  defp build_static_entry(config, base_url, language, is_default, domain_hosted?) do
     path = resolve_path(config)
 
     if path do
       prefixed = Map.get(config, "prefixed", false)
-      skip_language = Map.get(config, "skip_language_prefix", false)
+
+      # `skip_language_prefix` exists because the home page usually has no
+      # localized route. A language with its own domain does have one, and the
+      # prefix is what tells DomainMode which host to re-file the entry under —
+      # without it every language's home page collapses onto one URL.
+      skip_language =
+        Map.get(config, "skip_language_prefix", false) and (is_default or not domain_hosted?)
 
       # Canonical path without language prefix (for hreflang grouping)
       canonical_path = if prefixed, do: Routes.path(path), else: path

--- a/test/integration/sitemap/regenerate_test.exs
+++ b/test/integration/sitemap/regenerate_test.exs
@@ -24,11 +24,20 @@ defmodule PhoenixKit.Integration.Sitemap.RegenerateTest do
   test "regenerate/1 runs the generator instead of returning a placeholder" do
     {:ok, _} = Settings.update_boolean_setting("sitemap_enabled", true)
 
+    # Give the run something it must find, so the assertions below prove real
+    # collection happened rather than an empty-but-valid document.
+    {:ok, _} =
+      Settings.update_setting(
+        "sitemap_custom_urls",
+        JSON.encode!([%{"path" => "/regenerate-probe", "title" => "Probe"}])
+      )
+
     assert {:ok, result} = Sitemap.regenerate(:test_scope)
 
     refute match?(%{status: :pending}, result)
-    assert is_integer(result.total_urls)
+    assert result.total_urls >= 1
     assert result.index_xml =~ "<?xml"
+    assert result.index_xml =~ "/regenerate-probe"
   end
 
   test "regenerate/1 refuses when no base URL is configured" do

--- a/test/integration/sitemap/regenerate_test.exs
+++ b/test/integration/sitemap/regenerate_test.exs
@@ -31,6 +31,16 @@ defmodule PhoenixKit.Integration.Sitemap.RegenerateTest do
     assert result.index_xml =~ "<?xml"
   end
 
+  test "regenerate/1 refuses when no base URL is configured" do
+    {:ok, _} = Settings.update_boolean_setting("sitemap_enabled", true)
+    {:ok, _} = Settings.update_setting("site_url", "")
+
+    # Generator.generate_all/1 only rejects nil, so an unset site_url would
+    # otherwise be written into the files as host-less <loc>s. The scheduler
+    # guards this; so must this entry point.
+    assert Sitemap.regenerate() == {:error, :base_url_not_configured}
+  end
+
   test "regenerate/1 refuses when the module is disabled" do
     {:ok, _} = Settings.update_boolean_setting("sitemap_enabled", false)
 

--- a/test/integration/sitemap/router_discovery_api_pipeline_test.exs
+++ b/test/integration/sitemap/router_discovery_api_pipeline_test.exs
@@ -85,6 +85,28 @@ defmodule PhoenixKit.Integration.Sitemap.RouterDiscoveryApiPipelineTest do
     assert locs == ["#{@base_url}/about"]
   end
 
+  test "sitemap_non_page_pipelines replaces the defaults, so a host can rescue its own :api" do
+    # A host whose :api pipeline serves real pages takes it off the list.
+    {:ok, _} =
+      Settings.update_setting("sitemap_non_page_pipelines", JSON.encode!(["phoenix_kit_api"]))
+
+    locs = RouterDiscovery.collect(base_url: @base_url) |> Enum.map(& &1.loc) |> Enum.sort()
+
+    assert locs == ["#{@base_url}/about", "#{@base_url}/caddy/ask"]
+  end
+
+  test "an empty sitemap_non_page_pipelines turns pipeline-based exclusion off" do
+    {:ok, _} = Settings.update_setting("sitemap_non_page_pipelines", JSON.encode!([]))
+
+    locs = RouterDiscovery.collect(base_url: @base_url) |> Enum.map(& &1.loc) |> Enum.sort()
+
+    assert locs == [
+             "#{@base_url}/about",
+             "#{@base_url}/caddy/ask",
+             "#{@base_url}/sync/api/status"
+           ]
+  end
+
   test "default_non_page_pipelines/0 exposes the JSON pipelines it filters on" do
     defaults = RouterDiscovery.default_non_page_pipelines()
 

--- a/test/integration/sitemap/static_domain_pages_test.exs
+++ b/test/integration/sitemap/static_domain_pages_test.exs
@@ -81,6 +81,29 @@ defmodule PhoenixKit.Integration.Sitemap.StaticDomainPagesTest do
     assert collect("en", true) == ["#{@base}/"]
   end
 
+  test "a custom URL reaches the mapped domain prefix-free, not as a /lang/ path" do
+    {:ok, _} =
+      Settings.update_setting(
+        "sitemap_custom_urls",
+        JSON.encode!([%{"path" => "/lookbook", "title" => "Lookbook"}])
+      )
+
+    # The prefix on the collected entry is bookkeeping for DomainMode, not the
+    # published URL: re-hosting strips it, so the crawler is given the same
+    # path it is served on that host — never https://<fr-host>/fr/lookbook.
+    assert "#{@base}/fr/lookbook" in collect("fr", false)
+
+    entries =
+      Static.collect(base_url: @base, language: "en", is_default_language: true) ++
+        Static.collect(base_url: @base, language: "fr", is_default_language: false)
+
+    result = DomainMode.rebuild_for_domains(entries, @base)
+    fr_locs = Enum.map(result["site.example.fr"], & &1.loc)
+
+    assert "https://site.example.fr/lookbook" in fr_locs
+    refute Enum.any?(fr_locs, &String.contains?(&1, "/fr/"))
+  end
+
   test "the mapped domain's file ends up carrying its own home page" do
     entries = Static.collect(base_url: @base, language: "en", is_default_language: true)
 

--- a/test/integration/sitemap/static_domain_pages_test.exs
+++ b/test/integration/sitemap/static_domain_pages_test.exs
@@ -28,6 +28,8 @@ defmodule PhoenixKit.Integration.Sitemap.StaticDomainPagesTest do
 
   alias PhoenixKit.Integration.Sitemap.StaticDomainPagesProviderStub, as: Stub
   alias PhoenixKit.Modules.Sitemap.DomainMode
+  alias PhoenixKit.Modules.Sitemap.FileStorage
+  alias PhoenixKit.Modules.Sitemap.Generator
   alias PhoenixKit.Modules.Sitemap.Sources.Static
   alias PhoenixKit.Settings
 
@@ -56,14 +58,22 @@ defmodule PhoenixKit.Integration.Sitemap.StaticDomainPagesTest do
     :ok
   end
 
-  defp collect(language, is_default?) do
-    [base_url: @base, language: language, is_default_language: is_default?]
+  defp collect(language, is_default?, extra \\ [domain_pass: true]) do
+    ([base_url: @base, language: language, is_default_language: is_default?] ++ extra)
     |> Static.collect()
     |> Enum.map(& &1.loc)
   end
 
   test "a language with its own domain gets the static pages, prefixed for re-hosting" do
     assert collect("fr", false) == ["#{@base}/fr/"]
+  end
+
+  test "without the domain pass a mapped language still gets nothing" do
+    # The prefixed URL is an intermediate for DomainMode only. The legacy
+    # collection (served verbatim to unmapped hosts) must not see it — there
+    # is nothing there to strip the prefix, and https://<primary>/fr/ is
+    # usually not a page.
+    assert collect("fr", false, []) == []
   end
 
   test "a language without a domain still gets nothing" do
@@ -95,7 +105,12 @@ defmodule PhoenixKit.Integration.Sitemap.StaticDomainPagesTest do
 
     entries =
       Static.collect(base_url: @base, language: "en", is_default_language: true) ++
-        Static.collect(base_url: @base, language: "fr", is_default_language: false)
+        Static.collect(
+          base_url: @base,
+          language: "fr",
+          is_default_language: false,
+          domain_pass: true
+        )
 
     result = DomainMode.rebuild_for_domains(entries, @base)
     fr_locs = Enum.map(result["site.example.fr"], & &1.loc)
@@ -104,11 +119,35 @@ defmodule PhoenixKit.Integration.Sitemap.StaticDomainPagesTest do
     refute Enum.any?(fr_locs, &String.contains?(&1, "/fr/"))
   end
 
+  test "generate_all keeps the prefixed intermediate out of the legacy set" do
+    {:ok, _} = Settings.update_boolean_setting("sitemap_enabled", true)
+    {:ok, _} = Settings.update_boolean_setting("crawlers_no_index", false)
+    {:ok, _} = Settings.update_setting("site_url", @base)
+
+    assert {:ok, %{index_xml: index_xml}} = Generator.generate_all(base_url: @base)
+
+    # The legacy file is what an unmapped host is served, verbatim.
+    refute index_xml =~ "#{@base}/fr/"
+
+    # ...while the fr domain's own file gets the home page it was missing.
+    {:ok, path} = FileStorage.domain_file_path("site.example.fr", "sitemap")
+    assert File.exists?(path)
+    fr_xml = File.read!(path)
+    assert fr_xml =~ "<loc>https://site.example.fr/</loc>"
+    refute fr_xml =~ "/fr/"
+  end
+
   test "the mapped domain's file ends up carrying its own home page" do
     entries = Static.collect(base_url: @base, language: "en", is_default_language: true)
 
     entries =
-      entries ++ Static.collect(base_url: @base, language: "fr", is_default_language: false)
+      entries ++
+        Static.collect(
+          base_url: @base,
+          language: "fr",
+          is_default_language: false,
+          domain_pass: true
+        )
 
     result = DomainMode.rebuild_for_domains(entries, @base)
 

--- a/test/integration/sitemap/static_domain_pages_test.exs
+++ b/test/integration/sitemap/static_domain_pages_test.exs
@@ -1,0 +1,103 @@
+defmodule PhoenixKit.Integration.Sitemap.StaticDomainPagesProviderStub do
+  @moduledoc false
+  def ok do
+    [
+      %{host: "site.example.com", language: "en", primary: true},
+      %{host: "site.example.fr", language: "fr", primary: false}
+    ]
+  end
+
+  def empty, do: []
+end
+
+defmodule PhoenixKit.Integration.Sitemap.StaticDomainPagesTest do
+  @moduledoc """
+  Pins that static pages reach the domain of every language that has one.
+
+  The Static source emits URLs for the default language only, because in a
+  prefix-based install a `/de/...` static page would 404. Under domain mode
+  that premise does not hold: the language has its own host, and the page is
+  served there prefix-free — verified on a live 3-domain install, where
+  `https://<de-host>/` answers 200 with `lang="de"`.
+
+  The consequence was that every non-primary domain's sitemap was missing its
+  own home page — the single most important URL of that domain — while
+  listing its products.
+  """
+  use PhoenixKit.DataCase, async: false
+
+  alias PhoenixKit.Integration.Sitemap.StaticDomainPagesProviderStub, as: Stub
+  alias PhoenixKit.Modules.Sitemap.DomainMode
+  alias PhoenixKit.Modules.Sitemap.Sources.Static
+  alias PhoenixKit.Settings
+
+  @base "https://site.example.com"
+
+  setup do
+    Settings.update_setting("languages_enabled", "true")
+
+    Settings.update_json_setting("languages_config", %{
+      "languages" => [
+        %{"code" => "en-US", "name" => "English", "is_default" => true, "is_enabled" => true},
+        %{"code" => "fr", "name" => "French", "is_default" => false, "is_enabled" => true},
+        %{"code" => "de", "name" => "German", "is_default" => false, "is_enabled" => true}
+      ]
+    })
+
+    # Keep the assertions about the home page alone.
+    {:ok, _} = Settings.update_boolean_setting("sitemap_include_registration", false)
+    Application.put_env(:phoenix_kit, :sitemap_domains_provider, {Stub, :ok})
+
+    on_exit(fn ->
+      Application.delete_env(:phoenix_kit, :sitemap_domains_provider)
+      Settings.update_setting("languages_enabled", "false")
+    end)
+
+    :ok
+  end
+
+  defp collect(language, is_default?) do
+    [base_url: @base, language: language, is_default_language: is_default?]
+    |> Static.collect()
+    |> Enum.map(& &1.loc)
+  end
+
+  test "a language with its own domain gets the static pages, prefixed for re-hosting" do
+    assert collect("fr", false) == ["#{@base}/fr/"]
+  end
+
+  test "a language without a domain still gets nothing" do
+    assert collect("de", false) == []
+  end
+
+  test "the default language is unchanged" do
+    assert collect("en", true) == ["#{@base}/"]
+  end
+
+  test "domain mode off leaves every non-default language empty" do
+    Application.put_env(:phoenix_kit, :sitemap_domains_provider, {Stub, :empty})
+
+    assert collect("fr", false) == []
+    assert collect("en", true) == ["#{@base}/"]
+  end
+
+  test "the mapped domain's file ends up carrying its own home page" do
+    entries = Static.collect(base_url: @base, language: "en", is_default_language: true)
+
+    entries =
+      entries ++ Static.collect(base_url: @base, language: "fr", is_default_language: false)
+
+    result = DomainMode.rebuild_for_domains(entries, @base)
+
+    assert Enum.map(result["site.example.com"], & &1.loc) == ["https://site.example.com/"]
+    assert Enum.map(result["site.example.fr"], & &1.loc) == ["https://site.example.fr/"]
+
+    # Both home pages belong to one canonical group, so each carries the
+    # other as an alternate.
+    [fr_entry] = result["site.example.fr"]
+    hrefs = Map.new(fr_entry.alternates, &{&1.hreflang, &1.href})
+    assert hrefs["en"] == "https://site.example.com/"
+    assert hrefs["fr"] == "https://site.example.fr/"
+    assert hrefs["x-default"] == "https://site.example.com/"
+  end
+end


### PR DESCRIPTION
## What's wrong today

The Static source emits URLs for the default language only:

```elixir
# Static pages only generate URLs for the default language
# Non-default language URLs would lead to 404 errors
if is_default do
```

That premise is right for a prefix-based install — `/de/` has no localized route there. Under **domain mode** it does not hold: the language has a host of its own and serves those pages from it, prefix-free.

The consequence is that every non-primary domain's sitemap is missing **its own home page** — the most important URL of that domain — while listing its products, which come from a source that does emit per-language entries.

Verified on a live 3-domain install (one language per host):

| | `.com` (primary, en) | `.de` | `.fr` |
|---|---|---|---|
| home page served | 200, `lang="en"` | **200, `lang="de"`**, self-referential canonical | **200, `lang="fr"`** |
| home page in that domain's sitemap | yes | **no** | **no** |

`/users/register` (the other built-in static route, when `sitemap_include_registration` is on) behaves the same way and answers 200 on all three hosts.

## What this changes

Static also collects for a language that has a domain of its own, and keeps the locale prefix on those entries. The prefix matters: `skip_language_prefix` is what collapses every language's home page onto a single URL, and the prefix is what tells `DomainMode` which host to re-file the entry under — it strips the prefix again when re-hosting, so the published URL is `https://<de-host>/`.

Unchanged:

- **languages without a domain** — their prefixed URLs really would 404, so they still get nothing;
- **the default language** — same single unprefixed entry as before;
- **domain mode inactive** — `DomainMode.domains()` is `[]`, so no language is "domain hosted" and the source behaves exactly as it does today.

## What's tested

New `test/integration/sitemap/static_domain_pages_test.exs` — provider with `en` primary + `fr` mapped, `de` enabled but unmapped:

- **`a language with its own domain gets the static pages, prefixed for re-hosting`** — `fr` yields `https://site.example.com/fr/`. Fails before the change with `left: []`.
- **`the mapped domain's file ends up carrying its own home page`** — end to end through `DomainMode.rebuild_for_domains/2`: `site.example.fr` ends up with `https://site.example.fr/`, carrying `en`/`fr`/`x-default` alternates pointing at both home pages. Fails before the change with `left: []` — this is the reported symptom, reproduced in the suite.
- **`a language without a domain still gets nothing`** (`de` ⇒ `[]`), **`the default language is unchanged`**, **`domain mode off leaves every non-default language empty`** — the three no-op guarantees.

Full suite from a clean database, twice: **43 doctests + 3810 tests**, one run clean, one with two failures — `PhoenixKit.Integration.Users.PermissionsTest` and `PhoenixKit.Install.CommonUnreachableTest`, both sandbox-ownership flakes that touch nothing in this change and pass together in isolation (33 tests, 0 failures). Every sitemap suite is green in both runs. `mix format --check-formatted` and `mix credo --strict` clean on the touched file.

---

## Follow-up commit: review findings on this PR and on the three sitemap fixes in 2.11.0

An adversarial review of this change plus #725/#726/#727 found three things worth fixing. They live in the same subsystem and are small; say the word if you would rather have them as their own PR.

1. **Router discovery had no escape hatch for the JSON-pipeline exclusion (#727).** `:api` is the name `mix phx.new` generates. A host that serves real pages through a pipeline of that name lost them from its sitemap silently — and `sitemap_router_discovery_include_only` cannot rescue a route the pipeline check rejects, so there was no way back. `sitemap_non_page_pipelines` now **replaces** the default list (deliberately replace, not extend the way `sitemap_protected_pipelines` does — the point is being able to drop `:api`); `[]` disables pipeline-based exclusion entirely. Two tests: a host rescuing its own `:api`, and the empty-list case.

2. **`Sitemap.regenerate/1` accepted an unconfigured base URL (#726).** `get_base_url/0` falls back to `""`, and `generate_all/1` only rejects `nil` — so a fresh install with the sitemap enabled and no `site_url` would have written host-less `<loc>`s and reported `{:ok, ...}`. `SchedulerWorker` already guarded exactly this (`base_url != ""`); `regenerate/1` was the odd one out. Now `{:error, :base_url_not_configured}`, with a test.

3. **One redundant provider call per generation pass (this PR).** The static source resolved "does this language have a domain" for the default language too, which needs no such lookup.

**One review point did not hold, and is pinned by a test instead of argued:** the claim that custom URLs (`sitemap_custom_urls`) would now be advertised as `https://<lang-host>/<lang>/<path>` and 404. `DomainMode` strips the language prefix when re-hosting, so the published URL is `https://<lang-host>/<path>` — the same path the host already serves there. The new test asserts both the presence of that URL and the absence of any `/<lang>/` segment in the mapped domain's file.

Full suite after the follow-up, from a clean database: **43 doctests + 3814 tests, 0 failures**. `mix format --check-formatted` and `mix credo --strict` clean on all three touched files.
