### PR TITLE
Fix duplicate <loc> on the primary domain, and a settings typo emptying router discovery

### DIFF
--- a/lib/modules/sitemap/domain_mode.ex
+++ b/lib/modules/sitemap/domain_mode.ex
@@ -129,7 +129,7 @@ defmodule PhoenixKit.Modules.Sitemap.DomainMode do
             if primary?,
               do:
                 Enum.sort_by(
-                  own ++ domainless_entries(groups, host_by_lang, primary, base_url),
+                  own ++ extra_for_primary(own, groups, host_by_lang, primary, base_url),
                   & &1.loc
                 ),
               else: own
@@ -137,6 +137,20 @@ defmodule PhoenixKit.Modules.Sitemap.DomainMode do
           {host, entries}
         end)
     end
+  end
+
+  # The primary domain's own language owns its URLs. A domainless language's
+  # entry can land on the same URL when the site's default language is NOT the
+  # primary domain's language and has no domain: its URLs carry no locale
+  # prefix, so re-hosting puts them on the primary's root — where that domain's
+  # own language already is. Publishing both would put the same <loc> in one
+  # file twice; the host's own language wins.
+  defp extra_for_primary(own, groups, host_by_lang, primary, base_url) do
+    taken = MapSet.new(own, & &1.loc)
+
+    groups
+    |> domainless_entries(host_by_lang, primary, base_url)
+    |> Enum.reject(&MapSet.member?(taken, &1.loc))
   end
 
   # An enabled language that has no domain of its own is served with its locale

--- a/lib/modules/sitemap/sources/router_discovery.ex
+++ b/lib/modules/sitemap/sources/router_discovery.ex
@@ -338,12 +338,12 @@ defmodule PhoenixKit.Modules.Sitemap.Sources.RouterDiscovery do
 
       json_string when is_binary(json_string) ->
         case JSON.decode(json_string) do
-          {:ok, pipelines} when is_list(pipelines) -> Enum.map(pipelines, &safe_to_atom/1)
+          {:ok, pipelines} when is_list(pipelines) -> to_atoms(pipelines)
           _ -> @default_non_page_pipelines
         end
 
       pipelines when is_list(pipelines) ->
-        Enum.map(pipelines, &safe_to_atom/1)
+        to_atoms(pipelines)
 
       _ ->
         @default_non_page_pipelines
@@ -392,22 +392,30 @@ defmodule PhoenixKit.Modules.Sitemap.Sources.RouterDiscovery do
       json_string when is_binary(json_string) ->
         case JSON.decode(json_string) do
           {:ok, pipelines} when is_list(pipelines) ->
-            Enum.map(pipelines, &safe_to_atom/1)
+            to_atoms(pipelines)
 
           _ ->
             []
         end
 
       pipelines when is_list(pipelines) ->
-        Enum.map(pipelines, &safe_to_atom/1)
+        to_atoms(pipelines)
 
       _ ->
         []
     end
   end
 
+  defp to_atoms(values), do: values |> Enum.map(&safe_to_atom/1) |> Enum.reject(&is_nil/1)
+
   defp safe_to_atom(value) when is_atom(value), do: value
   defp safe_to_atom(value) when is_binary(value), do: String.to_atom(value)
+
+  # A settings list is hand-edited JSON; one bad element must not take the
+  # source down with it. Without this clause the FunctionClauseError is caught
+  # by `collect/1`'s rescue and every discovered route disappears from the
+  # sitemap silently — a typo in a settings field emptying a whole source.
+  defp safe_to_atom(_other), do: nil
 
   defp disabled_module_route?(path) do
     Enum.any?(@module_route_prefixes, fn {prefix, {mod, fun}} ->

--- a/test/integration/sitemap/router_discovery_api_pipeline_test.exs
+++ b/test/integration/sitemap/router_discovery_api_pipeline_test.exs
@@ -107,6 +107,19 @@ defmodule PhoenixKit.Integration.Sitemap.RouterDiscoveryApiPipelineTest do
            ]
   end
 
+  test "a junk element in sitemap_non_page_pipelines does not take the source down" do
+    # The setting is hand-edited JSON. A non-string element used to raise inside
+    # collect/1, whose rescue swallowed it and returned [] — one typo in a
+    # settings field emptied the entire router-discovery source, silently.
+    {:ok, _} =
+      Settings.update_setting("sitemap_non_page_pipelines", JSON.encode!(["phoenix_kit_api", 1]))
+
+    locs = RouterDiscovery.collect(base_url: @base_url) |> Enum.map(& &1.loc) |> Enum.sort()
+
+    # The good element still filters; the junk one is ignored, not fatal.
+    assert locs == ["#{@base_url}/about", "#{@base_url}/caddy/ask"]
+  end
+
   test "default_non_page_pipelines/0 exposes the JSON pipelines it filters on" do
     defaults = RouterDiscovery.default_non_page_pipelines()
 

--- a/test/integration/sitemap/static_domain_pages_test.exs
+++ b/test/integration/sitemap/static_domain_pages_test.exs
@@ -162,6 +162,26 @@ defmodule PhoenixKit.Integration.Sitemap.StaticDomainPagesTest do
     refute fr_xml =~ "/fr/"
   end
 
+  test "index mode keeps it out of the per-module static file too" do
+    # Flat vs index is decided by router discovery; the test above only
+    # exercises flat mode, where the legacy set is one urlset. In index mode the
+    # legacy set is per-module files, and sitemap-static.xml is the one that
+    # would carry a leaked /fr/ entry.
+    {:ok, _} = Settings.update_boolean_setting("sitemap_router_discovery_enabled", false)
+    {:ok, _} = Settings.update_boolean_setting("sitemap_enabled", true)
+    {:ok, _} = Settings.update_boolean_setting("crawlers_no_index", false)
+    {:ok, _} = Settings.update_setting("site_url", @base)
+
+    assert {:ok, _} = Generator.generate_all(base_url: @base)
+
+    static_path = FileStorage.module_file_path("sitemap-static")
+    assert File.exists?(static_path)
+    refute File.read!(static_path) =~ "#{@base}/fr/"
+
+    {:ok, fr_path} = FileStorage.domain_file_path("site.example.fr", "sitemap")
+    assert File.read!(fr_path) =~ "<loc>https://site.example.fr/</loc>"
+  end
+
   test "the mapped domain's file ends up carrying its own home page" do
     entries = Static.collect(base_url: @base, language: "en", is_default_language: true)
 

--- a/test/integration/sitemap/static_domain_pages_test.exs
+++ b/test/integration/sitemap/static_domain_pages_test.exs
@@ -8,6 +8,10 @@ defmodule PhoenixKit.Integration.Sitemap.StaticDomainPagesProviderStub do
   end
 
   def empty, do: []
+
+  # The primary domain hosts a language that is NOT the site default, and the
+  # site default (en) has no domain at all.
+  def primary_is_not_default, do: [%{host: "site.example.fr", language: "fr", primary: true}]
 end
 
 defmodule PhoenixKit.Integration.Sitemap.StaticDomainPagesTest do
@@ -117,6 +121,27 @@ defmodule PhoenixKit.Integration.Sitemap.StaticDomainPagesTest do
 
     assert "https://site.example.fr/lookbook" in fr_locs
     refute Enum.any?(fr_locs, &String.contains?(&1, "/fr/"))
+  end
+
+  test "primary hosting a non-default language does not duplicate its home page" do
+    # The site default (en) has no domain, so its unprefixed home page URL
+    # re-hosts onto the primary's root — where the primary's own language (fr)
+    # now also has one. Both would be the same <loc> in the same file.
+    Application.put_env(:phoenix_kit, :sitemap_domains_provider, {Stub, :primary_is_not_default})
+
+    entries =
+      Static.collect(base_url: @base, language: "en", is_default_language: true) ++
+        Static.collect(
+          base_url: @base,
+          language: "fr",
+          is_default_language: false,
+          domain_pass: true
+        )
+
+    locs = DomainMode.rebuild_for_domains(entries, @base)["site.example.fr"] |> Enum.map(& &1.loc)
+
+    assert locs == ["https://site.example.fr/"]
+    assert Enum.uniq(locs) == locs
   end
 
   test "generate_all keeps the prefixed intermediate out of the legacy set" do


### PR DESCRIPTION
Two defects in code that landed with #730, found by reviewing that PR's own follow-up commits after it was already merged. Both are confirmed with tests that fail on `main` as it stands (2.12.0).

## 1. Duplicate `<loc>` on the primary domain

`domain_static_entries/2` (generator.ex) excludes the **Languages-module default** language, but `DomainMode`'s `domainless_entries/4` re-hosts that same default language onto the **DomainMode primary** host. When those two are not the same language — the primary domain maps `fr`, the site default is `en`, and `en` has no domain of its own — the default language's unprefixed home page lands on exactly the URL the primary's own language already occupies.

Before #730 this could not happen: `Static` emitted for the default language only, so the primary's own language had no static entry to collide with.

```
provider: [%{host: "site.example.fr", language: "fr", primary: true}]
languages: en (default, unmapped), fr

site.example.fr's file:
  <loc>https://site.example.fr/</loc>
  <loc>https://site.example.fr/</loc>     ← same URL, twice, one file
```

Fixed by `extra_for_primary/5`: the host's own language owns its URLs, and a domainless entry that resolves to a URL already taken is dropped.

## 2. One junk element in a pipeline setting empties the whole source, silently

`non_page_pipelines/0` maps a JSON-decoded settings list through `safe_to_atom/1`, which has clauses for atoms and binaries only. A value saved as `["phoenix_kit_api", 1]` raises `FunctionClauseError` — and `collect/1`'s top-level rescue swallows it and returns `[]`. Every router-discovered URL disappears from the sitemap, with nothing in the log to say why. A typo in a hand-edited settings field should not empty a source.

Fixed with a `to_atoms/1` helper that drops elements it cannot convert. This also hardens `sitemap_protected_pipelines`, which shares the helper and had the same weakness (pre-existing, harmless to fix here since it is one line at the same call site).

## What's tested

- `primary hosting a non-default language does not duplicate its home page` — the exact provider/language shape above; asserts the primary's file has one entry and that the set is duplicate-free.
- `a junk element in sitemap_non_page_pipelines does not take the source down` — `["phoenix_kit_api", 1]`: the good element still filters the JSON-pipeline route, the junk one is ignored, and `/about` survives.
- `index mode keeps it out of the per-module static file too` — coverage the merged tests lacked: the existing legacy-set test only exercises flat mode (the default, since `flat_mode?` follows router discovery), so a leak into `sitemap-static.xml` in index mode would not have been caught. Index mode was already correct; this pins it.

Full suite from a clean database on this branch, rebased on current `main` (5fff25fc, 2.12.0): **43 doctests + 3819 tests, 0 failures**. `mix format --check-formatted` clean.

## How they were found

Reviewing #730's follow-up commits — the two rounds of self-review folded into that PR — with a fresh reviewer over the same diffs. Both defects were traced independently twice (once by hand against the mismatch configuration, once by the reviewer), which is why they are stated as confirmed rather than suspected.
