### PR TITLE
Add canonical/hreflang to the stable auth pages

### DIFF
--- a/lib/phoenix_kit_web/users/auth_seo.ex
+++ b/lib/phoenix_kit_web/users/auth_seo.ex
@@ -1,0 +1,113 @@
+defmodule PhoenixKitWeb.Users.AuthSEO do
+  @moduledoc """
+  Canonical / hreflang assigns for the auth LiveViews whose path is stable
+  and token-free (registration, log-in, magic-link registration request).
+
+  Mirrors `PhoenixKitEcommerce.Web.SEOHelpers`'s contract so a multi-domain
+  host wires one resolver for both the shop and auth surfaces: the canonical
+  host per language comes from the workspace-wide
+  `config :phoenix_kit, :canonical_host_resolver, {mod, fun}` MFA (nil or
+  absent ⇒ the site-wide `PhoenixKit.Utils.Routes.base_url/0`, today's
+  behavior). On a language's own resolved host the locale segment is dropped
+  (`Routes.path(url_path, locale: :none)`) — the domain itself carries the
+  language, so a `/en` (or any other) prefix on top of it would be redundant.
+
+  Deliberately excludes every token-bearing auth page (email confirmation,
+  password reset, magic-link verify, QR-login confirm): a one-time token in
+  the URL makes canonical/hreflang meaningless — there is no duplicate-content
+  signal to consolidate — and actively wrong, since the link a search engine
+  would be told about goes dead the moment the token is spent.
+
+  Setting these assigns is enough on its own: the root layout that renders
+  `@canonical_url` / `@hreflang_links` into `<head>` is the HOST app's, per
+  the same cross-package contract `phoenix_kit_ecommerce`'s catalog pages
+  already rely on (see `PhoenixKitEcommerce.Web.SEOHelpers`). Nothing here
+  renders anything itself.
+  """
+
+  require Logger
+
+  alias PhoenixKit.Modules.Languages
+  alias PhoenixKit.Modules.Languages.DialectMapper
+  alias PhoenixKit.Utils.Routes
+
+  @doc """
+  Canonical + hreflang assigns for a stable, token-free auth path, e.g.
+  `"/users/register"`.
+
+  `hreflang_links` is `[]` when Languages is disabled or fewer than two
+  languages are enabled — one language is not a hreflang set.
+  """
+  @spec seo_assigns(String.t()) :: %{canonical_url: String.t(), hreflang_links: [map()]}
+  def seo_assigns(url_path) when is_binary(url_path) do
+    %{
+      canonical_url: canonical_absolute_url(current_language(), url_path),
+      hreflang_links: hreflang_links(url_path)
+    }
+  end
+
+  defp hreflang_links(url_path) do
+    links =
+      enabled_languages()
+      |> Enum.map(&DialectMapper.extract_base(&1.code))
+      |> Enum.uniq()
+      |> Enum.map(&%{code: &1, url: canonical_absolute_url(&1, url_path)})
+
+    if length(links) < 2, do: [], else: links
+  end
+
+  defp enabled_languages do
+    if Languages.enabled?(), do: Languages.get_enabled_languages(), else: []
+  end
+
+  # These assigns are computed from inside `mount/3`, before the locale
+  # `handle_params` hook (`PhoenixKitWeb.Users.Auth.attach_locale_hook/1`)
+  # has run — so `socket.assigns[:current_locale_base]` is still unset here.
+  # The HTTP-layer locale plug already put the right value into Gettext
+  # before the LiveView mounted, which is exactly what `Routes.path/2` (called
+  # elsewhere in the same `do_mount`, e.g. for presence tracking) relies on
+  # too when it's not given an explicit `:locale`.
+  defp current_language do
+    PhoenixKitWeb.Gettext
+    |> Gettext.get_locale()
+    |> DialectMapper.extract_base()
+  end
+
+  defp canonical_absolute_url(language, url_path) do
+    case resolve_canonical_host(language) do
+      nil ->
+        Routes.base_url() <> Routes.path(url_path, locale: language)
+
+      host ->
+        # The language's own home domain implies the language — no locale
+        # segment needed on top of it, for the primary language or any other.
+        "https://#{host}" <> Routes.path(url_path, locale: :none)
+    end
+  end
+
+  defp resolve_canonical_host(language) do
+    case Application.get_env(:phoenix_kit, :canonical_host_resolver) do
+      {mod, fun} -> apply(mod, fun, [language])
+      _ -> nil
+    end
+  rescue
+    error ->
+      Logger.warning(
+        "[AuthSEO] canonical_host_resolver raised, falling back to site base: " <>
+          Exception.message(error)
+      )
+
+      nil
+  catch
+    # A connection-pool failure under the host's resolver EXITS rather than
+    # raising (see `Routes.get_default_language_base/0` for the same class of
+    # bug) — `rescue` alone does not catch it.
+    :exit, reason ->
+      Logger.warning(
+        "[AuthSEO] canonical_host_resolver exited, falling back to site base: " <>
+          inspect(reason)
+      )
+
+      nil
+  end
+end

--- a/lib/phoenix_kit_web/users/login.ex
+++ b/lib/phoenix_kit_web/users/login.ex
@@ -14,6 +14,7 @@ defmodule PhoenixKitWeb.Users.Login do
   alias PhoenixKit.Utils.IpAddress
   alias PhoenixKit.Utils.Routes
   alias PhoenixKitWeb.Users.Auth
+  alias PhoenixKitWeb.Users.AuthSEO
 
   def mount(params, session, socket) do
     case Auth.maybe_redirect_authenticated(socket) do
@@ -49,6 +50,8 @@ defmodule PhoenixKitWeb.Users.Login do
         # Support return_to query param for post-login redirect (e.g., from guest checkout)
         return_to = sanitize_return_to(params["return_to"])
 
+        seo = AuthSEO.seo_assigns("/users/log-in")
+
         socket =
           assign(socket,
             form: form,
@@ -58,7 +61,9 @@ defmodule PhoenixKitWeb.Users.Login do
             qr_login_enabled: qr_login_enabled,
             remember_me_available: Auth.remember_me_enabled?(),
             remember_me: Auth.remember_me_default?(),
-            return_to: return_to
+            return_to: return_to,
+            canonical_url: seo.canonical_url,
+            hreflang_links: seo.hreflang_links
           )
 
         {:ok, socket, temporary_assigns: [form: form]}

--- a/lib/phoenix_kit_web/users/magic_link_registration_request.ex
+++ b/lib/phoenix_kit_web/users/magic_link_registration_request.ex
@@ -13,6 +13,7 @@ defmodule PhoenixKitWeb.Users.MagicLinkRegistrationRequest do
   alias PhoenixKit.Utils.IpAddress
   alias PhoenixKit.Utils.Routes
   alias PhoenixKitWeb.Users.Auth
+  alias PhoenixKitWeb.Users.AuthSEO
 
   @impl true
   def mount(_params, _session, socket) do
@@ -29,6 +30,7 @@ defmodule PhoenixKitWeb.Users.MagicLinkRegistrationRequest do
              Auth.magic_link_registration_enabled?() do
           # Get project title from settings (with Config fallback)
           project_title = PhoenixKit.Settings.get_project_title()
+          seo = AuthSEO.seo_assigns("/users/register/magic-link")
 
           {:ok,
            socket
@@ -38,7 +40,9 @@ defmodule PhoenixKitWeb.Users.MagicLinkRegistrationRequest do
            |> assign(:ip_address, IpAddress.extract_from_socket(socket))
            |> assign(:email_sent, false)
            |> assign(:error_message, nil)
-           |> assign(:loading, false)}
+           |> assign(:loading, false)
+           |> assign(:canonical_url, seo.canonical_url)
+           |> assign(:hreflang_links, seo.hreflang_links)}
         else
           socket =
             socket

--- a/lib/phoenix_kit_web/users/registration.ex
+++ b/lib/phoenix_kit_web/users/registration.ex
@@ -18,6 +18,7 @@ defmodule PhoenixKitWeb.Users.Registration do
   alias PhoenixKit.Utils.IpAddress
   alias PhoenixKit.Utils.Routes
   alias PhoenixKitWeb.Users.Auth, as: WebAuth
+  alias PhoenixKitWeb.Users.AuthSEO
 
   def mount(params, session, socket) do
     case WebAuth.maybe_redirect_authenticated(socket) do
@@ -68,6 +69,8 @@ defmodule PhoenixKitWeb.Users.Registration do
       # Extract and store IP address during mount for later use
       ip_address = IpAddress.extract_from_socket(socket)
 
+      seo = AuthSEO.seo_assigns("/users/register")
+
       # Parse invitation token from URL params
       invitation_token = Map.get(params, "invitation")
       pending_invitation = load_pending_invitation(invitation_token)
@@ -81,6 +84,8 @@ defmodule PhoenixKitWeb.Users.Registration do
         |> assign(trigger_submit: false, check_errors: false)
         |> assign(username_edited: false)
         |> assign(project_title: project_title)
+        |> assign(canonical_url: seo.canonical_url)
+        |> assign(hreflang_links: seo.hreflang_links)
         |> assign(referral_codes_enabled: referral_codes_config.enabled)
         |> assign(referral_codes_required: referral_codes_config.required)
         |> assign(referral_code: nil)

--- a/test/phoenix_kit_web/users/auth_seo_mount_test.exs
+++ b/test/phoenix_kit_web/users/auth_seo_mount_test.exs
@@ -1,0 +1,75 @@
+defmodule PhoenixKitWeb.Users.AuthSEOMountTest do
+  @moduledoc """
+  Confirms `PhoenixKitWeb.Users.AuthSEO.seo_assigns/1` is actually wired into
+  `mount/3` for the three stable, token-free auth LiveViews (registration,
+  log-in, magic-link registration request) — `auth_seo_test.exs` covers the
+  helper's own correctness, this covers that each LiveView calls it and
+  assigns the result to the socket.
+
+  There is nothing to see in the rendered HTML: `@canonical_url` /
+  `@hreflang_links` are consumed by the HOST app's root layout (see the
+  moduledoc on `AuthSEO`), which this library's own test endpoint does not
+  render — same reasoning as `QrLoginConfirmTest` for reading state at the
+  same layer the assign lands on, rather than through a render that was never
+  going to show it. `:sys.get_state/1` on the LiveView pid is the documented
+  house technique for reaching process state without a render or a sleep
+  (see `AGENTS.md`'s test guidelines).
+  """
+
+  use PhoenixKitWeb.ConnCase, async: false
+
+  alias PhoenixKitWeb.Users.AuthSEO
+
+  # Registration and log-in track an anonymous visitor session on connected
+  # mount via `PhoenixKit.Admin.SimplePresence`. In a real host app that
+  # GenServer is started by `PhoenixKit.Supervisor` (part of the host's own
+  # supervision tree); this library's own test suite doesn't run inside one,
+  # so any test that connects one of those two LiveViews has to start it —
+  # mirrors `QrLoginConfirmTest`'s `start_supervised!(Keyfob.Store.ETS)` for
+  # the same class of gap.
+  setup do
+    start_supervised!(PhoenixKit.Admin.SimplePresence)
+    :ok
+  end
+
+  defp seo_assigns_of(view) do
+    %{socket: socket} = :sys.get_state(view.pid)
+    socket.assigns
+  end
+
+  describe "registration" do
+    test "assigns canonical_url and hreflang_links matching AuthSEO", %{conn: conn} do
+      expected = AuthSEO.seo_assigns("/users/register")
+
+      {:ok, view, _html} = live(conn, "/phoenix_kit/users/register")
+
+      assigns = seo_assigns_of(view)
+      assert assigns.canonical_url == expected.canonical_url
+      assert assigns.hreflang_links == expected.hreflang_links
+    end
+  end
+
+  describe "log-in" do
+    test "assigns canonical_url and hreflang_links matching AuthSEO", %{conn: conn} do
+      expected = AuthSEO.seo_assigns("/users/log-in")
+
+      {:ok, view, _html} = live(conn, "/phoenix_kit/users/log-in")
+
+      assigns = seo_assigns_of(view)
+      assert assigns.canonical_url == expected.canonical_url
+      assert assigns.hreflang_links == expected.hreflang_links
+    end
+  end
+
+  describe "magic-link registration request" do
+    test "assigns canonical_url and hreflang_links matching AuthSEO", %{conn: conn} do
+      expected = AuthSEO.seo_assigns("/users/register/magic-link")
+
+      {:ok, view, _html} = live(conn, "/phoenix_kit/users/register/magic-link")
+
+      assigns = seo_assigns_of(view)
+      assert assigns.canonical_url == expected.canonical_url
+      assert assigns.hreflang_links == expected.hreflang_links
+    end
+  end
+end

--- a/test/phoenix_kit_web/users/auth_seo_test.exs
+++ b/test/phoenix_kit_web/users/auth_seo_test.exs
@@ -1,0 +1,177 @@
+defmodule PhoenixKitWeb.Users.AuthSEOTest.FakeResolver do
+  @moduledoc false
+  def host_for("en"), do: "en.example.test"
+  def host_for("es"), do: "es.example.test"
+  def host_for(_), do: nil
+end
+
+defmodule PhoenixKitWeb.Users.AuthSEOTest.RaisingResolver do
+  @moduledoc false
+  def host_for(_language), do: raise("boom")
+end
+
+defmodule PhoenixKitWeb.Users.AuthSEOTest.ExitingResolver do
+  @moduledoc false
+  def host_for(_language), do: exit(:boom)
+end
+
+defmodule PhoenixKitWeb.Users.AuthSEOTest do
+  @moduledoc """
+  `PhoenixKitWeb.Users.AuthSEO.seo_assigns/1` — canonical/hreflang for the
+  stable, token-free auth pages (registration, log-in, magic-link
+  registration request).
+
+  Needs a DB-backed `Settings` read for `Languages.enabled?/0` and
+  `Languages.get_enabled_languages/0`, so this uses `DataCase` rather than a
+  no-DB unit test (mirrors `auth_locale_test.exs`).
+  """
+
+  use PhoenixKit.DataCase, async: false
+
+  alias PhoenixKit.Settings
+  alias PhoenixKitWeb.Users.AuthSEO
+
+  setup do
+    on_exit(fn ->
+      Application.delete_env(:phoenix_kit, :canonical_host_resolver)
+      Settings.update_setting("languages_enabled", "false")
+    end)
+
+    :ok
+  end
+
+  defp enable_languages(langs) do
+    config = %{"languages" => langs}
+    Settings.update_setting("languages_enabled", "true")
+    Settings.update_json_setting("languages_config", config)
+  end
+
+  describe "with Languages disabled (single-language install)" do
+    test "sets a self-referencing canonical_url and an empty hreflang set" do
+      seo = AuthSEO.seo_assigns("/users/register")
+
+      assert seo.canonical_url =~ "/users/register"
+      assert seo.hreflang_links == []
+    end
+  end
+
+  describe "with two enabled languages" do
+    setup do
+      enable_languages([
+        %{"code" => "en", "name" => "English", "is_default" => true, "is_enabled" => true},
+        %{"code" => "es", "name" => "Spanish", "is_default" => false, "is_enabled" => true}
+      ])
+
+      :ok
+    end
+
+    test "canonical_url is the current (Gettext) locale's own path" do
+      seo = AuthSEO.seo_assigns("/users/log-in")
+
+      # The test process's Gettext locale defaults to English.
+      assert seo.canonical_url =~ "/en/users/log-in"
+    end
+
+    test "hreflang_links carries one absolute URL per enabled language" do
+      seo = AuthSEO.seo_assigns("/users/register")
+
+      assert %{code: "en", url: en_url} =
+               Enum.find(seo.hreflang_links, &(&1.code == "en"))
+
+      assert %{code: "es", url: es_url} =
+               Enum.find(seo.hreflang_links, &(&1.code == "es"))
+
+      assert en_url =~ "/en/users/register"
+      assert es_url =~ "/es/users/register"
+      assert length(seo.hreflang_links) == 2
+    end
+
+    test "a disabled language is excluded from hreflang_links" do
+      enable_languages([
+        %{"code" => "en", "name" => "English", "is_default" => true, "is_enabled" => true},
+        %{"code" => "es", "name" => "Spanish", "is_default" => false, "is_enabled" => true},
+        %{"code" => "fr", "name" => "French", "is_default" => false, "is_enabled" => false}
+      ])
+
+      seo = AuthSEO.seo_assigns("/users/register")
+
+      refute Enum.any?(seo.hreflang_links, &(&1.code == "fr"))
+    end
+  end
+
+  describe "with only one enabled language" do
+    test "hreflang_links is empty — one language is not a hreflang set" do
+      enable_languages([
+        %{"code" => "en", "name" => "English", "is_default" => true, "is_enabled" => true}
+      ])
+
+      seo = AuthSEO.seo_assigns("/users/register")
+
+      assert seo.hreflang_links == []
+    end
+  end
+
+  describe "canonical_host_resolver" do
+    setup do
+      enable_languages([
+        %{"code" => "en", "name" => "English", "is_default" => true, "is_enabled" => true},
+        %{"code" => "es", "name" => "Spanish", "is_default" => false, "is_enabled" => true}
+      ])
+
+      :ok
+    end
+
+    test "an absent resolver falls back to the site base URL" do
+      seo = AuthSEO.seo_assigns("/users/register")
+
+      refute seo.canonical_url =~ "https://en.example.test"
+    end
+
+    test "a configured resolver puts the language on its own host, prefix stripped" do
+      Application.put_env(
+        :phoenix_kit,
+        :canonical_host_resolver,
+        {PhoenixKitWeb.Users.AuthSEOTest.FakeResolver, :host_for}
+      )
+
+      seo = AuthSEO.seo_assigns("/users/register")
+
+      # English is the resolver's own home domain, so its locale prefix is
+      # stripped: the domain itself carries the language. The PhoenixKit
+      # mount prefix ("/phoenix_kit" in this test app) is not a locale
+      # segment and stays.
+      assert seo.canonical_url == "https://en.example.test/phoenix_kit/users/register"
+      refute seo.canonical_url =~ "/en/"
+
+      es_link = Enum.find(seo.hreflang_links, &(&1.code == "es"))
+      assert es_link.url == "https://es.example.test/phoenix_kit/users/register"
+      refute es_link.url =~ "/es/"
+    end
+
+    test "a resolver that raises falls back to the site base URL instead of crashing the mount" do
+      Application.put_env(
+        :phoenix_kit,
+        :canonical_host_resolver,
+        {PhoenixKitWeb.Users.AuthSEOTest.RaisingResolver, :host_for}
+      )
+
+      seo = AuthSEO.seo_assigns("/users/register")
+
+      assert seo.canonical_url =~ "/en/users/register"
+      refute seo.canonical_url =~ "https://"
+    end
+
+    test "a resolver that exits falls back to the site base URL instead of crashing the mount" do
+      Application.put_env(
+        :phoenix_kit,
+        :canonical_host_resolver,
+        {PhoenixKitWeb.Users.AuthSEOTest.ExitingResolver, :host_for}
+      )
+
+      seo = AuthSEO.seo_assigns("/users/register")
+
+      assert seo.canonical_url =~ "/en/users/register"
+      refute seo.canonical_url =~ "https://"
+    end
+  end
+end


### PR DESCRIPTION
Auth pages in core carry no canonical/hreflang assigns at all. On a multi-domain, multi-language install that means several near-duplicate versions of each are served with nothing telling a search engine which is preferred.

This adds `PhoenixKitWeb.Users.AuthSEO` and wires it into three of them:

- `/users/register` (`Users.Registration`)
- `/users/log-in` (`Users.Login`)
- `/users/register/magic-link` (`Users.MagicLinkRegistrationRequest`)

**Scope — corrected from the first version of this description.** That version claimed these were "the only public LiveViews without canonical/hreflang". That was wrong, and I would rather say so than let it stand. Five more public auth routes have a stable, token-free path and qualify by exactly the same criterion:

| route | module |
|---|---|
| `/users/magic-link` | `Users.MagicLink` |
| `/users/qr-login` | `Users.QrLogin` |
| `/users/reset-password` | `Users.ForgotPassword` |
| `/users/confirm` | `Users.ConfirmationInstructions` |
| `/users/referral` | `Users.ReferralGate` |

They are not covered here, and deliberately not added to this PR. The three above are the registration and sign-in entry points — the pages a multi-domain install actually competes with itself on. Whether the remaining five want SEO assigns at all is a separate question (several are functional forms that arguably should not be indexed in the first place), and it deserves its own change with its own reasoning rather than being folded into a reviewed one. Tracked on our side.

**Deliberately excluded, and these should stay excluded:** every route carrying a one-time token — `/users/confirm/:token`, `/users/reset-password/:token`, `/users/register/complete/:token`, `/users/register/verify/:token`, `/users/magic-link/:token`, `/users/qr-login/scan/:token`, `/users/qr-login/finish/:token`. Canonical/hreflang there is meaningless (nothing to consolidate) and actively wrong (the advertised link dies with the token). Noted in the module docstring so it does not get "fixed" later.

Note that `/users/reset-password` and `/users/reset-password/:token` are different modules — `Users.ForgotPassword` (the request form, path-stable) and `Users.ResetPassword` (token-bearing). The first version of this description said "reset-password" was deliberately excluded, which read as covering both. Only the token-bearing one is.

**Design.** `AuthSEO` mirrors `PhoenixKitEcommerce.Web.SEOHelpers`'s `canonical_host_resolver` contract (`config :phoenix_kit, :canonical_host_resolver, {mod, fun}`), so a multi-domain host wires one resolver for both the shop and auth surfaces. Setting the assigns is enough — rendering `@canonical_url`/`@hreflang_links` into `<head>` is the host app's root layout, same as it already is for shop pages.

One deliberate divergence from that reference: `AuthSEO` does not copy `strip_language_prefix/2`, which splits the path on `/` and takes the first segment as the locale. It uses `Routes.path(url_path, locale: :none)` instead. A test surfaced why: when `url_prefix` is non-empty (e.g. `/phoenix_kit/en/...`) the locale is no longer the first segment and the split picks up the prefix. `phoenix_kit_ecommerce` carries that bug for installs with a non-empty prefix — out of scope here, but worth its own issue.

`hreflang_links` is `[]` when Languages is disabled or fewer than two languages are enabled; one language is not a hreflang set. `x-default` is not emitted here, matching `SEOHelpers` — hosts that want it add it in their own rendering layer.

**Test plan**
- `mix test test/phoenix_kit_web/users/auth_seo_test.exs test/phoenix_kit_web/users/auth_seo_mount_test.exs` — 12 new tests
- `mix test` — full suite, 43 doctests + 3858 tests, 0 failures
- `mix format --check-formatted`, `mix credo --strict`, `mix compile --warnings-as-errors --all-warnings` — clean
- Dialyzer not run: no PLT built in this clone. Say if you want it before merge.
