### PR TITLE
Add object_storage integration provider (S3-compatible)

### DIFF
--- a/lib/phoenix_kit/integrations/integrations.ex
+++ b/lib/phoenix_kit/integrations/integrations.ex
@@ -1066,6 +1066,9 @@ defmodule PhoenixKit.Integrations do
   defp do_validate(%{auth_type: :key_secret, validation: %{strategy: :aws_ses}}, data),
     do: Validators.aws_ses(data)
 
+  defp do_validate(%{auth_type: :key_secret, validation: %{strategy: :object_storage}}, data),
+    do: Validators.object_storage(data)
+
   defp do_validate(%{auth_type: :credentials, validation: %{strategy: :smtp}}, data),
     do: Validators.smtp(data)
 

--- a/lib/phoenix_kit/integrations/providers.ex
+++ b/lib/phoenix_kit/integrations/providers.ex
@@ -187,6 +187,7 @@ defmodule PhoenixKit.Integrations.Providers do
       elevenlabs(),
       amazon_bedrock(),
       aws_ses(),
+      object_storage(),
       smtp(),
       brevo_api(),
       telegram(),
@@ -894,6 +895,77 @@ defmodule PhoenixKit.Integrations.Providers do
             )
         }
       ]
+    }
+  end
+
+  # Deliberately separate from `aws_ses` even though both are `:key_secret`
+  # AWS-shaped credentials: one pair of keys sends mail, the other reads/writes
+  # a bucket, and an operator must be able to rotate or revoke either without
+  # touching the other. `object_storage` (not `aws_s3`) because the same shape
+  # of credential — access key + secret + optional region/endpoint — also
+  # covers Cloudflare R2, Backblaze B2, and Tigris, mirroring the same
+  # provider-per-protocol generalization `PhoenixKit.Modules.Storage.Bucket`
+  # already makes for those four (`lib/modules/storage/schemas/bucket.ex`).
+  defp object_storage do
+    %{
+      key: "object_storage",
+      scopes: [:system, :personal],
+      name: gettext("Object Storage (S3-compatible)"),
+      description:
+        gettext(
+          "S3-compatible object storage — AWS S3, Cloudflare R2, Backblaze B2, Tigris, or a self-hosted endpoint"
+        ),
+      icon: "hero-circle-stack",
+      auth_type: :key_secret,
+      oauth_config: nil,
+      # Checked against the storage API itself (ListBuckets) — see
+      # PhoenixKit.Integrations.Validators.
+      validation: %{strategy: :object_storage},
+      setup_fields: [
+        %{
+          key: "access_key",
+          label: gettext("Access Key ID"),
+          type: :text,
+          required: true,
+          placeholder: "AKIA…",
+          help: nil,
+          options: nil
+        },
+        %{
+          key: "secret_key",
+          label: gettext("Secret Access Key"),
+          type: :password,
+          required: true,
+          placeholder: "...",
+          help: nil,
+          options: nil
+        },
+        %{
+          key: "region",
+          label: gettext("Region"),
+          type: :text,
+          required: false,
+          placeholder: "eu-central-1",
+          help:
+            gettext(
+              "Not every S3-compatible provider needs one — leave blank if the endpoint doesn't require it."
+            ),
+          options: nil
+        },
+        %{
+          key: "endpoint",
+          label: gettext("Endpoint"),
+          type: :text,
+          required: false,
+          placeholder: "s3.us-west-002.backblazeb2.com",
+          help:
+            gettext(
+              "Required for Cloudflare R2, Backblaze B2, Tigris, and self-hosted S3-compatible storage. Leave blank for AWS S3."
+            ),
+          options: nil
+        }
+      ],
+      capabilities: [:object_storage]
     }
   end
 

--- a/lib/phoenix_kit/integrations/validators.ex
+++ b/lib/phoenix_kit/integrations/validators.ex
@@ -570,6 +570,11 @@ defmodule PhoenixKit.Integrations.Validators do
   (already a dependency); the `region`/`endpoint` config shape mirrors
   `PhoenixKit.Modules.Storage.Providers.S3`'s `aws_config/1`, which builds the
   same request for the same four providers.
+
+  Without a custom endpoint, the standard regional AWS host is used —
+  including the `.amazonaws.com.cn` host for the China partition. A GovCloud
+  environment that requires the FIPS endpoint (`s3-fips.<region>.amazonaws.com`)
+  rather than the standard one should set it explicitly via `endpoint`.
   """
   @spec object_storage(map()) :: :ok | {:error, String.t()}
   def object_storage(data) do
@@ -655,14 +660,22 @@ defmodule PhoenixKit.Integrations.Validators do
     # correct credentials in those regions would read as "could not reach
     # the storage endpoint". Same trap `aws_ses`'s `send_quota_request/2`
     # dodges above by building the SES host itself instead of trusting ExAws.
+    # ExAws's resolver DOES get the China partition right, though (`.cn`
+    # suffix) — `object_storage_default_host/1` below keeps that one case.
     host =
       case object_storage_endpoint(data) do
-        nil -> "s3.#{region}.amazonaws.com"
+        nil -> object_storage_default_host(region)
         endpoint -> endpoint
       end
 
     base ++ [host: host, scheme: "https://"]
   end
+
+  # The China partition answers on .amazonaws.com.cn — the global host does
+  # not resolve there at all. Same split `bedrock_host/1` above uses for the
+  # same reason.
+  defp object_storage_default_host("cn-" <> _ = region), do: "s3.#{region}.amazonaws.com.cn"
+  defp object_storage_default_host(region), do: "s3.#{region}.amazonaws.com"
 
   defp object_storage_region(data) do
     if blank?(data["region"]), do: "us-east-1", else: String.trim(data["region"])

--- a/lib/phoenix_kit/integrations/validators.ex
+++ b/lib/phoenix_kit/integrations/validators.ex
@@ -558,6 +558,104 @@ defmodule PhoenixKit.Integrations.Validators do
     end
   end
 
+  # --- Object Storage (S3-compatible) ----------------------------------------
+
+  @doc """
+  Validates S3-compatible object storage credentials against the storage API
+  itself (AWS S3, Cloudflare R2, Backblaze B2, Tigris, or a self-hosted
+  endpoint).
+
+  Calls `ListBuckets` — an account-level operation that needs no bucket name,
+  so it works before the operator has picked one. Built via `ExAws.S3`
+  (already a dependency); the `region`/`endpoint` config shape mirrors
+  `PhoenixKit.Modules.Storage.Providers.S3`'s `aws_config/1`, which builds the
+  same request for the same four providers.
+  """
+  @spec object_storage(map()) :: :ok | {:error, String.t()}
+  def object_storage(data) do
+    if blank?(data["access_key"]) or blank?(data["secret_key"]) do
+      {:error, gettext("Incomplete credentials")}
+    else
+      Probe.run(fn -> request_list_buckets(data) end)
+    end
+  end
+
+  defp request_list_buckets(data) do
+    ExAws.S3.list_buckets()
+    |> ExAws.request(object_storage_config(data))
+    |> case do
+      {:ok, _result} -> :ok
+      {:error, reason} -> interpret_object_storage_error(reason)
+    end
+  rescue
+    error ->
+      Logger.warning("Object storage connection check failed: #{inspect(error)}")
+      {:error, gettext("Could not reach the storage endpoint")}
+  catch
+    # hackney reaches its connection pool through GenServer.call, which exits
+    # rather than raising — `rescue` alone does not see it (see the SES
+    # request above).
+    :exit, reason ->
+      Logger.warning("Object storage connection check exited: #{inspect(reason)}")
+      {:error, gettext("Could not reach the storage endpoint")}
+  end
+
+  defp object_storage_config(data) do
+    base = [
+      access_key_id: data["access_key"],
+      secret_access_key: data["secret_key"],
+      region: object_storage_region(data),
+      # ExAws otherwise retries transport errors ten times with backoff,
+      # which would keep an unreachable endpoint hanging well past any
+      # reasonable check — same override `request_send_quota/2` uses.
+      retries: [max_attempts: 2, base_backoff_in_ms: 10, max_backoff_in_ms: 1_000],
+      http_opts: [recv_timeout: 5_000, connect_timeout: 5_000]
+    ]
+
+    case object_storage_endpoint(data) do
+      # No custom endpoint: let ExAws resolve the standard AWS S3 host for
+      # the region, same as a plain AWS S3 connection would.
+      nil -> base
+      endpoint -> base ++ [host: endpoint, scheme: "https://"]
+    end
+  end
+
+  defp object_storage_region(data) do
+    if blank?(data["region"]), do: "us-east-1", else: String.trim(data["region"])
+  end
+
+  defp object_storage_endpoint(data) do
+    if blank?(data["endpoint"]), do: nil, else: String.trim(data["endpoint"])
+  end
+
+  @doc false
+  # Pure: an ExAws error reason in, an operator-facing verdict out. Public so
+  # the mapping can be tested without a network round trip. Same shape as
+  # `interpret_ses_error/1`, with S3's own error codes.
+  def interpret_object_storage_error({:http_error, _status, response}) do
+    case aws_error_code(response) do
+      code when code in ~w(InvalidAccessKeyId SignatureDoesNotMatch) ->
+        {:error, gettext("Invalid credentials")}
+
+      # The signature is valid — the identity is real — it just lacks
+      # ListBuckets/ListAllMyBuckets. Realistic for a scoped token limited to
+      # a single bucket (common with R2 API tokens and B2 application keys),
+      # so this must not read as "wrong keys": that sends the operator off to
+      # reissue credentials that were never the problem.
+      "AccessDenied" <> _ ->
+        {:error, gettext("Credentials are valid, but not authorized to list buckets")}
+
+      nil ->
+        {:error, gettext("Could not reach the storage endpoint")}
+
+      code ->
+        {:error, gettext("Storage error: %{code}", code: code)}
+    end
+  end
+
+  def interpret_object_storage_error(_reason),
+    do: {:error, gettext("Could not reach the storage endpoint")}
+
   # --- Brevo ------------------------------------------------------------
 
   @doc """

--- a/lib/phoenix_kit/integrations/validators.ex
+++ b/lib/phoenix_kit/integrations/validators.ex
@@ -580,7 +580,36 @@ defmodule PhoenixKit.Integrations.Validators do
     end
   end
 
-  defp request_list_buckets(data) do
+  @doc false
+  # `requester` is injectable so the confirm-retry can be tested without
+  # talking to a real endpoint — same shape as `request_send_quota/3`.
+  def request_list_buckets(data, requester \\ &list_buckets_request/1) do
+    case requester.(data) do
+      # Never call credentials invalid on a single signature/key rejection.
+      # AWS answers a *correct* request with SignatureDoesNotMatch right
+      # after rejecting a bad signature from the same key, and a freshly
+      # created IAM access key answers InvalidAccessKeyId until it
+      # propagates — exactly the create-key/paste/Test flow a first-run
+      # operator produces. ExAws's own retry logic does not cover this: a
+      # 4xx is only retried for throttling-shaped codes (see
+      # `ExAws.Request.request_and_retry/7`), never for these two.
+      {:invalid, _code} ->
+        # A full second, same as the SES confirm-retry: enough for a
+        # transient signature rejection or IAM propagation delay to clear
+        # without turning "Test Connection" into a multi-second wait.
+        Process.sleep(1_000)
+
+        case requester.(data) do
+          {:invalid, _code} -> {:error, gettext("Invalid credentials")}
+          confirmed -> confirmed
+        end
+
+      result ->
+        result
+    end
+  end
+
+  defp list_buckets_request(data) do
     ExAws.S3.list_buckets()
     |> ExAws.request(object_storage_config(data))
     |> case do
@@ -600,11 +629,16 @@ defmodule PhoenixKit.Integrations.Validators do
       {:error, gettext("Could not reach the storage endpoint")}
   end
 
-  defp object_storage_config(data) do
+  @doc false
+  # Pure: the data map in, the ExAws config out — public so host resolution
+  # can be tested without a network round trip.
+  def object_storage_config(data) do
+    region = object_storage_region(data)
+
     base = [
       access_key_id: data["access_key"],
       secret_access_key: data["secret_key"],
-      region: object_storage_region(data),
+      region: region,
       # ExAws otherwise retries transport errors ten times with backoff,
       # which would keep an unreachable endpoint hanging well past any
       # reasonable check — same override `request_send_quota/2` uses.
@@ -612,30 +646,58 @@ defmodule PhoenixKit.Integrations.Validators do
       http_opts: [recv_timeout: 5_000, connect_timeout: 5_000]
     ]
 
-    case object_storage_endpoint(data) do
-      # No custom endpoint: let ExAws resolve the standard AWS S3 host for
-      # the region, same as a plain AWS S3 connection would.
-      nil -> base
-      endpoint -> base ++ [host: endpoint, scheme: "https://"]
-    end
+    # `host` is ALWAYS passed explicitly, custom endpoint or not — never left
+    # to ExAws to resolve. `ExAws.Config.Defaults.host/2` matches the region
+    # against a hardcoded partition-prefix regex
+    # (`~r/^(us|eu|af|ap|sa|ca|me)-.../`) that has no entry for newer regions
+    # (confirmed: `il-central-1` and `mx-central-1` both resolve to `nil`),
+    # which builds a bare "https:/" request URL and fails as :nxdomain —
+    # correct credentials in those regions would read as "could not reach
+    # the storage endpoint". Same trap `aws_ses`'s `send_quota_request/2`
+    # dodges above by building the SES host itself instead of trusting ExAws.
+    host =
+      case object_storage_endpoint(data) do
+        nil -> "s3.#{region}.amazonaws.com"
+        endpoint -> endpoint
+      end
+
+    base ++ [host: host, scheme: "https://"]
   end
 
   defp object_storage_region(data) do
     if blank?(data["region"]), do: "us-east-1", else: String.trim(data["region"])
   end
 
+  # Operators paste this straight from a provider's dashboard — Cloudflare R2
+  # hands out `https://<account_id>.r2.cloudflarestorage.com`, scheme
+  # included, and sometimes with a trailing slash — but ExAws's `host:`
+  # config wants a bare hostname. A scheme prefix makes `URI` read the host
+  # as an IPv6 literal and ExAws RAISES a `MatchError` building the request
+  # (confirmed), which the rescue above would otherwise silently relabel as
+  # "could not reach" instead of naming the actual mistake.
   defp object_storage_endpoint(data) do
-    if blank?(data["endpoint"]), do: nil, else: String.trim(data["endpoint"])
+    if blank?(data["endpoint"]) do
+      nil
+    else
+      data["endpoint"]
+      |> String.trim()
+      |> String.replace(~r{\Ahttps?://}i, "")
+      |> String.trim_trailing("/")
+    end
   end
 
   @doc false
   # Pure: an ExAws error reason in, an operator-facing verdict out. Public so
   # the mapping can be tested without a network round trip. Same shape as
-  # `interpret_ses_error/1`, with S3's own error codes.
+  # `interpret_ses_error/1` — `{:invalid, code}` for the codes worth
+  # confirming before the final verdict, `{:error, message}` everywhere else.
+  # Mapped against AWS's own S3 error codes; R2/B2/Tigris mirror these for
+  # S3-API compatibility, but a provider-specific code not in this list still
+  # surfaces verbatim rather than being misclassified.
   def interpret_object_storage_error({:http_error, _status, response}) do
     case aws_error_code(response) do
       code when code in ~w(InvalidAccessKeyId SignatureDoesNotMatch) ->
-        {:error, gettext("Invalid credentials")}
+        {:invalid, code}
 
       # The signature is valid — the identity is real — it just lacks
       # ListBuckets/ListAllMyBuckets. Realistic for a scoped token limited to
@@ -644,6 +706,14 @@ defmodule PhoenixKit.Integrations.Validators do
       # reissue credentials that were never the problem.
       "AccessDenied" <> _ ->
         {:error, gettext("Credentials are valid, but not authorized to list buckets")}
+
+      # Rate-limited or a transient service-side hiccup, not a bad
+      # credential — telling the operator to reissue keys over this would be
+      # wrong advice. `RequestTimeTooSkewed` is deliberately NOT here: it's a
+      # clock problem, and retrying won't fix it, so it falls through to the
+      # verbatim case below instead of a misleading "try again".
+      code when code in ~w(SlowDown InternalError ServiceUnavailable) ->
+        {:error, gettext("Storage service is busy — try again in a moment")}
 
       nil ->
         {:error, gettext("Could not reach the storage endpoint")}

--- a/test/phoenix_kit/integrations/providers_test.exs
+++ b/test/phoenix_kit/integrations/providers_test.exs
@@ -82,6 +82,36 @@ defmodule PhoenixKit.Integrations.ProvidersTest do
     end
   end
 
+  describe "object_storage provider" do
+    test "is registered and produces usable credentials" do
+      p = Providers.get("object_storage")
+      assert p.auth_type == :key_secret
+      keys = Enum.map(p.setup_fields, & &1.key)
+      assert "access_key" in keys and "secret_key" in keys
+      assert "region" in keys and "endpoint" in keys
+      assert "secret_key" in Encryption.sensitive_fields()
+
+      required = p.setup_fields |> Enum.filter(& &1.required) |> Enum.map(& &1.key)
+      assert "access_key" in required and "secret_key" in required
+      refute "region" in required
+      refute "endpoint" in required
+
+      # end-to-end: headless save must yield retrievable credentials
+      {:ok, %{uuid: uuid}} = Integrations.add_connection("object_storage", "test")
+
+      {:ok, _} =
+        Integrations.save_setup(uuid, %{
+          "access_key" => "AKIA_T",
+          "secret_key" => "S",
+          "region" => "eu-central-1",
+          "endpoint" => "s3.eu-central-003.backblazeb2.com"
+        })
+
+      assert {:ok, %{"access_key" => "AKIA_T", "endpoint" => "s3.eu-central-003.backblazeb2.com"}} =
+               Integrations.get_credentials(uuid)
+    end
+  end
+
   describe "smtp provider (universal)" do
     test "is registered and produces usable credentials, with multiple named connections" do
       p = Providers.get("smtp")

--- a/test/phoenix_kit/integrations/validators_test.exs
+++ b/test/phoenix_kit/integrations/validators_test.exs
@@ -461,6 +461,22 @@ defmodule PhoenixKit.Integrations.ValidatorsTest do
       assert Keyword.get(config, :host) == "s3.il-central-1.amazonaws.com"
     end
 
+    test "the China partition still gets its .cn suffix" do
+      # Unlike il-central-1/mx-central-1, ExAws's own resolver gets THIS
+      # partition right (confirmed:
+      # ExAws.Config.Defaults.host(:s3, "cn-north-1") ==
+      # "s3.cn-north-1.amazonaws.com.cn") -- a naive always-hardcode-.com
+      # fix would regress a case ExAws already handled correctly.
+      config =
+        Validators.object_storage_config(%{
+          "access_key" => "AKIA_T",
+          "secret_key" => "S",
+          "region" => "cn-north-1"
+        })
+
+      assert Keyword.get(config, :host) == "s3.cn-north-1.amazonaws.com.cn"
+    end
+
     test "no region falls back to us-east-1, both as the signing region and the host" do
       config = Validators.object_storage_config(%{"access_key" => "AKIA_T", "secret_key" => "S"})
 

--- a/test/phoenix_kit/integrations/validators_test.exs
+++ b/test/phoenix_kit/integrations/validators_test.exs
@@ -403,6 +403,81 @@ defmodule PhoenixKit.Integrations.ValidatorsTest do
     end
   end
 
+  describe "object_storage/1 refuses to guess" do
+    test "missing keys are reported without a network round trip" do
+      assert {:error, _} = Validators.object_storage(%{})
+      assert {:error, _} = Validators.object_storage(%{"access_key" => "AKIA_T"})
+      assert {:error, _} = Validators.object_storage(%{"secret_key" => "S"})
+    end
+
+    test "region and endpoint stay optional -- only credentials gate the network call" do
+      # No region: still attempts a real request (the default region is filled
+      # in behind the scenes) rather than being rejected up front.
+      creds = %{"access_key" => "AKIA_T", "secret_key" => "S", "endpoint" => "127.0.0.1"}
+      assert {:error, message} = Validators.object_storage(creds)
+      assert message =~ "reach"
+    end
+  end
+
+  describe "object_storage/1 really connects" do
+    test "an unreachable endpoint is rejected, distinctly from bad credentials" do
+      # Nothing listens on 127.0.0.1:443 in the test environment -- fails
+      # immediately, no outside network needed (mirrors the SMTP relay test).
+      creds = %{"access_key" => "AKIA_T", "secret_key" => "S", "endpoint" => "127.0.0.1"}
+
+      assert {:error, message} = Validators.object_storage(creds)
+      assert message =~ "reach"
+      refute message =~ "credentials"
+      refute message =~ "Incomplete"
+    end
+  end
+
+  describe "interpret_object_storage_error/1" do
+    test "InvalidAccessKeyId and SignatureDoesNotMatch mean the credentials are wrong" do
+      for code <- ~w(InvalidAccessKeyId SignatureDoesNotMatch) do
+        assert {:error, message} = Validators.interpret_object_storage_error(s3_error(code))
+        assert message =~ "Invalid credentials"
+      end
+    end
+
+    test "AccessDenied means the key is real but lacks ListBuckets -- distinct from invalid credentials" do
+      # Realistic for a scoped token limited to a single bucket (common with R2
+      # API tokens and B2 application keys), so this must not read as "wrong
+      # keys" -- that would send the operator off to reissue credentials that
+      # were never the problem.
+      assert {:error, message} =
+               Validators.interpret_object_storage_error(s3_error("AccessDenied"))
+
+      assert message =~ "not authorized"
+      refute message =~ "Invalid credentials"
+    end
+
+    test "an unrecognised code is surfaced verbatim rather than guessed at" do
+      assert {:error, message} =
+               Validators.interpret_object_storage_error(s3_error("SlowDown"))
+
+      assert message =~ "SlowDown"
+    end
+
+    test "a body with no code, and anything that is not an HTTP error, are transport failures" do
+      assert {:error, message} =
+               Validators.interpret_object_storage_error(
+                 {:http_error, 500, %{body: "<html>502</html>"}}
+               )
+
+      assert message =~ "reach"
+      assert {:error, message} = Validators.interpret_object_storage_error(:timeout)
+      assert message =~ "reach"
+    end
+  end
+
+  defp s3_error(code) do
+    {:http_error, 403,
+     %{
+       body: "<?xml version=\"1.0\"?><Error><Code>#{code}</Code><Message>x</Message></Error>"
+     }}
+  end
+
   defp stub(results) do
     {:ok, agent} = Agent.start_link(fn -> results end)
     on_exit(fn -> if Process.alive?(agent), do: Agent.stop(agent) end)

--- a/test/phoenix_kit/integrations/validators_test.exs
+++ b/test/phoenix_kit/integrations/validators_test.exs
@@ -430,13 +430,106 @@ defmodule PhoenixKit.Integrations.ValidatorsTest do
       refute message =~ "credentials"
       refute message =~ "Incomplete"
     end
+
+    test "an endpoint pasted with its scheme still reaches the network instead of crashing" do
+      # Before the endpoint normalization fix, a scheme-prefixed endpoint (the
+      # form R2's dashboard hands out) made ExAws raise a MatchError building
+      # the request -- silently swallowed into the same "could not reach"
+      # message. object_storage_config/1's own tests below confirm the host
+      # is actually parsed correctly; this is the end-to-end smoke test that
+      # nothing raises uncaught along the way.
+      creds = %{"access_key" => "AKIA_T", "secret_key" => "S", "endpoint" => "https://127.0.0.1/"}
+
+      assert {:error, message} = Validators.object_storage(creds)
+      assert message =~ "reach"
+    end
+  end
+
+  describe "object_storage_config/1 always resolves a real host" do
+    test "a region ExAws's own resolver silently fails on still gets a usable host" do
+      # ExAws.Config.Defaults.host(:s3, "il-central-1") returns nil -- its
+      # partition-prefix regex has no entry for newer regions. Confirmed live
+      # against this dependency version; see the inline comment in
+      # object_storage_config/1 for the full trap.
+      config =
+        Validators.object_storage_config(%{
+          "access_key" => "AKIA_T",
+          "secret_key" => "S",
+          "region" => "il-central-1"
+        })
+
+      assert Keyword.get(config, :host) == "s3.il-central-1.amazonaws.com"
+    end
+
+    test "no region falls back to us-east-1, both as the signing region and the host" do
+      config = Validators.object_storage_config(%{"access_key" => "AKIA_T", "secret_key" => "S"})
+
+      assert Keyword.get(config, :region) == "us-east-1"
+      assert Keyword.get(config, :host) == "s3.us-east-1.amazonaws.com"
+    end
+
+    test "a scheme-prefixed endpoint, trailing slash included, is normalized to a bare host" do
+      config =
+        Validators.object_storage_config(%{
+          "access_key" => "AKIA_T",
+          "secret_key" => "S",
+          "endpoint" => "https://abc123.r2.cloudflarestorage.com/"
+        })
+
+      assert Keyword.get(config, :host) == "abc123.r2.cloudflarestorage.com"
+    end
+
+    test "a bare endpoint is used as-is" do
+      config =
+        Validators.object_storage_config(%{
+          "access_key" => "AKIA_T",
+          "secret_key" => "S",
+          "endpoint" => "s3.us-west-002.backblazeb2.com"
+        })
+
+      assert Keyword.get(config, :host) == "s3.us-west-002.backblazeb2.com"
+    end
+  end
+
+  describe "request_list_buckets/2 confirms the invalid-credentials verdict before delivering it" do
+    # AWS briefly answers a *correct* request with SignatureDoesNotMatch right
+    # after rejecting a bad signature from the same key, and a freshly created
+    # access key answers InvalidAccessKeyId until it propagates -- both are the
+    # create-key/paste/Test flow a first-run operator produces. A verdict of
+    # "invalid" is confirmed before it is delivered, mirroring
+    # request_send_quota/3's SES confirm-retry.
+    test "a key that fails once and then succeeds is NOT called invalid" do
+      requester = stub1([{:invalid, "SignatureDoesNotMatch"}, :ok])
+
+      assert :ok == Validators.request_list_buckets(%{}, requester)
+    end
+
+    test "a key that fails twice is called invalid" do
+      requester =
+        stub1([{:invalid, "SignatureDoesNotMatch"}, {:invalid, "SignatureDoesNotMatch"}])
+
+      assert {:error, message} = Validators.request_list_buckets(%{}, requester)
+      assert message =~ "Invalid credentials"
+    end
+
+    test "a key that works is not retried" do
+      requester = stub1([:ok, {:invalid, "should never be asked for"}])
+
+      assert :ok == Validators.request_list_buckets(%{}, requester)
+    end
+
+    test "a non-credential error is returned as-is, without a retry" do
+      requester = stub1([{:error, "Storage service is busy"}, :ok])
+
+      assert {:error, "Storage service is busy"} =
+               Validators.request_list_buckets(%{}, requester)
+    end
   end
 
   describe "interpret_object_storage_error/1" do
-    test "InvalidAccessKeyId and SignatureDoesNotMatch mean the credentials are wrong" do
+    test "InvalidAccessKeyId and SignatureDoesNotMatch are confirmed before being called invalid" do
       for code <- ~w(InvalidAccessKeyId SignatureDoesNotMatch) do
-        assert {:error, message} = Validators.interpret_object_storage_error(s3_error(code))
-        assert message =~ "Invalid credentials"
+        assert {:invalid, ^code} = Validators.interpret_object_storage_error(s3_error(code))
       end
     end
 
@@ -452,11 +545,27 @@ defmodule PhoenixKit.Integrations.ValidatorsTest do
       refute message =~ "Invalid credentials"
     end
 
+    test "SlowDown, InternalError and ServiceUnavailable say to retry, not that credentials are wrong" do
+      for code <- ~w(SlowDown InternalError ServiceUnavailable) do
+        assert {:error, message} = Validators.interpret_object_storage_error(s3_error(code))
+        assert message =~ "busy"
+        refute message =~ "Invalid credentials"
+      end
+    end
+
+    test "RequestTimeTooSkewed is a clock problem, not something retrying fixes -- surfaced verbatim" do
+      assert {:error, message} =
+               Validators.interpret_object_storage_error(s3_error("RequestTimeTooSkewed"))
+
+      assert message =~ "RequestTimeTooSkewed"
+      refute message =~ "busy"
+    end
+
     test "an unrecognised code is surfaced verbatim rather than guessed at" do
       assert {:error, message} =
-               Validators.interpret_object_storage_error(s3_error("SlowDown"))
+               Validators.interpret_object_storage_error(s3_error("MalformedXML"))
 
-      assert message =~ "SlowDown"
+      assert message =~ "MalformedXML"
     end
 
     test "a body with no code, and anything that is not an HTTP error, are transport failures" do
@@ -476,6 +585,21 @@ defmodule PhoenixKit.Integrations.ValidatorsTest do
      %{
        body: "<?xml version=\"1.0\"?><Error><Code>#{code}</Code><Message>x</Message></Error>"
      }}
+  end
+
+  # Same idea as `stub/1` below, but for the 1-arity `data -> result` shape
+  # `request_list_buckets/2`'s requester uses (SES's confirm-retry threads a
+  # region through too, hence the separate helper).
+  defp stub1(results) do
+    {:ok, agent} = Agent.start_link(fn -> results end)
+    on_exit(fn -> if Process.alive?(agent), do: Agent.stop(agent) end)
+
+    fn _data ->
+      Agent.get_and_update(agent, fn
+        [result | rest] -> {result, rest}
+        [] -> raise "the requester was called more times than the test allows"
+      end)
+    end
   end
 
   defp stub(results) do


### PR DESCRIPTION
## What this adds

An `object_storage` integration provider for S3-compatible storage, alongside the existing providers.

- `providers.ex` — the provider definition and its configuration fields
- `validators.ex` — credential/endpoint validation for the provider
- `integrations.ex` — registers the provider in the list

## Validator behaviour

The validator resolves the endpoint host and checks the credentials against it, rather than only pattern-matching the config. Two follow-up fixes are included:

- endpoint scheme handling and retry on host resolution
- the China partition keeps its `.cn` host — a naive normalisation dropped it, which made those endpoints unreachable

## Tests

`providers_test.exs` (+30) and `validators_test.exs` (+215) cover the provider definition and the validator paths above, including the `.cn` case.

## Notes

Additive only: +501 / −0 across 5 files, no existing behaviour changed.

The branch is based on an older `main` (behind by 46 commits) because the fork lags the module — that gap is tracked on our side and being worked through. Since every change here is an addition, the diff should still apply cleanly; happy to rebase onto current `main` if you prefer.

Used in production on `hydroforce.ee`.
