### PR TITLE
Fix duplicate <loc> and a crash-to-empty-sitemap defect left after #730

### DIFF
--- a/lib/modules/sitemap/domain_mode.ex
+++ b/lib/modules/sitemap/domain_mode.ex
@@ -129,7 +129,7 @@ defmodule PhoenixKit.Modules.Sitemap.DomainMode do
             if primary?,
               do:
                 Enum.sort_by(
-                  own ++ domainless_entries(groups, host_by_lang, primary, base_url),
+                  own ++ extra_for_primary(own, groups, host_by_lang, primary, base_url),
                   & &1.loc
                 ),
               else: own
@@ -137,6 +137,20 @@ defmodule PhoenixKit.Modules.Sitemap.DomainMode do
           {host, entries}
         end)
     end
+  end
+
+  # The primary domain's own language owns its URLs. A domainless language's
+  # entry can land on the same URL when the site's default language is NOT the
+  # primary domain's language and has no domain: its URLs carry no locale
+  # prefix, so re-hosting puts them on the primary's root — where that domain's
+  # own language already is. Publishing both would put the same <loc> in one
+  # file twice; the host's own language wins.
+  defp extra_for_primary(own, groups, host_by_lang, primary, base_url) do
+    taken = MapSet.new(own, & &1.loc)
+
+    groups
+    |> domainless_entries(host_by_lang, primary, base_url)
+    |> Enum.reject(&MapSet.member?(taken, &1.loc))
   end
 
   # An enabled language that has no domain of its own is served with its locale

--- a/lib/modules/sitemap/sources/router_discovery.ex
+++ b/lib/modules/sitemap/sources/router_discovery.ex
@@ -338,12 +338,12 @@ defmodule PhoenixKit.Modules.Sitemap.Sources.RouterDiscovery do
 
       json_string when is_binary(json_string) ->
         case JSON.decode(json_string) do
-          {:ok, pipelines} when is_list(pipelines) -> Enum.map(pipelines, &safe_to_atom/1)
+          {:ok, pipelines} when is_list(pipelines) -> to_atoms(pipelines)
           _ -> @default_non_page_pipelines
         end
 
       pipelines when is_list(pipelines) ->
-        Enum.map(pipelines, &safe_to_atom/1)
+        to_atoms(pipelines)
 
       _ ->
         @default_non_page_pipelines
@@ -392,22 +392,30 @@ defmodule PhoenixKit.Modules.Sitemap.Sources.RouterDiscovery do
       json_string when is_binary(json_string) ->
         case JSON.decode(json_string) do
           {:ok, pipelines} when is_list(pipelines) ->
-            Enum.map(pipelines, &safe_to_atom/1)
+            to_atoms(pipelines)
 
           _ ->
             []
         end
 
       pipelines when is_list(pipelines) ->
-        Enum.map(pipelines, &safe_to_atom/1)
+        to_atoms(pipelines)
 
       _ ->
         []
     end
   end
 
+  defp to_atoms(values), do: values |> Enum.map(&safe_to_atom/1) |> Enum.reject(&is_nil/1)
+
   defp safe_to_atom(value) when is_atom(value), do: value
   defp safe_to_atom(value) when is_binary(value), do: String.to_atom(value)
+
+  # A settings list is hand-edited JSON; one bad element must not take the
+  # source down with it. Without this clause the FunctionClauseError is caught
+  # by `collect/1`'s rescue and every discovered route disappears from the
+  # sitemap silently — a typo in a settings field emptying a whole source.
+  defp safe_to_atom(_other), do: nil
 
   defp disabled_module_route?(path) do
     Enum.any?(@module_route_prefixes, fn {prefix, {mod, fun}} ->

--- a/test/integration/sitemap/router_discovery_api_pipeline_test.exs
+++ b/test/integration/sitemap/router_discovery_api_pipeline_test.exs
@@ -107,6 +107,19 @@ defmodule PhoenixKit.Integration.Sitemap.RouterDiscoveryApiPipelineTest do
            ]
   end
 
+  test "a junk element in sitemap_non_page_pipelines does not take the source down" do
+    # The setting is hand-edited JSON. A non-string element used to raise inside
+    # collect/1, whose rescue swallowed it and returned [] — one typo in a
+    # settings field emptied the entire router-discovery source, silently.
+    {:ok, _} =
+      Settings.update_setting("sitemap_non_page_pipelines", JSON.encode!(["phoenix_kit_api", 1]))
+
+    locs = RouterDiscovery.collect(base_url: @base_url) |> Enum.map(& &1.loc) |> Enum.sort()
+
+    # The good element still filters; the junk one is ignored, not fatal.
+    assert locs == ["#{@base_url}/about", "#{@base_url}/caddy/ask"]
+  end
+
   test "default_non_page_pipelines/0 exposes the JSON pipelines it filters on" do
     defaults = RouterDiscovery.default_non_page_pipelines()
 

--- a/test/integration/sitemap/static_domain_pages_test.exs
+++ b/test/integration/sitemap/static_domain_pages_test.exs
@@ -162,6 +162,26 @@ defmodule PhoenixKit.Integration.Sitemap.StaticDomainPagesTest do
     refute fr_xml =~ "/fr/"
   end
 
+  test "index mode keeps it out of the per-module static file too" do
+    # Flat vs index is decided by router discovery; the test above only
+    # exercises flat mode, where the legacy set is one urlset. In index mode the
+    # legacy set is per-module files, and sitemap-static.xml is the one that
+    # would carry a leaked /fr/ entry.
+    {:ok, _} = Settings.update_boolean_setting("sitemap_router_discovery_enabled", false)
+    {:ok, _} = Settings.update_boolean_setting("sitemap_enabled", true)
+    {:ok, _} = Settings.update_boolean_setting("crawlers_no_index", false)
+    {:ok, _} = Settings.update_setting("site_url", @base)
+
+    assert {:ok, _} = Generator.generate_all(base_url: @base)
+
+    static_path = FileStorage.module_file_path("sitemap-static")
+    assert File.exists?(static_path)
+    refute File.read!(static_path) =~ "#{@base}/fr/"
+
+    {:ok, fr_path} = FileStorage.domain_file_path("site.example.fr", "sitemap")
+    assert File.read!(fr_path) =~ "<loc>https://site.example.fr/</loc>"
+  end
+
   test "the mapped domain's file ends up carrying its own home page" do
     entries = Static.collect(base_url: @base, language: "en", is_default_language: true)
 

--- a/test/integration/sitemap/static_domain_pages_test.exs
+++ b/test/integration/sitemap/static_domain_pages_test.exs
@@ -8,6 +8,10 @@ defmodule PhoenixKit.Integration.Sitemap.StaticDomainPagesProviderStub do
   end
 
   def empty, do: []
+
+  # The primary domain hosts a language that is NOT the site default, and the
+  # site default (en) has no domain at all.
+  def primary_is_not_default, do: [%{host: "site.example.fr", language: "fr", primary: true}]
 end
 
 defmodule PhoenixKit.Integration.Sitemap.StaticDomainPagesTest do
@@ -117,6 +121,27 @@ defmodule PhoenixKit.Integration.Sitemap.StaticDomainPagesTest do
 
     assert "https://site.example.fr/lookbook" in fr_locs
     refute Enum.any?(fr_locs, &String.contains?(&1, "/fr/"))
+  end
+
+  test "primary hosting a non-default language does not duplicate its home page" do
+    # The site default (en) has no domain, so its unprefixed home page URL
+    # re-hosts onto the primary's root — where the primary's own language (fr)
+    # now also has one. Both would be the same <loc> in the same file.
+    Application.put_env(:phoenix_kit, :sitemap_domains_provider, {Stub, :primary_is_not_default})
+
+    entries =
+      Static.collect(base_url: @base, language: "en", is_default_language: true) ++
+        Static.collect(
+          base_url: @base,
+          language: "fr",
+          is_default_language: false,
+          domain_pass: true
+        )
+
+    locs = DomainMode.rebuild_for_domains(entries, @base)["site.example.fr"] |> Enum.map(& &1.loc)
+
+    assert locs == ["https://site.example.fr/"]
+    assert Enum.uniq(locs) == locs
   end
 
   test "generate_all keeps the prefixed intermediate out of the legacy set" do


### PR DESCRIPTION
## What's broken

Two defects in the sitemap module, both introduced by the mapped-domain
static-pages work in #730 (merged) and left unfixed on that branch after
merge:

1. **Duplicate `<loc>` on the primary domain.** When the primary domain
   hosts a language that is NOT the site default, and the site default has
   no domain of its own, the default language's unprefixed home page
   re-hosts onto the primary's root — where the primary's own language now
   also has one, since #730 gave every mapped language its static pages.
   Both got published: the same URL twice in one sitemap file.

2. **One bad pipeline element emptied the whole source.** `safe_to_atom/1`
   only handled atoms and binaries, so a JSON array setting value like
   `["phoenix_kit_api", 1]` raised `FunctionClauseError` — silently
   swallowed by `collect/1`'s rescue, which returned `[]` and dropped
   *every* discovered route from the sitemap, with nothing logged. A typo
   in a hand-edited pipeline setting emptied the entire source.

## Fix

1. The host's own language now wins its unprefixed URL; the colliding
   domainless entry is dropped instead of double-published.
2. Junk pipeline elements are now ignored instead of raising; the good
   elements still apply. Same fix applied to `sitemap_protected_pipelines`,
   which shares the helper and had the same weakness.

Both pinned by tests that fail on the previous code (new tests included).
A third commit adds index-mode coverage to the legacy-set leak test — flat
mode was already tested, index mode (per-module legacy files) wasn't.

## Scope

Exactly these 4 files, nothing else riding along:
`lib/modules/sitemap/domain_mode.ex`,
`lib/modules/sitemap/sources/router_discovery.ex`,
`test/integration/sitemap/router_discovery_api_pipeline_test.exs`,
`test/integration/sitemap/static_domain_pages_test.exs`.
