### PR TITLE
Fix Ecto.CastError on OAuth registration with geolocation tracking enabled

### DIFF
--- a/lib/phoenix_kit/users/auth.ex
+++ b/lib/phoenix_kit/users/auth.ex
@@ -554,10 +554,7 @@ defmodule PhoenixKit.Users.Auth do
   end
 
   defp stringify_keys(attrs) do
-    Map.new(attrs, fn
-      {key, value} when is_atom(key) -> {Atom.to_string(key), value}
-      {key, value} -> {key, value}
-    end)
+    Map.new(attrs, fn {key, value} -> {to_string(key), value} end)
   end
 
   @doc """

--- a/lib/phoenix_kit/users/auth.ex
+++ b/lib/phoenix_kit/users/auth.ex
@@ -515,6 +515,12 @@ defmodule PhoenixKit.Users.Auth do
       {:error, %Ecto.Changeset{}}
   """
   def register_user_with_geolocation(attrs, ip_address) when is_binary(ip_address) do
+    # `attrs` may arrive atom-keyed (e.g. the OAuth registration path) or
+    # string-keyed (e.g. form params). Normalize to string keys before
+    # merging in any of our own string-keyed fields below — Ecto.Changeset.cast/3
+    # raises Ecto.CastError on a map with mixed atom/string keys.
+    attrs = stringify_keys(attrs)
+
     # Start with the IP address
     enhanced_attrs = Map.put(attrs, "registration_ip", ip_address)
 
@@ -545,6 +551,13 @@ defmodule PhoenixKit.Users.Auth do
   def register_user_with_geolocation(attrs, _invalid_ip) do
     # Invalid IP provided, register without geolocation data
     register_user(attrs, nil)
+  end
+
+  defp stringify_keys(attrs) do
+    Map.new(attrs, fn
+      {key, value} when is_atom(key) -> {Atom.to_string(key), value}
+      {key, value} -> {key, value}
+    end)
   end
 
   @doc """

--- a/test/integration/users/oauth_email_verification_test.exs
+++ b/test/integration/users/oauth_email_verification_test.exs
@@ -246,6 +246,27 @@ defmodule PhoenixKit.Integration.Users.OAuthEmailVerificationTest do
       assert created.confirmed_at
       assert confirm_tokens_for(created) == 0
     end
+
+    test "is created when geolocation tracking is enabled, even though the OAuth attrs arrive atom-keyed" do
+      # `register_oauth_user/3` builds `attrs` with ATOM keys (:email,
+      # :password, ...). `Auth.register_user_with_geolocation/2` used to
+      # `Map.put(attrs, "registration_ip", ip)` — a STRING key — producing a
+      # mixed atom/string-keyed map that `Ecto.Changeset.cast/3` refuses
+      # outright with `Ecto.CastError`. This is the real production path:
+      # `handle_oauth_callback/2` runs with `track_geolocation: true` and a
+      # real IP whenever the host app turns geolocation tracking on.
+      #
+      # "127.0.0.1" hits `Geolocation.lookup_location/1`'s early-return
+      # branch, so this stays network-free while still exercising the exact
+      # mixed-key merge that crashed in production.
+      email = unique_email()
+
+      assert {:ok, created, :created} =
+               OAuth.find_or_create_user(oauth_data(email), true, "127.0.0.1")
+
+      assert created.email == email
+      assert created.registration_ip == "127.0.0.1"
+    end
   end
 
   defp confirm_tokens_for(user) do


### PR DESCRIPTION
## Summary
- `register_oauth_user/3` builds `attrs` with atom keys (`:email`, `:password`, `:first_name`, `:last_name`) for the OAuth registration path.
- With geolocation tracking enabled, `register_user_with_geolocation/2` merged its own string-keyed fields (`"registration_ip"`, `"registration_country"`, ...) into that map without normalizing key types first, producing a mixed atom/string-keyed map.
- `Ecto.Changeset.cast/3` raises `Ecto.CastError` on a mixed-key map, so **every** OAuth sign-in/registration crashed on any host with geolocation tracking enabled and a non-localhost client IP.
- Fix: normalize `attrs` to string keys at the top of `register_user_with_geolocation/2` before merging in the IP/geolocation fields, so the merge is always homogeneous regardless of the caller's key style.

## Test plan
- [x] Added a regression test reproducing the exact production crash (atom-keyed OAuth attrs + `track_geolocation: true` + a real IP), using `127.0.0.1` to stay network-free (hits `Geolocation.lookup_location/1`'s early-return branch).
- [x] `pk-test test/integration/users/oauth_email_verification_test.exs` — 16 tests, 0 failures.
- [x] `pk-test test/integration/users/` (full users integration suite) — 390 tests, 0 failures.
- [x] Verified live via Tidewave against a running host app pinned to `phoenix_kit 2.13.1` (same code path) — reproduced the crash before the fix, confirmed `{:ok, %User{}}` after.