### PR TITLE
Stop leaking OAuth/AWS secret values into the General and Users settings pages

### DIFF
--- a/lib/phoenix_kit/settings/settings.ex
+++ b/lib/phoenix_kit/settings/settings.ex
@@ -83,6 +83,93 @@ defmodule PhoenixKit.Settings do
   # is how the halves of a read/write pair drift apart.
   @not_found_sentinel :__setting_does_not_exist__
 
+  # S007: keys that hold live credential material, not just data an admin
+  # would rather keep quiet. `oauth_*_client_id`/`oauth_*_app_id` are NOT
+  # here on purpose — they are public by OAuth's own design (visible in the
+  # authorization redirect URL) and carry no exposure to guard.
+  @restricted_setting_keys ~w(
+    oauth_google_client_secret
+    oauth_github_client_secret
+    oauth_facebook_app_secret
+    aws_access_key_id
+    aws_secret_access_key
+  )
+
+  # The explicit ALLOW list `list_public_settings/0` reads from. Deliberately
+  # NOT "get_defaults() keys minus @restricted_setting_keys" — that would
+  # make every future setting public by default until someone remembers to
+  # blacklist it, which is exactly the failure mode this replaces (the core
+  # only recognized a setting as sensitive by `module == "integrations"`,
+  # which OAuth login credentials never belonged to). A key missing from
+  # BOTH this list and @restricted_setting_keys fails the partition
+  # invariant in settings_test.exs instead of silently defaulting to shown.
+  @public_setting_keys ~w(
+    project_title
+    site_url
+    main_page_path
+    allow_registration
+    require_email_confirmation
+    remember_me_enabled
+    remember_me_default
+    dev_mailbox_enabled
+    after_login_path
+    after_registration_path
+    oauth_enabled
+    oauth_google_enabled
+    oauth_github_enabled
+    oauth_facebook_enabled
+    oauth_require_verified_email
+    magic_link_login_enabled
+    magic_link_registration_enabled
+    qr_login_enabled
+    new_login_alert_enabled
+    mentions_enabled
+    mentions_redact_titles
+    new_user_default_role
+    new_user_default_status
+    week_start_day
+    time_zone
+    date_format
+    time_format
+    editor_default_mode
+    track_registration_geolocation
+    registration_show_username
+    site_icon_file_uuid
+    default_tab_title
+    auth_logo_file_uuid
+    auth_background_image_file_uuid
+    auth_background_image_mobile_file_uuid
+    auth_background_color
+    email_enabled
+    email_save_body
+    email_ses_events
+    email_retention_days
+    email_sampling_rate
+    email_compress_body
+    email_archive_to_s3
+    aws_region
+    aws_sns_topic_arn
+    aws_sqs_queue_url
+    aws_sqs_queue_arn
+    aws_sqs_dlq_url
+    aws_ses_configuration_set
+    sqs_polling_enabled
+    sqs_polling_interval_ms
+    sqs_max_messages_per_poll
+    sqs_visibility_timeout
+    crawlers_module_enabled
+    crawlers_no_index
+    enable_organization_accounts
+    webhook_verify_sns_signature
+    webhook_check_aws_ip
+    webhook_rate_limit_enabled
+    oauth_google_client_id
+    oauth_github_client_id
+    oauth_facebook_app_id
+    notifications_enabled
+    multi_session_enabled
+  )
+
   @doc """
   Gets default values for all settings.
 
@@ -1089,6 +1176,31 @@ defmodule PhoenixKit.Settings do
   def list_settings do
     Queries.list_settings()
   end
+
+  @doc """
+  Lists settings safe to load on admin pages that do not manage OAuth login
+  credentials or AWS keys (General, Users) — same shape as
+  `list_all_settings/0`, filtered down to `@public_setting_keys`.
+
+  The Authorization page manages the OAuth credentials themselves and keeps
+  calling `list_all_settings/0` directly; it has a legitimate reason to hold
+  those values that General and Users do not.
+
+  ## Examples
+
+      iex> PhoenixKit.Settings.list_public_settings()
+      %{"time_zone" => "0", "date_format" => "Y-m-d"}
+  """
+  def list_public_settings do
+    list_all_settings()
+    |> Map.take(@public_setting_keys)
+  end
+
+  @doc false
+  def public_setting_keys, do: @public_setting_keys
+
+  @doc false
+  def restricted_setting_keys, do: @restricted_setting_keys
 
   @doc """
   Gets the available role options for the new user default role setting.

--- a/lib/phoenix_kit_web/live/settings.ex
+++ b/lib/phoenix_kit_web/live/settings.ex
@@ -23,13 +23,22 @@ defmodule PhoenixKitWeb.Live.Settings do
       SettingsEvents.subscribe_to_settings()
     end
 
-    # Load current settings from database
-    current_settings = Settings.list_all_settings()
+    # Load current settings from database. S007: this page never renders the
+    # OAuth login secrets or AWS keys (that's the Authorization page's job),
+    # so it has no reason to hold their real values in socket state at all —
+    # list_public_settings/0 (an explicit allow list, not a redaction of
+    # list_all_settings/0) leaves them out entirely.
+    current_settings = Settings.list_public_settings()
     defaults = Settings.get_defaults()
     setting_options = Settings.get_setting_options()
 
-    # Merge defaults with current settings to ensure all keys exist
-    merged_settings = Map.merge(defaults, current_settings)
+    # Merge defaults with current settings to ensure all keys exist, then
+    # take only the public keys again — defaults still lists the restricted
+    # ones (with their harmless placeholder values), and the merge must not
+    # reintroduce them.
+    merged_settings =
+      Map.merge(defaults, current_settings)
+      |> Map.take(Settings.public_setting_keys())
 
     # Create form changeset
     changeset = Settings.change_settings(merged_settings)

--- a/lib/phoenix_kit_web/live/settings/users.ex
+++ b/lib/phoenix_kit_web/live/settings/users.ex
@@ -16,13 +16,20 @@ defmodule PhoenixKitWeb.Live.Settings.Users do
   def mount(_params, _session, socket) do
     # Set locale for LiveView process
 
-    # Load current settings
-    current_settings = Settings.list_all_settings()
+    # Load current settings. S007: this page never renders the OAuth login
+    # secrets or AWS keys, so it has no reason to hold their real values in
+    # socket state — list_public_settings/0 (an explicit allow list) leaves
+    # them out entirely rather than loading and merely not rendering them.
+    current_settings = Settings.list_public_settings()
     defaults = Settings.get_defaults()
     setting_options = Settings.get_setting_options()
 
-    # Merge defaults with current settings
-    merged_settings = Map.merge(defaults, current_settings)
+    # Merge defaults with current settings, then take only the public keys
+    # again — defaults still lists the restricted ones (harmless placeholder
+    # values), and the merge must not reintroduce them.
+    merged_settings =
+      Map.merge(defaults, current_settings)
+      |> Map.take(Settings.public_setting_keys())
 
     # Load custom fields
     field_definitions = CustomFields.list_field_definitions()

--- a/test/phoenix_kit/settings_test.exs
+++ b/test/phoenix_kit/settings_test.exs
@@ -1,0 +1,136 @@
+defmodule PhoenixKit.SettingsTest do
+  @moduledoc """
+  S007: General and Users load settings into a LiveView socket that never
+  renders the OAuth login secrets or the AWS key pair — only the
+  Authorization page's template does. Before this, all three mounts called
+  `list_all_settings/0` unconditionally, so those two pages held the real
+  secret values in process state for no reason anyone could point to.
+
+  The core's only notion of "sensitive" was `module == "integrations"`
+  (`PhoenixKit.Integrations.Encryption`), and OAuth login credentials never
+  belonged to that module — a black list that was silent about the one
+  thing it needed to catch. `list_public_settings/0` replaces it with an
+  explicit allow list (`@public_setting_keys` in settings.ex): a setting
+  key that is neither on the allow list nor on `@restricted_setting_keys`
+  fails the partition test below instead of silently landing wherever
+  `list_public_settings/0` is called.
+  """
+  use PhoenixKit.DataCase, async: false
+
+  alias PhoenixKit.Settings
+
+  describe "public/restricted setting-key partition" do
+    test "every get_defaults/0 key is classified exactly once" do
+      all_keys = Settings.get_defaults() |> Map.keys() |> Enum.sort()
+
+      classified =
+        (Settings.public_setting_keys() ++ Settings.restricted_setting_keys())
+        |> Enum.sort()
+
+      assert classified == all_keys, """
+      The following setting keys exist in `PhoenixKit.Settings.get_defaults/0` \
+      but are on neither `@public_setting_keys` nor `@restricted_setting_keys` \
+      in `PhoenixKit.Settings` (or a key was removed from get_defaults/0 while \
+      still listed there):
+
+        missing from the partition: #{inspect(all_keys -- classified)}
+        extra in the partition:     #{inspect(classified -- all_keys)}
+
+      A new setting is not safe to expose by default. Classify it explicitly: \
+      add it to `@public_setting_keys` if General/Users may hold its real \
+      value, or to `@restricted_setting_keys` if only the page that manages \
+      it should (see S007).
+      """
+    end
+
+    test "public and restricted keys do not overlap" do
+      public = MapSet.new(Settings.public_setting_keys())
+      restricted = MapSet.new(Settings.restricted_setting_keys())
+
+      assert MapSet.disjoint?(public, restricted),
+             "a key on both lists is ambiguous: #{inspect(MapSet.intersection(public, restricted))}"
+    end
+
+    test "the OAuth secrets and AWS credentials are restricted, not public" do
+      for key <- ~w(
+            oauth_google_client_secret
+            oauth_github_client_secret
+            oauth_facebook_app_secret
+            aws_access_key_id
+            aws_secret_access_key
+          ) do
+        assert key in Settings.restricted_setting_keys(), "#{key} must be restricted"
+        refute key in Settings.public_setting_keys(), "#{key} must not be public"
+      end
+    end
+
+    test "the OAuth client/app identifiers stay public (they are public by OAuth's design)" do
+      for key <- ~w(oauth_google_client_id oauth_github_client_id oauth_facebook_app_id) do
+        assert key in Settings.public_setting_keys(), "#{key} must stay public"
+      end
+    end
+  end
+
+  # The tests above only prove today's lists happen to satisfy the
+  # invariant — not that the invariant would actually catch a violation.
+  # These re-run the same comparison the first test makes, fed a
+  # deliberately corrupted list, and require it to fail. Mutating the real
+  # `@public_setting_keys`/`@restricted_setting_keys` attributes isn't
+  # possible from a test (they're compiled into the module), so this is the
+  # closest equivalent: prove the check itself is not vacuous.
+  describe "partition invariant is not vacuous" do
+    test "a secret key wrongly added to the public list makes the partition fail" do
+      corrupted_public = ["oauth_google_client_secret" | Settings.public_setting_keys()]
+      all_keys = Settings.get_defaults() |> Map.keys() |> Enum.sort()
+
+      classified =
+        (corrupted_public ++ Settings.restricted_setting_keys())
+        |> Enum.sort()
+
+      refute classified == all_keys,
+             "expected the corrupted list to fail the partition check, but it passed"
+    end
+
+    test "a new setting key missing from both lists makes the partition fail" do
+      all_keys =
+        Settings.get_defaults()
+        |> Map.keys()
+        |> Kernel.++(["a_setting_nobody_classified_yet"])
+        |> Enum.sort()
+
+      classified =
+        (Settings.public_setting_keys() ++ Settings.restricted_setting_keys())
+        |> Enum.sort()
+
+      refute classified == all_keys,
+             "expected the unclassified key to fail the partition check, but it passed"
+    end
+  end
+
+  describe "list_public_settings/0" do
+    test "returns a stored public value" do
+      {:ok, _} = Settings.update_setting("project_title", "S007 Test Project")
+
+      assert Settings.list_public_settings()["project_title"] == "S007 Test Project"
+    end
+
+    test "does not return a stored OAuth secret, even when one is set" do
+      {:ok, _} = Settings.update_setting("oauth_google_client_secret", "GOCSPX-test-secret-value")
+
+      refute Map.has_key?(Settings.list_public_settings(), "oauth_google_client_secret")
+    end
+
+    test "does not return a stored AWS secret key, even when one is set" do
+      {:ok, _} = Settings.update_setting("aws_secret_access_key", "test-aws-secret-value")
+
+      refute Map.has_key?(Settings.list_public_settings(), "aws_secret_access_key")
+    end
+
+    test "list_all_settings/0 still returns the secret (it is the unfiltered read the Authorization page needs)" do
+      {:ok, _} = Settings.update_setting("oauth_google_client_secret", "GOCSPX-test-secret-value")
+
+      assert Settings.list_all_settings()["oauth_google_client_secret"] ==
+               "GOCSPX-test-secret-value"
+    end
+  end
+end


### PR DESCRIPTION
## Problem

The General and Users settings pages both loaded `Settings.list_all_settings/0`
unconditionally on mount, which returns every setting including the real
values of `oauth_google_client_secret`, `oauth_github_client_secret`,
`oauth_facebook_app_secret`, `aws_access_key_id`, and `aws_secret_access_key`.
Neither page renders these fields, but their real values were held in
LiveView socket assigns regardless.

The core only classified a setting as sensitive when its owning module was
`"integrations"` (`PhoenixKit.Integrations.Encryption`). OAuth login
credentials and AWS keys never belonged to that module, so nothing flagged
them, and the two admin pages silently carried live credential material in
process state.

## Fix

Adds `Settings.list_public_settings/0`, which reads from an explicit
allow list (`@public_setting_keys`) instead of deriving "public" as
"everything except a denylist". A setting key that is on neither the allow
list nor the new `@restricted_setting_keys` list fails a partition test in
`test/phoenix_kit/settings_test.exs` -- so a future setting cannot become
public by omission.

The General and Users LiveViews now call `list_public_settings/0`. The
Authorization page keeps calling `list_all_settings/0`, since it is the one
page that legitimately manages the OAuth credentials and needs the real
values.

## Scope

This does not address the Authorization page own DOM exposure of the
secret value (it renders the field it manages, by design) -- tracked
separately.

## Tests

`test/phoenix_kit/settings_test.exs` (new): the key partition covers every
`get_defaults/0` key exactly once, the partition invariant is proven
non-vacuous (a deliberately corrupted list is asserted to fail the same
check), and `list_public_settings/0` is asserted to omit stored OAuth/AWS
secrets while `list_all_settings/0` still returns them.
