### PR TITLE
Fix Authorization page leaking OAuth secrets via DOM and event logs

### DIFF
--- a/lib/phoenix_kit_web/live/settings/authorization.ex
+++ b/lib/phoenix_kit_web/live/settings/authorization.ex
@@ -15,6 +15,16 @@ defmodule PhoenixKitWeb.Live.Settings.Authorization do
 
   require Logger
 
+  # S009: the only OAuth setting keys this page renders as `type="password"`
+  # inputs. The template never echoes the real value into `value=` (see
+  # authorization.html.heex), so an untouched field submits blank on every
+  # `validate_settings`/`save_settings` event — `preserve_unset_secrets/2`
+  # is what keeps that blank from overwriting the real stored secret.
+  # Deliberately NOT `Settings.restricted_setting_keys()`: that list also
+  # covers `aws_access_key_id`/`aws_secret_access_key`, which this page
+  # never renders.
+  @oauth_secret_keys ~w(oauth_google_client_secret oauth_github_client_secret oauth_facebook_app_secret)
+
   def mount(_params, _session, socket) do
     current_settings = Settings.list_all_settings()
     defaults = Settings.get_defaults()
@@ -44,6 +54,7 @@ defmodule PhoenixKitWeb.Live.Settings.Authorization do
   end
 
   def handle_event("validate_settings", %{"settings" => settings_params}, socket) do
+    settings_params = preserve_unset_secrets(settings_params, socket.assigns.settings)
     changeset = Settings.validate_settings(settings_params)
 
     socket =
@@ -151,7 +162,25 @@ defmodule PhoenixKitWeb.Live.Settings.Authorization do
 
   defp validate_background_color(_settings_params), do: :ok
 
+  # S009: the template never renders a real OAuth secret into `value=`
+  # (view-source can't leak it), so an untouched password field arrives here
+  # blank. Blindly assigning that would blank out `@settings` for the key on
+  # the next `validate_settings` event and wipe the stored secret on the
+  # next `save_settings` — this restores the currently-held value for any of
+  # `@oauth_secret_keys` that comes in blank, while a non-blank incoming
+  # value (the admin actively typing a new secret) always wins.
+  defp preserve_unset_secrets(new_params, current_settings) do
+    Enum.reduce(@oauth_secret_keys, new_params, fn key, params ->
+      case Map.get(params, key) do
+        value when value in [nil, ""] -> Map.put(params, key, Map.get(current_settings, key, ""))
+        _value -> params
+      end
+    end)
+  end
+
   defp do_save_settings(socket, settings_params) do
+    settings_params = preserve_unset_secrets(settings_params, socket.assigns.settings)
+
     case Settings.update_settings(settings_params) do
       {:ok, updated_settings} ->
         OAuthConfig.configure_providers()
@@ -205,6 +234,18 @@ defmodule PhoenixKitWeb.Live.Settings.Authorization do
     base_prefix = if url_prefix == "/", do: "", else: url_prefix
 
     "#{site_url}#{base_prefix}/users/auth/#{provider}/callback"
+  end
+
+  # S009: the three OAuth secret inputs render `value=""` unconditionally
+  # (see authorization.html.heex), so this placeholder is the only signal an
+  # admin gets that a secret is already stored, without ever putting the
+  # real value in the DOM.
+  def oauth_secret_placeholder(current_value, unset_placeholder) do
+    if current_value in [nil, ""] do
+      unset_placeholder
+    else
+      gettext("A secret is already configured — leave blank to keep the current value")
+    end
   end
 
   # Builds the credentials map OAuthConfig.test_connection/2 expects, from

--- a/lib/phoenix_kit_web/live/settings/authorization.html.heex
+++ b/lib/phoenix_kit_web/live/settings/authorization.html.heex
@@ -384,9 +384,14 @@
                       <.input
                         type="password"
                         name="settings[oauth_google_client_secret]"
-                        value={@settings["oauth_google_client_secret"] || ""}
+                        value=""
                         label={gettext("Client Secret")}
-                        placeholder={gettext("Your Google OAuth Client Secret")}
+                        placeholder={
+                          oauth_secret_placeholder(
+                            @settings["oauth_google_client_secret"],
+                            gettext("Your Google OAuth Client Secret")
+                          )
+                        }
                       />
                     </div>
                   </div>
@@ -464,9 +469,14 @@
                     <.input
                       type="password"
                       name="settings[oauth_github_client_secret]"
-                      value={@settings["oauth_github_client_secret"] || ""}
+                      value=""
                       label={gettext("Client Secret")}
-                      placeholder={gettext("Your GitHub OAuth Client Secret")}
+                      placeholder={
+                        oauth_secret_placeholder(
+                          @settings["oauth_github_client_secret"],
+                          gettext("Your GitHub OAuth Client Secret")
+                        )
+                      }
                     />
                   </div>
                 </div>
@@ -547,9 +557,14 @@
                     <.input
                       type="password"
                       name="settings[oauth_facebook_app_secret]"
-                      value={@settings["oauth_facebook_app_secret"] || ""}
+                      value=""
                       label={gettext("App Secret")}
-                      placeholder={gettext("Your Facebook App Secret")}
+                      placeholder={
+                        oauth_secret_placeholder(
+                          @settings["oauth_facebook_app_secret"],
+                          gettext("Your Facebook App Secret")
+                        )
+                      }
                     />
                   </div>
                 </div>

--- a/test/integration/phoenix_kit_web/live/settings/authorization_secret_leak_test.exs
+++ b/test/integration/phoenix_kit_web/live/settings/authorization_secret_leak_test.exs
@@ -1,0 +1,114 @@
+defmodule PhoenixKitWeb.Live.Settings.AuthorizationSecretLeakTest do
+  @moduledoc """
+  S009: the Authorization settings page rendered the real OAuth client
+  secrets into `value=` on `type="password"` inputs — `type="password"` only
+  masks the on-screen rendering, the real value still sits in the HTML
+  `value=` attribute in plaintext (view-source/DevTools).
+
+  Because the pre-filled real secret round-tripped back through the DOM,
+  editing ANY other field re-submitted it as part of the `validate_settings`
+  event's full-form params (LiveView `phx-change` sends the whole form on
+  every change), which Phoenix's own built-in LiveView event telemetry
+  logger then wrote to the application log. There is no `filter_parameters`
+  fix available here: it's a host-app `Application` env key and phoenix_kit
+  is a dependency, so this can only be fixed at the root — never let the
+  real secret round-trip through the DOM/event params in the first place.
+  """
+  use PhoenixKitWeb.ConnCase, async: false
+
+  import ExUnit.CaptureLog
+
+  alias PhoenixKit.Settings
+  alias PhoenixKit.Utils.Routes
+
+  @google_secret "GOCSPX-super-secret-google-value"
+  @github_secret "gh-super-secret-github-value"
+  @facebook_secret "fb-super-secret-facebook-value"
+
+  setup do
+    {:ok, _} = Settings.update_setting("oauth_enabled", "true")
+    {:ok, _} = Settings.update_setting("oauth_google_client_secret", @google_secret)
+    {:ok, _} = Settings.update_setting("oauth_github_client_secret", @github_secret)
+    {:ok, _} = Settings.update_setting("oauth_facebook_app_secret", @facebook_secret)
+
+    :ok
+  end
+
+  defp login(conn) do
+    {admin, _token} = create_admin_user()
+    log_in_user(conn, admin)
+  end
+
+  test "rendering the page never puts the real secrets in the HTML", %{conn: conn} do
+    conn = login(conn)
+
+    {:ok, view, html} = live(conn, Routes.path("/admin/settings/authorization"))
+
+    refute html =~ @google_secret
+    refute html =~ @github_secret
+    refute html =~ @facebook_secret
+
+    # Also true of the live-rendered state, not just the initial static markup.
+    rendered = render(view)
+    refute rendered =~ @google_secret
+    refute rendered =~ @github_secret
+    refute rendered =~ @facebook_secret
+  end
+
+  test "editing another field does not leak the real secret via HTML or logs", %{conn: conn} do
+    conn = login(conn)
+
+    {:ok, view, _html} = live(conn, Routes.path("/admin/settings/authorization"))
+
+    {html, log} =
+      with_log(fn ->
+        render_change(view, "validate_settings", %{
+          "settings" => %{
+            "oauth_enabled" => "true",
+            "oauth_google_enabled" => "true",
+            "oauth_google_client_id" => "new-client-id.apps.googleusercontent.com",
+            "oauth_google_client_secret" => ""
+          }
+        })
+      end)
+
+    refute html =~ @google_secret
+    refute log =~ @google_secret
+  end
+
+  test "saving with the secret fields left blank does not wipe the stored secrets", %{
+    conn: conn
+  } do
+    conn = login(conn)
+
+    {:ok, view, _html} = live(conn, Routes.path("/admin/settings/authorization"))
+
+    view
+    |> form("#authorization_settings_form", %{
+      "settings" => %{
+        "oauth_google_client_secret" => "",
+        "oauth_github_client_secret" => "",
+        "oauth_facebook_app_secret" => ""
+      }
+    })
+    |> render_submit()
+
+    assert Settings.get_setting("oauth_google_client_secret") == @google_secret
+    assert Settings.get_setting("oauth_github_client_secret") == @github_secret
+    assert Settings.get_setting("oauth_facebook_app_secret") == @facebook_secret
+  end
+
+  test "saving with a newly typed secret updates the stored value", %{conn: conn} do
+    conn = login(conn)
+
+    {:ok, view, _html} = live(conn, Routes.path("/admin/settings/authorization"))
+
+    view
+    |> form("#authorization_settings_form", %{
+      "settings" => %{"oauth_google_client_secret" => "brand-new-google-secret"}
+    })
+    |> render_submit()
+
+    assert Settings.get_setting("oauth_google_client_secret") == "brand-new-google-secret"
+  end
+end


### PR DESCRIPTION
## Problem

`authorization.html.heex` rendered the real Google/GitHub/Facebook OAuth client secrets into `value=` on `type="password"` inputs. `type="password"` only masks the on-screen rendering — the real value sits in the HTML `value=` attribute in plaintext, visible via view-source or DevTools to anyone who can load the page.

Because the DOM echoed the real secret back, editing any other field on the page re-submitted it as part of the `validate_settings` `phx-change` event's full-form params (LiveView sends the whole form on every change, not just the changed field), and Phoenix's built-in LiveView event telemetry logger then wrote those params to the application log.

Neither leak is closable via `filter_parameters`: that's a host-app `Application` env key, and a dependency's own `config/config.exs` isn't merged into a consuming app at boot, so this can't be fixed from phoenix_kit's own config. The only real fix is root-cause: never let the real secret round-trip through the DOM/event params in the first place.

This is a different problem from #741 — that fix was about not *loading* the secrets into General/Users assigns unnecessarily. The Authorization page legitimately needs the real values (it manages OAuth credentials, and `test_oauth` uses them to test the live connection), so the fix here is safe output, not a key filter.

## Fix

- The three OAuth secret inputs (Google/GitHub/Facebook client secrets) now render `value=""` unconditionally instead of the real stored value. A placeholder communicates whether a secret is already configured, without ever showing it. Client ID / App ID fields are untouched — those are intentionally public.
- `@settings` still holds the real secret values at all times, so `test_oauth` keeps working unchanged.
- `validate_settings` and `save_settings` now run incoming params through `preserve_unset_secrets/2`: a blank incoming value for one of the three secret keys falls back to the currently-held real value instead of overwriting/logging it; a non-blank value (an admin actively typing a new secret) always wins. This also fixes `save_settings` silently wiping a stored secret whenever the form was submitted without retyping it.

## Verified

- New test suite (`test/integration/phoenix_kit_web/live/settings/authorization_secret_leak_test.exs`, 4 tests, 0 failures):
  - the real secret is absent from both the initial and live-rendered HTML for all three providers — confirmed by asserting it's not present in the actual page source, not by checking that the field displays masked;
  - editing an unrelated field does not leak the secret into either the rendered HTML or `ExUnit.CaptureLog`-captured logs;
  - saving with the secret fields left blank preserves all three stored secrets (the "don't break the scenario" check — an admin must still be able to tell a secret is configured and must not have it wiped by an untouched save);
  - saving with a newly typed value updates the stored secret (an admin must still be able to set a new one).
- Regression: broader settings suite, 116 tests, 0 failures.
- `mix quality` (format, `credo --strict`, dialyzer): clean.