### PR TITLE
Make nav_tabs adoptable (patch, variant, badge tone) and fix the daisyUI tabs class

### DIFF
--- a/lib/phoenix_kit_web/components/core/nav_tabs.ex
+++ b/lib/phoenix_kit_web/components/core/nav_tabs.ex
@@ -51,7 +51,7 @@ defmodule PhoenixKitWeb.Components.Core.NavTabs do
 
   def nav_tabs(assigns) do
     ~H"""
-    <div role="tablist" class={["tabs tabs-boxed bg-base-200 p-1", @class]}>
+    <div role="tablist" class={["tabs tabs-box bg-base-200 p-1", @class]}>
       <%= for tab <- @tabs do %>
         <%= if Map.has_key?(tab, :path) do %>
           <.link

--- a/lib/phoenix_kit_web/components/core/nav_tabs.ex
+++ b/lib/phoenix_kit_web/components/core/nav_tabs.ex
@@ -4,14 +4,14 @@ defmodule PhoenixKitWeb.Components.Core.NavTabs do
 
   Supports two modes with identical visual appearance:
 
-  **Navigation tabs** — each tab has a `path`, renders as `<.link navigate={...}>`:
+  **Navigation tabs** — each tab carries a URL, renders as `<.link>`:
 
       <.nav_tabs active_tab="general" tabs={[
-        %{id: "general", label: "General", icon: "hero-cog-6-tooth", path: "/admin/settings"},
-        %{id: "advanced", label: "Advanced", path: "/admin/settings/advanced"}
+        %{id: "general", label: "General", icon: "hero-cog-6-tooth", navigate: "/admin/settings"},
+        %{id: "advanced", label: "Advanced", navigate: "/admin/settings/advanced"}
       ]} />
 
-  **Event tabs** — no paths, uses `on_change` event via `phx-click`:
+  **Event tabs** — no URL, uses `on_change` via `phx-click`:
 
       <.nav_tabs active_tab={@active_tab} on_change="switch_tab" tabs={[
         %{id: "oban", label: "Oban Jobs"},
@@ -21,79 +21,181 @@ defmodule PhoenixKitWeb.Components.Core.NavTabs do
   **With badges** (works in both modes):
 
       <.nav_tabs active_tab={@tab} tabs={[
-        %{id: "followers", label: "Followers", path: "/connections?tab=followers", badge: @followers_count},
-        %{id: "following", label: "Following", path: "/connections?tab=following", badge: @following_count}
+        %{id: "followers", label: "Followers", patch: "/connections?tab=followers", badge: @followers_count},
+        %{id: "following", label: "Following", patch: "/connections?tab=following", badge: @following_count}
       ]} />
 
   ## Tab map keys
 
   Required: `:id`, `:label`
-  Optional: `:icon` (Heroicon name), `:path` (navigation URL), `:badge` (count/text)
+
+  Optional: `:icon` (Heroicon name), `:badge` (count/text), and at most one
+  link key — `:navigate`, `:patch`, or `:path`.
+
+  The link keys mirror `Phoenix.Component.link/1` rather than inventing a
+  parallel vocabulary: `:navigate` for a full LiveView navigation, `:patch`
+  to stay in the current LiveView (query-param tabs want this — a `:navigate`
+  there remounts and loses socket state). `:path` is the original spelling
+  and is kept as a permanent alias for `:navigate`, so nothing that already
+  uses it has to change. Setting more than one link key raises; a key whose
+  value is `nil` counts as absent, so a conditional path is safe.
+
+  A tab with no link key renders as a button and needs `on_change`; without
+  it the tab is inert and the component logs a warning rather than raising —
+  a dead tab should not take a whole LiveView down. A strip may freely mix
+  link tabs and event tabs.
+
+  ## Event payload
+
+  Event tabs dispatch `phx-value-tab`, so handlers match on:
+
+      def handle_event("switch_tab", %{"tab" => id}, socket)
+
+  The key is deliberately not configurable, and deliberately not `value`:
+  LiveView's `extractMeta` overwrites `meta.value` with the element's own
+  `.value` DOM property, so a `<button>` (whose `.value` is `""`) silently
+  delivers an empty string unless a native `value=` attribute is also set.
+  Standardising on `tab` removes the trap rather than making it selectable.
+
+  ## Variants
+
+  `variant={:boxed}` (default) is the filled strip used across admin pages.
+  `variant={:plain}` drops the frame for tabs that sit inside an
+  already-framed container — a filter row inside a picker, say.
+
+  It exists because `class` can only ADD to the container: with the frame
+  baked in, a caller had no way to take it off, and hand-rolling the markup
+  was the only escape. That is how the copies started.
   """
 
   use Phoenix.Component
+
+  require Logger
 
   import PhoenixKitWeb.Components.Core.Icon, only: [icon: 1]
 
   alias PhoenixKit.Utils.Routes
 
+  @doc """
+  The daisyUI class list for a tablist container.
+
+  Exposed so anything rendering tab-styled markup that is NOT a tab strip
+  (segmented form controls, for instance) can share one definition instead
+  of repeating the class string. A daisyUI rename should be a change here,
+  not a sweep across every call site — `tabs-boxed` became `tabs-box` in
+  daisyUI 5 and had to be fixed in 21 places across 8 repositories.
+  """
+  def tablist_class(variant \\ :boxed, extra \\ nil)
+  def tablist_class(:boxed, extra), do: ["tabs tabs-box bg-base-200 p-1", extra]
+
+  # `tabs-box` IS the daisyUI frame — it sets background-color, padding,
+  # border-radius and box-shadow itself, which is why `:boxed`'s own
+  # `bg-base-200 p-1` are redundant overrides rather than the frame. Dropping
+  # only those would have left the box in place, so `:plain` drops the
+  # modifier and keeps the bare `tabs` layout.
+  def tablist_class(:plain, extra), do: ["tabs", extra]
+
+  @doc """
+  The daisyUI class list for a single tab. See `tablist_class/2`.
+  """
+  def tab_class(active?, extra \\ nil), do: ["tab gap-2", active? && "tab-active", extra]
+
   attr :active_tab, :string, required: true
 
   attr :tabs, :list,
     required: true,
-    doc: "List of tab maps with :id, :label, and optional :icon, :path, :badge"
+    doc: "List of tab maps with :id, :label, and optional :icon, :badge, :navigate/:patch/:path"
 
   attr :on_change, :string,
     default: nil,
-    doc: "phx-click event name for event-based tabs (when tabs have no :path)"
+    doc: "phx-click event name for event-based tabs (tabs with no link key)"
+
+  attr :variant, :atom,
+    values: [:boxed, :plain],
+    default: :boxed,
+    doc: ":boxed fills the strip; :plain drops the background and padding"
 
   attr :class, :string, default: nil
 
   def nav_tabs(assigns) do
+    assigns = assign(assigns, :tabs, Enum.map(assigns.tabs, &normalize(&1, assigns.on_change)))
+
     ~H"""
-    <div role="tablist" class={["tabs tabs-box bg-base-200 p-1", @class]}>
+    <div role="tablist" class={tablist_class(@variant, @class)}>
       <%= for tab <- @tabs do %>
-        <%= if Map.has_key?(tab, :path) do %>
-          <.link
-            navigate={Routes.path(tab.path)}
-            role="tab"
-            class={["tab gap-2", tab.id == @active_tab && "tab-active"]}
-          >
-            <.icon :if={Map.has_key?(tab, :icon)} name={tab.icon} class="w-4 h-4" />
-            {tab.label}
-            <span
-              :if={Map.has_key?(tab, :badge)}
-              class={["badge badge-sm", tab.id == @active_tab && "badge-primary"]}
-            >
-              {tab.badge}
-            </span>
-          </.link>
-        <% else %>
-          <%!-- While the switch round-trips, LiveView tags the clicked tab
-               with phx-click-loading — pulse it so a switch whose content
-               needs server work still gives instant feedback. --%>
-          <button
-            type="button"
-            role="tab"
-            phx-click={@on_change}
-            phx-value-tab={tab.id}
-            class={[
-              "tab gap-2 [&.phx-click-loading]:animate-pulse",
-              tab.id == @active_tab && "tab-active"
-            ]}
-          >
-            <.icon :if={Map.has_key?(tab, :icon)} name={tab.icon} class="w-4 h-4" />
-            {tab.label}
-            <span
-              :if={Map.has_key?(tab, :badge)}
-              class={["badge badge-sm", tab.id == @active_tab && "badge-primary"]}
-            >
-              {tab.badge}
-            </span>
-          </button>
-        <% end %>
+        <.link
+          :if={tab.link_attrs != nil}
+          {tab.link_attrs}
+          role="tab"
+          class={tab_class(tab.id == @active_tab)}
+        >
+          <.tab_body tab={tab} active?={tab.id == @active_tab} />
+        </.link>
+        <%!-- While the switch round-trips, LiveView tags the clicked tab
+             with phx-click-loading — pulse it so a switch whose content
+             needs server work still gives instant feedback. --%>
+        <button
+          :if={tab.link_attrs == nil}
+          type="button"
+          role="tab"
+          phx-click={@on_change}
+          phx-value-tab={tab.id}
+          class={tab_class(tab.id == @active_tab, "[&.phx-click-loading]:animate-pulse")}
+        >
+          <.tab_body tab={tab} active?={tab.id == @active_tab} />
+        </button>
       <% end %>
     </div>
     """
+  end
+
+  defp tab_body(assigns) do
+    ~H"""
+    <.icon :if={Map.has_key?(@tab, :icon)} name={@tab.icon} class="w-4 h-4" />
+    {@tab.label}
+    <span :if={Map.has_key?(@tab, :badge)} class={["badge badge-sm", @active? && "badge-primary"]}>
+      {@tab.badge}
+    </span>
+    """
+  end
+
+  # Resolves the link keys ONCE, up front, so the template stays a template.
+  #
+  # `nil` counts as absent, not as "set to nil": tab lists are frequently built
+  # with a conditional path (`path: if(admin?, do: "/x")`), and treating that as
+  # a link would hand `Routes.path/1` a nil and raise from inside a render.
+  defp normalize(tab, on_change) do
+    links =
+      [navigate: :navigate, patch: :patch, path: :navigate]
+      |> Enum.map(fn {key, kind} -> {key, kind, Map.get(tab, key)} end)
+      |> Enum.reject(fn {_key, _kind, to} -> to == nil end)
+
+    link_attrs = resolve_link(links, tab)
+
+    # NOT a raise. This renders a button wired to `phx-click={nil}` — a dead
+    # tab, which is bad, but taking the whole LiveView down over a tab strip is
+    # worse, and this is a library whose consumers we cannot audit. Warn so it
+    # is findable, and render what the caller asked for.
+    if link_attrs == nil and on_change == nil do
+      Logger.warning(
+        "nav_tabs: tab #{inspect(tab[:id])} has no :navigate/:patch/:path and no on_change " <>
+          "was given, so it renders a button that does nothing"
+      )
+    end
+
+    Map.put(tab, :link_attrs, link_attrs)
+  end
+
+  defp resolve_link([], _tab), do: nil
+  defp resolve_link([{_key, kind, to}], _tab), do: [{kind, Routes.path(to)}]
+
+  # Two link keys is unambiguously a mistake rather than a degraded render:
+  # there is no defensible way to pick one, and `:navigate`/`:patch` are new
+  # enough that no existing caller can trip this.
+  defp resolve_link(links, tab) do
+    raise ArgumentError,
+          "nav_tabs: tab #{inspect(tab[:id])} sets more than one link key " <>
+            "(#{inspect(Enum.map(links, &elem(&1, 0)))}) — pick one, exactly as " <>
+            "Phoenix.Component.link/1 requires"
   end
 end

--- a/lib/phoenix_kit_web/components/core/nav_tabs.ex
+++ b/lib/phoenix_kit_web/components/core/nav_tabs.ex
@@ -29,8 +29,12 @@ defmodule PhoenixKitWeb.Components.Core.NavTabs do
 
   Required: `:id`, `:label`
 
-  Optional: `:icon` (Heroicon name), `:badge` (count/text), and at most one
-  link key — `:navigate`, `:patch`, or `:path`.
+  Optional: `:icon` (Heroicon name), `:badge` (count/text), `:badge_class`
+  (a daisyUI tone such as `"badge-warning"`, which wins over the active-tab
+  default), and at most one link key — `:navigate`, `:patch`, or `:path`.
+
+  Every optional key treats `nil` as absent, so the common
+  `badge: if(count > 0, do: count)` renders no badge rather than an empty one.
 
   The link keys mirror `Phoenix.Component.link/1` rather than inventing a
   parallel vocabulary: `:navigate` for a full LiveView navigation, `:patch`
@@ -149,15 +153,23 @@ defmodule PhoenixKitWeb.Components.Core.NavTabs do
     """
   end
 
+  # `!= nil` rather than `Map.has_key?/2` throughout: a count that is only
+  # shown when non-zero is normally written `badge: if(n > 0, do: n)`, and
+  # keying on presence rendered that as an empty badge.
   defp tab_body(assigns) do
     ~H"""
-    <.icon :if={Map.has_key?(@tab, :icon)} name={@tab.icon} class="w-4 h-4" />
+    <.icon :if={@tab[:icon] != nil} name={@tab.icon} class="w-4 h-4" />
     {@tab.label}
-    <span :if={Map.has_key?(@tab, :badge)} class={["badge badge-sm", @active? && "badge-primary"]}>
+    <span :if={@tab[:badge] != nil} class={["badge badge-sm", badge_tone(@tab, @active?)]}>
       {@tab.badge}
     </span>
     """
   end
+
+  # A tab may state its own badge tone — a pending-requests count stays
+  # `badge-warning` whether or not its tab is the active one — and that has to
+  # win over the active-tab default rather than fight it in the class list.
+  defp badge_tone(tab, active?), do: tab[:badge_class] || (active? && "badge-primary")
 
   # Resolves the link keys ONCE, up front, so the template stays a template.
   #

--- a/lib/phoenix_kit_web/live/users/live_sessions.ex
+++ b/lib/phoenix_kit_web/live/users/live_sessions.ex
@@ -100,7 +100,11 @@ defmodule PhoenixKitWeb.Live.Users.LiveSessions do
     {:noreply, push_url_state(socket, [search_query: search_query], replace: true)}
   end
 
-  def handle_event("filter_by", %{"type" => filter_type}, socket) do
+  # `tab` rather than `type`: nav_tabs standardises the payload key, because
+  # LiveView's extractMeta overwrites meta.value with a button's own (empty)
+  # .value DOM property — so `value` is a trap and a per-caller key is just
+  # that trap made selectable.
+  def handle_event("filter_by", %{"tab" => filter_type}, socket) do
     {:noreply, push_url_state(socket, filter_type: filter_type)}
   end
 

--- a/lib/phoenix_kit_web/live/users/live_sessions.html.heex
+++ b/lib/phoenix_kit_web/live/users/live_sessions.html.heex
@@ -128,7 +128,7 @@
                but this page's handler reads phx-value-type — converting would
                desync the param key from handle_event("filter_by", %{"type" => ...}),
                and live_sessions.ex is outside this batch's file scope) --%>
-          <div class="tabs tabs-boxed tabs-sm">
+          <div class="tabs tabs-box tabs-sm">
             <button
               phx-click="filter_by"
               phx-value-type="all"

--- a/lib/phoenix_kit_web/live/users/live_sessions.html.heex
+++ b/lib/phoenix_kit_web/live/users/live_sessions.html.heex
@@ -124,33 +124,27 @@
             placeholder={gettext("Search by IP, User-Agent, email...")}
             class="w-40 sm:w-52 lg:w-64 min-w-0"
           />
-          <%!-- Filter Tabs (kept hand-rolled: <.nav_tabs> hardcodes phx-value-tab,
-               but this page's handler reads phx-value-type — converting would
-               desync the param key from handle_event("filter_by", %{"type" => ...}),
-               and live_sessions.ex is outside this batch's file scope) --%>
-          <div class="tabs tabs-box tabs-sm">
-            <button
-              phx-click="filter_by"
-              phx-value-type="all"
-              class={["tab", if(@filter_type == "all", do: "tab-active", else: "")]}
-            >
-              {gettext("All")} ({@total_sessions})
-            </button>
-            <button
-              phx-click="filter_by"
-              phx-value-type="anonymous"
-              class={["tab", if(@filter_type == "anonymous", do: "tab-active", else: "")]}
-            >
-              {gettext("Anonymous")} ({@presence_stats.anonymous_sessions})
-            </button>
-            <button
-              phx-click="filter_by"
-              phx-value-type="authenticated"
-              class={["tab", if(@filter_type == "authenticated", do: "tab-active", else: "")]}
-            >
-              {gettext("Authenticated")} ({@presence_stats.authenticated_sessions})
-            </button>
-          </div>
+          <%!-- Boxed (the default) is the original look: this was
+               `tabs tabs-boxed tabs-sm`, and in daisyUI 4 `tabs-boxed` drew
+               the frame. It was hand-rolled only because the component
+               hardcodes phx-value-tab while this page's handler read
+               phx-value-type — that handler now matches on "tab". --%>
+          <.nav_tabs
+            active_tab={@filter_type}
+            on_change="filter_by"
+            class="tabs-sm"
+            tabs={[
+              %{id: "all", label: "#{gettext("All")} (#{@total_sessions})"},
+              %{
+                id: "anonymous",
+                label: "#{gettext("Anonymous")} (#{@presence_stats.anonymous_sessions})"
+              },
+              %{
+                id: "authenticated",
+                label: "#{gettext("Authenticated")} (#{@presence_stats.authenticated_sessions})"
+              }
+            ]}
+          />
         </div>
       </:toolbar_title>
       <:card_header :let={session}>

--- a/test/phoenix_kit_web/components/core/nav_tabs_test.exs
+++ b/test/phoenix_kit_web/components/core/nav_tabs_test.exs
@@ -198,6 +198,46 @@ defmodule PhoenixKitWeb.Components.Core.NavTabsTest do
     end
   end
 
+  describe "badges" do
+    test "a nil badge renders nothing, not an empty badge" do
+      # `badge: if(count > 0, do: count)` is the normal way to write a count
+      # that only shows when non-zero; keying on key PRESENCE rendered that
+      # as an empty pill.
+      html = render_tabs(%{tabs: [%{id: "a", label: "Requests", navigate: "/x", badge: nil}]})
+
+      assert html =~ "Requests"
+      refute html =~ "badge"
+    end
+
+    test "a zero badge still renders — only nil is absent" do
+      html = render_tabs(%{tabs: [%{id: "a", label: "Requests", navigate: "/x", badge: 0}]})
+
+      assert html =~ "badge"
+    end
+
+    test "badge_class wins over the active-tab default" do
+      # A pending-requests count stays badge-warning whether or not its tab
+      # is the active one.
+      html =
+        render_tabs(%{
+          active_tab: "a",
+          tabs: [
+            %{id: "a", label: "Requests", navigate: "/x", badge: 3, badge_class: "badge-warning"}
+          ]
+        })
+
+      assert html =~ "badge-warning"
+      refute html =~ "badge-primary"
+    end
+
+    test "without badge_class the active tab still gets the primary tone" do
+      html =
+        render_tabs(%{active_tab: "a", tabs: [%{id: "a", label: "A", navigate: "/x", badge: 3}]})
+
+      assert html =~ "badge-primary"
+    end
+  end
+
   describe "icons and badges" do
     test "both render, in either mode" do
       html =

--- a/test/phoenix_kit_web/components/core/nav_tabs_test.exs
+++ b/test/phoenix_kit_web/components/core/nav_tabs_test.exs
@@ -1,0 +1,215 @@
+defmodule PhoenixKitWeb.Components.Core.NavTabsTest do
+  @moduledoc """
+  `nav_tabs/1` is the ecosystem's tab component, and until now most tab strips
+  in the module libraries reimplemented it instead of calling it — which is why
+  a single daisyUI class rename (`tabs-boxed` -> `tabs-box` in v5) had to be
+  applied at 21 hand-rolled sites across 8 repositories.
+
+  Two things blocked adoption, and these tests pin both fixes:
+
+  - a query-param tab strip needs `patch` (a `navigate` remounts the LiveView
+    and drops socket state), and the component only ever emitted `navigate`;
+  - the container's `bg-base-200 p-1` was baked in, and `class` can only ADD,
+    so a strip nested in an already-framed container had no way to shed it.
+
+  Plus the failure mode that makes silent breakage possible at all: the tab
+  LINK KEYS live in a runtime map, so no `attr` declaration can validate them.
+  A module passing `:patch` to an older core would land in the button branch
+  with `on_change` nil and render a strip wired to `phx-click={nil}` — right
+  down to the styling. Those cases raise now.
+  """
+  use ExUnit.Case, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias PhoenixKitWeb.Components.Core.NavTabs
+
+  defp render_tabs(assigns) do
+    assigns = Map.put_new(assigns, :active_tab, "a")
+    render_component(&NavTabs.nav_tabs/1, assigns)
+  end
+
+  describe "link modes" do
+    test ":patch renders a patch link, not a navigate one" do
+      html =
+        render_tabs(%{
+          tabs: [
+            %{id: "followers", label: "Followers", patch: "/profile/connections?tab=followers"}
+          ]
+        })
+
+      # data-phx-link=patch is what keeps the click inside the current
+      # LiveView; navigate would remount it and lose the socket state.
+      assert html =~ ~s(data-phx-link="patch")
+      refute html =~ ~s(data-phx-link="redirect")
+    end
+
+    test ":navigate renders a navigation link" do
+      html = render_tabs(%{tabs: [%{id: "a", label: "General", navigate: "/admin/settings"}]})
+
+      assert html =~ ~s(data-phx-link="redirect")
+      refute html =~ ~s(data-phx-link="patch")
+    end
+
+    test ":path still means navigate — the original spelling never breaks" do
+      from_path = render_tabs(%{tabs: [%{id: "a", label: "General", path: "/admin/settings"}]})
+
+      from_navigate =
+        render_tabs(%{tabs: [%{id: "a", label: "General", navigate: "/admin/settings"}]})
+
+      assert from_path == from_navigate
+    end
+
+    test "a query string survives the route helper intact" do
+      html =
+        render_tabs(%{
+          tabs: [
+            %{id: "followers", label: "Followers", patch: "/profile/connections?tab=followers"}
+          ]
+        })
+
+      # If the helper dropped or re-encoded the query, the tab would render
+      # but the active state would never stick on reload.
+      assert html =~ "?tab=followers"
+    end
+
+    test "a strip may mix link tabs and event tabs" do
+      html =
+        render_tabs(%{
+          on_change: "switch",
+          tabs: [
+            %{id: "a", label: "Linked", navigate: "/admin/settings"},
+            %{id: "b", label: "Evented"}
+          ]
+        })
+
+      assert html =~ ~s(data-phx-link="redirect")
+      assert html =~ ~s(phx-value-tab="b")
+    end
+  end
+
+  describe "event payload" do
+    test "event tabs dispatch phx-value-tab, never phx-value-value" do
+      html = render_tabs(%{on_change: "switch_tab", tabs: [%{id: "oban", label: "Oban"}]})
+
+      assert html =~ ~s(phx-value-tab="oban")
+
+      # `value` is the hazardous key: LiveView's extractMeta overwrites
+      # meta.value with the element's own .value DOM property, so a <button>
+      # would deliver "". The component must never emit it.
+      refute html =~ "phx-value-value"
+    end
+  end
+
+  describe "variants" do
+    test ":boxed is the default and keeps the filled strip" do
+      html = render_tabs(%{on_change: "s", tabs: [%{id: "a", label: "A"}]})
+
+      assert html =~ "bg-base-200"
+      assert html =~ "tabs-box"
+    end
+
+    test ":plain drops the frame a caller could not otherwise remove" do
+      html = render_tabs(%{variant: :plain, on_change: "s", tabs: [%{id: "a", label: "A"}]})
+
+      refute html =~ "bg-base-200"
+
+      # `tabs-box` must go too: it IS the daisyUI frame (background, padding,
+      # radius, shadow), so dropping only the bg-base-200/p-1 overrides would
+      # leave the box drawn and make :plain a lie.
+      refute html =~ "tabs-box"
+
+      # Still a tab strip, just unframed.
+      assert html =~ "tabs"
+    end
+
+    test "class ADDS to the container rather than replacing it" do
+      html =
+        render_tabs(%{
+          variant: :plain,
+          class: "inline-flex",
+          on_change: "s",
+          tabs: [%{id: "a", label: "A"}]
+        })
+
+      # Appended to the variant's classes, not swapped for them.
+      assert html =~ "inline-flex"
+      assert html =~ "tabs"
+    end
+  end
+
+  describe "malformed tabs" do
+    test "a tab with no link key and no on_change warns but still renders" do
+      # Deliberately NOT a raise. This is a library: a dead tab is bad, but
+      # taking the whole LiveView down over a tab strip is worse, and we
+      # cannot audit every consumer. It has to stay findable, though.
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          html = render_tabs(%{tabs: [%{id: "a", label: "A"}]})
+          assert html =~ "<button"
+        end)
+
+      assert log =~ "renders a button that does nothing"
+    end
+
+    test "setting more than one link key raises" do
+      # No degraded render is defensible here — there is no way to choose —
+      # and :navigate/:patch are new enough that no existing caller can trip it.
+      for tab <- [
+            %{id: "a", label: "A", navigate: "/x", patch: "/y"},
+            %{id: "a", label: "A", navigate: "/x", path: "/y"},
+            %{id: "a", label: "A", patch: "/x", path: "/y"}
+          ] do
+        assert_raise ArgumentError, ~r/more than one link key/, fn ->
+          render_tabs(%{tabs: [tab]})
+        end
+      end
+    end
+
+    test "a nil link value counts as absent, not as a link to nowhere" do
+      # Tab lists are routinely built with a conditional path; treating that
+      # nil as a link hands Routes.path/1 a nil and raises mid-render.
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          html = render_tabs(%{on_change: "s", tabs: [%{id: "a", label: "A", path: nil}]})
+
+          assert html =~ ~s(phx-value-tab="a")
+          refute html =~ "data-phx-link"
+        end)
+
+      # It fell back to the event tab cleanly, so nothing to warn about.
+      refute log =~ "does nothing"
+    end
+  end
+
+  describe "class helpers" do
+    test "tablist_class/2 is what the component itself renders" do
+      # Shared so tab-styled markup that is NOT a tab strip can reuse one
+      # definition — the next daisyUI rename should be a change here, not a
+      # sweep across every call site.
+      assert NavTabs.tablist_class(:boxed) == ["tabs tabs-box bg-base-200 p-1", nil]
+      assert NavTabs.tablist_class(:plain) == ["tabs", nil]
+      assert NavTabs.tablist_class(:plain, "inline-flex") == ["tabs", "inline-flex"]
+    end
+
+    test "tab_class/2 marks the active tab" do
+      assert NavTabs.tab_class(true) == ["tab gap-2", "tab-active", nil]
+      assert NavTabs.tab_class(false) == ["tab gap-2", false, nil]
+    end
+  end
+
+  describe "icons and badges" do
+    test "both render, in either mode" do
+      html =
+        render_tabs(%{
+          tabs: [
+            %{id: "a", label: "Followers", navigate: "/x", icon: "hero-user", badge: 12}
+          ]
+        })
+
+      assert html =~ "hero-user"
+      assert html =~ "badge"
+      assert html =~ "12"
+    end
+  end
+end


### PR DESCRIPTION
Three commits. Core already ships a "universal tab component", but most tab strips in the module libraries reimplement it — which is why renaming one daisyUI class took **21 edits across 8 repositories**. `nav_tabs` was itself one of the 21.

The companion PRs migrate seven of those strips onto this component. This is what made them possible.

## Replace daisyUI 4 `tabs-boxed` with v5 `tabs-box`

daisyUI 5 renamed the class, so every remaining use was styling nothing. Verified against the vendored daisyUI running on max-dev: it defines `tabs-box` and `tabs-lift`, with **zero** occurrences of `tabs-boxed`.

## Add patch links and an unframed variant

**No `patch`.** A query-param tab strip needs it; `navigate` remounts the LiveView and drops socket state. Tabs now take `:navigate` / `:patch`, mirroring `Phoenix.Component.link/1` rather than inventing a parallel vocabulary. `:path` stays a permanent alias for `:navigate`, so **no existing caller changes**.

**The frame was baked in.** `class` can only ADD, so a strip nested in an already-framed container had no way to shed the background and got hand-rolled instead. `variant={:plain}` drops it.

Worth recording: the frame is **`tabs-box` itself** — it draws the background, padding, radius and shadow. So `:boxed`'s `bg-base-200 p-1` are redundant overrides, and `:plain` has to drop the *modifier*, not just those two utilities. An earlier revision of this branch shipped a `:plain` that still drew the box.

## Add badge_class and nil-tolerant badges

Migrating the connections strip — the very example this moduledoc uses — turned up the last two gaps: a tab may state its own `:badge_class` (so a pending-requests count keeps `badge-warning` instead of taking the active tone), and every optional key now treats `nil` as absent, so the usual `badge: if(n > 0, do: n)` renders no badge rather than an empty pill. Zero still renders — only nil is absent.

## Failure behaviour

Setting two link keys raises — there is no defensible way to choose, and the new keys are new enough that no existing caller can trip it. A `nil` link value counts as absent, so a conditional `path:` is safe.

A tab with no link key **and** no `on_change` logs a warning and still renders. Deliberately not a raise: that combination produces a button wired to `phx-click={nil}` — a dead tab, which is bad, but taking a whole LiveView down over a tab strip is worse, and consumers of a published library cannot be audited.

## Scope

`tablist_class/2` and `tab_class/2` are public so tab-styled markup that is *not* a tab strip can share one definition — the next daisyUI rename should be a change here, not another sweep.

The Open Graph editor's 9 segmented controls stay **out** of the component: they are radio inputs inside a `phx-change` form, so they want `role="radiogroup"` and form plumbing, not `role="tab"`. Four independent model reviews agreed on that boundary.

Also migrates `live_sessions`' filter row, which carried a comment explaining it *could not* use the component because the payload key differed.

## Merge order

Merge this **before** phoenix_kit_user_connections#7 — that one uses `patch` / `badge_class`, and tab link keys are runtime map data, so against an older core its tabs render inert rather than failing to compile. The other six module PRs use only the pre-2.0 API and are order-independent.

## Checks

- `mix precommit` green.
- `mix test`: 3950 tests, 43 doctests. One unrelated media-browser URL-sync failure that passes in isolation and has zero references to tabs — the suite has order-dependent sandbox flakes.
- 19 component tests covering both link modes, the payload key, both variants, badges, and each failure path.