### PR TITLE
Add the border variant and make nav_tabs link keys verbatim

### DIFF
--- a/lib/phoenix_kit_web/components/core/nav_tabs.ex
+++ b/lib/phoenix_kit_web/components/core/nav_tabs.ex
@@ -7,8 +7,8 @@ defmodule PhoenixKitWeb.Components.Core.NavTabs do
   **Navigation tabs** — each tab carries a URL, renders as `<.link>`:
 
       <.nav_tabs active_tab="general" tabs={[
-        %{id: "general", label: "General", icon: "hero-cog-6-tooth", navigate: "/admin/settings"},
-        %{id: "advanced", label: "Advanced", navigate: "/admin/settings/advanced"}
+        %{id: "general", label: "General", icon: "hero-cog-6-tooth", navigate: Routes.path("/admin/settings")},
+        %{id: "advanced", label: "Advanced", navigate: Routes.path("/admin/settings/advanced")}
       ]} />
 
   **Event tabs** — no URL, uses `on_change` via `phx-click`:
@@ -21,8 +21,8 @@ defmodule PhoenixKitWeb.Components.Core.NavTabs do
   **With badges** (works in both modes):
 
       <.nav_tabs active_tab={@tab} tabs={[
-        %{id: "followers", label: "Followers", patch: "/connections?tab=followers", badge: @followers_count},
-        %{id: "following", label: "Following", patch: "/connections?tab=following", badge: @following_count}
+        %{id: "followers", label: "Followers", patch: Routes.path("/connections?tab=followers"), badge: @followers_count},
+        %{id: "following", label: "Following", patch: Routes.path("/connections?tab=following"), badge: @following_count}
       ]} />
 
   ## Tab map keys
@@ -39,9 +39,15 @@ defmodule PhoenixKitWeb.Components.Core.NavTabs do
   The link keys mirror `Phoenix.Component.link/1` rather than inventing a
   parallel vocabulary: `:navigate` for a full LiveView navigation, `:patch`
   to stay in the current LiveView (query-param tabs want this — a `:navigate`
-  there remounts and loses socket state). `:path` is the original spelling
-  and is kept as a permanent alias for `:navigate`, so nothing that already
-  uses it has to change. Setting more than one link key raises; a key whose
+  there remounts and loses socket state). Both pass through VERBATIM, again
+  like `link/1` — build them with your module's Paths helpers (or
+  `Routes.path/1` yourself). `:path` is the legacy
+  spelling: the same link KIND as `:navigate`, but with different prefix
+  rules — it is the one key the component still runs through
+  `Routes.path/1`, because its callers predate the link keys and have
+  always passed unprefixed paths. The two are NOT interchangeable: swapping
+  `path:` for `navigate:` while keeping an unprefixed value under-prefixes,
+  and the reverse double-prefixes. Setting more than one link key raises; a key whose
   value is `nil` counts as absent, so a conditional path is safe.
 
   A tab with no link key renders as a button and needs `on_change`; without
@@ -66,6 +72,8 @@ defmodule PhoenixKitWeb.Components.Core.NavTabs do
   `variant={:boxed}` (default) is the filled strip used across admin pages.
   `variant={:plain}` drops the frame for tabs that sit inside an
   already-framed container — a filter row inside a picker, say.
+  `variant={:border}` is daisyUI's underline look, the convention on
+  show-page and settings tab strips.
 
   It exists because `class` can only ADD to the container: with the frame
   baked in, a caller had no way to take it off, and hand-rolling the markup
@@ -92,6 +100,12 @@ defmodule PhoenixKitWeb.Components.Core.NavTabs do
   def tablist_class(variant \\ :boxed, extra \\ nil)
   def tablist_class(:boxed, extra), do: ["tabs tabs-box bg-base-200 p-1", extra]
 
+  # The underline family: daisyUI's third tab look, used by the show-page
+  # and settings strips across the modules. Unlike `tabs-box`, `tabs-border`
+  # draws only the underline — there is no frame to shed, so no bg/padding
+  # overrides ride along.
+  def tablist_class(:border, extra), do: ["tabs tabs-border", extra]
+
   # `tabs-box` IS the daisyUI frame — it sets background-color, padding,
   # border-radius and box-shadow itself, which is why `:boxed`'s own
   # `bg-base-200 p-1` are redundant overrides rather than the frame. Dropping
@@ -115,9 +129,9 @@ defmodule PhoenixKitWeb.Components.Core.NavTabs do
     doc: "phx-click event name for event-based tabs (tabs with no link key)"
 
   attr :variant, :atom,
-    values: [:boxed, :plain],
+    values: [:boxed, :plain, :border],
     default: :boxed,
-    doc: ":boxed fills the strip; :plain drops the background and padding"
+    doc: ":boxed fills the strip; :plain drops the frame; :border is the underline look"
 
   attr :class, :string, default: nil
 
@@ -199,7 +213,16 @@ defmodule PhoenixKitWeb.Components.Core.NavTabs do
   end
 
   defp resolve_link([], _tab), do: nil
-  defp resolve_link([{_key, kind, to}], _tab), do: [{kind, Routes.path(to)}]
+
+  # `:navigate`/`:patch` pass through VERBATIM, exactly like
+  # `Phoenix.Component.link/1` — modules build their URLs with their own
+  # Paths helpers, which already apply the URL prefix and locale, and
+  # applying `Routes.path/1` a second time double-prefixes them (found
+  # migrating the CRM show pages). Only the legacy `:path` key keeps the
+  # helper treatment: it predates the link keys and its callers have always
+  # passed unprefixed paths.
+  defp resolve_link([{:path, kind, to}], _tab), do: [{kind, Routes.path(to)}]
+  defp resolve_link([{_key, kind, to}], _tab), do: [{kind, to}]
 
   # Two link keys is unambiguously a mistake rather than a degraded render:
   # there is no defensible way to pick one, and `:navigate`/`:patch` are new

--- a/test/phoenix_kit_web/components/core/nav_tabs_test.exs
+++ b/test/phoenix_kit_web/components/core/nav_tabs_test.exs
@@ -52,13 +52,25 @@ defmodule PhoenixKitWeb.Components.Core.NavTabsTest do
       refute html =~ ~s(data-phx-link="patch")
     end
 
-    test ":path still means navigate — the original spelling never breaks" do
+    test ":path still means navigate AND still gets the route-helper treatment" do
       from_path = render_tabs(%{tabs: [%{id: "a", label: "General", path: "/admin/settings"}]})
 
-      from_navigate =
-        render_tabs(%{tabs: [%{id: "a", label: "General", navigate: "/admin/settings"}]})
+      assert from_path =~ ~s(data-phx-link="redirect")
+      # Routes.path applied (locale/prefix injection) — the pre-link-keys
+      # contract every legacy caller relies on.
+      assert from_path =~ "/admin/settings"
+    end
 
-      assert from_path == from_navigate
+    test ":navigate and :patch pass through verbatim — no double-prefixing" do
+      # Modules build tab URLs with their own Paths helpers, which already
+      # apply the URL prefix and locale. Running them through Routes.path/1
+      # again double-prefixes; only legacy :path gets the helper.
+      html =
+        render_tabs(%{
+          tabs: [%{id: "a", label: "A", patch: "/phoenix_kit/en/admin/crm/contacts/x?tab=files"}]
+        })
+
+      assert html =~ ~s(href="/phoenix_kit/en/admin/crm/contacts/x?tab=files")
     end
 
     test "a query string survives the route helper intact" do
@@ -122,6 +134,23 @@ defmodule PhoenixKitWeb.Components.Core.NavTabsTest do
 
       # Still a tab strip, just unframed.
       assert html =~ "tabs"
+    end
+
+    test ":border is the underline family — no box, no frame overrides" do
+      html = render_tabs(%{variant: :border, on_change: "s", tabs: [%{id: "a", label: "A"}]})
+
+      assert html =~ "tabs-border"
+      refute html =~ "tabs-box"
+      refute html =~ "bg-base-200"
+    end
+
+    test "adding :border changed nothing about :boxed or :plain" do
+      boxed = render_tabs(%{on_change: "s", tabs: [%{id: "a", label: "A"}]})
+      plain = render_tabs(%{variant: :plain, on_change: "s", tabs: [%{id: "a", label: "A"}]})
+
+      assert boxed =~ "tabs tabs-box bg-base-200 p-1"
+      assert plain =~ ~s(class="tabs")
+      refute plain =~ "tabs-border"
     end
 
     test "class ADDS to the container rather than replacing it" do
@@ -191,6 +220,11 @@ defmodule PhoenixKitWeb.Components.Core.NavTabsTest do
       assert NavTabs.tablist_class(:boxed) == ["tabs tabs-box bg-base-200 p-1", nil]
       assert NavTabs.tablist_class(:plain) == ["tabs", nil]
       assert NavTabs.tablist_class(:plain, "inline-flex") == ["tabs", "inline-flex"]
+      assert NavTabs.tablist_class(:border) == ["tabs tabs-border", nil]
+    end
+
+    test "an unknown variant fails loud, not as a silently unstyled strip" do
+      assert_raise FunctionClauseError, fn -> NavTabs.tablist_class(:bogus) end
     end
 
     test "tab_class/2 marks the active tab" do


### PR DESCRIPTION
The second tab-consolidation wave: the underline family. Two core changes the seven companion PRs build on.

## `variant={:border}`

daisyUI's third tab look — the convention on show-page and settings strips, of which the modules carried **13 hand-rolled copies** (CRM ×6, catalogue ×3, entities, locations, sync, +1 shared component). Unlike `tabs-box` there is no frame to shed, so no bg/padding overrides ride along.

## `:navigate` / `:patch` pass through verbatim

Migrating the CRM show pages surfaced a design fault in what shipped in 2.13.5: the component ran `:patch`/`:navigate` values through `Routes.path/1` — but every module builds its tab URLs with its own **Paths helpers, which are already prefixed**, so the component double-prefixed them. That trap was latent in every Paths-using module.

The keys now mirror `Phoenix.Component.link/1` exactly: **verbatim**. Only the legacy `:path` key keeps the helper treatment — its callers predate the link keys and have always passed unprefixed paths. The moduledoc now states plainly that `:path` and `:navigate` are the same link *kind* with **different prefix rules**, not interchangeable spellings.

**Census of the semantic change:** exactly one `:patch`/`:navigate` consumer existed against 2.13.5 (user_connections' strip, migrated two days ago). Its companion PR switches it back to `Routes.path`-built URLs — restoring exactly what its pre-migration markup always did. Every call site in this wave was verified to pass prefixed values, and the component's own doc examples now show `Routes.path(...)` so they can't teach the bare-string habit.

## Merge order

**This PR first, then release, then the seven module PRs** — `variant={:border}` fails the attr-values check against 2.13.5, so module CI stays red until the release is on Hex (the same sequencing as the first wave; disclosed in each module PR).

## Companion PRs

CRM (6 strips), entities, sync, locations (its `LocationTabs` wrapper now renders through `nav_tabs`), open_graph (preview switcher), bookings (2 strips — staying `:boxed`, their current look), user_connections (the verbatim-semantics fix).

**Deliberately excluded:** catalogue's 3 strips (PR #76 is open in that repo — follow-up after it merges), ecommerce's `translation_tabs` (a language switcher for translation editing — multilang semantics, not navigation), OG's `template.ex:637` (per-button event names) and its 9 segmented form controls (radio inputs, not tabs).

## Checks

23 component tests (border variant, verbatim pass-through incl. the no-double-prefix pin, `:path` legacy behaviour, unknown-variant fail-loud). `mix precommit` green here and in all seven companion repos (run against local core). Whole wave deployed to max-dev: pages route, logs clean.
