### PR TITLE
Translate authentication and session flash messages

### DIFF
--- a/lib/phoenix_kit_web/controllers/context_controller.ex
+++ b/lib/phoenix_kit_web/controllers/context_controller.ex
@@ -79,7 +79,7 @@ defmodule PhoenixKitWeb.ContextController do
 
   def set(conn, _params) do
     conn
-    |> put_flash(:error, "Invalid context")
+    |> put_flash(:error, gettext("Invalid context"))
     |> redirect(to: get_redirect_path(conn))
   end
 
@@ -98,7 +98,7 @@ defmodule PhoenixKitWeb.ContextController do
       |> redirect(to: redirect_path)
     else
       conn
-      |> put_flash(:error, "Context switching is not enabled")
+      |> put_flash(:error, gettext("Context switching is not enabled"))
       |> redirect(to: default_redirect())
     end
   end

--- a/lib/phoenix_kit_web/users/auth.ex
+++ b/lib/phoenix_kit_web/users/auth.ex
@@ -36,6 +36,7 @@ defmodule PhoenixKitWeb.Users.Auth do
   `PhoenixKitWeb.Integration.phoenix_kit_routes/0` macro in your router.
   """
   use PhoenixKitWeb, :verified_routes
+  use Gettext, backend: PhoenixKitWeb.Gettext
 
   import Plug.Conn
   import Phoenix.Controller
@@ -107,7 +108,7 @@ defmodule PhoenixKitWeb.Users.Auth do
     conn
     |> Phoenix.Controller.put_flash(
       :error,
-      "This account is not active. Contact an administrator."
+      gettext("This account is not active. Contact an administrator.")
     )
     |> Phoenix.Controller.redirect(to: Routes.path("/users/log-in"))
     |> halt()
@@ -673,7 +674,10 @@ defmodule PhoenixKitWeb.Users.Auth do
           # No `skip_admin`: the rejected visitor may well be an Admin, who
           # legitimately belongs in `/admin` — that area is gated by
           # `:phoenix_kit_ensure_admin`, not by this hook, so there is no loop.
-          |> Phoenix.LiveView.put_flash(:error, "You must be an owner to access this page.")
+          |> Phoenix.LiveView.put_flash(
+            :error,
+            gettext("You must be an owner to access this page.")
+          )
           |> Phoenix.LiveView.redirect(to: Routes.safe_destination(socket, scope: scope))
 
         {:halt, socket}
@@ -717,7 +721,7 @@ defmodule PhoenixKitWeb.Users.Auth do
             socket
             |> Phoenix.LiveView.put_flash(
               :error,
-              "You do not have the required permission to access this page."
+              gettext("You do not have the required permission to access this page.")
             )
             |> Phoenix.LiveView.redirect(
               to: Routes.safe_destination(socket, scope: scope, skip_admin: true)
@@ -742,7 +746,7 @@ defmodule PhoenixKitWeb.Users.Auth do
             socket
             |> Phoenix.LiveView.put_flash(
               :error,
-              "You do not have permission to access this section."
+              gettext("You do not have permission to access this section.")
             )
             |> Phoenix.LiveView.redirect(to: redirect_to)
 
@@ -871,7 +875,7 @@ defmodule PhoenixKitWeb.Users.Auth do
     socket
     |> Phoenix.LiveView.put_flash(
       :error,
-      "You do not have the required permission to access this page."
+      gettext("You do not have the required permission to access this page.")
     )
     # `skip_admin: true` states the invariant at the call site: this is the
     # admin-area rejection, so the destination must never be an admin page the
@@ -896,7 +900,7 @@ defmodule PhoenixKitWeb.Users.Auth do
 
   defp redirect_to_login(socket) do
     socket
-    |> Phoenix.LiveView.put_flash(:error, "You must log in to access this page.")
+    |> Phoenix.LiveView.put_flash(:error, gettext("You must log in to access this page."))
     |> Phoenix.LiveView.redirect(to: login_path_with_return_to(socket))
   end
 
@@ -1408,7 +1412,10 @@ defmodule PhoenixKitWeb.Users.Auth do
 
   defp apply_scope_refresh_decision(socket, :evict_admin_area, new_scope) do
     socket
-    |> LiveView.put_flash(:error, "You must be an admin to access this page.")
+    |> LiveView.put_flash(
+      :error,
+      gettext("You must be an admin to access this page.")
+    )
     |> LiveView.push_navigate(
       to: Routes.safe_destination(socket, scope: new_scope, skip_admin: true)
     )
@@ -1416,7 +1423,10 @@ defmodule PhoenixKitWeb.Users.Auth do
 
   defp apply_scope_refresh_decision(socket, :evict_module, new_scope) do
     socket
-    |> LiveView.put_flash(:error, "You no longer have permission to access this section.")
+    |> LiveView.put_flash(
+      :error,
+      gettext("You no longer have permission to access this section.")
+    )
     |> LiveView.push_navigate(to: best_available_admin_path(socket, new_scope))
   end
 
@@ -1860,7 +1870,7 @@ defmodule PhoenixKitWeb.Users.Auth do
     # The label is localized, so the sentence around it must be too — an
     # English frame around a translated name reads worse than either alone.
     message =
-      Gettext.dgettext(PhoenixKitWeb.Gettext, "default", "%{label} module is not enabled",
+      gettext("%{label} module is not enabled",
         label: label
       )
 
@@ -1879,7 +1889,7 @@ defmodule PhoenixKitWeb.Users.Auth do
       socket
       |> Phoenix.LiveView.put_flash(
         :error,
-        "You do not have permission to access this section."
+        gettext("You do not have permission to access this section.")
       )
       |> Phoenix.LiveView.redirect(to: redirect_to)
 
@@ -2279,7 +2289,7 @@ defmodule PhoenixKitWeb.Users.Auth do
 
     if is_nil(user) do
       conn
-      |> put_flash(:error, "You must log in to access this page.")
+      |> put_flash(:error, gettext("You must log in to access this page."))
       |> maybe_store_return_to()
       |> redirect(to: Routes.path("/users/log-in"))
       |> halt()
@@ -2316,7 +2326,7 @@ defmodule PhoenixKitWeb.Users.Auth do
           end
         else
           conn
-          |> put_flash(:error, "You must log in to access this page.")
+          |> put_flash(:error, gettext("You must log in to access this page."))
           |> maybe_store_return_to()
           |> redirect(to: Routes.path("/users/log-in"))
           |> halt()
@@ -2349,10 +2359,11 @@ defmodule PhoenixKitWeb.Users.Auth do
   defp account_gate(subject) do
     cond do
       not email_confirmed?(subject) and confirmation_required?() ->
-        {:halt, "Please confirm your email before accessing the application.", "/users/confirm"}
+        {:halt, gettext("Please confirm your email before accessing the application."),
+         "/users/confirm"}
 
       not Referrals.access_satisfied?(subject) ->
-        {:halt, "Enter your referral code to continue.", "/users/referral"}
+        {:halt, gettext("Enter your referral code to continue."), "/users/referral"}
 
       true ->
         :ok
@@ -2409,7 +2420,7 @@ defmodule PhoenixKitWeb.Users.Auth do
               conn
             else
               conn
-              |> put_flash(:error, "You must be an owner to access this page.")
+              |> put_flash(:error, gettext("You must be an owner to access this page."))
               |> redirect(to: Routes.safe_destination(conn, scope: scope))
               |> halt()
             end
@@ -2446,14 +2457,14 @@ defmodule PhoenixKitWeb.Users.Auth do
                 conn
                 |> put_flash(
                   :error,
-                  "You do not have the required permission to access this page."
+                  gettext("You do not have the required permission to access this page.")
                 )
                 |> redirect(to: Routes.safe_destination(conn, scope: scope, skip_admin: true))
                 |> halt()
 
               true ->
                 conn
-                |> put_flash(:error, "You must log in to access this page.")
+                |> put_flash(:error, gettext("You must log in to access this page."))
                 |> redirect(to: Routes.path("/users/log-in"))
                 |> halt()
             end
@@ -2482,7 +2493,7 @@ defmodule PhoenixKitWeb.Users.Auth do
                 conn
                 |> put_flash(
                   :error,
-                  "You do not have the required permission to access this page."
+                  gettext("You do not have the required permission to access this page.")
                 )
                 |> redirect(to: Routes.safe_destination(conn, scope: scope, skip_admin: true))
                 |> halt()
@@ -2495,7 +2506,10 @@ defmodule PhoenixKitWeb.Users.Auth do
 
               true ->
                 conn
-                |> put_flash(:error, "You do not have permission to access this section.")
+                |> put_flash(
+                  :error,
+                  gettext("You do not have permission to access this section.")
+                )
                 |> redirect(to: best_available_admin_path(conn, scope))
                 |> halt()
             end
@@ -2520,7 +2534,12 @@ defmodule PhoenixKitWeb.Users.Auth do
               conn
             else
               conn
-              |> put_flash(:error, "You must have the #{role_name} role to access this page.")
+              |> put_flash(
+                :error,
+                gettext("You must have the %{role_name} role to access this page.",
+                  role_name: role_name
+                )
+              )
               |> redirect(to: Routes.safe_destination(conn, scope: scope))
               |> halt()
             end

--- a/lib/phoenix_kit_web/users/confirmation.ex
+++ b/lib/phoenix_kit_web/users/confirmation.ex
@@ -47,7 +47,7 @@ defmodule PhoenixKitWeb.Users.Confirmation do
 
         {:noreply,
          socket
-         |> put_flash(:info, "User confirmed successfully.")
+         |> put_flash(:info, gettext("User confirmed successfully."))
          |> redirect(to: destination)}
 
       :error ->
@@ -63,7 +63,10 @@ defmodule PhoenixKitWeb.Users.Confirmation do
           %{} ->
             {:noreply,
              socket
-             |> put_flash(:error, "User confirmation link is invalid or it has expired.")
+             |> put_flash(
+               :error,
+               gettext("User confirmation link is invalid or it has expired.")
+             )
              |> redirect(
                to:
                  Routes.safe_destination(socket,

--- a/lib/phoenix_kit_web/users/confirmation_instructions.ex
+++ b/lib/phoenix_kit_web/users/confirmation_instructions.ex
@@ -86,7 +86,9 @@ defmodule PhoenixKitWeb.Users.ConfirmationInstructions do
     end
 
     info =
-      "If your email is in our system and it has not been confirmed yet, you will receive an email with instructions shortly."
+      gettext(
+        "If your email is in our system and it has not been confirmed yet, you will receive an email with instructions shortly."
+      )
 
     socket = put_flash(socket, :info, info)
 

--- a/lib/phoenix_kit_web/users/forgot_password.ex
+++ b/lib/phoenix_kit_web/users/forgot_password.ex
@@ -46,7 +46,9 @@ defmodule PhoenixKitWeb.Users.ForgotPassword do
     end
 
     info =
-      "If your email is in our system, you will receive instructions to reset your password shortly."
+      gettext(
+        "If your email is in our system, you will receive instructions to reset your password shortly."
+      )
 
     {:noreply,
      socket

--- a/lib/phoenix_kit_web/users/magic_link.ex
+++ b/lib/phoenix_kit_web/users/magic_link.ex
@@ -36,7 +36,7 @@ defmodule PhoenixKitWeb.Users.MagicLink do
         else
           {:ok,
            socket
-           |> put_flash(:error, "Magic link sign-in is currently disabled.")
+           |> put_flash(:error, gettext("Magic link sign-in is currently disabled."))
            |> redirect(to: Routes.path("/users/log-in"))}
         end
     end
@@ -107,7 +107,7 @@ defmodule PhoenixKitWeb.Users.MagicLink do
          socket
          |> assign(:sent, true)
          |> assign(:loading, false)
-         |> put_flash(:info, "Magic link sent! Check your email.")}
+         |> put_flash(:info, gettext("Magic link sent! Check your email."))}
 
       {:error, _} ->
         # For security, we don't reveal whether the email exists or not
@@ -115,7 +115,10 @@ defmodule PhoenixKitWeb.Users.MagicLink do
          socket
          |> assign(:sent, true)
          |> assign(:loading, false)
-         |> put_flash(:info, "If that email address exists, a magic link has been sent.")}
+         |> put_flash(
+           :info,
+           gettext("If that email address exists, a magic link has been sent.")
+         )}
     end
   end
 

--- a/lib/phoenix_kit_web/users/magic_link_registration.ex
+++ b/lib/phoenix_kit_web/users/magic_link_registration.ex
@@ -32,13 +32,13 @@ defmodule PhoenixKitWeb.Users.MagicLinkRegistration do
             # Registration is closed outright, so /users/register is no help.
             {:ok,
              socket
-             |> put_flash(:error, "Registration is currently disabled.")
+             |> put_flash(:error, gettext("Registration is currently disabled."))
              |> redirect(to: Routes.path("/users/log-in"))}
 
           not WebAuth.magic_link_registration_enabled?() ->
             {:ok,
              socket
-             |> put_flash(:error, "Magic link registration is currently disabled.")
+             |> put_flash(:error, gettext("Magic link registration is currently disabled."))
              |> redirect(to: Routes.path("/users/register"))}
 
           true ->
@@ -89,7 +89,7 @@ defmodule PhoenixKitWeb.Users.MagicLinkRegistration do
       {:error, _} ->
         {:ok,
          socket
-         |> put_flash(:error, "Registration link is invalid or has expired.")
+         |> put_flash(:error, gettext("Registration link is invalid or has expired."))
          |> redirect(to: Routes.path("/users/register"))}
     end
   end
@@ -182,10 +182,10 @@ defmodule PhoenixKitWeb.Users.MagicLinkRegistration do
   end
 
   defp completion_error_message(:email_already_exists),
-    do: "That email is already registered. Please log in instead."
+    do: gettext("That email is already registered. Please log in instead.")
 
   defp completion_error_message(_),
-    do: "Registration link is invalid or has expired. Please request a new one."
+    do: gettext("Registration link is invalid or has expired. Please request a new one.")
 
   # Only what this form legitimately owns. `registration_changeset/3` also casts
   # `custom_fields` and the geo columns — fine for server-side callers, but a

--- a/lib/phoenix_kit_web/users/magic_link_registration_request.ex
+++ b/lib/phoenix_kit_web/users/magic_link_registration_request.ex
@@ -48,7 +48,7 @@ defmodule PhoenixKitWeb.Users.MagicLinkRegistrationRequest do
             socket
             |> put_flash(
               :error,
-              "User registration is currently disabled. Please contact an administrator."
+              gettext("User registration is currently disabled. Please contact an administrator.")
             )
             |> redirect(to: Routes.path("/users/log-in"))
 
@@ -74,7 +74,7 @@ defmodule PhoenixKitWeb.Users.MagicLinkRegistrationRequest do
     else
       {:noreply,
        socket
-       |> put_flash(:error, "User registration is currently disabled.")
+       |> put_flash(:error, gettext("User registration is currently disabled."))
        |> redirect(to: Routes.path("/users/log-in"))}
     end
   end
@@ -89,7 +89,7 @@ defmodule PhoenixKitWeb.Users.MagicLinkRegistrationRequest do
          |> assign(:email, sent_email)
          |> assign(:loading, false)
          |> assign(:error_message, nil)
-         |> put_flash(:info, "Registration link sent! Check your email.")}
+         |> put_flash(:info, gettext("Registration link sent! Check your email."))}
 
       # Deliberately indistinguishable from success: saying "already
       # registered" here turned this public form into an account-existence
@@ -100,18 +100,22 @@ defmodule PhoenixKitWeb.Users.MagicLinkRegistrationRequest do
          |> assign(:email_sent, true)
          |> assign(:loading, false)
          |> assign(:error_message, nil)
-         |> put_flash(:info, "Registration link sent! Check your email.")}
+         |> put_flash(:info, gettext("Registration link sent! Check your email."))}
 
       {:error, :invalid_email} ->
         {:noreply,
-         error_state(socket, "Please enter a valid email address.", "Invalid email format")}
+         error_state(
+           socket,
+           "Please enter a valid email address.",
+           gettext("Invalid email format")
+         )}
 
       {:error, :rate_limit_exceeded} ->
         {:noreply,
          error_state(
            socket,
            "Too many registration attempts. Please try again later.",
-           "Too many attempts"
+           gettext("Too many attempts")
          )}
 
       {:error, _reason} ->
@@ -137,7 +141,7 @@ defmodule PhoenixKitWeb.Users.MagicLinkRegistrationRequest do
     error_state(
       socket,
       "Failed to send registration link. Please try again.",
-      "Something went wrong"
+      gettext("Something went wrong")
     )
   end
 

--- a/lib/phoenix_kit_web/users/magic_link_registration_verify.ex
+++ b/lib/phoenix_kit_web/users/magic_link_registration_verify.ex
@@ -21,7 +21,7 @@ defmodule PhoenixKitWeb.Users.MagicLinkRegistrationVerify do
         conn
         |> put_flash(
           :error,
-          "Registration link is invalid or has expired. Please request a new one."
+          gettext("Registration link is invalid or has expired. Please request a new one.")
         )
         |> redirect(to: Routes.path("/users/register"))
     end
@@ -29,7 +29,7 @@ defmodule PhoenixKitWeb.Users.MagicLinkRegistrationVerify do
 
   def verify(conn, _params) do
     conn
-    |> put_flash(:error, "Invalid registration link. Please request a new one.")
+    |> put_flash(:error, gettext("Invalid registration link. Please request a new one."))
     |> redirect(to: Routes.path("/users/register"))
   end
 end

--- a/lib/phoenix_kit_web/users/magic_link_verify.ex
+++ b/lib/phoenix_kit_web/users/magic_link_verify.ex
@@ -30,14 +30,14 @@ defmodule PhoenixKitWeb.Users.MagicLinkVerify do
       # token already sitting in an inbox is a way around the setting. They are
       # short-lived, so the window this affects is small.
       conn
-      |> put_flash(:error, "Magic link sign-in is currently disabled.")
+      |> put_flash(:error, gettext("Magic link sign-in is currently disabled."))
       |> redirect(to: Routes.path("/users/log-in"))
     end
   end
 
   def verify(conn, _params) do
     conn
-    |> put_flash(:error, "Invalid magic link. Please request a new one.")
+    |> put_flash(:error, gettext("Invalid magic link. Please request a new one."))
     |> redirect(to: Routes.path("/users/log-in"))
   end
 
@@ -53,12 +53,15 @@ defmodule PhoenixKitWeb.Users.MagicLinkVerify do
         # (re-sanitized) destination the emailed link carried before signing in.
         conn
         |> maybe_store_return_to(params["return_to"])
-        |> put_flash(:info, "Successfully logged in with magic link!")
+        |> put_flash(:info, gettext("Successfully logged in with magic link!"))
         |> UserAuth.log_in_user(user, UserAuth.remember_me_params())
 
       {:error, :invalid_token} ->
         conn
-        |> put_flash(:error, "Magic link is invalid or has expired. Please request a new one.")
+        |> put_flash(
+          :error,
+          gettext("Magic link is invalid or has expired. Please request a new one.")
+        )
         |> redirect(to: Routes.path("/users/log-in"))
     end
   end

--- a/lib/phoenix_kit_web/users/oauth.ex
+++ b/lib/phoenix_kit_web/users/oauth.ex
@@ -79,14 +79,20 @@ if Code.ensure_loaded?(Ueberauth) do
             Logger.warning("PhoenixKit OAuth: Unknown provider '#{provider}'")
 
             conn
-            |> put_flash(:error, "Unknown OAuth provider: #{provider}")
+            |> put_flash(
+              :error,
+              gettext("Unknown OAuth provider: %{provider}", provider: provider)
+            )
             |> redirect(to: Routes.path("/users/log-in"))
 
           {:error, :provider_disabled} ->
             Logger.warning("PhoenixKit OAuth: Provider '#{provider}' is disabled in settings")
 
             conn
-            |> put_flash(:error, "OAuth provider '#{provider}' is currently disabled.")
+            |> put_flash(
+              :error,
+              gettext("OAuth provider '%{provider}' is currently disabled.", provider: provider)
+            )
             |> redirect(to: Routes.path("/users/log-in"))
 
           {:error, :no_credentials} ->
@@ -97,7 +103,10 @@ if Code.ensure_loaded?(Ueberauth) do
             conn
             |> put_flash(
               :error,
-              "OAuth provider '#{provider}' is not configured. Please contact your administrator."
+              gettext(
+                "OAuth provider '%{provider}' is not configured. Please contact your administrator.",
+                provider: provider
+              )
             )
             |> redirect(to: Routes.path("/users/log-in"))
         end
@@ -107,7 +116,9 @@ if Code.ensure_loaded?(Ueberauth) do
         conn
         |> put_flash(
           :error,
-          "OAuth authentication is currently disabled. Please contact your administrator to enable it."
+          gettext(
+            "OAuth authentication is currently disabled. Please contact your administrator to enable it."
+          )
         )
         |> redirect(to: Routes.path("/users/log-in"))
       end
@@ -196,7 +207,7 @@ if Code.ensure_loaded?(Ueberauth) do
           Logger.error("PhoenixKit OAuth: Unknown provider in callback: #{provider}")
 
           conn
-          |> put_flash(:error, "Unknown OAuth provider: #{provider}")
+          |> put_flash(:error, gettext("Unknown OAuth provider: %{provider}", provider: provider))
           |> redirect(to: Routes.path("/users/log-in"))
 
         strategy_module ->
@@ -258,12 +269,14 @@ if Code.ensure_loaded?(Ueberauth) do
             # full login — surface it and return home.
             add_account_intent == "add_account" ->
               conn
-              |> put_flash(:error, "Account switching is currently disabled.")
+              |> put_flash(:error, gettext("Account switching is currently disabled."))
               |> redirect(to: Routes.safe_destination(conn, scope: conn_scope(conn)))
 
             true ->
               flash_message =
-                "Successfully signed in with #{format_provider_name(auth.provider)}!"
+                gettext("Successfully signed in with %{provider}!",
+                  provider: format_provider_name(auth.provider)
+                )
 
               # No checkbox in an OAuth round-trip, so persistence follows the
               # site-wide policy setting.
@@ -283,7 +296,7 @@ if Code.ensure_loaded?(Ueberauth) do
           )
 
           conn
-          |> put_flash(:error, "Authentication failed: #{errors}")
+          |> put_flash(:error, gettext("Authentication failed: %{errors}", errors: errors))
           |> redirect(to: Routes.path("/users/log-in"))
 
         {:error, :provider_email_unverified} ->
@@ -300,8 +313,9 @@ if Code.ensure_loaded?(Ueberauth) do
           conn
           |> put_flash(
             :error,
-            "An account already exists for that email address. Sign in with your password " <>
-              "first, then connect this provider from your account settings."
+            gettext(
+              "An account already exists for that email address. Sign in with your password first, then connect this provider from your account settings."
+            )
           )
           |> redirect(to: Routes.path("/users/log-in"))
 
@@ -311,7 +325,7 @@ if Code.ensure_loaded?(Ueberauth) do
           conn
           |> put_flash(
             :error,
-            "Authentication failed. Please try again or use a different sign-in method."
+            gettext("Authentication failed. Please try again or use a different sign-in method.")
           )
           |> redirect(to: Routes.path("/users/log-in"))
       end
@@ -338,7 +352,7 @@ if Code.ensure_loaded?(Ueberauth) do
       # Clear every transient OAuth key so a later normal sign-in can't inherit
       # this abandoned attempt's redirect target or referral attribution.
       |> clear_oauth_session_keys()
-      |> put_flash(:error, "Authentication failed. Please try again.")
+      |> put_flash(:error, gettext("Authentication failed. Please try again."))
       |> redirect(to: Routes.path("/users/log-in"))
     end
 
@@ -348,22 +362,22 @@ if Code.ensure_loaded?(Ueberauth) do
       case MultiSession.add_authenticated_user(conn, user) do
         {:ok, conn} ->
           conn
-          |> put_flash(:info, "Account added.")
+          |> put_flash(:info, gettext("Account added."))
           |> redirect_back(return_to)
 
         {:error, :stack_full} ->
           conn
-          |> put_flash(:error, "Maximum number of accounts reached.")
+          |> put_flash(:error, gettext("Maximum number of accounts reached."))
           |> redirect_back(return_to)
 
         {:error, :already_in_stack} ->
           conn
-          |> put_flash(:error, "That account is already in your session.")
+          |> put_flash(:error, gettext("That account is already in your session."))
           |> redirect_back(return_to)
 
         {:error, :inactive} ->
           conn
-          |> put_flash(:error, "That account is inactive.")
+          |> put_flash(:error, gettext("That account is inactive."))
           |> redirect_back(return_to)
       end
     end
@@ -421,13 +435,13 @@ if Code.ensure_loaded?(Ueberauth) do
     defp format_ueberauth_failure(%Ueberauth.Failure{errors: errors}) do
       case errors do
         [] ->
-          "Authentication failed. Please try again."
+          gettext("Authentication failed. Please try again.")
 
         [%{message: message} | _] when is_binary(message) ->
-          "Authentication failed: #{message}"
+          gettext("Authentication failed: %{message}", message: message)
 
         _ ->
-          "Authentication failed. Please try again."
+          gettext("Authentication failed. Please try again.")
       end
     end
   end
@@ -465,7 +479,10 @@ else
       conn
       |> put_flash(
         :error,
-        "OAuth authentication is not available. Please install the required dependencies (ueberauth, ueberauth_#{provider}) and configure your application. See PhoenixKit documentation for details."
+        gettext(
+          "OAuth authentication is not available. Please install the required dependencies (ueberauth, ueberauth_%{provider}) and configure your application. See PhoenixKit documentation for details.",
+          provider: provider
+        )
       )
       |> redirect(to: Routes.path("/users/log-in"))
     end
@@ -481,7 +498,7 @@ else
       conn
       |> put_flash(
         :error,
-        "OAuth authentication is not configured. Please contact your administrator."
+        gettext("OAuth authentication is not configured. Please contact your administrator.")
       )
       |> redirect(to: Routes.path("/users/log-in"))
     end

--- a/lib/phoenix_kit_web/users/registration.ex
+++ b/lib/phoenix_kit_web/users/registration.ex
@@ -107,7 +107,7 @@ defmodule PhoenixKitWeb.Users.Registration do
         socket
         |> put_flash(
           :error,
-          "User registration is currently disabled. Please contact an administrator."
+          gettext("User registration is currently disabled. Please contact an administrator.")
         )
         |> redirect(to: Routes.path("/users/log-in"))
 
@@ -125,7 +125,7 @@ defmodule PhoenixKitWeb.Users.Registration do
       # closing registration has to close the submit, not only the entrance.
       {:noreply,
        socket
-       |> put_flash(:error, "Registration is currently disabled.")
+       |> put_flash(:error, gettext("Registration is currently disabled."))
        |> redirect(to: Routes.path("/users/log-in"))}
     end
   end

--- a/lib/phoenix_kit_web/users/reset_password.ex
+++ b/lib/phoenix_kit_web/users/reset_password.ex
@@ -38,7 +38,7 @@ defmodule PhoenixKitWeb.Users.ResetPassword do
       {:ok, _} ->
         {:noreply,
          socket
-         |> put_flash(:info, "Password reset successfully.")
+         |> put_flash(:info, gettext("Password reset successfully."))
          |> redirect(to: Routes.path("/users/log-in"))}
 
       {:error, changeset} ->
@@ -56,7 +56,7 @@ defmodule PhoenixKitWeb.Users.ResetPassword do
       assign(socket, user: user, token: token)
     else
       socket
-      |> put_flash(:error, "Reset password link is invalid or it has expired.")
+      |> put_flash(:error, gettext("Reset password link is invalid or it has expired."))
       |> redirect(
         to: Routes.safe_destination(socket, scope: socket.assigns[:phoenix_kit_current_scope])
       )

--- a/lib/phoenix_kit_web/users/session.ex
+++ b/lib/phoenix_kit_web/users/session.ex
@@ -24,20 +24,20 @@ defmodule PhoenixKitWeb.Users.Session do
   alias PhoenixKitWeb.Users.MultiSession
 
   def create(conn, %{"_action" => "registered"} = params) do
-    create(conn, params, "Account created successfully!", :registered)
+    create(conn, params, gettext("Account created successfully!"), :registered)
   end
 
   def create(conn, %{"_action" => "password_updated"} = params) do
     create(
       conn,
       carry_remember_me(conn, params),
-      "Password updated successfully!",
+      gettext("Password updated successfully!"),
       :password_updated
     )
   end
 
   def create(conn, params) do
-    create(conn, params, "Welcome back!", :login)
+    create(conn, params, gettext("Welcome back!"), :login)
   end
 
   # The destination is stashed only once the credentials check out. Doing it up
@@ -63,7 +63,9 @@ defmodule PhoenixKitWeb.Users.Session do
         conn
         |> put_flash(
           :error,
-          "Your account is currently inactive. Please contact the team if you believe this is an error."
+          gettext(
+            "Your account is currently inactive. Please contact the team if you believe this is an error."
+          )
         )
         |> put_flash(:email_or_username, String.slice(email_or_username, 0, 160))
         |> redirect(to: Routes.path("/users/log-in"))
@@ -79,7 +81,7 @@ defmodule PhoenixKitWeb.Users.Session do
       {:error, :rate_limit_exceeded} ->
         # Rate limit exceeded - show specific error message
         conn
-        |> put_flash(:error, "Too many login attempts. Please try again later.")
+        |> put_flash(:error, gettext("Too many login attempts. Please try again later."))
         |> put_flash(:email_or_username, String.slice(email_or_username, 0, 160))
         |> redirect(to: Routes.path("/users/log-in"))
 
@@ -87,7 +89,7 @@ defmodule PhoenixKitWeb.Users.Session do
         # Invalid credentials (wrong email/username or password)
         # In order to prevent user enumeration attacks, don't disclose whether the email/username is registered.
         conn
-        |> put_flash(:error, "Invalid email/username or password")
+        |> put_flash(:error, gettext("Invalid email/username or password"))
         |> put_flash(:email_or_username, String.slice(email_or_username, 0, 160))
         |> redirect(to: Routes.path("/users/log-in"))
     end
@@ -99,7 +101,7 @@ defmodule PhoenixKitWeb.Users.Session do
     # log_out_user/1 drains the whole multi-session stack, so this is now just a
     # relabelled full logout (kept distinct for the clearer flash message).
     conn
-    |> put_flash(:info, "Logged out of all accounts.")
+    |> put_flash(:info, gettext("Logged out of all accounts."))
     |> UserAuth.log_out_user()
   end
 
@@ -117,7 +119,7 @@ defmodule PhoenixKitWeb.Users.Session do
         # Root account is active → full logout. log_out_user/1 drains the whole
         # stack (after resolving the user for the disconnect broadcast).
         conn
-        |> put_flash(:info, "Logged out successfully.")
+        |> put_flash(:info, gettext("Logged out successfully."))
         |> UserAuth.log_out_user()
     end
   end
@@ -132,7 +134,7 @@ defmodule PhoenixKitWeb.Users.Session do
       # redirect (302) lets the flash render; a 403 would swallow it (the browser
       # never follows the Location header on a non-3xx response).
       conn
-      |> put_flash(:error, "Multi-account switching is not available.")
+      |> put_flash(:error, gettext("Multi-account switching is not available."))
       |> redirect(to: Routes.safe_destination(conn, scope: conn_scope(conn)))
     end
   end
@@ -230,7 +232,7 @@ defmodule PhoenixKitWeb.Users.Session do
   # multi-session stack, so secondary tokens are invalidated here too.
   def get_logout(conn, _params) do
     conn
-    |> put_flash(:info, "Logged out successfully.")
+    |> put_flash(:info, gettext("Logged out successfully."))
     |> UserAuth.log_out_user()
   end
 
@@ -240,21 +242,21 @@ defmodule PhoenixKitWeb.Users.Session do
     with_gate(conn, params, fn conn ->
       case MultiSession.add_account(conn, email_or_username, password) do
         {:ok, conn} ->
-          conn |> put_flash(:info, "Account added.") |> redirect_back(params)
+          conn |> put_flash(:info, gettext("Account added.")) |> redirect_back(params)
 
         {:error, :stack_full} ->
           conn
-          |> put_flash(:error, "Maximum number of accounts reached.")
+          |> put_flash(:error, gettext("Maximum number of accounts reached."))
           |> redirect_back(params)
 
         {:error, :already_in_stack} ->
           conn
-          |> put_flash(:error, "That account is already in your session.")
+          |> put_flash(:error, gettext("That account is already in your session."))
           |> redirect_back(params)
 
         {:error, _reason} ->
           conn
-          |> put_flash(:error, "Invalid email/username or password.")
+          |> put_flash(:error, gettext("Invalid email/username or password."))
           |> redirect_back(params)
       end
     end)
@@ -269,7 +271,7 @@ defmodule PhoenixKitWeb.Users.Session do
           |> redirect_back(params)
 
         {:error, _reason} ->
-          conn |> put_flash(:error, "Could not switch account.") |> redirect_back(params)
+          conn |> put_flash(:error, gettext("Could not switch account.")) |> redirect_back(params)
       end
     end)
   end
@@ -351,15 +353,17 @@ defmodule PhoenixKitWeb.Users.Session do
     with_gate(conn, params, fn conn ->
       case MultiSession.remove_account(conn, ref) do
         {:ok, conn} ->
-          conn |> put_flash(:info, "Account removed.") |> redirect_back(params)
+          conn |> put_flash(:info, gettext("Account removed.")) |> redirect_back(params)
 
         {:error, :cannot_remove_root} ->
           conn
-          |> put_flash(:error, "Cannot remove your primary account.")
+          |> put_flash(:error, gettext("Cannot remove your primary account."))
           |> redirect_back(params)
 
         {:error, _reason} ->
-          conn |> put_flash(:error, "Could not remove account.") |> redirect_back(params)
+          conn
+          |> put_flash(:error, gettext("Could not remove account."))
+          |> redirect_back(params)
       end
     end)
   end

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -69,7 +69,7 @@ msgstr "Rollenverwaltung"
 
 #: lib/phoenix_kit/dashboard/admin_tabs.ex:119
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:138
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:647
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:662
 #: lib/phoenix_kit_web/live/settings/users.html.heex:130
 #, elixir-autogen
 msgid "Sessions"
@@ -235,7 +235,7 @@ msgstr "Verbindungen in Echtzeit"
 
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:320
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:64
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:144
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:140
 #, elixir-autogen
 msgid "Anonymous"
 msgstr "Anonym"
@@ -248,7 +248,7 @@ msgstr "Nicht registrierte Besucher"
 
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:331
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:77
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:151
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:144
 #, elixir-autogen
 msgid "Authenticated"
 msgstr "Authentifiziert"
@@ -345,7 +345,7 @@ msgstr "Standard-Zugriffsebene"
 msgid "Role System"
 msgstr "Rollensystem"
 
-#: lib/phoenix_kit/integrations/providers.ex:991
+#: lib/phoenix_kit/integrations/providers.ex:1063
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:450
 #, elixir-autogen
 msgid "Authentication"
@@ -357,7 +357,7 @@ msgstr "Authentifizierung"
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:445
 #: lib/phoenix_kit_web/live/modules.html.heex:65
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:114
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:273
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:267
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:145
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:297
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:682
@@ -463,8 +463,8 @@ msgstr "Über Berechtigungen"
 msgid "Accept All"
 msgstr "Alle akzeptieren"
 
-#: lib/phoenix_kit/integrations/integrations.ex:1133
-#: lib/phoenix_kit/integrations/validators.ex:598
+#: lib/phoenix_kit/integrations/integrations.ex:1136
+#: lib/phoenix_kit/integrations/validators.ex:779
 #: lib/phoenix_kit_web/live/activity/index.ex:66
 #: lib/phoenix_kit_web/live/activity/show.ex:56
 #, elixir-autogen, elixir-format
@@ -502,7 +502,7 @@ msgid "Actions"
 msgstr "Aktionen"
 
 #: lib/phoenix_kit_web/components/media_gallery.html.heex:86
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:585
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:600
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:266
 #: lib/phoenix_kit_web/live/settings/users.html.heex:693
 #: lib/phoenix_kit_web/users/user_form.html.heex:719
@@ -610,7 +610,7 @@ msgstr "Grundinformationen"
 msgid "Billing profiles and payment methods"
 msgstr "Abrechnungsprofile und Zahlungsmethoden"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:98
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:124
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:501
 #, elixir-autogen, elixir-format
 msgid "Blocked"
@@ -1550,7 +1550,7 @@ msgstr "Seite erfolgreich erstellt"
 msgid "Page published successfully"
 msgstr "Seite erfolgreich veröffentlicht"
 
-#: lib/phoenix_kit/integrations/providers.ex:956
+#: lib/phoenix_kit/integrations/providers.ex:1028
 #: lib/phoenix_kit_web/components/user_dashboard_nav.ex:277
 #: lib/phoenix_kit_web/users/login.html.heex:39
 #: lib/phoenix_kit_web/users/magic_link_registration.html.heex:42
@@ -1811,8 +1811,8 @@ msgstr "SWIFT/BIC"
 #: lib/phoenix_kit_web/components/core/markdown_editor.ex:440
 #: lib/phoenix_kit_web/components/media_browser.html.heex:1349
 #: lib/phoenix_kit_web/live/notifications/settings.ex:436
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:219
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:267
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:245
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:293
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr "Speichern"
@@ -1855,7 +1855,7 @@ msgstr "Gespeichert"
 #: lib/phoenix_kit_web/components/core/markdown_editor.ex:333
 #: lib/phoenix_kit_web/components/core/markdown_editor.ex:417
 #: lib/phoenix_kit_web/live/settings.html.heex:592
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:683
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:698
 #: lib/phoenix_kit_web/live/settings/users.html.heex:546
 #, elixir-autogen, elixir-format
 msgid "Saving..."
@@ -1942,7 +1942,7 @@ msgstr "Bundesland/Provinz"
 #: lib/phoenix_kit_web/live/settings/users.html.heex:367
 #: lib/phoenix_kit_web/live/settings/users.html.heex:408
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:114
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:199
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:193
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:247
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:294
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:650
@@ -2048,7 +2048,7 @@ msgstr "Rollen insgesamt"
 #: lib/phoenix_kit_web/live/settings/users.html.heex:361
 #: lib/phoenix_kit_web/live/settings/users.html.heex:404
 #: lib/phoenix_kit_web/live/settings/users.html.heex:602
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:192
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:186
 #: lib/phoenix_kit_web/live/users/roles.html.heex:92
 #: lib/phoenix_kit_web/live/users/roles.html.heex:160
 #, elixir-autogen, elixir-format
@@ -2064,7 +2064,7 @@ msgstr "Unbestätigt"
 #: lib/phoenix_kit_web/components/core/time_display.ex:183
 #: lib/phoenix_kit_web/components/language_switcher.ex:832
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:108
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:255
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:249
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr "Unbekannt"
@@ -2122,7 +2122,7 @@ msgstr "Benutzer nicht gefunden"
 msgid "User-defined roles"
 msgstr "Benutzerdefinierte Rollen"
 
-#: lib/phoenix_kit/integrations/providers.ex:944
+#: lib/phoenix_kit/integrations/providers.ex:1016
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:255
 #: lib/phoenix_kit_web/users/magic_link_registration.html.heex:30
 #: lib/phoenix_kit_web/users/registration.html.heex:69
@@ -2440,22 +2440,22 @@ msgstr "(leer)"
 msgid "(registration disabled)"
 msgstr "(Registrierung deaktiviert)"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:622
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:637
 #, elixir-autogen, elixir-format
 msgid "1. Enable the provider above and save settings"
 msgstr "1. Aktivieren Sie den Anbieter oben und speichern Sie die Einstellungen"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:623
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:638
 #, elixir-autogen, elixir-format
 msgid "2. Enter your OAuth credentials in the form that appears"
 msgstr "2. Geben Sie Ihre OAuth-Anmeldedaten in das erscheinende Formular ein"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:624
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:639
 #, elixir-autogen, elixir-format
 msgid "3. Save settings again to store credentials"
 msgstr "3. Speichern Sie die Einstellungen erneut, um die Anmeldedaten zu hinterlegen"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:625
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:640
 #, elixir-autogen, elixir-format
 msgid "4. Click \"Test Credentials\" to verify configuration"
 msgstr "4. Klicken Sie auf „Anmeldedaten testen“, um die Konfiguration zu überprüfen"
@@ -2466,7 +2466,8 @@ msgid "Access Credentials"
 msgstr "Zugangsdaten"
 
 #: lib/modules/storage/web/bucket_form.html.heex:227
-#: lib/phoenix_kit/integrations/providers.ex:842
+#: lib/phoenix_kit/integrations/providers.ex:843
+#: lib/phoenix_kit/integrations/providers.ex:927
 #, elixir-autogen, elixir-format
 msgid "Access Key ID"
 msgstr "Access Key ID"
@@ -2516,9 +2517,9 @@ msgstr "Bildabmessung hinzufügen"
 msgid "Add Video Dimension"
 msgstr "Videoabmessung hinzufügen"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:429
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:507
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:592
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:434
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:517
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:607
 #, elixir-autogen, elixir-format
 msgid "Add callback URL above to"
 msgstr "Fügen Sie oben die Callback-URL hinzu, um"
@@ -2550,12 +2551,12 @@ msgstr "Alle neuen Benutzer erhalten Administratorrechte und Zugriff auf den Adm
 msgid "Anyone can register"
 msgstr "Jeder kann sich registrieren"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:541
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:551
 #, elixir-autogen, elixir-format
 msgid "App ID"
 msgstr "App-ID"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:551
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:561
 #, elixir-autogen, elixir-format
 msgid "App Secret"
 msgstr "App-Secret"
@@ -2674,7 +2675,7 @@ msgstr "Buckets können lokale Verzeichnisse oder Cloud-Speicheranbieter sein (A
 msgid "CSS color or gradient for auth page background. Ignored if a background image is set."
 msgstr "CSS-Farbe oder -Gradient für den Hintergrund der Anmeldeseite. Wird ignoriert, wenn ein Hintergrundbild festgelegt ist."
 
-#: lib/phoenix_kit_web/live/settings/authorization.ex:261
+#: lib/phoenix_kit_web/live/settings/authorization.ex:302
 #, elixir-autogen, elixir-format
 msgid "Callback URL"
 msgstr "Callback-URL"
@@ -2684,25 +2685,25 @@ msgstr "Callback-URL"
 msgid "Changes will be saved immediately"
 msgstr "Änderungen werden sofort gespeichert"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:434
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:511
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:518
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:609
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:439
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:521
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:528
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:624
 #, elixir-autogen, elixir-format
 msgid "Click"
 msgstr "Klicken"
 
-#: lib/phoenix_kit/integrations/providers.ex:215
+#: lib/phoenix_kit/integrations/providers.ex:216
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:378
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:458
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:463
 #, elixir-autogen, elixir-format
 msgid "Client ID"
 msgstr "Client-ID"
 
-#: lib/phoenix_kit/integrations/providers.ex:224
-#: lib/phoenix_kit/integrations/providers.ex:1169
+#: lib/phoenix_kit/integrations/providers.ex:225
+#: lib/phoenix_kit/integrations/providers.ex:1241
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:388
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:468
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:473
 #, elixir-autogen, elixir-format
 msgid "Client Secret"
 msgstr "Client-Secret"
@@ -2733,34 +2734,34 @@ msgstr "Systemeinstellungen und Optionen konfigurieren"
 msgid "Consider \"User\" for most installations to maintain security."
 msgstr "Für die meisten Installationen empfiehlt sich „Benutzer“, um die Sicherheit zu erhalten."
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:514
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:599
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:142
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:524
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:614
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:168
 #, elixir-autogen, elixir-format
 msgid "Copy"
 msgstr "Kopieren"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:432
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:437
 #, elixir-autogen, elixir-format
 msgid "Copy Client ID and Secret to fields above"
 msgstr "Client-ID und Secret in die Felder oben kopieren"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:568
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:583
 #, elixir-autogen, elixir-format
 msgid "Copy this URL to Facebook App Settings"
 msgstr "Diese URL in die Facebook-App-Einstellungen kopieren"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:485
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:495
 #, elixir-autogen, elixir-format
 msgid "Copy this URL to GitHub OAuth Apps"
 msgstr "Diese URL in die GitHub-OAuth-Apps kopieren"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:405
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:410
 #, elixir-autogen, elixir-format
 msgid "Copy this URL to Google Cloud Console"
 msgstr "Diese URL in die Google Cloud Console kopieren"
 
-#: lib/phoenix_kit_web/live/settings/authorization.ex:271
+#: lib/phoenix_kit_web/live/settings/authorization.ex:312
 #, elixir-autogen, elixir-format
 msgid "Copy to clipboard"
 msgstr "In die Zwischenablage kopieren"
@@ -2785,12 +2786,12 @@ msgstr "Speicherpfad erstellen"
 msgid "Create Your First Bucket"
 msgstr "Erstellen Sie Ihren ersten Bucket"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:582
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:597
 #, elixir-autogen, elixir-format
 msgid "Create a new app or select existing one"
 msgstr "Neue App erstellen oder eine bestehende auswählen"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:418
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:423
 #, elixir-autogen, elixir-format
 msgid "Create project or select existing one"
 msgstr "Projekt erstellen oder ein bestehendes auswählen"
@@ -2861,11 +2862,12 @@ msgid "Enable OAuth (Master Switch)"
 msgstr "OAuth aktivieren (Hauptschalter)"
 
 #: lib/modules/storage/web/bucket_form.html.heex:194
+#: lib/phoenix_kit/integrations/providers.ex:957
 #, elixir-autogen, elixir-format
 msgid "Endpoint"
 msgstr "Endpunkt"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:503
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:513
 #, elixir-autogen, elixir-format
 msgid "Enter"
 msgstr "Eingeben"
@@ -2900,7 +2902,7 @@ msgstr "FFmpeg nicht installiert"
 msgid "FFmpeg is required for video processing, transcoding, and thumbnail generation."
 msgstr "FFmpeg ist für Videoverarbeitung, Transkodierung und Vorschaubilder erforderlich."
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:532
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:542
 #, elixir-autogen, elixir-format
 msgid "Facebook OAuth Credentials"
 msgstr "Facebook-OAuth-Anmeldedaten"
@@ -2943,7 +2945,7 @@ msgstr "Format überschreiben"
 msgid "Format Override:"
 msgstr "Format überschreiben:"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:449
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:454
 #, elixir-autogen, elixir-format
 msgid "GitHub OAuth Credentials"
 msgstr "GitHub-OAuth-Anmeldedaten"
@@ -2953,10 +2955,10 @@ msgstr "GitHub-OAuth-Anmeldedaten"
 msgid "GitHub Sign-In"
 msgstr "Anmeldung mit GitHub"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:420
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:499
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:588
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:596
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:425
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:509
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:603
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:611
 #, elixir-autogen, elixir-format
 msgid "Go to"
 msgstr "Gehe zu"
@@ -2986,7 +2988,7 @@ msgstr "Wie Datumsangaben angezeigt werden"
 msgid "How times are displayed"
 msgstr "Wie Uhrzeiten angezeigt werden"
 
-#: lib/phoenix_kit_web/live/settings/authorization.ex:296
+#: lib/phoenix_kit_web/live/settings/authorization.ex:337
 #, elixir-autogen, elixir-format
 msgid "If behind nginx/apache, ensure"
 msgstr "Hinter nginx/Apache stellen Sie sicher, dass"
@@ -3173,7 +3175,7 @@ msgstr "Keine"
 msgid "Note"
 msgstr "Hinweis"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:627
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:642
 #, elixir-autogen, elixir-format
 msgid "Note: OAuth providers require ueberauth dependencies to be installed."
 msgstr "Hinweis: OAuth-Anbieter setzen voraus, dass die ueberauth-Abhängigkeiten installiert sind."
@@ -3188,7 +3190,7 @@ msgstr "Anzahl der zu speichernden Kopien"
 msgid "OAuth Providers"
 msgstr "OAuth-Anbieter"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:620
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:635
 #, elixir-autogen, elixir-format
 msgid "OAuth Setup Instructions"
 msgstr "OAuth-Einrichtungsanleitung"
@@ -3261,7 +3263,7 @@ msgstr "Reduzieren Sie die Redundanz oder aktivieren Sie weitere Buckets."
 msgid "Redundancy Copies"
 msgstr "Redundanzkopien"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:642
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:657
 #, elixir-autogen, elixir-format
 msgid "Reload OAuth Configuration"
 msgstr "OAuth-Konfiguration neu laden"
@@ -3288,7 +3290,7 @@ msgstr "Auf Standardwerte zurücksetzen"
 msgid "Resolution"
 msgstr "Auflösung"
 
-#: lib/phoenix_kit_web/live/settings/authorization.ex:294
+#: lib/phoenix_kit_web/live/settings/authorization.ex:335
 #, elixir-autogen, elixir-format
 msgid "Reverse Proxy Users:"
 msgstr "Nutzer eines Reverse-Proxys:"
@@ -3314,7 +3316,7 @@ msgstr "Rolle, die neuen Registrierungen zugewiesen wird"
 msgid "Save All Settings"
 msgstr "Alle Einstellungen speichern"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:685
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:700
 #, elixir-autogen, elixir-format
 msgid "Save Authorization Settings"
 msgstr "Autorisierungseinstellungen speichern"
@@ -3330,7 +3332,8 @@ msgid "Search engines are instructed to skip this environment. Remove this befor
 msgstr "Suchmaschinen werden angewiesen, diese Umgebung zu überspringen. Entfernen Sie dies vor dem Start."
 
 #: lib/modules/storage/web/bucket_form.html.heex:241
-#: lib/phoenix_kit/integrations/providers.ex:851
+#: lib/phoenix_kit/integrations/providers.ex:852
+#: lib/phoenix_kit/integrations/providers.ex:936
 #, elixir-autogen, elixir-format
 msgid "Secret Access Key"
 msgstr "Secret Access Key"
@@ -3347,7 +3350,7 @@ msgstr "Sicherheitshinweis: mittleres Risiko"
 
 #: lib/phoenix_kit_web/components/media_browser.html.heex:1180
 #: lib/phoenix_kit_web/components/media_browser.html.heex:1182
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:425
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:430
 #, elixir-autogen, elixir-format
 msgid "Select"
 msgstr "Auswählen"
@@ -3377,7 +3380,7 @@ msgid "Set"
 msgstr "Festlegen"
 
 #: lib/phoenix_kit_web/components/core/integrations_ui.ex:311
-#: lib/phoenix_kit_web/live/settings/authorization.ex:249
+#: lib/phoenix_kit_web/live/settings/authorization.ex:290
 #: lib/phoenix_kit_web/live/settings/integration_form.html.heex:378
 #, elixir-autogen, elixir-format
 msgid "Setup Instructions"
@@ -3414,7 +3417,7 @@ msgstr "Speicheranbieter"
 msgid "Success!"
 msgstr "Erfolg!"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:604
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:619
 #, elixir-autogen, elixir-format
 msgid "Switch app from"
 msgstr "App wechseln von"
@@ -3439,9 +3442,9 @@ msgstr "Standardzeitzone des Systems"
 msgid "Target Width (px)"
 msgstr "Zielbreite (px)"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:400
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:480
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:563
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:405
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:490
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:578
 #, elixir-autogen, elixir-format
 msgid "Test Credentials"
 msgstr "Anmeldedaten testen"
@@ -3521,7 +3524,7 @@ msgstr "Benutzerkonfiguration"
 msgid "User Editable"
 msgstr "Vom Benutzer bearbeitbar"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:35
+#: lib/phoenix_kit_web/live/settings/users.ex:42
 #: lib/phoenix_kit_web/live/settings/users.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "User Settings"
@@ -3563,9 +3566,9 @@ msgstr "Videoeinstellungen:"
 msgid "Videos use CRF 0-51 scale (lower = higher quality)"
 msgstr "Videos verwenden die CRF-Skala 0–51 (niedriger = höhere Qualität)"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:409
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:489
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:572
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:414
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:499
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:587
 #, elixir-autogen, elixir-format
 msgid "Visit"
 msgstr "Besuchen"
@@ -3610,22 +3613,22 @@ msgstr "Ohne es funktioniert die Verarbeitung von Videodateien nicht."
 msgid "Would you like to create it now?"
 msgstr "Möchten Sie ihn jetzt erstellen?"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:542
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:552
 #, elixir-autogen, elixir-format
 msgid "Your Facebook App ID"
 msgstr "Ihre Facebook-App-ID"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:552
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:565
 #, elixir-autogen, elixir-format
 msgid "Your Facebook App Secret"
 msgstr "Ihr Facebook-App-Secret"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:459
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:464
 #, elixir-autogen, elixir-format
 msgid "Your GitHub OAuth Client ID"
 msgstr "Ihre GitHub-OAuth-Client-ID"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:469
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:477
 #, elixir-autogen, elixir-format
 msgid "Your GitHub OAuth Client Secret"
 msgstr "Ihr GitHub-OAuth-Client-Secret"
@@ -3635,19 +3638,19 @@ msgstr "Ihr GitHub-OAuth-Client-Secret"
 msgid "Your Google OAuth Client ID"
 msgstr "Ihre Google-OAuth-Client-ID"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:389
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:392
 #, elixir-autogen, elixir-format
 msgid "Your Google OAuth Client Secret"
 msgstr "Ihr Google-OAuth-Client-Secret"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:504
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:600
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:514
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:615
 #: lib/phoenix_kit_web/live/settings/integrations.ex:167
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr "und"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:515
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:525
 #, elixir-autogen, elixir-format
 msgid "and generate/copy"
 msgstr "und generieren/kopieren"
@@ -3668,12 +3671,12 @@ msgstr "z. B. thumbnail, medium, 720p"
 msgid "files"
 msgstr "Dateien"
 
-#: lib/phoenix_kit_web/live/settings/authorization.ex:300
+#: lib/phoenix_kit_web/live/settings/authorization.ex:341
 #, elixir-autogen, elixir-format
 msgid "header is set to"
 msgstr "Header ist gesetzt auf"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:606
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:621
 #, elixir-autogen, elixir-format
 msgid "mode"
 msgstr "Modus"
@@ -3683,12 +3686,12 @@ msgstr "Modus"
 msgid "option(s)"
 msgstr "Option(en)"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:585
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:600
 #, elixir-autogen, elixir-format
 msgid "product"
 msgstr "Produkt"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:605
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:620
 #, elixir-autogen, elixir-format
 msgid "to"
 msgstr "zu"
@@ -3698,19 +3701,19 @@ msgstr "zu"
 msgid "to every PhoenixKit layout, blocking crawlers from indexing or following links."
 msgstr "zu jedem PhoenixKit-Layout hinzu und verhindert, dass Crawler Links indexieren oder verfolgen."
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:601
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:616
 #, elixir-autogen, elixir-format
 msgid "to fields above"
 msgstr "in die Felder oben"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:435
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:519
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:610
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:440
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:529
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:625
 #, elixir-autogen, elixir-format
 msgid "to verify setup"
 msgstr "um die Einrichtung zu überprüfen"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:426
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:431
 #, elixir-autogen, elixir-format
 msgid "type"
 msgstr "Typ"
@@ -3845,7 +3848,7 @@ msgstr "Ein sprechender Name zur Identifizierung dieses Speicherorts"
 msgid "A unique name to identify this dimension preset"
 msgstr "Ein eindeutiger Name zur Identifizierung dieser Abmessungsvorlage"
 
-#: lib/phoenix_kit/integrations/providers.ex:388
+#: lib/phoenix_kit/integrations/providers.ex:389
 #, elixir-autogen, elixir-format
 msgid "AI model access via OpenRouter (100+ models)"
 msgstr "Zugriff auf KI-Modelle über OpenRouter (100+ Modelle)"
@@ -3855,13 +3858,13 @@ msgstr "Zugriff auf KI-Modelle über OpenRouter (100+ Modelle)"
 msgid "API Credentials"
 msgstr "API-Anmeldedaten"
 
-#: lib/phoenix_kit/integrations/providers.ex:332
-#: lib/phoenix_kit/integrations/providers.ex:402
-#: lib/phoenix_kit/integrations/providers.ex:460
-#: lib/phoenix_kit/integrations/providers.ex:523
-#: lib/phoenix_kit/integrations/providers.ex:586
-#: lib/phoenix_kit/integrations/providers.ex:653
-#: lib/phoenix_kit/integrations/providers.ex:1065
+#: lib/phoenix_kit/integrations/providers.ex:333
+#: lib/phoenix_kit/integrations/providers.ex:403
+#: lib/phoenix_kit/integrations/providers.ex:461
+#: lib/phoenix_kit/integrations/providers.ex:524
+#: lib/phoenix_kit/integrations/providers.ex:587
+#: lib/phoenix_kit/integrations/providers.ex:654
+#: lib/phoenix_kit/integrations/providers.ex:1137
 #, elixir-autogen, elixir-format
 msgid "API Key"
 msgstr "API-Schlüssel"
@@ -3922,7 +3925,7 @@ msgstr "Aktiv aufgrund des geplanten Zeitfensters."
 msgid "Add Integration"
 msgstr "Integration hinzufügen"
 
-#: lib/phoenix_kit/integrations/providers.ex:431
+#: lib/phoenix_kit/integrations/providers.ex:432
 #, elixir-autogen, elixir-format
 msgid "Add credits (optional)"
 msgstr "Guthaben hinzufügen (optional)"
@@ -3957,7 +3960,7 @@ msgstr "Alle Dateien erfüllen das Redundanzziel von %{n} Kopien."
 msgid "Alternative Formats"
 msgstr "Alternative Formate"
 
-#: lib/phoenix_kit/integrations/providers.ex:285
+#: lib/phoenix_kit/integrations/providers.ex:286
 #, elixir-autogen, elixir-format
 msgid "Application type: **Web application** (do not select \"Desktop app\" — it won't support redirect URIs)"
 msgstr "Anwendungstyp: **Webanwendung** (wählen Sie nicht „Desktop-App“ – sie unterstützt keine Weiterleitungs-URIs)"
@@ -4079,18 +4082,18 @@ msgstr "Wählen Sie einen Dienst zum Verbinden"
 msgid "Clear Schedule"
 msgstr "Zeitplan löschen"
 
-#: lib/phoenix_kit/integrations/providers.ex:284
+#: lib/phoenix_kit/integrations/providers.ex:285
 #, elixir-autogen, elixir-format
 msgid "Click **Create Credentials → OAuth client ID**"
 msgstr "Klicken Sie auf **Anmeldedaten erstellen → OAuth-Client-ID**"
 
-#: lib/phoenix_kit/integrations/providers.ex:425
+#: lib/phoenix_kit/integrations/providers.ex:426
 #, elixir-autogen, elixir-format
 msgid "Click **Create Key**"
 msgstr "Klicken Sie auf **Schlüssel erstellen**"
 
-#: lib/phoenix_kit/integrations/providers.ex:295
-#: lib/phoenix_kit/integrations/providers.ex:1248
+#: lib/phoenix_kit/integrations/providers.ex:296
+#: lib/phoenix_kit/integrations/providers.ex:1320
 #, elixir-autogen, elixir-format
 msgid "Click **Save**, then **Connect Account**"
 msgstr "Klicken Sie auf **Speichern** und dann auf **Konto verbinden**"
@@ -4140,8 +4143,8 @@ msgstr "%{provider}-Konto verbinden"
 msgid "Connect Account"
 msgstr "Konto verbinden"
 
-#: lib/phoenix_kit/integrations/providers.ex:293
-#: lib/phoenix_kit/integrations/providers.ex:1246
+#: lib/phoenix_kit/integrations/providers.ex:294
+#: lib/phoenix_kit/integrations/providers.ex:1318
 #, elixir-autogen, elixir-format
 msgid "Connect and authorize"
 msgstr "Verbinden und autorisieren"
@@ -4161,7 +4164,7 @@ msgstr "Externe Dienste für die modulübergreifende Nutzung verbinden"
 #: lib/phoenix_kit_web/live/settings/integration_form.html.heex:327
 #: lib/phoenix_kit_web/live/settings/integrations.ex:181
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:111
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:197
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:191
 #, elixir-autogen, elixir-format
 msgid "Connected"
 msgstr "Verbunden"
@@ -4202,48 +4205,48 @@ msgstr "Verbindung erfolgreich"
 msgid "Connection verified"
 msgstr "Verbindung überprüft"
 
-#: lib/phoenix_kit/integrations/providers.ex:289
+#: lib/phoenix_kit/integrations/providers.ex:290
 #, elixir-autogen, elixir-format
 msgid "Copy the **Client ID** and **Client Secret** into the form above"
 msgstr "Kopieren Sie die **Client-ID** und das **Client-Secret** in das Formular oben"
 
-#: lib/phoenix_kit/integrations/providers.ex:427
+#: lib/phoenix_kit/integrations/providers.ex:428
 #, elixir-autogen, elixir-format
 msgid "Copy the key and paste it into the form above"
 msgstr "Kopieren Sie den Schlüssel und fügen Sie ihn in das Formular oben ein"
 
-#: lib/phoenix_kit/integrations/integrations.ex:1135
+#: lib/phoenix_kit/integrations/integrations.ex:1138
 #: lib/phoenix_kit/integrations/probe.ex:102
 #, elixir-autogen, elixir-format
 msgid "Could not reach the service"
 msgstr "Der Dienst war nicht erreichbar"
 
-#: lib/phoenix_kit/integrations/providers.ex:235
+#: lib/phoenix_kit/integrations/providers.ex:236
 #, elixir-autogen, elixir-format
 msgid "Create a Google Cloud project"
 msgstr "Google-Cloud-Projekt erstellen"
 
-#: lib/phoenix_kit/integrations/providers.ex:238
+#: lib/phoenix_kit/integrations/providers.ex:239
 #, elixir-autogen, elixir-format
 msgid "Create a new project or select an existing one"
 msgstr "Neues Projekt erstellen oder ein bestehendes auswählen"
 
-#: lib/phoenix_kit/integrations/providers.ex:368
-#: lib/phoenix_kit/integrations/providers.ex:423
-#: lib/phoenix_kit/integrations/providers.ex:493
-#: lib/phoenix_kit/integrations/providers.ex:553
-#: lib/phoenix_kit/integrations/providers.ex:619
-#: lib/phoenix_kit/integrations/providers.ex:670
+#: lib/phoenix_kit/integrations/providers.ex:369
+#: lib/phoenix_kit/integrations/providers.ex:424
+#: lib/phoenix_kit/integrations/providers.ex:494
+#: lib/phoenix_kit/integrations/providers.ex:554
+#: lib/phoenix_kit/integrations/providers.ex:620
+#: lib/phoenix_kit/integrations/providers.ex:671
 #, elixir-autogen, elixir-format
 msgid "Create an API key"
 msgstr "API-Schlüssel erstellen"
 
-#: lib/phoenix_kit/integrations/providers.ex:279
+#: lib/phoenix_kit/integrations/providers.ex:280
 #, elixir-autogen, elixir-format
 msgid "Create an OAuth Client"
 msgstr "OAuth-Client erstellen"
 
-#: lib/phoenix_kit/integrations/providers.ex:416
+#: lib/phoenix_kit/integrations/providers.ex:417
 #, elixir-autogen, elixir-format
 msgid "Create an OpenRouter account"
 msgstr "OpenRouter-Konto erstellen"
@@ -4312,7 +4315,7 @@ msgstr "Trennen?"
 msgid "Disconnected"
 msgstr "Getrennt"
 
-#: lib/phoenix_kit/integrations/providers.ex:253
+#: lib/phoenix_kit/integrations/providers.ex:254
 #, elixir-autogen, elixir-format
 msgid "Drive API handles file listing, creation, copying, and PDF export. Docs API is used for reading document content and substituting template variables."
 msgstr "Die Drive-API übernimmt das Auflisten, Erstellen, Kopieren und den PDF-Export von Dateien. Die Docs-API wird zum Lesen von Dokumentinhalten und zum Ersetzen von Vorlagenvariablen verwendet."
@@ -4342,7 +4345,7 @@ msgstr "Bucket aktivieren"
 msgid "Enable organization accounts"
 msgstr "Organisationskonten aktivieren"
 
-#: lib/phoenix_kit/integrations/providers.ex:242
+#: lib/phoenix_kit/integrations/providers.ex:243
 #, elixir-autogen, elixir-format
 msgid "Enable required APIs"
 msgstr "Erforderliche APIs aktivieren"
@@ -4475,12 +4478,12 @@ msgstr "Dateien werden in PostgreSQL erfasst, mit Unterstützung für mehrere Me
 msgid "Files with completed variants"
 msgstr "Dateien mit fertigen Varianten"
 
-#: lib/phoenix_kit/integrations/providers.ex:219
+#: lib/phoenix_kit/integrations/providers.ex:220
 #, elixir-autogen, elixir-format
 msgid "From Google Cloud Console → APIs & Services → Credentials"
 msgstr "Aus der Google Cloud Console → APIs und Dienste → Anmeldedaten"
 
-#: lib/phoenix_kit/integrations/providers.ex:406
+#: lib/phoenix_kit/integrations/providers.ex:407
 #, elixir-autogen, elixir-format
 msgid "From openrouter.ai/keys"
 msgstr "Von openrouter.ai/keys"
@@ -4490,72 +4493,72 @@ msgstr "Von openrouter.ai/keys"
 msgid "Generate additional format variants alongside the primary format. Modern formats like WebP and AVIF offer better compression."
 msgstr "Erzeugen Sie zusätzliche Formatvarianten neben dem Hauptformat. Moderne Formate wie WebP und AVIF bieten eine bessere Kompression."
 
-#: lib/phoenix_kit/integrations/providers.ex:426
+#: lib/phoenix_kit/integrations/providers.ex:427
 #, elixir-autogen, elixir-format
 msgid "Give it a name (e.g., your app name)"
 msgstr "Geben Sie ihm einen Namen (z. B. den Namen Ihrer App)"
 
-#: lib/phoenix_kit/integrations/providers.ex:248
+#: lib/phoenix_kit/integrations/providers.ex:249
 #, elixir-autogen, elixir-format
 msgid "Go back to the Library and search for **Google Docs API**, click it, then click **Enable**"
 msgstr "Gehen Sie zurück zur Bibliothek, suchen Sie nach **Google Docs API**, klicken Sie darauf und dann auf **Aktivieren**"
 
-#: lib/phoenix_kit/integrations/providers.ex:281
+#: lib/phoenix_kit/integrations/providers.ex:282
 #, elixir-autogen, elixir-format
 msgid "Go to [APIs & Services → Credentials](https://console.cloud.google.com/apis/credentials)"
 msgstr "Gehen Sie zu [APIs und Dienste → Anmeldedaten](https://console.cloud.google.com/apis/credentials)"
 
-#: lib/phoenix_kit/integrations/providers.ex:244
+#: lib/phoenix_kit/integrations/providers.ex:245
 #, elixir-autogen, elixir-format
 msgid "Go to [APIs & Services → Library](https://console.cloud.google.com/apis/library)"
 msgstr "Gehen Sie zu [APIs und Dienste → Bibliothek](https://console.cloud.google.com/apis/library)"
 
-#: lib/phoenix_kit/integrations/providers.ex:263
+#: lib/phoenix_kit/integrations/providers.ex:264
 #, elixir-autogen, elixir-format
 msgid "Go to [Audience](https://console.cloud.google.com/auth/audience) — set user type to **External** (or Internal for Google Workspace)"
 msgstr "Gehen Sie zu [Zielgruppe](https://console.cloud.google.com/auth/audience) – setzen Sie den Nutzertyp auf **Extern** (oder Intern bei Google Workspace)"
 
-#: lib/phoenix_kit/integrations/providers.ex:260
+#: lib/phoenix_kit/integrations/providers.ex:261
 #, elixir-autogen, elixir-format
 msgid "Go to [Branding](https://console.cloud.google.com/auth/branding) in the sidebar — fill in the **App name** and **User support email**, then save"
 msgstr "Gehen Sie in der Seitenleiste zu [Branding](https://console.cloud.google.com/auth/branding) – füllen Sie **App-Name** und **Support-E-Mail** aus und speichern Sie"
 
-#: lib/phoenix_kit/integrations/providers.ex:434
+#: lib/phoenix_kit/integrations/providers.ex:435
 #, elixir-autogen, elixir-format
 msgid "Go to [Credits](https://openrouter.ai/credits) to add funds"
 msgstr "Gehen Sie zu [Credits](https://openrouter.ai/credits), um Guthaben aufzuladen"
 
-#: lib/phoenix_kit/integrations/providers.ex:269
+#: lib/phoenix_kit/integrations/providers.ex:270
 #, elixir-autogen, elixir-format
 msgid "Go to [Data Access](https://console.cloud.google.com/auth/scopes) — click **Add or Remove Scopes** and add the Drive and Docs scopes. This step may not be required — the app requests the needed scopes at connect time regardless."
 msgstr "Gehen Sie zu [Datenzugriff](https://console.cloud.google.com/auth/scopes) – klicken Sie auf **Bereiche hinzufügen oder entfernen** und fügen Sie die Drive- und Docs-Bereiche hinzu. Dieser Schritt ist möglicherweise nicht erforderlich – die App fordert die benötigten Bereiche beim Verbinden ohnehin an."
 
-#: lib/phoenix_kit/integrations/providers.ex:418
+#: lib/phoenix_kit/integrations/providers.ex:419
 #, elixir-autogen, elixir-format
 msgid "Go to [openrouter.ai](https://openrouter.ai) and sign up or log in"
 msgstr "Gehen Sie zu [openrouter.ai](https://openrouter.ai) und registrieren Sie sich oder melden Sie sich an"
 
-#: lib/phoenix_kit/integrations/providers.ex:237
+#: lib/phoenix_kit/integrations/providers.ex:238
 #, elixir-autogen, elixir-format
 msgid "Go to the [Google Cloud Console](https://console.cloud.google.com)"
 msgstr "Gehen Sie zur [Google Cloud Console](https://console.cloud.google.com)"
 
-#: lib/phoenix_kit/integrations/providers.ex:200
+#: lib/phoenix_kit/integrations/providers.ex:201
 #, elixir-autogen, elixir-format
 msgid "Google"
 msgstr "Google"
 
-#: lib/phoenix_kit/integrations/providers.ex:201
+#: lib/phoenix_kit/integrations/providers.ex:202
 #, elixir-autogen, elixir-format
 msgid "Google Docs, Drive, Calendar, Sheets, Gmail"
 msgstr "Google Docs, Drive, Kalender, Tabellen, Gmail"
 
-#: lib/phoenix_kit/integrations/providers.ex:296
+#: lib/phoenix_kit/integrations/providers.ex:297
 #, elixir-autogen, elixir-format
 msgid "Google will show an \"unverified app\" warning — click **Advanced → Go to (app name)** to proceed"
 msgstr "Google zeigt die Warnung „nicht verifizierte App“ – klicken Sie auf **Erweitert → Weiter zu (App-Name)**, um fortzufahren"
 
-#: lib/phoenix_kit/integrations/providers.ex:299
+#: lib/phoenix_kit/integrations/providers.ex:300
 #, elixir-autogen, elixir-format
 msgid "Grant access to Google Docs and Google Drive"
 msgstr "Zugriff auf Google Docs und Google Drive gewähren"
@@ -4591,11 +4594,12 @@ msgstr "Integration gelöscht"
 msgid "Integrations"
 msgstr "Integrationen"
 
-#: lib/phoenix_kit/integrations/integrations.ex:1132
+#: lib/phoenix_kit/integrations/integrations.ex:1135
 #: lib/phoenix_kit/integrations/validators.ex:208
 #: lib/phoenix_kit/integrations/validators.ex:378
 #: lib/phoenix_kit/integrations/validators.ex:412
-#: lib/phoenix_kit/integrations/validators.ex:595
+#: lib/phoenix_kit/integrations/validators.ex:608
+#: lib/phoenix_kit/integrations/validators.ex:776
 #, elixir-autogen, elixir-format
 msgid "Invalid credentials"
 msgstr "Ungültige Anmeldedaten"
@@ -4809,12 +4813,12 @@ msgstr "%{n} fehlen"
 msgid "Missing %{n} copies"
 msgstr "%{n} Kopien fehlen"
 
-#: lib/phoenix_kit/integrations/providers.ex:419
+#: lib/phoenix_kit/integrations/providers.ex:420
 #, elixir-autogen, elixir-format
 msgid "Navigate to [Keys](https://openrouter.ai/keys)"
 msgstr "Gehen Sie zu [Keys](https://openrouter.ai/keys)"
 
-#: lib/phoenix_kit/integrations/providers.ex:274
+#: lib/phoenix_kit/integrations/providers.ex:275
 #, elixir-autogen, elixir-format
 msgid "Navigate to the OAuth section using the search bar or the hamburger menu: search for \"OAuth\", or go to the sidebar: **APIs & Services → OAuth consent screen**. This opens a different section with its own sidebar."
 msgstr "Navigieren Sie über die Suchleiste oder das Hamburger-Menü zum OAuth-Bereich: suchen Sie nach „OAuth“, oder gehen Sie in der Seitenleiste zu **APIs und Dienste → OAuth-Zustimmungsbildschirm**. Dadurch öffnet sich ein anderer Bereich mit eigener Seitenleiste."
@@ -4835,9 +4839,9 @@ msgstr "Kein Zugriffstoken"
 msgid "No copies"
 msgstr "Keine Kopien"
 
-#: lib/phoenix_kit/integrations/integrations.ex:1115
+#: lib/phoenix_kit/integrations/integrations.ex:1118
 #: lib/phoenix_kit/integrations/validators.ex:170
-#: lib/phoenix_kit/integrations/validators.ex:577
+#: lib/phoenix_kit/integrations/validators.ex:758
 #, elixir-autogen, elixir-format
 msgid "No credentials configured"
 msgstr "Keine Anmeldedaten konfiguriert"
@@ -4918,7 +4922,7 @@ msgstr "Nur aktivierte Buckets erhalten neue Uploads"
 msgid "Only width is used, height is calculated automatically"
 msgstr "Es wird nur die Breite verwendet, die Höhe wird automatisch berechnet"
 
-#: lib/phoenix_kit/integrations/providers.ex:387
+#: lib/phoenix_kit/integrations/providers.ex:388
 #, elixir-autogen, elixir-format
 msgid "OpenRouter"
 msgstr "OpenRouter"
@@ -5099,7 +5103,7 @@ msgstr "Geplante Wartung"
 msgid "Scheduled window is currently active"
 msgstr "Das geplante Zeitfenster ist derzeit aktiv"
 
-#: lib/phoenix_kit/integrations/providers.ex:247
+#: lib/phoenix_kit/integrations/providers.ex:248
 #, elixir-autogen, elixir-format
 msgid "Search for **Google Drive API**, click it, then click **Enable**"
 msgstr "Suchen Sie nach **Google Drive API**, klicken Sie darauf und dann auf **Aktivieren**"
@@ -5126,7 +5130,7 @@ msgstr "Benutzer zum Hinzufügen auswählen …"
 msgid "Service"
 msgstr "Dienst"
 
-#: lib/phoenix_kit/integrations/integrations.ex:1134
+#: lib/phoenix_kit/integrations/integrations.ex:1137
 #, elixir-autogen, elixir-format
 msgid "Service error %{status}"
 msgstr "Dienstfehler %{status}"
@@ -5136,7 +5140,7 @@ msgstr "Dienstfehler %{status}"
 msgid "Set a time window for automatic maintenance activation."
 msgstr "Legen Sie ein Zeitfenster für die automatische Aktivierung der Wartung fest."
 
-#: lib/phoenix_kit/integrations/providers.ex:258
+#: lib/phoenix_kit/integrations/providers.ex:259
 #, elixir-autogen, elixir-format
 msgid "Set up OAuth consent"
 msgstr "OAuth-Zustimmung einrichten"
@@ -5146,7 +5150,7 @@ msgstr "OAuth-Zustimmung einrichten"
 msgid "Size Configuration"
 msgstr "Größenkonfiguration"
 
-#: lib/phoenix_kit/integrations/providers.ex:433
+#: lib/phoenix_kit/integrations/providers.ex:434
 #, elixir-autogen, elixir-format
 msgid "Some models are free, but most require credits"
 msgstr "Einige Modelle sind kostenlos, die meisten benötigen jedoch Guthaben"
@@ -5176,7 +5180,7 @@ msgstr "Schritt 1"
 msgid "Step 2"
 msgstr "Schritt 2"
 
-#: lib/phoenix_kit/integrations/providers.ex:266
+#: lib/phoenix_kit/integrations/providers.ex:267
 #, elixir-autogen, elixir-format
 msgid "Still on Audience — while the app is in **Testing** status, add the Google account you will connect as a **Test user** (this must be the same account whose Drive will store your files)"
 msgstr "Weiterhin unter „Zielgruppe“ – solange die App den Status **Testing** hat, fügen Sie das Google-Konto, das Sie verbinden möchten, als **Testnutzer** hinzu (es muss dasselbe Konto sein, in dessen Drive Ihre Dateien gespeichert werden)"
@@ -5311,7 +5315,7 @@ msgstr "Tigris-Region"
 msgid "Total Files"
 msgstr "Dateien insgesamt"
 
-#: lib/phoenix_kit/integrations/providers.ex:288
+#: lib/phoenix_kit/integrations/providers.ex:289
 #, elixir-autogen, elixir-format
 msgid "Under **Authorized redirect URIs**, add: `{redirect_uri}`"
 msgstr "Fügen Sie unter **Autorisierte Weiterleitungs-URIs** hinzu: `{redirect_uri}`"
@@ -5368,8 +5372,8 @@ msgstr "Sie sind der Organisation beigetreten!"
 msgid "You need to create at least one media bucket before files can be uploaded."
 msgstr "Sie müssen mindestens einen Medien-Bucket erstellen, bevor Dateien hochgeladen werden können."
 
-#: lib/phoenix_kit/integrations/providers.ex:300
-#: lib/phoenix_kit/integrations/providers.ex:1252
+#: lib/phoenix_kit/integrations/providers.ex:301
+#: lib/phoenix_kit/integrations/providers.ex:1324
 #, elixir-autogen, elixir-format
 msgid "You'll be redirected back here once connected"
 msgstr "Sie werden nach der Verbindung hierher zurückgeleitet"
@@ -5436,39 +5440,39 @@ msgstr "vor 1 Stunde"
 msgid "1 minute ago"
 msgstr "vor 1 Minute"
 
-#: lib/phoenix_kit/integrations/providers.ex:509
+#: lib/phoenix_kit/integrations/providers.ex:510
 #, elixir-autogen, elixir-format
 msgid "AI model access via DeepSeek (deepseek-chat, deepseek-reasoner)"
 msgstr "Zugriff auf KI-Modelle über DeepSeek (deepseek-chat, deepseek-reasoner)"
 
-#: lib/phoenix_kit/integrations/providers.ex:446
+#: lib/phoenix_kit/integrations/providers.ex:447
 #, elixir-autogen, elixir-format
 msgid "AI model access via Mistral AI (Mistral Large, Codestral, Pixtral)"
 msgstr "Zugriff auf KI-Modelle über Mistral AI (Mistral Large, Codestral, Pixtral)"
 
-#: lib/phoenix_kit/integrations/providers.ex:1218
+#: lib/phoenix_kit/integrations/providers.ex:1290
 #, elixir-autogen, elixir-format
 msgid "Add a client secret"
 msgstr "Client-Secret hinzufügen"
 
-#: lib/phoenix_kit/integrations/providers.ex:480
+#: lib/phoenix_kit/integrations/providers.ex:481
 #, elixir-autogen, elixir-format
 msgid "Add a payment method (required)"
 msgstr "Zahlungsmethode hinzufügen (erforderlich)"
 
-#: lib/phoenix_kit/integrations/providers.ex:357
-#: lib/phoenix_kit/integrations/providers.ex:542
-#: lib/phoenix_kit/integrations/providers.ex:611
+#: lib/phoenix_kit/integrations/providers.ex:358
+#: lib/phoenix_kit/integrations/providers.ex:543
+#: lib/phoenix_kit/integrations/providers.ex:612
 #, elixir-autogen, elixir-format
 msgid "Add credits"
 msgstr "Guthaben hinzufügen"
 
-#: lib/phoenix_kit/integrations/providers.ex:1233
+#: lib/phoenix_kit/integrations/providers.ex:1305
 #, elixir-autogen, elixir-format
 msgid "Add the permissions your integration needs: `User.Read` is included by default; add `Mail.Read`, `Files.Read.All`, `Calendars.Read`, etc. as required"
 msgstr "Fügen Sie die von Ihrer Integration benötigten Berechtigungen hinzu: `User.Read` ist standardmäßig enthalten; ergänzen Sie nach Bedarf `Mail.Read`, `Files.Read.All`, `Calendars.Read` usw."
 
-#: lib/phoenix_kit/integrations/providers.ex:1160
+#: lib/phoenix_kit/integrations/providers.ex:1232
 #, elixir-autogen, elixir-format
 msgid "Application (client) ID"
 msgstr "Anwendungs-(Client-)ID"
@@ -5478,28 +5482,28 @@ msgstr "Anwendungs-(Client-)ID"
 msgid "Clears the OAuth tokens. Credentials and the connection itself stay so you can reconnect with one click."
 msgstr "Löscht die OAuth-Token. Anmeldedaten und die Verbindung selbst bleiben erhalten, sodass Sie mit einem Klick wieder verbinden können."
 
-#: lib/phoenix_kit/integrations/providers.ex:556
-#: lib/phoenix_kit/integrations/providers.ex:622
+#: lib/phoenix_kit/integrations/providers.ex:557
+#: lib/phoenix_kit/integrations/providers.ex:623
 #, elixir-autogen, elixir-format
 msgid "Click **Create API key**, give it a name"
 msgstr "Klicken Sie auf **API-Schlüssel erstellen** und geben Sie ihm einen Namen"
 
-#: lib/phoenix_kit/integrations/providers.ex:496
+#: lib/phoenix_kit/integrations/providers.ex:497
 #, elixir-autogen, elixir-format
 msgid "Click **Create new key**, give it a name, set an expiry if desired"
 msgstr "Klicken Sie auf **Neuen Schlüssel erstellen**, geben Sie ihm einen Namen und legen Sie bei Bedarf ein Ablaufdatum fest"
 
-#: lib/phoenix_kit/integrations/providers.ex:1205
+#: lib/phoenix_kit/integrations/providers.ex:1277
 #, elixir-autogen, elixir-format
 msgid "Click **New registration**, give the app a name"
 msgstr "Klicken Sie auf **Neue Registrierung** und geben Sie der App einen Namen"
 
-#: lib/phoenix_kit/integrations/providers.ex:1210
+#: lib/phoenix_kit/integrations/providers.ex:1282
 #, elixir-autogen, elixir-format
 msgid "Click **Register**"
 msgstr "Klicken Sie auf **Registrieren**"
 
-#: lib/phoenix_kit/integrations/providers.ex:1228
+#: lib/phoenix_kit/integrations/providers.ex:1300
 #, elixir-autogen, elixir-format
 msgid "Configure API permissions"
 msgstr "API-Berechtigungen konfigurieren"
@@ -5520,16 +5524,16 @@ msgstr "Der Verbindungsname darf nicht leer sein."
 msgid "Connection renamed"
 msgstr "Verbindung umbenannt"
 
-#: lib/phoenix_kit/integrations/providers.ex:1222
+#: lib/phoenix_kit/integrations/providers.ex:1294
 #, elixir-autogen, elixir-format
 msgid "Copy the **Value** column (not the Secret ID) into the form above — the value is shown ONCE and disappears on page refresh"
 msgstr "Kopieren Sie die Spalte **Wert** (nicht die Secret-ID) in das Formular oben – der Wert wird nur EINMAL angezeigt und verschwindet beim Neuladen der Seite"
 
-#: lib/phoenix_kit/integrations/providers.ex:372
-#: lib/phoenix_kit/integrations/providers.ex:497
-#: lib/phoenix_kit/integrations/providers.ex:557
-#: lib/phoenix_kit/integrations/providers.ex:623
-#: lib/phoenix_kit/integrations/providers.ex:675
+#: lib/phoenix_kit/integrations/providers.ex:373
+#: lib/phoenix_kit/integrations/providers.ex:498
+#: lib/phoenix_kit/integrations/providers.ex:558
+#: lib/phoenix_kit/integrations/providers.ex:624
+#: lib/phoenix_kit/integrations/providers.ex:676
 #, elixir-autogen, elixir-format
 msgid "Copy the key (shown once) and paste it into the form above"
 msgstr "Kopieren Sie den Schlüssel (wird nur einmal angezeigt) und fügen Sie ihn in das Formular oben ein"
@@ -5540,12 +5544,12 @@ msgstr "Kopieren Sie den Schlüssel (wird nur einmal angezeigt) und fügen Sie i
 msgid "Create Connection"
 msgstr "Verbindung erstellen"
 
-#: lib/phoenix_kit/integrations/providers.ex:534
+#: lib/phoenix_kit/integrations/providers.ex:535
 #, elixir-autogen, elixir-format
 msgid "Create a DeepSeek account"
 msgstr "DeepSeek-Konto erstellen"
 
-#: lib/phoenix_kit/integrations/providers.ex:471
+#: lib/phoenix_kit/integrations/providers.ex:472
 #, elixir-autogen, elixir-format
 msgid "Create a Mistral account"
 msgstr "Mistral-Konto erstellen"
@@ -5556,12 +5560,12 @@ msgstr "Mistral-Konto erstellen"
 msgid "Danger Zone"
 msgstr "Gefahrenbereich"
 
-#: lib/phoenix_kit/integrations/providers.ex:508
+#: lib/phoenix_kit/integrations/providers.ex:509
 #, elixir-autogen, elixir-format
 msgid "DeepSeek"
 msgstr "DeepSeek"
 
-#: lib/phoenix_kit/integrations/providers.ex:547
+#: lib/phoenix_kit/integrations/providers.ex:548
 #, elixir-autogen, elixir-format
 msgid "DeepSeek requires a positive balance before you can call the chat or reasoner endpoints, even on cheap models"
 msgstr "DeepSeek erfordert ein positives Guthaben, bevor Sie die Chat- oder Reasoner-Endpunkte aufrufen können – auch bei günstigen Modellen"
@@ -5596,82 +5600,82 @@ msgstr "Verbindung konnte nicht entfernt werden."
 msgid "Failed to rename connection."
 msgstr "Verbindung konnte nicht umbenannt werden."
 
-#: lib/phoenix_kit/integrations/providers.ex:485
+#: lib/phoenix_kit/integrations/providers.ex:486
 #, elixir-autogen, elixir-format
 msgid "Free models still require a billing-enabled workspace"
 msgstr "Auch kostenlose Modelle erfordern einen Workspace mit aktivierter Abrechnung"
 
-#: lib/phoenix_kit/integrations/providers.ex:1164
+#: lib/phoenix_kit/integrations/providers.ex:1236
 #, elixir-autogen, elixir-format
 msgid "From Azure Portal → App registrations → your app → Overview"
 msgstr "Aus dem Azure-Portal → App-Registrierungen → Ihre App → Übersicht"
 
-#: lib/phoenix_kit/integrations/providers.ex:464
+#: lib/phoenix_kit/integrations/providers.ex:465
 #, elixir-autogen, elixir-format
 msgid "From console.mistral.ai/api-keys"
 msgstr "Von console.mistral.ai/api-keys"
 
-#: lib/phoenix_kit/integrations/providers.ex:527
+#: lib/phoenix_kit/integrations/providers.ex:528
 #, elixir-autogen, elixir-format
 msgid "From platform.deepseek.com/api_keys"
 msgstr "Von platform.deepseek.com/api_keys"
 
-#: lib/phoenix_kit/integrations/providers.ex:1174
+#: lib/phoenix_kit/integrations/providers.ex:1246
 #, elixir-autogen, elixir-format
 msgid "From your app → Certificates & secrets → New client secret. Copy the *Value*, not the Secret ID."
 msgstr "Aus Ihrer App → Zertifikate und Geheimnisse → Neues Client-Secret. Kopieren Sie den *Wert*, nicht die Secret-ID."
 
-#: lib/phoenix_kit/integrations/providers.ex:1230
+#: lib/phoenix_kit/integrations/providers.ex:1302
 #, elixir-autogen, elixir-format
 msgid "Go to **API permissions → Add a permission → Microsoft Graph → Delegated permissions**"
 msgstr "Gehen Sie zu **API-Berechtigungen → Berechtigung hinzufügen → Microsoft Graph → Delegierte Berechtigungen**"
 
-#: lib/phoenix_kit/integrations/providers.ex:1220
+#: lib/phoenix_kit/integrations/providers.ex:1292
 #, elixir-autogen, elixir-format
 msgid "Go to **Certificates & secrets → New client secret**"
 msgstr "Gehen Sie zu **Zertifikate und Geheimnisse → Neues Client-Secret**"
 
-#: lib/phoenix_kit/integrations/providers.ex:495
+#: lib/phoenix_kit/integrations/providers.ex:496
 #, elixir-autogen, elixir-format
 msgid "Go to [API Keys](https://console.mistral.ai/api-keys)"
 msgstr "Gehen Sie zu [API Keys](https://console.mistral.ai/api-keys)"
 
-#: lib/phoenix_kit/integrations/providers.ex:555
+#: lib/phoenix_kit/integrations/providers.ex:556
 #, elixir-autogen, elixir-format
 msgid "Go to [API Keys](https://platform.deepseek.com/api_keys)"
 msgstr "Gehen Sie zu [API Keys](https://platform.deepseek.com/api_keys)"
 
-#: lib/phoenix_kit/integrations/providers.ex:544
+#: lib/phoenix_kit/integrations/providers.ex:545
 #, elixir-autogen, elixir-format
 msgid "Go to [Top up](https://platform.deepseek.com/top_up) and add at least the minimum amount"
 msgstr "Gehen Sie zu [Top up](https://platform.deepseek.com/top_up) und laden Sie mindestens den Mindestbetrag auf"
 
-#: lib/phoenix_kit/integrations/providers.ex:482
+#: lib/phoenix_kit/integrations/providers.ex:483
 #, elixir-autogen, elixir-format
 msgid "Go to [Workspace → Billing](https://console.mistral.ai/billing/plans) and choose **Experiment** (pay-as-you-go) or a paid tier"
 msgstr "Gehen Sie zu [Workspace → Billing](https://console.mistral.ai/billing/plans) und wählen Sie **Experiment** (nutzungsbasiert) oder einen bezahlten Tarif"
 
-#: lib/phoenix_kit/integrations/providers.ex:473
+#: lib/phoenix_kit/integrations/providers.ex:474
 #, elixir-autogen, elixir-format
 msgid "Go to [console.mistral.ai](https://console.mistral.ai) and sign up or log in"
 msgstr "Gehen Sie zu [console.mistral.ai](https://console.mistral.ai) und registrieren Sie sich oder melden Sie sich an"
 
-#: lib/phoenix_kit/integrations/providers.ex:536
+#: lib/phoenix_kit/integrations/providers.ex:537
 #, elixir-autogen, elixir-format
 msgid "Go to [platform.deepseek.com](https://platform.deepseek.com) and sign up or log in"
 msgstr "Gehen Sie zu [platform.deepseek.com](https://platform.deepseek.com) und registrieren Sie sich oder melden Sie sich an"
 
-#: lib/phoenix_kit/integrations/providers.ex:1202
+#: lib/phoenix_kit/integrations/providers.ex:1274
 #, elixir-autogen, elixir-format
 msgid "Go to the [Azure Portal](https://portal.azure.com) and search for **App registrations**"
 msgstr "Gehen Sie zum [Azure-Portal](https://portal.azure.com) und suchen Sie nach **App-Registrierungen**"
 
-#: lib/phoenix_kit/integrations/providers.ex:1213
+#: lib/phoenix_kit/integrations/providers.ex:1285
 #, elixir-autogen, elixir-format
 msgid "If you picked a single-tenant audience, fill in **Tenant ID** above with your Directory (tenant) ID GUID — leaving it as `common` only works for multi-tenant + personal apps."
 msgstr "Wenn Sie eine Single-Tenant-Zielgruppe gewählt haben, tragen Sie oben unter **Tenant ID** die GUID Ihrer Verzeichnis-(Mandanten-)ID ein – der Wert `common` funktioniert nur für Multi-Tenant- und private Apps."
 
-#: lib/phoenix_kit/integrations/providers.ex:1236
+#: lib/phoenix_kit/integrations/providers.ex:1308
 #, elixir-autogen, elixir-format
 msgid "If your tenant requires admin consent, click **Grant admin consent for <tenant>** before the connect flow will work"
 msgstr "Wenn Ihr Mandant eine Administratorzustimmung erfordert, klicken Sie auf **Administratorzustimmung für <tenant> erteilen**, damit der Verbindungsvorgang funktioniert"
@@ -5688,32 +5692,32 @@ msgstr "Integration nicht gefunden"
 msgid "Last tested"
 msgstr "Zuletzt getestet"
 
-#: lib/phoenix_kit/integrations/providers.ex:1186
+#: lib/phoenix_kit/integrations/providers.ex:1258
 #, elixir-autogen, elixir-format
 msgid "Leave as `common` for multi-tenant + personal accounts. For single-tenant apps, paste your Directory (tenant) ID GUID. Use `consumers` for personal-only or `organizations` for any work-or-school account."
 msgstr "Belassen Sie `common` für Multi-Tenant- und private Konten. Für Single-Tenant-Apps fügen Sie die GUID Ihrer Verzeichnis-(Mandanten-)ID ein. Verwenden Sie `consumers` nur für private Konten oder `organizations` für alle Geschäfts- und Schulkonten."
 
-#: lib/phoenix_kit/integrations/providers.ex:1131
+#: lib/phoenix_kit/integrations/providers.ex:1203
 #, elixir-autogen, elixir-format
 msgid "Microsoft 365"
 msgstr "Microsoft 365"
 
-#: lib/phoenix_kit/integrations/providers.ex:1132
+#: lib/phoenix_kit/integrations/providers.ex:1204
 #, elixir-autogen, elixir-format
 msgid "Microsoft Graph — Outlook, OneDrive, Teams, Calendar, SharePoint"
 msgstr "Microsoft Graph – Outlook, OneDrive, Teams, Kalender, SharePoint"
 
-#: lib/phoenix_kit/integrations/providers.ex:1249
+#: lib/phoenix_kit/integrations/providers.ex:1321
 #, elixir-autogen, elixir-format
 msgid "Microsoft will show the consent screen — click **Accept** to grant the requested permissions"
 msgstr "Microsoft zeigt den Zustimmungsbildschirm – klicken Sie auf **Akzeptieren**, um die angeforderten Berechtigungen zu erteilen"
 
-#: lib/phoenix_kit/integrations/providers.ex:445
+#: lib/phoenix_kit/integrations/providers.ex:446
 #, elixir-autogen, elixir-format
 msgid "Mistral"
 msgstr "Mistral"
 
-#: lib/phoenix_kit/integrations/providers.ex:488
+#: lib/phoenix_kit/integrations/providers.ex:489
 #, elixir-autogen, elixir-format
 msgid "Mistral does not offer credits without billing setup; this is a hard requirement before keys can be created."
 msgstr "Mistral bietet kein Guthaben ohne eingerichtete Abrechnung; dies ist eine zwingende Voraussetzung für die Erstellung von Schlüsseln."
@@ -5724,7 +5728,7 @@ msgstr "Mistral bietet kein Guthaben ohne eingerichtete Abrechnung; dies ist ein
 msgid "Permanently delete this connection? This cannot be undone."
 msgstr "Diese Verbindung endgültig löschen? Dies kann nicht rückgängig gemacht werden."
 
-#: lib/phoenix_kit/integrations/providers.ex:1200
+#: lib/phoenix_kit/integrations/providers.ex:1272
 #, elixir-autogen, elixir-format
 msgid "Register an application in Microsoft Entra ID (Azure AD)"
 msgstr "Registrieren Sie eine Anwendung in Microsoft Entra ID (Azure AD)"
@@ -5740,32 +5744,32 @@ msgstr "Entfernt die Integration endgültig. Jedes Modul, das an diese Verbindun
 msgid "Search..."
 msgstr "Suchen …"
 
-#: lib/phoenix_kit/integrations/providers.ex:1221
+#: lib/phoenix_kit/integrations/providers.ex:1293
 #, elixir-autogen, elixir-format
 msgid "Set an expiration (24 months is common; renew before it lapses)"
 msgstr "Legen Sie ein Ablaufdatum fest (24 Monate sind üblich; erneuern Sie es vor Ablauf)"
 
-#: lib/phoenix_kit/integrations/providers.ex:1181
+#: lib/phoenix_kit/integrations/providers.ex:1253
 #, elixir-autogen, elixir-format
 msgid "Tenant ID"
 msgstr "Mandanten-ID"
 
-#: lib/phoenix_kit/integrations/providers.ex:1241
+#: lib/phoenix_kit/integrations/providers.ex:1313
 #, elixir-autogen, elixir-format
 msgid "The `default_scopes` in the provider definition request `openid email profile offline_access User.Read` — extra scopes can be added per-connect by passing `extra_scopes` to `authorization_url/5`."
 msgstr "Die `default_scopes` in der Anbieterdefinition fordern `openid email profile offline_access User.Read` an – zusätzliche Bereiche können pro Verbindung durch Übergabe von `extra_scopes` an `authorization_url/5` ergänzt werden."
 
-#: lib/phoenix_kit/integrations/providers.ex:1209
+#: lib/phoenix_kit/integrations/providers.ex:1281
 #, elixir-autogen, elixir-format
 msgid "Under **Redirect URI**, choose **Web** and enter: `{redirect_uri}`"
 msgstr "Wählen Sie unter **Umleitungs-URI** die Option **Web** und geben Sie ein: `{redirect_uri}`"
 
-#: lib/phoenix_kit/integrations/providers.ex:1206
+#: lib/phoenix_kit/integrations/providers.ex:1278
 #, elixir-autogen, elixir-format
 msgid "Under **Supported account types**, choose the audience: *Personal Microsoft accounts only*, *Accounts in any organizational directory*, or *Accounts in this organizational directory only* depending on who should sign in"
 msgstr "Wählen Sie unter **Unterstützte Kontotypen** die Zielgruppe: *Nur persönliche Microsoft-Konten*, *Konten in einem beliebigen Organisationsverzeichnis* oder *Nur Konten in diesem Organisationsverzeichnis* – je nachdem, wer sich anmelden soll"
 
-#: lib/phoenix_kit/integrations/providers.ex:476
+#: lib/phoenix_kit/integrations/providers.ex:477
 #, elixir-autogen, elixir-format
 msgid "You may need to verify your phone number before creating API keys"
 msgstr "Möglicherweise müssen Sie Ihre Telefonnummer bestätigen, bevor Sie API-Schlüssel erstellen können"
@@ -6032,14 +6036,14 @@ msgstr "Nicht installiert"
 
 #: lib/phoenix_kit_web/live/modules.html.heex:447
 #: lib/phoenix_kit_web/live/settings.html.heex:465
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:289
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:315
 #, elixir-autogen, elixir-format
 msgid "Off"
 msgstr "Aus"
 
 #: lib/phoenix_kit_web/live/modules.html.heex:447
 #: lib/phoenix_kit_web/live/settings.html.heex:464
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:289
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:315
 #, elixir-autogen, elixir-format
 msgid "On"
 msgstr "Ein"
@@ -7271,8 +7275,8 @@ msgstr "Antworten"
 msgid "Are you sure you want to delete this comment?"
 msgstr "Möchten Sie diesen Kommentar wirklich löschen?"
 
-#: lib/phoenix_kit_web/components/media_canvas_viewer.ex:1202
-#: lib/phoenix_kit_web/components/media_canvas_viewer.ex:1203
+#: lib/phoenix_kit_web/components/media_canvas_viewer.ex:1236
+#: lib/phoenix_kit_web/components/media_canvas_viewer.ex:1237
 #, elixir-autogen, elixir-format
 msgid "%b %d, %Y"
 msgstr "%d. %b %Y"
@@ -8386,14 +8390,14 @@ msgstr "Alle Felder sind bereits ausgewählt"
 msgid "All registered accounts"
 msgstr "Alle registrierten Konten"
 
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:185
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:224
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:179
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:218
 #, elixir-autogen, elixir-format
 msgid "Anon"
 msgstr "Anon."
 
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:178
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:245
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:172
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:239
 #, elixir-autogen, elixir-format
 msgid "Anonymous User"
 msgstr "Anonymer Benutzer"
@@ -8444,8 +8448,8 @@ msgstr "Möchten Sie diese Sitzung wirklich widerrufen für"
 msgid "Are you sure you want to unconfirm this user's email?"
 msgstr "Möchten Sie die Bestätigung der E-Mail-Adresse dieses Benutzers wirklich aufheben?"
 
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:170
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:220
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:164
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:214
 #, elixir-autogen, elixir-format
 msgid "Auth"
 msgstr "Auth"
@@ -8528,17 +8532,17 @@ msgid "Confirmed Email"
 msgstr "Bestätigte E-Mail"
 
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:109
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:195
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Current Page"
 msgstr "Aktuelle Seite"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:251
+#: lib/phoenix_kit_web/live/settings/users.ex:258
 #, elixir-autogen, elixir-format
 msgid "Custom field deleted successfully"
 msgstr "Benutzerdefiniertes Feld erfolgreich gelöscht"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:171
+#: lib/phoenix_kit_web/live/settings/users.ex:178
 #, elixir-autogen, elixir-format
 msgid "Custom field saved successfully"
 msgstr "Benutzerdefiniertes Feld erfolgreich gespeichert"
@@ -8553,17 +8557,17 @@ msgstr "Tabellenspalten anpassen"
 msgid "Drag to reorder selected columns above, or add new columns from the options below. Actions column is always included."
 msgstr "Ziehen Sie oben, um die ausgewählten Spalten neu anzuordnen, oder fügen Sie neue Spalten aus den Optionen unten hinzu. Die Spalte „Aktionen“ ist immer enthalten."
 
-#: lib/phoenix_kit_web/live/settings/users.ex:256
+#: lib/phoenix_kit_web/live/settings/users.ex:263
 #, elixir-autogen, elixir-format
 msgid "Failed to delete custom field"
 msgstr "Benutzerdefiniertes Feld konnte nicht gelöscht werden"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:184
+#: lib/phoenix_kit_web/live/settings/users.ex:191
 #, elixir-autogen, elixir-format
 msgid "Failed to save custom field"
 msgstr "Benutzerdefiniertes Feld konnte nicht gespeichert werden"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:285
+#: lib/phoenix_kit_web/live/settings/users.ex:292
 #, elixir-autogen, elixir-format
 msgid "Failed to update field"
 msgstr "Feld konnte nicht aktualisiert werden"
@@ -8596,23 +8600,23 @@ msgstr "Benutzerrollen konnten nicht aktualisiert werden"
 msgid "Failed to update user status"
 msgstr "Benutzerstatus konnte nicht aktualisiert werden"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:278
+#: lib/phoenix_kit_web/live/settings/users.ex:285
 #, elixir-autogen, elixir-format
 msgid "Field '%{label}' disabled"
 msgstr "Feld „%{label}“ deaktiviert"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:277
+#: lib/phoenix_kit_web/live/settings/users.ex:284
 #, elixir-autogen, elixir-format
 msgid "Field '%{label}' enabled"
 msgstr "Feld „%{label}“ aktiviert"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:289
+#: lib/phoenix_kit_web/live/settings/users.ex:296
 #, elixir-autogen, elixir-format
 msgid "Field not found"
 msgstr "Feld nicht gefunden"
 
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:108
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:194
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:188
 #, elixir-autogen, elixir-format
 msgid "IP Address"
 msgstr "IP-Adresse"
@@ -8644,7 +8648,7 @@ msgstr "Benutzerkonten und Rollen verwalten"
 msgid "Monitor and manage active user sessions"
 msgstr "Aktive Benutzersitzungen überwachen und verwalten"
 
-#: lib/phoenix_kit/integrations/providers.ex:1002
+#: lib/phoenix_kit/integrations/providers.ex:1074
 #: lib/phoenix_kit_web/live/users/users.ex:1048
 #: lib/phoenix_kit_web/live/users/users.html.heex:563
 #, elixir-autogen, elixir-format
@@ -8656,7 +8660,7 @@ msgstr "Nie"
 msgid "Next »"
 msgstr "Weiter »"
 
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:208
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:202
 #, elixir-autogen, elixir-format
 msgid "No active sessions"
 msgstr "Keine aktiven Sitzungen"
@@ -8808,7 +8812,7 @@ msgstr "Standardfelder"
 msgid "Table columns updated successfully"
 msgstr "Tabellenspalten erfolgreich aktualisiert"
 
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:209
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:203
 #, elixir-autogen, elixir-format
 msgid "There are currently no active sessions to display."
 msgstr "Derzeit gibt es keine aktiven Sitzungen zum Anzeigen."
@@ -8869,12 +8873,12 @@ msgstr "Bestätigung der E-Mail-Adresse des Benutzers erfolgreich aufgehoben"
 msgid "User roles updated successfully"
 msgstr "Benutzerrollen erfolgreich aktualisiert"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:84
+#: lib/phoenix_kit_web/live/settings/users.ex:91
 #, elixir-autogen, elixir-format
 msgid "User settings updated successfully"
 msgstr "Benutzereinstellungen erfolgreich aktualisiert"
 
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:193
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:187
 #, elixir-autogen, elixir-format
 msgid "User/Session"
 msgstr "Benutzer/Sitzung"
@@ -8908,7 +8912,7 @@ msgstr[1] "Möchten Sie wirklich alle %{count} Sitzungen des Benutzers %{email} 
 msgid "Last updated:"
 msgstr "Zuletzt aktualisiert:"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:656
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:671
 #, elixir-autogen, elixir-format
 msgid "Account switcher for signing in to several accounts at once"
 msgstr "Kontoumschalter für die gleichzeitige Anmeldung an mehreren Konten"
@@ -8918,7 +8922,7 @@ msgstr "Kontoumschalter für die gleichzeitige Anmeldung an mehreren Konten"
 msgid "Applying…"
 msgstr "Wird angewendet …"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:662
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:677
 #, elixir-autogen, elixir-format
 msgid "Enable the multi-account switcher in the header"
 msgstr "Den Mehrkonten-Umschalter in der Kopfzeile aktivieren"
@@ -8936,12 +8940,12 @@ msgstr "Mehr laden"
 msgid "Loading…"
 msgstr "Wird geladen …"
 
-#: lib/phoenix_kit_web/users/session.ex:113
+#: lib/phoenix_kit_web/users/session.ex:115
 #, elixir-autogen, elixir-format
 msgid "Logged out. Now signed in as %{email}."
 msgstr "Abgemeldet. Jetzt angemeldet als %{email}."
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:653
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:668
 #, elixir-autogen, elixir-format
 msgid "Multiple Sessions"
 msgstr "Mehrere Sitzungen"
@@ -8977,12 +8981,12 @@ msgstr "Das 1 ausgewählte %{noun} neu anordnen (andere Zeilen bleiben unveränd
 msgid "Showing %{loaded} of %{total} %{noun}"
 msgstr "%{loaded} von %{total} %{noun}"
 
-#: lib/phoenix_kit_web/users/session.ex:268
+#: lib/phoenix_kit_web/users/session.ex:270
 #, elixir-autogen, elixir-format
 msgid "Switched to %{email}."
 msgstr "Zu %{email} gewechselt."
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:665
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:680
 #, elixir-autogen, elixir-format
 msgid "When on, any signed-in user can add other accounts (with their password) and switch between them from the user menu."
 msgstr "Wenn aktiviert, kann jeder angemeldete Benutzer weitere Konten (mit deren Passwort) hinzufügen und über das Benutzermenü zwischen ihnen wechseln."
@@ -9062,7 +9066,7 @@ msgstr "Hier können nur die zulässigen Dateitypen hinzugefügt werden."
 msgid "View background job status and history"
 msgstr "Status und Verlauf der Hintergrundaufgaben anzeigen"
 
-#: lib/phoenix_kit/integrations/providers.ex:312
+#: lib/phoenix_kit/integrations/providers.ex:313
 #, elixir-autogen, elixir-format
 msgid "AI models via OpenAI (GPT, embeddings, images, audio)"
 msgstr "KI-Modelle über OpenAI (GPT, Embeddings, Bilder, Audio)"
@@ -9147,12 +9151,12 @@ msgstr "Ändern"
 msgid "Choose"
 msgstr "Auswählen"
 
-#: lib/phoenix_kit/integrations/providers.ex:674
+#: lib/phoenix_kit/integrations/providers.ex:675
 #, elixir-autogen, elixir-format
 msgid "Click **Create API Key**, give it a name"
 msgstr "Klicken Sie auf **API-Schlüssel erstellen** und geben Sie ihm einen Namen"
 
-#: lib/phoenix_kit/integrations/providers.ex:371
+#: lib/phoenix_kit/integrations/providers.ex:372
 #, elixir-autogen, elixir-format
 msgid "Click **Create new secret key**, give it a name"
 msgstr "Klicken Sie auf **Create new secret key** und geben Sie ihm einen Namen"
@@ -9163,12 +9167,12 @@ msgstr "Klicken Sie auf **Create new secret key** und geben Sie ihm einen Namen"
 msgid "Close search"
 msgstr "Suche schließen"
 
-#: lib/phoenix_kit/integrations/providers.ex:664
+#: lib/phoenix_kit/integrations/providers.ex:665
 #, elixir-autogen, elixir-format
 msgid "Create an ElevenLabs account"
 msgstr "ElevenLabs-Konto erstellen"
 
-#: lib/phoenix_kit/integrations/providers.ex:349
+#: lib/phoenix_kit/integrations/providers.ex:350
 #, elixir-autogen, elixir-format
 msgid "Create an OpenAI account"
 msgstr "OpenAI-Konto erstellen"
@@ -9232,7 +9236,7 @@ msgstr "Beschreibung bearbeiten"
 msgid "Edit header"
 msgstr "Kopfzeile bearbeiten"
 
-#: lib/phoenix_kit/integrations/providers.ex:634
+#: lib/phoenix_kit/integrations/providers.ex:635
 #, elixir-autogen, elixir-format
 msgid "ElevenLabs"
 msgstr "ElevenLabs"
@@ -9302,37 +9306,37 @@ msgstr "Der Ordnername darf nicht leer sein"
 msgid "Forgot password"
 msgstr "Passwort vergessen"
 
-#: lib/phoenix_kit/integrations/providers.ex:657
+#: lib/phoenix_kit/integrations/providers.ex:658
 #, elixir-autogen, elixir-format
 msgid "From elevenlabs.io → Settings → API Keys"
 msgstr "Von elevenlabs.io → Einstellungen → API Keys"
 
-#: lib/phoenix_kit/integrations/providers.ex:336
+#: lib/phoenix_kit/integrations/providers.ex:337
 #, elixir-autogen, elixir-format
 msgid "From platform.openai.com/api-keys"
 msgstr "Von platform.openai.com/api-keys"
 
-#: lib/phoenix_kit/integrations/providers.ex:370
+#: lib/phoenix_kit/integrations/providers.ex:371
 #, elixir-autogen, elixir-format
 msgid "Go to [API Keys](https://platform.openai.com/api-keys)"
 msgstr "Gehen Sie zu [API Keys](https://platform.openai.com/api-keys)"
 
-#: lib/phoenix_kit/integrations/providers.ex:359
+#: lib/phoenix_kit/integrations/providers.ex:360
 #, elixir-autogen, elixir-format
 msgid "Go to [Billing](https://platform.openai.com/account/billing/overview) and add a payment method or credits"
 msgstr "Gehen Sie zu [Billing](https://platform.openai.com/account/billing/overview) und fügen Sie eine Zahlungsmethode oder Guthaben hinzu"
 
-#: lib/phoenix_kit/integrations/providers.ex:672
+#: lib/phoenix_kit/integrations/providers.ex:673
 #, elixir-autogen, elixir-format
 msgid "Go to [Settings → API Keys](https://elevenlabs.io/app/settings/api-keys)"
 msgstr "Gehen Sie zu [Settings → API Keys](https://elevenlabs.io/app/settings/api-keys)"
 
-#: lib/phoenix_kit/integrations/providers.ex:666
+#: lib/phoenix_kit/integrations/providers.ex:667
 #, elixir-autogen, elixir-format
 msgid "Go to [elevenlabs.io](https://elevenlabs.io) and sign up or log in"
 msgstr "Gehen Sie zu [elevenlabs.io](https://elevenlabs.io) und registrieren Sie sich oder melden Sie sich an"
 
-#: lib/phoenix_kit/integrations/providers.ex:351
+#: lib/phoenix_kit/integrations/providers.ex:352
 #, elixir-autogen, elixir-format
 msgid "Go to [platform.openai.com](https://platform.openai.com) and sign up or log in"
 msgstr "Gehen Sie zu [platform.openai.com](https://platform.openai.com) und registrieren Sie sich oder melden Sie sich an"
@@ -9361,7 +9365,7 @@ msgstr "Überschrift %{level}"
 msgid "Icon"
 msgstr "Symbol"
 
-#: lib/phoenix_kit/integrations/providers.ex:375
+#: lib/phoenix_kit/integrations/providers.ex:376
 #, elixir-autogen, elixir-format
 msgid "If your account belongs to multiple organizations, keys are scoped to the org selected when the key was created."
 msgstr "Wenn Ihr Konto zu mehreren Organisationen gehört, gelten Schlüssel jeweils für die bei der Erstellung ausgewählte Organisation."
@@ -9461,12 +9465,12 @@ msgstr "Älteste zuerst"
 msgid "Open the media health dashboard to check file redundancy and re-sync files across storage locations."
 msgstr "Öffnen Sie die Übersicht zum Medienzustand, um die Dateiredundanz zu prüfen und Dateien zwischen Speicherorten neu zu synchronisieren."
 
-#: lib/phoenix_kit/integrations/providers.ex:311
+#: lib/phoenix_kit/integrations/providers.ex:312
 #, elixir-autogen, elixir-format
 msgid "OpenAI"
 msgstr "OpenAI"
 
-#: lib/phoenix_kit/integrations/providers.ex:362
+#: lib/phoenix_kit/integrations/providers.ex:363
 #, elixir-autogen, elixir-format
 msgid "OpenAI requires a positive balance before the API will return completions, even on cheaper models"
 msgstr "OpenAI erfordert ein positives Guthaben, bevor die API Completions zurückgibt – auch bei günstigeren Modellen"
@@ -9556,12 +9560,12 @@ msgstr "Sortierung"
 msgid "Stacks"
 msgstr "Stapel"
 
-#: lib/phoenix_kit/integrations/providers.ex:635
+#: lib/phoenix_kit/integrations/providers.ex:636
 #, elixir-autogen, elixir-format
 msgid "Text-to-speech and voice generation via ElevenLabs"
 msgstr "Text-zu-Sprache und Stimmenerzeugung über ElevenLabs"
 
-#: lib/phoenix_kit/integrations/providers.ex:678
+#: lib/phoenix_kit/integrations/providers.ex:679
 #, elixir-autogen, elixir-format
 msgid "The free tier includes a monthly character quota; paid plans raise the quota and unlock commercial use and additional voices."
 msgstr "Der kostenlose Tarif enthält ein monatliches Zeichenkontingent; bezahlte Tarife erhöhen das Kontingent und ermöglichen kommerzielle Nutzung sowie zusätzliche Stimmen."
@@ -10443,27 +10447,27 @@ msgstr "Oder hinzufügen über"
 msgid "Too many attempts. Please try again shortly."
 msgstr "Zu viele Versuche. Bitte versuchen Sie es in Kürze erneut."
 
-#: lib/phoenix_kit/integrations/providers.ex:569
+#: lib/phoenix_kit/integrations/providers.ex:570
 #, elixir-autogen, elixir-format
 msgid "AI model access via xAI (Grok models)"
 msgstr "Zugriff auf KI-Modelle über xAI (Grok-Modelle)"
 
-#: lib/phoenix_kit/integrations/providers.ex:827
+#: lib/phoenix_kit/integrations/providers.ex:828
 #, elixir-autogen, elixir-format
 msgid "AWS Simple Email Service (SMTP credentials via SES API)"
 msgstr "AWS Simple Email Service (SMTP-Anmeldedaten über die SES-API)"
 
-#: lib/phoenix_kit/integrations/providers.ex:826
+#: lib/phoenix_kit/integrations/providers.ex:827
 #, elixir-autogen, elixir-format
 msgid "Amazon SES"
 msgstr "Amazon SES"
 
-#: lib/phoenix_kit/integrations/providers.ex:1050
+#: lib/phoenix_kit/integrations/providers.ex:1122
 #, elixir-autogen, elixir-format
 msgid "Brevo API"
 msgstr "Brevo-API"
 
-#: lib/phoenix_kit/integrations/providers.ex:605
+#: lib/phoenix_kit/integrations/providers.ex:606
 #, elixir-autogen, elixir-format
 msgid "Create an xAI account"
 msgstr "xAI-Konto erstellen"
@@ -10473,37 +10477,37 @@ msgstr "xAI-Konto erstellen"
 msgid "Email users when their account is signed in from a new device"
 msgstr "Benutzer per E-Mail benachrichtigen, wenn sich ihr Konto von einem neuen Gerät anmeldet"
 
-#: lib/phoenix_kit/integrations/providers.ex:961
+#: lib/phoenix_kit/integrations/providers.ex:1033
 #, elixir-autogen, elixir-format
 msgid "For Brevo: the SMTP key starting with xsmtpsib- (SMTP & API → SMTP tab) — not the API key (xkeysib-)."
 msgstr "Für Brevo: der SMTP-Schlüssel, der mit xsmtpsib- beginnt (SMTP & API → Registerkarte SMTP) – nicht der API-Schlüssel (xkeysib-)."
 
-#: lib/phoenix_kit/integrations/providers.ex:949
+#: lib/phoenix_kit/integrations/providers.ex:1021
 #, elixir-autogen, elixir-format
 msgid "For Brevo: your account's SMTP login, shown as <subaccount>@smtp-brevo.com under SMTP & API → SMTP."
 msgstr "Für Brevo: der SMTP-Login Ihres Kontos, angezeigt als <subaccount>@smtp-brevo.com unter SMTP & API → SMTP."
 
-#: lib/phoenix_kit/integrations/providers.ex:1070
+#: lib/phoenix_kit/integrations/providers.ex:1142
 #, elixir-autogen, elixir-format
 msgid "From Brevo → SMTP & API → API Keys. Starts with xkeysib- — not the SMTP key (xsmtpsib-)."
 msgstr "Aus Brevo → SMTP & API → API Keys. Beginnt mit xkeysib- – nicht der SMTP-Schlüssel (xsmtpsib-)."
 
-#: lib/phoenix_kit/integrations/providers.ex:590
+#: lib/phoenix_kit/integrations/providers.ex:591
 #, elixir-autogen, elixir-format
 msgid "From console.x.ai/team/default/api-keys"
 msgstr "Von console.x.ai/team/default/api-keys"
 
-#: lib/phoenix_kit/integrations/providers.ex:621
+#: lib/phoenix_kit/integrations/providers.ex:622
 #, elixir-autogen, elixir-format
 msgid "Go to [API Keys](https://console.x.ai/team/default/api-keys)"
 msgstr "Gehen Sie zu [API Keys](https://console.x.ai/team/default/api-keys)"
 
-#: lib/phoenix_kit/integrations/providers.ex:607
+#: lib/phoenix_kit/integrations/providers.ex:608
 #, elixir-autogen, elixir-format
 msgid "Go to [accounts.x.ai](https://accounts.x.ai) and sign up or log in"
 msgstr "Gehen Sie zu [accounts.x.ai](https://accounts.x.ai) und registrieren Sie sich oder melden Sie sich an"
 
-#: lib/phoenix_kit/integrations/providers.ex:613
+#: lib/phoenix_kit/integrations/providers.ex:614
 #, elixir-autogen, elixir-format
 msgid "Go to [console.x.ai](https://console.x.ai) → Billing and add credits"
 msgstr "Gehen Sie zu [console.x.ai](https://console.x.ai) → Billing und laden Sie Guthaben auf"
@@ -10513,43 +10517,44 @@ msgstr "Gehen Sie zu [console.x.ai](https://console.x.ai) → Billing und laden 
 msgid "Login Notifications"
 msgstr "Anmeldebenachrichtigungen"
 
-#: lib/phoenix_kit/integrations/providers.ex:927
+#: lib/phoenix_kit/integrations/providers.ex:999
 #, elixir-autogen, elixir-format
 msgid "Port"
 msgstr "Port"
 
-#: lib/phoenix_kit/integrations/providers.ex:720
-#: lib/phoenix_kit/integrations/providers.ex:860
+#: lib/phoenix_kit/integrations/providers.ex:721
+#: lib/phoenix_kit/integrations/providers.ex:861
+#: lib/phoenix_kit/integrations/providers.ex:945
 #, elixir-autogen, elixir-format
 msgid "Region"
 msgstr "Region"
 
-#: lib/phoenix_kit/integrations/providers.ex:904
+#: lib/phoenix_kit/integrations/providers.ex:976
 #, elixir-autogen, elixir-format
 msgid "SMTP"
 msgstr "SMTP"
 
-#: lib/phoenix_kit/integrations/providers.ex:918
+#: lib/phoenix_kit/integrations/providers.ex:990
 #, elixir-autogen, elixir-format
 msgid "SMTP Host"
 msgstr "SMTP-Host"
 
-#: lib/phoenix_kit/integrations/providers.ex:1051
+#: lib/phoenix_kit/integrations/providers.ex:1123
 #, elixir-autogen, elixir-format
 msgid "Send email via the Brevo transactional email API"
 msgstr "E-Mails über die Brevo-API für Transaktions-E-Mails senden"
 
-#: lib/phoenix_kit/integrations/providers.ex:906
+#: lib/phoenix_kit/integrations/providers.ex:978
 #, elixir-autogen, elixir-format
 msgid "Universal SMTP relay — works with any vendor (Brevo, Mailgun, SendGrid, a self-hosted mail server, etc). Add one named connection per relay/account."
 msgstr "Universelles SMTP-Relay – funktioniert mit jedem Anbieter (Brevo, Mailgun, SendGrid, ein selbst gehosteter Mailserver usw.). Fügen Sie pro Relay/Konto eine benannte Verbindung hinzu."
 
-#: lib/phoenix_kit/integrations/providers.ex:568
+#: lib/phoenix_kit/integrations/providers.ex:569
 #, elixir-autogen, elixir-format
 msgid "xAI"
 msgstr "xAI"
 
-#: lib/phoenix_kit/integrations/providers.ex:615
+#: lib/phoenix_kit/integrations/providers.ex:616
 #, elixir-autogen, elixir-format
 msgid "xAI requires a funded account before the API will return completions"
 msgstr "xAI erfordert ein aufgeladenes Konto, bevor die API Completions zurückgibt"
@@ -10723,12 +10728,12 @@ msgstr "Keine Dateien entsprechen Ihrer Suche."
 msgid "Try a different term or clear the search"
 msgstr "Versuchen Sie einen anderen Suchbegriff oder setzen Sie die Suche zurück"
 
-#: lib/modules/storage/web/bucket_form.ex:294
+#: lib/modules/storage/web/bucket_form.ex:296
 #, elixir-autogen, elixir-format
 msgid "Add Storage Bucket"
 msgstr "Speicher-Bucket hinzufügen"
 
-#: lib/modules/storage/web/bucket_form.ex:295
+#: lib/modules/storage/web/bucket_form.ex:297
 #, elixir-autogen, elixir-format
 msgid "Edit Storage Bucket"
 msgstr "Speicher-Bucket bearbeiten"
@@ -10817,12 +10822,12 @@ msgstr "vor %{n} Min."
 msgid "%{provider} settings"
 msgstr "%{provider}-Einstellungen"
 
-#: lib/phoenix_kit/integrations/validators.ex:643
+#: lib/phoenix_kit/integrations/validators.ex:824
 #, elixir-autogen, elixir-format
 msgid "%{text} · resets %{date}"
 msgstr "%{text} · Zurücksetzung am %{date}"
 
-#: lib/phoenix_kit/integrations/validators.ex:632
+#: lib/phoenix_kit/integrations/validators.ex:813
 #, elixir-autogen, elixir-format
 msgid "%{type} · %{credits} credits left"
 msgstr "%{type} · %{credits} Guthaben übrig"
@@ -10878,12 +10883,12 @@ msgstr "Die gesamte ausgehende Systempost – Authentifizierung, Benachrichtigun
 msgid "Allow \"Keep me logged in\" (persistent sessions)"
 msgstr "„Angemeldet bleiben“ erlauben (dauerhafte Sitzungen)"
 
-#: lib/phoenix_kit/integrations/providers.ex:1001
+#: lib/phoenix_kit/integrations/providers.ex:1073
 #, elixir-autogen, elixir-format
 msgid "Always"
 msgstr "Immer"
 
-#: lib/phoenix_kit_web/users/session.ex:331
+#: lib/phoenix_kit_web/users/session.ex:333
 #, elixir-autogen, elixir-format
 msgid "An owner account cannot be used."
 msgstr "Ein Inhaberkonto kann nicht verwendet werden."
@@ -10893,12 +10898,12 @@ msgstr "Ein Inhaberkonto kann nicht verwendet werden."
 msgid "Applies site-wide wherever the rich-text editor is rendered (posts, comments). Users can still switch modes inside the editor."
 msgstr "Gilt websiteweit überall dort, wo der Rich-Text-Editor angezeigt wird (Beiträge, Kommentare). Benutzer können den Modus im Editor weiterhin wechseln."
 
-#: lib/phoenix_kit/integrations/providers.ex:982
+#: lib/phoenix_kit/integrations/providers.ex:1054
 #, elixir-autogen, elixir-format
 msgid "Auto (from port)"
 msgstr "Automatisch (nach Port)"
 
-#: lib/phoenix_kit/integrations/providers.ex:978
+#: lib/phoenix_kit/integrations/providers.ex:1050
 #, elixir-autogen, elixir-format
 msgid "Auto follows the port: 465 means implicit TLS, anything else STARTTLS (required when a login is set). Choose explicitly for a relay that ignores that convention."
 msgstr "„Automatisch“ richtet sich nach dem Port: 465 bedeutet implizites TLS, alles andere STARTTLS (erforderlich, wenn ein Login gesetzt ist). Wählen Sie es ausdrücklich für ein Relay, das diese Konvention ignoriert."
@@ -10913,22 +10918,22 @@ msgstr "Häufige Typen in periodische Zusammenfassungen bündeln – legen Sie p
 msgid "Best,\nThe Team"
 msgstr "Mit freundlichen Grüßen,\ndas Team"
 
-#: lib/phoenix_kit/integrations/providers.ex:1098
+#: lib/phoenix_kit/integrations/providers.ex:1170
 #, elixir-autogen, elixir-format
 msgid "Bot Token"
 msgstr "Bot-Token"
 
-#: lib/phoenix_kit/integrations/providers.ex:1118
+#: lib/phoenix_kit/integrations/providers.ex:1190
 #, elixir-autogen, elixir-format
 msgid "BotFather replies with an HTTP API token like `123456789:ABCdef...` — copy it"
 msgstr "BotFather antwortet mit einem HTTP-API-Token wie `123456789:ABCdef...` – kopieren Sie es"
 
-#: lib/phoenix_kit/integrations/validators.ex:601
+#: lib/phoenix_kit/integrations/validators.ex:782
 #, elixir-autogen, elixir-format
 msgid "Brevo error %{status}"
 msgstr "Brevo-Fehler %{status}"
 
-#: lib/phoenix_kit/integrations/providers.ex:1022
+#: lib/phoenix_kit/integrations/providers.ex:1094
 #, elixir-autogen, elixir-format
 msgid "CA certificate (PEM)"
 msgstr "CA-Zertifikat (PEM)"
@@ -10938,7 +10943,7 @@ msgstr "CA-Zertifikat (PEM)"
 msgid "Cannot delete send profile"
 msgstr "Sendeprofil kann nicht gelöscht werden"
 
-#: lib/phoenix_kit/integrations/providers.ex:1007
+#: lib/phoenix_kit/integrations/providers.ex:1079
 #, elixir-autogen, elixir-format
 msgid "Certificate verification"
 msgstr "Zertifikatsprüfung"
@@ -10983,7 +10988,7 @@ msgstr "Bestätigen Sie Ihre E-Mail-Adresse"
 msgid "Connect your own API keys and services. Only you can see these."
 msgstr "Verbinden Sie Ihre eigenen API-Schlüssel und Dienste. Nur Sie können sie sehen."
 
-#: lib/phoenix_kit/integrations/validators.ex:693
+#: lib/phoenix_kit/integrations/validators.ex:874
 #, elixir-autogen, elixir-format
 msgid "Connected as @%{username}"
 msgstr "Verbunden als @%{username}"
@@ -10999,7 +11004,7 @@ msgstr "Verbindung funktioniert"
 msgid "Content Editor"
 msgstr "Inhaltseditor"
 
-#: lib/phoenix_kit/integrations/providers.ex:1116
+#: lib/phoenix_kit/integrations/providers.ex:1188
 #, elixir-autogen, elixir-format
 msgid "Copy the bot token"
 msgstr "Bot-Token kopieren"
@@ -11017,12 +11022,12 @@ msgstr "Integration konnte nicht hinzugefügt werden"
 msgid "Could not reach AWS SES"
 msgstr "AWS SES war nicht erreichbar"
 
-#: lib/phoenix_kit/integrations/validators.ex:605
+#: lib/phoenix_kit/integrations/validators.ex:786
 #, elixir-autogen, elixir-format
 msgid "Could not reach Brevo"
 msgstr "Brevo war nicht erreichbar"
 
-#: lib/phoenix_kit/integrations/validators.ex:705
+#: lib/phoenix_kit/integrations/validators.ex:886
 #, elixir-autogen, elixir-format
 msgid "Could not reach Telegram"
 msgstr "Telegram war nicht erreichbar"
@@ -11083,7 +11088,7 @@ msgstr "Zusammenfassungseinstellungen konnten nicht aktualisiert werden."
 msgid "Could not update default send integration"
 msgstr "Standard-Sendeintegration konnte nicht aktualisiert werden"
 
-#: lib/phoenix_kit/integrations/providers.ex:1109
+#: lib/phoenix_kit/integrations/providers.ex:1181
 #, elixir-autogen, elixir-format
 msgid "Create a bot with BotFather"
 msgstr "Bot mit BotFather erstellen"
@@ -11159,7 +11164,7 @@ msgstr "Deaktivierte Profile werden nie zum Senden verwendet, auch nicht als Sta
 msgid "Dismiss"
 msgstr "Ausblenden"
 
-#: lib/phoenix_kit/integrations/providers.ex:1017
+#: lib/phoenix_kit/integrations/providers.ex:1089
 #, elixir-autogen, elixir-format
 msgid "Do not verify"
 msgstr "Nicht prüfen"
@@ -11191,7 +11196,7 @@ msgstr "Sendeprofil bearbeiten: %{name}"
 msgid "Email Sending"
 msgstr "E-Mail-Versand"
 
-#: lib/phoenix_kit_web/users/confirmation_instructions.ex:109
+#: lib/phoenix_kit_web/users/confirmation_instructions.ex:111
 #, elixir-autogen, elixir-format
 msgid "Email confirmed. Welcome!"
 msgstr "E-Mail-Adresse bestätigt. Willkommen!"
@@ -11201,7 +11206,7 @@ msgstr "E-Mail-Adresse bestätigt. Willkommen!"
 msgid "Email-capable integrations"
 msgstr "E-Mail-fähige Integrationen"
 
-#: lib/phoenix_kit/integrations/providers.ex:973
+#: lib/phoenix_kit/integrations/providers.ex:1045
 #, elixir-autogen, elixir-format
 msgid "Encryption"
 msgstr "Verschlüsselung"
@@ -11221,7 +11226,7 @@ msgstr "Alle 12 Stunden"
 msgid "Everyone who starts the bot"
 msgstr "Alle, die den Bot starten"
 
-#: lib/phoenix_kit/integrations/providers.ex:1027
+#: lib/phoenix_kit/integrations/providers.ex:1099
 #, elixir-autogen, elixir-format
 msgid "For a private or self-signed relay certificate. Replaces the system CA store for this connection only."
 msgstr "Für ein privates oder selbst signiertes Relay-Zertifikat. Ersetzt den System-CA-Speicher nur für diese Verbindung."
@@ -11232,7 +11237,7 @@ msgstr "Für ein privates oder selbst signiertes Relay-Zertifikat. Ersetzt den S
 msgid "From"
 msgstr "Absender"
 
-#: lib/phoenix_kit/integrations/providers.ex:1102
+#: lib/phoenix_kit/integrations/providers.ex:1174
 #, elixir-autogen, elixir-format
 msgid "From @BotFather → /newbot (or /token for an existing bot)"
 msgstr "Von @BotFather → /newbot (oder /token für einen bestehenden Bot)"
@@ -11259,7 +11264,7 @@ msgstr "Vollzugriff"
 msgid "Hourly"
 msgstr "Stündlich"
 
-#: lib/phoenix_kit/integrations/providers.ex:1000
+#: lib/phoenix_kit/integrations/providers.ex:1072
 #, elixir-autogen, elixir-format
 msgid "If offered (default)"
 msgstr "Wenn angeboten (Standard)"
@@ -11269,7 +11274,7 @@ msgstr "Wenn angeboten (Standard)"
 msgid "Immediate"
 msgstr "Sofort"
 
-#: lib/phoenix_kit/integrations/providers.ex:983
+#: lib/phoenix_kit/integrations/providers.ex:1055
 #, elixir-autogen, elixir-format
 msgid "Implicit TLS / SMTPS"
 msgstr "Implizites TLS / SMTPS"
@@ -11287,6 +11292,7 @@ msgid "Incomplete SMTP settings"
 msgstr "Unvollständige SMTP-Einstellungen"
 
 #: lib/phoenix_kit/integrations/validators.ex:57
+#: lib/phoenix_kit/integrations/validators.ex:582
 #, elixir-autogen, elixir-format
 msgid "Incomplete credentials"
 msgstr "Unvollständige Anmeldedaten"
@@ -11323,7 +11329,7 @@ msgstr "Ungültige SMTP-Einstellungen"
 msgid "Invalid SMTP settings: %{reason}"
 msgstr "Ungültige SMTP-Einstellungen: %{reason}"
 
-#: lib/phoenix_kit/integrations/validators.ex:698
+#: lib/phoenix_kit/integrations/validators.ex:879
 #, elixir-autogen, elixir-format
 msgid "Invalid bot token"
 msgstr "Ungültiges Bot-Token"
@@ -11343,7 +11349,7 @@ msgstr "Ungültiges Zeitlimit: %{value}"
 msgid "Leave a field blank to fall back to the application config or built-in default."
 msgstr "Lassen Sie ein Feld leer, um die Anwendungskonfiguration oder den integrierten Standardwert zu verwenden."
 
-#: lib/phoenix_kit/integrations/providers.ex:1038
+#: lib/phoenix_kit/integrations/providers.ex:1110
 #, elixir-autogen, elixir-format
 msgid "Leave blank for the gen_smtp default."
 msgstr "Leer lassen für den gen_smtp-Standardwert."
@@ -11384,7 +11390,7 @@ msgstr "Alle als gelesen markieren"
 msgid "Mark read"
 msgstr "Als gelesen markieren"
 
-#: lib/phoenix_kit_web/users/session.ex:340
+#: lib/phoenix_kit_web/users/session.ex:342
 #, elixir-autogen, elixir-format
 msgid "Maximum number of accounts reached — remove one first."
 msgstr "Maximale Anzahl an Konten erreicht – entfernen Sie zuerst eines."
@@ -11434,7 +11440,7 @@ msgstr "Neues Sendeprofil"
 msgid "No adapter configured for the static mailer. Set one in your application config, or connect an email-capable integration below and pick it as the default transactional integration."
 msgstr "Für den statischen Mailer ist kein Adapter konfiguriert. Legen Sie einen in Ihrer Anwendungskonfiguration fest oder verbinden Sie unten eine E-Mail-fähige Integration und wählen Sie sie als Standard-Transaktionsintegration."
 
-#: lib/phoenix_kit/integrations/validators.ex:682
+#: lib/phoenix_kit/integrations/validators.ex:863
 #, elixir-autogen, elixir-format
 msgid "No bot token configured"
 msgstr "Kein Bot-Token konfiguriert"
@@ -11474,7 +11480,7 @@ msgstr "Keine System-CA-Zertifikate gefunden, daher kann das Zertifikat des Rela
 msgid "No unread notifications"
 msgstr "Keine ungelesenen Benachrichtigungen"
 
-#: lib/phoenix_kit/integrations/providers.ex:986
+#: lib/phoenix_kit/integrations/providers.ex:1058
 #, elixir-autogen, elixir-format
 msgid "None — plaintext"
 msgstr "Keine – unverschlüsselt"
@@ -11504,7 +11510,7 @@ msgstr "Von Ihnen empfangene Benachrichtigungen erscheinen hier."
 msgid "Numeric ID of a verified Brevo sender. Leave empty to send from the From address above."
 msgstr "Numerische ID eines verifizierten Brevo-Absenders. Leer lassen, um von der oben angegebenen Absenderadresse zu senden."
 
-#: lib/phoenix_kit_web/users/session.ex:334
+#: lib/phoenix_kit_web/users/session.ex:336
 #, elixir-autogen, elixir-format
 msgid "Only an owner can sign in as another administrator."
 msgstr "Nur ein Inhaber kann sich als anderer Administrator anmelden."
@@ -11514,12 +11520,12 @@ msgstr "Nur ein Inhaber kann sich als anderer Administrator anmelden."
 msgid "Only me"
 msgstr "Nur ich"
 
-#: lib/phoenix_kit/integrations/providers.ex:1111
+#: lib/phoenix_kit/integrations/providers.ex:1183
 #, elixir-autogen, elixir-format
 msgid "Open [@BotFather](https://t.me/BotFather) in Telegram"
 msgstr "Öffnen Sie [@BotFather](https://t.me/BotFather) in Telegram"
 
-#: lib/phoenix_kit/integrations/providers.ex:1121
+#: lib/phoenix_kit/integrations/providers.ex:1193
 #, elixir-autogen, elixir-format
 msgid "Paste the token into the form above and press **Test Connection**"
 msgstr "Fügen Sie das Token in das Formular oben ein und drücken Sie **Verbindung testen**"
@@ -11539,7 +11545,7 @@ msgstr "Absenderidentität, Ratenbegrenzungen und anbieterspezifische Optionen p
 msgid "Persistent sessions last 60 days. Magic-link and social logins have no checkbox to tick, so they follow the default above. Turning the first option off hides the checkbox everywhere and keeps every login to the browser session."
 msgstr "Dauerhafte Sitzungen halten 60 Tage. Anmeldungen per Magic Link und über soziale Netzwerke haben kein Kontrollkästchen und folgen daher dem Standard oben. Wird die erste Option deaktiviert, verschwindet das Kontrollkästchen überall und jede Anmeldung bleibt auf die Browsersitzung begrenzt."
 
-#: lib/phoenix_kit/integrations/validators.ex:616
+#: lib/phoenix_kit/integrations/validators.ex:797
 #, elixir-autogen, elixir-format
 msgid "Plan: %{entries}"
 msgstr "Tarif: %{entries}"
@@ -11636,12 +11642,12 @@ msgstr "SMTP hat keine profilspezifischen Anbietereinstellungen – Relay, Port 
 msgid "SMTP server rejected the connection"
 msgstr "Der SMTP-Server hat die Verbindung abgelehnt"
 
-#: lib/phoenix_kit/integrations/providers.ex:985
+#: lib/phoenix_kit/integrations/providers.ex:1057
 #, elixir-autogen, elixir-format
 msgid "STARTTLS — if offered"
 msgstr "STARTTLS – wenn angeboten"
 
-#: lib/phoenix_kit/integrations/providers.ex:984
+#: lib/phoenix_kit/integrations/providers.ex:1056
 #, elixir-autogen, elixir-format
 msgid "STARTTLS — required"
 msgstr "STARTTLS – erforderlich"
@@ -11661,7 +11667,7 @@ msgstr "Absenderidentität speichern"
 msgid "Select an integration..."
 msgstr "Integration auswählen …"
 
-#: lib/phoenix_kit/integrations/providers.ex:1112
+#: lib/phoenix_kit/integrations/providers.ex:1184
 #, elixir-autogen, elixir-format
 msgid "Send **/newbot** and follow the prompts to name your bot"
 msgstr "Senden Sie **/newbot** und folgen Sie den Anweisungen, um Ihrem Bot einen Namen zu geben"
@@ -11675,7 +11681,7 @@ msgstr "Senden Sie **/newbot** und folgen Sie den Anweisungen, um Ihrem Bot eine
 msgid "Send Profiles"
 msgstr "Sendeprofile"
 
-#: lib/phoenix_kit/integrations/providers.ex:1087
+#: lib/phoenix_kit/integrations/providers.ex:1159
 #, elixir-autogen, elixir-format
 msgid "Send messages and notifications via your own Telegram bot"
 msgstr "Nachrichten und Benachrichtigungen über Ihren eigenen Telegram-Bot senden"
@@ -11765,13 +11771,13 @@ msgstr "TLS-Handshake fehlgeschlagen"
 msgid "Tags"
 msgstr "Tags"
 
-#: lib/phoenix_kit/integrations/providers.ex:1086
+#: lib/phoenix_kit/integrations/providers.ex:1158
 #: lib/phoenix_kit/notifications/channels/telegram.ex:36
 #, elixir-autogen, elixir-format
 msgid "Telegram"
 msgstr "Telegram"
 
-#: lib/phoenix_kit/integrations/validators.ex:701
+#: lib/phoenix_kit/integrations/validators.ex:882
 #, elixir-autogen, elixir-format
 msgid "Telegram error %{status}"
 msgstr "Telegram-Fehler %{status}"
@@ -11791,17 +11797,17 @@ msgstr "Test-E-Mail von %{site}"
 msgid "Test email sent to %{recipient}"
 msgstr "Test-E-Mail an %{recipient} gesendet"
 
-#: lib/phoenix_kit_web/users/session.ex:343
+#: lib/phoenix_kit_web/users/session.ex:345
 #, elixir-autogen, elixir-format
 msgid "That account is already in your session — switch to it instead."
 msgstr "Dieses Konto ist bereits in Ihrer Sitzung – wechseln Sie stattdessen dorthin."
 
-#: lib/phoenix_kit_web/users/session.ex:337
+#: lib/phoenix_kit_web/users/session.ex:339
 #, elixir-autogen, elixir-format
 msgid "That account is deactivated."
 msgstr "Dieses Konto ist deaktiviert."
 
-#: lib/phoenix_kit_web/users/session.ex:336
+#: lib/phoenix_kit_web/users/session.ex:338
 #, elixir-autogen, elixir-format
 msgid "That is already your account."
 msgstr "Das ist bereits Ihr Konto."
@@ -11842,7 +11848,7 @@ msgstr "Dieses Sendeprofil wird endgültig gelöscht."
 msgid "This sender address cannot be logged"
 msgstr "Diese Absenderadresse kann nicht protokolliert werden"
 
-#: lib/phoenix_kit/integrations/providers.ex:1034
+#: lib/phoenix_kit/integrations/providers.ex:1106
 #, elixir-autogen, elixir-format
 msgid "Timeout (seconds)"
 msgstr "Zeitlimit (Sekunden)"
@@ -11852,7 +11858,7 @@ msgstr "Zeitlimit (Sekunden)"
 msgid "Transport"
 msgstr "Transport"
 
-#: lib/phoenix_kit/integrations/providers.ex:1012
+#: lib/phoenix_kit/integrations/providers.ex:1084
 #, elixir-autogen, elixir-format
 msgid "Turning verification off means the login travels to whoever answers, including an impostor. Use a CA certificate below instead whenever you can."
 msgstr "Wenn die Prüfung deaktiviert wird, gelangt der Login zu jedem, der antwortet – auch zu einem Betrüger. Verwenden Sie stattdessen möglichst ein CA-Zertifikat unten."
@@ -11882,12 +11888,12 @@ msgstr "Sendeprofil aktualisieren"
 msgid "Used when no default transactional integration is selected below."
 msgstr "Wird verwendet, wenn unten keine Standard-Transaktionsintegration ausgewählt ist."
 
-#: lib/phoenix_kit_web/users/session.ex:309
+#: lib/phoenix_kit_web/users/session.ex:311
 #, elixir-autogen, elixir-format
 msgid "User not found."
 msgstr "Benutzer nicht gefunden."
 
-#: lib/phoenix_kit/integrations/providers.ex:1016
+#: lib/phoenix_kit/integrations/providers.ex:1088
 #, elixir-autogen, elixir-format
 msgid "Verify (default)"
 msgstr "Prüfen (Standard)"
@@ -11907,7 +11913,7 @@ msgstr "Website-Integrationen"
 msgid "Where a freshly registered account lands. Empty = after-login path."
 msgstr "Wo ein neu registriertes Konto landet. Leer = Pfad nach der Anmeldung."
 
-#: lib/phoenix_kit/integrations/providers.ex:996
+#: lib/phoenix_kit/integrations/providers.ex:1068
 #, elixir-autogen, elixir-format
 msgid "Whether to send the login at all. “If offered” follows the relay; “Never” is for relays that authenticate by IP."
 msgstr "Ob der Login überhaupt gesendet wird. „Wenn angeboten“ folgt dem Relay; „Nie“ ist für Relays, die per IP authentifizieren."
@@ -11922,12 +11928,12 @@ msgstr "Wem schreibt dieser Bot?"
 msgid "Yesterday"
 msgstr "Gestern"
 
-#: lib/phoenix_kit_web/users/session.ex:320
+#: lib/phoenix_kit_web/users/session.ex:322
 #, elixir-autogen, elixir-format
 msgid "You are now signed in as %{email}."
 msgstr "Sie sind jetzt als %{email} angemeldet."
 
-#: lib/phoenix_kit_web/users/session.ex:329
+#: lib/phoenix_kit_web/users/session.ex:331
 #, elixir-autogen, elixir-format
 msgid "You do not have permission to sign in as another user."
 msgstr "Sie sind nicht berechtigt, sich als anderer Benutzer anzumelden."
@@ -12043,7 +12049,7 @@ msgstr "Wird geprüft …"
 msgid "Continue"
 msgstr "Weiter"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:143
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:169
 #, elixir-autogen, elixir-format
 msgid "Copied!"
 msgstr "Kopiert!"
@@ -12053,7 +12059,7 @@ msgstr "Kopiert!"
 msgid "Couldn't reach hex.pm, so the package list is unavailable right now."
 msgstr "hex.pm ist nicht erreichbar, daher ist die Paketliste derzeit nicht verfügbar."
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:119
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:145
 #, elixir-autogen, elixir-format
 msgid "Crawler Instructions"
 msgstr "Crawler-Anweisungen"
@@ -12107,7 +12113,7 @@ msgstr "Willkommen! Ihr Empfehlungscode wurde akzeptiert."
 msgid "has the robots.txt line that points crawlers here."
 msgstr "enthält die robots.txt-Zeile, die Crawler hierher verweist."
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:173
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:199
 #, elixir-autogen, elixir-format
 msgid "priv/static/robots.txt points crawlers at your sitemap."
 msgstr "priv/static/robots.txt verweist Crawler auf Ihre Sitemap."
@@ -12211,17 +12217,17 @@ msgstr "Sie sind nicht berechtigt, diesen Benutzer zu löschen"
 msgid "You don't have permission to manage this user's credentials"
 msgstr "Sie sind nicht berechtigt, die Anmeldedaten dieses Benutzers zu verwalten"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:190
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:216
 #, elixir-autogen, elixir-format
 msgid "AI Discovery"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:698
+#: lib/phoenix_kit/integrations/providers.ex:699
 #, elixir-autogen, elixir-format
 msgid "AWS Bedrock LLMs via a Bedrock API key (OpenAI-compatible endpoint: gpt-oss models; the rest via native Converse)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:715
+#: lib/phoenix_kit/integrations/providers.ex:716
 #, elixir-autogen, elixir-format
 msgid "AWS console → Amazon Bedrock → API keys (long-term key)"
 msgstr ""
@@ -12236,22 +12242,22 @@ msgstr ""
 msgid "Account %{id}"
 msgstr "Konto"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:303
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:329
 #, elixir-autogen, elixir-format
 msgid "Advisory-grade: anything can send any User-Agent, so a scraper that lies passes through. Real enforcement belongs at your CDN or reverse proxy — this catches the honest-but-ignorant. Bots identified only by robots.txt tokens (Google-Extended, Applebot-Extended) crawl under their main user agent and are never matched here, so blocking AI training cannot 403 Googlebot."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:98
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:124
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Allowed"
 msgstr "Alle"
 
-#: lib/phoenix_kit/integrations/providers.ex:696
+#: lib/phoenix_kit/integrations/providers.ex:697
 #, elixir-autogen, elixir-format
 msgid "Amazon Bedrock"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:282
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:308
 #, elixir-autogen, elixir-format
 msgid "Answer 403 to requests whose User-Agent matches a blocked group, for bots that ignore robots.txt."
 msgstr ""
@@ -12261,7 +12267,7 @@ msgstr ""
 msgid "Auth mail carries single-use tokens, and /dev/mailbox has no authentication — anyone who can reach this server can read them. Only for closed environments."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:711
+#: lib/phoenix_kit/integrations/providers.ex:712
 #, elixir-autogen, elixir-format
 msgid "Bedrock API key"
 msgstr ""
@@ -12271,7 +12277,7 @@ msgstr ""
 msgid "Bedrock error %{status}"
 msgstr "Brevo-Fehler %{status}"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:280
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:306
 #, elixir-autogen, elixir-format
 msgid "Block at the application"
 msgstr ""
@@ -12281,7 +12287,7 @@ msgstr ""
 msgid "Blocked groups"
 msgstr "Gesperrt"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:77
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:103
 #, elixir-autogen, elixir-format
 msgid "Bot Access"
 msgstr ""
@@ -12296,12 +12302,12 @@ msgstr ""
 msgid "Control how search engines and AI bots crawl and index this site"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:739
+#: lib/phoenix_kit/integrations/providers.ex:740
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Copy the key (shown once, `ABSK…`) and paste it into the form above"
 msgstr "Kopieren Sie den Schlüssel (wird nur einmal angezeigt) und fügen Sie ihn in das Formular oben ein"
 
-#: lib/phoenix_kit/integrations/providers.ex:815
+#: lib/phoenix_kit/integrations/providers.ex:816
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Copy the token and paste it into the form above"
 msgstr "Kopieren Sie den Schlüssel und fügen Sie ihn in das Formular oben ein"
@@ -12342,22 +12348,22 @@ msgstr ""
 msgid "Crawlers module is disabled. Enable it from the Modules page to configure settings."
 msgstr "Das SEO-Modul ist deaktiviert. Aktivieren Sie es auf der Seite „Module“, um die Einstellungen zu konfigurieren."
 
-#: lib/phoenix_kit/integrations/providers.ex:731
+#: lib/phoenix_kit/integrations/providers.ex:732
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Create a Bedrock API key"
 msgstr "API-Schlüssel erstellen"
 
-#: lib/phoenix_kit/integrations/providers.ex:807
+#: lib/phoenix_kit/integrations/providers.ex:808
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Create a token"
 msgstr "Rolle erstellen"
 
-#: lib/phoenix_kit/integrations/providers.ex:871
+#: lib/phoenix_kit/integrations/providers.ex:872
 #, elixir-autogen, elixir-format
 msgid "Create an IAM user with SES access"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:876
+#: lib/phoenix_kit/integrations/providers.ex:877
 #, elixir-autogen, elixir-format
 msgid "Create an access key for that user (Security credentials → Create access key) and paste the ID and secret above"
 msgstr ""
@@ -12372,41 +12378,42 @@ msgstr ""
 msgid "Deliver development mail to /dev/mailbox"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:747
+#: lib/phoenix_kit/integrations/providers.ex:748
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enable model access"
 msgstr "Aktivieren Sie das Modul, um auf die Einstellungen zuzugreifen"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:278
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:304
 #, elixir-autogen, elixir-format
 msgid "Enforcement"
 msgstr ""
 
 #: lib/phoenix_kit_web/live/settings/crawlers.ex:90
-#: lib/phoenix_kit_web/live/settings/crawlers.ex:109
-#: lib/phoenix_kit_web/live/settings/crawlers.ex:120
-#: lib/phoenix_kit_web/live/settings/crawlers.ex:136
-#: lib/phoenix_kit_web/live/settings/crawlers.ex:149
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:102
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:121
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:132
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:148
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:161
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to update crawler settings"
 msgstr "Einstellung konnte nicht aktualisiert werden"
 
-#: lib/phoenix_kit/integrations/providers.ex:780
+#: lib/phoenix_kit/integrations/providers.ex:781
 #, elixir-autogen, elixir-format, fuzzy
 msgid "GitHub"
 msgstr "Anmeldung mit GitHub"
 
-#: lib/phoenix_kit/integrations/providers.ex:782
+#: lib/phoenix_kit/integrations/providers.ex:783
 #, elixir-autogen, elixir-format
 msgid "GitHub API token — org statistics, repositories (read-only is enough)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:809
+#: lib/phoenix_kit/integrations/providers.ex:810
 #, elixir-autogen, elixir-format
 msgid "Go to [Fine-grained tokens](https://github.com/settings/personal-access-tokens) and click **Generate new token**"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:81
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:107
 #, elixir-autogen, elixir-format
 msgid "Grouped by why they visit. Blocking a group writes it into the generated robots.txt below; everything defaults to allowed."
 msgstr ""
@@ -12416,22 +12423,22 @@ msgstr ""
 msgid "Hide titles of records the reader can't open"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:749
+#: lib/phoenix_kit/integrations/providers.ex:750
 #, elixir-autogen, elixir-format
 msgid "In [Bedrock → Model access](https://console.aws.amazon.com/bedrock/home#/modelaccess) enable the models you plan to call — a key with no enabled models validates but cannot complete"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:763
+#: lib/phoenix_kit/integrations/providers.ex:764
 #, elixir-autogen, elixir-format
 msgid "In the AI module, create an endpoint pointing at this connection with a `gpt-oss` model and a base URL in the SAME region as this key"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:873
+#: lib/phoenix_kit/integrations/providers.ex:874
 #, elixir-autogen, elixir-format
 msgid "In the [IAM console](https://console.aws.amazon.com/iam/home#/users) create a user for programmatic access and attach an SES policy (least privilege: `ses:SendEmail`/`ses:SendRawEmail`; docs: [SES setup](https://docs.aws.amazon.com/ses/latest/dg/setting-up.html))"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:884
+#: lib/phoenix_kit/integrations/providers.ex:885
 #, elixir-autogen, elixir-format
 msgid "In the [SES console](https://console.aws.amazon.com/ses/home#/identities) verify your domain or sender address — SES refuses to send from unverified identities"
 msgstr ""
@@ -12476,7 +12483,7 @@ msgstr ""
 msgid "Model catalog in %{region}: %{count} (grants are configured separately)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:887
+#: lib/phoenix_kit/integrations/providers.ex:888
 #, elixir-autogen, elixir-format
 msgid "New accounts start in the SES sandbox (verified recipients only) — [request production access](https://docs.aws.amazon.com/ses/latest/dg/request-production-access.html) before real sending"
 msgstr ""
@@ -12491,7 +12498,7 @@ msgstr ""
 msgid "No longer available"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:165
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:191
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No priv/static/robots.txt found. Without one, crawlers assume everything is allowed — and any groups you blocked above are not being told."
 msgstr "Keine priv/static/robots.txt gefunden. Ohne sie gehen Crawler davon aus, dass alles erlaubt ist — meist unproblematisch, aber sie erfahren dann nicht, wo Ihre Sitemap liegt."
@@ -12506,47 +12513,47 @@ msgstr ""
 msgid "Note (optional)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:733
+#: lib/phoenix_kit/integrations/providers.ex:734
 #, elixir-autogen, elixir-format
 msgid "Open the [Bedrock console → API keys](https://console.aws.amazon.com/bedrock/home#/api-keys) and generate a **long-term** key (docs: [Bedrock API keys](https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys.html))"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:212
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:238
 #, elixir-autogen, elixir-format
 msgid "Optional markdown: a summary paragraph, key links, docs pointers…"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:736
+#: lib/phoenix_kit/integrations/providers.ex:737
 #, elixir-autogen, elixir-format
 msgid "Or attach one to an existing IAM user: [IAM console](https://console.aws.amazon.com/iam/home#/users) → user → Security credentials → Bedrock API keys"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:235
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:261
 #, elixir-autogen, elixir-format
 msgid "Paste the verification content Google Search Console or Bing Webmaster Tools gives you — the meta tags are added to every layout head. Pasting the whole <meta> tag also works; the content value is extracted."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:796
+#: lib/phoenix_kit/integrations/providers.ex:797
 #, elixir-autogen, elixir-format
 msgid "Personal access token"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:123
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:149
 #, elixir-autogen, elixir-format
 msgid "PhoenixKit does not serve this file — it is yours, served from priv/static before any route is consulted. This is the complete file your toggles above describe: paste it into priv/static/robots.txt."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:752
+#: lib/phoenix_kit/integrations/providers.ex:753
 #, elixir-autogen, elixir-format
 msgid "Pick the region where access was granted; the AI endpoint's base URL must use the same region"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:217
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:243
 #, elixir-autogen, elixir-format
 msgid "Preview of the served file:"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:812
+#: lib/phoenix_kit/integrations/providers.ex:813
 #, elixir-autogen, elixir-format
 msgid "Repository access: **Public repositories (read-only)** — no extra permissions needed for public-org statistics"
 msgstr ""
@@ -12556,7 +12563,7 @@ msgstr ""
 msgid "Request access"
 msgstr "Angefordert"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:233
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:259
 #, elixir-autogen, elixir-format
 msgid "Search engine verification"
 msgstr ""
@@ -12576,12 +12583,12 @@ msgstr "Ausstehend"
 msgid "Sign in to request access."
 msgstr "Als Benutzer anmelden"
 
-#: lib/phoenix_kit/integrations/providers.ex:760
+#: lib/phoenix_kit/integrations/providers.ex:761
 #, elixir-autogen, elixir-format
 msgid "The OpenAI-compatible endpoint (`…/openai/v1`) currently serves only the `openai.gpt-oss-*` models — Anthropic and the other Bedrock models answer on the native Converse API with the same key"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:742
+#: lib/phoenix_kit/integrations/providers.ex:743
 #, elixir-autogen, elixir-format
 msgid "The key's IAM identity must allow the `bedrock:CallWithBearerToken` action — without it every Bearer call answers 403 even when invoke permissions are in place."
 msgstr ""
@@ -12591,17 +12598,17 @@ msgstr ""
 msgid "The mailbox is off: outgoing mail is written to the server log instead."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:179
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:205
 #, elixir-autogen, elixir-format, fuzzy
 msgid "The noindex toggle and robots.txt are separate mechanisms: noindex is a per-page meta tag that tells crawlers not to index what they fetched, while robots.txt tells them what not to fetch at all. A staging site usually wants both."
 msgstr "Der noindex-Schalter oben und robots.txt sind zwei verschiedene Mechanismen: noindex ist ein Meta-Tag pro Seite, das Crawlern sagt, das Abgerufene nicht zu indexieren, während robots.txt ihnen sagt, was sie gar nicht erst abrufen sollen. Eine Staging-Site braucht meist beides."
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:194
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:220
 #, elixir-autogen, elixir-format
 msgid "The other half of bot policy: a markdown summary telling AI assistants what this site is about, served at"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:892
+#: lib/phoenix_kit/integrations/providers.ex:893
 #, elixir-autogen, elixir-format
 msgid "This connection stores the credential. The full sending pipeline — configuration set, SNS topic, SQS event queue, delivery tracking — is configured in Admin → Settings → Emails, which can select this connection as its credential source."
 msgstr ""
@@ -12618,22 +12625,22 @@ msgstr ""
 msgid "Unread · %{day}"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:758
+#: lib/phoenix_kit/integrations/providers.ex:759
 #, elixir-autogen, elixir-format
 msgid "Use it from the AI module"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:231
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:257
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Verification"
 msgstr "Benachrichtigungen"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.ex:133
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:145
 #, elixir-autogen, elixir-format
 msgid "Verification tags saved."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:882
+#: lib/phoenix_kit/integrations/providers.ex:883
 #, elixir-autogen, elixir-format
 msgid "Verify a sender in SES"
 msgstr ""
@@ -12648,7 +12655,7 @@ msgstr ""
 msgid "Where development mail goes while the resolved transport is the local adapter."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:79
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "Who may crawl this site"
 msgstr ""
@@ -12668,12 +12675,12 @@ msgstr ""
 msgid "You don't have access — click to request it"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:800
+#: lib/phoenix_kit/integrations/providers.ex:801
 #, elixir-autogen, elixir-format
 msgid "github.com/settings/personal-access-tokens — fine-grained, read-only"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.ex:146
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:158
 #, elixir-autogen, elixir-format
 msgid "llms.txt content saved."
 msgstr ""
@@ -12683,7 +12690,7 @@ msgstr ""
 msgid "management API: %{services}"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:169
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:195
 #, elixir-autogen, elixir-format, fuzzy
 msgid "priv/static/robots.txt exists but has no Sitemap: line. Paste the file above so crawlers are told where to look."
 msgstr "priv/static/robots.txt ist vorhanden, enthält aber keine Sitemap:-Zeile. Fügen Sie die obige Zeile hinzu, damit Crawler wissen, wo sie suchen sollen."
@@ -12693,7 +12700,7 @@ msgstr "priv/static/robots.txt ist vorhanden, enthält aber keine Sitemap:-Zeile
 msgid "private item"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:200
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:226
 #, elixir-autogen, elixir-format
 msgid "while this module is enabled. The heading comes from your project title; everything below it is yours."
 msgstr ""
@@ -12747,7 +12754,7 @@ msgstr "Audio auswählen"
 msgid "Select Avatar"
 msgstr "Avatar auswählen"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:701
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:716
 #, elixir-autogen, elixir-format
 msgid "Select Background Image"
 msgstr "Hintergrundbild auswählen"
@@ -12764,7 +12771,7 @@ msgstr "Bilder auswählen"
 
 #: lib/phoenix_kit_web/components/media_browser.html.heex:2469
 #: lib/phoenix_kit_web/live/settings.html.heex:636
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:702
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:717
 #, elixir-autogen, elixir-format
 msgid "Select Logo"
 msgstr "Logo auswählen"
@@ -12863,3 +12870,422 @@ msgstr "Die Verschlüsselung der Integrationsdaten erfordert Aufmerksamkeit"
 #, elixir-autogen, elixir-format
 msgid "The current encryption status could not be described by this admin page — it may be newer than what this page recognizes. Check PhoenixKit.Integrations.Encryption.status/0 directly."
 msgstr "Der aktuelle Verschlüsselungsstatus konnte auf dieser Admin-Seite nicht beschrieben werden — er ist möglicherweise neuer als das, was diese Seite erkennt. Prüfen Sie PhoenixKit.Integrations.Encryption.status/0 direkt."
+
+#: lib/phoenix_kit_web/live/settings/authorization.ex:247
+#, elixir-autogen, elixir-format
+msgid "A secret is already configured — leave blank to keep the current value"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:365
+#: lib/phoenix_kit_web/users/session.ex:245
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Account added."
+msgstr "Konto"
+
+#: lib/phoenix_kit_web/users/session.ex:27
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Account created successfully!"
+msgstr "Bucket erfolgreich aktiviert"
+
+#: lib/phoenix_kit_web/users/session.ex:356
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Account removed."
+msgstr "Konto"
+
+#: lib/phoenix_kit_web/users/oauth.ex:272
+#, elixir-autogen, elixir-format
+msgid "Account switching is currently disabled."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:316
+#, elixir-autogen, elixir-format
+msgid "An account already exists for that email address. Sign in with your password first, then connect this provider from your account settings."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:328
+#, elixir-autogen, elixir-format
+msgid "Authentication failed. Please try again or use a different sign-in method."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:355
+#: lib/phoenix_kit_web/users/oauth.ex:438
+#: lib/phoenix_kit_web/users/oauth.ex:444
+#, elixir-autogen, elixir-format
+msgid "Authentication failed. Please try again."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:299
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Authentication failed: %{errors}"
+msgstr "Authentifizierung"
+
+#: lib/phoenix_kit_web/users/oauth.ex:441
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Authentication failed: %{message}"
+msgstr "Authentifizierung"
+
+#: lib/phoenix_kit_web/users/session.ex:360
+#, elixir-autogen, elixir-format
+msgid "Cannot remove your primary account."
+msgstr ""
+
+#: lib/phoenix_kit_web/controllers/context_controller.ex:101
+#, elixir-autogen, elixir-format
+msgid "Context switching is not enabled"
+msgstr ""
+
+#: lib/phoenix_kit/integrations/validators.ex:627
+#: lib/phoenix_kit/integrations/validators.ex:634
+#: lib/phoenix_kit/integrations/validators.ex:732
+#: lib/phoenix_kit/integrations/validators.ex:740
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Could not reach the storage endpoint"
+msgstr "Der Dienst war nicht erreichbar"
+
+#: lib/phoenix_kit_web/users/session.ex:365
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Could not remove account."
+msgstr "Brevo war nicht erreichbar"
+
+#: lib/phoenix_kit_web/users/session.ex:274
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Could not switch account."
+msgstr "Chats konnten nicht getrennt werden"
+
+#: lib/phoenix_kit/integrations/validators.ex:721
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Credentials are valid, but not authorized to list buckets"
+msgstr "Die Anmeldedaten sind gültig, aber nicht für GetSendQuota berechtigt – der Versand wurde nicht überprüft"
+
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:85
+#, elixir-autogen, elixir-format
+msgid "Exempt"
+msgstr ""
+
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:86
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Follows noindex"
+msgstr "Folgt"
+
+#: lib/phoenix_kit_web/users/magic_link.ex:120
+#, elixir-autogen, elixir-format
+msgid "If that email address exists, a magic link has been sent."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/confirmation_instructions.ex:89
+#, elixir-autogen, elixir-format
+msgid "If your email is in our system and it has not been confirmed yet, you will receive an email with instructions shortly."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/forgot_password.ex:49
+#, elixir-autogen, elixir-format
+msgid "If your email is in our system, you will receive instructions to reset your password shortly."
+msgstr ""
+
+#: lib/phoenix_kit_web/controllers/context_controller.ex:82
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Invalid context"
+msgstr "Ungültiges Bot-Token"
+
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:110
+#, elixir-autogen, elixir-format
+msgid "Invalid email format"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/session.ex:92
+#, elixir-autogen, elixir-format
+msgid "Invalid email/username or password"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/session.ex:259
+#, elixir-autogen, elixir-format
+msgid "Invalid email/username or password."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_verify.ex:40
+#, elixir-autogen, elixir-format
+msgid "Invalid magic link. Please request a new one."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration_verify.ex:32
+#, elixir-autogen, elixir-format
+msgid "Invalid registration link. Please request a new one."
+msgstr ""
+
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:77
+#, elixir-autogen, elixir-format
+msgid "Keep publishing the sitemap's real URLs even while noindex is on, so the feed can be verified without exposing the site to indexing. The noindex meta tag above is unaffected either way."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/session.ex:104
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Logged out of all accounts."
+msgstr "Von allen Konten abmelden"
+
+#: lib/phoenix_kit_web/users/session.ex:122
+#: lib/phoenix_kit_web/users/session.ex:235
+#, elixir-autogen, elixir-format
+msgid "Logged out successfully."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_verify.ex:63
+#, elixir-autogen, elixir-format
+msgid "Magic link is invalid or has expired. Please request a new one."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration.ex:41
+#, elixir-autogen, elixir-format
+msgid "Magic link registration is currently disabled."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link.ex:110
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Magic link sent! Check your email."
+msgstr "Magic Link gesendet!"
+
+#: lib/phoenix_kit_web/users/magic_link.ex:39
+#: lib/phoenix_kit_web/users/magic_link_verify.ex:33
+#, elixir-autogen, elixir-format
+msgid "Magic link sign-in is currently disabled."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:370
+#: lib/phoenix_kit_web/users/session.ex:249
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Maximum number of accounts reached."
+msgstr "Maximale Anzahl an Konten erreicht – entfernen Sie zuerst eines."
+
+#: lib/phoenix_kit_web/users/session.ex:137
+#, elixir-autogen, elixir-format
+msgid "Multi-account switching is not available."
+msgstr ""
+
+#: lib/phoenix_kit/integrations/providers.ex:950
+#, elixir-autogen, elixir-format
+msgid "Not every S3-compatible provider needs one — leave blank if the endpoint doesn't require it."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:119
+#, elixir-autogen, elixir-format
+msgid "OAuth authentication is currently disabled. Please contact your administrator to enable it."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:94
+#, elixir-autogen, elixir-format
+msgid "OAuth provider '%{provider}' is currently disabled."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:106
+#, elixir-autogen, elixir-format
+msgid "OAuth provider '%{provider}' is not configured. Please contact your administrator."
+msgstr ""
+
+#: lib/phoenix_kit/integrations/providers.ex:913
+#, elixir-autogen, elixir-format
+msgid "Object Storage (S3-compatible)"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/reset_password.ex:41
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Password reset successfully."
+msgstr "Passwort erfolgreich geändert."
+
+#: lib/phoenix_kit_web/users/session.ex:34
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Password updated successfully!"
+msgstr "Passwort erfolgreich geändert."
+
+#: lib/phoenix_kit_web/users/magic_link_registration.ex:35
+#: lib/phoenix_kit_web/users/registration.ex:128
+#, elixir-autogen, elixir-format
+msgid "Registration is currently disabled."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration.ex:92
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Registration link is invalid or has expired."
+msgstr "Der Link zur E-Mail-Änderung ist ungültig oder abgelaufen."
+
+#: lib/phoenix_kit_web/users/magic_link_registration.ex:188
+#: lib/phoenix_kit_web/users/magic_link_registration_verify.ex:24
+#, elixir-autogen, elixir-format
+msgid "Registration link is invalid or has expired. Please request a new one."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:92
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:103
+#, elixir-autogen, elixir-format
+msgid "Registration link sent! Check your email."
+msgstr ""
+
+#: lib/phoenix_kit/integrations/providers.ex:962
+#, elixir-autogen, elixir-format
+msgid "Required for Cloudflare R2, Backblaze B2, Tigris, and self-hosted S3-compatible storage. Leave blank for AWS S3."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/reset_password.ex:59
+#, elixir-autogen, elixir-format
+msgid "Reset password link is invalid or it has expired."
+msgstr ""
+
+#: lib/phoenix_kit/integrations/providers.ex:915
+#, elixir-autogen, elixir-format
+msgid "S3-compatible object storage — AWS S3, Cloudflare R2, Backblaze B2, Tigris, or a self-hosted endpoint"
+msgstr ""
+
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:75
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Sitemap Exemption"
+msgstr "Sitemap-Einstellungen"
+
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:144
+#, elixir-autogen, elixir-format
+msgid "Something went wrong"
+msgstr ""
+
+#: lib/phoenix_kit/integrations/validators.ex:735
+#, elixir-autogen, elixir-format
+msgid "Storage error: %{code}"
+msgstr ""
+
+#: lib/phoenix_kit/integrations/validators.ex:729
+#, elixir-autogen, elixir-format
+msgid "Storage service is busy — try again in a moment"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_verify.ex:56
+#, elixir-autogen, elixir-format
+msgid "Successfully logged in with magic link!"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:277
+#, elixir-autogen, elixir-format
+msgid "Successfully signed in with %{provider}!"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:375
+#: lib/phoenix_kit_web/users/session.ex:254
+#, elixir-autogen, elixir-format, fuzzy
+msgid "That account is already in your session."
+msgstr "Dieses Konto ist bereits in Ihrer Sitzung – wechseln Sie stattdessen dorthin."
+
+#: lib/phoenix_kit_web/users/oauth.ex:380
+#, elixir-autogen, elixir-format, fuzzy
+msgid "That account is inactive."
+msgstr "Dieses Konto ist deaktiviert."
+
+#: lib/phoenix_kit_web/users/magic_link_registration.ex:185
+#, elixir-autogen, elixir-format
+msgid "That email is already registered. Please log in instead."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:118
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Too many attempts"
+msgstr "Zu viele Dateien"
+
+#: lib/phoenix_kit_web/users/session.ex:84
+#, elixir-autogen, elixir-format
+msgid "Too many login attempts. Please try again later."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:84
+#: lib/phoenix_kit_web/users/oauth.ex:210
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Unknown OAuth provider: %{provider}"
+msgstr "Unbekannter Anbieter"
+
+#: lib/phoenix_kit_web/users/confirmation.ex:68
+#, elixir-autogen, elixir-format
+msgid "User confirmation link is invalid or it has expired."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/confirmation.ex:50
+#, elixir-autogen, elixir-format, fuzzy
+msgid "User confirmed successfully."
+msgstr "Benutzer erfolgreich aktiviert"
+
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:77
+#, elixir-autogen, elixir-format
+msgid "User registration is currently disabled."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:51
+#: lib/phoenix_kit_web/users/registration.ex:110
+#, elixir-autogen, elixir-format
+msgid "User registration is currently disabled. Please contact an administrator."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/session.ex:40
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Welcome back!"
+msgstr "Willkommen zurück"
+
+#: lib/phoenix_kit_web/users/session.ex:66
+#, elixir-autogen, elixir-format
+msgid "Your account is currently inactive. Please contact the team if you believe this is an error."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:1873
+#, elixir-autogen, elixir-format
+msgid "%{label} module is not enabled"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:2366
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Enter your referral code to continue."
+msgstr "Geben Sie Ihren Empfehlungscode ein"
+
+#: lib/phoenix_kit_web/users/auth.ex:2362
+#, elixir-autogen, elixir-format
+msgid "Please confirm your email before accessing the application."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:111
+#, elixir-autogen, elixir-format
+msgid "This account is not active. Contact an administrator."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:749
+#: lib/phoenix_kit_web/users/auth.ex:1892
+#: lib/phoenix_kit_web/users/auth.ex:2511
+#, elixir-autogen, elixir-format, fuzzy
+msgid "You do not have permission to access this section."
+msgstr "Sie sind nicht berechtigt, sich als anderer Benutzer anzumelden."
+
+#: lib/phoenix_kit_web/users/auth.ex:724
+#: lib/phoenix_kit_web/users/auth.ex:878
+#: lib/phoenix_kit_web/users/auth.ex:2460
+#: lib/phoenix_kit_web/users/auth.ex:2496
+#, elixir-autogen, elixir-format, fuzzy
+msgid "You do not have the required permission to access this page."
+msgstr "Sie sind nicht berechtigt, sich als anderer Benutzer anzumelden."
+
+#: lib/phoenix_kit_web/users/auth.ex:1417
+#, elixir-autogen, elixir-format
+msgid "You must be an admin to access this page."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:679
+#: lib/phoenix_kit_web/users/auth.ex:2423
+#, elixir-autogen, elixir-format
+msgid "You must be an owner to access this page."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:2539
+#, elixir-autogen, elixir-format
+msgid "You must have the %{role_name} role to access this page."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:903
+#: lib/phoenix_kit_web/users/auth.ex:2292
+#: lib/phoenix_kit_web/users/auth.ex:2329
+#: lib/phoenix_kit_web/users/auth.ex:2467
+#, elixir-autogen, elixir-format
+msgid "You must log in to access this page."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:1428
+#, elixir-autogen, elixir-format
+msgid "You no longer have permission to access this section."
+msgstr ""

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -12878,19 +12878,19 @@ msgstr ""
 
 #: lib/phoenix_kit_web/users/oauth.ex:365
 #: lib/phoenix_kit_web/users/session.ex:245
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Account added."
-msgstr "Konto"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:27
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Account created successfully!"
-msgstr "Bucket erfolgreich aktiviert"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:356
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Account removed."
-msgstr "Konto"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/oauth.ex:272
 #, elixir-autogen, elixir-format
@@ -12915,14 +12915,14 @@ msgid "Authentication failed. Please try again."
 msgstr ""
 
 #: lib/phoenix_kit_web/users/oauth.ex:299
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Authentication failed: %{errors}"
-msgstr "Authentifizierung"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/oauth.ex:441
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Authentication failed: %{message}"
-msgstr "Authentifizierung"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:360
 #, elixir-autogen, elixir-format
@@ -12938,24 +12938,24 @@ msgstr ""
 #: lib/phoenix_kit/integrations/validators.ex:634
 #: lib/phoenix_kit/integrations/validators.ex:732
 #: lib/phoenix_kit/integrations/validators.ex:740
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Could not reach the storage endpoint"
-msgstr "Der Dienst war nicht erreichbar"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:365
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Could not remove account."
-msgstr "Brevo war nicht erreichbar"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:274
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Could not switch account."
-msgstr "Chats konnten nicht getrennt werden"
+msgstr ""
 
 #: lib/phoenix_kit/integrations/validators.ex:721
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Credentials are valid, but not authorized to list buckets"
-msgstr "Die Anmeldedaten sind gültig, aber nicht für GetSendQuota berechtigt – der Versand wurde nicht überprüft"
+msgstr ""
 
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:85
 #, elixir-autogen, elixir-format
@@ -12963,9 +12963,9 @@ msgid "Exempt"
 msgstr ""
 
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:86
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Follows noindex"
-msgstr "Folgt"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link.ex:120
 #, elixir-autogen, elixir-format
@@ -12983,9 +12983,9 @@ msgid "If your email is in our system, you will receive instructions to reset yo
 msgstr ""
 
 #: lib/phoenix_kit_web/controllers/context_controller.ex:82
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Invalid context"
-msgstr "Ungültiges Bot-Token"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link_registration_request.ex:110
 #, elixir-autogen, elixir-format
@@ -13018,9 +13018,9 @@ msgid "Keep publishing the sitemap's real URLs even while noindex is on, so the 
 msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:104
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Logged out of all accounts."
-msgstr "Von allen Konten abmelden"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:122
 #: lib/phoenix_kit_web/users/session.ex:235
@@ -13039,9 +13039,9 @@ msgid "Magic link registration is currently disabled."
 msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link.ex:110
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Magic link sent! Check your email."
-msgstr "Magic Link gesendet!"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link.ex:39
 #: lib/phoenix_kit_web/users/magic_link_verify.ex:33
@@ -13051,9 +13051,9 @@ msgstr ""
 
 #: lib/phoenix_kit_web/users/oauth.ex:370
 #: lib/phoenix_kit_web/users/session.ex:249
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Maximum number of accounts reached."
-msgstr "Maximale Anzahl an Konten erreicht – entfernen Sie zuerst eines."
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:137
 #, elixir-autogen, elixir-format
@@ -13086,14 +13086,14 @@ msgid "Object Storage (S3-compatible)"
 msgstr ""
 
 #: lib/phoenix_kit_web/users/reset_password.ex:41
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Password reset successfully."
-msgstr "Passwort erfolgreich geändert."
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:34
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Password updated successfully!"
-msgstr "Passwort erfolgreich geändert."
+msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link_registration.ex:35
 #: lib/phoenix_kit_web/users/registration.ex:128
@@ -13102,9 +13102,9 @@ msgid "Registration is currently disabled."
 msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link_registration.ex:92
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Registration link is invalid or has expired."
-msgstr "Der Link zur E-Mail-Änderung ist ungültig oder abgelaufen."
+msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link_registration.ex:188
 #: lib/phoenix_kit_web/users/magic_link_registration_verify.ex:24
@@ -13134,9 +13134,9 @@ msgid "S3-compatible object storage — AWS S3, Cloudflare R2, Backblaze B2, Tig
 msgstr ""
 
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:75
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Sitemap Exemption"
-msgstr "Sitemap-Einstellungen"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link_registration_request.ex:144
 #, elixir-autogen, elixir-format
@@ -13165,14 +13165,14 @@ msgstr ""
 
 #: lib/phoenix_kit_web/users/oauth.ex:375
 #: lib/phoenix_kit_web/users/session.ex:254
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "That account is already in your session."
-msgstr "Dieses Konto ist bereits in Ihrer Sitzung – wechseln Sie stattdessen dorthin."
+msgstr ""
 
 #: lib/phoenix_kit_web/users/oauth.ex:380
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "That account is inactive."
-msgstr "Dieses Konto ist deaktiviert."
+msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link_registration.ex:185
 #, elixir-autogen, elixir-format
@@ -13180,9 +13180,9 @@ msgid "That email is already registered. Please log in instead."
 msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link_registration_request.ex:118
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Too many attempts"
-msgstr "Zu viele Dateien"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:84
 #, elixir-autogen, elixir-format
@@ -13191,9 +13191,9 @@ msgstr ""
 
 #: lib/phoenix_kit_web/users/oauth.ex:84
 #: lib/phoenix_kit_web/users/oauth.ex:210
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Unknown OAuth provider: %{provider}"
-msgstr "Unbekannter Anbieter"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/confirmation.ex:68
 #, elixir-autogen, elixir-format
@@ -13201,9 +13201,9 @@ msgid "User confirmation link is invalid or it has expired."
 msgstr ""
 
 #: lib/phoenix_kit_web/users/confirmation.ex:50
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "User confirmed successfully."
-msgstr "Benutzer erfolgreich aktiviert"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link_registration_request.ex:77
 #, elixir-autogen, elixir-format
@@ -13217,9 +13217,9 @@ msgid "User registration is currently disabled. Please contact an administrator.
 msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:40
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Welcome back!"
-msgstr "Willkommen zurück"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:66
 #, elixir-autogen, elixir-format
@@ -13232,9 +13232,9 @@ msgid "%{label} module is not enabled"
 msgstr ""
 
 #: lib/phoenix_kit_web/users/auth.ex:2366
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Enter your referral code to continue."
-msgstr "Geben Sie Ihren Empfehlungscode ein"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/auth.ex:2362
 #, elixir-autogen, elixir-format
@@ -13249,17 +13249,17 @@ msgstr ""
 #: lib/phoenix_kit_web/users/auth.ex:749
 #: lib/phoenix_kit_web/users/auth.ex:1892
 #: lib/phoenix_kit_web/users/auth.ex:2511
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "You do not have permission to access this section."
-msgstr "Sie sind nicht berechtigt, sich als anderer Benutzer anzumelden."
+msgstr ""
 
 #: lib/phoenix_kit_web/users/auth.ex:724
 #: lib/phoenix_kit_web/users/auth.ex:878
 #: lib/phoenix_kit_web/users/auth.ex:2460
 #: lib/phoenix_kit_web/users/auth.ex:2496
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "You do not have the required permission to access this page."
-msgstr "Sie sind nicht berechtigt, sich als anderer Benutzer anzumelden."
+msgstr ""
 
 #: lib/phoenix_kit_web/users/auth.ex:1417
 #, elixir-autogen, elixir-format

--- a/priv/gettext/de/LC_MESSAGES/phoenix_kit.po
+++ b/priv/gettext/de/LC_MESSAGES/phoenix_kit.po
@@ -21,27 +21,27 @@ msgstr "Für diese E-Mail-Adresse besteht bereits eine offene Einladung"
 msgid "This user already belongs to an organization"
 msgstr "Dieser Benutzer gehört bereits zu einer Organisation"
 
-#: lib/phoenix_kit/users/auth.ex:1064
+#: lib/phoenix_kit/users/auth.ex:1074
 #, elixir-autogen, elixir-format
 msgid "cannot change to person while organization has members"
 msgstr "kann nicht auf „Person“ geändert werden, solange die Organisation Mitglieder hat"
 
-#: lib/phoenix_kit/users/auth.ex:1044
+#: lib/phoenix_kit/users/auth.ex:1054
 #, elixir-autogen, elixir-format
 msgid "cannot reference self"
 msgstr "kann nicht auf sich selbst verweisen"
 
-#: lib/phoenix_kit/users/auth.ex:1052
+#: lib/phoenix_kit/users/auth.ex:1062
 #, elixir-autogen, elixir-format
 msgid "only person accounts can join an organization"
 msgstr "nur Personenkonten können einer Organisation beitreten"
 
-#: lib/phoenix_kit/users/auth.ex:1039
+#: lib/phoenix_kit/users/auth.ex:1049
 #, elixir-autogen, elixir-format
 msgid "organization not found"
 msgstr "Organisation nicht gefunden"
 
-#: lib/phoenix_kit/users/auth.ex:1038
+#: lib/phoenix_kit/users/auth.ex:1048
 #, elixir-autogen, elixir-format
 msgid "target user is not an organization"
 msgstr "der Zielbenutzer ist keine Organisation"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -66,7 +66,7 @@ msgstr ""
 
 #: lib/phoenix_kit/dashboard/admin_tabs.ex:119
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:138
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:647
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:662
 #: lib/phoenix_kit_web/live/settings/users.html.heex:130
 #, elixir-autogen
 msgid "Sessions"
@@ -233,7 +233,7 @@ msgstr ""
 
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:320
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:64
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:144
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:140
 #, elixir-autogen
 msgid "Anonymous"
 msgstr ""
@@ -246,7 +246,7 @@ msgstr ""
 
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:331
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:77
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:151
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:144
 #, elixir-autogen
 msgid "Authenticated"
 msgstr ""
@@ -343,7 +343,7 @@ msgstr ""
 msgid "Role System"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:991
+#: lib/phoenix_kit/integrations/providers.ex:1063
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:450
 #, elixir-autogen
 msgid "Authentication"
@@ -355,7 +355,7 @@ msgstr ""
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:445
 #: lib/phoenix_kit_web/live/modules.html.heex:65
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:114
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:273
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:267
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:145
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:297
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:682
@@ -462,8 +462,8 @@ msgstr ""
 msgid "Accept All"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/integrations.ex:1133
-#: lib/phoenix_kit/integrations/validators.ex:598
+#: lib/phoenix_kit/integrations/integrations.ex:1136
+#: lib/phoenix_kit/integrations/validators.ex:779
 #: lib/phoenix_kit_web/live/activity/index.ex:66
 #: lib/phoenix_kit_web/live/activity/show.ex:56
 #, elixir-autogen, elixir-format
@@ -501,7 +501,7 @@ msgid "Actions"
 msgstr ""
 
 #: lib/phoenix_kit_web/components/media_gallery.html.heex:86
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:585
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:600
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:266
 #: lib/phoenix_kit_web/live/settings/users.html.heex:693
 #: lib/phoenix_kit_web/users/user_form.html.heex:719
@@ -609,7 +609,7 @@ msgstr ""
 msgid "Billing profiles and payment methods"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:98
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:124
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:501
 #, elixir-autogen, elixir-format
 msgid "Blocked"
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Page published successfully"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:956
+#: lib/phoenix_kit/integrations/providers.ex:1028
 #: lib/phoenix_kit_web/components/user_dashboard_nav.ex:277
 #: lib/phoenix_kit_web/users/login.html.heex:39
 #: lib/phoenix_kit_web/users/magic_link_registration.html.heex:42
@@ -1810,8 +1810,8 @@ msgstr ""
 #: lib/phoenix_kit_web/components/core/markdown_editor.ex:440
 #: lib/phoenix_kit_web/components/media_browser.html.heex:1349
 #: lib/phoenix_kit_web/live/notifications/settings.ex:436
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:219
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:267
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:245
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:293
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr ""
 #: lib/phoenix_kit_web/components/core/markdown_editor.ex:333
 #: lib/phoenix_kit_web/components/core/markdown_editor.ex:417
 #: lib/phoenix_kit_web/live/settings.html.heex:592
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:683
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:698
 #: lib/phoenix_kit_web/live/settings/users.html.heex:546
 #, elixir-autogen, elixir-format
 msgid "Saving..."
@@ -1941,7 +1941,7 @@ msgstr ""
 #: lib/phoenix_kit_web/live/settings/users.html.heex:367
 #: lib/phoenix_kit_web/live/settings/users.html.heex:408
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:114
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:199
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:193
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:247
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:294
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:650
@@ -2047,7 +2047,7 @@ msgstr ""
 #: lib/phoenix_kit_web/live/settings/users.html.heex:361
 #: lib/phoenix_kit_web/live/settings/users.html.heex:404
 #: lib/phoenix_kit_web/live/settings/users.html.heex:602
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:192
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:186
 #: lib/phoenix_kit_web/live/users/roles.html.heex:92
 #: lib/phoenix_kit_web/live/users/roles.html.heex:160
 #, elixir-autogen, elixir-format
@@ -2063,7 +2063,7 @@ msgstr ""
 #: lib/phoenix_kit_web/components/core/time_display.ex:183
 #: lib/phoenix_kit_web/components/language_switcher.ex:832
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:108
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:255
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:249
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr ""
@@ -2121,7 +2121,7 @@ msgstr ""
 msgid "User-defined roles"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:944
+#: lib/phoenix_kit/integrations/providers.ex:1016
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:255
 #: lib/phoenix_kit_web/users/magic_link_registration.html.heex:30
 #: lib/phoenix_kit_web/users/registration.html.heex:69
@@ -2439,22 +2439,22 @@ msgstr ""
 msgid "(registration disabled)"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:622
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:637
 #, elixir-autogen, elixir-format
 msgid "1. Enable the provider above and save settings"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:623
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:638
 #, elixir-autogen, elixir-format
 msgid "2. Enter your OAuth credentials in the form that appears"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:624
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:639
 #, elixir-autogen, elixir-format
 msgid "3. Save settings again to store credentials"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:625
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:640
 #, elixir-autogen, elixir-format
 msgid "4. Click \"Test Credentials\" to verify configuration"
 msgstr ""
@@ -2465,7 +2465,8 @@ msgid "Access Credentials"
 msgstr ""
 
 #: lib/modules/storage/web/bucket_form.html.heex:227
-#: lib/phoenix_kit/integrations/providers.ex:842
+#: lib/phoenix_kit/integrations/providers.ex:843
+#: lib/phoenix_kit/integrations/providers.ex:927
 #, elixir-autogen, elixir-format
 msgid "Access Key ID"
 msgstr ""
@@ -2515,9 +2516,9 @@ msgstr ""
 msgid "Add Video Dimension"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:429
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:507
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:592
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:434
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:517
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:607
 #, elixir-autogen, elixir-format
 msgid "Add callback URL above to"
 msgstr ""
@@ -2549,12 +2550,12 @@ msgstr ""
 msgid "Anyone can register"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:541
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:551
 #, elixir-autogen, elixir-format
 msgid "App ID"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:551
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:561
 #, elixir-autogen, elixir-format
 msgid "App Secret"
 msgstr ""
@@ -2673,7 +2674,7 @@ msgstr ""
 msgid "CSS color or gradient for auth page background. Ignored if a background image is set."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.ex:261
+#: lib/phoenix_kit_web/live/settings/authorization.ex:302
 #, elixir-autogen, elixir-format
 msgid "Callback URL"
 msgstr ""
@@ -2683,25 +2684,25 @@ msgstr ""
 msgid "Changes will be saved immediately"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:434
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:511
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:518
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:609
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:439
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:521
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:528
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:624
 #, elixir-autogen, elixir-format
 msgid "Click"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:215
+#: lib/phoenix_kit/integrations/providers.ex:216
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:378
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:458
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:463
 #, elixir-autogen, elixir-format
 msgid "Client ID"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:224
-#: lib/phoenix_kit/integrations/providers.ex:1169
+#: lib/phoenix_kit/integrations/providers.ex:225
+#: lib/phoenix_kit/integrations/providers.ex:1241
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:388
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:468
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:473
 #, elixir-autogen, elixir-format
 msgid "Client Secret"
 msgstr ""
@@ -2732,34 +2733,34 @@ msgstr ""
 msgid "Consider \"User\" for most installations to maintain security."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:514
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:599
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:142
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:524
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:614
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:168
 #, elixir-autogen, elixir-format
 msgid "Copy"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:432
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:437
 #, elixir-autogen, elixir-format
 msgid "Copy Client ID and Secret to fields above"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:568
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:583
 #, elixir-autogen, elixir-format
 msgid "Copy this URL to Facebook App Settings"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:485
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:495
 #, elixir-autogen, elixir-format
 msgid "Copy this URL to GitHub OAuth Apps"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:405
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:410
 #, elixir-autogen, elixir-format
 msgid "Copy this URL to Google Cloud Console"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.ex:271
+#: lib/phoenix_kit_web/live/settings/authorization.ex:312
 #, elixir-autogen, elixir-format
 msgid "Copy to clipboard"
 msgstr ""
@@ -2784,12 +2785,12 @@ msgstr ""
 msgid "Create Your First Bucket"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:582
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:597
 #, elixir-autogen, elixir-format
 msgid "Create a new app or select existing one"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:418
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:423
 #, elixir-autogen, elixir-format
 msgid "Create project or select existing one"
 msgstr ""
@@ -2860,11 +2861,12 @@ msgid "Enable OAuth (Master Switch)"
 msgstr ""
 
 #: lib/modules/storage/web/bucket_form.html.heex:194
+#: lib/phoenix_kit/integrations/providers.ex:957
 #, elixir-autogen, elixir-format
 msgid "Endpoint"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:503
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:513
 #, elixir-autogen, elixir-format
 msgid "Enter"
 msgstr ""
@@ -2899,7 +2901,7 @@ msgstr ""
 msgid "FFmpeg is required for video processing, transcoding, and thumbnail generation."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:532
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:542
 #, elixir-autogen, elixir-format
 msgid "Facebook OAuth Credentials"
 msgstr ""
@@ -2942,7 +2944,7 @@ msgstr ""
 msgid "Format Override:"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:449
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:454
 #, elixir-autogen, elixir-format
 msgid "GitHub OAuth Credentials"
 msgstr ""
@@ -2952,10 +2954,10 @@ msgstr ""
 msgid "GitHub Sign-In"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:420
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:499
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:588
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:596
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:425
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:509
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:603
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:611
 #, elixir-autogen, elixir-format
 msgid "Go to"
 msgstr ""
@@ -2985,7 +2987,7 @@ msgstr ""
 msgid "How times are displayed"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.ex:296
+#: lib/phoenix_kit_web/live/settings/authorization.ex:337
 #, elixir-autogen, elixir-format
 msgid "If behind nginx/apache, ensure"
 msgstr ""
@@ -3172,7 +3174,7 @@ msgstr ""
 msgid "Note"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:627
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:642
 #, elixir-autogen, elixir-format
 msgid "Note: OAuth providers require ueberauth dependencies to be installed."
 msgstr ""
@@ -3187,7 +3189,7 @@ msgstr ""
 msgid "OAuth Providers"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:620
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:635
 #, elixir-autogen, elixir-format
 msgid "OAuth Setup Instructions"
 msgstr ""
@@ -3260,7 +3262,7 @@ msgstr ""
 msgid "Redundancy Copies"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:642
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:657
 #, elixir-autogen, elixir-format
 msgid "Reload OAuth Configuration"
 msgstr ""
@@ -3287,7 +3289,7 @@ msgstr ""
 msgid "Resolution"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.ex:294
+#: lib/phoenix_kit_web/live/settings/authorization.ex:335
 #, elixir-autogen, elixir-format
 msgid "Reverse Proxy Users:"
 msgstr ""
@@ -3313,7 +3315,7 @@ msgstr ""
 msgid "Save All Settings"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:685
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:700
 #, elixir-autogen, elixir-format
 msgid "Save Authorization Settings"
 msgstr ""
@@ -3329,7 +3331,8 @@ msgid "Search engines are instructed to skip this environment. Remove this befor
 msgstr ""
 
 #: lib/modules/storage/web/bucket_form.html.heex:241
-#: lib/phoenix_kit/integrations/providers.ex:851
+#: lib/phoenix_kit/integrations/providers.ex:852
+#: lib/phoenix_kit/integrations/providers.ex:936
 #, elixir-autogen, elixir-format
 msgid "Secret Access Key"
 msgstr ""
@@ -3346,7 +3349,7 @@ msgstr ""
 
 #: lib/phoenix_kit_web/components/media_browser.html.heex:1180
 #: lib/phoenix_kit_web/components/media_browser.html.heex:1182
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:425
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:430
 #, elixir-autogen, elixir-format
 msgid "Select"
 msgstr ""
@@ -3376,7 +3379,7 @@ msgid "Set"
 msgstr ""
 
 #: lib/phoenix_kit_web/components/core/integrations_ui.ex:311
-#: lib/phoenix_kit_web/live/settings/authorization.ex:249
+#: lib/phoenix_kit_web/live/settings/authorization.ex:290
 #: lib/phoenix_kit_web/live/settings/integration_form.html.heex:378
 #, elixir-autogen, elixir-format
 msgid "Setup Instructions"
@@ -3413,7 +3416,7 @@ msgstr ""
 msgid "Success!"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:604
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:619
 #, elixir-autogen, elixir-format
 msgid "Switch app from"
 msgstr ""
@@ -3438,9 +3441,9 @@ msgstr ""
 msgid "Target Width (px)"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:400
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:480
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:563
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:405
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:490
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:578
 #, elixir-autogen, elixir-format
 msgid "Test Credentials"
 msgstr ""
@@ -3520,7 +3523,7 @@ msgstr ""
 msgid "User Editable"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/users.ex:35
+#: lib/phoenix_kit_web/live/settings/users.ex:42
 #: lib/phoenix_kit_web/live/settings/users.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "User Settings"
@@ -3562,9 +3565,9 @@ msgstr ""
 msgid "Videos use CRF 0-51 scale (lower = higher quality)"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:409
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:489
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:572
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:414
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:499
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:587
 #, elixir-autogen, elixir-format
 msgid "Visit"
 msgstr ""
@@ -3609,22 +3612,22 @@ msgstr ""
 msgid "Would you like to create it now?"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:542
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:552
 #, elixir-autogen, elixir-format
 msgid "Your Facebook App ID"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:552
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:565
 #, elixir-autogen, elixir-format
 msgid "Your Facebook App Secret"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:459
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:464
 #, elixir-autogen, elixir-format
 msgid "Your GitHub OAuth Client ID"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:469
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:477
 #, elixir-autogen, elixir-format
 msgid "Your GitHub OAuth Client Secret"
 msgstr ""
@@ -3634,19 +3637,19 @@ msgstr ""
 msgid "Your Google OAuth Client ID"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:389
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:392
 #, elixir-autogen, elixir-format
 msgid "Your Google OAuth Client Secret"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:504
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:600
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:514
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:615
 #: lib/phoenix_kit_web/live/settings/integrations.ex:167
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:515
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:525
 #, elixir-autogen, elixir-format
 msgid "and generate/copy"
 msgstr ""
@@ -3667,12 +3670,12 @@ msgstr ""
 msgid "files"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.ex:300
+#: lib/phoenix_kit_web/live/settings/authorization.ex:341
 #, elixir-autogen, elixir-format
 msgid "header is set to"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:606
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:621
 #, elixir-autogen, elixir-format
 msgid "mode"
 msgstr ""
@@ -3682,12 +3685,12 @@ msgstr ""
 msgid "option(s)"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:585
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:600
 #, elixir-autogen, elixir-format
 msgid "product"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:605
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:620
 #, elixir-autogen, elixir-format
 msgid "to"
 msgstr ""
@@ -3697,19 +3700,19 @@ msgstr ""
 msgid "to every PhoenixKit layout, blocking crawlers from indexing or following links."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:601
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:616
 #, elixir-autogen, elixir-format
 msgid "to fields above"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:435
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:519
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:610
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:440
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:529
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:625
 #, elixir-autogen, elixir-format
 msgid "to verify setup"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:426
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:431
 #, elixir-autogen, elixir-format
 msgid "type"
 msgstr ""
@@ -3844,7 +3847,7 @@ msgstr ""
 msgid "A unique name to identify this dimension preset"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:388
+#: lib/phoenix_kit/integrations/providers.ex:389
 #, elixir-autogen, elixir-format
 msgid "AI model access via OpenRouter (100+ models)"
 msgstr ""
@@ -3854,13 +3857,13 @@ msgstr ""
 msgid "API Credentials"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:332
-#: lib/phoenix_kit/integrations/providers.ex:402
-#: lib/phoenix_kit/integrations/providers.ex:460
-#: lib/phoenix_kit/integrations/providers.ex:523
-#: lib/phoenix_kit/integrations/providers.ex:586
-#: lib/phoenix_kit/integrations/providers.ex:653
-#: lib/phoenix_kit/integrations/providers.ex:1065
+#: lib/phoenix_kit/integrations/providers.ex:333
+#: lib/phoenix_kit/integrations/providers.ex:403
+#: lib/phoenix_kit/integrations/providers.ex:461
+#: lib/phoenix_kit/integrations/providers.ex:524
+#: lib/phoenix_kit/integrations/providers.ex:587
+#: lib/phoenix_kit/integrations/providers.ex:654
+#: lib/phoenix_kit/integrations/providers.ex:1137
 #, elixir-autogen, elixir-format
 msgid "API Key"
 msgstr ""
@@ -3921,7 +3924,7 @@ msgstr ""
 msgid "Add Integration"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:431
+#: lib/phoenix_kit/integrations/providers.ex:432
 #, elixir-autogen, elixir-format
 msgid "Add credits (optional)"
 msgstr ""
@@ -3956,7 +3959,7 @@ msgstr ""
 msgid "Alternative Formats"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:285
+#: lib/phoenix_kit/integrations/providers.ex:286
 #, elixir-autogen, elixir-format
 msgid "Application type: **Web application** (do not select \"Desktop app\" — it won't support redirect URIs)"
 msgstr ""
@@ -4078,18 +4081,18 @@ msgstr ""
 msgid "Clear Schedule"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:284
+#: lib/phoenix_kit/integrations/providers.ex:285
 #, elixir-autogen, elixir-format
 msgid "Click **Create Credentials → OAuth client ID**"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:425
+#: lib/phoenix_kit/integrations/providers.ex:426
 #, elixir-autogen, elixir-format
 msgid "Click **Create Key**"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:295
-#: lib/phoenix_kit/integrations/providers.ex:1248
+#: lib/phoenix_kit/integrations/providers.ex:296
+#: lib/phoenix_kit/integrations/providers.ex:1320
 #, elixir-autogen, elixir-format
 msgid "Click **Save**, then **Connect Account**"
 msgstr ""
@@ -4139,8 +4142,8 @@ msgstr ""
 msgid "Connect Account"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:293
-#: lib/phoenix_kit/integrations/providers.ex:1246
+#: lib/phoenix_kit/integrations/providers.ex:294
+#: lib/phoenix_kit/integrations/providers.ex:1318
 #, elixir-autogen, elixir-format
 msgid "Connect and authorize"
 msgstr ""
@@ -4160,7 +4163,7 @@ msgstr ""
 #: lib/phoenix_kit_web/live/settings/integration_form.html.heex:327
 #: lib/phoenix_kit_web/live/settings/integrations.ex:181
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:111
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:197
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:191
 #, elixir-autogen, elixir-format
 msgid "Connected"
 msgstr ""
@@ -4201,48 +4204,48 @@ msgstr ""
 msgid "Connection verified"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:289
+#: lib/phoenix_kit/integrations/providers.ex:290
 #, elixir-autogen, elixir-format
 msgid "Copy the **Client ID** and **Client Secret** into the form above"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:427
+#: lib/phoenix_kit/integrations/providers.ex:428
 #, elixir-autogen, elixir-format
 msgid "Copy the key and paste it into the form above"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/integrations.ex:1135
+#: lib/phoenix_kit/integrations/integrations.ex:1138
 #: lib/phoenix_kit/integrations/probe.ex:102
 #, elixir-autogen, elixir-format
 msgid "Could not reach the service"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:235
+#: lib/phoenix_kit/integrations/providers.ex:236
 #, elixir-autogen, elixir-format
 msgid "Create a Google Cloud project"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:238
+#: lib/phoenix_kit/integrations/providers.ex:239
 #, elixir-autogen, elixir-format
 msgid "Create a new project or select an existing one"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:368
-#: lib/phoenix_kit/integrations/providers.ex:423
-#: lib/phoenix_kit/integrations/providers.ex:493
-#: lib/phoenix_kit/integrations/providers.ex:553
-#: lib/phoenix_kit/integrations/providers.ex:619
-#: lib/phoenix_kit/integrations/providers.ex:670
+#: lib/phoenix_kit/integrations/providers.ex:369
+#: lib/phoenix_kit/integrations/providers.ex:424
+#: lib/phoenix_kit/integrations/providers.ex:494
+#: lib/phoenix_kit/integrations/providers.ex:554
+#: lib/phoenix_kit/integrations/providers.ex:620
+#: lib/phoenix_kit/integrations/providers.ex:671
 #, elixir-autogen, elixir-format
 msgid "Create an API key"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:279
+#: lib/phoenix_kit/integrations/providers.ex:280
 #, elixir-autogen, elixir-format
 msgid "Create an OAuth Client"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:416
+#: lib/phoenix_kit/integrations/providers.ex:417
 #, elixir-autogen, elixir-format
 msgid "Create an OpenRouter account"
 msgstr ""
@@ -4311,7 +4314,7 @@ msgstr ""
 msgid "Disconnected"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:253
+#: lib/phoenix_kit/integrations/providers.ex:254
 #, elixir-autogen, elixir-format
 msgid "Drive API handles file listing, creation, copying, and PDF export. Docs API is used for reading document content and substituting template variables."
 msgstr ""
@@ -4341,7 +4344,7 @@ msgstr ""
 msgid "Enable organization accounts"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:242
+#: lib/phoenix_kit/integrations/providers.ex:243
 #, elixir-autogen, elixir-format
 msgid "Enable required APIs"
 msgstr ""
@@ -4474,12 +4477,12 @@ msgstr ""
 msgid "Files with completed variants"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:219
+#: lib/phoenix_kit/integrations/providers.ex:220
 #, elixir-autogen, elixir-format
 msgid "From Google Cloud Console → APIs & Services → Credentials"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:406
+#: lib/phoenix_kit/integrations/providers.ex:407
 #, elixir-autogen, elixir-format
 msgid "From openrouter.ai/keys"
 msgstr ""
@@ -4489,72 +4492,72 @@ msgstr ""
 msgid "Generate additional format variants alongside the primary format. Modern formats like WebP and AVIF offer better compression."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:426
+#: lib/phoenix_kit/integrations/providers.ex:427
 #, elixir-autogen, elixir-format
 msgid "Give it a name (e.g., your app name)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:248
+#: lib/phoenix_kit/integrations/providers.ex:249
 #, elixir-autogen, elixir-format
 msgid "Go back to the Library and search for **Google Docs API**, click it, then click **Enable**"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:281
+#: lib/phoenix_kit/integrations/providers.ex:282
 #, elixir-autogen, elixir-format
 msgid "Go to [APIs & Services → Credentials](https://console.cloud.google.com/apis/credentials)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:244
+#: lib/phoenix_kit/integrations/providers.ex:245
 #, elixir-autogen, elixir-format
 msgid "Go to [APIs & Services → Library](https://console.cloud.google.com/apis/library)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:263
+#: lib/phoenix_kit/integrations/providers.ex:264
 #, elixir-autogen, elixir-format
 msgid "Go to [Audience](https://console.cloud.google.com/auth/audience) — set user type to **External** (or Internal for Google Workspace)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:260
+#: lib/phoenix_kit/integrations/providers.ex:261
 #, elixir-autogen, elixir-format
 msgid "Go to [Branding](https://console.cloud.google.com/auth/branding) in the sidebar — fill in the **App name** and **User support email**, then save"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:434
+#: lib/phoenix_kit/integrations/providers.ex:435
 #, elixir-autogen, elixir-format
 msgid "Go to [Credits](https://openrouter.ai/credits) to add funds"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:269
+#: lib/phoenix_kit/integrations/providers.ex:270
 #, elixir-autogen, elixir-format
 msgid "Go to [Data Access](https://console.cloud.google.com/auth/scopes) — click **Add or Remove Scopes** and add the Drive and Docs scopes. This step may not be required — the app requests the needed scopes at connect time regardless."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:418
+#: lib/phoenix_kit/integrations/providers.ex:419
 #, elixir-autogen, elixir-format
 msgid "Go to [openrouter.ai](https://openrouter.ai) and sign up or log in"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:237
+#: lib/phoenix_kit/integrations/providers.ex:238
 #, elixir-autogen, elixir-format
 msgid "Go to the [Google Cloud Console](https://console.cloud.google.com)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:200
+#: lib/phoenix_kit/integrations/providers.ex:201
 #, elixir-autogen, elixir-format
 msgid "Google"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:201
+#: lib/phoenix_kit/integrations/providers.ex:202
 #, elixir-autogen, elixir-format
 msgid "Google Docs, Drive, Calendar, Sheets, Gmail"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:296
+#: lib/phoenix_kit/integrations/providers.ex:297
 #, elixir-autogen, elixir-format
 msgid "Google will show an \"unverified app\" warning — click **Advanced → Go to (app name)** to proceed"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:299
+#: lib/phoenix_kit/integrations/providers.ex:300
 #, elixir-autogen, elixir-format
 msgid "Grant access to Google Docs and Google Drive"
 msgstr ""
@@ -4590,11 +4593,12 @@ msgstr ""
 msgid "Integrations"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/integrations.ex:1132
+#: lib/phoenix_kit/integrations/integrations.ex:1135
 #: lib/phoenix_kit/integrations/validators.ex:208
 #: lib/phoenix_kit/integrations/validators.ex:378
 #: lib/phoenix_kit/integrations/validators.ex:412
-#: lib/phoenix_kit/integrations/validators.ex:595
+#: lib/phoenix_kit/integrations/validators.ex:608
+#: lib/phoenix_kit/integrations/validators.ex:776
 #, elixir-autogen, elixir-format
 msgid "Invalid credentials"
 msgstr ""
@@ -4808,12 +4812,12 @@ msgstr ""
 msgid "Missing %{n} copies"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:419
+#: lib/phoenix_kit/integrations/providers.ex:420
 #, elixir-autogen, elixir-format
 msgid "Navigate to [Keys](https://openrouter.ai/keys)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:274
+#: lib/phoenix_kit/integrations/providers.ex:275
 #, elixir-autogen, elixir-format
 msgid "Navigate to the OAuth section using the search bar or the hamburger menu: search for \"OAuth\", or go to the sidebar: **APIs & Services → OAuth consent screen**. This opens a different section with its own sidebar."
 msgstr ""
@@ -4834,9 +4838,9 @@ msgstr ""
 msgid "No copies"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/integrations.ex:1115
+#: lib/phoenix_kit/integrations/integrations.ex:1118
 #: lib/phoenix_kit/integrations/validators.ex:170
-#: lib/phoenix_kit/integrations/validators.ex:577
+#: lib/phoenix_kit/integrations/validators.ex:758
 #, elixir-autogen, elixir-format
 msgid "No credentials configured"
 msgstr ""
@@ -4917,7 +4921,7 @@ msgstr ""
 msgid "Only width is used, height is calculated automatically"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:387
+#: lib/phoenix_kit/integrations/providers.ex:388
 #, elixir-autogen, elixir-format
 msgid "OpenRouter"
 msgstr ""
@@ -5098,7 +5102,7 @@ msgstr ""
 msgid "Scheduled window is currently active"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:247
+#: lib/phoenix_kit/integrations/providers.ex:248
 #, elixir-autogen, elixir-format
 msgid "Search for **Google Drive API**, click it, then click **Enable**"
 msgstr ""
@@ -5125,7 +5129,7 @@ msgstr ""
 msgid "Service"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/integrations.ex:1134
+#: lib/phoenix_kit/integrations/integrations.ex:1137
 #, elixir-autogen, elixir-format
 msgid "Service error %{status}"
 msgstr ""
@@ -5135,7 +5139,7 @@ msgstr ""
 msgid "Set a time window for automatic maintenance activation."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:258
+#: lib/phoenix_kit/integrations/providers.ex:259
 #, elixir-autogen, elixir-format
 msgid "Set up OAuth consent"
 msgstr ""
@@ -5145,7 +5149,7 @@ msgstr ""
 msgid "Size Configuration"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:433
+#: lib/phoenix_kit/integrations/providers.ex:434
 #, elixir-autogen, elixir-format
 msgid "Some models are free, but most require credits"
 msgstr ""
@@ -5175,7 +5179,7 @@ msgstr ""
 msgid "Step 2"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:266
+#: lib/phoenix_kit/integrations/providers.ex:267
 #, elixir-autogen, elixir-format
 msgid "Still on Audience — while the app is in **Testing** status, add the Google account you will connect as a **Test user** (this must be the same account whose Drive will store your files)"
 msgstr ""
@@ -5310,7 +5314,7 @@ msgstr ""
 msgid "Total Files"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:288
+#: lib/phoenix_kit/integrations/providers.ex:289
 #, elixir-autogen, elixir-format
 msgid "Under **Authorized redirect URIs**, add: `{redirect_uri}`"
 msgstr ""
@@ -5367,8 +5371,8 @@ msgstr ""
 msgid "You need to create at least one media bucket before files can be uploaded."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:300
-#: lib/phoenix_kit/integrations/providers.ex:1252
+#: lib/phoenix_kit/integrations/providers.ex:301
+#: lib/phoenix_kit/integrations/providers.ex:1324
 #, elixir-autogen, elixir-format
 msgid "You'll be redirected back here once connected"
 msgstr ""
@@ -5435,39 +5439,39 @@ msgstr ""
 msgid "1 minute ago"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:509
+#: lib/phoenix_kit/integrations/providers.ex:510
 #, elixir-autogen, elixir-format
 msgid "AI model access via DeepSeek (deepseek-chat, deepseek-reasoner)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:446
+#: lib/phoenix_kit/integrations/providers.ex:447
 #, elixir-autogen, elixir-format
 msgid "AI model access via Mistral AI (Mistral Large, Codestral, Pixtral)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1218
+#: lib/phoenix_kit/integrations/providers.ex:1290
 #, elixir-autogen, elixir-format
 msgid "Add a client secret"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:480
+#: lib/phoenix_kit/integrations/providers.ex:481
 #, elixir-autogen, elixir-format
 msgid "Add a payment method (required)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:357
-#: lib/phoenix_kit/integrations/providers.ex:542
-#: lib/phoenix_kit/integrations/providers.ex:611
+#: lib/phoenix_kit/integrations/providers.ex:358
+#: lib/phoenix_kit/integrations/providers.ex:543
+#: lib/phoenix_kit/integrations/providers.ex:612
 #, elixir-autogen, elixir-format
 msgid "Add credits"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1233
+#: lib/phoenix_kit/integrations/providers.ex:1305
 #, elixir-autogen, elixir-format
 msgid "Add the permissions your integration needs: `User.Read` is included by default; add `Mail.Read`, `Files.Read.All`, `Calendars.Read`, etc. as required"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1160
+#: lib/phoenix_kit/integrations/providers.ex:1232
 #, elixir-autogen, elixir-format
 msgid "Application (client) ID"
 msgstr ""
@@ -5477,28 +5481,28 @@ msgstr ""
 msgid "Clears the OAuth tokens. Credentials and the connection itself stay so you can reconnect with one click."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:556
-#: lib/phoenix_kit/integrations/providers.ex:622
+#: lib/phoenix_kit/integrations/providers.ex:557
+#: lib/phoenix_kit/integrations/providers.ex:623
 #, elixir-autogen, elixir-format
 msgid "Click **Create API key**, give it a name"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:496
+#: lib/phoenix_kit/integrations/providers.ex:497
 #, elixir-autogen, elixir-format
 msgid "Click **Create new key**, give it a name, set an expiry if desired"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1205
+#: lib/phoenix_kit/integrations/providers.ex:1277
 #, elixir-autogen, elixir-format
 msgid "Click **New registration**, give the app a name"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1210
+#: lib/phoenix_kit/integrations/providers.ex:1282
 #, elixir-autogen, elixir-format
 msgid "Click **Register**"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1228
+#: lib/phoenix_kit/integrations/providers.ex:1300
 #, elixir-autogen, elixir-format
 msgid "Configure API permissions"
 msgstr ""
@@ -5519,16 +5523,16 @@ msgstr ""
 msgid "Connection renamed"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1222
+#: lib/phoenix_kit/integrations/providers.ex:1294
 #, elixir-autogen, elixir-format
 msgid "Copy the **Value** column (not the Secret ID) into the form above — the value is shown ONCE and disappears on page refresh"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:372
-#: lib/phoenix_kit/integrations/providers.ex:497
-#: lib/phoenix_kit/integrations/providers.ex:557
-#: lib/phoenix_kit/integrations/providers.ex:623
-#: lib/phoenix_kit/integrations/providers.ex:675
+#: lib/phoenix_kit/integrations/providers.ex:373
+#: lib/phoenix_kit/integrations/providers.ex:498
+#: lib/phoenix_kit/integrations/providers.ex:558
+#: lib/phoenix_kit/integrations/providers.ex:624
+#: lib/phoenix_kit/integrations/providers.ex:676
 #, elixir-autogen, elixir-format
 msgid "Copy the key (shown once) and paste it into the form above"
 msgstr ""
@@ -5539,12 +5543,12 @@ msgstr ""
 msgid "Create Connection"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:534
+#: lib/phoenix_kit/integrations/providers.ex:535
 #, elixir-autogen, elixir-format
 msgid "Create a DeepSeek account"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:471
+#: lib/phoenix_kit/integrations/providers.ex:472
 #, elixir-autogen, elixir-format
 msgid "Create a Mistral account"
 msgstr ""
@@ -5555,12 +5559,12 @@ msgstr ""
 msgid "Danger Zone"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:508
+#: lib/phoenix_kit/integrations/providers.ex:509
 #, elixir-autogen, elixir-format
 msgid "DeepSeek"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:547
+#: lib/phoenix_kit/integrations/providers.ex:548
 #, elixir-autogen, elixir-format
 msgid "DeepSeek requires a positive balance before you can call the chat or reasoner endpoints, even on cheap models"
 msgstr ""
@@ -5595,82 +5599,82 @@ msgstr ""
 msgid "Failed to rename connection."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:485
+#: lib/phoenix_kit/integrations/providers.ex:486
 #, elixir-autogen, elixir-format
 msgid "Free models still require a billing-enabled workspace"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1164
+#: lib/phoenix_kit/integrations/providers.ex:1236
 #, elixir-autogen, elixir-format
 msgid "From Azure Portal → App registrations → your app → Overview"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:464
+#: lib/phoenix_kit/integrations/providers.ex:465
 #, elixir-autogen, elixir-format
 msgid "From console.mistral.ai/api-keys"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:527
+#: lib/phoenix_kit/integrations/providers.ex:528
 #, elixir-autogen, elixir-format
 msgid "From platform.deepseek.com/api_keys"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1174
+#: lib/phoenix_kit/integrations/providers.ex:1246
 #, elixir-autogen, elixir-format
 msgid "From your app → Certificates & secrets → New client secret. Copy the *Value*, not the Secret ID."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1230
+#: lib/phoenix_kit/integrations/providers.ex:1302
 #, elixir-autogen, elixir-format
 msgid "Go to **API permissions → Add a permission → Microsoft Graph → Delegated permissions**"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1220
+#: lib/phoenix_kit/integrations/providers.ex:1292
 #, elixir-autogen, elixir-format
 msgid "Go to **Certificates & secrets → New client secret**"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:495
+#: lib/phoenix_kit/integrations/providers.ex:496
 #, elixir-autogen, elixir-format
 msgid "Go to [API Keys](https://console.mistral.ai/api-keys)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:555
+#: lib/phoenix_kit/integrations/providers.ex:556
 #, elixir-autogen, elixir-format
 msgid "Go to [API Keys](https://platform.deepseek.com/api_keys)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:544
+#: lib/phoenix_kit/integrations/providers.ex:545
 #, elixir-autogen, elixir-format
 msgid "Go to [Top up](https://platform.deepseek.com/top_up) and add at least the minimum amount"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:482
+#: lib/phoenix_kit/integrations/providers.ex:483
 #, elixir-autogen, elixir-format
 msgid "Go to [Workspace → Billing](https://console.mistral.ai/billing/plans) and choose **Experiment** (pay-as-you-go) or a paid tier"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:473
+#: lib/phoenix_kit/integrations/providers.ex:474
 #, elixir-autogen, elixir-format
 msgid "Go to [console.mistral.ai](https://console.mistral.ai) and sign up or log in"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:536
+#: lib/phoenix_kit/integrations/providers.ex:537
 #, elixir-autogen, elixir-format
 msgid "Go to [platform.deepseek.com](https://platform.deepseek.com) and sign up or log in"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1202
+#: lib/phoenix_kit/integrations/providers.ex:1274
 #, elixir-autogen, elixir-format
 msgid "Go to the [Azure Portal](https://portal.azure.com) and search for **App registrations**"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1213
+#: lib/phoenix_kit/integrations/providers.ex:1285
 #, elixir-autogen, elixir-format
 msgid "If you picked a single-tenant audience, fill in **Tenant ID** above with your Directory (tenant) ID GUID — leaving it as `common` only works for multi-tenant + personal apps."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1236
+#: lib/phoenix_kit/integrations/providers.ex:1308
 #, elixir-autogen, elixir-format
 msgid "If your tenant requires admin consent, click **Grant admin consent for <tenant>** before the connect flow will work"
 msgstr ""
@@ -5687,32 +5691,32 @@ msgstr ""
 msgid "Last tested"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1186
+#: lib/phoenix_kit/integrations/providers.ex:1258
 #, elixir-autogen, elixir-format
 msgid "Leave as `common` for multi-tenant + personal accounts. For single-tenant apps, paste your Directory (tenant) ID GUID. Use `consumers` for personal-only or `organizations` for any work-or-school account."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1131
+#: lib/phoenix_kit/integrations/providers.ex:1203
 #, elixir-autogen, elixir-format
 msgid "Microsoft 365"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1132
+#: lib/phoenix_kit/integrations/providers.ex:1204
 #, elixir-autogen, elixir-format
 msgid "Microsoft Graph — Outlook, OneDrive, Teams, Calendar, SharePoint"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1249
+#: lib/phoenix_kit/integrations/providers.ex:1321
 #, elixir-autogen, elixir-format
 msgid "Microsoft will show the consent screen — click **Accept** to grant the requested permissions"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:445
+#: lib/phoenix_kit/integrations/providers.ex:446
 #, elixir-autogen, elixir-format
 msgid "Mistral"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:488
+#: lib/phoenix_kit/integrations/providers.ex:489
 #, elixir-autogen, elixir-format
 msgid "Mistral does not offer credits without billing setup; this is a hard requirement before keys can be created."
 msgstr ""
@@ -5723,7 +5727,7 @@ msgstr ""
 msgid "Permanently delete this connection? This cannot be undone."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1200
+#: lib/phoenix_kit/integrations/providers.ex:1272
 #, elixir-autogen, elixir-format
 msgid "Register an application in Microsoft Entra ID (Azure AD)"
 msgstr ""
@@ -5739,32 +5743,32 @@ msgstr ""
 msgid "Search..."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1221
+#: lib/phoenix_kit/integrations/providers.ex:1293
 #, elixir-autogen, elixir-format
 msgid "Set an expiration (24 months is common; renew before it lapses)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1181
+#: lib/phoenix_kit/integrations/providers.ex:1253
 #, elixir-autogen, elixir-format
 msgid "Tenant ID"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1241
+#: lib/phoenix_kit/integrations/providers.ex:1313
 #, elixir-autogen, elixir-format
 msgid "The `default_scopes` in the provider definition request `openid email profile offline_access User.Read` — extra scopes can be added per-connect by passing `extra_scopes` to `authorization_url/5`."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1209
+#: lib/phoenix_kit/integrations/providers.ex:1281
 #, elixir-autogen, elixir-format
 msgid "Under **Redirect URI**, choose **Web** and enter: `{redirect_uri}`"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1206
+#: lib/phoenix_kit/integrations/providers.ex:1278
 #, elixir-autogen, elixir-format
 msgid "Under **Supported account types**, choose the audience: *Personal Microsoft accounts only*, *Accounts in any organizational directory*, or *Accounts in this organizational directory only* depending on who should sign in"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:476
+#: lib/phoenix_kit/integrations/providers.ex:477
 #, elixir-autogen, elixir-format
 msgid "You may need to verify your phone number before creating API keys"
 msgstr ""
@@ -6031,14 +6035,14 @@ msgstr ""
 
 #: lib/phoenix_kit_web/live/modules.html.heex:447
 #: lib/phoenix_kit_web/live/settings.html.heex:465
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:289
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:315
 #, elixir-autogen, elixir-format
 msgid "Off"
 msgstr ""
 
 #: lib/phoenix_kit_web/live/modules.html.heex:447
 #: lib/phoenix_kit_web/live/settings.html.heex:464
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:289
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:315
 #, elixir-autogen, elixir-format
 msgid "On"
 msgstr ""
@@ -7270,8 +7274,8 @@ msgstr ""
 msgid "Are you sure you want to delete this comment?"
 msgstr ""
 
-#: lib/phoenix_kit_web/components/media_canvas_viewer.ex:1202
-#: lib/phoenix_kit_web/components/media_canvas_viewer.ex:1203
+#: lib/phoenix_kit_web/components/media_canvas_viewer.ex:1236
+#: lib/phoenix_kit_web/components/media_canvas_viewer.ex:1237
 #, elixir-autogen, elixir-format
 msgid "%b %d, %Y"
 msgstr ""
@@ -8385,14 +8389,14 @@ msgstr ""
 msgid "All registered accounts"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:185
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:224
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:179
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:218
 #, elixir-autogen, elixir-format
 msgid "Anon"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:178
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:245
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:172
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:239
 #, elixir-autogen, elixir-format
 msgid "Anonymous User"
 msgstr ""
@@ -8443,8 +8447,8 @@ msgstr ""
 msgid "Are you sure you want to unconfirm this user's email?"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:170
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:220
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:164
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:214
 #, elixir-autogen, elixir-format
 msgid "Auth"
 msgstr ""
@@ -8527,17 +8531,17 @@ msgid "Confirmed Email"
 msgstr ""
 
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:109
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:195
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Current Page"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/users.ex:251
+#: lib/phoenix_kit_web/live/settings/users.ex:258
 #, elixir-autogen, elixir-format
 msgid "Custom field deleted successfully"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/users.ex:171
+#: lib/phoenix_kit_web/live/settings/users.ex:178
 #, elixir-autogen, elixir-format
 msgid "Custom field saved successfully"
 msgstr ""
@@ -8552,17 +8556,17 @@ msgstr ""
 msgid "Drag to reorder selected columns above, or add new columns from the options below. Actions column is always included."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/users.ex:256
+#: lib/phoenix_kit_web/live/settings/users.ex:263
 #, elixir-autogen, elixir-format
 msgid "Failed to delete custom field"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/users.ex:184
+#: lib/phoenix_kit_web/live/settings/users.ex:191
 #, elixir-autogen, elixir-format
 msgid "Failed to save custom field"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/users.ex:285
+#: lib/phoenix_kit_web/live/settings/users.ex:292
 #, elixir-autogen, elixir-format
 msgid "Failed to update field"
 msgstr ""
@@ -8595,23 +8599,23 @@ msgstr ""
 msgid "Failed to update user status"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/users.ex:278
+#: lib/phoenix_kit_web/live/settings/users.ex:285
 #, elixir-autogen, elixir-format
 msgid "Field '%{label}' disabled"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/users.ex:277
+#: lib/phoenix_kit_web/live/settings/users.ex:284
 #, elixir-autogen, elixir-format
 msgid "Field '%{label}' enabled"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/users.ex:289
+#: lib/phoenix_kit_web/live/settings/users.ex:296
 #, elixir-autogen, elixir-format
 msgid "Field not found"
 msgstr ""
 
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:108
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:194
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:188
 #, elixir-autogen, elixir-format
 msgid "IP Address"
 msgstr ""
@@ -8643,7 +8647,7 @@ msgstr ""
 msgid "Monitor and manage active user sessions"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1002
+#: lib/phoenix_kit/integrations/providers.ex:1074
 #: lib/phoenix_kit_web/live/users/users.ex:1048
 #: lib/phoenix_kit_web/live/users/users.html.heex:563
 #, elixir-autogen, elixir-format
@@ -8655,7 +8659,7 @@ msgstr ""
 msgid "Next »"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:208
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:202
 #, elixir-autogen, elixir-format
 msgid "No active sessions"
 msgstr ""
@@ -8807,7 +8811,7 @@ msgstr ""
 msgid "Table columns updated successfully"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:209
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:203
 #, elixir-autogen, elixir-format
 msgid "There are currently no active sessions to display."
 msgstr ""
@@ -8868,12 +8872,12 @@ msgstr ""
 msgid "User roles updated successfully"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/users.ex:84
+#: lib/phoenix_kit_web/live/settings/users.ex:91
 #, elixir-autogen, elixir-format
 msgid "User settings updated successfully"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:193
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:187
 #, elixir-autogen, elixir-format
 msgid "User/Session"
 msgstr ""
@@ -8907,7 +8911,7 @@ msgstr[1] ""
 msgid "Last updated:"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:656
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:671
 #, elixir-autogen, elixir-format
 msgid "Account switcher for signing in to several accounts at once"
 msgstr ""
@@ -8917,7 +8921,7 @@ msgstr ""
 msgid "Applying…"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:662
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:677
 #, elixir-autogen, elixir-format
 msgid "Enable the multi-account switcher in the header"
 msgstr ""
@@ -8935,12 +8939,12 @@ msgstr ""
 msgid "Loading…"
 msgstr ""
 
-#: lib/phoenix_kit_web/users/session.ex:113
+#: lib/phoenix_kit_web/users/session.ex:115
 #, elixir-autogen, elixir-format
 msgid "Logged out. Now signed in as %{email}."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:653
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:668
 #, elixir-autogen, elixir-format
 msgid "Multiple Sessions"
 msgstr ""
@@ -8976,12 +8980,12 @@ msgstr ""
 msgid "Showing %{loaded} of %{total} %{noun}"
 msgstr ""
 
-#: lib/phoenix_kit_web/users/session.ex:268
+#: lib/phoenix_kit_web/users/session.ex:270
 #, elixir-autogen, elixir-format
 msgid "Switched to %{email}."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:665
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:680
 #, elixir-autogen, elixir-format
 msgid "When on, any signed-in user can add other accounts (with their password) and switch between them from the user menu."
 msgstr ""
@@ -9061,7 +9065,7 @@ msgstr ""
 msgid "View background job status and history"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:312
+#: lib/phoenix_kit/integrations/providers.ex:313
 #, elixir-autogen, elixir-format
 msgid "AI models via OpenAI (GPT, embeddings, images, audio)"
 msgstr ""
@@ -9146,12 +9150,12 @@ msgstr ""
 msgid "Choose"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:674
+#: lib/phoenix_kit/integrations/providers.ex:675
 #, elixir-autogen, elixir-format
 msgid "Click **Create API Key**, give it a name"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:371
+#: lib/phoenix_kit/integrations/providers.ex:372
 #, elixir-autogen, elixir-format
 msgid "Click **Create new secret key**, give it a name"
 msgstr ""
@@ -9162,12 +9166,12 @@ msgstr ""
 msgid "Close search"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:664
+#: lib/phoenix_kit/integrations/providers.ex:665
 #, elixir-autogen, elixir-format
 msgid "Create an ElevenLabs account"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:349
+#: lib/phoenix_kit/integrations/providers.ex:350
 #, elixir-autogen, elixir-format
 msgid "Create an OpenAI account"
 msgstr ""
@@ -9231,7 +9235,7 @@ msgstr ""
 msgid "Edit header"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:634
+#: lib/phoenix_kit/integrations/providers.ex:635
 #, elixir-autogen, elixir-format
 msgid "ElevenLabs"
 msgstr ""
@@ -9301,37 +9305,37 @@ msgstr ""
 msgid "Forgot password"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:657
+#: lib/phoenix_kit/integrations/providers.ex:658
 #, elixir-autogen, elixir-format
 msgid "From elevenlabs.io → Settings → API Keys"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:336
+#: lib/phoenix_kit/integrations/providers.ex:337
 #, elixir-autogen, elixir-format
 msgid "From platform.openai.com/api-keys"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:370
+#: lib/phoenix_kit/integrations/providers.ex:371
 #, elixir-autogen, elixir-format
 msgid "Go to [API Keys](https://platform.openai.com/api-keys)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:359
+#: lib/phoenix_kit/integrations/providers.ex:360
 #, elixir-autogen, elixir-format
 msgid "Go to [Billing](https://platform.openai.com/account/billing/overview) and add a payment method or credits"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:672
+#: lib/phoenix_kit/integrations/providers.ex:673
 #, elixir-autogen, elixir-format
 msgid "Go to [Settings → API Keys](https://elevenlabs.io/app/settings/api-keys)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:666
+#: lib/phoenix_kit/integrations/providers.ex:667
 #, elixir-autogen, elixir-format
 msgid "Go to [elevenlabs.io](https://elevenlabs.io) and sign up or log in"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:351
+#: lib/phoenix_kit/integrations/providers.ex:352
 #, elixir-autogen, elixir-format
 msgid "Go to [platform.openai.com](https://platform.openai.com) and sign up or log in"
 msgstr ""
@@ -9360,7 +9364,7 @@ msgstr ""
 msgid "Icon"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:375
+#: lib/phoenix_kit/integrations/providers.ex:376
 #, elixir-autogen, elixir-format
 msgid "If your account belongs to multiple organizations, keys are scoped to the org selected when the key was created."
 msgstr ""
@@ -9460,12 +9464,12 @@ msgstr ""
 msgid "Open the media health dashboard to check file redundancy and re-sync files across storage locations."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:311
+#: lib/phoenix_kit/integrations/providers.ex:312
 #, elixir-autogen, elixir-format
 msgid "OpenAI"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:362
+#: lib/phoenix_kit/integrations/providers.ex:363
 #, elixir-autogen, elixir-format
 msgid "OpenAI requires a positive balance before the API will return completions, even on cheaper models"
 msgstr ""
@@ -9555,12 +9559,12 @@ msgstr ""
 msgid "Stacks"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:635
+#: lib/phoenix_kit/integrations/providers.ex:636
 #, elixir-autogen, elixir-format
 msgid "Text-to-speech and voice generation via ElevenLabs"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:678
+#: lib/phoenix_kit/integrations/providers.ex:679
 #, elixir-autogen, elixir-format
 msgid "The free tier includes a monthly character quota; paid plans raise the quota and unlock commercial use and additional voices."
 msgstr ""
@@ -10442,27 +10446,27 @@ msgstr ""
 msgid "Too many attempts. Please try again shortly."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:569
+#: lib/phoenix_kit/integrations/providers.ex:570
 #, elixir-autogen, elixir-format
 msgid "AI model access via xAI (Grok models)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:827
+#: lib/phoenix_kit/integrations/providers.ex:828
 #, elixir-autogen, elixir-format
 msgid "AWS Simple Email Service (SMTP credentials via SES API)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:826
+#: lib/phoenix_kit/integrations/providers.ex:827
 #, elixir-autogen, elixir-format
 msgid "Amazon SES"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1050
+#: lib/phoenix_kit/integrations/providers.ex:1122
 #, elixir-autogen, elixir-format
 msgid "Brevo API"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:605
+#: lib/phoenix_kit/integrations/providers.ex:606
 #, elixir-autogen, elixir-format
 msgid "Create an xAI account"
 msgstr ""
@@ -10472,37 +10476,37 @@ msgstr ""
 msgid "Email users when their account is signed in from a new device"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:961
+#: lib/phoenix_kit/integrations/providers.ex:1033
 #, elixir-autogen, elixir-format
 msgid "For Brevo: the SMTP key starting with xsmtpsib- (SMTP & API → SMTP tab) — not the API key (xkeysib-)."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:949
+#: lib/phoenix_kit/integrations/providers.ex:1021
 #, elixir-autogen, elixir-format
 msgid "For Brevo: your account's SMTP login, shown as <subaccount>@smtp-brevo.com under SMTP & API → SMTP."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1070
+#: lib/phoenix_kit/integrations/providers.ex:1142
 #, elixir-autogen, elixir-format
 msgid "From Brevo → SMTP & API → API Keys. Starts with xkeysib- — not the SMTP key (xsmtpsib-)."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:590
+#: lib/phoenix_kit/integrations/providers.ex:591
 #, elixir-autogen, elixir-format
 msgid "From console.x.ai/team/default/api-keys"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:621
+#: lib/phoenix_kit/integrations/providers.ex:622
 #, elixir-autogen, elixir-format
 msgid "Go to [API Keys](https://console.x.ai/team/default/api-keys)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:607
+#: lib/phoenix_kit/integrations/providers.ex:608
 #, elixir-autogen, elixir-format
 msgid "Go to [accounts.x.ai](https://accounts.x.ai) and sign up or log in"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:613
+#: lib/phoenix_kit/integrations/providers.ex:614
 #, elixir-autogen, elixir-format
 msgid "Go to [console.x.ai](https://console.x.ai) → Billing and add credits"
 msgstr ""
@@ -10512,43 +10516,44 @@ msgstr ""
 msgid "Login Notifications"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:927
+#: lib/phoenix_kit/integrations/providers.ex:999
 #, elixir-autogen, elixir-format
 msgid "Port"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:720
-#: lib/phoenix_kit/integrations/providers.ex:860
+#: lib/phoenix_kit/integrations/providers.ex:721
+#: lib/phoenix_kit/integrations/providers.ex:861
+#: lib/phoenix_kit/integrations/providers.ex:945
 #, elixir-autogen, elixir-format
 msgid "Region"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:904
+#: lib/phoenix_kit/integrations/providers.ex:976
 #, elixir-autogen, elixir-format
 msgid "SMTP"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:918
+#: lib/phoenix_kit/integrations/providers.ex:990
 #, elixir-autogen, elixir-format
 msgid "SMTP Host"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1051
+#: lib/phoenix_kit/integrations/providers.ex:1123
 #, elixir-autogen, elixir-format
 msgid "Send email via the Brevo transactional email API"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:906
+#: lib/phoenix_kit/integrations/providers.ex:978
 #, elixir-autogen, elixir-format
 msgid "Universal SMTP relay — works with any vendor (Brevo, Mailgun, SendGrid, a self-hosted mail server, etc). Add one named connection per relay/account."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:568
+#: lib/phoenix_kit/integrations/providers.ex:569
 #, elixir-autogen, elixir-format
 msgid "xAI"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:615
+#: lib/phoenix_kit/integrations/providers.ex:616
 #, elixir-autogen, elixir-format
 msgid "xAI requires a funded account before the API will return completions"
 msgstr ""
@@ -10722,12 +10727,12 @@ msgstr ""
 msgid "Try a different term or clear the search"
 msgstr ""
 
-#: lib/modules/storage/web/bucket_form.ex:294
+#: lib/modules/storage/web/bucket_form.ex:296
 #, elixir-autogen, elixir-format
 msgid "Add Storage Bucket"
 msgstr ""
 
-#: lib/modules/storage/web/bucket_form.ex:295
+#: lib/modules/storage/web/bucket_form.ex:297
 #, elixir-autogen, elixir-format
 msgid "Edit Storage Bucket"
 msgstr ""
@@ -10816,12 +10821,12 @@ msgstr ""
 msgid "%{provider} settings"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/validators.ex:643
+#: lib/phoenix_kit/integrations/validators.ex:824
 #, elixir-autogen, elixir-format
 msgid "%{text} · resets %{date}"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/validators.ex:632
+#: lib/phoenix_kit/integrations/validators.ex:813
 #, elixir-autogen, elixir-format
 msgid "%{type} · %{credits} credits left"
 msgstr ""
@@ -10877,12 +10882,12 @@ msgstr ""
 msgid "Allow \"Keep me logged in\" (persistent sessions)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1001
+#: lib/phoenix_kit/integrations/providers.ex:1073
 #, elixir-autogen, elixir-format
 msgid "Always"
 msgstr ""
 
-#: lib/phoenix_kit_web/users/session.ex:331
+#: lib/phoenix_kit_web/users/session.ex:333
 #, elixir-autogen, elixir-format
 msgid "An owner account cannot be used."
 msgstr ""
@@ -10892,12 +10897,12 @@ msgstr ""
 msgid "Applies site-wide wherever the rich-text editor is rendered (posts, comments). Users can still switch modes inside the editor."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:982
+#: lib/phoenix_kit/integrations/providers.ex:1054
 #, elixir-autogen, elixir-format
 msgid "Auto (from port)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:978
+#: lib/phoenix_kit/integrations/providers.ex:1050
 #, elixir-autogen, elixir-format
 msgid "Auto follows the port: 465 means implicit TLS, anything else STARTTLS (required when a login is set). Choose explicitly for a relay that ignores that convention."
 msgstr ""
@@ -10912,22 +10917,22 @@ msgstr ""
 msgid "Best,\nThe Team"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1098
+#: lib/phoenix_kit/integrations/providers.ex:1170
 #, elixir-autogen, elixir-format
 msgid "Bot Token"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1118
+#: lib/phoenix_kit/integrations/providers.ex:1190
 #, elixir-autogen, elixir-format
 msgid "BotFather replies with an HTTP API token like `123456789:ABCdef...` — copy it"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/validators.ex:601
+#: lib/phoenix_kit/integrations/validators.ex:782
 #, elixir-autogen, elixir-format
 msgid "Brevo error %{status}"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1022
+#: lib/phoenix_kit/integrations/providers.ex:1094
 #, elixir-autogen, elixir-format
 msgid "CA certificate (PEM)"
 msgstr ""
@@ -10937,7 +10942,7 @@ msgstr ""
 msgid "Cannot delete send profile"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1007
+#: lib/phoenix_kit/integrations/providers.ex:1079
 #, elixir-autogen, elixir-format
 msgid "Certificate verification"
 msgstr ""
@@ -10982,7 +10987,7 @@ msgstr ""
 msgid "Connect your own API keys and services. Only you can see these."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/validators.ex:693
+#: lib/phoenix_kit/integrations/validators.ex:874
 #, elixir-autogen, elixir-format
 msgid "Connected as @%{username}"
 msgstr ""
@@ -10998,7 +11003,7 @@ msgstr ""
 msgid "Content Editor"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1116
+#: lib/phoenix_kit/integrations/providers.ex:1188
 #, elixir-autogen, elixir-format
 msgid "Copy the bot token"
 msgstr ""
@@ -11016,12 +11021,12 @@ msgstr ""
 msgid "Could not reach AWS SES"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/validators.ex:605
+#: lib/phoenix_kit/integrations/validators.ex:786
 #, elixir-autogen, elixir-format
 msgid "Could not reach Brevo"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/validators.ex:705
+#: lib/phoenix_kit/integrations/validators.ex:886
 #, elixir-autogen, elixir-format
 msgid "Could not reach Telegram"
 msgstr ""
@@ -11082,7 +11087,7 @@ msgstr ""
 msgid "Could not update default send integration"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1109
+#: lib/phoenix_kit/integrations/providers.ex:1181
 #, elixir-autogen, elixir-format
 msgid "Create a bot with BotFather"
 msgstr ""
@@ -11158,7 +11163,7 @@ msgstr ""
 msgid "Dismiss"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1017
+#: lib/phoenix_kit/integrations/providers.ex:1089
 #, elixir-autogen, elixir-format
 msgid "Do not verify"
 msgstr ""
@@ -11190,7 +11195,7 @@ msgstr ""
 msgid "Email Sending"
 msgstr ""
 
-#: lib/phoenix_kit_web/users/confirmation_instructions.ex:109
+#: lib/phoenix_kit_web/users/confirmation_instructions.ex:111
 #, elixir-autogen, elixir-format
 msgid "Email confirmed. Welcome!"
 msgstr ""
@@ -11200,7 +11205,7 @@ msgstr ""
 msgid "Email-capable integrations"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:973
+#: lib/phoenix_kit/integrations/providers.ex:1045
 #, elixir-autogen, elixir-format
 msgid "Encryption"
 msgstr ""
@@ -11220,7 +11225,7 @@ msgstr ""
 msgid "Everyone who starts the bot"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1027
+#: lib/phoenix_kit/integrations/providers.ex:1099
 #, elixir-autogen, elixir-format
 msgid "For a private or self-signed relay certificate. Replaces the system CA store for this connection only."
 msgstr ""
@@ -11231,7 +11236,7 @@ msgstr ""
 msgid "From"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1102
+#: lib/phoenix_kit/integrations/providers.ex:1174
 #, elixir-autogen, elixir-format
 msgid "From @BotFather → /newbot (or /token for an existing bot)"
 msgstr ""
@@ -11258,7 +11263,7 @@ msgstr ""
 msgid "Hourly"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1000
+#: lib/phoenix_kit/integrations/providers.ex:1072
 #, elixir-autogen, elixir-format
 msgid "If offered (default)"
 msgstr ""
@@ -11268,7 +11273,7 @@ msgstr ""
 msgid "Immediate"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:983
+#: lib/phoenix_kit/integrations/providers.ex:1055
 #, elixir-autogen, elixir-format
 msgid "Implicit TLS / SMTPS"
 msgstr ""
@@ -11286,6 +11291,7 @@ msgid "Incomplete SMTP settings"
 msgstr ""
 
 #: lib/phoenix_kit/integrations/validators.ex:57
+#: lib/phoenix_kit/integrations/validators.ex:582
 #, elixir-autogen, elixir-format
 msgid "Incomplete credentials"
 msgstr ""
@@ -11322,7 +11328,7 @@ msgstr ""
 msgid "Invalid SMTP settings: %{reason}"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/validators.ex:698
+#: lib/phoenix_kit/integrations/validators.ex:879
 #, elixir-autogen, elixir-format
 msgid "Invalid bot token"
 msgstr ""
@@ -11342,7 +11348,7 @@ msgstr ""
 msgid "Leave a field blank to fall back to the application config or built-in default."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1038
+#: lib/phoenix_kit/integrations/providers.ex:1110
 #, elixir-autogen, elixir-format
 msgid "Leave blank for the gen_smtp default."
 msgstr ""
@@ -11383,7 +11389,7 @@ msgstr ""
 msgid "Mark read"
 msgstr ""
 
-#: lib/phoenix_kit_web/users/session.ex:340
+#: lib/phoenix_kit_web/users/session.ex:342
 #, elixir-autogen, elixir-format
 msgid "Maximum number of accounts reached — remove one first."
 msgstr ""
@@ -11433,7 +11439,7 @@ msgstr ""
 msgid "No adapter configured for the static mailer. Set one in your application config, or connect an email-capable integration below and pick it as the default transactional integration."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/validators.ex:682
+#: lib/phoenix_kit/integrations/validators.ex:863
 #, elixir-autogen, elixir-format
 msgid "No bot token configured"
 msgstr ""
@@ -11473,7 +11479,7 @@ msgstr ""
 msgid "No unread notifications"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:986
+#: lib/phoenix_kit/integrations/providers.ex:1058
 #, elixir-autogen, elixir-format
 msgid "None — plaintext"
 msgstr ""
@@ -11503,7 +11509,7 @@ msgstr ""
 msgid "Numeric ID of a verified Brevo sender. Leave empty to send from the From address above."
 msgstr ""
 
-#: lib/phoenix_kit_web/users/session.ex:334
+#: lib/phoenix_kit_web/users/session.ex:336
 #, elixir-autogen, elixir-format
 msgid "Only an owner can sign in as another administrator."
 msgstr ""
@@ -11513,12 +11519,12 @@ msgstr ""
 msgid "Only me"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1111
+#: lib/phoenix_kit/integrations/providers.ex:1183
 #, elixir-autogen, elixir-format
 msgid "Open [@BotFather](https://t.me/BotFather) in Telegram"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1121
+#: lib/phoenix_kit/integrations/providers.ex:1193
 #, elixir-autogen, elixir-format
 msgid "Paste the token into the form above and press **Test Connection**"
 msgstr ""
@@ -11538,7 +11544,7 @@ msgstr ""
 msgid "Persistent sessions last 60 days. Magic-link and social logins have no checkbox to tick, so they follow the default above. Turning the first option off hides the checkbox everywhere and keeps every login to the browser session."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/validators.ex:616
+#: lib/phoenix_kit/integrations/validators.ex:797
 #, elixir-autogen, elixir-format
 msgid "Plan: %{entries}"
 msgstr ""
@@ -11635,12 +11641,12 @@ msgstr ""
 msgid "SMTP server rejected the connection"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:985
+#: lib/phoenix_kit/integrations/providers.ex:1057
 #, elixir-autogen, elixir-format
 msgid "STARTTLS — if offered"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:984
+#: lib/phoenix_kit/integrations/providers.ex:1056
 #, elixir-autogen, elixir-format
 msgid "STARTTLS — required"
 msgstr ""
@@ -11660,7 +11666,7 @@ msgstr ""
 msgid "Select an integration..."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1112
+#: lib/phoenix_kit/integrations/providers.ex:1184
 #, elixir-autogen, elixir-format
 msgid "Send **/newbot** and follow the prompts to name your bot"
 msgstr ""
@@ -11674,7 +11680,7 @@ msgstr ""
 msgid "Send Profiles"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1087
+#: lib/phoenix_kit/integrations/providers.ex:1159
 #, elixir-autogen, elixir-format
 msgid "Send messages and notifications via your own Telegram bot"
 msgstr ""
@@ -11764,13 +11770,13 @@ msgstr ""
 msgid "Tags"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1086
+#: lib/phoenix_kit/integrations/providers.ex:1158
 #: lib/phoenix_kit/notifications/channels/telegram.ex:36
 #, elixir-autogen, elixir-format
 msgid "Telegram"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/validators.ex:701
+#: lib/phoenix_kit/integrations/validators.ex:882
 #, elixir-autogen, elixir-format
 msgid "Telegram error %{status}"
 msgstr ""
@@ -11790,17 +11796,17 @@ msgstr ""
 msgid "Test email sent to %{recipient}"
 msgstr ""
 
-#: lib/phoenix_kit_web/users/session.ex:343
+#: lib/phoenix_kit_web/users/session.ex:345
 #, elixir-autogen, elixir-format
 msgid "That account is already in your session — switch to it instead."
 msgstr ""
 
-#: lib/phoenix_kit_web/users/session.ex:337
+#: lib/phoenix_kit_web/users/session.ex:339
 #, elixir-autogen, elixir-format
 msgid "That account is deactivated."
 msgstr ""
 
-#: lib/phoenix_kit_web/users/session.ex:336
+#: lib/phoenix_kit_web/users/session.ex:338
 #, elixir-autogen, elixir-format
 msgid "That is already your account."
 msgstr ""
@@ -11841,7 +11847,7 @@ msgstr ""
 msgid "This sender address cannot be logged"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1034
+#: lib/phoenix_kit/integrations/providers.ex:1106
 #, elixir-autogen, elixir-format
 msgid "Timeout (seconds)"
 msgstr ""
@@ -11851,7 +11857,7 @@ msgstr ""
 msgid "Transport"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1012
+#: lib/phoenix_kit/integrations/providers.ex:1084
 #, elixir-autogen, elixir-format
 msgid "Turning verification off means the login travels to whoever answers, including an impostor. Use a CA certificate below instead whenever you can."
 msgstr ""
@@ -11881,12 +11887,12 @@ msgstr ""
 msgid "Used when no default transactional integration is selected below."
 msgstr ""
 
-#: lib/phoenix_kit_web/users/session.ex:309
+#: lib/phoenix_kit_web/users/session.ex:311
 #, elixir-autogen, elixir-format
 msgid "User not found."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1016
+#: lib/phoenix_kit/integrations/providers.ex:1088
 #, elixir-autogen, elixir-format
 msgid "Verify (default)"
 msgstr ""
@@ -11906,7 +11912,7 @@ msgstr ""
 msgid "Where a freshly registered account lands. Empty = after-login path."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:996
+#: lib/phoenix_kit/integrations/providers.ex:1068
 #, elixir-autogen, elixir-format
 msgid "Whether to send the login at all. “If offered” follows the relay; “Never” is for relays that authenticate by IP."
 msgstr ""
@@ -11921,12 +11927,12 @@ msgstr ""
 msgid "Yesterday"
 msgstr ""
 
-#: lib/phoenix_kit_web/users/session.ex:320
+#: lib/phoenix_kit_web/users/session.ex:322
 #, elixir-autogen, elixir-format
 msgid "You are now signed in as %{email}."
 msgstr ""
 
-#: lib/phoenix_kit_web/users/session.ex:329
+#: lib/phoenix_kit_web/users/session.ex:331
 #, elixir-autogen, elixir-format
 msgid "You do not have permission to sign in as another user."
 msgstr ""
@@ -12042,7 +12048,7 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:143
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:169
 #, elixir-autogen, elixir-format
 msgid "Copied!"
 msgstr ""
@@ -12052,7 +12058,7 @@ msgstr ""
 msgid "Couldn't reach hex.pm, so the package list is unavailable right now."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:119
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:145
 #, elixir-autogen, elixir-format
 msgid "Crawler Instructions"
 msgstr ""
@@ -12106,7 +12112,7 @@ msgstr ""
 msgid "has the robots.txt line that points crawlers here."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:173
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:199
 #, elixir-autogen, elixir-format
 msgid "priv/static/robots.txt points crawlers at your sitemap."
 msgstr ""
@@ -12210,17 +12216,17 @@ msgstr ""
 msgid "You don't have permission to manage this user's credentials"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:190
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:216
 #, elixir-autogen, elixir-format
 msgid "AI Discovery"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:698
+#: lib/phoenix_kit/integrations/providers.ex:699
 #, elixir-autogen, elixir-format
 msgid "AWS Bedrock LLMs via a Bedrock API key (OpenAI-compatible endpoint: gpt-oss models; the rest via native Converse)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:715
+#: lib/phoenix_kit/integrations/providers.ex:716
 #, elixir-autogen, elixir-format
 msgid "AWS console → Amazon Bedrock → API keys (long-term key)"
 msgstr ""
@@ -12235,22 +12241,22 @@ msgstr ""
 msgid "Account %{id}"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:303
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:329
 #, elixir-autogen, elixir-format
 msgid "Advisory-grade: anything can send any User-Agent, so a scraper that lies passes through. Real enforcement belongs at your CDN or reverse proxy — this catches the honest-but-ignorant. Bots identified only by robots.txt tokens (Google-Extended, Applebot-Extended) crawl under their main user agent and are never matched here, so blocking AI training cannot 403 Googlebot."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:98
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:124
 #, elixir-autogen, elixir-format
 msgid "Allowed"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:696
+#: lib/phoenix_kit/integrations/providers.ex:697
 #, elixir-autogen, elixir-format
 msgid "Amazon Bedrock"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:282
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:308
 #, elixir-autogen, elixir-format
 msgid "Answer 403 to requests whose User-Agent matches a blocked group, for bots that ignore robots.txt."
 msgstr ""
@@ -12260,7 +12266,7 @@ msgstr ""
 msgid "Auth mail carries single-use tokens, and /dev/mailbox has no authentication — anyone who can reach this server can read them. Only for closed environments."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:711
+#: lib/phoenix_kit/integrations/providers.ex:712
 #, elixir-autogen, elixir-format
 msgid "Bedrock API key"
 msgstr ""
@@ -12270,7 +12276,7 @@ msgstr ""
 msgid "Bedrock error %{status}"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:280
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:306
 #, elixir-autogen, elixir-format
 msgid "Block at the application"
 msgstr ""
@@ -12280,7 +12286,7 @@ msgstr ""
 msgid "Blocked groups"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:77
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:103
 #, elixir-autogen, elixir-format
 msgid "Bot Access"
 msgstr ""
@@ -12295,12 +12301,12 @@ msgstr ""
 msgid "Control how search engines and AI bots crawl and index this site"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:739
+#: lib/phoenix_kit/integrations/providers.ex:740
 #, elixir-autogen, elixir-format
 msgid "Copy the key (shown once, `ABSK…`) and paste it into the form above"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:815
+#: lib/phoenix_kit/integrations/providers.ex:816
 #, elixir-autogen, elixir-format
 msgid "Copy the token and paste it into the form above"
 msgstr ""
@@ -12341,22 +12347,22 @@ msgstr ""
 msgid "Crawlers module is disabled. Enable it from the Modules page to configure settings."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:731
+#: lib/phoenix_kit/integrations/providers.ex:732
 #, elixir-autogen, elixir-format
 msgid "Create a Bedrock API key"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:807
+#: lib/phoenix_kit/integrations/providers.ex:808
 #, elixir-autogen, elixir-format
 msgid "Create a token"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:871
+#: lib/phoenix_kit/integrations/providers.ex:872
 #, elixir-autogen, elixir-format
 msgid "Create an IAM user with SES access"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:876
+#: lib/phoenix_kit/integrations/providers.ex:877
 #, elixir-autogen, elixir-format
 msgid "Create an access key for that user (Security credentials → Create access key) and paste the ID and secret above"
 msgstr ""
@@ -12371,41 +12377,42 @@ msgstr ""
 msgid "Deliver development mail to /dev/mailbox"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:747
+#: lib/phoenix_kit/integrations/providers.ex:748
 #, elixir-autogen, elixir-format
 msgid "Enable model access"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:278
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:304
 #, elixir-autogen, elixir-format
 msgid "Enforcement"
 msgstr ""
 
 #: lib/phoenix_kit_web/live/settings/crawlers.ex:90
-#: lib/phoenix_kit_web/live/settings/crawlers.ex:109
-#: lib/phoenix_kit_web/live/settings/crawlers.ex:120
-#: lib/phoenix_kit_web/live/settings/crawlers.ex:136
-#: lib/phoenix_kit_web/live/settings/crawlers.ex:149
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:102
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:121
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:132
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:148
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:161
 #, elixir-autogen, elixir-format
 msgid "Failed to update crawler settings"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:780
+#: lib/phoenix_kit/integrations/providers.ex:781
 #, elixir-autogen, elixir-format
 msgid "GitHub"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:782
+#: lib/phoenix_kit/integrations/providers.ex:783
 #, elixir-autogen, elixir-format
 msgid "GitHub API token — org statistics, repositories (read-only is enough)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:809
+#: lib/phoenix_kit/integrations/providers.ex:810
 #, elixir-autogen, elixir-format
 msgid "Go to [Fine-grained tokens](https://github.com/settings/personal-access-tokens) and click **Generate new token**"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:81
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:107
 #, elixir-autogen, elixir-format
 msgid "Grouped by why they visit. Blocking a group writes it into the generated robots.txt below; everything defaults to allowed."
 msgstr ""
@@ -12415,22 +12422,22 @@ msgstr ""
 msgid "Hide titles of records the reader can't open"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:749
+#: lib/phoenix_kit/integrations/providers.ex:750
 #, elixir-autogen, elixir-format
 msgid "In [Bedrock → Model access](https://console.aws.amazon.com/bedrock/home#/modelaccess) enable the models you plan to call — a key with no enabled models validates but cannot complete"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:763
+#: lib/phoenix_kit/integrations/providers.ex:764
 #, elixir-autogen, elixir-format
 msgid "In the AI module, create an endpoint pointing at this connection with a `gpt-oss` model and a base URL in the SAME region as this key"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:873
+#: lib/phoenix_kit/integrations/providers.ex:874
 #, elixir-autogen, elixir-format
 msgid "In the [IAM console](https://console.aws.amazon.com/iam/home#/users) create a user for programmatic access and attach an SES policy (least privilege: `ses:SendEmail`/`ses:SendRawEmail`; docs: [SES setup](https://docs.aws.amazon.com/ses/latest/dg/setting-up.html))"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:884
+#: lib/phoenix_kit/integrations/providers.ex:885
 #, elixir-autogen, elixir-format
 msgid "In the [SES console](https://console.aws.amazon.com/ses/home#/identities) verify your domain or sender address — SES refuses to send from unverified identities"
 msgstr ""
@@ -12475,7 +12482,7 @@ msgstr ""
 msgid "Model catalog in %{region}: %{count} (grants are configured separately)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:887
+#: lib/phoenix_kit/integrations/providers.ex:888
 #, elixir-autogen, elixir-format
 msgid "New accounts start in the SES sandbox (verified recipients only) — [request production access](https://docs.aws.amazon.com/ses/latest/dg/request-production-access.html) before real sending"
 msgstr ""
@@ -12490,7 +12497,7 @@ msgstr ""
 msgid "No longer available"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:165
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:191
 #, elixir-autogen, elixir-format
 msgid "No priv/static/robots.txt found. Without one, crawlers assume everything is allowed — and any groups you blocked above are not being told."
 msgstr ""
@@ -12505,47 +12512,47 @@ msgstr ""
 msgid "Note (optional)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:733
+#: lib/phoenix_kit/integrations/providers.ex:734
 #, elixir-autogen, elixir-format
 msgid "Open the [Bedrock console → API keys](https://console.aws.amazon.com/bedrock/home#/api-keys) and generate a **long-term** key (docs: [Bedrock API keys](https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys.html))"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:212
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:238
 #, elixir-autogen, elixir-format
 msgid "Optional markdown: a summary paragraph, key links, docs pointers…"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:736
+#: lib/phoenix_kit/integrations/providers.ex:737
 #, elixir-autogen, elixir-format
 msgid "Or attach one to an existing IAM user: [IAM console](https://console.aws.amazon.com/iam/home#/users) → user → Security credentials → Bedrock API keys"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:235
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:261
 #, elixir-autogen, elixir-format
 msgid "Paste the verification content Google Search Console or Bing Webmaster Tools gives you — the meta tags are added to every layout head. Pasting the whole <meta> tag also works; the content value is extracted."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:796
+#: lib/phoenix_kit/integrations/providers.ex:797
 #, elixir-autogen, elixir-format
 msgid "Personal access token"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:123
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:149
 #, elixir-autogen, elixir-format
 msgid "PhoenixKit does not serve this file — it is yours, served from priv/static before any route is consulted. This is the complete file your toggles above describe: paste it into priv/static/robots.txt."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:752
+#: lib/phoenix_kit/integrations/providers.ex:753
 #, elixir-autogen, elixir-format
 msgid "Pick the region where access was granted; the AI endpoint's base URL must use the same region"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:217
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:243
 #, elixir-autogen, elixir-format
 msgid "Preview of the served file:"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:812
+#: lib/phoenix_kit/integrations/providers.ex:813
 #, elixir-autogen, elixir-format
 msgid "Repository access: **Public repositories (read-only)** — no extra permissions needed for public-org statistics"
 msgstr ""
@@ -12555,7 +12562,7 @@ msgstr ""
 msgid "Request access"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:233
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:259
 #, elixir-autogen, elixir-format
 msgid "Search engine verification"
 msgstr ""
@@ -12575,12 +12582,12 @@ msgstr ""
 msgid "Sign in to request access."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:760
+#: lib/phoenix_kit/integrations/providers.ex:761
 #, elixir-autogen, elixir-format
 msgid "The OpenAI-compatible endpoint (`…/openai/v1`) currently serves only the `openai.gpt-oss-*` models — Anthropic and the other Bedrock models answer on the native Converse API with the same key"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:742
+#: lib/phoenix_kit/integrations/providers.ex:743
 #, elixir-autogen, elixir-format
 msgid "The key's IAM identity must allow the `bedrock:CallWithBearerToken` action — without it every Bearer call answers 403 even when invoke permissions are in place."
 msgstr ""
@@ -12590,17 +12597,17 @@ msgstr ""
 msgid "The mailbox is off: outgoing mail is written to the server log instead."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:179
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:205
 #, elixir-autogen, elixir-format
 msgid "The noindex toggle and robots.txt are separate mechanisms: noindex is a per-page meta tag that tells crawlers not to index what they fetched, while robots.txt tells them what not to fetch at all. A staging site usually wants both."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:194
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:220
 #, elixir-autogen, elixir-format
 msgid "The other half of bot policy: a markdown summary telling AI assistants what this site is about, served at"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:892
+#: lib/phoenix_kit/integrations/providers.ex:893
 #, elixir-autogen, elixir-format
 msgid "This connection stores the credential. The full sending pipeline — configuration set, SNS topic, SQS event queue, delivery tracking — is configured in Admin → Settings → Emails, which can select this connection as its credential source."
 msgstr ""
@@ -12617,22 +12624,22 @@ msgstr ""
 msgid "Unread · %{day}"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:758
+#: lib/phoenix_kit/integrations/providers.ex:759
 #, elixir-autogen, elixir-format
 msgid "Use it from the AI module"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:231
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:257
 #, elixir-autogen, elixir-format
 msgid "Verification"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.ex:133
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:145
 #, elixir-autogen, elixir-format
 msgid "Verification tags saved."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:882
+#: lib/phoenix_kit/integrations/providers.ex:883
 #, elixir-autogen, elixir-format
 msgid "Verify a sender in SES"
 msgstr ""
@@ -12647,7 +12654,7 @@ msgstr ""
 msgid "Where development mail goes while the resolved transport is the local adapter."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:79
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "Who may crawl this site"
 msgstr ""
@@ -12667,12 +12674,12 @@ msgstr ""
 msgid "You don't have access — click to request it"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:800
+#: lib/phoenix_kit/integrations/providers.ex:801
 #, elixir-autogen, elixir-format
 msgid "github.com/settings/personal-access-tokens — fine-grained, read-only"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.ex:146
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:158
 #, elixir-autogen, elixir-format
 msgid "llms.txt content saved."
 msgstr ""
@@ -12682,7 +12689,7 @@ msgstr ""
 msgid "management API: %{services}"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:169
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:195
 #, elixir-autogen, elixir-format
 msgid "priv/static/robots.txt exists but has no Sitemap: line. Paste the file above so crawlers are told where to look."
 msgstr ""
@@ -12692,7 +12699,7 @@ msgstr ""
 msgid "private item"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:200
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:226
 #, elixir-autogen, elixir-format
 msgid "while this module is enabled. The heading comes from your project title; everything below it is yours."
 msgstr ""
@@ -12746,7 +12753,7 @@ msgstr ""
 msgid "Select Avatar"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:701
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:716
 #, elixir-autogen, elixir-format
 msgid "Select Background Image"
 msgstr ""
@@ -12763,7 +12770,7 @@ msgstr ""
 
 #: lib/phoenix_kit_web/components/media_browser.html.heex:2469
 #: lib/phoenix_kit_web/live/settings.html.heex:636
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:702
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:717
 #, elixir-autogen, elixir-format
 msgid "Select Logo"
 msgstr ""
@@ -12861,4 +12868,423 @@ msgstr ""
 #: lib/phoenix_kit_web/live/settings/integrations.ex:231
 #, elixir-autogen, elixir-format
 msgid "The current encryption status could not be described by this admin page — it may be newer than what this page recognizes. Check PhoenixKit.Integrations.Encryption.status/0 directly."
+msgstr ""
+
+#: lib/phoenix_kit_web/live/settings/authorization.ex:247
+#, elixir-autogen, elixir-format
+msgid "A secret is already configured — leave blank to keep the current value"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:365
+#: lib/phoenix_kit_web/users/session.ex:245
+#, elixir-autogen, elixir-format
+msgid "Account added."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/session.ex:27
+#, elixir-autogen, elixir-format
+msgid "Account created successfully!"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/session.ex:356
+#, elixir-autogen, elixir-format
+msgid "Account removed."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:272
+#, elixir-autogen, elixir-format
+msgid "Account switching is currently disabled."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:316
+#, elixir-autogen, elixir-format
+msgid "An account already exists for that email address. Sign in with your password first, then connect this provider from your account settings."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:328
+#, elixir-autogen, elixir-format
+msgid "Authentication failed. Please try again or use a different sign-in method."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:355
+#: lib/phoenix_kit_web/users/oauth.ex:438
+#: lib/phoenix_kit_web/users/oauth.ex:444
+#, elixir-autogen, elixir-format
+msgid "Authentication failed. Please try again."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:299
+#, elixir-autogen, elixir-format
+msgid "Authentication failed: %{errors}"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:441
+#, elixir-autogen, elixir-format
+msgid "Authentication failed: %{message}"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/session.ex:360
+#, elixir-autogen, elixir-format
+msgid "Cannot remove your primary account."
+msgstr ""
+
+#: lib/phoenix_kit_web/controllers/context_controller.ex:101
+#, elixir-autogen, elixir-format
+msgid "Context switching is not enabled"
+msgstr ""
+
+#: lib/phoenix_kit/integrations/validators.ex:627
+#: lib/phoenix_kit/integrations/validators.ex:634
+#: lib/phoenix_kit/integrations/validators.ex:732
+#: lib/phoenix_kit/integrations/validators.ex:740
+#, elixir-autogen, elixir-format
+msgid "Could not reach the storage endpoint"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/session.ex:365
+#, elixir-autogen, elixir-format
+msgid "Could not remove account."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/session.ex:274
+#, elixir-autogen, elixir-format
+msgid "Could not switch account."
+msgstr ""
+
+#: lib/phoenix_kit/integrations/validators.ex:721
+#, elixir-autogen, elixir-format
+msgid "Credentials are valid, but not authorized to list buckets"
+msgstr ""
+
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:85
+#, elixir-autogen, elixir-format
+msgid "Exempt"
+msgstr ""
+
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:86
+#, elixir-autogen, elixir-format
+msgid "Follows noindex"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link.ex:120
+#, elixir-autogen, elixir-format
+msgid "If that email address exists, a magic link has been sent."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/confirmation_instructions.ex:89
+#, elixir-autogen, elixir-format
+msgid "If your email is in our system and it has not been confirmed yet, you will receive an email with instructions shortly."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/forgot_password.ex:49
+#, elixir-autogen, elixir-format
+msgid "If your email is in our system, you will receive instructions to reset your password shortly."
+msgstr ""
+
+#: lib/phoenix_kit_web/controllers/context_controller.ex:82
+#, elixir-autogen, elixir-format
+msgid "Invalid context"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:110
+#, elixir-autogen, elixir-format
+msgid "Invalid email format"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/session.ex:92
+#, elixir-autogen, elixir-format
+msgid "Invalid email/username or password"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/session.ex:259
+#, elixir-autogen, elixir-format
+msgid "Invalid email/username or password."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_verify.ex:40
+#, elixir-autogen, elixir-format
+msgid "Invalid magic link. Please request a new one."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration_verify.ex:32
+#, elixir-autogen, elixir-format
+msgid "Invalid registration link. Please request a new one."
+msgstr ""
+
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:77
+#, elixir-autogen, elixir-format
+msgid "Keep publishing the sitemap's real URLs even while noindex is on, so the feed can be verified without exposing the site to indexing. The noindex meta tag above is unaffected either way."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/session.ex:104
+#, elixir-autogen, elixir-format
+msgid "Logged out of all accounts."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/session.ex:122
+#: lib/phoenix_kit_web/users/session.ex:235
+#, elixir-autogen, elixir-format
+msgid "Logged out successfully."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_verify.ex:63
+#, elixir-autogen, elixir-format
+msgid "Magic link is invalid or has expired. Please request a new one."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration.ex:41
+#, elixir-autogen, elixir-format
+msgid "Magic link registration is currently disabled."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link.ex:110
+#, elixir-autogen, elixir-format
+msgid "Magic link sent! Check your email."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link.ex:39
+#: lib/phoenix_kit_web/users/magic_link_verify.ex:33
+#, elixir-autogen, elixir-format
+msgid "Magic link sign-in is currently disabled."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:370
+#: lib/phoenix_kit_web/users/session.ex:249
+#, elixir-autogen, elixir-format
+msgid "Maximum number of accounts reached."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/session.ex:137
+#, elixir-autogen, elixir-format
+msgid "Multi-account switching is not available."
+msgstr ""
+
+#: lib/phoenix_kit/integrations/providers.ex:950
+#, elixir-autogen, elixir-format
+msgid "Not every S3-compatible provider needs one — leave blank if the endpoint doesn't require it."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:119
+#, elixir-autogen, elixir-format
+msgid "OAuth authentication is currently disabled. Please contact your administrator to enable it."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:94
+#, elixir-autogen, elixir-format
+msgid "OAuth provider '%{provider}' is currently disabled."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:106
+#, elixir-autogen, elixir-format
+msgid "OAuth provider '%{provider}' is not configured. Please contact your administrator."
+msgstr ""
+
+#: lib/phoenix_kit/integrations/providers.ex:913
+#, elixir-autogen, elixir-format
+msgid "Object Storage (S3-compatible)"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/reset_password.ex:41
+#, elixir-autogen, elixir-format
+msgid "Password reset successfully."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/session.ex:34
+#, elixir-autogen, elixir-format
+msgid "Password updated successfully!"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration.ex:35
+#: lib/phoenix_kit_web/users/registration.ex:128
+#, elixir-autogen, elixir-format
+msgid "Registration is currently disabled."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration.ex:92
+#, elixir-autogen, elixir-format
+msgid "Registration link is invalid or has expired."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration.ex:188
+#: lib/phoenix_kit_web/users/magic_link_registration_verify.ex:24
+#, elixir-autogen, elixir-format
+msgid "Registration link is invalid or has expired. Please request a new one."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:92
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:103
+#, elixir-autogen, elixir-format
+msgid "Registration link sent! Check your email."
+msgstr ""
+
+#: lib/phoenix_kit/integrations/providers.ex:962
+#, elixir-autogen, elixir-format
+msgid "Required for Cloudflare R2, Backblaze B2, Tigris, and self-hosted S3-compatible storage. Leave blank for AWS S3."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/reset_password.ex:59
+#, elixir-autogen, elixir-format
+msgid "Reset password link is invalid or it has expired."
+msgstr ""
+
+#: lib/phoenix_kit/integrations/providers.ex:915
+#, elixir-autogen, elixir-format
+msgid "S3-compatible object storage — AWS S3, Cloudflare R2, Backblaze B2, Tigris, or a self-hosted endpoint"
+msgstr ""
+
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:75
+#, elixir-autogen, elixir-format
+msgid "Sitemap Exemption"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:144
+#, elixir-autogen, elixir-format
+msgid "Something went wrong"
+msgstr ""
+
+#: lib/phoenix_kit/integrations/validators.ex:735
+#, elixir-autogen, elixir-format
+msgid "Storage error: %{code}"
+msgstr ""
+
+#: lib/phoenix_kit/integrations/validators.ex:729
+#, elixir-autogen, elixir-format
+msgid "Storage service is busy — try again in a moment"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_verify.ex:56
+#, elixir-autogen, elixir-format
+msgid "Successfully logged in with magic link!"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:277
+#, elixir-autogen, elixir-format
+msgid "Successfully signed in with %{provider}!"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:375
+#: lib/phoenix_kit_web/users/session.ex:254
+#, elixir-autogen, elixir-format
+msgid "That account is already in your session."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:380
+#, elixir-autogen, elixir-format
+msgid "That account is inactive."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration.ex:185
+#, elixir-autogen, elixir-format
+msgid "That email is already registered. Please log in instead."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:118
+#, elixir-autogen, elixir-format
+msgid "Too many attempts"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/session.ex:84
+#, elixir-autogen, elixir-format
+msgid "Too many login attempts. Please try again later."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:84
+#: lib/phoenix_kit_web/users/oauth.ex:210
+#, elixir-autogen, elixir-format
+msgid "Unknown OAuth provider: %{provider}"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/confirmation.ex:68
+#, elixir-autogen, elixir-format
+msgid "User confirmation link is invalid or it has expired."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/confirmation.ex:50
+#, elixir-autogen, elixir-format
+msgid "User confirmed successfully."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:77
+#, elixir-autogen, elixir-format
+msgid "User registration is currently disabled."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:51
+#: lib/phoenix_kit_web/users/registration.ex:110
+#, elixir-autogen, elixir-format
+msgid "User registration is currently disabled. Please contact an administrator."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/session.ex:40
+#, elixir-autogen, elixir-format
+msgid "Welcome back!"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/session.ex:66
+#, elixir-autogen, elixir-format
+msgid "Your account is currently inactive. Please contact the team if you believe this is an error."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:1873
+#, elixir-autogen, elixir-format
+msgid "%{label} module is not enabled"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:2366
+#, elixir-autogen, elixir-format
+msgid "Enter your referral code to continue."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:2362
+#, elixir-autogen, elixir-format
+msgid "Please confirm your email before accessing the application."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:111
+#, elixir-autogen, elixir-format
+msgid "This account is not active. Contact an administrator."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:749
+#: lib/phoenix_kit_web/users/auth.ex:1892
+#: lib/phoenix_kit_web/users/auth.ex:2511
+#, elixir-autogen, elixir-format
+msgid "You do not have permission to access this section."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:724
+#: lib/phoenix_kit_web/users/auth.ex:878
+#: lib/phoenix_kit_web/users/auth.ex:2460
+#: lib/phoenix_kit_web/users/auth.ex:2496
+#, elixir-autogen, elixir-format
+msgid "You do not have the required permission to access this page."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:1417
+#, elixir-autogen, elixir-format
+msgid "You must be an admin to access this page."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:679
+#: lib/phoenix_kit_web/users/auth.ex:2423
+#, elixir-autogen, elixir-format
+msgid "You must be an owner to access this page."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:2539
+#, elixir-autogen, elixir-format
+msgid "You must have the %{role_name} role to access this page."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:903
+#: lib/phoenix_kit_web/users/auth.ex:2292
+#: lib/phoenix_kit_web/users/auth.ex:2329
+#: lib/phoenix_kit_web/users/auth.ex:2467
+#, elixir-autogen, elixir-format
+msgid "You must log in to access this page."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:1428
+#, elixir-autogen, elixir-format
+msgid "You no longer have permission to access this section."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -69,7 +69,7 @@ msgstr ""
 
 #: lib/phoenix_kit/dashboard/admin_tabs.ex:119
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:138
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:647
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:662
 #: lib/phoenix_kit_web/live/settings/users.html.heex:130
 #, elixir-autogen
 msgid "Sessions"
@@ -235,7 +235,7 @@ msgstr ""
 
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:320
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:64
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:144
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:140
 #, elixir-autogen
 msgid "Anonymous"
 msgstr ""
@@ -248,7 +248,7 @@ msgstr ""
 
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:331
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:77
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:151
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:144
 #, elixir-autogen
 msgid "Authenticated"
 msgstr ""
@@ -345,7 +345,7 @@ msgstr ""
 msgid "Role System"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:991
+#: lib/phoenix_kit/integrations/providers.ex:1063
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:450
 #, elixir-autogen
 msgid "Authentication"
@@ -357,7 +357,7 @@ msgstr ""
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:445
 #: lib/phoenix_kit_web/live/modules.html.heex:65
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:114
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:273
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:267
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:145
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:297
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:682
@@ -463,8 +463,8 @@ msgstr ""
 msgid "Accept All"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/integrations.ex:1133
-#: lib/phoenix_kit/integrations/validators.ex:598
+#: lib/phoenix_kit/integrations/integrations.ex:1136
+#: lib/phoenix_kit/integrations/validators.ex:779
 #: lib/phoenix_kit_web/live/activity/index.ex:66
 #: lib/phoenix_kit_web/live/activity/show.ex:56
 #, elixir-autogen, elixir-format
@@ -502,7 +502,7 @@ msgid "Actions"
 msgstr ""
 
 #: lib/phoenix_kit_web/components/media_gallery.html.heex:86
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:585
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:600
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:266
 #: lib/phoenix_kit_web/live/settings/users.html.heex:693
 #: lib/phoenix_kit_web/users/user_form.html.heex:719
@@ -610,7 +610,7 @@ msgstr ""
 msgid "Billing profiles and payment methods"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:98
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:124
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:501
 #, elixir-autogen, elixir-format
 msgid "Blocked"
@@ -1550,7 +1550,7 @@ msgstr ""
 msgid "Page published successfully"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:956
+#: lib/phoenix_kit/integrations/providers.ex:1028
 #: lib/phoenix_kit_web/components/user_dashboard_nav.ex:277
 #: lib/phoenix_kit_web/users/login.html.heex:39
 #: lib/phoenix_kit_web/users/magic_link_registration.html.heex:42
@@ -1811,8 +1811,8 @@ msgstr ""
 #: lib/phoenix_kit_web/components/core/markdown_editor.ex:440
 #: lib/phoenix_kit_web/components/media_browser.html.heex:1349
 #: lib/phoenix_kit_web/live/notifications/settings.ex:436
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:219
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:267
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:245
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:293
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr ""
@@ -1855,7 +1855,7 @@ msgstr ""
 #: lib/phoenix_kit_web/components/core/markdown_editor.ex:333
 #: lib/phoenix_kit_web/components/core/markdown_editor.ex:417
 #: lib/phoenix_kit_web/live/settings.html.heex:592
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:683
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:698
 #: lib/phoenix_kit_web/live/settings/users.html.heex:546
 #, elixir-autogen, elixir-format
 msgid "Saving..."
@@ -1942,7 +1942,7 @@ msgstr ""
 #: lib/phoenix_kit_web/live/settings/users.html.heex:367
 #: lib/phoenix_kit_web/live/settings/users.html.heex:408
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:114
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:199
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:193
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:247
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:294
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:650
@@ -2048,7 +2048,7 @@ msgstr ""
 #: lib/phoenix_kit_web/live/settings/users.html.heex:361
 #: lib/phoenix_kit_web/live/settings/users.html.heex:404
 #: lib/phoenix_kit_web/live/settings/users.html.heex:602
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:192
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:186
 #: lib/phoenix_kit_web/live/users/roles.html.heex:92
 #: lib/phoenix_kit_web/live/users/roles.html.heex:160
 #, elixir-autogen, elixir-format
@@ -2064,7 +2064,7 @@ msgstr ""
 #: lib/phoenix_kit_web/components/core/time_display.ex:183
 #: lib/phoenix_kit_web/components/language_switcher.ex:832
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:108
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:255
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:249
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr ""
@@ -2122,7 +2122,7 @@ msgstr ""
 msgid "User-defined roles"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:944
+#: lib/phoenix_kit/integrations/providers.ex:1016
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:255
 #: lib/phoenix_kit_web/users/magic_link_registration.html.heex:30
 #: lib/phoenix_kit_web/users/registration.html.heex:69
@@ -2440,22 +2440,22 @@ msgstr ""
 msgid "(registration disabled)"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:622
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:637
 #, elixir-autogen, elixir-format
 msgid "1. Enable the provider above and save settings"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:623
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:638
 #, elixir-autogen, elixir-format
 msgid "2. Enter your OAuth credentials in the form that appears"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:624
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:639
 #, elixir-autogen, elixir-format
 msgid "3. Save settings again to store credentials"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:625
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:640
 #, elixir-autogen, elixir-format
 msgid "4. Click \"Test Credentials\" to verify configuration"
 msgstr ""
@@ -2466,7 +2466,8 @@ msgid "Access Credentials"
 msgstr ""
 
 #: lib/modules/storage/web/bucket_form.html.heex:227
-#: lib/phoenix_kit/integrations/providers.ex:842
+#: lib/phoenix_kit/integrations/providers.ex:843
+#: lib/phoenix_kit/integrations/providers.ex:927
 #, elixir-autogen, elixir-format
 msgid "Access Key ID"
 msgstr ""
@@ -2516,9 +2517,9 @@ msgstr ""
 msgid "Add Video Dimension"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:429
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:507
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:592
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:434
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:517
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:607
 #, elixir-autogen, elixir-format
 msgid "Add callback URL above to"
 msgstr ""
@@ -2550,12 +2551,12 @@ msgstr ""
 msgid "Anyone can register"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:541
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:551
 #, elixir-autogen, elixir-format
 msgid "App ID"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:551
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:561
 #, elixir-autogen, elixir-format
 msgid "App Secret"
 msgstr ""
@@ -2674,7 +2675,7 @@ msgstr ""
 msgid "CSS color or gradient for auth page background. Ignored if a background image is set."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.ex:261
+#: lib/phoenix_kit_web/live/settings/authorization.ex:302
 #, elixir-autogen, elixir-format
 msgid "Callback URL"
 msgstr ""
@@ -2684,25 +2685,25 @@ msgstr ""
 msgid "Changes will be saved immediately"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:434
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:511
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:518
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:609
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:439
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:521
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:528
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:624
 #, elixir-autogen, elixir-format
 msgid "Click"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:215
+#: lib/phoenix_kit/integrations/providers.ex:216
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:378
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:458
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:463
 #, elixir-autogen, elixir-format
 msgid "Client ID"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:224
-#: lib/phoenix_kit/integrations/providers.ex:1169
+#: lib/phoenix_kit/integrations/providers.ex:225
+#: lib/phoenix_kit/integrations/providers.ex:1241
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:388
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:468
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:473
 #, elixir-autogen, elixir-format
 msgid "Client Secret"
 msgstr ""
@@ -2733,34 +2734,34 @@ msgstr ""
 msgid "Consider \"User\" for most installations to maintain security."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:514
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:599
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:142
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:524
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:614
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:168
 #, elixir-autogen, elixir-format
 msgid "Copy"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:432
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:437
 #, elixir-autogen, elixir-format
 msgid "Copy Client ID and Secret to fields above"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:568
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:583
 #, elixir-autogen, elixir-format
 msgid "Copy this URL to Facebook App Settings"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:485
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:495
 #, elixir-autogen, elixir-format
 msgid "Copy this URL to GitHub OAuth Apps"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:405
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:410
 #, elixir-autogen, elixir-format
 msgid "Copy this URL to Google Cloud Console"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.ex:271
+#: lib/phoenix_kit_web/live/settings/authorization.ex:312
 #, elixir-autogen, elixir-format
 msgid "Copy to clipboard"
 msgstr ""
@@ -2785,12 +2786,12 @@ msgstr ""
 msgid "Create Your First Bucket"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:582
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:597
 #, elixir-autogen, elixir-format
 msgid "Create a new app or select existing one"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:418
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:423
 #, elixir-autogen, elixir-format
 msgid "Create project or select existing one"
 msgstr ""
@@ -2861,11 +2862,12 @@ msgid "Enable OAuth (Master Switch)"
 msgstr ""
 
 #: lib/modules/storage/web/bucket_form.html.heex:194
+#: lib/phoenix_kit/integrations/providers.ex:957
 #, elixir-autogen, elixir-format
 msgid "Endpoint"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:503
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:513
 #, elixir-autogen, elixir-format
 msgid "Enter"
 msgstr ""
@@ -2900,7 +2902,7 @@ msgstr ""
 msgid "FFmpeg is required for video processing, transcoding, and thumbnail generation."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:532
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:542
 #, elixir-autogen, elixir-format
 msgid "Facebook OAuth Credentials"
 msgstr ""
@@ -2943,7 +2945,7 @@ msgstr ""
 msgid "Format Override:"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:449
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:454
 #, elixir-autogen, elixir-format
 msgid "GitHub OAuth Credentials"
 msgstr ""
@@ -2953,10 +2955,10 @@ msgstr ""
 msgid "GitHub Sign-In"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:420
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:499
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:588
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:596
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:425
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:509
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:603
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:611
 #, elixir-autogen, elixir-format
 msgid "Go to"
 msgstr ""
@@ -2986,7 +2988,7 @@ msgstr ""
 msgid "How times are displayed"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.ex:296
+#: lib/phoenix_kit_web/live/settings/authorization.ex:337
 #, elixir-autogen, elixir-format
 msgid "If behind nginx/apache, ensure"
 msgstr ""
@@ -3173,7 +3175,7 @@ msgstr ""
 msgid "Note"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:627
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:642
 #, elixir-autogen, elixir-format
 msgid "Note: OAuth providers require ueberauth dependencies to be installed."
 msgstr ""
@@ -3188,7 +3190,7 @@ msgstr ""
 msgid "OAuth Providers"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:620
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:635
 #, elixir-autogen, elixir-format
 msgid "OAuth Setup Instructions"
 msgstr ""
@@ -3261,7 +3263,7 @@ msgstr ""
 msgid "Redundancy Copies"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:642
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:657
 #, elixir-autogen, elixir-format
 msgid "Reload OAuth Configuration"
 msgstr ""
@@ -3288,7 +3290,7 @@ msgstr ""
 msgid "Resolution"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.ex:294
+#: lib/phoenix_kit_web/live/settings/authorization.ex:335
 #, elixir-autogen, elixir-format
 msgid "Reverse Proxy Users:"
 msgstr ""
@@ -3314,7 +3316,7 @@ msgstr ""
 msgid "Save All Settings"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:685
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:700
 #, elixir-autogen, elixir-format
 msgid "Save Authorization Settings"
 msgstr ""
@@ -3330,7 +3332,8 @@ msgid "Search engines are instructed to skip this environment. Remove this befor
 msgstr ""
 
 #: lib/modules/storage/web/bucket_form.html.heex:241
-#: lib/phoenix_kit/integrations/providers.ex:851
+#: lib/phoenix_kit/integrations/providers.ex:852
+#: lib/phoenix_kit/integrations/providers.ex:936
 #, elixir-autogen, elixir-format
 msgid "Secret Access Key"
 msgstr ""
@@ -3347,7 +3350,7 @@ msgstr ""
 
 #: lib/phoenix_kit_web/components/media_browser.html.heex:1180
 #: lib/phoenix_kit_web/components/media_browser.html.heex:1182
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:425
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:430
 #, elixir-autogen, elixir-format
 msgid "Select"
 msgstr ""
@@ -3377,7 +3380,7 @@ msgid "Set"
 msgstr ""
 
 #: lib/phoenix_kit_web/components/core/integrations_ui.ex:311
-#: lib/phoenix_kit_web/live/settings/authorization.ex:249
+#: lib/phoenix_kit_web/live/settings/authorization.ex:290
 #: lib/phoenix_kit_web/live/settings/integration_form.html.heex:378
 #, elixir-autogen, elixir-format
 msgid "Setup Instructions"
@@ -3414,7 +3417,7 @@ msgstr ""
 msgid "Success!"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:604
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:619
 #, elixir-autogen, elixir-format
 msgid "Switch app from"
 msgstr ""
@@ -3439,9 +3442,9 @@ msgstr ""
 msgid "Target Width (px)"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:400
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:480
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:563
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:405
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:490
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:578
 #, elixir-autogen, elixir-format
 msgid "Test Credentials"
 msgstr ""
@@ -3521,7 +3524,7 @@ msgstr ""
 msgid "User Editable"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/users.ex:35
+#: lib/phoenix_kit_web/live/settings/users.ex:42
 #: lib/phoenix_kit_web/live/settings/users.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "User Settings"
@@ -3563,9 +3566,9 @@ msgstr ""
 msgid "Videos use CRF 0-51 scale (lower = higher quality)"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:409
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:489
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:572
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:414
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:499
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:587
 #, elixir-autogen, elixir-format
 msgid "Visit"
 msgstr ""
@@ -3610,22 +3613,22 @@ msgstr ""
 msgid "Would you like to create it now?"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:542
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:552
 #, elixir-autogen, elixir-format
 msgid "Your Facebook App ID"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:552
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:565
 #, elixir-autogen, elixir-format
 msgid "Your Facebook App Secret"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:459
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:464
 #, elixir-autogen, elixir-format
 msgid "Your GitHub OAuth Client ID"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:469
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:477
 #, elixir-autogen, elixir-format
 msgid "Your GitHub OAuth Client Secret"
 msgstr ""
@@ -3635,19 +3638,19 @@ msgstr ""
 msgid "Your Google OAuth Client ID"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:389
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:392
 #, elixir-autogen, elixir-format
 msgid "Your Google OAuth Client Secret"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:504
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:600
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:514
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:615
 #: lib/phoenix_kit_web/live/settings/integrations.ex:167
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:515
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:525
 #, elixir-autogen, elixir-format
 msgid "and generate/copy"
 msgstr ""
@@ -3668,12 +3671,12 @@ msgstr ""
 msgid "files"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.ex:300
+#: lib/phoenix_kit_web/live/settings/authorization.ex:341
 #, elixir-autogen, elixir-format
 msgid "header is set to"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:606
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:621
 #, elixir-autogen, elixir-format
 msgid "mode"
 msgstr ""
@@ -3683,12 +3686,12 @@ msgstr ""
 msgid "option(s)"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:585
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:600
 #, elixir-autogen, elixir-format
 msgid "product"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:605
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:620
 #, elixir-autogen, elixir-format
 msgid "to"
 msgstr ""
@@ -3698,19 +3701,19 @@ msgstr ""
 msgid "to every PhoenixKit layout, blocking crawlers from indexing or following links."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:601
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:616
 #, elixir-autogen, elixir-format
 msgid "to fields above"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:435
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:519
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:610
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:440
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:529
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:625
 #, elixir-autogen, elixir-format
 msgid "to verify setup"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:426
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:431
 #, elixir-autogen, elixir-format
 msgid "type"
 msgstr ""
@@ -3845,7 +3848,7 @@ msgstr ""
 msgid "A unique name to identify this dimension preset"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:388
+#: lib/phoenix_kit/integrations/providers.ex:389
 #, elixir-autogen, elixir-format
 msgid "AI model access via OpenRouter (100+ models)"
 msgstr ""
@@ -3855,13 +3858,13 @@ msgstr ""
 msgid "API Credentials"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:332
-#: lib/phoenix_kit/integrations/providers.ex:402
-#: lib/phoenix_kit/integrations/providers.ex:460
-#: lib/phoenix_kit/integrations/providers.ex:523
-#: lib/phoenix_kit/integrations/providers.ex:586
-#: lib/phoenix_kit/integrations/providers.ex:653
-#: lib/phoenix_kit/integrations/providers.ex:1065
+#: lib/phoenix_kit/integrations/providers.ex:333
+#: lib/phoenix_kit/integrations/providers.ex:403
+#: lib/phoenix_kit/integrations/providers.ex:461
+#: lib/phoenix_kit/integrations/providers.ex:524
+#: lib/phoenix_kit/integrations/providers.ex:587
+#: lib/phoenix_kit/integrations/providers.ex:654
+#: lib/phoenix_kit/integrations/providers.ex:1137
 #, elixir-autogen, elixir-format
 msgid "API Key"
 msgstr ""
@@ -3922,7 +3925,7 @@ msgstr ""
 msgid "Add Integration"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:431
+#: lib/phoenix_kit/integrations/providers.ex:432
 #, elixir-autogen, elixir-format
 msgid "Add credits (optional)"
 msgstr ""
@@ -3957,7 +3960,7 @@ msgstr ""
 msgid "Alternative Formats"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:285
+#: lib/phoenix_kit/integrations/providers.ex:286
 #, elixir-autogen, elixir-format
 msgid "Application type: **Web application** (do not select \"Desktop app\" — it won't support redirect URIs)"
 msgstr ""
@@ -4079,18 +4082,18 @@ msgstr ""
 msgid "Clear Schedule"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:284
+#: lib/phoenix_kit/integrations/providers.ex:285
 #, elixir-autogen, elixir-format
 msgid "Click **Create Credentials → OAuth client ID**"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:425
+#: lib/phoenix_kit/integrations/providers.ex:426
 #, elixir-autogen, elixir-format
 msgid "Click **Create Key**"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:295
-#: lib/phoenix_kit/integrations/providers.ex:1248
+#: lib/phoenix_kit/integrations/providers.ex:296
+#: lib/phoenix_kit/integrations/providers.ex:1320
 #, elixir-autogen, elixir-format
 msgid "Click **Save**, then **Connect Account**"
 msgstr ""
@@ -4140,8 +4143,8 @@ msgstr ""
 msgid "Connect Account"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:293
-#: lib/phoenix_kit/integrations/providers.ex:1246
+#: lib/phoenix_kit/integrations/providers.ex:294
+#: lib/phoenix_kit/integrations/providers.ex:1318
 #, elixir-autogen, elixir-format
 msgid "Connect and authorize"
 msgstr ""
@@ -4161,7 +4164,7 @@ msgstr ""
 #: lib/phoenix_kit_web/live/settings/integration_form.html.heex:327
 #: lib/phoenix_kit_web/live/settings/integrations.ex:181
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:111
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:197
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:191
 #, elixir-autogen, elixir-format
 msgid "Connected"
 msgstr ""
@@ -4202,48 +4205,48 @@ msgstr ""
 msgid "Connection verified"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:289
+#: lib/phoenix_kit/integrations/providers.ex:290
 #, elixir-autogen, elixir-format
 msgid "Copy the **Client ID** and **Client Secret** into the form above"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:427
+#: lib/phoenix_kit/integrations/providers.ex:428
 #, elixir-autogen, elixir-format
 msgid "Copy the key and paste it into the form above"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/integrations.ex:1135
+#: lib/phoenix_kit/integrations/integrations.ex:1138
 #: lib/phoenix_kit/integrations/probe.ex:102
 #, elixir-autogen, elixir-format
 msgid "Could not reach the service"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:235
+#: lib/phoenix_kit/integrations/providers.ex:236
 #, elixir-autogen, elixir-format
 msgid "Create a Google Cloud project"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:238
+#: lib/phoenix_kit/integrations/providers.ex:239
 #, elixir-autogen, elixir-format
 msgid "Create a new project or select an existing one"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:368
-#: lib/phoenix_kit/integrations/providers.ex:423
-#: lib/phoenix_kit/integrations/providers.ex:493
-#: lib/phoenix_kit/integrations/providers.ex:553
-#: lib/phoenix_kit/integrations/providers.ex:619
-#: lib/phoenix_kit/integrations/providers.ex:670
+#: lib/phoenix_kit/integrations/providers.ex:369
+#: lib/phoenix_kit/integrations/providers.ex:424
+#: lib/phoenix_kit/integrations/providers.ex:494
+#: lib/phoenix_kit/integrations/providers.ex:554
+#: lib/phoenix_kit/integrations/providers.ex:620
+#: lib/phoenix_kit/integrations/providers.ex:671
 #, elixir-autogen, elixir-format
 msgid "Create an API key"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:279
+#: lib/phoenix_kit/integrations/providers.ex:280
 #, elixir-autogen, elixir-format
 msgid "Create an OAuth Client"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:416
+#: lib/phoenix_kit/integrations/providers.ex:417
 #, elixir-autogen, elixir-format
 msgid "Create an OpenRouter account"
 msgstr ""
@@ -4312,7 +4315,7 @@ msgstr ""
 msgid "Disconnected"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:253
+#: lib/phoenix_kit/integrations/providers.ex:254
 #, elixir-autogen, elixir-format
 msgid "Drive API handles file listing, creation, copying, and PDF export. Docs API is used for reading document content and substituting template variables."
 msgstr ""
@@ -4342,7 +4345,7 @@ msgstr ""
 msgid "Enable organization accounts"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:242
+#: lib/phoenix_kit/integrations/providers.ex:243
 #, elixir-autogen, elixir-format
 msgid "Enable required APIs"
 msgstr ""
@@ -4475,12 +4478,12 @@ msgstr ""
 msgid "Files with completed variants"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:219
+#: lib/phoenix_kit/integrations/providers.ex:220
 #, elixir-autogen, elixir-format
 msgid "From Google Cloud Console → APIs & Services → Credentials"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:406
+#: lib/phoenix_kit/integrations/providers.ex:407
 #, elixir-autogen, elixir-format
 msgid "From openrouter.ai/keys"
 msgstr ""
@@ -4490,72 +4493,72 @@ msgstr ""
 msgid "Generate additional format variants alongside the primary format. Modern formats like WebP and AVIF offer better compression."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:426
+#: lib/phoenix_kit/integrations/providers.ex:427
 #, elixir-autogen, elixir-format
 msgid "Give it a name (e.g., your app name)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:248
+#: lib/phoenix_kit/integrations/providers.ex:249
 #, elixir-autogen, elixir-format
 msgid "Go back to the Library and search for **Google Docs API**, click it, then click **Enable**"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:281
+#: lib/phoenix_kit/integrations/providers.ex:282
 #, elixir-autogen, elixir-format
 msgid "Go to [APIs & Services → Credentials](https://console.cloud.google.com/apis/credentials)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:244
+#: lib/phoenix_kit/integrations/providers.ex:245
 #, elixir-autogen, elixir-format
 msgid "Go to [APIs & Services → Library](https://console.cloud.google.com/apis/library)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:263
+#: lib/phoenix_kit/integrations/providers.ex:264
 #, elixir-autogen, elixir-format
 msgid "Go to [Audience](https://console.cloud.google.com/auth/audience) — set user type to **External** (or Internal for Google Workspace)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:260
+#: lib/phoenix_kit/integrations/providers.ex:261
 #, elixir-autogen, elixir-format
 msgid "Go to [Branding](https://console.cloud.google.com/auth/branding) in the sidebar — fill in the **App name** and **User support email**, then save"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:434
+#: lib/phoenix_kit/integrations/providers.ex:435
 #, elixir-autogen, elixir-format
 msgid "Go to [Credits](https://openrouter.ai/credits) to add funds"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:269
+#: lib/phoenix_kit/integrations/providers.ex:270
 #, elixir-autogen, elixir-format
 msgid "Go to [Data Access](https://console.cloud.google.com/auth/scopes) — click **Add or Remove Scopes** and add the Drive and Docs scopes. This step may not be required — the app requests the needed scopes at connect time regardless."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:418
+#: lib/phoenix_kit/integrations/providers.ex:419
 #, elixir-autogen, elixir-format
 msgid "Go to [openrouter.ai](https://openrouter.ai) and sign up or log in"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:237
+#: lib/phoenix_kit/integrations/providers.ex:238
 #, elixir-autogen, elixir-format
 msgid "Go to the [Google Cloud Console](https://console.cloud.google.com)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:200
+#: lib/phoenix_kit/integrations/providers.ex:201
 #, elixir-autogen, elixir-format
 msgid "Google"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:201
+#: lib/phoenix_kit/integrations/providers.ex:202
 #, elixir-autogen, elixir-format
 msgid "Google Docs, Drive, Calendar, Sheets, Gmail"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:296
+#: lib/phoenix_kit/integrations/providers.ex:297
 #, elixir-autogen, elixir-format
 msgid "Google will show an \"unverified app\" warning — click **Advanced → Go to (app name)** to proceed"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:299
+#: lib/phoenix_kit/integrations/providers.ex:300
 #, elixir-autogen, elixir-format
 msgid "Grant access to Google Docs and Google Drive"
 msgstr ""
@@ -4591,11 +4594,12 @@ msgstr ""
 msgid "Integrations"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/integrations.ex:1132
+#: lib/phoenix_kit/integrations/integrations.ex:1135
 #: lib/phoenix_kit/integrations/validators.ex:208
 #: lib/phoenix_kit/integrations/validators.ex:378
 #: lib/phoenix_kit/integrations/validators.ex:412
-#: lib/phoenix_kit/integrations/validators.ex:595
+#: lib/phoenix_kit/integrations/validators.ex:608
+#: lib/phoenix_kit/integrations/validators.ex:776
 #, elixir-autogen, elixir-format
 msgid "Invalid credentials"
 msgstr ""
@@ -4809,12 +4813,12 @@ msgstr ""
 msgid "Missing %{n} copies"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:419
+#: lib/phoenix_kit/integrations/providers.ex:420
 #, elixir-autogen, elixir-format
 msgid "Navigate to [Keys](https://openrouter.ai/keys)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:274
+#: lib/phoenix_kit/integrations/providers.ex:275
 #, elixir-autogen, elixir-format
 msgid "Navigate to the OAuth section using the search bar or the hamburger menu: search for \"OAuth\", or go to the sidebar: **APIs & Services → OAuth consent screen**. This opens a different section with its own sidebar."
 msgstr ""
@@ -4835,9 +4839,9 @@ msgstr ""
 msgid "No copies"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/integrations.ex:1115
+#: lib/phoenix_kit/integrations/integrations.ex:1118
 #: lib/phoenix_kit/integrations/validators.ex:170
-#: lib/phoenix_kit/integrations/validators.ex:577
+#: lib/phoenix_kit/integrations/validators.ex:758
 #, elixir-autogen, elixir-format
 msgid "No credentials configured"
 msgstr ""
@@ -4918,7 +4922,7 @@ msgstr ""
 msgid "Only width is used, height is calculated automatically"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:387
+#: lib/phoenix_kit/integrations/providers.ex:388
 #, elixir-autogen, elixir-format
 msgid "OpenRouter"
 msgstr ""
@@ -5099,7 +5103,7 @@ msgstr ""
 msgid "Scheduled window is currently active"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:247
+#: lib/phoenix_kit/integrations/providers.ex:248
 #, elixir-autogen, elixir-format
 msgid "Search for **Google Drive API**, click it, then click **Enable**"
 msgstr ""
@@ -5126,7 +5130,7 @@ msgstr ""
 msgid "Service"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/integrations.ex:1134
+#: lib/phoenix_kit/integrations/integrations.ex:1137
 #, elixir-autogen, elixir-format
 msgid "Service error %{status}"
 msgstr ""
@@ -5136,7 +5140,7 @@ msgstr ""
 msgid "Set a time window for automatic maintenance activation."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:258
+#: lib/phoenix_kit/integrations/providers.ex:259
 #, elixir-autogen, elixir-format
 msgid "Set up OAuth consent"
 msgstr ""
@@ -5146,7 +5150,7 @@ msgstr ""
 msgid "Size Configuration"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:433
+#: lib/phoenix_kit/integrations/providers.ex:434
 #, elixir-autogen, elixir-format
 msgid "Some models are free, but most require credits"
 msgstr ""
@@ -5176,7 +5180,7 @@ msgstr ""
 msgid "Step 2"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:266
+#: lib/phoenix_kit/integrations/providers.ex:267
 #, elixir-autogen, elixir-format
 msgid "Still on Audience — while the app is in **Testing** status, add the Google account you will connect as a **Test user** (this must be the same account whose Drive will store your files)"
 msgstr ""
@@ -5311,7 +5315,7 @@ msgstr ""
 msgid "Total Files"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:288
+#: lib/phoenix_kit/integrations/providers.ex:289
 #, elixir-autogen, elixir-format
 msgid "Under **Authorized redirect URIs**, add: `{redirect_uri}`"
 msgstr ""
@@ -5368,8 +5372,8 @@ msgstr ""
 msgid "You need to create at least one media bucket before files can be uploaded."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:300
-#: lib/phoenix_kit/integrations/providers.ex:1252
+#: lib/phoenix_kit/integrations/providers.ex:301
+#: lib/phoenix_kit/integrations/providers.ex:1324
 #, elixir-autogen, elixir-format
 msgid "You'll be redirected back here once connected"
 msgstr ""
@@ -5436,39 +5440,39 @@ msgstr ""
 msgid "1 minute ago"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:509
+#: lib/phoenix_kit/integrations/providers.ex:510
 #, elixir-autogen, elixir-format
 msgid "AI model access via DeepSeek (deepseek-chat, deepseek-reasoner)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:446
+#: lib/phoenix_kit/integrations/providers.ex:447
 #, elixir-autogen, elixir-format
 msgid "AI model access via Mistral AI (Mistral Large, Codestral, Pixtral)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1218
+#: lib/phoenix_kit/integrations/providers.ex:1290
 #, elixir-autogen, elixir-format
 msgid "Add a client secret"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:480
+#: lib/phoenix_kit/integrations/providers.ex:481
 #, elixir-autogen, elixir-format
 msgid "Add a payment method (required)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:357
-#: lib/phoenix_kit/integrations/providers.ex:542
-#: lib/phoenix_kit/integrations/providers.ex:611
+#: lib/phoenix_kit/integrations/providers.ex:358
+#: lib/phoenix_kit/integrations/providers.ex:543
+#: lib/phoenix_kit/integrations/providers.ex:612
 #, elixir-autogen, elixir-format
 msgid "Add credits"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1233
+#: lib/phoenix_kit/integrations/providers.ex:1305
 #, elixir-autogen, elixir-format
 msgid "Add the permissions your integration needs: `User.Read` is included by default; add `Mail.Read`, `Files.Read.All`, `Calendars.Read`, etc. as required"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1160
+#: lib/phoenix_kit/integrations/providers.ex:1232
 #, elixir-autogen, elixir-format
 msgid "Application (client) ID"
 msgstr ""
@@ -5478,28 +5482,28 @@ msgstr ""
 msgid "Clears the OAuth tokens. Credentials and the connection itself stay so you can reconnect with one click."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:556
-#: lib/phoenix_kit/integrations/providers.ex:622
+#: lib/phoenix_kit/integrations/providers.ex:557
+#: lib/phoenix_kit/integrations/providers.ex:623
 #, elixir-autogen, elixir-format
 msgid "Click **Create API key**, give it a name"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:496
+#: lib/phoenix_kit/integrations/providers.ex:497
 #, elixir-autogen, elixir-format
 msgid "Click **Create new key**, give it a name, set an expiry if desired"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1205
+#: lib/phoenix_kit/integrations/providers.ex:1277
 #, elixir-autogen, elixir-format
 msgid "Click **New registration**, give the app a name"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1210
+#: lib/phoenix_kit/integrations/providers.ex:1282
 #, elixir-autogen, elixir-format
 msgid "Click **Register**"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1228
+#: lib/phoenix_kit/integrations/providers.ex:1300
 #, elixir-autogen, elixir-format
 msgid "Configure API permissions"
 msgstr ""
@@ -5520,16 +5524,16 @@ msgstr ""
 msgid "Connection renamed"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1222
+#: lib/phoenix_kit/integrations/providers.ex:1294
 #, elixir-autogen, elixir-format
 msgid "Copy the **Value** column (not the Secret ID) into the form above — the value is shown ONCE and disappears on page refresh"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:372
-#: lib/phoenix_kit/integrations/providers.ex:497
-#: lib/phoenix_kit/integrations/providers.ex:557
-#: lib/phoenix_kit/integrations/providers.ex:623
-#: lib/phoenix_kit/integrations/providers.ex:675
+#: lib/phoenix_kit/integrations/providers.ex:373
+#: lib/phoenix_kit/integrations/providers.ex:498
+#: lib/phoenix_kit/integrations/providers.ex:558
+#: lib/phoenix_kit/integrations/providers.ex:624
+#: lib/phoenix_kit/integrations/providers.ex:676
 #, elixir-autogen, elixir-format
 msgid "Copy the key (shown once) and paste it into the form above"
 msgstr ""
@@ -5540,12 +5544,12 @@ msgstr ""
 msgid "Create Connection"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:534
+#: lib/phoenix_kit/integrations/providers.ex:535
 #, elixir-autogen, elixir-format
 msgid "Create a DeepSeek account"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:471
+#: lib/phoenix_kit/integrations/providers.ex:472
 #, elixir-autogen, elixir-format
 msgid "Create a Mistral account"
 msgstr ""
@@ -5556,12 +5560,12 @@ msgstr ""
 msgid "Danger Zone"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:508
+#: lib/phoenix_kit/integrations/providers.ex:509
 #, elixir-autogen, elixir-format
 msgid "DeepSeek"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:547
+#: lib/phoenix_kit/integrations/providers.ex:548
 #, elixir-autogen, elixir-format
 msgid "DeepSeek requires a positive balance before you can call the chat or reasoner endpoints, even on cheap models"
 msgstr ""
@@ -5596,82 +5600,82 @@ msgstr ""
 msgid "Failed to rename connection."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:485
+#: lib/phoenix_kit/integrations/providers.ex:486
 #, elixir-autogen, elixir-format
 msgid "Free models still require a billing-enabled workspace"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1164
+#: lib/phoenix_kit/integrations/providers.ex:1236
 #, elixir-autogen, elixir-format
 msgid "From Azure Portal → App registrations → your app → Overview"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:464
+#: lib/phoenix_kit/integrations/providers.ex:465
 #, elixir-autogen, elixir-format
 msgid "From console.mistral.ai/api-keys"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:527
+#: lib/phoenix_kit/integrations/providers.ex:528
 #, elixir-autogen, elixir-format
 msgid "From platform.deepseek.com/api_keys"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1174
+#: lib/phoenix_kit/integrations/providers.ex:1246
 #, elixir-autogen, elixir-format
 msgid "From your app → Certificates & secrets → New client secret. Copy the *Value*, not the Secret ID."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1230
+#: lib/phoenix_kit/integrations/providers.ex:1302
 #, elixir-autogen, elixir-format
 msgid "Go to **API permissions → Add a permission → Microsoft Graph → Delegated permissions**"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1220
+#: lib/phoenix_kit/integrations/providers.ex:1292
 #, elixir-autogen, elixir-format
 msgid "Go to **Certificates & secrets → New client secret**"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:495
+#: lib/phoenix_kit/integrations/providers.ex:496
 #, elixir-autogen, elixir-format
 msgid "Go to [API Keys](https://console.mistral.ai/api-keys)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:555
+#: lib/phoenix_kit/integrations/providers.ex:556
 #, elixir-autogen, elixir-format
 msgid "Go to [API Keys](https://platform.deepseek.com/api_keys)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:544
+#: lib/phoenix_kit/integrations/providers.ex:545
 #, elixir-autogen, elixir-format
 msgid "Go to [Top up](https://platform.deepseek.com/top_up) and add at least the minimum amount"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:482
+#: lib/phoenix_kit/integrations/providers.ex:483
 #, elixir-autogen, elixir-format
 msgid "Go to [Workspace → Billing](https://console.mistral.ai/billing/plans) and choose **Experiment** (pay-as-you-go) or a paid tier"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:473
+#: lib/phoenix_kit/integrations/providers.ex:474
 #, elixir-autogen, elixir-format
 msgid "Go to [console.mistral.ai](https://console.mistral.ai) and sign up or log in"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:536
+#: lib/phoenix_kit/integrations/providers.ex:537
 #, elixir-autogen, elixir-format
 msgid "Go to [platform.deepseek.com](https://platform.deepseek.com) and sign up or log in"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1202
+#: lib/phoenix_kit/integrations/providers.ex:1274
 #, elixir-autogen, elixir-format
 msgid "Go to the [Azure Portal](https://portal.azure.com) and search for **App registrations**"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1213
+#: lib/phoenix_kit/integrations/providers.ex:1285
 #, elixir-autogen, elixir-format
 msgid "If you picked a single-tenant audience, fill in **Tenant ID** above with your Directory (tenant) ID GUID — leaving it as `common` only works for multi-tenant + personal apps."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1236
+#: lib/phoenix_kit/integrations/providers.ex:1308
 #, elixir-autogen, elixir-format
 msgid "If your tenant requires admin consent, click **Grant admin consent for <tenant>** before the connect flow will work"
 msgstr ""
@@ -5688,32 +5692,32 @@ msgstr ""
 msgid "Last tested"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1186
+#: lib/phoenix_kit/integrations/providers.ex:1258
 #, elixir-autogen, elixir-format
 msgid "Leave as `common` for multi-tenant + personal accounts. For single-tenant apps, paste your Directory (tenant) ID GUID. Use `consumers` for personal-only or `organizations` for any work-or-school account."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1131
+#: lib/phoenix_kit/integrations/providers.ex:1203
 #, elixir-autogen, elixir-format
 msgid "Microsoft 365"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1132
+#: lib/phoenix_kit/integrations/providers.ex:1204
 #, elixir-autogen, elixir-format
 msgid "Microsoft Graph — Outlook, OneDrive, Teams, Calendar, SharePoint"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1249
+#: lib/phoenix_kit/integrations/providers.ex:1321
 #, elixir-autogen, elixir-format
 msgid "Microsoft will show the consent screen — click **Accept** to grant the requested permissions"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:445
+#: lib/phoenix_kit/integrations/providers.ex:446
 #, elixir-autogen, elixir-format
 msgid "Mistral"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:488
+#: lib/phoenix_kit/integrations/providers.ex:489
 #, elixir-autogen, elixir-format
 msgid "Mistral does not offer credits without billing setup; this is a hard requirement before keys can be created."
 msgstr ""
@@ -5724,7 +5728,7 @@ msgstr ""
 msgid "Permanently delete this connection? This cannot be undone."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1200
+#: lib/phoenix_kit/integrations/providers.ex:1272
 #, elixir-autogen, elixir-format
 msgid "Register an application in Microsoft Entra ID (Azure AD)"
 msgstr ""
@@ -5740,32 +5744,32 @@ msgstr ""
 msgid "Search..."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1221
+#: lib/phoenix_kit/integrations/providers.ex:1293
 #, elixir-autogen, elixir-format
 msgid "Set an expiration (24 months is common; renew before it lapses)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1181
+#: lib/phoenix_kit/integrations/providers.ex:1253
 #, elixir-autogen, elixir-format
 msgid "Tenant ID"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1241
+#: lib/phoenix_kit/integrations/providers.ex:1313
 #, elixir-autogen, elixir-format
 msgid "The `default_scopes` in the provider definition request `openid email profile offline_access User.Read` — extra scopes can be added per-connect by passing `extra_scopes` to `authorization_url/5`."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1209
+#: lib/phoenix_kit/integrations/providers.ex:1281
 #, elixir-autogen, elixir-format
 msgid "Under **Redirect URI**, choose **Web** and enter: `{redirect_uri}`"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1206
+#: lib/phoenix_kit/integrations/providers.ex:1278
 #, elixir-autogen, elixir-format
 msgid "Under **Supported account types**, choose the audience: *Personal Microsoft accounts only*, *Accounts in any organizational directory*, or *Accounts in this organizational directory only* depending on who should sign in"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:476
+#: lib/phoenix_kit/integrations/providers.ex:477
 #, elixir-autogen, elixir-format
 msgid "You may need to verify your phone number before creating API keys"
 msgstr ""
@@ -6032,14 +6036,14 @@ msgstr ""
 
 #: lib/phoenix_kit_web/live/modules.html.heex:447
 #: lib/phoenix_kit_web/live/settings.html.heex:465
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:289
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:315
 #, elixir-autogen, elixir-format
 msgid "Off"
 msgstr ""
 
 #: lib/phoenix_kit_web/live/modules.html.heex:447
 #: lib/phoenix_kit_web/live/settings.html.heex:464
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:289
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:315
 #, elixir-autogen, elixir-format
 msgid "On"
 msgstr ""
@@ -7271,8 +7275,8 @@ msgstr ""
 msgid "Are you sure you want to delete this comment?"
 msgstr ""
 
-#: lib/phoenix_kit_web/components/media_canvas_viewer.ex:1202
-#: lib/phoenix_kit_web/components/media_canvas_viewer.ex:1203
+#: lib/phoenix_kit_web/components/media_canvas_viewer.ex:1236
+#: lib/phoenix_kit_web/components/media_canvas_viewer.ex:1237
 #, elixir-autogen, elixir-format
 msgid "%b %d, %Y"
 msgstr ""
@@ -8386,14 +8390,14 @@ msgstr ""
 msgid "All registered accounts"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:185
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:224
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:179
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:218
 #, elixir-autogen, elixir-format
 msgid "Anon"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:178
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:245
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:172
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:239
 #, elixir-autogen, elixir-format
 msgid "Anonymous User"
 msgstr ""
@@ -8444,8 +8448,8 @@ msgstr ""
 msgid "Are you sure you want to unconfirm this user's email?"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:170
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:220
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:164
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:214
 #, elixir-autogen, elixir-format
 msgid "Auth"
 msgstr ""
@@ -8528,17 +8532,17 @@ msgid "Confirmed Email"
 msgstr ""
 
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:109
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:195
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Current Page"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/users.ex:251
+#: lib/phoenix_kit_web/live/settings/users.ex:258
 #, elixir-autogen, elixir-format
 msgid "Custom field deleted successfully"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/users.ex:171
+#: lib/phoenix_kit_web/live/settings/users.ex:178
 #, elixir-autogen, elixir-format
 msgid "Custom field saved successfully"
 msgstr ""
@@ -8553,17 +8557,17 @@ msgstr ""
 msgid "Drag to reorder selected columns above, or add new columns from the options below. Actions column is always included."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/users.ex:256
+#: lib/phoenix_kit_web/live/settings/users.ex:263
 #, elixir-autogen, elixir-format
 msgid "Failed to delete custom field"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/users.ex:184
+#: lib/phoenix_kit_web/live/settings/users.ex:191
 #, elixir-autogen, elixir-format
 msgid "Failed to save custom field"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/users.ex:285
+#: lib/phoenix_kit_web/live/settings/users.ex:292
 #, elixir-autogen, elixir-format
 msgid "Failed to update field"
 msgstr ""
@@ -8596,23 +8600,23 @@ msgstr ""
 msgid "Failed to update user status"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/users.ex:278
+#: lib/phoenix_kit_web/live/settings/users.ex:285
 #, elixir-autogen, elixir-format
 msgid "Field '%{label}' disabled"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/users.ex:277
+#: lib/phoenix_kit_web/live/settings/users.ex:284
 #, elixir-autogen, elixir-format
 msgid "Field '%{label}' enabled"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/users.ex:289
+#: lib/phoenix_kit_web/live/settings/users.ex:296
 #, elixir-autogen, elixir-format
 msgid "Field not found"
 msgstr ""
 
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:108
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:194
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:188
 #, elixir-autogen, elixir-format
 msgid "IP Address"
 msgstr ""
@@ -8644,7 +8648,7 @@ msgstr ""
 msgid "Monitor and manage active user sessions"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1002
+#: lib/phoenix_kit/integrations/providers.ex:1074
 #: lib/phoenix_kit_web/live/users/users.ex:1048
 #: lib/phoenix_kit_web/live/users/users.html.heex:563
 #, elixir-autogen, elixir-format
@@ -8656,7 +8660,7 @@ msgstr ""
 msgid "Next »"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:208
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:202
 #, elixir-autogen, elixir-format
 msgid "No active sessions"
 msgstr ""
@@ -8808,7 +8812,7 @@ msgstr ""
 msgid "Table columns updated successfully"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:209
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:203
 #, elixir-autogen, elixir-format
 msgid "There are currently no active sessions to display."
 msgstr ""
@@ -8869,12 +8873,12 @@ msgstr ""
 msgid "User roles updated successfully"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/users.ex:84
+#: lib/phoenix_kit_web/live/settings/users.ex:91
 #, elixir-autogen, elixir-format
 msgid "User settings updated successfully"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:193
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:187
 #, elixir-autogen, elixir-format
 msgid "User/Session"
 msgstr ""
@@ -8908,7 +8912,7 @@ msgstr[1] ""
 msgid "Last updated:"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:656
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:671
 #, elixir-autogen, elixir-format
 msgid "Account switcher for signing in to several accounts at once"
 msgstr ""
@@ -8918,7 +8922,7 @@ msgstr ""
 msgid "Applying…"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:662
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:677
 #, elixir-autogen, elixir-format
 msgid "Enable the multi-account switcher in the header"
 msgstr ""
@@ -8936,12 +8940,12 @@ msgstr ""
 msgid "Loading…"
 msgstr ""
 
-#: lib/phoenix_kit_web/users/session.ex:113
+#: lib/phoenix_kit_web/users/session.ex:115
 #, elixir-autogen, elixir-format
 msgid "Logged out. Now signed in as %{email}."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:653
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:668
 #, elixir-autogen, elixir-format
 msgid "Multiple Sessions"
 msgstr ""
@@ -8977,12 +8981,12 @@ msgstr ""
 msgid "Showing %{loaded} of %{total} %{noun}"
 msgstr ""
 
-#: lib/phoenix_kit_web/users/session.ex:268
+#: lib/phoenix_kit_web/users/session.ex:270
 #, elixir-autogen, elixir-format
 msgid "Switched to %{email}."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:665
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:680
 #, elixir-autogen, elixir-format
 msgid "When on, any signed-in user can add other accounts (with their password) and switch between them from the user menu."
 msgstr ""
@@ -9062,7 +9066,7 @@ msgstr ""
 msgid "View background job status and history"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:312
+#: lib/phoenix_kit/integrations/providers.ex:313
 #, elixir-autogen, elixir-format
 msgid "AI models via OpenAI (GPT, embeddings, images, audio)"
 msgstr ""
@@ -9147,12 +9151,12 @@ msgstr ""
 msgid "Choose"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:674
+#: lib/phoenix_kit/integrations/providers.ex:675
 #, elixir-autogen, elixir-format
 msgid "Click **Create API Key**, give it a name"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:371
+#: lib/phoenix_kit/integrations/providers.ex:372
 #, elixir-autogen, elixir-format
 msgid "Click **Create new secret key**, give it a name"
 msgstr ""
@@ -9163,12 +9167,12 @@ msgstr ""
 msgid "Close search"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:664
+#: lib/phoenix_kit/integrations/providers.ex:665
 #, elixir-autogen, elixir-format
 msgid "Create an ElevenLabs account"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:349
+#: lib/phoenix_kit/integrations/providers.ex:350
 #, elixir-autogen, elixir-format
 msgid "Create an OpenAI account"
 msgstr ""
@@ -9232,7 +9236,7 @@ msgstr ""
 msgid "Edit header"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:634
+#: lib/phoenix_kit/integrations/providers.ex:635
 #, elixir-autogen, elixir-format
 msgid "ElevenLabs"
 msgstr ""
@@ -9302,37 +9306,37 @@ msgstr ""
 msgid "Forgot password"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:657
+#: lib/phoenix_kit/integrations/providers.ex:658
 #, elixir-autogen, elixir-format
 msgid "From elevenlabs.io → Settings → API Keys"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:336
+#: lib/phoenix_kit/integrations/providers.ex:337
 #, elixir-autogen, elixir-format
 msgid "From platform.openai.com/api-keys"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:370
+#: lib/phoenix_kit/integrations/providers.ex:371
 #, elixir-autogen, elixir-format
 msgid "Go to [API Keys](https://platform.openai.com/api-keys)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:359
+#: lib/phoenix_kit/integrations/providers.ex:360
 #, elixir-autogen, elixir-format
 msgid "Go to [Billing](https://platform.openai.com/account/billing/overview) and add a payment method or credits"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:672
+#: lib/phoenix_kit/integrations/providers.ex:673
 #, elixir-autogen, elixir-format
 msgid "Go to [Settings → API Keys](https://elevenlabs.io/app/settings/api-keys)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:666
+#: lib/phoenix_kit/integrations/providers.ex:667
 #, elixir-autogen, elixir-format
 msgid "Go to [elevenlabs.io](https://elevenlabs.io) and sign up or log in"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:351
+#: lib/phoenix_kit/integrations/providers.ex:352
 #, elixir-autogen, elixir-format
 msgid "Go to [platform.openai.com](https://platform.openai.com) and sign up or log in"
 msgstr ""
@@ -9361,7 +9365,7 @@ msgstr ""
 msgid "Icon"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:375
+#: lib/phoenix_kit/integrations/providers.ex:376
 #, elixir-autogen, elixir-format
 msgid "If your account belongs to multiple organizations, keys are scoped to the org selected when the key was created."
 msgstr ""
@@ -9461,12 +9465,12 @@ msgstr ""
 msgid "Open the media health dashboard to check file redundancy and re-sync files across storage locations."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:311
+#: lib/phoenix_kit/integrations/providers.ex:312
 #, elixir-autogen, elixir-format
 msgid "OpenAI"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:362
+#: lib/phoenix_kit/integrations/providers.ex:363
 #, elixir-autogen, elixir-format
 msgid "OpenAI requires a positive balance before the API will return completions, even on cheaper models"
 msgstr ""
@@ -9556,12 +9560,12 @@ msgstr ""
 msgid "Stacks"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:635
+#: lib/phoenix_kit/integrations/providers.ex:636
 #, elixir-autogen, elixir-format
 msgid "Text-to-speech and voice generation via ElevenLabs"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:678
+#: lib/phoenix_kit/integrations/providers.ex:679
 #, elixir-autogen, elixir-format
 msgid "The free tier includes a monthly character quota; paid plans raise the quota and unlock commercial use and additional voices."
 msgstr ""
@@ -10443,27 +10447,27 @@ msgstr ""
 msgid "Too many attempts. Please try again shortly."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:569
+#: lib/phoenix_kit/integrations/providers.ex:570
 #, elixir-autogen, elixir-format
 msgid "AI model access via xAI (Grok models)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:827
+#: lib/phoenix_kit/integrations/providers.ex:828
 #, elixir-autogen, elixir-format
 msgid "AWS Simple Email Service (SMTP credentials via SES API)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:826
+#: lib/phoenix_kit/integrations/providers.ex:827
 #, elixir-autogen, elixir-format
 msgid "Amazon SES"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1050
+#: lib/phoenix_kit/integrations/providers.ex:1122
 #, elixir-autogen, elixir-format
 msgid "Brevo API"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:605
+#: lib/phoenix_kit/integrations/providers.ex:606
 #, elixir-autogen, elixir-format
 msgid "Create an xAI account"
 msgstr ""
@@ -10473,37 +10477,37 @@ msgstr ""
 msgid "Email users when their account is signed in from a new device"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:961
+#: lib/phoenix_kit/integrations/providers.ex:1033
 #, elixir-autogen, elixir-format
 msgid "For Brevo: the SMTP key starting with xsmtpsib- (SMTP & API → SMTP tab) — not the API key (xkeysib-)."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:949
+#: lib/phoenix_kit/integrations/providers.ex:1021
 #, elixir-autogen, elixir-format
 msgid "For Brevo: your account's SMTP login, shown as <subaccount>@smtp-brevo.com under SMTP & API → SMTP."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1070
+#: lib/phoenix_kit/integrations/providers.ex:1142
 #, elixir-autogen, elixir-format
 msgid "From Brevo → SMTP & API → API Keys. Starts with xkeysib- — not the SMTP key (xsmtpsib-)."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:590
+#: lib/phoenix_kit/integrations/providers.ex:591
 #, elixir-autogen, elixir-format
 msgid "From console.x.ai/team/default/api-keys"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:621
+#: lib/phoenix_kit/integrations/providers.ex:622
 #, elixir-autogen, elixir-format
 msgid "Go to [API Keys](https://console.x.ai/team/default/api-keys)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:607
+#: lib/phoenix_kit/integrations/providers.ex:608
 #, elixir-autogen, elixir-format
 msgid "Go to [accounts.x.ai](https://accounts.x.ai) and sign up or log in"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:613
+#: lib/phoenix_kit/integrations/providers.ex:614
 #, elixir-autogen, elixir-format
 msgid "Go to [console.x.ai](https://console.x.ai) → Billing and add credits"
 msgstr ""
@@ -10513,43 +10517,44 @@ msgstr ""
 msgid "Login Notifications"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:927
+#: lib/phoenix_kit/integrations/providers.ex:999
 #, elixir-autogen, elixir-format
 msgid "Port"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:720
-#: lib/phoenix_kit/integrations/providers.ex:860
+#: lib/phoenix_kit/integrations/providers.ex:721
+#: lib/phoenix_kit/integrations/providers.ex:861
+#: lib/phoenix_kit/integrations/providers.ex:945
 #, elixir-autogen, elixir-format
 msgid "Region"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:904
+#: lib/phoenix_kit/integrations/providers.ex:976
 #, elixir-autogen, elixir-format
 msgid "SMTP"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:918
+#: lib/phoenix_kit/integrations/providers.ex:990
 #, elixir-autogen, elixir-format
 msgid "SMTP Host"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1051
+#: lib/phoenix_kit/integrations/providers.ex:1123
 #, elixir-autogen, elixir-format
 msgid "Send email via the Brevo transactional email API"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:906
+#: lib/phoenix_kit/integrations/providers.ex:978
 #, elixir-autogen, elixir-format
 msgid "Universal SMTP relay — works with any vendor (Brevo, Mailgun, SendGrid, a self-hosted mail server, etc). Add one named connection per relay/account."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:568
+#: lib/phoenix_kit/integrations/providers.ex:569
 #, elixir-autogen, elixir-format
 msgid "xAI"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:615
+#: lib/phoenix_kit/integrations/providers.ex:616
 #, elixir-autogen, elixir-format
 msgid "xAI requires a funded account before the API will return completions"
 msgstr ""
@@ -10723,12 +10728,12 @@ msgstr ""
 msgid "Try a different term or clear the search"
 msgstr ""
 
-#: lib/modules/storage/web/bucket_form.ex:294
+#: lib/modules/storage/web/bucket_form.ex:296
 #, elixir-autogen, elixir-format
 msgid "Add Storage Bucket"
 msgstr ""
 
-#: lib/modules/storage/web/bucket_form.ex:295
+#: lib/modules/storage/web/bucket_form.ex:297
 #, elixir-autogen, elixir-format
 msgid "Edit Storage Bucket"
 msgstr ""
@@ -10817,12 +10822,12 @@ msgstr ""
 msgid "%{provider} settings"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/validators.ex:643
+#: lib/phoenix_kit/integrations/validators.ex:824
 #, elixir-autogen, elixir-format
 msgid "%{text} · resets %{date}"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/validators.ex:632
+#: lib/phoenix_kit/integrations/validators.ex:813
 #, elixir-autogen, elixir-format
 msgid "%{type} · %{credits} credits left"
 msgstr ""
@@ -10878,12 +10883,12 @@ msgstr ""
 msgid "Allow \"Keep me logged in\" (persistent sessions)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1001
+#: lib/phoenix_kit/integrations/providers.ex:1073
 #, elixir-autogen, elixir-format
 msgid "Always"
 msgstr ""
 
-#: lib/phoenix_kit_web/users/session.ex:331
+#: lib/phoenix_kit_web/users/session.ex:333
 #, elixir-autogen, elixir-format
 msgid "An owner account cannot be used."
 msgstr ""
@@ -10893,12 +10898,12 @@ msgstr ""
 msgid "Applies site-wide wherever the rich-text editor is rendered (posts, comments). Users can still switch modes inside the editor."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:982
+#: lib/phoenix_kit/integrations/providers.ex:1054
 #, elixir-autogen, elixir-format
 msgid "Auto (from port)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:978
+#: lib/phoenix_kit/integrations/providers.ex:1050
 #, elixir-autogen, elixir-format
 msgid "Auto follows the port: 465 means implicit TLS, anything else STARTTLS (required when a login is set). Choose explicitly for a relay that ignores that convention."
 msgstr ""
@@ -10913,22 +10918,22 @@ msgstr ""
 msgid "Best,\nThe Team"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1098
+#: lib/phoenix_kit/integrations/providers.ex:1170
 #, elixir-autogen, elixir-format
 msgid "Bot Token"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1118
+#: lib/phoenix_kit/integrations/providers.ex:1190
 #, elixir-autogen, elixir-format
 msgid "BotFather replies with an HTTP API token like `123456789:ABCdef...` — copy it"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/validators.ex:601
+#: lib/phoenix_kit/integrations/validators.ex:782
 #, elixir-autogen, elixir-format
 msgid "Brevo error %{status}"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1022
+#: lib/phoenix_kit/integrations/providers.ex:1094
 #, elixir-autogen, elixir-format
 msgid "CA certificate (PEM)"
 msgstr ""
@@ -10938,7 +10943,7 @@ msgstr ""
 msgid "Cannot delete send profile"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1007
+#: lib/phoenix_kit/integrations/providers.ex:1079
 #, elixir-autogen, elixir-format
 msgid "Certificate verification"
 msgstr ""
@@ -10983,7 +10988,7 @@ msgstr ""
 msgid "Connect your own API keys and services. Only you can see these."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/validators.ex:693
+#: lib/phoenix_kit/integrations/validators.ex:874
 #, elixir-autogen, elixir-format
 msgid "Connected as @%{username}"
 msgstr ""
@@ -10999,7 +11004,7 @@ msgstr ""
 msgid "Content Editor"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1116
+#: lib/phoenix_kit/integrations/providers.ex:1188
 #, elixir-autogen, elixir-format
 msgid "Copy the bot token"
 msgstr ""
@@ -11017,12 +11022,12 @@ msgstr ""
 msgid "Could not reach AWS SES"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/validators.ex:605
+#: lib/phoenix_kit/integrations/validators.ex:786
 #, elixir-autogen, elixir-format
 msgid "Could not reach Brevo"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/validators.ex:705
+#: lib/phoenix_kit/integrations/validators.ex:886
 #, elixir-autogen, elixir-format
 msgid "Could not reach Telegram"
 msgstr ""
@@ -11083,7 +11088,7 @@ msgstr ""
 msgid "Could not update default send integration"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1109
+#: lib/phoenix_kit/integrations/providers.ex:1181
 #, elixir-autogen, elixir-format
 msgid "Create a bot with BotFather"
 msgstr ""
@@ -11159,7 +11164,7 @@ msgstr ""
 msgid "Dismiss"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1017
+#: lib/phoenix_kit/integrations/providers.ex:1089
 #, elixir-autogen, elixir-format
 msgid "Do not verify"
 msgstr ""
@@ -11191,7 +11196,7 @@ msgstr ""
 msgid "Email Sending"
 msgstr ""
 
-#: lib/phoenix_kit_web/users/confirmation_instructions.ex:109
+#: lib/phoenix_kit_web/users/confirmation_instructions.ex:111
 #, elixir-autogen, elixir-format
 msgid "Email confirmed. Welcome!"
 msgstr ""
@@ -11201,7 +11206,7 @@ msgstr ""
 msgid "Email-capable integrations"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:973
+#: lib/phoenix_kit/integrations/providers.ex:1045
 #, elixir-autogen, elixir-format
 msgid "Encryption"
 msgstr ""
@@ -11221,7 +11226,7 @@ msgstr ""
 msgid "Everyone who starts the bot"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1027
+#: lib/phoenix_kit/integrations/providers.ex:1099
 #, elixir-autogen, elixir-format
 msgid "For a private or self-signed relay certificate. Replaces the system CA store for this connection only."
 msgstr ""
@@ -11232,7 +11237,7 @@ msgstr ""
 msgid "From"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1102
+#: lib/phoenix_kit/integrations/providers.ex:1174
 #, elixir-autogen, elixir-format
 msgid "From @BotFather → /newbot (or /token for an existing bot)"
 msgstr ""
@@ -11259,7 +11264,7 @@ msgstr ""
 msgid "Hourly"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1000
+#: lib/phoenix_kit/integrations/providers.ex:1072
 #, elixir-autogen, elixir-format
 msgid "If offered (default)"
 msgstr ""
@@ -11269,7 +11274,7 @@ msgstr ""
 msgid "Immediate"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:983
+#: lib/phoenix_kit/integrations/providers.ex:1055
 #, elixir-autogen, elixir-format
 msgid "Implicit TLS / SMTPS"
 msgstr ""
@@ -11287,6 +11292,7 @@ msgid "Incomplete SMTP settings"
 msgstr ""
 
 #: lib/phoenix_kit/integrations/validators.ex:57
+#: lib/phoenix_kit/integrations/validators.ex:582
 #, elixir-autogen, elixir-format
 msgid "Incomplete credentials"
 msgstr ""
@@ -11323,7 +11329,7 @@ msgstr ""
 msgid "Invalid SMTP settings: %{reason}"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/validators.ex:698
+#: lib/phoenix_kit/integrations/validators.ex:879
 #, elixir-autogen, elixir-format
 msgid "Invalid bot token"
 msgstr ""
@@ -11343,7 +11349,7 @@ msgstr ""
 msgid "Leave a field blank to fall back to the application config or built-in default."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1038
+#: lib/phoenix_kit/integrations/providers.ex:1110
 #, elixir-autogen, elixir-format
 msgid "Leave blank for the gen_smtp default."
 msgstr ""
@@ -11384,7 +11390,7 @@ msgstr ""
 msgid "Mark read"
 msgstr ""
 
-#: lib/phoenix_kit_web/users/session.ex:340
+#: lib/phoenix_kit_web/users/session.ex:342
 #, elixir-autogen, elixir-format
 msgid "Maximum number of accounts reached — remove one first."
 msgstr ""
@@ -11434,7 +11440,7 @@ msgstr ""
 msgid "No adapter configured for the static mailer. Set one in your application config, or connect an email-capable integration below and pick it as the default transactional integration."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/validators.ex:682
+#: lib/phoenix_kit/integrations/validators.ex:863
 #, elixir-autogen, elixir-format
 msgid "No bot token configured"
 msgstr ""
@@ -11474,7 +11480,7 @@ msgstr ""
 msgid "No unread notifications"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:986
+#: lib/phoenix_kit/integrations/providers.ex:1058
 #, elixir-autogen, elixir-format
 msgid "None — plaintext"
 msgstr ""
@@ -11504,7 +11510,7 @@ msgstr ""
 msgid "Numeric ID of a verified Brevo sender. Leave empty to send from the From address above."
 msgstr ""
 
-#: lib/phoenix_kit_web/users/session.ex:334
+#: lib/phoenix_kit_web/users/session.ex:336
 #, elixir-autogen, elixir-format
 msgid "Only an owner can sign in as another administrator."
 msgstr ""
@@ -11514,12 +11520,12 @@ msgstr ""
 msgid "Only me"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1111
+#: lib/phoenix_kit/integrations/providers.ex:1183
 #, elixir-autogen, elixir-format
 msgid "Open [@BotFather](https://t.me/BotFather) in Telegram"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1121
+#: lib/phoenix_kit/integrations/providers.ex:1193
 #, elixir-autogen, elixir-format
 msgid "Paste the token into the form above and press **Test Connection**"
 msgstr ""
@@ -11539,7 +11545,7 @@ msgstr ""
 msgid "Persistent sessions last 60 days. Magic-link and social logins have no checkbox to tick, so they follow the default above. Turning the first option off hides the checkbox everywhere and keeps every login to the browser session."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/validators.ex:616
+#: lib/phoenix_kit/integrations/validators.ex:797
 #, elixir-autogen, elixir-format
 msgid "Plan: %{entries}"
 msgstr ""
@@ -11636,12 +11642,12 @@ msgstr ""
 msgid "SMTP server rejected the connection"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:985
+#: lib/phoenix_kit/integrations/providers.ex:1057
 #, elixir-autogen, elixir-format
 msgid "STARTTLS — if offered"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:984
+#: lib/phoenix_kit/integrations/providers.ex:1056
 #, elixir-autogen, elixir-format
 msgid "STARTTLS — required"
 msgstr ""
@@ -11661,7 +11667,7 @@ msgstr ""
 msgid "Select an integration..."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1112
+#: lib/phoenix_kit/integrations/providers.ex:1184
 #, elixir-autogen, elixir-format
 msgid "Send **/newbot** and follow the prompts to name your bot"
 msgstr ""
@@ -11675,7 +11681,7 @@ msgstr ""
 msgid "Send Profiles"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1087
+#: lib/phoenix_kit/integrations/providers.ex:1159
 #, elixir-autogen, elixir-format
 msgid "Send messages and notifications via your own Telegram bot"
 msgstr ""
@@ -11765,13 +11771,13 @@ msgstr ""
 msgid "Tags"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1086
+#: lib/phoenix_kit/integrations/providers.ex:1158
 #: lib/phoenix_kit/notifications/channels/telegram.ex:36
 #, elixir-autogen, elixir-format
 msgid "Telegram"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/validators.ex:701
+#: lib/phoenix_kit/integrations/validators.ex:882
 #, elixir-autogen, elixir-format
 msgid "Telegram error %{status}"
 msgstr ""
@@ -11791,17 +11797,17 @@ msgstr ""
 msgid "Test email sent to %{recipient}"
 msgstr ""
 
-#: lib/phoenix_kit_web/users/session.ex:343
+#: lib/phoenix_kit_web/users/session.ex:345
 #, elixir-autogen, elixir-format
 msgid "That account is already in your session — switch to it instead."
 msgstr ""
 
-#: lib/phoenix_kit_web/users/session.ex:337
+#: lib/phoenix_kit_web/users/session.ex:339
 #, elixir-autogen, elixir-format
 msgid "That account is deactivated."
 msgstr ""
 
-#: lib/phoenix_kit_web/users/session.ex:336
+#: lib/phoenix_kit_web/users/session.ex:338
 #, elixir-autogen, elixir-format
 msgid "That is already your account."
 msgstr ""
@@ -11842,7 +11848,7 @@ msgstr ""
 msgid "This sender address cannot be logged"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1034
+#: lib/phoenix_kit/integrations/providers.ex:1106
 #, elixir-autogen, elixir-format
 msgid "Timeout (seconds)"
 msgstr ""
@@ -11852,7 +11858,7 @@ msgstr ""
 msgid "Transport"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1012
+#: lib/phoenix_kit/integrations/providers.ex:1084
 #, elixir-autogen, elixir-format
 msgid "Turning verification off means the login travels to whoever answers, including an impostor. Use a CA certificate below instead whenever you can."
 msgstr ""
@@ -11882,12 +11888,12 @@ msgstr ""
 msgid "Used when no default transactional integration is selected below."
 msgstr ""
 
-#: lib/phoenix_kit_web/users/session.ex:309
+#: lib/phoenix_kit_web/users/session.ex:311
 #, elixir-autogen, elixir-format
 msgid "User not found."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:1016
+#: lib/phoenix_kit/integrations/providers.ex:1088
 #, elixir-autogen, elixir-format
 msgid "Verify (default)"
 msgstr ""
@@ -11907,7 +11913,7 @@ msgstr ""
 msgid "Where a freshly registered account lands. Empty = after-login path."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:996
+#: lib/phoenix_kit/integrations/providers.ex:1068
 #, elixir-autogen, elixir-format
 msgid "Whether to send the login at all. “If offered” follows the relay; “Never” is for relays that authenticate by IP."
 msgstr ""
@@ -11922,12 +11928,12 @@ msgstr ""
 msgid "Yesterday"
 msgstr ""
 
-#: lib/phoenix_kit_web/users/session.ex:320
+#: lib/phoenix_kit_web/users/session.ex:322
 #, elixir-autogen, elixir-format
 msgid "You are now signed in as %{email}."
 msgstr ""
 
-#: lib/phoenix_kit_web/users/session.ex:329
+#: lib/phoenix_kit_web/users/session.ex:331
 #, elixir-autogen, elixir-format
 msgid "You do not have permission to sign in as another user."
 msgstr ""
@@ -12043,7 +12049,7 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:143
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:169
 #, elixir-autogen, elixir-format
 msgid "Copied!"
 msgstr ""
@@ -12053,7 +12059,7 @@ msgstr ""
 msgid "Couldn't reach hex.pm, so the package list is unavailable right now."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:119
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:145
 #, elixir-autogen, elixir-format
 msgid "Crawler Instructions"
 msgstr ""
@@ -12107,7 +12113,7 @@ msgstr ""
 msgid "has the robots.txt line that points crawlers here."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:173
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:199
 #, elixir-autogen, elixir-format
 msgid "priv/static/robots.txt points crawlers at your sitemap."
 msgstr ""
@@ -12211,17 +12217,17 @@ msgstr ""
 msgid "You don't have permission to manage this user's credentials"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:190
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:216
 #, elixir-autogen, elixir-format
 msgid "AI Discovery"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:698
+#: lib/phoenix_kit/integrations/providers.ex:699
 #, elixir-autogen, elixir-format
 msgid "AWS Bedrock LLMs via a Bedrock API key (OpenAI-compatible endpoint: gpt-oss models; the rest via native Converse)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:715
+#: lib/phoenix_kit/integrations/providers.ex:716
 #, elixir-autogen, elixir-format
 msgid "AWS console → Amazon Bedrock → API keys (long-term key)"
 msgstr ""
@@ -12236,22 +12242,22 @@ msgstr ""
 msgid "Account %{id}"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:303
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:329
 #, elixir-autogen, elixir-format
 msgid "Advisory-grade: anything can send any User-Agent, so a scraper that lies passes through. Real enforcement belongs at your CDN or reverse proxy — this catches the honest-but-ignorant. Bots identified only by robots.txt tokens (Google-Extended, Applebot-Extended) crawl under their main user agent and are never matched here, so blocking AI training cannot 403 Googlebot."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:98
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:124
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Allowed"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:696
+#: lib/phoenix_kit/integrations/providers.ex:697
 #, elixir-autogen, elixir-format
 msgid "Amazon Bedrock"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:282
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:308
 #, elixir-autogen, elixir-format
 msgid "Answer 403 to requests whose User-Agent matches a blocked group, for bots that ignore robots.txt."
 msgstr ""
@@ -12261,7 +12267,7 @@ msgstr ""
 msgid "Auth mail carries single-use tokens, and /dev/mailbox has no authentication — anyone who can reach this server can read them. Only for closed environments."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:711
+#: lib/phoenix_kit/integrations/providers.ex:712
 #, elixir-autogen, elixir-format
 msgid "Bedrock API key"
 msgstr ""
@@ -12271,7 +12277,7 @@ msgstr ""
 msgid "Bedrock error %{status}"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:280
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:306
 #, elixir-autogen, elixir-format
 msgid "Block at the application"
 msgstr ""
@@ -12281,7 +12287,7 @@ msgstr ""
 msgid "Blocked groups"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:77
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:103
 #, elixir-autogen, elixir-format
 msgid "Bot Access"
 msgstr ""
@@ -12296,12 +12302,12 @@ msgstr ""
 msgid "Control how search engines and AI bots crawl and index this site"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:739
+#: lib/phoenix_kit/integrations/providers.ex:740
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Copy the key (shown once, `ABSK…`) and paste it into the form above"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:815
+#: lib/phoenix_kit/integrations/providers.ex:816
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Copy the token and paste it into the form above"
 msgstr ""
@@ -12342,22 +12348,22 @@ msgstr ""
 msgid "Crawlers module is disabled. Enable it from the Modules page to configure settings."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:731
+#: lib/phoenix_kit/integrations/providers.ex:732
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Create a Bedrock API key"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:807
+#: lib/phoenix_kit/integrations/providers.ex:808
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Create a token"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:871
+#: lib/phoenix_kit/integrations/providers.ex:872
 #, elixir-autogen, elixir-format
 msgid "Create an IAM user with SES access"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:876
+#: lib/phoenix_kit/integrations/providers.ex:877
 #, elixir-autogen, elixir-format
 msgid "Create an access key for that user (Security credentials → Create access key) and paste the ID and secret above"
 msgstr ""
@@ -12372,41 +12378,42 @@ msgstr ""
 msgid "Deliver development mail to /dev/mailbox"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:747
+#: lib/phoenix_kit/integrations/providers.ex:748
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enable model access"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:278
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:304
 #, elixir-autogen, elixir-format
 msgid "Enforcement"
 msgstr ""
 
 #: lib/phoenix_kit_web/live/settings/crawlers.ex:90
-#: lib/phoenix_kit_web/live/settings/crawlers.ex:109
-#: lib/phoenix_kit_web/live/settings/crawlers.ex:120
-#: lib/phoenix_kit_web/live/settings/crawlers.ex:136
-#: lib/phoenix_kit_web/live/settings/crawlers.ex:149
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:102
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:121
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:132
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:148
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:161
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to update crawler settings"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:780
+#: lib/phoenix_kit/integrations/providers.ex:781
 #, elixir-autogen, elixir-format, fuzzy
 msgid "GitHub"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:782
+#: lib/phoenix_kit/integrations/providers.ex:783
 #, elixir-autogen, elixir-format
 msgid "GitHub API token — org statistics, repositories (read-only is enough)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:809
+#: lib/phoenix_kit/integrations/providers.ex:810
 #, elixir-autogen, elixir-format
 msgid "Go to [Fine-grained tokens](https://github.com/settings/personal-access-tokens) and click **Generate new token**"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:81
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:107
 #, elixir-autogen, elixir-format
 msgid "Grouped by why they visit. Blocking a group writes it into the generated robots.txt below; everything defaults to allowed."
 msgstr ""
@@ -12416,22 +12423,22 @@ msgstr ""
 msgid "Hide titles of records the reader can't open"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:749
+#: lib/phoenix_kit/integrations/providers.ex:750
 #, elixir-autogen, elixir-format
 msgid "In [Bedrock → Model access](https://console.aws.amazon.com/bedrock/home#/modelaccess) enable the models you plan to call — a key with no enabled models validates but cannot complete"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:763
+#: lib/phoenix_kit/integrations/providers.ex:764
 #, elixir-autogen, elixir-format
 msgid "In the AI module, create an endpoint pointing at this connection with a `gpt-oss` model and a base URL in the SAME region as this key"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:873
+#: lib/phoenix_kit/integrations/providers.ex:874
 #, elixir-autogen, elixir-format
 msgid "In the [IAM console](https://console.aws.amazon.com/iam/home#/users) create a user for programmatic access and attach an SES policy (least privilege: `ses:SendEmail`/`ses:SendRawEmail`; docs: [SES setup](https://docs.aws.amazon.com/ses/latest/dg/setting-up.html))"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:884
+#: lib/phoenix_kit/integrations/providers.ex:885
 #, elixir-autogen, elixir-format
 msgid "In the [SES console](https://console.aws.amazon.com/ses/home#/identities) verify your domain or sender address — SES refuses to send from unverified identities"
 msgstr ""
@@ -12476,7 +12483,7 @@ msgstr ""
 msgid "Model catalog in %{region}: %{count} (grants are configured separately)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:887
+#: lib/phoenix_kit/integrations/providers.ex:888
 #, elixir-autogen, elixir-format
 msgid "New accounts start in the SES sandbox (verified recipients only) — [request production access](https://docs.aws.amazon.com/ses/latest/dg/request-production-access.html) before real sending"
 msgstr ""
@@ -12491,7 +12498,7 @@ msgstr ""
 msgid "No longer available"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:165
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:191
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No priv/static/robots.txt found. Without one, crawlers assume everything is allowed — and any groups you blocked above are not being told."
 msgstr ""
@@ -12506,47 +12513,47 @@ msgstr ""
 msgid "Note (optional)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:733
+#: lib/phoenix_kit/integrations/providers.ex:734
 #, elixir-autogen, elixir-format
 msgid "Open the [Bedrock console → API keys](https://console.aws.amazon.com/bedrock/home#/api-keys) and generate a **long-term** key (docs: [Bedrock API keys](https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys.html))"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:212
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:238
 #, elixir-autogen, elixir-format
 msgid "Optional markdown: a summary paragraph, key links, docs pointers…"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:736
+#: lib/phoenix_kit/integrations/providers.ex:737
 #, elixir-autogen, elixir-format
 msgid "Or attach one to an existing IAM user: [IAM console](https://console.aws.amazon.com/iam/home#/users) → user → Security credentials → Bedrock API keys"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:235
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:261
 #, elixir-autogen, elixir-format
 msgid "Paste the verification content Google Search Console or Bing Webmaster Tools gives you — the meta tags are added to every layout head. Pasting the whole <meta> tag also works; the content value is extracted."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:796
+#: lib/phoenix_kit/integrations/providers.ex:797
 #, elixir-autogen, elixir-format
 msgid "Personal access token"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:123
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:149
 #, elixir-autogen, elixir-format
 msgid "PhoenixKit does not serve this file — it is yours, served from priv/static before any route is consulted. This is the complete file your toggles above describe: paste it into priv/static/robots.txt."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:752
+#: lib/phoenix_kit/integrations/providers.ex:753
 #, elixir-autogen, elixir-format
 msgid "Pick the region where access was granted; the AI endpoint's base URL must use the same region"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:217
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:243
 #, elixir-autogen, elixir-format
 msgid "Preview of the served file:"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:812
+#: lib/phoenix_kit/integrations/providers.ex:813
 #, elixir-autogen, elixir-format
 msgid "Repository access: **Public repositories (read-only)** — no extra permissions needed for public-org statistics"
 msgstr ""
@@ -12556,7 +12563,7 @@ msgstr ""
 msgid "Request access"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:233
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:259
 #, elixir-autogen, elixir-format
 msgid "Search engine verification"
 msgstr ""
@@ -12576,12 +12583,12 @@ msgstr ""
 msgid "Sign in to request access."
 msgstr "Sign in as user"
 
-#: lib/phoenix_kit/integrations/providers.ex:760
+#: lib/phoenix_kit/integrations/providers.ex:761
 #, elixir-autogen, elixir-format
 msgid "The OpenAI-compatible endpoint (`…/openai/v1`) currently serves only the `openai.gpt-oss-*` models — Anthropic and the other Bedrock models answer on the native Converse API with the same key"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:742
+#: lib/phoenix_kit/integrations/providers.ex:743
 #, elixir-autogen, elixir-format
 msgid "The key's IAM identity must allow the `bedrock:CallWithBearerToken` action — without it every Bearer call answers 403 even when invoke permissions are in place."
 msgstr ""
@@ -12591,17 +12598,17 @@ msgstr ""
 msgid "The mailbox is off: outgoing mail is written to the server log instead."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:179
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:205
 #, elixir-autogen, elixir-format, fuzzy
 msgid "The noindex toggle and robots.txt are separate mechanisms: noindex is a per-page meta tag that tells crawlers not to index what they fetched, while robots.txt tells them what not to fetch at all. A staging site usually wants both."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:194
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:220
 #, elixir-autogen, elixir-format
 msgid "The other half of bot policy: a markdown summary telling AI assistants what this site is about, served at"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:892
+#: lib/phoenix_kit/integrations/providers.ex:893
 #, elixir-autogen, elixir-format
 msgid "This connection stores the credential. The full sending pipeline — configuration set, SNS topic, SQS event queue, delivery tracking — is configured in Admin → Settings → Emails, which can select this connection as its credential source."
 msgstr ""
@@ -12618,22 +12625,22 @@ msgstr ""
 msgid "Unread · %{day}"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:758
+#: lib/phoenix_kit/integrations/providers.ex:759
 #, elixir-autogen, elixir-format
 msgid "Use it from the AI module"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:231
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:257
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Verification"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.ex:133
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:145
 #, elixir-autogen, elixir-format
 msgid "Verification tags saved."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:882
+#: lib/phoenix_kit/integrations/providers.ex:883
 #, elixir-autogen, elixir-format
 msgid "Verify a sender in SES"
 msgstr ""
@@ -12648,7 +12655,7 @@ msgstr ""
 msgid "Where development mail goes while the resolved transport is the local adapter."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:79
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "Who may crawl this site"
 msgstr ""
@@ -12668,12 +12675,12 @@ msgstr ""
 msgid "You don't have access — click to request it"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:800
+#: lib/phoenix_kit/integrations/providers.ex:801
 #, elixir-autogen, elixir-format
 msgid "github.com/settings/personal-access-tokens — fine-grained, read-only"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.ex:146
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:158
 #, elixir-autogen, elixir-format
 msgid "llms.txt content saved."
 msgstr ""
@@ -12683,7 +12690,7 @@ msgstr ""
 msgid "management API: %{services}"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:169
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:195
 #, elixir-autogen, elixir-format, fuzzy
 msgid "priv/static/robots.txt exists but has no Sitemap: line. Paste the file above so crawlers are told where to look."
 msgstr ""
@@ -12693,7 +12700,7 @@ msgstr ""
 msgid "private item"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:200
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:226
 #, elixir-autogen, elixir-format
 msgid "while this module is enabled. The heading comes from your project title; everything below it is yours."
 msgstr ""
@@ -12747,7 +12754,7 @@ msgstr ""
 msgid "Select Avatar"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:701
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:716
 #, elixir-autogen, elixir-format
 msgid "Select Background Image"
 msgstr ""
@@ -12764,7 +12771,7 @@ msgstr ""
 
 #: lib/phoenix_kit_web/components/media_browser.html.heex:2469
 #: lib/phoenix_kit_web/live/settings.html.heex:636
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:702
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:717
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select Logo"
 msgstr ""
@@ -12862,4 +12869,423 @@ msgstr ""
 #: lib/phoenix_kit_web/live/settings/integrations.ex:231
 #, elixir-autogen, elixir-format
 msgid "The current encryption status could not be described by this admin page — it may be newer than what this page recognizes. Check PhoenixKit.Integrations.Encryption.status/0 directly."
+msgstr ""
+
+#: lib/phoenix_kit_web/live/settings/authorization.ex:247
+#, elixir-autogen, elixir-format
+msgid "A secret is already configured — leave blank to keep the current value"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:365
+#: lib/phoenix_kit_web/users/session.ex:245
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Account added."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/session.ex:27
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Account created successfully!"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/session.ex:356
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Account removed."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:272
+#, elixir-autogen, elixir-format
+msgid "Account switching is currently disabled."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:316
+#, elixir-autogen, elixir-format
+msgid "An account already exists for that email address. Sign in with your password first, then connect this provider from your account settings."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:328
+#, elixir-autogen, elixir-format
+msgid "Authentication failed. Please try again or use a different sign-in method."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:355
+#: lib/phoenix_kit_web/users/oauth.ex:438
+#: lib/phoenix_kit_web/users/oauth.ex:444
+#, elixir-autogen, elixir-format
+msgid "Authentication failed. Please try again."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:299
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Authentication failed: %{errors}"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:441
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Authentication failed: %{message}"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/session.ex:360
+#, elixir-autogen, elixir-format
+msgid "Cannot remove your primary account."
+msgstr ""
+
+#: lib/phoenix_kit_web/controllers/context_controller.ex:101
+#, elixir-autogen, elixir-format
+msgid "Context switching is not enabled"
+msgstr ""
+
+#: lib/phoenix_kit/integrations/validators.ex:627
+#: lib/phoenix_kit/integrations/validators.ex:634
+#: lib/phoenix_kit/integrations/validators.ex:732
+#: lib/phoenix_kit/integrations/validators.ex:740
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Could not reach the storage endpoint"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/session.ex:365
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Could not remove account."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/session.ex:274
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Could not switch account."
+msgstr ""
+
+#: lib/phoenix_kit/integrations/validators.ex:721
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Credentials are valid, but not authorized to list buckets"
+msgstr ""
+
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:85
+#, elixir-autogen, elixir-format
+msgid "Exempt"
+msgstr ""
+
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:86
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Follows noindex"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link.ex:120
+#, elixir-autogen, elixir-format
+msgid "If that email address exists, a magic link has been sent."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/confirmation_instructions.ex:89
+#, elixir-autogen, elixir-format
+msgid "If your email is in our system and it has not been confirmed yet, you will receive an email with instructions shortly."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/forgot_password.ex:49
+#, elixir-autogen, elixir-format
+msgid "If your email is in our system, you will receive instructions to reset your password shortly."
+msgstr ""
+
+#: lib/phoenix_kit_web/controllers/context_controller.ex:82
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Invalid context"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:110
+#, elixir-autogen, elixir-format
+msgid "Invalid email format"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/session.ex:92
+#, elixir-autogen, elixir-format
+msgid "Invalid email/username or password"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/session.ex:259
+#, elixir-autogen, elixir-format
+msgid "Invalid email/username or password."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_verify.ex:40
+#, elixir-autogen, elixir-format
+msgid "Invalid magic link. Please request a new one."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration_verify.ex:32
+#, elixir-autogen, elixir-format
+msgid "Invalid registration link. Please request a new one."
+msgstr ""
+
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:77
+#, elixir-autogen, elixir-format
+msgid "Keep publishing the sitemap's real URLs even while noindex is on, so the feed can be verified without exposing the site to indexing. The noindex meta tag above is unaffected either way."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/session.ex:104
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Logged out of all accounts."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/session.ex:122
+#: lib/phoenix_kit_web/users/session.ex:235
+#, elixir-autogen, elixir-format
+msgid "Logged out successfully."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_verify.ex:63
+#, elixir-autogen, elixir-format
+msgid "Magic link is invalid or has expired. Please request a new one."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration.ex:41
+#, elixir-autogen, elixir-format
+msgid "Magic link registration is currently disabled."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link.ex:110
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Magic link sent! Check your email."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link.ex:39
+#: lib/phoenix_kit_web/users/magic_link_verify.ex:33
+#, elixir-autogen, elixir-format
+msgid "Magic link sign-in is currently disabled."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:370
+#: lib/phoenix_kit_web/users/session.ex:249
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Maximum number of accounts reached."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/session.ex:137
+#, elixir-autogen, elixir-format
+msgid "Multi-account switching is not available."
+msgstr ""
+
+#: lib/phoenix_kit/integrations/providers.ex:950
+#, elixir-autogen, elixir-format
+msgid "Not every S3-compatible provider needs one — leave blank if the endpoint doesn't require it."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:119
+#, elixir-autogen, elixir-format
+msgid "OAuth authentication is currently disabled. Please contact your administrator to enable it."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:94
+#, elixir-autogen, elixir-format
+msgid "OAuth provider '%{provider}' is currently disabled."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:106
+#, elixir-autogen, elixir-format
+msgid "OAuth provider '%{provider}' is not configured. Please contact your administrator."
+msgstr ""
+
+#: lib/phoenix_kit/integrations/providers.ex:913
+#, elixir-autogen, elixir-format
+msgid "Object Storage (S3-compatible)"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/reset_password.ex:41
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Password reset successfully."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/session.ex:34
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Password updated successfully!"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration.ex:35
+#: lib/phoenix_kit_web/users/registration.ex:128
+#, elixir-autogen, elixir-format
+msgid "Registration is currently disabled."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration.ex:92
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Registration link is invalid or has expired."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration.ex:188
+#: lib/phoenix_kit_web/users/magic_link_registration_verify.ex:24
+#, elixir-autogen, elixir-format
+msgid "Registration link is invalid or has expired. Please request a new one."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:92
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:103
+#, elixir-autogen, elixir-format
+msgid "Registration link sent! Check your email."
+msgstr ""
+
+#: lib/phoenix_kit/integrations/providers.ex:962
+#, elixir-autogen, elixir-format
+msgid "Required for Cloudflare R2, Backblaze B2, Tigris, and self-hosted S3-compatible storage. Leave blank for AWS S3."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/reset_password.ex:59
+#, elixir-autogen, elixir-format
+msgid "Reset password link is invalid or it has expired."
+msgstr ""
+
+#: lib/phoenix_kit/integrations/providers.ex:915
+#, elixir-autogen, elixir-format
+msgid "S3-compatible object storage — AWS S3, Cloudflare R2, Backblaze B2, Tigris, or a self-hosted endpoint"
+msgstr ""
+
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:75
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Sitemap Exemption"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:144
+#, elixir-autogen, elixir-format
+msgid "Something went wrong"
+msgstr ""
+
+#: lib/phoenix_kit/integrations/validators.ex:735
+#, elixir-autogen, elixir-format
+msgid "Storage error: %{code}"
+msgstr ""
+
+#: lib/phoenix_kit/integrations/validators.ex:729
+#, elixir-autogen, elixir-format
+msgid "Storage service is busy — try again in a moment"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_verify.ex:56
+#, elixir-autogen, elixir-format
+msgid "Successfully logged in with magic link!"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:277
+#, elixir-autogen, elixir-format
+msgid "Successfully signed in with %{provider}!"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:375
+#: lib/phoenix_kit_web/users/session.ex:254
+#, elixir-autogen, elixir-format, fuzzy
+msgid "That account is already in your session."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:380
+#, elixir-autogen, elixir-format, fuzzy
+msgid "That account is inactive."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration.ex:185
+#, elixir-autogen, elixir-format
+msgid "That email is already registered. Please log in instead."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:118
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Too many attempts"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/session.ex:84
+#, elixir-autogen, elixir-format
+msgid "Too many login attempts. Please try again later."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:84
+#: lib/phoenix_kit_web/users/oauth.ex:210
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Unknown OAuth provider: %{provider}"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/confirmation.ex:68
+#, elixir-autogen, elixir-format
+msgid "User confirmation link is invalid or it has expired."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/confirmation.ex:50
+#, elixir-autogen, elixir-format, fuzzy
+msgid "User confirmed successfully."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:77
+#, elixir-autogen, elixir-format
+msgid "User registration is currently disabled."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:51
+#: lib/phoenix_kit_web/users/registration.ex:110
+#, elixir-autogen, elixir-format
+msgid "User registration is currently disabled. Please contact an administrator."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/session.ex:40
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Welcome back!"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/session.ex:66
+#, elixir-autogen, elixir-format
+msgid "Your account is currently inactive. Please contact the team if you believe this is an error."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:1873
+#, elixir-autogen, elixir-format
+msgid "%{label} module is not enabled"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:2366
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Enter your referral code to continue."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:2362
+#, elixir-autogen, elixir-format
+msgid "Please confirm your email before accessing the application."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:111
+#, elixir-autogen, elixir-format
+msgid "This account is not active. Contact an administrator."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:749
+#: lib/phoenix_kit_web/users/auth.ex:1892
+#: lib/phoenix_kit_web/users/auth.ex:2511
+#, elixir-autogen, elixir-format, fuzzy
+msgid "You do not have permission to access this section."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:724
+#: lib/phoenix_kit_web/users/auth.ex:878
+#: lib/phoenix_kit_web/users/auth.ex:2460
+#: lib/phoenix_kit_web/users/auth.ex:2496
+#, elixir-autogen, elixir-format, fuzzy
+msgid "You do not have the required permission to access this page."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:1417
+#, elixir-autogen, elixir-format
+msgid "You must be an admin to access this page."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:679
+#: lib/phoenix_kit_web/users/auth.ex:2423
+#, elixir-autogen, elixir-format
+msgid "You must be an owner to access this page."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:2539
+#, elixir-autogen, elixir-format
+msgid "You must have the %{role_name} role to access this page."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:903
+#: lib/phoenix_kit_web/users/auth.ex:2292
+#: lib/phoenix_kit_web/users/auth.ex:2329
+#: lib/phoenix_kit_web/users/auth.ex:2467
+#, elixir-autogen, elixir-format
+msgid "You must log in to access this page."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:1428
+#, elixir-autogen, elixir-format
+msgid "You no longer have permission to access this section."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -12878,17 +12878,17 @@ msgstr ""
 
 #: lib/phoenix_kit_web/users/oauth.ex:365
 #: lib/phoenix_kit_web/users/session.ex:245
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Account added."
 msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:27
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Account created successfully!"
 msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:356
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Account removed."
 msgstr ""
 
@@ -12915,12 +12915,12 @@ msgid "Authentication failed. Please try again."
 msgstr ""
 
 #: lib/phoenix_kit_web/users/oauth.ex:299
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Authentication failed: %{errors}"
 msgstr ""
 
 #: lib/phoenix_kit_web/users/oauth.ex:441
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Authentication failed: %{message}"
 msgstr ""
 
@@ -12938,22 +12938,22 @@ msgstr ""
 #: lib/phoenix_kit/integrations/validators.ex:634
 #: lib/phoenix_kit/integrations/validators.ex:732
 #: lib/phoenix_kit/integrations/validators.ex:740
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Could not reach the storage endpoint"
 msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:365
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Could not remove account."
 msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:274
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Could not switch account."
 msgstr ""
 
 #: lib/phoenix_kit/integrations/validators.ex:721
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Credentials are valid, but not authorized to list buckets"
 msgstr ""
 
@@ -12963,7 +12963,7 @@ msgid "Exempt"
 msgstr ""
 
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:86
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Follows noindex"
 msgstr ""
 
@@ -12983,7 +12983,7 @@ msgid "If your email is in our system, you will receive instructions to reset yo
 msgstr ""
 
 #: lib/phoenix_kit_web/controllers/context_controller.ex:82
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Invalid context"
 msgstr ""
 
@@ -13018,7 +13018,7 @@ msgid "Keep publishing the sitemap's real URLs even while noindex is on, so the 
 msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:104
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Logged out of all accounts."
 msgstr ""
 
@@ -13039,7 +13039,7 @@ msgid "Magic link registration is currently disabled."
 msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link.ex:110
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Magic link sent! Check your email."
 msgstr ""
 
@@ -13051,7 +13051,7 @@ msgstr ""
 
 #: lib/phoenix_kit_web/users/oauth.ex:370
 #: lib/phoenix_kit_web/users/session.ex:249
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Maximum number of accounts reached."
 msgstr ""
 
@@ -13086,12 +13086,12 @@ msgid "Object Storage (S3-compatible)"
 msgstr ""
 
 #: lib/phoenix_kit_web/users/reset_password.ex:41
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Password reset successfully."
 msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:34
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Password updated successfully!"
 msgstr ""
 
@@ -13102,7 +13102,7 @@ msgid "Registration is currently disabled."
 msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link_registration.ex:92
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Registration link is invalid or has expired."
 msgstr ""
 
@@ -13134,7 +13134,7 @@ msgid "S3-compatible object storage — AWS S3, Cloudflare R2, Backblaze B2, Tig
 msgstr ""
 
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:75
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Sitemap Exemption"
 msgstr ""
 
@@ -13165,12 +13165,12 @@ msgstr ""
 
 #: lib/phoenix_kit_web/users/oauth.ex:375
 #: lib/phoenix_kit_web/users/session.ex:254
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "That account is already in your session."
 msgstr ""
 
 #: lib/phoenix_kit_web/users/oauth.ex:380
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "That account is inactive."
 msgstr ""
 
@@ -13180,7 +13180,7 @@ msgid "That email is already registered. Please log in instead."
 msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link_registration_request.ex:118
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Too many attempts"
 msgstr ""
 
@@ -13191,7 +13191,7 @@ msgstr ""
 
 #: lib/phoenix_kit_web/users/oauth.ex:84
 #: lib/phoenix_kit_web/users/oauth.ex:210
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Unknown OAuth provider: %{provider}"
 msgstr ""
 
@@ -13201,7 +13201,7 @@ msgid "User confirmation link is invalid or it has expired."
 msgstr ""
 
 #: lib/phoenix_kit_web/users/confirmation.ex:50
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "User confirmed successfully."
 msgstr ""
 
@@ -13217,7 +13217,7 @@ msgid "User registration is currently disabled. Please contact an administrator.
 msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:40
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Welcome back!"
 msgstr ""
 
@@ -13232,7 +13232,7 @@ msgid "%{label} module is not enabled"
 msgstr ""
 
 #: lib/phoenix_kit_web/users/auth.ex:2366
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Enter your referral code to continue."
 msgstr ""
 
@@ -13249,7 +13249,7 @@ msgstr ""
 #: lib/phoenix_kit_web/users/auth.ex:749
 #: lib/phoenix_kit_web/users/auth.ex:1892
 #: lib/phoenix_kit_web/users/auth.ex:2511
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "You do not have permission to access this section."
 msgstr ""
 
@@ -13257,7 +13257,7 @@ msgstr ""
 #: lib/phoenix_kit_web/users/auth.ex:878
 #: lib/phoenix_kit_web/users/auth.ex:2460
 #: lib/phoenix_kit_web/users/auth.ex:2496
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "You do not have the required permission to access this page."
 msgstr ""
 

--- a/priv/gettext/en/LC_MESSAGES/phoenix_kit.po
+++ b/priv/gettext/en/LC_MESSAGES/phoenix_kit.po
@@ -21,27 +21,27 @@ msgstr ""
 msgid "This user already belongs to an organization"
 msgstr ""
 
-#: lib/phoenix_kit/users/auth.ex:1064
+#: lib/phoenix_kit/users/auth.ex:1074
 #, elixir-autogen, elixir-format
 msgid "cannot change to person while organization has members"
 msgstr ""
 
-#: lib/phoenix_kit/users/auth.ex:1044
+#: lib/phoenix_kit/users/auth.ex:1054
 #, elixir-autogen, elixir-format
 msgid "cannot reference self"
 msgstr ""
 
-#: lib/phoenix_kit/users/auth.ex:1052
+#: lib/phoenix_kit/users/auth.ex:1062
 #, elixir-autogen, elixir-format
 msgid "only person accounts can join an organization"
 msgstr ""
 
-#: lib/phoenix_kit/users/auth.ex:1039
+#: lib/phoenix_kit/users/auth.ex:1049
 #, elixir-autogen, elixir-format
 msgid "organization not found"
 msgstr ""
 
-#: lib/phoenix_kit/users/auth.ex:1038
+#: lib/phoenix_kit/users/auth.ex:1048
 #, elixir-autogen, elixir-format
 msgid "target user is not an organization"
 msgstr ""

--- a/priv/gettext/es/LC_MESSAGES/default.po
+++ b/priv/gettext/es/LC_MESSAGES/default.po
@@ -12886,19 +12886,19 @@ msgstr ""
 
 #: lib/phoenix_kit_web/users/oauth.ex:365
 #: lib/phoenix_kit_web/users/session.ex:245
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Account added."
-msgstr "Cuenta"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:27
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Account created successfully!"
-msgstr "Bucket habilitado correctamente"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:356
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Account removed."
-msgstr "Cuenta"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/oauth.ex:272
 #, elixir-autogen, elixir-format
@@ -12923,14 +12923,14 @@ msgid "Authentication failed. Please try again."
 msgstr ""
 
 #: lib/phoenix_kit_web/users/oauth.ex:299
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Authentication failed: %{errors}"
-msgstr "Autenticación"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/oauth.ex:441
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Authentication failed: %{message}"
-msgstr "Autenticación"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:360
 #, elixir-autogen, elixir-format
@@ -12946,24 +12946,24 @@ msgstr ""
 #: lib/phoenix_kit/integrations/validators.ex:634
 #: lib/phoenix_kit/integrations/validators.ex:732
 #: lib/phoenix_kit/integrations/validators.ex:740
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Could not reach the storage endpoint"
-msgstr "No se pudo contactar con el servicio"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:365
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Could not remove account."
-msgstr "No se pudo contactar con Brevo"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:274
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Could not switch account."
-msgstr "No se pudieron desvincular los chats"
+msgstr ""
 
 #: lib/phoenix_kit/integrations/validators.ex:721
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Credentials are valid, but not authorized to list buckets"
-msgstr "Las credenciales son válidas pero no están autorizadas para GetSendQuota: no se verificó el envío"
+msgstr ""
 
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:85
 #, elixir-autogen, elixir-format
@@ -12971,9 +12971,9 @@ msgid "Exempt"
 msgstr ""
 
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:86
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Follows noindex"
-msgstr "Seguidos"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link.ex:120
 #, elixir-autogen, elixir-format
@@ -12991,9 +12991,9 @@ msgid "If your email is in our system, you will receive instructions to reset yo
 msgstr ""
 
 #: lib/phoenix_kit_web/controllers/context_controller.ex:82
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Invalid context"
-msgstr "Token del bot no válido"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link_registration_request.ex:110
 #, elixir-autogen, elixir-format
@@ -13026,9 +13026,9 @@ msgid "Keep publishing the sitemap's real URLs even while noindex is on, so the 
 msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:104
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Logged out of all accounts."
-msgstr "Cerrar sesión en todas las cuentas"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:122
 #: lib/phoenix_kit_web/users/session.ex:235
@@ -13047,9 +13047,9 @@ msgid "Magic link registration is currently disabled."
 msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link.ex:110
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Magic link sent! Check your email."
-msgstr "¡Enlace mágico enviado!"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link.ex:39
 #: lib/phoenix_kit_web/users/magic_link_verify.ex:33
@@ -13059,9 +13059,9 @@ msgstr ""
 
 #: lib/phoenix_kit_web/users/oauth.ex:370
 #: lib/phoenix_kit_web/users/session.ex:249
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Maximum number of accounts reached."
-msgstr "Se alcanzó el número máximo de cuentas: quite una primero."
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:137
 #, elixir-autogen, elixir-format
@@ -13094,14 +13094,14 @@ msgid "Object Storage (S3-compatible)"
 msgstr ""
 
 #: lib/phoenix_kit_web/users/reset_password.ex:41
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Password reset successfully."
-msgstr "Contraseña cambiada correctamente."
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:34
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Password updated successfully!"
-msgstr "Contraseña cambiada correctamente."
+msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link_registration.ex:35
 #: lib/phoenix_kit_web/users/registration.ex:128
@@ -13110,9 +13110,9 @@ msgid "Registration is currently disabled."
 msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link_registration.ex:92
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Registration link is invalid or has expired."
-msgstr "El enlace de cambio de correo no es válido o ha caducado."
+msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link_registration.ex:188
 #: lib/phoenix_kit_web/users/magic_link_registration_verify.ex:24
@@ -13142,9 +13142,9 @@ msgid "S3-compatible object storage — AWS S3, Cloudflare R2, Backblaze B2, Tig
 msgstr ""
 
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:75
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Sitemap Exemption"
-msgstr "Ajustes del sitemap"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link_registration_request.ex:144
 #, elixir-autogen, elixir-format
@@ -13173,14 +13173,14 @@ msgstr ""
 
 #: lib/phoenix_kit_web/users/oauth.ex:375
 #: lib/phoenix_kit_web/users/session.ex:254
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "That account is already in your session."
-msgstr "Esa cuenta ya está en su sesión: cambie a ella en su lugar."
+msgstr ""
 
 #: lib/phoenix_kit_web/users/oauth.ex:380
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "That account is inactive."
-msgstr "Esa cuenta está desactivada."
+msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link_registration.ex:185
 #, elixir-autogen, elixir-format
@@ -13188,9 +13188,9 @@ msgid "That email is already registered. Please log in instead."
 msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link_registration_request.ex:118
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Too many attempts"
-msgstr "Demasiados archivos"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:84
 #, elixir-autogen, elixir-format
@@ -13199,9 +13199,9 @@ msgstr ""
 
 #: lib/phoenix_kit_web/users/oauth.ex:84
 #: lib/phoenix_kit_web/users/oauth.ex:210
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Unknown OAuth provider: %{provider}"
-msgstr "Proveedor desconocido"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/confirmation.ex:68
 #, elixir-autogen, elixir-format
@@ -13209,9 +13209,9 @@ msgid "User confirmation link is invalid or it has expired."
 msgstr ""
 
 #: lib/phoenix_kit_web/users/confirmation.ex:50
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "User confirmed successfully."
-msgstr "Usuario activado correctamente"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link_registration_request.ex:77
 #, elixir-autogen, elixir-format
@@ -13225,9 +13225,9 @@ msgid "User registration is currently disabled. Please contact an administrator.
 msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:40
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Welcome back!"
-msgstr "Bienvenido de nuevo"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:66
 #, elixir-autogen, elixir-format
@@ -13240,9 +13240,9 @@ msgid "%{label} module is not enabled"
 msgstr ""
 
 #: lib/phoenix_kit_web/users/auth.ex:2366
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Enter your referral code to continue."
-msgstr "Introduzca su código de referencia"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/auth.ex:2362
 #, elixir-autogen, elixir-format
@@ -13257,17 +13257,17 @@ msgstr ""
 #: lib/phoenix_kit_web/users/auth.ex:749
 #: lib/phoenix_kit_web/users/auth.ex:1892
 #: lib/phoenix_kit_web/users/auth.ex:2511
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "You do not have permission to access this section."
-msgstr "No tiene permiso para iniciar sesión como otro usuario."
+msgstr ""
 
 #: lib/phoenix_kit_web/users/auth.ex:724
 #: lib/phoenix_kit_web/users/auth.ex:878
 #: lib/phoenix_kit_web/users/auth.ex:2460
 #: lib/phoenix_kit_web/users/auth.ex:2496
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "You do not have the required permission to access this page."
-msgstr "No tiene permiso para iniciar sesión como otro usuario."
+msgstr ""
 
 #: lib/phoenix_kit_web/users/auth.ex:1417
 #, elixir-autogen, elixir-format

--- a/priv/gettext/es/LC_MESSAGES/default.po
+++ b/priv/gettext/es/LC_MESSAGES/default.po
@@ -70,7 +70,7 @@ msgstr "Gestión de roles"
 
 #: lib/phoenix_kit/dashboard/admin_tabs.ex:119
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:138
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:647
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:662
 #: lib/phoenix_kit_web/live/settings/users.html.heex:130
 #, elixir-autogen
 msgid "Sessions"
@@ -237,7 +237,7 @@ msgstr "Conexiones en tiempo real"
 
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:320
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:64
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:144
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:140
 #, elixir-autogen
 msgid "Anonymous"
 msgstr "Anónimos"
@@ -250,7 +250,7 @@ msgstr "Visitantes no registrados"
 
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:331
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:77
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:151
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:144
 #, elixir-autogen
 msgid "Authenticated"
 msgstr "Autenticados"
@@ -347,7 +347,7 @@ msgstr "Nivel de acceso estándar"
 msgid "Role System"
 msgstr "Sistema de Roles"
 
-#: lib/phoenix_kit/integrations/providers.ex:991
+#: lib/phoenix_kit/integrations/providers.ex:1063
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:450
 #, elixir-autogen
 msgid "Authentication"
@@ -359,7 +359,7 @@ msgstr "Autenticación"
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:445
 #: lib/phoenix_kit_web/live/modules.html.heex:65
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:114
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:273
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:267
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:145
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:297
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:682
@@ -466,8 +466,8 @@ msgstr "Acerca de los permisos"
 msgid "Accept All"
 msgstr "Aceptar todo"
 
-#: lib/phoenix_kit/integrations/integrations.ex:1133
-#: lib/phoenix_kit/integrations/validators.ex:598
+#: lib/phoenix_kit/integrations/integrations.ex:1136
+#: lib/phoenix_kit/integrations/validators.ex:779
 #: lib/phoenix_kit_web/live/activity/index.ex:66
 #: lib/phoenix_kit_web/live/activity/show.ex:56
 #, elixir-autogen, elixir-format
@@ -505,7 +505,7 @@ msgid "Actions"
 msgstr "Acciones"
 
 #: lib/phoenix_kit_web/components/media_gallery.html.heex:86
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:585
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:600
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:266
 #: lib/phoenix_kit_web/live/settings/users.html.heex:693
 #: lib/phoenix_kit_web/users/user_form.html.heex:719
@@ -613,7 +613,7 @@ msgstr "Información básica"
 msgid "Billing profiles and payment methods"
 msgstr "Perfiles de facturación y métodos de pago"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:98
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:124
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:501
 #, elixir-autogen, elixir-format
 msgid "Blocked"
@@ -1553,7 +1553,7 @@ msgstr "Página generada correctamente"
 msgid "Page published successfully"
 msgstr "Página publicada correctamente"
 
-#: lib/phoenix_kit/integrations/providers.ex:956
+#: lib/phoenix_kit/integrations/providers.ex:1028
 #: lib/phoenix_kit_web/components/user_dashboard_nav.ex:277
 #: lib/phoenix_kit_web/users/login.html.heex:39
 #: lib/phoenix_kit_web/users/magic_link_registration.html.heex:42
@@ -1814,8 +1814,8 @@ msgstr "SWIFT/BIC"
 #: lib/phoenix_kit_web/components/core/markdown_editor.ex:440
 #: lib/phoenix_kit_web/components/media_browser.html.heex:1349
 #: lib/phoenix_kit_web/live/notifications/settings.ex:436
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:219
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:267
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:245
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:293
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr "Guardar"
@@ -1858,7 +1858,7 @@ msgstr "Guardado"
 #: lib/phoenix_kit_web/components/core/markdown_editor.ex:333
 #: lib/phoenix_kit_web/components/core/markdown_editor.ex:417
 #: lib/phoenix_kit_web/live/settings.html.heex:592
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:683
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:698
 #: lib/phoenix_kit_web/live/settings/users.html.heex:546
 #, elixir-autogen, elixir-format
 msgid "Saving..."
@@ -1945,7 +1945,7 @@ msgstr "Estado/Provincia"
 #: lib/phoenix_kit_web/live/settings/users.html.heex:367
 #: lib/phoenix_kit_web/live/settings/users.html.heex:408
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:114
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:199
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:193
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:247
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:294
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:650
@@ -2052,7 +2052,7 @@ msgstr "Roles totales"
 #: lib/phoenix_kit_web/live/settings/users.html.heex:361
 #: lib/phoenix_kit_web/live/settings/users.html.heex:404
 #: lib/phoenix_kit_web/live/settings/users.html.heex:602
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:192
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:186
 #: lib/phoenix_kit_web/live/users/roles.html.heex:92
 #: lib/phoenix_kit_web/live/users/roles.html.heex:160
 #, elixir-autogen, elixir-format
@@ -2068,7 +2068,7 @@ msgstr "Sin confirmar"
 #: lib/phoenix_kit_web/components/core/time_display.ex:183
 #: lib/phoenix_kit_web/components/language_switcher.ex:832
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:108
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:255
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:249
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr "Desconocido"
@@ -2126,7 +2126,7 @@ msgstr "Usuario no encontrado"
 msgid "User-defined roles"
 msgstr "Roles definidos por el usuario"
 
-#: lib/phoenix_kit/integrations/providers.ex:944
+#: lib/phoenix_kit/integrations/providers.ex:1016
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:255
 #: lib/phoenix_kit_web/users/magic_link_registration.html.heex:30
 #: lib/phoenix_kit_web/users/registration.html.heex:69
@@ -2446,22 +2446,22 @@ msgstr "(vacío)"
 msgid "(registration disabled)"
 msgstr "(registro desactivado)"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:622
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:637
 #, elixir-autogen, elixir-format
 msgid "1. Enable the provider above and save settings"
 msgstr "1. Active el proveedor arriba y guarde la configuración"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:623
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:638
 #, elixir-autogen, elixir-format
 msgid "2. Enter your OAuth credentials in the form that appears"
 msgstr "2. Introduzca sus credenciales de OAuth en el formulario que aparece"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:624
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:639
 #, elixir-autogen, elixir-format
 msgid "3. Save settings again to store credentials"
 msgstr "3. Guarde la configuración de nuevo para almacenar las credenciales"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:625
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:640
 #, elixir-autogen, elixir-format
 msgid "4. Click \"Test Credentials\" to verify configuration"
 msgstr "4. Haga clic en «Probar credenciales» para verificar la configuración"
@@ -2472,7 +2472,8 @@ msgid "Access Credentials"
 msgstr "Credenciales de acceso"
 
 #: lib/modules/storage/web/bucket_form.html.heex:227
-#: lib/phoenix_kit/integrations/providers.ex:842
+#: lib/phoenix_kit/integrations/providers.ex:843
+#: lib/phoenix_kit/integrations/providers.ex:927
 #, elixir-autogen, elixir-format
 msgid "Access Key ID"
 msgstr "ID de clave de acceso"
@@ -2522,9 +2523,9 @@ msgstr "Agregar dimensión de imagen"
 msgid "Add Video Dimension"
 msgstr "Agregar dimensión de vídeo"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:429
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:507
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:592
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:434
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:517
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:607
 #, elixir-autogen, elixir-format
 msgid "Add callback URL above to"
 msgstr "Agregue la URL de retorno arriba para"
@@ -2556,12 +2557,12 @@ msgstr "Todos los nuevos usuarios recibirán privilegios administrativos y acces
 msgid "Anyone can register"
 msgstr "Cualquiera puede registrarse"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:541
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:551
 #, elixir-autogen, elixir-format
 msgid "App ID"
 msgstr "ID de la aplicación"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:551
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:561
 #, elixir-autogen, elixir-format
 msgid "App Secret"
 msgstr "Secreto de la aplicación"
@@ -2680,7 +2681,7 @@ msgstr "Los buckets pueden ser directorios locales o proveedores de almacenamien
 msgid "CSS color or gradient for auth page background. Ignored if a background image is set."
 msgstr "Color o degradado CSS para el fondo de la página de autenticación. Se ignora si hay una imagen de fondo."
 
-#: lib/phoenix_kit_web/live/settings/authorization.ex:261
+#: lib/phoenix_kit_web/live/settings/authorization.ex:302
 #, elixir-autogen, elixir-format
 msgid "Callback URL"
 msgstr "URL de retorno"
@@ -2690,25 +2691,25 @@ msgstr "URL de retorno"
 msgid "Changes will be saved immediately"
 msgstr "Los cambios se guardarán inmediatamente"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:434
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:511
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:518
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:609
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:439
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:521
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:528
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:624
 #, elixir-autogen, elixir-format
 msgid "Click"
 msgstr "Haga clic"
 
-#: lib/phoenix_kit/integrations/providers.ex:215
+#: lib/phoenix_kit/integrations/providers.ex:216
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:378
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:458
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:463
 #, elixir-autogen, elixir-format
 msgid "Client ID"
 msgstr "ID de cliente"
 
-#: lib/phoenix_kit/integrations/providers.ex:224
-#: lib/phoenix_kit/integrations/providers.ex:1169
+#: lib/phoenix_kit/integrations/providers.ex:225
+#: lib/phoenix_kit/integrations/providers.ex:1241
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:388
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:468
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:473
 #, elixir-autogen, elixir-format
 msgid "Client Secret"
 msgstr "Secreto de cliente"
@@ -2739,34 +2740,34 @@ msgstr "Configure las preferencias y opciones del sistema"
 msgid "Consider \"User\" for most installations to maintain security."
 msgstr "Considere «Usuario» para la mayoría de las instalaciones a fin de mantener la seguridad."
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:514
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:599
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:142
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:524
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:614
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:168
 #, elixir-autogen, elixir-format
 msgid "Copy"
 msgstr "Copiar"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:432
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:437
 #, elixir-autogen, elixir-format
 msgid "Copy Client ID and Secret to fields above"
 msgstr "Copie el ID de cliente y el secreto en los campos de arriba"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:568
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:583
 #, elixir-autogen, elixir-format
 msgid "Copy this URL to Facebook App Settings"
 msgstr "Copie esta URL en la configuración de la app de Facebook"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:485
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:495
 #, elixir-autogen, elixir-format
 msgid "Copy this URL to GitHub OAuth Apps"
 msgstr "Copie esta URL en las apps OAuth de GitHub"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:405
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:410
 #, elixir-autogen, elixir-format
 msgid "Copy this URL to Google Cloud Console"
 msgstr "Copie esta URL en la consola de Google Cloud"
 
-#: lib/phoenix_kit_web/live/settings/authorization.ex:271
+#: lib/phoenix_kit_web/live/settings/authorization.ex:312
 #, elixir-autogen, elixir-format
 msgid "Copy to clipboard"
 msgstr "Copiar al portapapeles"
@@ -2791,12 +2792,12 @@ msgstr "Crear ruta de almacenamiento"
 msgid "Create Your First Bucket"
 msgstr "Cree su primer bucket"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:582
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:597
 #, elixir-autogen, elixir-format
 msgid "Create a new app or select existing one"
 msgstr "Cree una nueva app o seleccione una existente"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:418
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:423
 #, elixir-autogen, elixir-format
 msgid "Create project or select existing one"
 msgstr "Cree un proyecto o seleccione uno existente"
@@ -2867,11 +2868,12 @@ msgid "Enable OAuth (Master Switch)"
 msgstr "Habilitar OAuth (interruptor principal)"
 
 #: lib/modules/storage/web/bucket_form.html.heex:194
+#: lib/phoenix_kit/integrations/providers.ex:957
 #, elixir-autogen, elixir-format
 msgid "Endpoint"
 msgstr "Punto de conexión"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:503
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:513
 #, elixir-autogen, elixir-format
 msgid "Enter"
 msgstr "Introducir"
@@ -2906,7 +2908,7 @@ msgstr "FFmpeg no está instalado"
 msgid "FFmpeg is required for video processing, transcoding, and thumbnail generation."
 msgstr "FFmpeg es necesario para el procesamiento de vídeo, la transcodificación y la generación de miniaturas."
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:532
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:542
 #, elixir-autogen, elixir-format
 msgid "Facebook OAuth Credentials"
 msgstr "Credenciales OAuth de Facebook"
@@ -2949,7 +2951,7 @@ msgstr "Anular el formato"
 msgid "Format Override:"
 msgstr "Anular el formato:"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:449
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:454
 #, elixir-autogen, elixir-format
 msgid "GitHub OAuth Credentials"
 msgstr "Credenciales OAuth de GitHub"
@@ -2959,10 +2961,10 @@ msgstr "Credenciales OAuth de GitHub"
 msgid "GitHub Sign-In"
 msgstr "Inicio de sesión con GitHub"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:420
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:499
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:588
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:596
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:425
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:509
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:603
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:611
 #, elixir-autogen, elixir-format
 msgid "Go to"
 msgstr "Ir a"
@@ -2992,7 +2994,7 @@ msgstr "Cómo se muestran las fechas"
 msgid "How times are displayed"
 msgstr "Cómo se muestran las horas"
 
-#: lib/phoenix_kit_web/live/settings/authorization.ex:296
+#: lib/phoenix_kit_web/live/settings/authorization.ex:337
 #, elixir-autogen, elixir-format
 msgid "If behind nginx/apache, ensure"
 msgstr "Si está detrás de nginx/apache, asegúrese de que"
@@ -3179,7 +3181,7 @@ msgstr "Ninguno"
 msgid "Note"
 msgstr "Nota"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:627
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:642
 #, elixir-autogen, elixir-format
 msgid "Note: OAuth providers require ueberauth dependencies to be installed."
 msgstr "Nota: los proveedores OAuth requieren que se instalen las dependencias de ueberauth."
@@ -3194,7 +3196,7 @@ msgstr "Número de copias que se almacenarán"
 msgid "OAuth Providers"
 msgstr "Proveedores OAuth"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:620
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:635
 #, elixir-autogen, elixir-format
 msgid "OAuth Setup Instructions"
 msgstr "Instrucciones de configuración de OAuth"
@@ -3267,7 +3269,7 @@ msgstr "Reduzca la redundancia o habilite más buckets."
 msgid "Redundancy Copies"
 msgstr "Copias de redundancia"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:642
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:657
 #, elixir-autogen, elixir-format
 msgid "Reload OAuth Configuration"
 msgstr "Recargar la configuración de OAuth"
@@ -3294,7 +3296,7 @@ msgstr "Restablecer los valores predeterminados"
 msgid "Resolution"
 msgstr "Resolución"
 
-#: lib/phoenix_kit_web/live/settings/authorization.ex:294
+#: lib/phoenix_kit_web/live/settings/authorization.ex:335
 #, elixir-autogen, elixir-format
 msgid "Reverse Proxy Users:"
 msgstr "Usuarios con proxy inverso:"
@@ -3320,7 +3322,7 @@ msgstr "Rol asignado a los nuevos registros de usuarios"
 msgid "Save All Settings"
 msgstr "Guardar todos los ajustes"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:685
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:700
 #, elixir-autogen, elixir-format
 msgid "Save Authorization Settings"
 msgstr "Guardar los ajustes de autorización"
@@ -3336,7 +3338,8 @@ msgid "Search engines are instructed to skip this environment. Remove this befor
 msgstr "Se indica a los motores de búsqueda que omitan este entorno. Quítelo antes del lanzamiento."
 
 #: lib/modules/storage/web/bucket_form.html.heex:241
-#: lib/phoenix_kit/integrations/providers.ex:851
+#: lib/phoenix_kit/integrations/providers.ex:852
+#: lib/phoenix_kit/integrations/providers.ex:936
 #, elixir-autogen, elixir-format
 msgid "Secret Access Key"
 msgstr "Clave de acceso secreta"
@@ -3353,7 +3356,7 @@ msgstr "Aviso de seguridad: riesgo medio"
 
 #: lib/phoenix_kit_web/components/media_browser.html.heex:1180
 #: lib/phoenix_kit_web/components/media_browser.html.heex:1182
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:425
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:430
 #, elixir-autogen, elixir-format
 msgid "Select"
 msgstr "Seleccionar"
@@ -3383,7 +3386,7 @@ msgid "Set"
 msgstr "Establecer"
 
 #: lib/phoenix_kit_web/components/core/integrations_ui.ex:311
-#: lib/phoenix_kit_web/live/settings/authorization.ex:249
+#: lib/phoenix_kit_web/live/settings/authorization.ex:290
 #: lib/phoenix_kit_web/live/settings/integration_form.html.heex:378
 #, elixir-autogen, elixir-format
 msgid "Setup Instructions"
@@ -3420,7 +3423,7 @@ msgstr "Proveedor de almacenamiento"
 msgid "Success!"
 msgstr "¡Listo!"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:604
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:619
 #, elixir-autogen, elixir-format
 msgid "Switch app from"
 msgstr "Cambiar la app de"
@@ -3445,9 +3448,9 @@ msgstr "Zona horaria predeterminada del sistema"
 msgid "Target Width (px)"
 msgstr "Anchura objetivo (px)"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:400
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:480
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:563
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:405
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:490
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:578
 #, elixir-autogen, elixir-format
 msgid "Test Credentials"
 msgstr "Probar credenciales"
@@ -3528,7 +3531,7 @@ msgstr "Configuración de usuarios"
 msgid "User Editable"
 msgstr "Editable por el usuario"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:35
+#: lib/phoenix_kit_web/live/settings/users.ex:42
 #: lib/phoenix_kit_web/live/settings/users.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "User Settings"
@@ -3570,9 +3573,9 @@ msgstr "Ajustes de vídeo:"
 msgid "Videos use CRF 0-51 scale (lower = higher quality)"
 msgstr "Los vídeos usan la escala CRF de 0 a 51 (menor = mayor calidad)"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:409
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:489
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:572
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:414
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:499
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:587
 #, elixir-autogen, elixir-format
 msgid "Visit"
 msgstr "Visite"
@@ -3617,22 +3620,22 @@ msgstr "Sin él, el procesamiento de archivos de vídeo no funcionará."
 msgid "Would you like to create it now?"
 msgstr "¿Desea crearla ahora?"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:542
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:552
 #, elixir-autogen, elixir-format
 msgid "Your Facebook App ID"
 msgstr "Su ID de aplicación de Facebook"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:552
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:565
 #, elixir-autogen, elixir-format
 msgid "Your Facebook App Secret"
 msgstr "Su secreto de aplicación de Facebook"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:459
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:464
 #, elixir-autogen, elixir-format
 msgid "Your GitHub OAuth Client ID"
 msgstr "Su ID de cliente OAuth de GitHub"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:469
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:477
 #, elixir-autogen, elixir-format
 msgid "Your GitHub OAuth Client Secret"
 msgstr "Su secreto de cliente OAuth de GitHub"
@@ -3642,19 +3645,19 @@ msgstr "Su secreto de cliente OAuth de GitHub"
 msgid "Your Google OAuth Client ID"
 msgstr "Su ID de cliente OAuth de Google"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:389
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:392
 #, elixir-autogen, elixir-format
 msgid "Your Google OAuth Client Secret"
 msgstr "Su secreto de cliente OAuth de Google"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:504
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:600
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:514
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:615
 #: lib/phoenix_kit_web/live/settings/integrations.ex:167
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr "y"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:515
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:525
 #, elixir-autogen, elixir-format
 msgid "and generate/copy"
 msgstr "y genere/copie"
@@ -3675,12 +3678,12 @@ msgstr "p. ej., thumbnail, medium, 720p"
 msgid "files"
 msgstr "archivos"
 
-#: lib/phoenix_kit_web/live/settings/authorization.ex:300
+#: lib/phoenix_kit_web/live/settings/authorization.ex:341
 #, elixir-autogen, elixir-format
 msgid "header is set to"
 msgstr "el encabezado está establecido en"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:606
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:621
 #, elixir-autogen, elixir-format
 msgid "mode"
 msgstr "modo"
@@ -3690,12 +3693,12 @@ msgstr "modo"
 msgid "option(s)"
 msgstr "opción(es)"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:585
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:600
 #, elixir-autogen, elixir-format
 msgid "product"
 msgstr "producto"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:605
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:620
 #, elixir-autogen, elixir-format
 msgid "to"
 msgstr "a"
@@ -3705,19 +3708,19 @@ msgstr "a"
 msgid "to every PhoenixKit layout, blocking crawlers from indexing or following links."
 msgstr "a cada plantilla de PhoenixKit, impidiendo que los rastreadores indexen o sigan enlaces."
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:601
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:616
 #, elixir-autogen, elixir-format
 msgid "to fields above"
 msgstr "en los campos de arriba"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:435
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:519
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:610
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:440
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:529
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:625
 #, elixir-autogen, elixir-format
 msgid "to verify setup"
 msgstr "para verificar la configuración"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:426
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:431
 #, elixir-autogen, elixir-format
 msgid "type"
 msgstr "tipo"
@@ -3852,7 +3855,7 @@ msgstr "Un nombre descriptivo para identificar esta ubicación de almacenamiento
 msgid "A unique name to identify this dimension preset"
 msgstr "Un nombre único para identificar este ajuste de dimensiones"
 
-#: lib/phoenix_kit/integrations/providers.ex:388
+#: lib/phoenix_kit/integrations/providers.ex:389
 #, elixir-autogen, elixir-format
 msgid "AI model access via OpenRouter (100+ models)"
 msgstr "Acceso a modelos de IA a través de OpenRouter (más de 100 modelos)"
@@ -3862,13 +3865,13 @@ msgstr "Acceso a modelos de IA a través de OpenRouter (más de 100 modelos)"
 msgid "API Credentials"
 msgstr "Credenciales de la API"
 
-#: lib/phoenix_kit/integrations/providers.ex:332
-#: lib/phoenix_kit/integrations/providers.ex:402
-#: lib/phoenix_kit/integrations/providers.ex:460
-#: lib/phoenix_kit/integrations/providers.ex:523
-#: lib/phoenix_kit/integrations/providers.ex:586
-#: lib/phoenix_kit/integrations/providers.ex:653
-#: lib/phoenix_kit/integrations/providers.ex:1065
+#: lib/phoenix_kit/integrations/providers.ex:333
+#: lib/phoenix_kit/integrations/providers.ex:403
+#: lib/phoenix_kit/integrations/providers.ex:461
+#: lib/phoenix_kit/integrations/providers.ex:524
+#: lib/phoenix_kit/integrations/providers.ex:587
+#: lib/phoenix_kit/integrations/providers.ex:654
+#: lib/phoenix_kit/integrations/providers.ex:1137
 #, elixir-autogen, elixir-format
 msgid "API Key"
 msgstr "Clave de API"
@@ -3929,7 +3932,7 @@ msgstr "Activo por la ventana programada."
 msgid "Add Integration"
 msgstr "Agregar integración"
 
-#: lib/phoenix_kit/integrations/providers.ex:431
+#: lib/phoenix_kit/integrations/providers.ex:432
 #, elixir-autogen, elixir-format
 msgid "Add credits (optional)"
 msgstr "Agregar créditos (opcional)"
@@ -3964,7 +3967,7 @@ msgstr "Todos los archivos cumplen el objetivo de redundancia de %{n} copias."
 msgid "Alternative Formats"
 msgstr "Formatos alternativos"
 
-#: lib/phoenix_kit/integrations/providers.ex:285
+#: lib/phoenix_kit/integrations/providers.ex:286
 #, elixir-autogen, elixir-format
 msgid "Application type: **Web application** (do not select \"Desktop app\" — it won't support redirect URIs)"
 msgstr "Tipo de aplicación: **aplicación web** (no seleccione «aplicación de escritorio», no admite URI de redirección)"
@@ -4086,18 +4089,18 @@ msgstr "Elija un servicio para conectar"
 msgid "Clear Schedule"
 msgstr "Borrar la programación"
 
-#: lib/phoenix_kit/integrations/providers.ex:284
+#: lib/phoenix_kit/integrations/providers.ex:285
 #, elixir-autogen, elixir-format
 msgid "Click **Create Credentials → OAuth client ID**"
 msgstr "Haga clic en **Crear credenciales → ID de cliente de OAuth**"
 
-#: lib/phoenix_kit/integrations/providers.ex:425
+#: lib/phoenix_kit/integrations/providers.ex:426
 #, elixir-autogen, elixir-format
 msgid "Click **Create Key**"
 msgstr "Haga clic en **Crear clave**"
 
-#: lib/phoenix_kit/integrations/providers.ex:295
-#: lib/phoenix_kit/integrations/providers.ex:1248
+#: lib/phoenix_kit/integrations/providers.ex:296
+#: lib/phoenix_kit/integrations/providers.ex:1320
 #, elixir-autogen, elixir-format
 msgid "Click **Save**, then **Connect Account**"
 msgstr "Haga clic en **Guardar** y luego en **Conectar cuenta**"
@@ -4147,8 +4150,8 @@ msgstr "Conectar la cuenta de %{provider}"
 msgid "Connect Account"
 msgstr "Conectar cuenta"
 
-#: lib/phoenix_kit/integrations/providers.ex:293
-#: lib/phoenix_kit/integrations/providers.ex:1246
+#: lib/phoenix_kit/integrations/providers.ex:294
+#: lib/phoenix_kit/integrations/providers.ex:1318
 #, elixir-autogen, elixir-format
 msgid "Connect and authorize"
 msgstr "Conectar y autorizar"
@@ -4168,7 +4171,7 @@ msgstr "Conecte servicios externos para usarlos en todos los módulos"
 #: lib/phoenix_kit_web/live/settings/integration_form.html.heex:327
 #: lib/phoenix_kit_web/live/settings/integrations.ex:181
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:111
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:197
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:191
 #, elixir-autogen, elixir-format
 msgid "Connected"
 msgstr "Conectado"
@@ -4209,48 +4212,48 @@ msgstr "Conexión correcta"
 msgid "Connection verified"
 msgstr "Conexión verificada"
 
-#: lib/phoenix_kit/integrations/providers.ex:289
+#: lib/phoenix_kit/integrations/providers.ex:290
 #, elixir-autogen, elixir-format
 msgid "Copy the **Client ID** and **Client Secret** into the form above"
 msgstr "Copie el **ID de cliente** y el **secreto de cliente** en el formulario de arriba"
 
-#: lib/phoenix_kit/integrations/providers.ex:427
+#: lib/phoenix_kit/integrations/providers.ex:428
 #, elixir-autogen, elixir-format
 msgid "Copy the key and paste it into the form above"
 msgstr "Copie la clave y péguela en el formulario de arriba"
 
-#: lib/phoenix_kit/integrations/integrations.ex:1135
+#: lib/phoenix_kit/integrations/integrations.ex:1138
 #: lib/phoenix_kit/integrations/probe.ex:102
 #, elixir-autogen, elixir-format
 msgid "Could not reach the service"
 msgstr "No se pudo contactar con el servicio"
 
-#: lib/phoenix_kit/integrations/providers.ex:235
+#: lib/phoenix_kit/integrations/providers.ex:236
 #, elixir-autogen, elixir-format
 msgid "Create a Google Cloud project"
 msgstr "Cree un proyecto de Google Cloud"
 
-#: lib/phoenix_kit/integrations/providers.ex:238
+#: lib/phoenix_kit/integrations/providers.ex:239
 #, elixir-autogen, elixir-format
 msgid "Create a new project or select an existing one"
 msgstr "Cree un nuevo proyecto o seleccione uno existente"
 
-#: lib/phoenix_kit/integrations/providers.ex:368
-#: lib/phoenix_kit/integrations/providers.ex:423
-#: lib/phoenix_kit/integrations/providers.ex:493
-#: lib/phoenix_kit/integrations/providers.ex:553
-#: lib/phoenix_kit/integrations/providers.ex:619
-#: lib/phoenix_kit/integrations/providers.ex:670
+#: lib/phoenix_kit/integrations/providers.ex:369
+#: lib/phoenix_kit/integrations/providers.ex:424
+#: lib/phoenix_kit/integrations/providers.ex:494
+#: lib/phoenix_kit/integrations/providers.ex:554
+#: lib/phoenix_kit/integrations/providers.ex:620
+#: lib/phoenix_kit/integrations/providers.ex:671
 #, elixir-autogen, elixir-format
 msgid "Create an API key"
 msgstr "Cree una clave de API"
 
-#: lib/phoenix_kit/integrations/providers.ex:279
+#: lib/phoenix_kit/integrations/providers.ex:280
 #, elixir-autogen, elixir-format
 msgid "Create an OAuth Client"
 msgstr "Cree un cliente OAuth"
 
-#: lib/phoenix_kit/integrations/providers.ex:416
+#: lib/phoenix_kit/integrations/providers.ex:417
 #, elixir-autogen, elixir-format
 msgid "Create an OpenRouter account"
 msgstr "Cree una cuenta de OpenRouter"
@@ -4319,7 +4322,7 @@ msgstr "¿Desconectar?"
 msgid "Disconnected"
 msgstr "Desconectado"
 
-#: lib/phoenix_kit/integrations/providers.ex:253
+#: lib/phoenix_kit/integrations/providers.ex:254
 #, elixir-autogen, elixir-format
 msgid "Drive API handles file listing, creation, copying, and PDF export. Docs API is used for reading document content and substituting template variables."
 msgstr "La API de Drive se encarga de listar, crear, copiar y exportar archivos a PDF. La API de Docs se usa para leer el contenido de los documentos y sustituir variables de plantilla."
@@ -4349,7 +4352,7 @@ msgstr "Habilitar bucket"
 msgid "Enable organization accounts"
 msgstr "Habilitar cuentas de organización"
 
-#: lib/phoenix_kit/integrations/providers.ex:242
+#: lib/phoenix_kit/integrations/providers.ex:243
 #, elixir-autogen, elixir-format
 msgid "Enable required APIs"
 msgstr "Habilite las APIs necesarias"
@@ -4482,12 +4485,12 @@ msgstr "Los archivos se registran en PostgreSQL con soporte para varias ubicacio
 msgid "Files with completed variants"
 msgstr "Archivos con variantes completadas"
 
-#: lib/phoenix_kit/integrations/providers.ex:219
+#: lib/phoenix_kit/integrations/providers.ex:220
 #, elixir-autogen, elixir-format
 msgid "From Google Cloud Console → APIs & Services → Credentials"
 msgstr "Desde la consola de Google Cloud → APIs y servicios → Credenciales"
 
-#: lib/phoenix_kit/integrations/providers.ex:406
+#: lib/phoenix_kit/integrations/providers.ex:407
 #, elixir-autogen, elixir-format
 msgid "From openrouter.ai/keys"
 msgstr "Desde openrouter.ai/keys"
@@ -4497,72 +4500,72 @@ msgstr "Desde openrouter.ai/keys"
 msgid "Generate additional format variants alongside the primary format. Modern formats like WebP and AVIF offer better compression."
 msgstr "Genere variantes de formato adicionales junto al formato principal. Los formatos modernos como WebP y AVIF ofrecen mejor compresión."
 
-#: lib/phoenix_kit/integrations/providers.ex:426
+#: lib/phoenix_kit/integrations/providers.ex:427
 #, elixir-autogen, elixir-format
 msgid "Give it a name (e.g., your app name)"
 msgstr "Póngale un nombre (p. ej., el nombre de su app)"
 
-#: lib/phoenix_kit/integrations/providers.ex:248
+#: lib/phoenix_kit/integrations/providers.ex:249
 #, elixir-autogen, elixir-format
 msgid "Go back to the Library and search for **Google Docs API**, click it, then click **Enable**"
 msgstr "Vuelva a la biblioteca, busque **Google Docs API**, haga clic en ella y luego en **Habilitar**"
 
-#: lib/phoenix_kit/integrations/providers.ex:281
+#: lib/phoenix_kit/integrations/providers.ex:282
 #, elixir-autogen, elixir-format
 msgid "Go to [APIs & Services → Credentials](https://console.cloud.google.com/apis/credentials)"
 msgstr "Vaya a [APIs y servicios → Credenciales](https://console.cloud.google.com/apis/credentials)"
 
-#: lib/phoenix_kit/integrations/providers.ex:244
+#: lib/phoenix_kit/integrations/providers.ex:245
 #, elixir-autogen, elixir-format
 msgid "Go to [APIs & Services → Library](https://console.cloud.google.com/apis/library)"
 msgstr "Vaya a [APIs y servicios → Biblioteca](https://console.cloud.google.com/apis/library)"
 
-#: lib/phoenix_kit/integrations/providers.ex:263
+#: lib/phoenix_kit/integrations/providers.ex:264
 #, elixir-autogen, elixir-format
 msgid "Go to [Audience](https://console.cloud.google.com/auth/audience) — set user type to **External** (or Internal for Google Workspace)"
 msgstr "Vaya a [Audiencia](https://console.cloud.google.com/auth/audience) — establezca el tipo de usuario en **Externo** (o Interno para Google Workspace)"
 
-#: lib/phoenix_kit/integrations/providers.ex:260
+#: lib/phoenix_kit/integrations/providers.ex:261
 #, elixir-autogen, elixir-format
 msgid "Go to [Branding](https://console.cloud.google.com/auth/branding) in the sidebar — fill in the **App name** and **User support email**, then save"
 msgstr "Vaya a [Marca](https://console.cloud.google.com/auth/branding) en la barra lateral — rellene el **nombre de la app** y el **correo de soporte**, y guarde"
 
-#: lib/phoenix_kit/integrations/providers.ex:434
+#: lib/phoenix_kit/integrations/providers.ex:435
 #, elixir-autogen, elixir-format
 msgid "Go to [Credits](https://openrouter.ai/credits) to add funds"
 msgstr "Vaya a [Credits](https://openrouter.ai/credits) para añadir fondos"
 
-#: lib/phoenix_kit/integrations/providers.ex:269
+#: lib/phoenix_kit/integrations/providers.ex:270
 #, elixir-autogen, elixir-format
 msgid "Go to [Data Access](https://console.cloud.google.com/auth/scopes) — click **Add or Remove Scopes** and add the Drive and Docs scopes. This step may not be required — the app requests the needed scopes at connect time regardless."
 msgstr "Vaya a [Acceso a datos](https://console.cloud.google.com/auth/scopes) — haga clic en **Agregar o quitar ámbitos** y añada los ámbitos de Drive y Docs. Puede que este paso no sea necesario: la app solicita los ámbitos necesarios al conectarse de todos modos."
 
-#: lib/phoenix_kit/integrations/providers.ex:418
+#: lib/phoenix_kit/integrations/providers.ex:419
 #, elixir-autogen, elixir-format
 msgid "Go to [openrouter.ai](https://openrouter.ai) and sign up or log in"
 msgstr "Vaya a [openrouter.ai](https://openrouter.ai) y regístrese o inicie sesión"
 
-#: lib/phoenix_kit/integrations/providers.ex:237
+#: lib/phoenix_kit/integrations/providers.ex:238
 #, elixir-autogen, elixir-format
 msgid "Go to the [Google Cloud Console](https://console.cloud.google.com)"
 msgstr "Vaya a la [consola de Google Cloud](https://console.cloud.google.com)"
 
-#: lib/phoenix_kit/integrations/providers.ex:200
+#: lib/phoenix_kit/integrations/providers.ex:201
 #, elixir-autogen, elixir-format
 msgid "Google"
 msgstr "Google"
 
-#: lib/phoenix_kit/integrations/providers.ex:201
+#: lib/phoenix_kit/integrations/providers.ex:202
 #, elixir-autogen, elixir-format
 msgid "Google Docs, Drive, Calendar, Sheets, Gmail"
 msgstr "Google Docs, Drive, Calendar, Sheets, Gmail"
 
-#: lib/phoenix_kit/integrations/providers.ex:296
+#: lib/phoenix_kit/integrations/providers.ex:297
 #, elixir-autogen, elixir-format
 msgid "Google will show an \"unverified app\" warning — click **Advanced → Go to (app name)** to proceed"
 msgstr "Google mostrará una advertencia de «aplicación no verificada»: haga clic en **Avanzado → Ir a (nombre de la app)** para continuar"
 
-#: lib/phoenix_kit/integrations/providers.ex:299
+#: lib/phoenix_kit/integrations/providers.ex:300
 #, elixir-autogen, elixir-format
 msgid "Grant access to Google Docs and Google Drive"
 msgstr "Conceda acceso a Google Docs y Google Drive"
@@ -4598,11 +4601,12 @@ msgstr "Integración eliminada"
 msgid "Integrations"
 msgstr "Integraciones"
 
-#: lib/phoenix_kit/integrations/integrations.ex:1132
+#: lib/phoenix_kit/integrations/integrations.ex:1135
 #: lib/phoenix_kit/integrations/validators.ex:208
 #: lib/phoenix_kit/integrations/validators.ex:378
 #: lib/phoenix_kit/integrations/validators.ex:412
-#: lib/phoenix_kit/integrations/validators.ex:595
+#: lib/phoenix_kit/integrations/validators.ex:608
+#: lib/phoenix_kit/integrations/validators.ex:776
 #, elixir-autogen, elixir-format
 msgid "Invalid credentials"
 msgstr "Credenciales no válidas"
@@ -4816,12 +4820,12 @@ msgstr "Faltan %{n}"
 msgid "Missing %{n} copies"
 msgstr "Faltan %{n} copias"
 
-#: lib/phoenix_kit/integrations/providers.ex:419
+#: lib/phoenix_kit/integrations/providers.ex:420
 #, elixir-autogen, elixir-format
 msgid "Navigate to [Keys](https://openrouter.ai/keys)"
 msgstr "Vaya a [Keys](https://openrouter.ai/keys)"
 
-#: lib/phoenix_kit/integrations/providers.ex:274
+#: lib/phoenix_kit/integrations/providers.ex:275
 #, elixir-autogen, elixir-format
 msgid "Navigate to the OAuth section using the search bar or the hamburger menu: search for \"OAuth\", or go to the sidebar: **APIs & Services → OAuth consent screen**. This opens a different section with its own sidebar."
 msgstr "Vaya a la sección de OAuth con la barra de búsqueda o el menú de hamburguesa: busque «OAuth», o vaya a la barra lateral: **APIs y servicios → Pantalla de consentimiento de OAuth**. Se abrirá otra sección con su propia barra lateral."
@@ -4842,9 +4846,9 @@ msgstr "Sin token de acceso"
 msgid "No copies"
 msgstr "Sin copias"
 
-#: lib/phoenix_kit/integrations/integrations.ex:1115
+#: lib/phoenix_kit/integrations/integrations.ex:1118
 #: lib/phoenix_kit/integrations/validators.ex:170
-#: lib/phoenix_kit/integrations/validators.ex:577
+#: lib/phoenix_kit/integrations/validators.ex:758
 #, elixir-autogen, elixir-format
 msgid "No credentials configured"
 msgstr "No hay credenciales configuradas"
@@ -4925,7 +4929,7 @@ msgstr "Solo los buckets habilitados reciben nuevas subidas"
 msgid "Only width is used, height is calculated automatically"
 msgstr "Solo se usa la anchura; la altura se calcula automáticamente"
 
-#: lib/phoenix_kit/integrations/providers.ex:387
+#: lib/phoenix_kit/integrations/providers.ex:388
 #, elixir-autogen, elixir-format
 msgid "OpenRouter"
 msgstr "OpenRouter"
@@ -5106,7 +5110,7 @@ msgstr "Mantenimiento programado"
 msgid "Scheduled window is currently active"
 msgstr "La ventana programada está activa actualmente"
 
-#: lib/phoenix_kit/integrations/providers.ex:247
+#: lib/phoenix_kit/integrations/providers.ex:248
 #, elixir-autogen, elixir-format
 msgid "Search for **Google Drive API**, click it, then click **Enable**"
 msgstr "Busque **Google Drive API**, haga clic en ella y luego en **Habilitar**"
@@ -5133,7 +5137,7 @@ msgstr "Seleccione un usuario para agregar…"
 msgid "Service"
 msgstr "Servicio"
 
-#: lib/phoenix_kit/integrations/integrations.ex:1134
+#: lib/phoenix_kit/integrations/integrations.ex:1137
 #, elixir-autogen, elixir-format
 msgid "Service error %{status}"
 msgstr "Error del servicio %{status}"
@@ -5143,7 +5147,7 @@ msgstr "Error del servicio %{status}"
 msgid "Set a time window for automatic maintenance activation."
 msgstr "Establezca una ventana horaria para la activación automática del mantenimiento."
 
-#: lib/phoenix_kit/integrations/providers.ex:258
+#: lib/phoenix_kit/integrations/providers.ex:259
 #, elixir-autogen, elixir-format
 msgid "Set up OAuth consent"
 msgstr "Configure el consentimiento de OAuth"
@@ -5153,7 +5157,7 @@ msgstr "Configure el consentimiento de OAuth"
 msgid "Size Configuration"
 msgstr "Configuración de tamaños"
 
-#: lib/phoenix_kit/integrations/providers.ex:433
+#: lib/phoenix_kit/integrations/providers.ex:434
 #, elixir-autogen, elixir-format
 msgid "Some models are free, but most require credits"
 msgstr "Algunos modelos son gratuitos, pero la mayoría requiere créditos"
@@ -5183,7 +5187,7 @@ msgstr "Paso 1"
 msgid "Step 2"
 msgstr "Paso 2"
 
-#: lib/phoenix_kit/integrations/providers.ex:266
+#: lib/phoenix_kit/integrations/providers.ex:267
 #, elixir-autogen, elixir-format
 msgid "Still on Audience — while the app is in **Testing** status, add the Google account you will connect as a **Test user** (this must be the same account whose Drive will store your files)"
 msgstr "Aún en Audiencia: mientras la app esté en estado **Prueba**, añada la cuenta de Google que va a conectar como **usuario de prueba** (debe ser la misma cuenta cuyo Drive almacenará sus archivos)"
@@ -5318,7 +5322,7 @@ msgstr "Región de Tigris"
 msgid "Total Files"
 msgstr "Archivos totales"
 
-#: lib/phoenix_kit/integrations/providers.ex:288
+#: lib/phoenix_kit/integrations/providers.ex:289
 #, elixir-autogen, elixir-format
 msgid "Under **Authorized redirect URIs**, add: `{redirect_uri}`"
 msgstr "En **URI de redirección autorizados**, añada: `{redirect_uri}`"
@@ -5375,8 +5379,8 @@ msgstr "¡Se ha unido a la organización!"
 msgid "You need to create at least one media bucket before files can be uploaded."
 msgstr "Debe crear al menos un bucket de medios antes de poder subir archivos."
 
-#: lib/phoenix_kit/integrations/providers.ex:300
-#: lib/phoenix_kit/integrations/providers.ex:1252
+#: lib/phoenix_kit/integrations/providers.ex:301
+#: lib/phoenix_kit/integrations/providers.ex:1324
 #, elixir-autogen, elixir-format
 msgid "You'll be redirected back here once connected"
 msgstr "Se le redirigirá aquí una vez conectado"
@@ -5443,39 +5447,39 @@ msgstr "hace 1 hora"
 msgid "1 minute ago"
 msgstr "hace 1 minuto"
 
-#: lib/phoenix_kit/integrations/providers.ex:509
+#: lib/phoenix_kit/integrations/providers.ex:510
 #, elixir-autogen, elixir-format
 msgid "AI model access via DeepSeek (deepseek-chat, deepseek-reasoner)"
 msgstr "Acceso a modelos de IA a través de DeepSeek (deepseek-chat, deepseek-reasoner)"
 
-#: lib/phoenix_kit/integrations/providers.ex:446
+#: lib/phoenix_kit/integrations/providers.ex:447
 #, elixir-autogen, elixir-format
 msgid "AI model access via Mistral AI (Mistral Large, Codestral, Pixtral)"
 msgstr "Acceso a modelos de IA a través de Mistral AI (Mistral Large, Codestral, Pixtral)"
 
-#: lib/phoenix_kit/integrations/providers.ex:1218
+#: lib/phoenix_kit/integrations/providers.ex:1290
 #, elixir-autogen, elixir-format
 msgid "Add a client secret"
 msgstr "Agregue un secreto de cliente"
 
-#: lib/phoenix_kit/integrations/providers.ex:480
+#: lib/phoenix_kit/integrations/providers.ex:481
 #, elixir-autogen, elixir-format
 msgid "Add a payment method (required)"
 msgstr "Agregue un método de pago (obligatorio)"
 
-#: lib/phoenix_kit/integrations/providers.ex:357
-#: lib/phoenix_kit/integrations/providers.ex:542
-#: lib/phoenix_kit/integrations/providers.ex:611
+#: lib/phoenix_kit/integrations/providers.ex:358
+#: lib/phoenix_kit/integrations/providers.ex:543
+#: lib/phoenix_kit/integrations/providers.ex:612
 #, elixir-autogen, elixir-format
 msgid "Add credits"
 msgstr "Agregar créditos"
 
-#: lib/phoenix_kit/integrations/providers.ex:1233
+#: lib/phoenix_kit/integrations/providers.ex:1305
 #, elixir-autogen, elixir-format
 msgid "Add the permissions your integration needs: `User.Read` is included by default; add `Mail.Read`, `Files.Read.All`, `Calendars.Read`, etc. as required"
 msgstr "Añada los permisos que necesite su integración: `User.Read` se incluye por defecto; agregue `Mail.Read`, `Files.Read.All`, `Calendars.Read`, etc. según sea necesario"
 
-#: lib/phoenix_kit/integrations/providers.ex:1160
+#: lib/phoenix_kit/integrations/providers.ex:1232
 #, elixir-autogen, elixir-format
 msgid "Application (client) ID"
 msgstr "ID de aplicación (cliente)"
@@ -5485,28 +5489,28 @@ msgstr "ID de aplicación (cliente)"
 msgid "Clears the OAuth tokens. Credentials and the connection itself stay so you can reconnect with one click."
 msgstr "Borra los tokens de OAuth. Las credenciales y la conexión se conservan para que pueda reconectar con un clic."
 
-#: lib/phoenix_kit/integrations/providers.ex:556
-#: lib/phoenix_kit/integrations/providers.ex:622
+#: lib/phoenix_kit/integrations/providers.ex:557
+#: lib/phoenix_kit/integrations/providers.ex:623
 #, elixir-autogen, elixir-format
 msgid "Click **Create API key**, give it a name"
 msgstr "Haga clic en **Crear clave de API** y póngale un nombre"
 
-#: lib/phoenix_kit/integrations/providers.ex:496
+#: lib/phoenix_kit/integrations/providers.ex:497
 #, elixir-autogen, elixir-format
 msgid "Click **Create new key**, give it a name, set an expiry if desired"
 msgstr "Haga clic en **Crear clave nueva**, póngale un nombre y establezca una caducidad si lo desea"
 
-#: lib/phoenix_kit/integrations/providers.ex:1205
+#: lib/phoenix_kit/integrations/providers.ex:1277
 #, elixir-autogen, elixir-format
 msgid "Click **New registration**, give the app a name"
 msgstr "Haga clic en **Nuevo registro** y póngale un nombre a la app"
 
-#: lib/phoenix_kit/integrations/providers.ex:1210
+#: lib/phoenix_kit/integrations/providers.ex:1282
 #, elixir-autogen, elixir-format
 msgid "Click **Register**"
 msgstr "Haga clic en **Registrar**"
 
-#: lib/phoenix_kit/integrations/providers.ex:1228
+#: lib/phoenix_kit/integrations/providers.ex:1300
 #, elixir-autogen, elixir-format
 msgid "Configure API permissions"
 msgstr "Configure los permisos de la API"
@@ -5527,16 +5531,16 @@ msgstr "El nombre de la conexión no puede estar vacío."
 msgid "Connection renamed"
 msgstr "Conexión renombrada"
 
-#: lib/phoenix_kit/integrations/providers.ex:1222
+#: lib/phoenix_kit/integrations/providers.ex:1294
 #, elixir-autogen, elixir-format
 msgid "Copy the **Value** column (not the Secret ID) into the form above — the value is shown ONCE and disappears on page refresh"
 msgstr "Copie la columna **Valor** (no el ID del secreto) en el formulario de arriba: el valor se muestra UNA sola vez y desaparece al recargar la página"
 
-#: lib/phoenix_kit/integrations/providers.ex:372
-#: lib/phoenix_kit/integrations/providers.ex:497
-#: lib/phoenix_kit/integrations/providers.ex:557
-#: lib/phoenix_kit/integrations/providers.ex:623
-#: lib/phoenix_kit/integrations/providers.ex:675
+#: lib/phoenix_kit/integrations/providers.ex:373
+#: lib/phoenix_kit/integrations/providers.ex:498
+#: lib/phoenix_kit/integrations/providers.ex:558
+#: lib/phoenix_kit/integrations/providers.ex:624
+#: lib/phoenix_kit/integrations/providers.ex:676
 #, elixir-autogen, elixir-format
 msgid "Copy the key (shown once) and paste it into the form above"
 msgstr "Copie la clave (se muestra una sola vez) y péguela en el formulario de arriba"
@@ -5547,12 +5551,12 @@ msgstr "Copie la clave (se muestra una sola vez) y péguela en el formulario de 
 msgid "Create Connection"
 msgstr "Crear conexión"
 
-#: lib/phoenix_kit/integrations/providers.ex:534
+#: lib/phoenix_kit/integrations/providers.ex:535
 #, elixir-autogen, elixir-format
 msgid "Create a DeepSeek account"
 msgstr "Cree una cuenta de DeepSeek"
 
-#: lib/phoenix_kit/integrations/providers.ex:471
+#: lib/phoenix_kit/integrations/providers.ex:472
 #, elixir-autogen, elixir-format
 msgid "Create a Mistral account"
 msgstr "Cree una cuenta de Mistral"
@@ -5563,12 +5567,12 @@ msgstr "Cree una cuenta de Mistral"
 msgid "Danger Zone"
 msgstr "Zona de riesgo"
 
-#: lib/phoenix_kit/integrations/providers.ex:508
+#: lib/phoenix_kit/integrations/providers.ex:509
 #, elixir-autogen, elixir-format
 msgid "DeepSeek"
 msgstr "DeepSeek"
 
-#: lib/phoenix_kit/integrations/providers.ex:547
+#: lib/phoenix_kit/integrations/providers.ex:548
 #, elixir-autogen, elixir-format
 msgid "DeepSeek requires a positive balance before you can call the chat or reasoner endpoints, even on cheap models"
 msgstr "DeepSeek requiere un saldo positivo para poder llamar a los endpoints de chat o reasoner, incluso en modelos económicos"
@@ -5603,82 +5607,82 @@ msgstr "No se pudo eliminar la conexión."
 msgid "Failed to rename connection."
 msgstr "No se pudo renombrar la conexión."
 
-#: lib/phoenix_kit/integrations/providers.ex:485
+#: lib/phoenix_kit/integrations/providers.ex:486
 #, elixir-autogen, elixir-format
 msgid "Free models still require a billing-enabled workspace"
 msgstr "Los modelos gratuitos también requieren un espacio de trabajo con facturación habilitada"
 
-#: lib/phoenix_kit/integrations/providers.ex:1164
+#: lib/phoenix_kit/integrations/providers.ex:1236
 #, elixir-autogen, elixir-format
 msgid "From Azure Portal → App registrations → your app → Overview"
 msgstr "Desde el portal de Azure → Registros de aplicaciones → su app → Información general"
 
-#: lib/phoenix_kit/integrations/providers.ex:464
+#: lib/phoenix_kit/integrations/providers.ex:465
 #, elixir-autogen, elixir-format
 msgid "From console.mistral.ai/api-keys"
 msgstr "Desde console.mistral.ai/api-keys"
 
-#: lib/phoenix_kit/integrations/providers.ex:527
+#: lib/phoenix_kit/integrations/providers.ex:528
 #, elixir-autogen, elixir-format
 msgid "From platform.deepseek.com/api_keys"
 msgstr "Desde platform.deepseek.com/api_keys"
 
-#: lib/phoenix_kit/integrations/providers.ex:1174
+#: lib/phoenix_kit/integrations/providers.ex:1246
 #, elixir-autogen, elixir-format
 msgid "From your app → Certificates & secrets → New client secret. Copy the *Value*, not the Secret ID."
 msgstr "Desde su app → Certificados y secretos → Nuevo secreto de cliente. Copie el *Valor*, no el ID del secreto."
 
-#: lib/phoenix_kit/integrations/providers.ex:1230
+#: lib/phoenix_kit/integrations/providers.ex:1302
 #, elixir-autogen, elixir-format
 msgid "Go to **API permissions → Add a permission → Microsoft Graph → Delegated permissions**"
 msgstr "Vaya a **Permisos de API → Agregar un permiso → Microsoft Graph → Permisos delegados**"
 
-#: lib/phoenix_kit/integrations/providers.ex:1220
+#: lib/phoenix_kit/integrations/providers.ex:1292
 #, elixir-autogen, elixir-format
 msgid "Go to **Certificates & secrets → New client secret**"
 msgstr "Vaya a **Certificados y secretos → Nuevo secreto de cliente**"
 
-#: lib/phoenix_kit/integrations/providers.ex:495
+#: lib/phoenix_kit/integrations/providers.ex:496
 #, elixir-autogen, elixir-format
 msgid "Go to [API Keys](https://console.mistral.ai/api-keys)"
 msgstr "Vaya a [API Keys](https://console.mistral.ai/api-keys)"
 
-#: lib/phoenix_kit/integrations/providers.ex:555
+#: lib/phoenix_kit/integrations/providers.ex:556
 #, elixir-autogen, elixir-format
 msgid "Go to [API Keys](https://platform.deepseek.com/api_keys)"
 msgstr "Vaya a [API Keys](https://platform.deepseek.com/api_keys)"
 
-#: lib/phoenix_kit/integrations/providers.ex:544
+#: lib/phoenix_kit/integrations/providers.ex:545
 #, elixir-autogen, elixir-format
 msgid "Go to [Top up](https://platform.deepseek.com/top_up) and add at least the minimum amount"
 msgstr "Vaya a [Top up](https://platform.deepseek.com/top_up) y añada al menos el importe mínimo"
 
-#: lib/phoenix_kit/integrations/providers.ex:482
+#: lib/phoenix_kit/integrations/providers.ex:483
 #, elixir-autogen, elixir-format
 msgid "Go to [Workspace → Billing](https://console.mistral.ai/billing/plans) and choose **Experiment** (pay-as-you-go) or a paid tier"
 msgstr "Vaya a [Workspace → Billing](https://console.mistral.ai/billing/plans) y elija **Experiment** (pago por uso) o un plan de pago"
 
-#: lib/phoenix_kit/integrations/providers.ex:473
+#: lib/phoenix_kit/integrations/providers.ex:474
 #, elixir-autogen, elixir-format
 msgid "Go to [console.mistral.ai](https://console.mistral.ai) and sign up or log in"
 msgstr "Vaya a [console.mistral.ai](https://console.mistral.ai) y regístrese o inicie sesión"
 
-#: lib/phoenix_kit/integrations/providers.ex:536
+#: lib/phoenix_kit/integrations/providers.ex:537
 #, elixir-autogen, elixir-format
 msgid "Go to [platform.deepseek.com](https://platform.deepseek.com) and sign up or log in"
 msgstr "Vaya a [platform.deepseek.com](https://platform.deepseek.com) y regístrese o inicie sesión"
 
-#: lib/phoenix_kit/integrations/providers.ex:1202
+#: lib/phoenix_kit/integrations/providers.ex:1274
 #, elixir-autogen, elixir-format
 msgid "Go to the [Azure Portal](https://portal.azure.com) and search for **App registrations**"
 msgstr "Vaya al [portal de Azure](https://portal.azure.com) y busque **Registros de aplicaciones**"
 
-#: lib/phoenix_kit/integrations/providers.ex:1213
+#: lib/phoenix_kit/integrations/providers.ex:1285
 #, elixir-autogen, elixir-format
 msgid "If you picked a single-tenant audience, fill in **Tenant ID** above with your Directory (tenant) ID GUID — leaving it as `common` only works for multi-tenant + personal apps."
 msgstr "Si eligió una audiencia de un solo inquilino, rellene **Tenant ID** arriba con el GUID del ID de su directorio (inquilino): dejarlo como `common` solo funciona para apps multiinquilino y personales."
 
-#: lib/phoenix_kit/integrations/providers.ex:1236
+#: lib/phoenix_kit/integrations/providers.ex:1308
 #, elixir-autogen, elixir-format
 msgid "If your tenant requires admin consent, click **Grant admin consent for <tenant>** before the connect flow will work"
 msgstr "Si su inquilino requiere consentimiento del administrador, haga clic en **Otorgar consentimiento de administrador para <tenant>** antes de que funcione el flujo de conexión"
@@ -5695,32 +5699,32 @@ msgstr "Integración no encontrada"
 msgid "Last tested"
 msgstr "Última prueba"
 
-#: lib/phoenix_kit/integrations/providers.ex:1186
+#: lib/phoenix_kit/integrations/providers.ex:1258
 #, elixir-autogen, elixir-format
 msgid "Leave as `common` for multi-tenant + personal accounts. For single-tenant apps, paste your Directory (tenant) ID GUID. Use `consumers` for personal-only or `organizations` for any work-or-school account."
 msgstr "Deje `common` para cuentas multiinquilino y personales. Para apps de un solo inquilino, pegue el GUID del ID de su directorio (inquilino). Use `consumers` solo para cuentas personales u `organizations` para cualquier cuenta profesional o educativa."
 
-#: lib/phoenix_kit/integrations/providers.ex:1131
+#: lib/phoenix_kit/integrations/providers.ex:1203
 #, elixir-autogen, elixir-format
 msgid "Microsoft 365"
 msgstr "Microsoft 365"
 
-#: lib/phoenix_kit/integrations/providers.ex:1132
+#: lib/phoenix_kit/integrations/providers.ex:1204
 #, elixir-autogen, elixir-format
 msgid "Microsoft Graph — Outlook, OneDrive, Teams, Calendar, SharePoint"
 msgstr "Microsoft Graph — Outlook, OneDrive, Teams, Calendar, SharePoint"
 
-#: lib/phoenix_kit/integrations/providers.ex:1249
+#: lib/phoenix_kit/integrations/providers.ex:1321
 #, elixir-autogen, elixir-format
 msgid "Microsoft will show the consent screen — click **Accept** to grant the requested permissions"
 msgstr "Microsoft mostrará la pantalla de consentimiento: haga clic en **Aceptar** para conceder los permisos solicitados"
 
-#: lib/phoenix_kit/integrations/providers.ex:445
+#: lib/phoenix_kit/integrations/providers.ex:446
 #, elixir-autogen, elixir-format
 msgid "Mistral"
 msgstr "Mistral"
 
-#: lib/phoenix_kit/integrations/providers.ex:488
+#: lib/phoenix_kit/integrations/providers.ex:489
 #, elixir-autogen, elixir-format
 msgid "Mistral does not offer credits without billing setup; this is a hard requirement before keys can be created."
 msgstr "Mistral no ofrece créditos sin configurar la facturación; es un requisito imprescindible antes de poder crear claves."
@@ -5731,7 +5735,7 @@ msgstr "Mistral no ofrece créditos sin configurar la facturación; es un requis
 msgid "Permanently delete this connection? This cannot be undone."
 msgstr "¿Eliminar permanentemente esta conexión? Esta acción no se puede deshacer."
 
-#: lib/phoenix_kit/integrations/providers.ex:1200
+#: lib/phoenix_kit/integrations/providers.ex:1272
 #, elixir-autogen, elixir-format
 msgid "Register an application in Microsoft Entra ID (Azure AD)"
 msgstr "Registre una aplicación en Microsoft Entra ID (Azure AD)"
@@ -5747,32 +5751,32 @@ msgstr "Elimina la integración de forma permanente. Cualquier módulo vinculado
 msgid "Search..."
 msgstr "Buscar…"
 
-#: lib/phoenix_kit/integrations/providers.ex:1221
+#: lib/phoenix_kit/integrations/providers.ex:1293
 #, elixir-autogen, elixir-format
 msgid "Set an expiration (24 months is common; renew before it lapses)"
 msgstr "Establezca una caducidad (24 meses es habitual; renuévela antes de que expire)"
 
-#: lib/phoenix_kit/integrations/providers.ex:1181
+#: lib/phoenix_kit/integrations/providers.ex:1253
 #, elixir-autogen, elixir-format
 msgid "Tenant ID"
 msgstr "ID de inquilino"
 
-#: lib/phoenix_kit/integrations/providers.ex:1241
+#: lib/phoenix_kit/integrations/providers.ex:1313
 #, elixir-autogen, elixir-format
 msgid "The `default_scopes` in the provider definition request `openid email profile offline_access User.Read` — extra scopes can be added per-connect by passing `extra_scopes` to `authorization_url/5`."
 msgstr "Los `default_scopes` de la definición del proveedor solicitan `openid email profile offline_access User.Read`; se pueden añadir ámbitos adicionales por conexión pasando `extra_scopes` a `authorization_url/5`."
 
-#: lib/phoenix_kit/integrations/providers.ex:1209
+#: lib/phoenix_kit/integrations/providers.ex:1281
 #, elixir-autogen, elixir-format
 msgid "Under **Redirect URI**, choose **Web** and enter: `{redirect_uri}`"
 msgstr "En **URI de redirección**, elija **Web** e introduzca: `{redirect_uri}`"
 
-#: lib/phoenix_kit/integrations/providers.ex:1206
+#: lib/phoenix_kit/integrations/providers.ex:1278
 #, elixir-autogen, elixir-format
 msgid "Under **Supported account types**, choose the audience: *Personal Microsoft accounts only*, *Accounts in any organizational directory*, or *Accounts in this organizational directory only* depending on who should sign in"
 msgstr "En **Tipos de cuenta admitidos**, elija la audiencia: *Solo cuentas personales de Microsoft*, *Cuentas en cualquier directorio organizativo* o *Solo cuentas en este directorio organizativo*, según quién deba iniciar sesión"
 
-#: lib/phoenix_kit/integrations/providers.ex:476
+#: lib/phoenix_kit/integrations/providers.ex:477
 #, elixir-autogen, elixir-format
 msgid "You may need to verify your phone number before creating API keys"
 msgstr "Puede que deba verificar su número de teléfono antes de crear claves de API"
@@ -6039,14 +6043,14 @@ msgstr "No instalado"
 
 #: lib/phoenix_kit_web/live/modules.html.heex:447
 #: lib/phoenix_kit_web/live/settings.html.heex:465
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:289
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:315
 #, elixir-autogen, elixir-format
 msgid "Off"
 msgstr "Desactivado"
 
 #: lib/phoenix_kit_web/live/modules.html.heex:447
 #: lib/phoenix_kit_web/live/settings.html.heex:464
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:289
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:315
 #, elixir-autogen, elixir-format
 msgid "On"
 msgstr "Activado"
@@ -7278,8 +7282,8 @@ msgstr "Responder"
 msgid "Are you sure you want to delete this comment?"
 msgstr "¿Seguro que quiere eliminar este comentario?"
 
-#: lib/phoenix_kit_web/components/media_canvas_viewer.ex:1202
-#: lib/phoenix_kit_web/components/media_canvas_viewer.ex:1203
+#: lib/phoenix_kit_web/components/media_canvas_viewer.ex:1236
+#: lib/phoenix_kit_web/components/media_canvas_viewer.ex:1237
 #, elixir-autogen, elixir-format
 msgid "%b %d, %Y"
 msgstr "%d %b %Y"
@@ -8393,14 +8397,14 @@ msgstr "Todos los campos ya están seleccionados"
 msgid "All registered accounts"
 msgstr "Todas las cuentas registradas"
 
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:185
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:224
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:179
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:218
 #, elixir-autogen, elixir-format
 msgid "Anon"
 msgstr "Anón."
 
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:178
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:245
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:172
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:239
 #, elixir-autogen, elixir-format
 msgid "Anonymous User"
 msgstr "Usuario anónimo"
@@ -8451,8 +8455,8 @@ msgstr "¿Seguro que quiere revocar esta sesión de"
 msgid "Are you sure you want to unconfirm this user's email?"
 msgstr "¿Seguro que quiere anular la confirmación del correo de este usuario?"
 
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:170
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:220
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:164
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:214
 #, elixir-autogen, elixir-format
 msgid "Auth"
 msgstr "Autenticación"
@@ -8535,17 +8539,17 @@ msgid "Confirmed Email"
 msgstr "Correo confirmado"
 
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:109
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:195
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Current Page"
 msgstr "Página actual"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:251
+#: lib/phoenix_kit_web/live/settings/users.ex:258
 #, elixir-autogen, elixir-format
 msgid "Custom field deleted successfully"
 msgstr "Campo personalizado eliminado correctamente"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:171
+#: lib/phoenix_kit_web/live/settings/users.ex:178
 #, elixir-autogen, elixir-format
 msgid "Custom field saved successfully"
 msgstr "Campo personalizado guardado correctamente"
@@ -8560,17 +8564,17 @@ msgstr "Personalizar las columnas de la tabla"
 msgid "Drag to reorder selected columns above, or add new columns from the options below. Actions column is always included."
 msgstr "Arrastre para reordenar las columnas seleccionadas arriba, o agregue columnas nuevas desde las opciones de abajo. La columna Acciones siempre se incluye."
 
-#: lib/phoenix_kit_web/live/settings/users.ex:256
+#: lib/phoenix_kit_web/live/settings/users.ex:263
 #, elixir-autogen, elixir-format
 msgid "Failed to delete custom field"
 msgstr "No se pudo eliminar el campo personalizado"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:184
+#: lib/phoenix_kit_web/live/settings/users.ex:191
 #, elixir-autogen, elixir-format
 msgid "Failed to save custom field"
 msgstr "No se pudo guardar el campo personalizado"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:285
+#: lib/phoenix_kit_web/live/settings/users.ex:292
 #, elixir-autogen, elixir-format
 msgid "Failed to update field"
 msgstr "No se pudo actualizar el campo"
@@ -8603,23 +8607,23 @@ msgstr "No se pudieron actualizar los roles del usuario"
 msgid "Failed to update user status"
 msgstr "No se pudo actualizar el estado del usuario"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:278
+#: lib/phoenix_kit_web/live/settings/users.ex:285
 #, elixir-autogen, elixir-format
 msgid "Field '%{label}' disabled"
 msgstr "Campo «%{label}» deshabilitado"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:277
+#: lib/phoenix_kit_web/live/settings/users.ex:284
 #, elixir-autogen, elixir-format
 msgid "Field '%{label}' enabled"
 msgstr "Campo «%{label}» habilitado"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:289
+#: lib/phoenix_kit_web/live/settings/users.ex:296
 #, elixir-autogen, elixir-format
 msgid "Field not found"
 msgstr "Campo no encontrado"
 
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:108
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:194
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:188
 #, elixir-autogen, elixir-format
 msgid "IP Address"
 msgstr "Dirección IP"
@@ -8651,7 +8655,7 @@ msgstr "Gestione las cuentas de usuario y los roles"
 msgid "Monitor and manage active user sessions"
 msgstr "Supervise y gestione las sesiones activas de los usuarios"
 
-#: lib/phoenix_kit/integrations/providers.ex:1002
+#: lib/phoenix_kit/integrations/providers.ex:1074
 #: lib/phoenix_kit_web/live/users/users.ex:1048
 #: lib/phoenix_kit_web/live/users/users.html.heex:563
 #, elixir-autogen, elixir-format
@@ -8663,7 +8667,7 @@ msgstr "Nunca"
 msgid "Next »"
 msgstr "Siguiente »"
 
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:208
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:202
 #, elixir-autogen, elixir-format
 msgid "No active sessions"
 msgstr "Sin sesiones activas"
@@ -8815,7 +8819,7 @@ msgstr "Campos estándar"
 msgid "Table columns updated successfully"
 msgstr "Columnas de la tabla actualizadas correctamente"
 
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:209
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:203
 #, elixir-autogen, elixir-format
 msgid "There are currently no active sessions to display."
 msgstr "Actualmente no hay sesiones activas que mostrar."
@@ -8876,13 +8880,13 @@ msgstr "Confirmación del correo del usuario anulada correctamente"
 msgid "User roles updated successfully"
 msgstr "Roles del usuario actualizados correctamente"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:84
+#: lib/phoenix_kit_web/live/settings/users.ex:91
 #, elixir-autogen, elixir-format
 msgid "User settings updated successfully"
 msgstr "Ajustes de usuario actualizados correctamente"
 
 ## Navigation menu items
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:193
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:187
 #, elixir-autogen, elixir-format
 msgid "User/Session"
 msgstr "Usuario/Sesión"
@@ -8916,7 +8920,7 @@ msgstr[1] "¿Seguro que quiere revocar las %{count} sesiones del usuario %{email
 msgid "Last updated:"
 msgstr "Última actualización:"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:656
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:671
 #, elixir-autogen, elixir-format
 msgid "Account switcher for signing in to several accounts at once"
 msgstr "Selector de cuentas para iniciar sesión en varias cuentas a la vez"
@@ -8926,7 +8930,7 @@ msgstr "Selector de cuentas para iniciar sesión en varias cuentas a la vez"
 msgid "Applying…"
 msgstr "Aplicando…"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:662
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:677
 #, elixir-autogen, elixir-format
 msgid "Enable the multi-account switcher in the header"
 msgstr "Habilitar el selector de varias cuentas en el encabezado"
@@ -8944,12 +8948,12 @@ msgstr "Cargar más"
 msgid "Loading…"
 msgstr "Cargando…"
 
-#: lib/phoenix_kit_web/users/session.ex:113
+#: lib/phoenix_kit_web/users/session.ex:115
 #, elixir-autogen, elixir-format
 msgid "Logged out. Now signed in as %{email}."
 msgstr "Sesión cerrada. Ahora está conectado como %{email}."
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:653
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:668
 #, elixir-autogen, elixir-format
 msgid "Multiple Sessions"
 msgstr "Varias sesiones"
@@ -8985,12 +8989,12 @@ msgstr "Reordenar el %{noun} seleccionado (las demás filas no se mueven)."
 msgid "Showing %{loaded} of %{total} %{noun}"
 msgstr "Mostrando %{loaded} de %{total} %{noun}"
 
-#: lib/phoenix_kit_web/users/session.ex:268
+#: lib/phoenix_kit_web/users/session.ex:270
 #, elixir-autogen, elixir-format
 msgid "Switched to %{email}."
 msgstr "Se cambió a %{email}."
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:665
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:680
 #, elixir-autogen, elixir-format
 msgid "When on, any signed-in user can add other accounts (with their password) and switch between them from the user menu."
 msgstr "Si está activado, cualquier usuario conectado puede agregar otras cuentas (con su contraseña) y alternar entre ellas desde el menú de usuario."
@@ -9070,7 +9074,7 @@ msgstr "Aquí solo se pueden agregar los tipos de archivo permitidos."
 msgid "View background job status and history"
 msgstr "Ver el estado y el historial de las tareas en segundo plano"
 
-#: lib/phoenix_kit/integrations/providers.ex:312
+#: lib/phoenix_kit/integrations/providers.ex:313
 #, elixir-autogen, elixir-format
 msgid "AI models via OpenAI (GPT, embeddings, images, audio)"
 msgstr "Modelos de IA a través de OpenAI (GPT, embeddings, imágenes, audio)"
@@ -9155,12 +9159,12 @@ msgstr "Cambiar"
 msgid "Choose"
 msgstr "Elegir"
 
-#: lib/phoenix_kit/integrations/providers.ex:674
+#: lib/phoenix_kit/integrations/providers.ex:675
 #, elixir-autogen, elixir-format
 msgid "Click **Create API Key**, give it a name"
 msgstr "Haga clic en **Crear clave de API** y póngale un nombre"
 
-#: lib/phoenix_kit/integrations/providers.ex:371
+#: lib/phoenix_kit/integrations/providers.ex:372
 #, elixir-autogen, elixir-format
 msgid "Click **Create new secret key**, give it a name"
 msgstr "Haga clic en **Create new secret key** y póngale un nombre"
@@ -9171,12 +9175,12 @@ msgstr "Haga clic en **Create new secret key** y póngale un nombre"
 msgid "Close search"
 msgstr "Cerrar la búsqueda"
 
-#: lib/phoenix_kit/integrations/providers.ex:664
+#: lib/phoenix_kit/integrations/providers.ex:665
 #, elixir-autogen, elixir-format
 msgid "Create an ElevenLabs account"
 msgstr "Cree una cuenta de ElevenLabs"
 
-#: lib/phoenix_kit/integrations/providers.ex:349
+#: lib/phoenix_kit/integrations/providers.ex:350
 #, elixir-autogen, elixir-format
 msgid "Create an OpenAI account"
 msgstr "Cree una cuenta de OpenAI"
@@ -9240,7 +9244,7 @@ msgstr "Editar la descripción"
 msgid "Edit header"
 msgstr "Editar el encabezado"
 
-#: lib/phoenix_kit/integrations/providers.ex:634
+#: lib/phoenix_kit/integrations/providers.ex:635
 #, elixir-autogen, elixir-format
 msgid "ElevenLabs"
 msgstr "ElevenLabs"
@@ -9310,37 +9314,37 @@ msgstr "El nombre de la carpeta no puede estar vacío"
 msgid "Forgot password"
 msgstr "Olvidé mi contraseña"
 
-#: lib/phoenix_kit/integrations/providers.ex:657
+#: lib/phoenix_kit/integrations/providers.ex:658
 #, elixir-autogen, elixir-format
 msgid "From elevenlabs.io → Settings → API Keys"
 msgstr "Desde elevenlabs.io → Configuración → API Keys"
 
-#: lib/phoenix_kit/integrations/providers.ex:336
+#: lib/phoenix_kit/integrations/providers.ex:337
 #, elixir-autogen, elixir-format
 msgid "From platform.openai.com/api-keys"
 msgstr "Desde platform.openai.com/api-keys"
 
-#: lib/phoenix_kit/integrations/providers.ex:370
+#: lib/phoenix_kit/integrations/providers.ex:371
 #, elixir-autogen, elixir-format
 msgid "Go to [API Keys](https://platform.openai.com/api-keys)"
 msgstr "Vaya a [API Keys](https://platform.openai.com/api-keys)"
 
-#: lib/phoenix_kit/integrations/providers.ex:359
+#: lib/phoenix_kit/integrations/providers.ex:360
 #, elixir-autogen, elixir-format
 msgid "Go to [Billing](https://platform.openai.com/account/billing/overview) and add a payment method or credits"
 msgstr "Vaya a [Billing](https://platform.openai.com/account/billing/overview) y añada un método de pago o créditos"
 
-#: lib/phoenix_kit/integrations/providers.ex:672
+#: lib/phoenix_kit/integrations/providers.ex:673
 #, elixir-autogen, elixir-format
 msgid "Go to [Settings → API Keys](https://elevenlabs.io/app/settings/api-keys)"
 msgstr "Vaya a [Settings → API Keys](https://elevenlabs.io/app/settings/api-keys)"
 
-#: lib/phoenix_kit/integrations/providers.ex:666
+#: lib/phoenix_kit/integrations/providers.ex:667
 #, elixir-autogen, elixir-format
 msgid "Go to [elevenlabs.io](https://elevenlabs.io) and sign up or log in"
 msgstr "Vaya a [elevenlabs.io](https://elevenlabs.io) y regístrese o inicie sesión"
 
-#: lib/phoenix_kit/integrations/providers.ex:351
+#: lib/phoenix_kit/integrations/providers.ex:352
 #, elixir-autogen, elixir-format
 msgid "Go to [platform.openai.com](https://platform.openai.com) and sign up or log in"
 msgstr "Vaya a [platform.openai.com](https://platform.openai.com) y regístrese o inicie sesión"
@@ -9369,7 +9373,7 @@ msgstr "Encabezado %{level}"
 msgid "Icon"
 msgstr "Icono"
 
-#: lib/phoenix_kit/integrations/providers.ex:375
+#: lib/phoenix_kit/integrations/providers.ex:376
 #, elixir-autogen, elixir-format
 msgid "If your account belongs to multiple organizations, keys are scoped to the org selected when the key was created."
 msgstr "Si su cuenta pertenece a varias organizaciones, las claves se limitan a la organización seleccionada al crearlas."
@@ -9469,12 +9473,12 @@ msgstr "Los más antiguos primero"
 msgid "Open the media health dashboard to check file redundancy and re-sync files across storage locations."
 msgstr "Abra el panel de estado de los medios para comprobar la redundancia de los archivos y volver a sincronizarlos entre las ubicaciones de almacenamiento."
 
-#: lib/phoenix_kit/integrations/providers.ex:311
+#: lib/phoenix_kit/integrations/providers.ex:312
 #, elixir-autogen, elixir-format
 msgid "OpenAI"
 msgstr "OpenAI"
 
-#: lib/phoenix_kit/integrations/providers.ex:362
+#: lib/phoenix_kit/integrations/providers.ex:363
 #, elixir-autogen, elixir-format
 msgid "OpenAI requires a positive balance before the API will return completions, even on cheaper models"
 msgstr "OpenAI requiere un saldo positivo para que la API devuelva completions, incluso en modelos más económicos"
@@ -9564,12 +9568,12 @@ msgstr "Ordenar"
 msgid "Stacks"
 msgstr "Pilas"
 
-#: lib/phoenix_kit/integrations/providers.ex:635
+#: lib/phoenix_kit/integrations/providers.ex:636
 #, elixir-autogen, elixir-format
 msgid "Text-to-speech and voice generation via ElevenLabs"
 msgstr "Texto a voz y generación de voces con ElevenLabs"
 
-#: lib/phoenix_kit/integrations/providers.ex:678
+#: lib/phoenix_kit/integrations/providers.ex:679
 #, elixir-autogen, elixir-format
 msgid "The free tier includes a monthly character quota; paid plans raise the quota and unlock commercial use and additional voices."
 msgstr "El plan gratuito incluye una cuota mensual de caracteres; los planes de pago aumentan la cuota y habilitan el uso comercial y voces adicionales."
@@ -10451,27 +10455,27 @@ msgstr "O agregar con"
 msgid "Too many attempts. Please try again shortly."
 msgstr "Demasiados intentos. Vuelva a intentarlo en breve."
 
-#: lib/phoenix_kit/integrations/providers.ex:569
+#: lib/phoenix_kit/integrations/providers.ex:570
 #, elixir-autogen, elixir-format
 msgid "AI model access via xAI (Grok models)"
 msgstr "Acceso a modelos de IA a través de xAI (modelos Grok)"
 
-#: lib/phoenix_kit/integrations/providers.ex:827
+#: lib/phoenix_kit/integrations/providers.ex:828
 #, elixir-autogen, elixir-format
 msgid "AWS Simple Email Service (SMTP credentials via SES API)"
 msgstr "AWS Simple Email Service (credenciales SMTP mediante la API de SES)"
 
-#: lib/phoenix_kit/integrations/providers.ex:826
+#: lib/phoenix_kit/integrations/providers.ex:827
 #, elixir-autogen, elixir-format
 msgid "Amazon SES"
 msgstr "Amazon SES"
 
-#: lib/phoenix_kit/integrations/providers.ex:1050
+#: lib/phoenix_kit/integrations/providers.ex:1122
 #, elixir-autogen, elixir-format
 msgid "Brevo API"
 msgstr "API de Brevo"
 
-#: lib/phoenix_kit/integrations/providers.ex:605
+#: lib/phoenix_kit/integrations/providers.ex:606
 #, elixir-autogen, elixir-format
 msgid "Create an xAI account"
 msgstr "Cree una cuenta de xAI"
@@ -10481,37 +10485,37 @@ msgstr "Cree una cuenta de xAI"
 msgid "Email users when their account is signed in from a new device"
 msgstr "Enviar un correo a los usuarios cuando se inicie sesión en su cuenta desde un dispositivo nuevo"
 
-#: lib/phoenix_kit/integrations/providers.ex:961
+#: lib/phoenix_kit/integrations/providers.ex:1033
 #, elixir-autogen, elixir-format
 msgid "For Brevo: the SMTP key starting with xsmtpsib- (SMTP & API → SMTP tab) — not the API key (xkeysib-)."
 msgstr "Para Brevo: la clave SMTP que empieza por xsmtpsib- (SMTP & API → pestaña SMTP), no la clave de API (xkeysib-)."
 
-#: lib/phoenix_kit/integrations/providers.ex:949
+#: lib/phoenix_kit/integrations/providers.ex:1021
 #, elixir-autogen, elixir-format
 msgid "For Brevo: your account's SMTP login, shown as <subaccount>@smtp-brevo.com under SMTP & API → SMTP."
 msgstr "Para Brevo: el usuario SMTP de su cuenta, mostrado como <subaccount>@smtp-brevo.com en SMTP & API → SMTP."
 
-#: lib/phoenix_kit/integrations/providers.ex:1070
+#: lib/phoenix_kit/integrations/providers.ex:1142
 #, elixir-autogen, elixir-format
 msgid "From Brevo → SMTP & API → API Keys. Starts with xkeysib- — not the SMTP key (xsmtpsib-)."
 msgstr "Desde Brevo → SMTP & API → API Keys. Empieza por xkeysib-, no la clave SMTP (xsmtpsib-)."
 
-#: lib/phoenix_kit/integrations/providers.ex:590
+#: lib/phoenix_kit/integrations/providers.ex:591
 #, elixir-autogen, elixir-format
 msgid "From console.x.ai/team/default/api-keys"
 msgstr "Desde console.x.ai/team/default/api-keys"
 
-#: lib/phoenix_kit/integrations/providers.ex:621
+#: lib/phoenix_kit/integrations/providers.ex:622
 #, elixir-autogen, elixir-format
 msgid "Go to [API Keys](https://console.x.ai/team/default/api-keys)"
 msgstr "Vaya a [API Keys](https://console.x.ai/team/default/api-keys)"
 
-#: lib/phoenix_kit/integrations/providers.ex:607
+#: lib/phoenix_kit/integrations/providers.ex:608
 #, elixir-autogen, elixir-format
 msgid "Go to [accounts.x.ai](https://accounts.x.ai) and sign up or log in"
 msgstr "Vaya a [accounts.x.ai](https://accounts.x.ai) y regístrese o inicie sesión"
 
-#: lib/phoenix_kit/integrations/providers.ex:613
+#: lib/phoenix_kit/integrations/providers.ex:614
 #, elixir-autogen, elixir-format
 msgid "Go to [console.x.ai](https://console.x.ai) → Billing and add credits"
 msgstr "Vaya a [console.x.ai](https://console.x.ai) → Billing y añada créditos"
@@ -10521,43 +10525,44 @@ msgstr "Vaya a [console.x.ai](https://console.x.ai) → Billing y añada crédit
 msgid "Login Notifications"
 msgstr "Notificaciones de inicio de sesión"
 
-#: lib/phoenix_kit/integrations/providers.ex:927
+#: lib/phoenix_kit/integrations/providers.ex:999
 #, elixir-autogen, elixir-format
 msgid "Port"
 msgstr "Puerto"
 
-#: lib/phoenix_kit/integrations/providers.ex:720
-#: lib/phoenix_kit/integrations/providers.ex:860
+#: lib/phoenix_kit/integrations/providers.ex:721
+#: lib/phoenix_kit/integrations/providers.ex:861
+#: lib/phoenix_kit/integrations/providers.ex:945
 #, elixir-autogen, elixir-format
 msgid "Region"
 msgstr "Región"
 
-#: lib/phoenix_kit/integrations/providers.ex:904
+#: lib/phoenix_kit/integrations/providers.ex:976
 #, elixir-autogen, elixir-format
 msgid "SMTP"
 msgstr "SMTP"
 
-#: lib/phoenix_kit/integrations/providers.ex:918
+#: lib/phoenix_kit/integrations/providers.ex:990
 #, elixir-autogen, elixir-format
 msgid "SMTP Host"
 msgstr "Host SMTP"
 
-#: lib/phoenix_kit/integrations/providers.ex:1051
+#: lib/phoenix_kit/integrations/providers.ex:1123
 #, elixir-autogen, elixir-format
 msgid "Send email via the Brevo transactional email API"
 msgstr "Enviar correos mediante la API de correo transaccional de Brevo"
 
-#: lib/phoenix_kit/integrations/providers.ex:906
+#: lib/phoenix_kit/integrations/providers.ex:978
 #, elixir-autogen, elixir-format
 msgid "Universal SMTP relay — works with any vendor (Brevo, Mailgun, SendGrid, a self-hosted mail server, etc). Add one named connection per relay/account."
 msgstr "Relé SMTP universal: funciona con cualquier proveedor (Brevo, Mailgun, SendGrid, un servidor de correo propio, etc.). Agregue una conexión con nombre por relé o cuenta."
 
-#: lib/phoenix_kit/integrations/providers.ex:568
+#: lib/phoenix_kit/integrations/providers.ex:569
 #, elixir-autogen, elixir-format
 msgid "xAI"
 msgstr "xAI"
 
-#: lib/phoenix_kit/integrations/providers.ex:615
+#: lib/phoenix_kit/integrations/providers.ex:616
 #, elixir-autogen, elixir-format
 msgid "xAI requires a funded account before the API will return completions"
 msgstr "xAI requiere una cuenta con saldo para que la API devuelva completions"
@@ -10731,12 +10736,12 @@ msgstr "Ningún archivo coincide con su búsqueda."
 msgid "Try a different term or clear the search"
 msgstr "Pruebe otro término o borre la búsqueda"
 
-#: lib/modules/storage/web/bucket_form.ex:294
+#: lib/modules/storage/web/bucket_form.ex:296
 #, elixir-autogen, elixir-format
 msgid "Add Storage Bucket"
 msgstr "Agregar bucket de almacenamiento"
 
-#: lib/modules/storage/web/bucket_form.ex:295
+#: lib/modules/storage/web/bucket_form.ex:297
 #, elixir-autogen, elixir-format
 msgid "Edit Storage Bucket"
 msgstr "Editar el bucket de almacenamiento"
@@ -10825,12 +10830,12 @@ msgstr "hace %{n} min"
 msgid "%{provider} settings"
 msgstr "Ajustes de %{provider}"
 
-#: lib/phoenix_kit/integrations/validators.ex:643
+#: lib/phoenix_kit/integrations/validators.ex:824
 #, elixir-autogen, elixir-format
 msgid "%{text} · resets %{date}"
 msgstr "%{text} · se restablece el %{date}"
 
-#: lib/phoenix_kit/integrations/validators.ex:632
+#: lib/phoenix_kit/integrations/validators.ex:813
 #, elixir-autogen, elixir-format
 msgid "%{type} · %{credits} credits left"
 msgstr "%{type} · quedan %{credits} créditos"
@@ -10886,12 +10891,12 @@ msgstr "Todo el correo saliente del sistema (autenticación, notificaciones) se 
 msgid "Allow \"Keep me logged in\" (persistent sessions)"
 msgstr "Permitir «Mantener la sesión abierta» (sesiones persistentes)"
 
-#: lib/phoenix_kit/integrations/providers.ex:1001
+#: lib/phoenix_kit/integrations/providers.ex:1073
 #, elixir-autogen, elixir-format
 msgid "Always"
 msgstr "Siempre"
 
-#: lib/phoenix_kit_web/users/session.ex:331
+#: lib/phoenix_kit_web/users/session.ex:333
 #, elixir-autogen, elixir-format
 msgid "An owner account cannot be used."
 msgstr "No se puede usar una cuenta de propietario."
@@ -10901,12 +10906,12 @@ msgstr "No se puede usar una cuenta de propietario."
 msgid "Applies site-wide wherever the rich-text editor is rendered (posts, comments). Users can still switch modes inside the editor."
 msgstr "Se aplica en todo el sitio donde se muestre el editor de texto enriquecido (publicaciones, comentarios). Los usuarios pueden seguir cambiando de modo dentro del editor."
 
-#: lib/phoenix_kit/integrations/providers.ex:982
+#: lib/phoenix_kit/integrations/providers.ex:1054
 #, elixir-autogen, elixir-format
 msgid "Auto (from port)"
 msgstr "Automático (según el puerto)"
 
-#: lib/phoenix_kit/integrations/providers.ex:978
+#: lib/phoenix_kit/integrations/providers.ex:1050
 #, elixir-autogen, elixir-format
 msgid "Auto follows the port: 465 means implicit TLS, anything else STARTTLS (required when a login is set). Choose explicitly for a relay that ignores that convention."
 msgstr "«Automático» sigue el puerto: 465 significa TLS implícito y cualquier otro STARTTLS (obligatorio si se define un usuario). Elíjalo explícitamente para un relé que ignore esa convención."
@@ -10921,22 +10926,22 @@ msgstr "Agrupe los tipos de gran volumen en resúmenes periódicos: defina una f
 msgid "Best,\nThe Team"
 msgstr "Saludos,\nel equipo"
 
-#: lib/phoenix_kit/integrations/providers.ex:1098
+#: lib/phoenix_kit/integrations/providers.ex:1170
 #, elixir-autogen, elixir-format
 msgid "Bot Token"
 msgstr "Token del bot"
 
-#: lib/phoenix_kit/integrations/providers.ex:1118
+#: lib/phoenix_kit/integrations/providers.ex:1190
 #, elixir-autogen, elixir-format
 msgid "BotFather replies with an HTTP API token like `123456789:ABCdef...` — copy it"
 msgstr "BotFather responde con un token de API HTTP como `123456789:ABCdef...`: cópielo"
 
-#: lib/phoenix_kit/integrations/validators.ex:601
+#: lib/phoenix_kit/integrations/validators.ex:782
 #, elixir-autogen, elixir-format
 msgid "Brevo error %{status}"
 msgstr "Error de Brevo %{status}"
 
-#: lib/phoenix_kit/integrations/providers.ex:1022
+#: lib/phoenix_kit/integrations/providers.ex:1094
 #, elixir-autogen, elixir-format
 msgid "CA certificate (PEM)"
 msgstr "Certificado de CA (PEM)"
@@ -10946,7 +10951,7 @@ msgstr "Certificado de CA (PEM)"
 msgid "Cannot delete send profile"
 msgstr "No se puede eliminar el perfil de envío"
 
-#: lib/phoenix_kit/integrations/providers.ex:1007
+#: lib/phoenix_kit/integrations/providers.ex:1079
 #, elixir-autogen, elixir-format
 msgid "Certificate verification"
 msgstr "Verificación del certificado"
@@ -10991,7 +10996,7 @@ msgstr "Confirme su correo"
 msgid "Connect your own API keys and services. Only you can see these."
 msgstr "Conecte sus propias claves de API y servicios. Solo usted puede verlos."
 
-#: lib/phoenix_kit/integrations/validators.ex:693
+#: lib/phoenix_kit/integrations/validators.ex:874
 #, elixir-autogen, elixir-format
 msgid "Connected as @%{username}"
 msgstr "Conectado como @%{username}"
@@ -11007,7 +11012,7 @@ msgstr "La conexión funciona"
 msgid "Content Editor"
 msgstr "Editor de contenido"
 
-#: lib/phoenix_kit/integrations/providers.ex:1116
+#: lib/phoenix_kit/integrations/providers.ex:1188
 #, elixir-autogen, elixir-format
 msgid "Copy the bot token"
 msgstr "Copie el token del bot"
@@ -11025,12 +11030,12 @@ msgstr "No se pudo agregar la integración"
 msgid "Could not reach AWS SES"
 msgstr "No se pudo contactar con AWS SES"
 
-#: lib/phoenix_kit/integrations/validators.ex:605
+#: lib/phoenix_kit/integrations/validators.ex:786
 #, elixir-autogen, elixir-format
 msgid "Could not reach Brevo"
 msgstr "No se pudo contactar con Brevo"
 
-#: lib/phoenix_kit/integrations/validators.ex:705
+#: lib/phoenix_kit/integrations/validators.ex:886
 #, elixir-autogen, elixir-format
 msgid "Could not reach Telegram"
 msgstr "No se pudo contactar con Telegram"
@@ -11091,7 +11096,7 @@ msgstr "No se pudieron actualizar los ajustes de agrupación."
 msgid "Could not update default send integration"
 msgstr "No se pudo actualizar la integración de envío predeterminada"
 
-#: lib/phoenix_kit/integrations/providers.ex:1109
+#: lib/phoenix_kit/integrations/providers.ex:1181
 #, elixir-autogen, elixir-format
 msgid "Create a bot with BotFather"
 msgstr "Cree un bot con BotFather"
@@ -11167,7 +11172,7 @@ msgstr "Los perfiles deshabilitados nunca se usan para enviar, ni siquiera como 
 msgid "Dismiss"
 msgstr "Descartar"
 
-#: lib/phoenix_kit/integrations/providers.ex:1017
+#: lib/phoenix_kit/integrations/providers.ex:1089
 #, elixir-autogen, elixir-format
 msgid "Do not verify"
 msgstr "No verificar"
@@ -11199,7 +11204,7 @@ msgstr "Editar el perfil de envío: %{name}"
 msgid "Email Sending"
 msgstr "Envío de correo"
 
-#: lib/phoenix_kit_web/users/confirmation_instructions.ex:109
+#: lib/phoenix_kit_web/users/confirmation_instructions.ex:111
 #, elixir-autogen, elixir-format
 msgid "Email confirmed. Welcome!"
 msgstr "¡Correo confirmado. Bienvenido!"
@@ -11209,7 +11214,7 @@ msgstr "¡Correo confirmado. Bienvenido!"
 msgid "Email-capable integrations"
 msgstr "Integraciones con soporte de correo"
 
-#: lib/phoenix_kit/integrations/providers.ex:973
+#: lib/phoenix_kit/integrations/providers.ex:1045
 #, elixir-autogen, elixir-format
 msgid "Encryption"
 msgstr "Cifrado"
@@ -11229,7 +11234,7 @@ msgstr "Cada 12 horas"
 msgid "Everyone who starts the bot"
 msgstr "Todos los que inicien el bot"
 
-#: lib/phoenix_kit/integrations/providers.ex:1027
+#: lib/phoenix_kit/integrations/providers.ex:1099
 #, elixir-autogen, elixir-format
 msgid "For a private or self-signed relay certificate. Replaces the system CA store for this connection only."
 msgstr "Para un certificado de relé privado o autofirmado. Reemplaza el almacén de CA del sistema solo para esta conexión."
@@ -11240,7 +11245,7 @@ msgstr "Para un certificado de relé privado o autofirmado. Reemplaza el almacé
 msgid "From"
 msgstr "Remitente"
 
-#: lib/phoenix_kit/integrations/providers.ex:1102
+#: lib/phoenix_kit/integrations/providers.ex:1174
 #, elixir-autogen, elixir-format
 msgid "From @BotFather → /newbot (or /token for an existing bot)"
 msgstr "De @BotFather → /newbot (o /token para un bot existente)"
@@ -11267,7 +11272,7 @@ msgstr "Acceso completo"
 msgid "Hourly"
 msgstr "Cada hora"
 
-#: lib/phoenix_kit/integrations/providers.ex:1000
+#: lib/phoenix_kit/integrations/providers.ex:1072
 #, elixir-autogen, elixir-format
 msgid "If offered (default)"
 msgstr "Si se ofrece (predeterminado)"
@@ -11277,7 +11282,7 @@ msgstr "Si se ofrece (predeterminado)"
 msgid "Immediate"
 msgstr "Inmediato"
 
-#: lib/phoenix_kit/integrations/providers.ex:983
+#: lib/phoenix_kit/integrations/providers.ex:1055
 #, elixir-autogen, elixir-format
 msgid "Implicit TLS / SMTPS"
 msgstr "TLS implícito / SMTPS"
@@ -11295,6 +11300,7 @@ msgid "Incomplete SMTP settings"
 msgstr "Ajustes SMTP incompletos"
 
 #: lib/phoenix_kit/integrations/validators.ex:57
+#: lib/phoenix_kit/integrations/validators.ex:582
 #, elixir-autogen, elixir-format
 msgid "Incomplete credentials"
 msgstr "Credenciales incompletas"
@@ -11331,7 +11337,7 @@ msgstr "Ajustes SMTP no válidos"
 msgid "Invalid SMTP settings: %{reason}"
 msgstr "Ajustes SMTP no válidos: %{reason}"
 
-#: lib/phoenix_kit/integrations/validators.ex:698
+#: lib/phoenix_kit/integrations/validators.ex:879
 #, elixir-autogen, elixir-format
 msgid "Invalid bot token"
 msgstr "Token del bot no válido"
@@ -11351,7 +11357,7 @@ msgstr "Tiempo de espera no válido: %{value}"
 msgid "Leave a field blank to fall back to the application config or built-in default."
 msgstr "Deje un campo vacío para usar la configuración de la aplicación o el valor predeterminado integrado."
 
-#: lib/phoenix_kit/integrations/providers.ex:1038
+#: lib/phoenix_kit/integrations/providers.ex:1110
 #, elixir-autogen, elixir-format
 msgid "Leave blank for the gen_smtp default."
 msgstr "Déjelo vacío para el valor predeterminado de gen_smtp."
@@ -11392,7 +11398,7 @@ msgstr "Marcar todo como leído"
 msgid "Mark read"
 msgstr "Marcar como leído"
 
-#: lib/phoenix_kit_web/users/session.ex:340
+#: lib/phoenix_kit_web/users/session.ex:342
 #, elixir-autogen, elixir-format
 msgid "Maximum number of accounts reached — remove one first."
 msgstr "Se alcanzó el número máximo de cuentas: quite una primero."
@@ -11442,7 +11448,7 @@ msgstr "Nuevo perfil de envío"
 msgid "No adapter configured for the static mailer. Set one in your application config, or connect an email-capable integration below and pick it as the default transactional integration."
 msgstr "No hay adaptador configurado para el mailer estático. Defina uno en la configuración de su aplicación o conecte abajo una integración con soporte de correo y elíjala como integración transaccional predeterminada."
 
-#: lib/phoenix_kit/integrations/validators.ex:682
+#: lib/phoenix_kit/integrations/validators.ex:863
 #, elixir-autogen, elixir-format
 msgid "No bot token configured"
 msgstr "No hay token del bot configurado"
@@ -11482,7 +11488,7 @@ msgstr "No se encontraron certificados de CA del sistema, por lo que no se puede
 msgid "No unread notifications"
 msgstr "No hay notificaciones sin leer"
 
-#: lib/phoenix_kit/integrations/providers.ex:986
+#: lib/phoenix_kit/integrations/providers.ex:1058
 #, elixir-autogen, elixir-format
 msgid "None — plaintext"
 msgstr "Ninguno: sin cifrar"
@@ -11512,7 +11518,7 @@ msgstr "Las notificaciones que reciba aparecerán aquí."
 msgid "Numeric ID of a verified Brevo sender. Leave empty to send from the From address above."
 msgstr "ID numérico de un remitente verificado de Brevo. Déjelo vacío para enviar desde la dirección indicada arriba."
 
-#: lib/phoenix_kit_web/users/session.ex:334
+#: lib/phoenix_kit_web/users/session.ex:336
 #, elixir-autogen, elixir-format
 msgid "Only an owner can sign in as another administrator."
 msgstr "Solo un propietario puede iniciar sesión como otro administrador."
@@ -11522,12 +11528,12 @@ msgstr "Solo un propietario puede iniciar sesión como otro administrador."
 msgid "Only me"
 msgstr "Solo yo"
 
-#: lib/phoenix_kit/integrations/providers.ex:1111
+#: lib/phoenix_kit/integrations/providers.ex:1183
 #, elixir-autogen, elixir-format
 msgid "Open [@BotFather](https://t.me/BotFather) in Telegram"
 msgstr "Abra [@BotFather](https://t.me/BotFather) en Telegram"
 
-#: lib/phoenix_kit/integrations/providers.ex:1121
+#: lib/phoenix_kit/integrations/providers.ex:1193
 #, elixir-autogen, elixir-format
 msgid "Paste the token into the form above and press **Test Connection**"
 msgstr "Pegue el token en el formulario de arriba y pulse **Probar la conexión**"
@@ -11547,7 +11553,7 @@ msgstr "Identidad del remitente, límites de tasa y opciones específicas del pr
 msgid "Persistent sessions last 60 days. Magic-link and social logins have no checkbox to tick, so they follow the default above. Turning the first option off hides the checkbox everywhere and keeps every login to the browser session."
 msgstr "Las sesiones persistentes duran 60 días. Los inicios de sesión con enlace mágico y redes sociales no tienen casilla, por lo que siguen el valor predeterminado de arriba. Si desactiva la primera opción, la casilla se oculta en todas partes y cada inicio de sesión queda limitado a la sesión del navegador."
 
-#: lib/phoenix_kit/integrations/validators.ex:616
+#: lib/phoenix_kit/integrations/validators.ex:797
 #, elixir-autogen, elixir-format
 msgid "Plan: %{entries}"
 msgstr "Plan: %{entries}"
@@ -11644,12 +11650,12 @@ msgstr "SMTP no tiene ajustes de proveedor por perfil: el relé, el puerto y el 
 msgid "SMTP server rejected the connection"
 msgstr "El servidor SMTP rechazó la conexión"
 
-#: lib/phoenix_kit/integrations/providers.ex:985
+#: lib/phoenix_kit/integrations/providers.ex:1057
 #, elixir-autogen, elixir-format
 msgid "STARTTLS — if offered"
 msgstr "STARTTLS: si se ofrece"
 
-#: lib/phoenix_kit/integrations/providers.ex:984
+#: lib/phoenix_kit/integrations/providers.ex:1056
 #, elixir-autogen, elixir-format
 msgid "STARTTLS — required"
 msgstr "STARTTLS: obligatorio"
@@ -11669,7 +11675,7 @@ msgstr "Guardar la identidad del remitente"
 msgid "Select an integration..."
 msgstr "Seleccione una integración…"
 
-#: lib/phoenix_kit/integrations/providers.ex:1112
+#: lib/phoenix_kit/integrations/providers.ex:1184
 #, elixir-autogen, elixir-format
 msgid "Send **/newbot** and follow the prompts to name your bot"
 msgstr "Envíe **/newbot** y siga las indicaciones para nombrar su bot"
@@ -11683,7 +11689,7 @@ msgstr "Envíe **/newbot** y siga las indicaciones para nombrar su bot"
 msgid "Send Profiles"
 msgstr "Perfiles de envío"
 
-#: lib/phoenix_kit/integrations/providers.ex:1087
+#: lib/phoenix_kit/integrations/providers.ex:1159
 #, elixir-autogen, elixir-format
 msgid "Send messages and notifications via your own Telegram bot"
 msgstr "Envíe mensajes y notificaciones mediante su propio bot de Telegram"
@@ -11773,13 +11779,13 @@ msgstr "Falló el saludo TLS"
 msgid "Tags"
 msgstr "Etiquetas"
 
-#: lib/phoenix_kit/integrations/providers.ex:1086
+#: lib/phoenix_kit/integrations/providers.ex:1158
 #: lib/phoenix_kit/notifications/channels/telegram.ex:36
 #, elixir-autogen, elixir-format
 msgid "Telegram"
 msgstr "Telegram"
 
-#: lib/phoenix_kit/integrations/validators.ex:701
+#: lib/phoenix_kit/integrations/validators.ex:882
 #, elixir-autogen, elixir-format
 msgid "Telegram error %{status}"
 msgstr "Error de Telegram %{status}"
@@ -11799,17 +11805,17 @@ msgstr "Correo de prueba de %{site}"
 msgid "Test email sent to %{recipient}"
 msgstr "Correo de prueba enviado a %{recipient}"
 
-#: lib/phoenix_kit_web/users/session.ex:343
+#: lib/phoenix_kit_web/users/session.ex:345
 #, elixir-autogen, elixir-format
 msgid "That account is already in your session — switch to it instead."
 msgstr "Esa cuenta ya está en su sesión: cambie a ella en su lugar."
 
-#: lib/phoenix_kit_web/users/session.ex:337
+#: lib/phoenix_kit_web/users/session.ex:339
 #, elixir-autogen, elixir-format
 msgid "That account is deactivated."
 msgstr "Esa cuenta está desactivada."
 
-#: lib/phoenix_kit_web/users/session.ex:336
+#: lib/phoenix_kit_web/users/session.ex:338
 #, elixir-autogen, elixir-format
 msgid "That is already your account."
 msgstr "Esa ya es su cuenta."
@@ -11850,7 +11856,7 @@ msgstr "Este perfil de envío se eliminará permanentemente."
 msgid "This sender address cannot be logged"
 msgstr "Esta dirección de remitente no se puede registrar"
 
-#: lib/phoenix_kit/integrations/providers.ex:1034
+#: lib/phoenix_kit/integrations/providers.ex:1106
 #, elixir-autogen, elixir-format
 msgid "Timeout (seconds)"
 msgstr "Tiempo de espera (segundos)"
@@ -11860,7 +11866,7 @@ msgstr "Tiempo de espera (segundos)"
 msgid "Transport"
 msgstr "Transporte"
 
-#: lib/phoenix_kit/integrations/providers.ex:1012
+#: lib/phoenix_kit/integrations/providers.ex:1084
 #, elixir-autogen, elixir-format
 msgid "Turning verification off means the login travels to whoever answers, including an impostor. Use a CA certificate below instead whenever you can."
 msgstr "Si desactiva la verificación, el usuario y la contraseña llegan a quien responda, incluido un impostor. Cuando pueda, use mejor un certificado de CA abajo."
@@ -11890,12 +11896,12 @@ msgstr "Actualizar el perfil de envío"
 msgid "Used when no default transactional integration is selected below."
 msgstr "Se usa cuando no hay una integración transaccional predeterminada seleccionada abajo."
 
-#: lib/phoenix_kit_web/users/session.ex:309
+#: lib/phoenix_kit_web/users/session.ex:311
 #, elixir-autogen, elixir-format
 msgid "User not found."
 msgstr "Usuario no encontrado."
 
-#: lib/phoenix_kit/integrations/providers.ex:1016
+#: lib/phoenix_kit/integrations/providers.ex:1088
 #, elixir-autogen, elixir-format
 msgid "Verify (default)"
 msgstr "Verificar (predeterminado)"
@@ -11915,7 +11921,7 @@ msgstr "Integraciones del sitio web"
 msgid "Where a freshly registered account lands. Empty = after-login path."
 msgstr "Dónde llega una cuenta recién registrada. Vacío = ruta después del inicio de sesión."
 
-#: lib/phoenix_kit/integrations/providers.ex:996
+#: lib/phoenix_kit/integrations/providers.ex:1068
 #, elixir-autogen, elixir-format
 msgid "Whether to send the login at all. “If offered” follows the relay; “Never” is for relays that authenticate by IP."
 msgstr "Si se debe enviar el usuario y la contraseña. «Si se ofrece» sigue al relé; «Nunca» es para relés que autentican por IP."
@@ -11930,12 +11936,12 @@ msgstr "¿A quién escribe este bot?"
 msgid "Yesterday"
 msgstr "Ayer"
 
-#: lib/phoenix_kit_web/users/session.ex:320
+#: lib/phoenix_kit_web/users/session.ex:322
 #, elixir-autogen, elixir-format
 msgid "You are now signed in as %{email}."
 msgstr "Ahora está conectado como %{email}."
 
-#: lib/phoenix_kit_web/users/session.ex:329
+#: lib/phoenix_kit_web/users/session.ex:331
 #, elixir-autogen, elixir-format
 msgid "You do not have permission to sign in as another user."
 msgstr "No tiene permiso para iniciar sesión como otro usuario."
@@ -12051,7 +12057,7 @@ msgstr "Comprobando…"
 msgid "Continue"
 msgstr "Continuar"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:143
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:169
 #, elixir-autogen, elixir-format
 msgid "Copied!"
 msgstr "¡Copiado!"
@@ -12061,7 +12067,7 @@ msgstr "¡Copiado!"
 msgid "Couldn't reach hex.pm, so the package list is unavailable right now."
 msgstr "No se ha podido contactar con hex.pm, por lo que la lista de paquetes no está disponible en este momento."
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:119
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:145
 #, elixir-autogen, elixir-format
 msgid "Crawler Instructions"
 msgstr "Instrucciones para los rastreadores"
@@ -12115,7 +12121,7 @@ msgstr "¡Bienvenido! Su código de referencia ha sido aceptado."
 msgid "has the robots.txt line that points crawlers here."
 msgstr "tiene la línea de robots.txt que dirige aquí a los rastreadores."
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:173
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:199
 #, elixir-autogen, elixir-format
 msgid "priv/static/robots.txt points crawlers at your sitemap."
 msgstr "priv/static/robots.txt dirige a los rastreadores a su sitemap."
@@ -12219,17 +12225,17 @@ msgstr "No tiene permiso para eliminar a este usuario"
 msgid "You don't have permission to manage this user's credentials"
 msgstr "No tiene permiso para gestionar las credenciales de este usuario"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:190
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:216
 #, elixir-autogen, elixir-format
 msgid "AI Discovery"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:698
+#: lib/phoenix_kit/integrations/providers.ex:699
 #, elixir-autogen, elixir-format
 msgid "AWS Bedrock LLMs via a Bedrock API key (OpenAI-compatible endpoint: gpt-oss models; the rest via native Converse)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:715
+#: lib/phoenix_kit/integrations/providers.ex:716
 #, elixir-autogen, elixir-format
 msgid "AWS console → Amazon Bedrock → API keys (long-term key)"
 msgstr ""
@@ -12244,22 +12250,22 @@ msgstr ""
 msgid "Account %{id}"
 msgstr "Cuenta"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:303
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:329
 #, elixir-autogen, elixir-format
 msgid "Advisory-grade: anything can send any User-Agent, so a scraper that lies passes through. Real enforcement belongs at your CDN or reverse proxy — this catches the honest-but-ignorant. Bots identified only by robots.txt tokens (Google-Extended, Applebot-Extended) crawl under their main user agent and are never matched here, so blocking AI training cannot 403 Googlebot."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:98
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:124
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Allowed"
 msgstr "Todos"
 
-#: lib/phoenix_kit/integrations/providers.ex:696
+#: lib/phoenix_kit/integrations/providers.ex:697
 #, elixir-autogen, elixir-format
 msgid "Amazon Bedrock"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:282
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:308
 #, elixir-autogen, elixir-format
 msgid "Answer 403 to requests whose User-Agent matches a blocked group, for bots that ignore robots.txt."
 msgstr ""
@@ -12269,7 +12275,7 @@ msgstr ""
 msgid "Auth mail carries single-use tokens, and /dev/mailbox has no authentication — anyone who can reach this server can read them. Only for closed environments."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:711
+#: lib/phoenix_kit/integrations/providers.ex:712
 #, elixir-autogen, elixir-format
 msgid "Bedrock API key"
 msgstr ""
@@ -12279,7 +12285,7 @@ msgstr ""
 msgid "Bedrock error %{status}"
 msgstr "Error de Brevo %{status}"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:280
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:306
 #, elixir-autogen, elixir-format
 msgid "Block at the application"
 msgstr ""
@@ -12289,7 +12295,7 @@ msgstr ""
 msgid "Blocked groups"
 msgstr "Bloqueado"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:77
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:103
 #, elixir-autogen, elixir-format
 msgid "Bot Access"
 msgstr ""
@@ -12304,12 +12310,12 @@ msgstr ""
 msgid "Control how search engines and AI bots crawl and index this site"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:739
+#: lib/phoenix_kit/integrations/providers.ex:740
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Copy the key (shown once, `ABSK…`) and paste it into the form above"
 msgstr "Copie la clave (se muestra una sola vez) y péguela en el formulario de arriba"
 
-#: lib/phoenix_kit/integrations/providers.ex:815
+#: lib/phoenix_kit/integrations/providers.ex:816
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Copy the token and paste it into the form above"
 msgstr "Copie la clave y péguela en el formulario de arriba"
@@ -12350,22 +12356,22 @@ msgstr ""
 msgid "Crawlers module is disabled. Enable it from the Modules page to configure settings."
 msgstr "El módulo SEO está desactivado. Actívelo desde la página Módulos para configurar los ajustes."
 
-#: lib/phoenix_kit/integrations/providers.ex:731
+#: lib/phoenix_kit/integrations/providers.ex:732
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Create a Bedrock API key"
 msgstr "Cree una clave de API"
 
-#: lib/phoenix_kit/integrations/providers.ex:807
+#: lib/phoenix_kit/integrations/providers.ex:808
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Create a token"
 msgstr "Crear rol"
 
-#: lib/phoenix_kit/integrations/providers.ex:871
+#: lib/phoenix_kit/integrations/providers.ex:872
 #, elixir-autogen, elixir-format
 msgid "Create an IAM user with SES access"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:876
+#: lib/phoenix_kit/integrations/providers.ex:877
 #, elixir-autogen, elixir-format
 msgid "Create an access key for that user (Security credentials → Create access key) and paste the ID and secret above"
 msgstr ""
@@ -12380,41 +12386,42 @@ msgstr ""
 msgid "Deliver development mail to /dev/mailbox"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:747
+#: lib/phoenix_kit/integrations/providers.ex:748
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enable model access"
 msgstr "Habilite el módulo para acceder a los ajustes"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:278
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:304
 #, elixir-autogen, elixir-format
 msgid "Enforcement"
 msgstr ""
 
 #: lib/phoenix_kit_web/live/settings/crawlers.ex:90
-#: lib/phoenix_kit_web/live/settings/crawlers.ex:109
-#: lib/phoenix_kit_web/live/settings/crawlers.ex:120
-#: lib/phoenix_kit_web/live/settings/crawlers.ex:136
-#: lib/phoenix_kit_web/live/settings/crawlers.ex:149
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:102
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:121
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:132
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:148
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:161
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to update crawler settings"
 msgstr "No se pudo actualizar la configuración"
 
-#: lib/phoenix_kit/integrations/providers.ex:780
+#: lib/phoenix_kit/integrations/providers.ex:781
 #, elixir-autogen, elixir-format, fuzzy
 msgid "GitHub"
 msgstr "Inicio de sesión con GitHub"
 
-#: lib/phoenix_kit/integrations/providers.ex:782
+#: lib/phoenix_kit/integrations/providers.ex:783
 #, elixir-autogen, elixir-format
 msgid "GitHub API token — org statistics, repositories (read-only is enough)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:809
+#: lib/phoenix_kit/integrations/providers.ex:810
 #, elixir-autogen, elixir-format
 msgid "Go to [Fine-grained tokens](https://github.com/settings/personal-access-tokens) and click **Generate new token**"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:81
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:107
 #, elixir-autogen, elixir-format
 msgid "Grouped by why they visit. Blocking a group writes it into the generated robots.txt below; everything defaults to allowed."
 msgstr ""
@@ -12424,22 +12431,22 @@ msgstr ""
 msgid "Hide titles of records the reader can't open"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:749
+#: lib/phoenix_kit/integrations/providers.ex:750
 #, elixir-autogen, elixir-format
 msgid "In [Bedrock → Model access](https://console.aws.amazon.com/bedrock/home#/modelaccess) enable the models you plan to call — a key with no enabled models validates but cannot complete"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:763
+#: lib/phoenix_kit/integrations/providers.ex:764
 #, elixir-autogen, elixir-format
 msgid "In the AI module, create an endpoint pointing at this connection with a `gpt-oss` model and a base URL in the SAME region as this key"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:873
+#: lib/phoenix_kit/integrations/providers.ex:874
 #, elixir-autogen, elixir-format
 msgid "In the [IAM console](https://console.aws.amazon.com/iam/home#/users) create a user for programmatic access and attach an SES policy (least privilege: `ses:SendEmail`/`ses:SendRawEmail`; docs: [SES setup](https://docs.aws.amazon.com/ses/latest/dg/setting-up.html))"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:884
+#: lib/phoenix_kit/integrations/providers.ex:885
 #, elixir-autogen, elixir-format
 msgid "In the [SES console](https://console.aws.amazon.com/ses/home#/identities) verify your domain or sender address — SES refuses to send from unverified identities"
 msgstr ""
@@ -12484,7 +12491,7 @@ msgstr ""
 msgid "Model catalog in %{region}: %{count} (grants are configured separately)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:887
+#: lib/phoenix_kit/integrations/providers.ex:888
 #, elixir-autogen, elixir-format
 msgid "New accounts start in the SES sandbox (verified recipients only) — [request production access](https://docs.aws.amazon.com/ses/latest/dg/request-production-access.html) before real sending"
 msgstr ""
@@ -12499,7 +12506,7 @@ msgstr ""
 msgid "No longer available"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:165
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:191
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No priv/static/robots.txt found. Without one, crawlers assume everything is allowed — and any groups you blocked above are not being told."
 msgstr "No se ha encontrado priv/static/robots.txt. Sin él, los rastreadores asumen que todo está permitido — algo que suele estar bien, pero no sabrán dónde está su sitemap."
@@ -12514,47 +12521,47 @@ msgstr ""
 msgid "Note (optional)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:733
+#: lib/phoenix_kit/integrations/providers.ex:734
 #, elixir-autogen, elixir-format
 msgid "Open the [Bedrock console → API keys](https://console.aws.amazon.com/bedrock/home#/api-keys) and generate a **long-term** key (docs: [Bedrock API keys](https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys.html))"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:212
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:238
 #, elixir-autogen, elixir-format
 msgid "Optional markdown: a summary paragraph, key links, docs pointers…"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:736
+#: lib/phoenix_kit/integrations/providers.ex:737
 #, elixir-autogen, elixir-format
 msgid "Or attach one to an existing IAM user: [IAM console](https://console.aws.amazon.com/iam/home#/users) → user → Security credentials → Bedrock API keys"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:235
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:261
 #, elixir-autogen, elixir-format
 msgid "Paste the verification content Google Search Console or Bing Webmaster Tools gives you — the meta tags are added to every layout head. Pasting the whole <meta> tag also works; the content value is extracted."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:796
+#: lib/phoenix_kit/integrations/providers.ex:797
 #, elixir-autogen, elixir-format
 msgid "Personal access token"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:123
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:149
 #, elixir-autogen, elixir-format
 msgid "PhoenixKit does not serve this file — it is yours, served from priv/static before any route is consulted. This is the complete file your toggles above describe: paste it into priv/static/robots.txt."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:752
+#: lib/phoenix_kit/integrations/providers.ex:753
 #, elixir-autogen, elixir-format
 msgid "Pick the region where access was granted; the AI endpoint's base URL must use the same region"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:217
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:243
 #, elixir-autogen, elixir-format
 msgid "Preview of the served file:"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:812
+#: lib/phoenix_kit/integrations/providers.ex:813
 #, elixir-autogen, elixir-format
 msgid "Repository access: **Public repositories (read-only)** — no extra permissions needed for public-org statistics"
 msgstr ""
@@ -12564,7 +12571,7 @@ msgstr ""
 msgid "Request access"
 msgstr "Solicitado"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:233
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:259
 #, elixir-autogen, elixir-format
 msgid "Search engine verification"
 msgstr ""
@@ -12584,12 +12591,12 @@ msgstr "Pendiente"
 msgid "Sign in to request access."
 msgstr "Iniciar sesión como usuario"
 
-#: lib/phoenix_kit/integrations/providers.ex:760
+#: lib/phoenix_kit/integrations/providers.ex:761
 #, elixir-autogen, elixir-format
 msgid "The OpenAI-compatible endpoint (`…/openai/v1`) currently serves only the `openai.gpt-oss-*` models — Anthropic and the other Bedrock models answer on the native Converse API with the same key"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:742
+#: lib/phoenix_kit/integrations/providers.ex:743
 #, elixir-autogen, elixir-format
 msgid "The key's IAM identity must allow the `bedrock:CallWithBearerToken` action — without it every Bearer call answers 403 even when invoke permissions are in place."
 msgstr ""
@@ -12599,17 +12606,17 @@ msgstr ""
 msgid "The mailbox is off: outgoing mail is written to the server log instead."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:179
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:205
 #, elixir-autogen, elixir-format, fuzzy
 msgid "The noindex toggle and robots.txt are separate mechanisms: noindex is a per-page meta tag that tells crawlers not to index what they fetched, while robots.txt tells them what not to fetch at all. A staging site usually wants both."
 msgstr "La opción noindex de arriba y robots.txt son mecanismos distintos: noindex es una etiqueta meta por página que indica a los rastreadores que no indexen lo que han descargado, mientras que robots.txt les indica qué no deben descargar siquiera. Un sitio de preproducción suele necesitar ambos."
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:194
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:220
 #, elixir-autogen, elixir-format
 msgid "The other half of bot policy: a markdown summary telling AI assistants what this site is about, served at"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:892
+#: lib/phoenix_kit/integrations/providers.ex:893
 #, elixir-autogen, elixir-format
 msgid "This connection stores the credential. The full sending pipeline — configuration set, SNS topic, SQS event queue, delivery tracking — is configured in Admin → Settings → Emails, which can select this connection as its credential source."
 msgstr ""
@@ -12626,22 +12633,22 @@ msgstr ""
 msgid "Unread · %{day}"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:758
+#: lib/phoenix_kit/integrations/providers.ex:759
 #, elixir-autogen, elixir-format
 msgid "Use it from the AI module"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:231
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:257
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Verification"
 msgstr "Notificaciones"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.ex:133
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:145
 #, elixir-autogen, elixir-format
 msgid "Verification tags saved."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:882
+#: lib/phoenix_kit/integrations/providers.ex:883
 #, elixir-autogen, elixir-format
 msgid "Verify a sender in SES"
 msgstr ""
@@ -12656,7 +12663,7 @@ msgstr ""
 msgid "Where development mail goes while the resolved transport is the local adapter."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:79
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "Who may crawl this site"
 msgstr ""
@@ -12676,12 +12683,12 @@ msgstr ""
 msgid "You don't have access — click to request it"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:800
+#: lib/phoenix_kit/integrations/providers.ex:801
 #, elixir-autogen, elixir-format
 msgid "github.com/settings/personal-access-tokens — fine-grained, read-only"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.ex:146
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:158
 #, elixir-autogen, elixir-format
 msgid "llms.txt content saved."
 msgstr ""
@@ -12691,7 +12698,7 @@ msgstr ""
 msgid "management API: %{services}"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:169
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:195
 #, elixir-autogen, elixir-format, fuzzy
 msgid "priv/static/robots.txt exists but has no Sitemap: line. Paste the file above so crawlers are told where to look."
 msgstr "priv/static/robots.txt existe pero no tiene una línea Sitemap:. Añada la línea de arriba para indicar a los rastreadores dónde buscar."
@@ -12701,7 +12708,7 @@ msgstr "priv/static/robots.txt existe pero no tiene una línea Sitemap:. Añada 
 msgid "private item"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:200
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:226
 #, elixir-autogen, elixir-format
 msgid "while this module is enabled. The heading comes from your project title; everything below it is yours."
 msgstr ""
@@ -12755,7 +12762,7 @@ msgstr "Seleccionar audio"
 msgid "Select Avatar"
 msgstr "Seleccionar avatar"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:701
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:716
 #, elixir-autogen, elixir-format
 msgid "Select Background Image"
 msgstr "Seleccionar imagen de fondo"
@@ -12772,7 +12779,7 @@ msgstr "Seleccionar imágenes"
 
 #: lib/phoenix_kit_web/components/media_browser.html.heex:2469
 #: lib/phoenix_kit_web/live/settings.html.heex:636
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:702
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:717
 #, elixir-autogen, elixir-format
 msgid "Select Logo"
 msgstr "Seleccionar logo"
@@ -12871,3 +12878,422 @@ msgstr "El cifrado de credenciales de integración requiere atención"
 #, elixir-autogen, elixir-format
 msgid "The current encryption status could not be described by this admin page — it may be newer than what this page recognizes. Check PhoenixKit.Integrations.Encryption.status/0 directly."
 msgstr "El estado de cifrado actual no pudo describirse en esta página de administración — puede ser más reciente de lo que esta página reconoce. Compruebe PhoenixKit.Integrations.Encryption.status/0 directamente."
+
+#: lib/phoenix_kit_web/live/settings/authorization.ex:247
+#, elixir-autogen, elixir-format
+msgid "A secret is already configured — leave blank to keep the current value"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:365
+#: lib/phoenix_kit_web/users/session.ex:245
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Account added."
+msgstr "Cuenta"
+
+#: lib/phoenix_kit_web/users/session.ex:27
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Account created successfully!"
+msgstr "Bucket habilitado correctamente"
+
+#: lib/phoenix_kit_web/users/session.ex:356
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Account removed."
+msgstr "Cuenta"
+
+#: lib/phoenix_kit_web/users/oauth.ex:272
+#, elixir-autogen, elixir-format
+msgid "Account switching is currently disabled."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:316
+#, elixir-autogen, elixir-format
+msgid "An account already exists for that email address. Sign in with your password first, then connect this provider from your account settings."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:328
+#, elixir-autogen, elixir-format
+msgid "Authentication failed. Please try again or use a different sign-in method."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:355
+#: lib/phoenix_kit_web/users/oauth.ex:438
+#: lib/phoenix_kit_web/users/oauth.ex:444
+#, elixir-autogen, elixir-format
+msgid "Authentication failed. Please try again."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:299
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Authentication failed: %{errors}"
+msgstr "Autenticación"
+
+#: lib/phoenix_kit_web/users/oauth.ex:441
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Authentication failed: %{message}"
+msgstr "Autenticación"
+
+#: lib/phoenix_kit_web/users/session.ex:360
+#, elixir-autogen, elixir-format
+msgid "Cannot remove your primary account."
+msgstr ""
+
+#: lib/phoenix_kit_web/controllers/context_controller.ex:101
+#, elixir-autogen, elixir-format
+msgid "Context switching is not enabled"
+msgstr ""
+
+#: lib/phoenix_kit/integrations/validators.ex:627
+#: lib/phoenix_kit/integrations/validators.ex:634
+#: lib/phoenix_kit/integrations/validators.ex:732
+#: lib/phoenix_kit/integrations/validators.ex:740
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Could not reach the storage endpoint"
+msgstr "No se pudo contactar con el servicio"
+
+#: lib/phoenix_kit_web/users/session.ex:365
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Could not remove account."
+msgstr "No se pudo contactar con Brevo"
+
+#: lib/phoenix_kit_web/users/session.ex:274
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Could not switch account."
+msgstr "No se pudieron desvincular los chats"
+
+#: lib/phoenix_kit/integrations/validators.ex:721
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Credentials are valid, but not authorized to list buckets"
+msgstr "Las credenciales son válidas pero no están autorizadas para GetSendQuota: no se verificó el envío"
+
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:85
+#, elixir-autogen, elixir-format
+msgid "Exempt"
+msgstr ""
+
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:86
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Follows noindex"
+msgstr "Seguidos"
+
+#: lib/phoenix_kit_web/users/magic_link.ex:120
+#, elixir-autogen, elixir-format
+msgid "If that email address exists, a magic link has been sent."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/confirmation_instructions.ex:89
+#, elixir-autogen, elixir-format
+msgid "If your email is in our system and it has not been confirmed yet, you will receive an email with instructions shortly."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/forgot_password.ex:49
+#, elixir-autogen, elixir-format
+msgid "If your email is in our system, you will receive instructions to reset your password shortly."
+msgstr ""
+
+#: lib/phoenix_kit_web/controllers/context_controller.ex:82
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Invalid context"
+msgstr "Token del bot no válido"
+
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:110
+#, elixir-autogen, elixir-format
+msgid "Invalid email format"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/session.ex:92
+#, elixir-autogen, elixir-format
+msgid "Invalid email/username or password"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/session.ex:259
+#, elixir-autogen, elixir-format
+msgid "Invalid email/username or password."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_verify.ex:40
+#, elixir-autogen, elixir-format
+msgid "Invalid magic link. Please request a new one."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration_verify.ex:32
+#, elixir-autogen, elixir-format
+msgid "Invalid registration link. Please request a new one."
+msgstr ""
+
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:77
+#, elixir-autogen, elixir-format
+msgid "Keep publishing the sitemap's real URLs even while noindex is on, so the feed can be verified without exposing the site to indexing. The noindex meta tag above is unaffected either way."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/session.ex:104
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Logged out of all accounts."
+msgstr "Cerrar sesión en todas las cuentas"
+
+#: lib/phoenix_kit_web/users/session.ex:122
+#: lib/phoenix_kit_web/users/session.ex:235
+#, elixir-autogen, elixir-format
+msgid "Logged out successfully."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_verify.ex:63
+#, elixir-autogen, elixir-format
+msgid "Magic link is invalid or has expired. Please request a new one."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration.ex:41
+#, elixir-autogen, elixir-format
+msgid "Magic link registration is currently disabled."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link.ex:110
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Magic link sent! Check your email."
+msgstr "¡Enlace mágico enviado!"
+
+#: lib/phoenix_kit_web/users/magic_link.ex:39
+#: lib/phoenix_kit_web/users/magic_link_verify.ex:33
+#, elixir-autogen, elixir-format
+msgid "Magic link sign-in is currently disabled."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:370
+#: lib/phoenix_kit_web/users/session.ex:249
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Maximum number of accounts reached."
+msgstr "Se alcanzó el número máximo de cuentas: quite una primero."
+
+#: lib/phoenix_kit_web/users/session.ex:137
+#, elixir-autogen, elixir-format
+msgid "Multi-account switching is not available."
+msgstr ""
+
+#: lib/phoenix_kit/integrations/providers.ex:950
+#, elixir-autogen, elixir-format
+msgid "Not every S3-compatible provider needs one — leave blank if the endpoint doesn't require it."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:119
+#, elixir-autogen, elixir-format
+msgid "OAuth authentication is currently disabled. Please contact your administrator to enable it."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:94
+#, elixir-autogen, elixir-format
+msgid "OAuth provider '%{provider}' is currently disabled."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:106
+#, elixir-autogen, elixir-format
+msgid "OAuth provider '%{provider}' is not configured. Please contact your administrator."
+msgstr ""
+
+#: lib/phoenix_kit/integrations/providers.ex:913
+#, elixir-autogen, elixir-format
+msgid "Object Storage (S3-compatible)"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/reset_password.ex:41
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Password reset successfully."
+msgstr "Contraseña cambiada correctamente."
+
+#: lib/phoenix_kit_web/users/session.ex:34
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Password updated successfully!"
+msgstr "Contraseña cambiada correctamente."
+
+#: lib/phoenix_kit_web/users/magic_link_registration.ex:35
+#: lib/phoenix_kit_web/users/registration.ex:128
+#, elixir-autogen, elixir-format
+msgid "Registration is currently disabled."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration.ex:92
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Registration link is invalid or has expired."
+msgstr "El enlace de cambio de correo no es válido o ha caducado."
+
+#: lib/phoenix_kit_web/users/magic_link_registration.ex:188
+#: lib/phoenix_kit_web/users/magic_link_registration_verify.ex:24
+#, elixir-autogen, elixir-format
+msgid "Registration link is invalid or has expired. Please request a new one."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:92
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:103
+#, elixir-autogen, elixir-format
+msgid "Registration link sent! Check your email."
+msgstr ""
+
+#: lib/phoenix_kit/integrations/providers.ex:962
+#, elixir-autogen, elixir-format
+msgid "Required for Cloudflare R2, Backblaze B2, Tigris, and self-hosted S3-compatible storage. Leave blank for AWS S3."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/reset_password.ex:59
+#, elixir-autogen, elixir-format
+msgid "Reset password link is invalid or it has expired."
+msgstr ""
+
+#: lib/phoenix_kit/integrations/providers.ex:915
+#, elixir-autogen, elixir-format
+msgid "S3-compatible object storage — AWS S3, Cloudflare R2, Backblaze B2, Tigris, or a self-hosted endpoint"
+msgstr ""
+
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:75
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Sitemap Exemption"
+msgstr "Ajustes del sitemap"
+
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:144
+#, elixir-autogen, elixir-format
+msgid "Something went wrong"
+msgstr ""
+
+#: lib/phoenix_kit/integrations/validators.ex:735
+#, elixir-autogen, elixir-format
+msgid "Storage error: %{code}"
+msgstr ""
+
+#: lib/phoenix_kit/integrations/validators.ex:729
+#, elixir-autogen, elixir-format
+msgid "Storage service is busy — try again in a moment"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_verify.ex:56
+#, elixir-autogen, elixir-format
+msgid "Successfully logged in with magic link!"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:277
+#, elixir-autogen, elixir-format
+msgid "Successfully signed in with %{provider}!"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:375
+#: lib/phoenix_kit_web/users/session.ex:254
+#, elixir-autogen, elixir-format, fuzzy
+msgid "That account is already in your session."
+msgstr "Esa cuenta ya está en su sesión: cambie a ella en su lugar."
+
+#: lib/phoenix_kit_web/users/oauth.ex:380
+#, elixir-autogen, elixir-format, fuzzy
+msgid "That account is inactive."
+msgstr "Esa cuenta está desactivada."
+
+#: lib/phoenix_kit_web/users/magic_link_registration.ex:185
+#, elixir-autogen, elixir-format
+msgid "That email is already registered. Please log in instead."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:118
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Too many attempts"
+msgstr "Demasiados archivos"
+
+#: lib/phoenix_kit_web/users/session.ex:84
+#, elixir-autogen, elixir-format
+msgid "Too many login attempts. Please try again later."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:84
+#: lib/phoenix_kit_web/users/oauth.ex:210
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Unknown OAuth provider: %{provider}"
+msgstr "Proveedor desconocido"
+
+#: lib/phoenix_kit_web/users/confirmation.ex:68
+#, elixir-autogen, elixir-format
+msgid "User confirmation link is invalid or it has expired."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/confirmation.ex:50
+#, elixir-autogen, elixir-format, fuzzy
+msgid "User confirmed successfully."
+msgstr "Usuario activado correctamente"
+
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:77
+#, elixir-autogen, elixir-format
+msgid "User registration is currently disabled."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:51
+#: lib/phoenix_kit_web/users/registration.ex:110
+#, elixir-autogen, elixir-format
+msgid "User registration is currently disabled. Please contact an administrator."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/session.ex:40
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Welcome back!"
+msgstr "Bienvenido de nuevo"
+
+#: lib/phoenix_kit_web/users/session.ex:66
+#, elixir-autogen, elixir-format
+msgid "Your account is currently inactive. Please contact the team if you believe this is an error."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:1873
+#, elixir-autogen, elixir-format
+msgid "%{label} module is not enabled"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:2366
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Enter your referral code to continue."
+msgstr "Introduzca su código de referencia"
+
+#: lib/phoenix_kit_web/users/auth.ex:2362
+#, elixir-autogen, elixir-format
+msgid "Please confirm your email before accessing the application."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:111
+#, elixir-autogen, elixir-format
+msgid "This account is not active. Contact an administrator."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:749
+#: lib/phoenix_kit_web/users/auth.ex:1892
+#: lib/phoenix_kit_web/users/auth.ex:2511
+#, elixir-autogen, elixir-format, fuzzy
+msgid "You do not have permission to access this section."
+msgstr "No tiene permiso para iniciar sesión como otro usuario."
+
+#: lib/phoenix_kit_web/users/auth.ex:724
+#: lib/phoenix_kit_web/users/auth.ex:878
+#: lib/phoenix_kit_web/users/auth.ex:2460
+#: lib/phoenix_kit_web/users/auth.ex:2496
+#, elixir-autogen, elixir-format, fuzzy
+msgid "You do not have the required permission to access this page."
+msgstr "No tiene permiso para iniciar sesión como otro usuario."
+
+#: lib/phoenix_kit_web/users/auth.ex:1417
+#, elixir-autogen, elixir-format
+msgid "You must be an admin to access this page."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:679
+#: lib/phoenix_kit_web/users/auth.ex:2423
+#, elixir-autogen, elixir-format
+msgid "You must be an owner to access this page."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:2539
+#, elixir-autogen, elixir-format
+msgid "You must have the %{role_name} role to access this page."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:903
+#: lib/phoenix_kit_web/users/auth.ex:2292
+#: lib/phoenix_kit_web/users/auth.ex:2329
+#: lib/phoenix_kit_web/users/auth.ex:2467
+#, elixir-autogen, elixir-format
+msgid "You must log in to access this page."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:1428
+#, elixir-autogen, elixir-format
+msgid "You no longer have permission to access this section."
+msgstr ""

--- a/priv/gettext/es/LC_MESSAGES/phoenix_kit.po
+++ b/priv/gettext/es/LC_MESSAGES/phoenix_kit.po
@@ -21,27 +21,27 @@ msgstr "Ya existe una invitación pendiente para este correo"
 msgid "This user already belongs to an organization"
 msgstr "Este usuario ya pertenece a una organización"
 
-#: lib/phoenix_kit/users/auth.ex:1064
+#: lib/phoenix_kit/users/auth.ex:1074
 #, elixir-autogen, elixir-format
 msgid "cannot change to person while organization has members"
 msgstr "no se puede cambiar a persona mientras la organización tenga miembros"
 
-#: lib/phoenix_kit/users/auth.ex:1044
+#: lib/phoenix_kit/users/auth.ex:1054
 #, elixir-autogen, elixir-format
 msgid "cannot reference self"
 msgstr "no puede referenciarse a sí mismo"
 
-#: lib/phoenix_kit/users/auth.ex:1052
+#: lib/phoenix_kit/users/auth.ex:1062
 #, elixir-autogen, elixir-format
 msgid "only person accounts can join an organization"
 msgstr "solo las cuentas de persona pueden unirse a una organización"
 
-#: lib/phoenix_kit/users/auth.ex:1039
+#: lib/phoenix_kit/users/auth.ex:1049
 #, elixir-autogen, elixir-format
 msgid "organization not found"
 msgstr "organización no encontrada"
 
-#: lib/phoenix_kit/users/auth.ex:1038
+#: lib/phoenix_kit/users/auth.ex:1048
 #, elixir-autogen, elixir-format
 msgid "target user is not an organization"
 msgstr "el usuario de destino no es una organización"

--- a/priv/gettext/et/LC_MESSAGES/default.po
+++ b/priv/gettext/et/LC_MESSAGES/default.po
@@ -10,14 +10,22 @@ msgid ""
 msgstr ""
 "Language: et\n"
 
-## This is a PO Template file.
-##
-## `msgid`s here are often extracted from source code.
-## Add new translations manually only if they're dynamic
-## translations that can't be statically extracted.
-## Run `mix gettext.extract` to bring this file up to
-## date. Leave `msgstr`s empty as changing them here has no
-## effect: edit them in PO (`.po`) files instead.
+## Manually added (A030): the fallback OAuth controller only compiles when
+## `Code.ensure_loaded?(Ueberauth)` is false, so `mix gettext.extract` can
+## never see these two calls in an environment where ueberauth is an
+## installed dependency (it always is here). Per the top-of-file note in
+## this domain's .pot, this is the sanctioned case for adding entries by
+## hand — a translation that can't be statically extracted.
+#: lib/phoenix_kit_web/users/oauth.ex:483
+#, elixir-format
+msgid "OAuth authentication is not available. Please install the required dependencies (ueberauth, ueberauth_%{provider}) and configure your application. See PhoenixKit documentation for details."
+msgstr "OAuth autentimine ei ole saadaval. Palun paigaldage vajalikud sõltuvused (ueberauth, ueberauth_%{provider}) ja seadistage oma rakendus. Täpsema info leiate PhoenixKiti dokumentatsioonist."
+
+#: lib/phoenix_kit_web/users/oauth.ex:501
+#, elixir-format
+msgid "OAuth authentication is not configured. Please contact your administrator."
+msgstr "OAuth autentimine ei ole seadistatud. Palun võtke ühendust administraatoriga."
+
 ## Dashboard page translations
 #: lib/phoenix_kit/dashboard/admin_tabs.ex:64
 #: lib/phoenix_kit_web/components/user_dashboard_nav.ex:135
@@ -78,7 +86,7 @@ msgstr "Rollide haldamine"
 
 #: lib/phoenix_kit/dashboard/admin_tabs.ex:119
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:138
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:647
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:662
 #: lib/phoenix_kit_web/live/settings/users.html.heex:130
 #, elixir-autogen
 msgid "Sessions"
@@ -245,7 +253,7 @@ msgstr "Reaalajas ühendused"
 
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:320
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:64
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:144
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:140
 #, elixir-autogen
 msgid "Anonymous"
 msgstr "Anonüümne"
@@ -258,7 +266,7 @@ msgstr "Registreerimata külastajad"
 
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:331
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:77
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:151
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:144
 #, elixir-autogen
 msgid "Authenticated"
 msgstr "Autentitud"
@@ -355,7 +363,7 @@ msgstr "Standardne juurdepääsutase"
 msgid "Role System"
 msgstr "Rollisüsteem"
 
-#: lib/phoenix_kit/integrations/providers.ex:991
+#: lib/phoenix_kit/integrations/providers.ex:1063
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:450
 #, elixir-autogen
 msgid "Authentication"
@@ -367,7 +375,7 @@ msgstr "Autentimine"
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:445
 #: lib/phoenix_kit_web/live/modules.html.heex:65
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:114
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:273
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:267
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:145
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:297
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:682
@@ -474,8 +482,8 @@ msgstr "Õiguste kohta"
 msgid "Accept All"
 msgstr "Nõustu kõigega"
 
-#: lib/phoenix_kit/integrations/integrations.ex:1133
-#: lib/phoenix_kit/integrations/validators.ex:598
+#: lib/phoenix_kit/integrations/integrations.ex:1136
+#: lib/phoenix_kit/integrations/validators.ex:779
 #: lib/phoenix_kit_web/live/activity/index.ex:66
 #: lib/phoenix_kit_web/live/activity/show.ex:56
 #, elixir-autogen, elixir-format
@@ -513,7 +521,7 @@ msgid "Actions"
 msgstr "Tegevused"
 
 #: lib/phoenix_kit_web/components/media_gallery.html.heex:86
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:585
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:600
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:266
 #: lib/phoenix_kit_web/live/settings/users.html.heex:693
 #: lib/phoenix_kit_web/users/user_form.html.heex:719
@@ -621,7 +629,7 @@ msgstr "Põhiandmed"
 msgid "Billing profiles and payment methods"
 msgstr "Arveldusprofiilid ja maksemeetodid"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:98
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:124
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:501
 #, elixir-autogen, elixir-format
 msgid "Blocked"
@@ -1561,7 +1569,7 @@ msgstr "Leht genereeritud edukalt"
 msgid "Page published successfully"
 msgstr "Leht avaldatud edukalt"
 
-#: lib/phoenix_kit/integrations/providers.ex:956
+#: lib/phoenix_kit/integrations/providers.ex:1028
 #: lib/phoenix_kit_web/components/user_dashboard_nav.ex:277
 #: lib/phoenix_kit_web/users/login.html.heex:39
 #: lib/phoenix_kit_web/users/magic_link_registration.html.heex:42
@@ -1822,8 +1830,8 @@ msgstr "SWIFT/BIC"
 #: lib/phoenix_kit_web/components/core/markdown_editor.ex:440
 #: lib/phoenix_kit_web/components/media_browser.html.heex:1349
 #: lib/phoenix_kit_web/live/notifications/settings.ex:436
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:219
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:267
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:245
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:293
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr "Salvesta"
@@ -1866,7 +1874,7 @@ msgstr "Salvestatud"
 #: lib/phoenix_kit_web/components/core/markdown_editor.ex:333
 #: lib/phoenix_kit_web/components/core/markdown_editor.ex:417
 #: lib/phoenix_kit_web/live/settings.html.heex:592
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:683
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:698
 #: lib/phoenix_kit_web/live/settings/users.html.heex:546
 #, elixir-autogen, elixir-format
 msgid "Saving..."
@@ -1954,7 +1962,7 @@ msgstr "Maakond/provints"
 #: lib/phoenix_kit_web/live/settings/users.html.heex:367
 #: lib/phoenix_kit_web/live/settings/users.html.heex:408
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:114
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:199
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:193
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:247
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:294
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:650
@@ -2060,7 +2068,7 @@ msgstr "Rolle kokku"
 #: lib/phoenix_kit_web/live/settings/users.html.heex:361
 #: lib/phoenix_kit_web/live/settings/users.html.heex:404
 #: lib/phoenix_kit_web/live/settings/users.html.heex:602
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:192
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:186
 #: lib/phoenix_kit_web/live/users/roles.html.heex:92
 #: lib/phoenix_kit_web/live/users/roles.html.heex:160
 #, elixir-autogen, elixir-format
@@ -2076,7 +2084,7 @@ msgstr "Kinnitamata"
 #: lib/phoenix_kit_web/components/core/time_display.ex:183
 #: lib/phoenix_kit_web/components/language_switcher.ex:832
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:108
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:255
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:249
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr "Tundmatu"
@@ -2134,7 +2142,7 @@ msgstr "Kasutajat ei leitud"
 msgid "User-defined roles"
 msgstr "Kasutaja määratud rollid"
 
-#: lib/phoenix_kit/integrations/providers.ex:944
+#: lib/phoenix_kit/integrations/providers.ex:1016
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:255
 #: lib/phoenix_kit_web/users/magic_link_registration.html.heex:30
 #: lib/phoenix_kit_web/users/registration.html.heex:69
@@ -2452,22 +2460,22 @@ msgstr "(tühi)"
 msgid "(registration disabled)"
 msgstr "(registreerimine keelatud)"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:622
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:637
 #, elixir-autogen, elixir-format
 msgid "1. Enable the provider above and save settings"
 msgstr "1. Luba ülalolev teenusepakkuja ja salvesta seaded"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:623
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:638
 #, elixir-autogen, elixir-format
 msgid "2. Enter your OAuth credentials in the form that appears"
 msgstr "2. Sisesta oma OAuth mandaadid ilmuvas vormis"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:624
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:639
 #, elixir-autogen, elixir-format
 msgid "3. Save settings again to store credentials"
 msgstr "3. Salvesta seaded uuesti mandaatide salvestamiseks"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:625
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:640
 #, elixir-autogen, elixir-format
 msgid "4. Click \"Test Credentials\" to verify configuration"
 msgstr "4. Klõpsake \"Test Credentials\", et kontrollida seadistust"
@@ -2478,7 +2486,8 @@ msgid "Access Credentials"
 msgstr "Juurdepääsumandaadid"
 
 #: lib/modules/storage/web/bucket_form.html.heex:227
-#: lib/phoenix_kit/integrations/providers.ex:842
+#: lib/phoenix_kit/integrations/providers.ex:843
+#: lib/phoenix_kit/integrations/providers.ex:927
 #, elixir-autogen, elixir-format
 msgid "Access Key ID"
 msgstr "Juurdepääsuvõtme ID"
@@ -2528,9 +2537,9 @@ msgstr "Lisa pildi dimensioon"
 msgid "Add Video Dimension"
 msgstr "Lisa video dimensioon"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:429
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:507
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:592
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:434
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:517
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:607
 #, elixir-autogen, elixir-format
 msgid "Add callback URL above to"
 msgstr "Lisa tagasihelistamise URL ülal"
@@ -2562,12 +2571,12 @@ msgstr "Kõik uued kasutajad saavad administraatori õigused ja juurdepääsu ad
 msgid "Anyone can register"
 msgstr "Kõik saavad registreeruda"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:541
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:551
 #, elixir-autogen, elixir-format
 msgid "App ID"
 msgstr "Rakenduse ID"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:551
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:561
 #, elixir-autogen, elixir-format
 msgid "App Secret"
 msgstr "Rakenduse saladus"
@@ -2686,7 +2695,7 @@ msgstr "Bucketid võivad olla kohalikud kataloogid või pilvemälupakkujad (AWS 
 msgid "CSS color or gradient for auth page background. Ignored if a background image is set."
 msgstr "CSS värv või gradient autentimislehe taustaks. Ignoreeritakse, kui taustapilt on määratud."
 
-#: lib/phoenix_kit_web/live/settings/authorization.ex:261
+#: lib/phoenix_kit_web/live/settings/authorization.ex:302
 #, elixir-autogen, elixir-format
 msgid "Callback URL"
 msgstr "Tagasihelistamise URL"
@@ -2696,25 +2705,25 @@ msgstr "Tagasihelistamise URL"
 msgid "Changes will be saved immediately"
 msgstr "Muudatused salvestatakse kohe"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:434
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:511
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:518
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:609
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:439
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:521
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:528
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:624
 #, elixir-autogen, elixir-format
 msgid "Click"
 msgstr "Klõpsa"
 
-#: lib/phoenix_kit/integrations/providers.ex:215
+#: lib/phoenix_kit/integrations/providers.ex:216
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:378
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:458
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:463
 #, elixir-autogen, elixir-format
 msgid "Client ID"
 msgstr "Kliendi ID"
 
-#: lib/phoenix_kit/integrations/providers.ex:224
-#: lib/phoenix_kit/integrations/providers.ex:1169
+#: lib/phoenix_kit/integrations/providers.ex:225
+#: lib/phoenix_kit/integrations/providers.ex:1241
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:388
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:468
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:473
 #, elixir-autogen, elixir-format
 msgid "Client Secret"
 msgstr "Kliendi saladus"
@@ -2745,34 +2754,34 @@ msgstr "Seadista süsteemi eelistused ja valikud"
 msgid "Consider \"User\" for most installations to maintain security."
 msgstr "Enamiku paigalduste puhul kasutage turbe tagamiseks \"Kasutaja\"."
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:514
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:599
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:142
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:524
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:614
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:168
 #, elixir-autogen, elixir-format
 msgid "Copy"
 msgstr "Kopeeri"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:432
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:437
 #, elixir-autogen, elixir-format
 msgid "Copy Client ID and Secret to fields above"
 msgstr "Kopeeri Kliendi ID ja Saladus ülal olevatesse väljadesse"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:568
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:583
 #, elixir-autogen, elixir-format
 msgid "Copy this URL to Facebook App Settings"
 msgstr "Kopeeri see URL Facebook App Settings'isse"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:485
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:495
 #, elixir-autogen, elixir-format
 msgid "Copy this URL to GitHub OAuth Apps"
 msgstr "Kopeeri see URL GitHub OAuth Apps'i"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:405
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:410
 #, elixir-autogen, elixir-format
 msgid "Copy this URL to Google Cloud Console"
 msgstr "Kopeeri see URL Google Cloud Console'i"
 
-#: lib/phoenix_kit_web/live/settings/authorization.ex:271
+#: lib/phoenix_kit_web/live/settings/authorization.ex:312
 #, elixir-autogen, elixir-format
 msgid "Copy to clipboard"
 msgstr "Kopeeri lõikelauale"
@@ -2797,12 +2806,12 @@ msgstr "Loo salvestustee"
 msgid "Create Your First Bucket"
 msgstr "Loo oma esimene bucket"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:582
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:597
 #, elixir-autogen, elixir-format
 msgid "Create a new app or select existing one"
 msgstr "Loo uus rakendus või vali olemasolev"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:418
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:423
 #, elixir-autogen, elixir-format
 msgid "Create project or select existing one"
 msgstr "Loo projekt või vali olemasolev"
@@ -2873,11 +2882,12 @@ msgid "Enable OAuth (Master Switch)"
 msgstr "Luba OAuth (peamine lüliti)"
 
 #: lib/modules/storage/web/bucket_form.html.heex:194
+#: lib/phoenix_kit/integrations/providers.ex:957
 #, elixir-autogen, elixir-format
 msgid "Endpoint"
 msgstr "Lõpp-punkt"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:503
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:513
 #, elixir-autogen, elixir-format
 msgid "Enter"
 msgstr "Sisesta"
@@ -2912,7 +2922,7 @@ msgstr "FFmpeg ei ole paigaldatud"
 msgid "FFmpeg is required for video processing, transcoding, and thumbnail generation."
 msgstr "FFmpeg on vajalik video töötlemiseks, transkodeerimiseks ja pisipiltide genereerimiseks."
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:532
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:542
 #, elixir-autogen, elixir-format
 msgid "Facebook OAuth Credentials"
 msgstr "Facebook OAuth mandaadid"
@@ -2955,7 +2965,7 @@ msgstr "Vormingu alistamine"
 msgid "Format Override:"
 msgstr "Vormingu alistamine:"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:449
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:454
 #, elixir-autogen, elixir-format
 msgid "GitHub OAuth Credentials"
 msgstr "GitHub OAuth mandaadid"
@@ -2965,10 +2975,10 @@ msgstr "GitHub OAuth mandaadid"
 msgid "GitHub Sign-In"
 msgstr "GitHub sisselogimine"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:420
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:499
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:588
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:596
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:425
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:509
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:603
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:611
 #, elixir-autogen, elixir-format
 msgid "Go to"
 msgstr "Mine"
@@ -2998,7 +3008,7 @@ msgstr "Kuidas kuupäevi kuvatakse"
 msgid "How times are displayed"
 msgstr "Kuidas kellaaegu kuvatakse"
 
-#: lib/phoenix_kit_web/live/settings/authorization.ex:296
+#: lib/phoenix_kit_web/live/settings/authorization.ex:337
 #, elixir-autogen, elixir-format
 msgid "If behind nginx/apache, ensure"
 msgstr "Kui kasutate nginx/apache'i, veenduge"
@@ -3185,7 +3195,7 @@ msgstr "Puudub"
 msgid "Note"
 msgstr "Märkus"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:627
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:642
 #, elixir-autogen, elixir-format
 msgid "Note: OAuth providers require ueberauth dependencies to be installed."
 msgstr "Märkus: OAuth teenusepakkujad vajavad ueberauth sõltuvuste paigaldamist."
@@ -3200,7 +3210,7 @@ msgstr "Salvestatavate koopiate arv"
 msgid "OAuth Providers"
 msgstr "OAuth teenusepakkujad"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:620
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:635
 #, elixir-autogen, elixir-format
 msgid "OAuth Setup Instructions"
 msgstr "OAuth seadistamisjuhised"
@@ -3273,7 +3283,7 @@ msgstr "Vähenda redundantsust või luba rohkem buckete."
 msgid "Redundancy Copies"
 msgstr "Redundantsuse koopiad"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:642
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:657
 #, elixir-autogen, elixir-format
 msgid "Reload OAuth Configuration"
 msgstr "Laadi OAuth konfiguratsioon uuesti"
@@ -3300,7 +3310,7 @@ msgstr "Lähtesta vaikimisi seadetele"
 msgid "Resolution"
 msgstr "Resolutsioon"
 
-#: lib/phoenix_kit_web/live/settings/authorization.ex:294
+#: lib/phoenix_kit_web/live/settings/authorization.ex:335
 #, elixir-autogen, elixir-format
 msgid "Reverse Proxy Users:"
 msgstr "Pöördproxy kasutajad:"
@@ -3326,7 +3336,7 @@ msgstr "Roll määratud uutele kasutajate registreerimistele"
 msgid "Save All Settings"
 msgstr "Salvesta kõik seaded"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:685
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:700
 #, elixir-autogen, elixir-format
 msgid "Save Authorization Settings"
 msgstr "Salvesta volitamise seaded"
@@ -3342,7 +3352,8 @@ msgid "Search engines are instructed to skip this environment. Remove this befor
 msgstr "Otsingumootorid on juhendatud seda keskkonda vahele jätma. Eemalda see enne käivitamist."
 
 #: lib/modules/storage/web/bucket_form.html.heex:241
-#: lib/phoenix_kit/integrations/providers.ex:851
+#: lib/phoenix_kit/integrations/providers.ex:852
+#: lib/phoenix_kit/integrations/providers.ex:936
 #, elixir-autogen, elixir-format
 msgid "Secret Access Key"
 msgstr "Salajane juurdepääsuvõti"
@@ -3359,7 +3370,7 @@ msgstr "Turvahoiatus: keskmine risk"
 
 #: lib/phoenix_kit_web/components/media_browser.html.heex:1180
 #: lib/phoenix_kit_web/components/media_browser.html.heex:1182
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:425
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:430
 #, elixir-autogen, elixir-format
 msgid "Select"
 msgstr "Vali"
@@ -3389,7 +3400,7 @@ msgid "Set"
 msgstr "Määra"
 
 #: lib/phoenix_kit_web/components/core/integrations_ui.ex:311
-#: lib/phoenix_kit_web/live/settings/authorization.ex:249
+#: lib/phoenix_kit_web/live/settings/authorization.ex:290
 #: lib/phoenix_kit_web/live/settings/integration_form.html.heex:378
 #, elixir-autogen, elixir-format
 msgid "Setup Instructions"
@@ -3426,7 +3437,7 @@ msgstr "Salvestuspakkuja"
 msgid "Success!"
 msgstr "Õnnestus!"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:604
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:619
 #, elixir-autogen, elixir-format
 msgid "Switch app from"
 msgstr "Vaheta rakendus"
@@ -3451,9 +3462,9 @@ msgstr "Süsteemi vaikimisi ajavöönd"
 msgid "Target Width (px)"
 msgstr "Sihilaius (px)"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:400
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:480
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:563
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:405
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:490
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:578
 #, elixir-autogen, elixir-format
 msgid "Test Credentials"
 msgstr "Testi mandaate"
@@ -3534,7 +3545,7 @@ msgstr "Kasutaja konfiguratsioon"
 msgid "User Editable"
 msgstr "Kasutaja muudetav"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:35
+#: lib/phoenix_kit_web/live/settings/users.ex:42
 #: lib/phoenix_kit_web/live/settings/users.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "User Settings"
@@ -3576,9 +3587,9 @@ msgstr "Video seaded:"
 msgid "Videos use CRF 0-51 scale (lower = higher quality)"
 msgstr "Videod kasutavad CRF 0-51 skaalat (madalam = parem kvaliteet)"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:409
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:489
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:572
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:414
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:499
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:587
 #, elixir-autogen, elixir-format
 msgid "Visit"
 msgstr "Külasta"
@@ -3623,22 +3634,22 @@ msgstr "Ilma selleta ei tööta videofailide töötlemine."
 msgid "Would you like to create it now?"
 msgstr "Kas soovid selle nüüd luua?"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:542
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:552
 #, elixir-autogen, elixir-format
 msgid "Your Facebook App ID"
 msgstr "Teie Facebook rakenduse ID"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:552
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:565
 #, elixir-autogen, elixir-format
 msgid "Your Facebook App Secret"
 msgstr "Teie Facebook rakenduse saladus"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:459
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:464
 #, elixir-autogen, elixir-format
 msgid "Your GitHub OAuth Client ID"
 msgstr "Teie GitHub OAuth kliendi ID"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:469
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:477
 #, elixir-autogen, elixir-format
 msgid "Your GitHub OAuth Client Secret"
 msgstr "Teie GitHub OAuth kliendi saladus"
@@ -3648,19 +3659,19 @@ msgstr "Teie GitHub OAuth kliendi saladus"
 msgid "Your Google OAuth Client ID"
 msgstr "Teie Google OAuth kliendi ID"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:389
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:392
 #, elixir-autogen, elixir-format
 msgid "Your Google OAuth Client Secret"
 msgstr "Teie Google OAuth kliendi saladus"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:504
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:600
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:514
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:615
 #: lib/phoenix_kit_web/live/settings/integrations.ex:167
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr "ja"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:515
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:525
 #, elixir-autogen, elixir-format
 msgid "and generate/copy"
 msgstr "ja genereeri/kopeeri"
@@ -3681,12 +3692,12 @@ msgstr "nt pisipilt, keskmine, 720p"
 msgid "files"
 msgstr "faili"
 
-#: lib/phoenix_kit_web/live/settings/authorization.ex:300
+#: lib/phoenix_kit_web/live/settings/authorization.ex:341
 #, elixir-autogen, elixir-format
 msgid "header is set to"
 msgstr "päis on seatud"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:606
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:621
 #, elixir-autogen, elixir-format
 msgid "mode"
 msgstr "režiim"
@@ -3696,12 +3707,12 @@ msgstr "režiim"
 msgid "option(s)"
 msgstr "valik(ud)"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:585
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:600
 #, elixir-autogen, elixir-format
 msgid "product"
 msgstr "toode"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:605
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:620
 #, elixir-autogen, elixir-format
 msgid "to"
 msgstr "aadressile"
@@ -3711,19 +3722,19 @@ msgstr "aadressile"
 msgid "to every PhoenixKit layout, blocking crawlers from indexing or following links."
 msgstr "igale PhoenixKiti paigutusele, blokeerides roomajad indekseerimisest ja linkide jälgimisest."
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:601
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:616
 #, elixir-autogen, elixir-format
 msgid "to fields above"
 msgstr "ülal olevatesse väljadesse"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:435
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:519
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:610
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:440
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:529
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:625
 #, elixir-autogen, elixir-format
 msgid "to verify setup"
 msgstr "konfiguratsiooni kontrollimiseks"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:426
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:431
 #, elixir-autogen, elixir-format
 msgid "type"
 msgstr "tüüp"
@@ -3858,7 +3869,7 @@ msgstr "Sõbralik nimi selle salvestuskoha tuvastamiseks"
 msgid "A unique name to identify this dimension preset"
 msgstr "Unikaalne nimi selle dimensioonipreset'i tuvastamiseks"
 
-#: lib/phoenix_kit/integrations/providers.ex:388
+#: lib/phoenix_kit/integrations/providers.ex:389
 #, elixir-autogen, elixir-format
 msgid "AI model access via OpenRouter (100+ models)"
 msgstr "Juurdepääs AI mudelitele OpenRouteri kaudu (100+ mudelit)"
@@ -3868,13 +3879,13 @@ msgstr "Juurdepääs AI mudelitele OpenRouteri kaudu (100+ mudelit)"
 msgid "API Credentials"
 msgstr "API mandaadid"
 
-#: lib/phoenix_kit/integrations/providers.ex:332
-#: lib/phoenix_kit/integrations/providers.ex:402
-#: lib/phoenix_kit/integrations/providers.ex:460
-#: lib/phoenix_kit/integrations/providers.ex:523
-#: lib/phoenix_kit/integrations/providers.ex:586
-#: lib/phoenix_kit/integrations/providers.ex:653
-#: lib/phoenix_kit/integrations/providers.ex:1065
+#: lib/phoenix_kit/integrations/providers.ex:333
+#: lib/phoenix_kit/integrations/providers.ex:403
+#: lib/phoenix_kit/integrations/providers.ex:461
+#: lib/phoenix_kit/integrations/providers.ex:524
+#: lib/phoenix_kit/integrations/providers.ex:587
+#: lib/phoenix_kit/integrations/providers.ex:654
+#: lib/phoenix_kit/integrations/providers.ex:1137
 #, elixir-autogen, elixir-format
 msgid "API Key"
 msgstr "API võti"
@@ -3935,7 +3946,7 @@ msgstr "Aktiivne planeeritud akna tõttu."
 msgid "Add Integration"
 msgstr "Lisa integratsioon"
 
-#: lib/phoenix_kit/integrations/providers.ex:431
+#: lib/phoenix_kit/integrations/providers.ex:432
 #, elixir-autogen, elixir-format
 msgid "Add credits (optional)"
 msgstr "Lisa krediite (valikuline)"
@@ -3970,7 +3981,7 @@ msgstr "Kõik failid vastavad redundantsuse eesmärgile %{n} koopiat."
 msgid "Alternative Formats"
 msgstr "Alternatiivsed vormingud"
 
-#: lib/phoenix_kit/integrations/providers.ex:285
+#: lib/phoenix_kit/integrations/providers.ex:286
 #, elixir-autogen, elixir-format
 msgid "Application type: **Web application** (do not select \"Desktop app\" — it won't support redirect URIs)"
 msgstr "Rakenduse tüüp: **Veebirakendus** (ärge valige \"Töölauarakendus\" — see ei toeta suunamisteede URI-sid)"
@@ -4092,18 +4103,18 @@ msgstr "Vali ühendatav teenus"
 msgid "Clear Schedule"
 msgstr "Tühista ajakava"
 
-#: lib/phoenix_kit/integrations/providers.ex:284
+#: lib/phoenix_kit/integrations/providers.ex:285
 #, elixir-autogen, elixir-format
 msgid "Click **Create Credentials → OAuth client ID**"
 msgstr "Klõpsa **Loo mandaadid → OAuth kliendi ID**"
 
-#: lib/phoenix_kit/integrations/providers.ex:425
+#: lib/phoenix_kit/integrations/providers.ex:426
 #, elixir-autogen, elixir-format
 msgid "Click **Create Key**"
 msgstr "Klõpsa **Loo võti**"
 
-#: lib/phoenix_kit/integrations/providers.ex:295
-#: lib/phoenix_kit/integrations/providers.ex:1248
+#: lib/phoenix_kit/integrations/providers.ex:296
+#: lib/phoenix_kit/integrations/providers.ex:1320
 #, elixir-autogen, elixir-format
 msgid "Click **Save**, then **Connect Account**"
 msgstr "Klõpsa **Salvesta**, seejärel **Ühenda konto**"
@@ -4153,8 +4164,8 @@ msgstr "Ühenda %{provider} konto"
 msgid "Connect Account"
 msgstr "Ühenda konto"
 
-#: lib/phoenix_kit/integrations/providers.ex:293
-#: lib/phoenix_kit/integrations/providers.ex:1246
+#: lib/phoenix_kit/integrations/providers.ex:294
+#: lib/phoenix_kit/integrations/providers.ex:1318
 #, elixir-autogen, elixir-format
 msgid "Connect and authorize"
 msgstr "Ühenda ja volita"
@@ -4174,7 +4185,7 @@ msgstr "Ühenda välised teenused kasutamiseks kõigis moodulites"
 #: lib/phoenix_kit_web/live/settings/integration_form.html.heex:327
 #: lib/phoenix_kit_web/live/settings/integrations.ex:181
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:111
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:197
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:191
 #, elixir-autogen, elixir-format
 msgid "Connected"
 msgstr "Ühendatud"
@@ -4215,48 +4226,48 @@ msgstr "Ühendus õnnestus"
 msgid "Connection verified"
 msgstr "Ühendus kontrollitud"
 
-#: lib/phoenix_kit/integrations/providers.ex:289
+#: lib/phoenix_kit/integrations/providers.ex:290
 #, elixir-autogen, elixir-format
 msgid "Copy the **Client ID** and **Client Secret** into the form above"
 msgstr "Kopeeri **Kliendi ID** ja **Kliendi saladus** ülalolevasse vormi"
 
-#: lib/phoenix_kit/integrations/providers.ex:427
+#: lib/phoenix_kit/integrations/providers.ex:428
 #, elixir-autogen, elixir-format
 msgid "Copy the key and paste it into the form above"
 msgstr "Kopeeri võti ja kleebi see ülalolevasse vormi"
 
-#: lib/phoenix_kit/integrations/integrations.ex:1135
+#: lib/phoenix_kit/integrations/integrations.ex:1138
 #: lib/phoenix_kit/integrations/probe.ex:102
 #, elixir-autogen, elixir-format
 msgid "Could not reach the service"
 msgstr "Teenusele ei saanud juurde pääseda"
 
-#: lib/phoenix_kit/integrations/providers.ex:235
+#: lib/phoenix_kit/integrations/providers.ex:236
 #, elixir-autogen, elixir-format
 msgid "Create a Google Cloud project"
 msgstr "Loo Google Cloud projekt"
 
-#: lib/phoenix_kit/integrations/providers.ex:238
+#: lib/phoenix_kit/integrations/providers.ex:239
 #, elixir-autogen, elixir-format
 msgid "Create a new project or select an existing one"
 msgstr "Loo uus projekt või vali olemasolev"
 
-#: lib/phoenix_kit/integrations/providers.ex:368
-#: lib/phoenix_kit/integrations/providers.ex:423
-#: lib/phoenix_kit/integrations/providers.ex:493
-#: lib/phoenix_kit/integrations/providers.ex:553
-#: lib/phoenix_kit/integrations/providers.ex:619
-#: lib/phoenix_kit/integrations/providers.ex:670
+#: lib/phoenix_kit/integrations/providers.ex:369
+#: lib/phoenix_kit/integrations/providers.ex:424
+#: lib/phoenix_kit/integrations/providers.ex:494
+#: lib/phoenix_kit/integrations/providers.ex:554
+#: lib/phoenix_kit/integrations/providers.ex:620
+#: lib/phoenix_kit/integrations/providers.ex:671
 #, elixir-autogen, elixir-format
 msgid "Create an API key"
 msgstr "Loo API võti"
 
-#: lib/phoenix_kit/integrations/providers.ex:279
+#: lib/phoenix_kit/integrations/providers.ex:280
 #, elixir-autogen, elixir-format
 msgid "Create an OAuth Client"
 msgstr "Loo OAuth klient"
 
-#: lib/phoenix_kit/integrations/providers.ex:416
+#: lib/phoenix_kit/integrations/providers.ex:417
 #, elixir-autogen, elixir-format
 msgid "Create an OpenRouter account"
 msgstr "Loo OpenRouteri konto"
@@ -4325,7 +4336,7 @@ msgstr "Ühenda lahti?"
 msgid "Disconnected"
 msgstr "Ühendus katkestatud"
 
-#: lib/phoenix_kit/integrations/providers.ex:253
+#: lib/phoenix_kit/integrations/providers.ex:254
 #, elixir-autogen, elixir-format
 msgid "Drive API handles file listing, creation, copying, and PDF export. Docs API is used for reading document content and substituting template variables."
 msgstr "Drive API haldab failide loetlemist, loomist, kopeerimist ja PDF-eksporti. Docs API-d kasutatakse dokumendi sisu lugemiseks ja mallmuutujate asendamiseks."
@@ -4355,7 +4366,7 @@ msgstr "Luba bucket"
 msgid "Enable organization accounts"
 msgstr "Luba organisatsioonikontod"
 
-#: lib/phoenix_kit/integrations/providers.ex:242
+#: lib/phoenix_kit/integrations/providers.ex:243
 #, elixir-autogen, elixir-format
 msgid "Enable required APIs"
 msgstr "Luba vajalikud API-d"
@@ -4488,12 +4499,12 @@ msgstr "Faile jälgitakse PostgreSQL-is mitme meediumiasukoha toega (kohalik, S3
 msgid "Files with completed variants"
 msgstr "Failid lõpetatud variantidega"
 
-#: lib/phoenix_kit/integrations/providers.ex:219
+#: lib/phoenix_kit/integrations/providers.ex:220
 #, elixir-autogen, elixir-format
 msgid "From Google Cloud Console → APIs & Services → Credentials"
 msgstr "Google Cloud Console → API-d ja teenused → Mandaadid alt"
 
-#: lib/phoenix_kit/integrations/providers.ex:406
+#: lib/phoenix_kit/integrations/providers.ex:407
 #, elixir-autogen, elixir-format
 msgid "From openrouter.ai/keys"
 msgstr "openrouter.ai/keys alt"
@@ -4503,72 +4514,72 @@ msgstr "openrouter.ai/keys alt"
 msgid "Generate additional format variants alongside the primary format. Modern formats like WebP and AVIF offer better compression."
 msgstr "Genereeri täiendavaid vorminguvariantide kõrval peamise vorminguga. Kaasaegsed vormingud nagu WebP ja AVIF pakuvad paremat tihendust."
 
-#: lib/phoenix_kit/integrations/providers.ex:426
+#: lib/phoenix_kit/integrations/providers.ex:427
 #, elixir-autogen, elixir-format
 msgid "Give it a name (e.g., your app name)"
 msgstr "Andke sellele nimi (nt teie rakenduse nimi)"
 
-#: lib/phoenix_kit/integrations/providers.ex:248
+#: lib/phoenix_kit/integrations/providers.ex:249
 #, elixir-autogen, elixir-format
 msgid "Go back to the Library and search for **Google Docs API**, click it, then click **Enable**"
 msgstr "Minge tagasi Raamatukogusse ja otsige **Google Docs API**, klõpsake seda, seejärel klõpsake **Luba**"
 
-#: lib/phoenix_kit/integrations/providers.ex:281
+#: lib/phoenix_kit/integrations/providers.ex:282
 #, elixir-autogen, elixir-format
 msgid "Go to [APIs & Services → Credentials](https://console.cloud.google.com/apis/credentials)"
 msgstr "Mine [API-d ja teenused → Mandaadid](https://console.cloud.google.com/apis/credentials) lehele"
 
-#: lib/phoenix_kit/integrations/providers.ex:244
+#: lib/phoenix_kit/integrations/providers.ex:245
 #, elixir-autogen, elixir-format
 msgid "Go to [APIs & Services → Library](https://console.cloud.google.com/apis/library)"
 msgstr "Mine [API-d ja teenused → Raamatukogu](https://console.cloud.google.com/apis/library) lehele"
 
-#: lib/phoenix_kit/integrations/providers.ex:263
+#: lib/phoenix_kit/integrations/providers.ex:264
 #, elixir-autogen, elixir-format
 msgid "Go to [Audience](https://console.cloud.google.com/auth/audience) — set user type to **External** (or Internal for Google Workspace)"
 msgstr "Mine [Sihtrühm](https://console.cloud.google.com/auth/audience) lehele — määra kasutajatüübiks **Väline** (või Sisemine Google Workspace'i jaoks)"
 
-#: lib/phoenix_kit/integrations/providers.ex:260
+#: lib/phoenix_kit/integrations/providers.ex:261
 #, elixir-autogen, elixir-format
 msgid "Go to [Branding](https://console.cloud.google.com/auth/branding) in the sidebar — fill in the **App name** and **User support email**, then save"
 msgstr "Mine [Kujundus](https://console.cloud.google.com/auth/branding) lehele külgribal — täida **Rakenduse nimi** ja **Kasutajatoe e-post**, seejärel salvesta"
 
-#: lib/phoenix_kit/integrations/providers.ex:434
+#: lib/phoenix_kit/integrations/providers.ex:435
 #, elixir-autogen, elixir-format
 msgid "Go to [Credits](https://openrouter.ai/credits) to add funds"
 msgstr "Mine [Krediidid](https://openrouter.ai/credits) lehele raha lisamiseks"
 
-#: lib/phoenix_kit/integrations/providers.ex:269
+#: lib/phoenix_kit/integrations/providers.ex:270
 #, elixir-autogen, elixir-format
 msgid "Go to [Data Access](https://console.cloud.google.com/auth/scopes) — click **Add or Remove Scopes** and add the Drive and Docs scopes. This step may not be required — the app requests the needed scopes at connect time regardless."
 msgstr "Mine [Andmete juurdepääs](https://console.cloud.google.com/auth/scopes) lehele — klõpsa **Lisa või eemalda ulatus** ja lisa Drive ja Docs ulatused. See samm ei pruugi olla vajalik — rakendus küsib vajalikud ulatused igal juhul ühendamise ajal."
 
-#: lib/phoenix_kit/integrations/providers.ex:418
+#: lib/phoenix_kit/integrations/providers.ex:419
 #, elixir-autogen, elixir-format
 msgid "Go to [openrouter.ai](https://openrouter.ai) and sign up or log in"
 msgstr "Mine [openrouter.ai](https://openrouter.ai) lehele ja registreeru või logi sisse"
 
-#: lib/phoenix_kit/integrations/providers.ex:237
+#: lib/phoenix_kit/integrations/providers.ex:238
 #, elixir-autogen, elixir-format
 msgid "Go to the [Google Cloud Console](https://console.cloud.google.com)"
 msgstr "Mine [Google Cloud Console](https://console.cloud.google.com) lehele"
 
-#: lib/phoenix_kit/integrations/providers.ex:200
+#: lib/phoenix_kit/integrations/providers.ex:201
 #, elixir-autogen, elixir-format
 msgid "Google"
 msgstr "Google"
 
-#: lib/phoenix_kit/integrations/providers.ex:201
+#: lib/phoenix_kit/integrations/providers.ex:202
 #, elixir-autogen, elixir-format
 msgid "Google Docs, Drive, Calendar, Sheets, Gmail"
 msgstr "Google Docs, Drive, Calendar, Sheets, Gmail"
 
-#: lib/phoenix_kit/integrations/providers.ex:296
+#: lib/phoenix_kit/integrations/providers.ex:297
 #, elixir-autogen, elixir-format
 msgid "Google will show an \"unverified app\" warning — click **Advanced → Go to (app name)** to proceed"
 msgstr "Google kuvab hoiatuse \"Kontrollimata rakendus\" — jätkamiseks klõpsake **Täpsemalt → Mine (rakenduse nimi)**"
 
-#: lib/phoenix_kit/integrations/providers.ex:299
+#: lib/phoenix_kit/integrations/providers.ex:300
 #, elixir-autogen, elixir-format
 msgid "Grant access to Google Docs and Google Drive"
 msgstr "Anna juurdepääs Google Docs'ile ja Google Drive'ile"
@@ -4604,11 +4615,12 @@ msgstr "Integratsioon kustutatud"
 msgid "Integrations"
 msgstr "Integratsioonid"
 
-#: lib/phoenix_kit/integrations/integrations.ex:1132
+#: lib/phoenix_kit/integrations/integrations.ex:1135
 #: lib/phoenix_kit/integrations/validators.ex:208
 #: lib/phoenix_kit/integrations/validators.ex:378
 #: lib/phoenix_kit/integrations/validators.ex:412
-#: lib/phoenix_kit/integrations/validators.ex:595
+#: lib/phoenix_kit/integrations/validators.ex:608
+#: lib/phoenix_kit/integrations/validators.ex:776
 #, elixir-autogen, elixir-format
 msgid "Invalid credentials"
 msgstr "Valed mandaadid"
@@ -4822,12 +4834,12 @@ msgstr "Puudub %{n}"
 msgid "Missing %{n} copies"
 msgstr "Puudub %{n} koopiat"
 
-#: lib/phoenix_kit/integrations/providers.ex:419
+#: lib/phoenix_kit/integrations/providers.ex:420
 #, elixir-autogen, elixir-format
 msgid "Navigate to [Keys](https://openrouter.ai/keys)"
 msgstr "Mine [Võtmed](https://openrouter.ai/keys) lehele"
 
-#: lib/phoenix_kit/integrations/providers.ex:274
+#: lib/phoenix_kit/integrations/providers.ex:275
 #, elixir-autogen, elixir-format
 msgid "Navigate to the OAuth section using the search bar or the hamburger menu: search for \"OAuth\", or go to the sidebar: **APIs & Services → OAuth consent screen**. This opens a different section with its own sidebar."
 msgstr "Navigeerige OAuth jaotisesse otsinguribi või hamburgeri menüü abil: otsige \"OAuth\" või minge külgribale: **APIs & Services → OAuth consent screen**. See avab eraldi jaotise oma külgribaga."
@@ -4848,9 +4860,9 @@ msgstr "Juurdepääsutokenit pole"
 msgid "No copies"
 msgstr "Koopiaid pole"
 
-#: lib/phoenix_kit/integrations/integrations.ex:1115
+#: lib/phoenix_kit/integrations/integrations.ex:1118
 #: lib/phoenix_kit/integrations/validators.ex:170
-#: lib/phoenix_kit/integrations/validators.ex:577
+#: lib/phoenix_kit/integrations/validators.ex:758
 #, elixir-autogen, elixir-format
 msgid "No credentials configured"
 msgstr "Mandaadid pole konfigureeritud"
@@ -4931,7 +4943,7 @@ msgstr "Ainult lubatud bucketid saavad uusi üleslaadimisi"
 msgid "Only width is used, height is calculated automatically"
 msgstr "Kasutatakse ainult laiust, kõrgus arvutatakse automaatselt"
 
-#: lib/phoenix_kit/integrations/providers.ex:387
+#: lib/phoenix_kit/integrations/providers.ex:388
 #, elixir-autogen, elixir-format
 msgid "OpenRouter"
 msgstr "OpenRouter"
@@ -5112,7 +5124,7 @@ msgstr "Planeeritud hooldus"
 msgid "Scheduled window is currently active"
 msgstr "Planeeritud aken on praegu aktiivne"
 
-#: lib/phoenix_kit/integrations/providers.ex:247
+#: lib/phoenix_kit/integrations/providers.ex:248
 #, elixir-autogen, elixir-format
 msgid "Search for **Google Drive API**, click it, then click **Enable**"
 msgstr "Otsi **Google Drive API**, klõpsa seda, seejärel klõpsa **Luba**"
@@ -5139,7 +5151,7 @@ msgstr "Vali lisatav kasutaja..."
 msgid "Service"
 msgstr "Teenus"
 
-#: lib/phoenix_kit/integrations/integrations.ex:1134
+#: lib/phoenix_kit/integrations/integrations.ex:1137
 #, elixir-autogen, elixir-format
 msgid "Service error %{status}"
 msgstr "Teenuse viga %{status}"
@@ -5149,7 +5161,7 @@ msgstr "Teenuse viga %{status}"
 msgid "Set a time window for automatic maintenance activation."
 msgstr "Määra ajaaken automaatseks hoolduse aktiveerimiseks."
 
-#: lib/phoenix_kit/integrations/providers.ex:258
+#: lib/phoenix_kit/integrations/providers.ex:259
 #, elixir-autogen, elixir-format
 msgid "Set up OAuth consent"
 msgstr "Seadista OAuth nõusolek"
@@ -5159,7 +5171,7 @@ msgstr "Seadista OAuth nõusolek"
 msgid "Size Configuration"
 msgstr "Suuruse konfiguratsioon"
 
-#: lib/phoenix_kit/integrations/providers.ex:433
+#: lib/phoenix_kit/integrations/providers.ex:434
 #, elixir-autogen, elixir-format
 msgid "Some models are free, but most require credits"
 msgstr "Mõned mudelid on tasuta, kuid enamik vajab krediite"
@@ -5189,7 +5201,7 @@ msgstr "Samm 1"
 msgid "Step 2"
 msgstr "Samm 2"
 
-#: lib/phoenix_kit/integrations/providers.ex:266
+#: lib/phoenix_kit/integrations/providers.ex:267
 #, elixir-autogen, elixir-format
 msgid "Still on Audience — while the app is in **Testing** status, add the Google account you will connect as a **Test user** (this must be the same account whose Drive will store your files)"
 msgstr "Ikka Sihtrühm lehel — kuni rakendus on **Testimine** olekus, lisage Google konto, mille ühendate, kui **Testkasutaja** (see peab olema sama konto, mille Drive salvestab teie failid)"
@@ -5324,7 +5336,7 @@ msgstr "Tigris piirkond"
 msgid "Total Files"
 msgstr "Faile kokku"
 
-#: lib/phoenix_kit/integrations/providers.ex:288
+#: lib/phoenix_kit/integrations/providers.ex:289
 #, elixir-autogen, elixir-format
 msgid "Under **Authorized redirect URIs**, add: `{redirect_uri}`"
 msgstr "**Volitatud ümbersuunamise URL-id** all lisage: `{redirect_uri}`"
@@ -5381,8 +5393,8 @@ msgstr "Liitusite organisatsiooniga!"
 msgid "You need to create at least one media bucket before files can be uploaded."
 msgstr "Enne failide üleslaadimist peate looma vähemalt ühe meedia bucketi."
 
-#: lib/phoenix_kit/integrations/providers.ex:300
-#: lib/phoenix_kit/integrations/providers.ex:1252
+#: lib/phoenix_kit/integrations/providers.ex:301
+#: lib/phoenix_kit/integrations/providers.ex:1324
 #, elixir-autogen, elixir-format
 msgid "You'll be redirected back here once connected"
 msgstr "Teid suunatakse tagasi siia pärast ühendamist"
@@ -5449,39 +5461,39 @@ msgstr "1 tund tagasi"
 msgid "1 minute ago"
 msgstr "1 minut tagasi"
 
-#: lib/phoenix_kit/integrations/providers.ex:509
+#: lib/phoenix_kit/integrations/providers.ex:510
 #, elixir-autogen, elixir-format
 msgid "AI model access via DeepSeek (deepseek-chat, deepseek-reasoner)"
 msgstr "Juurdepääs AI mudelitele DeepSeeki kaudu (deepseek-chat, deepseek-reasoner)"
 
-#: lib/phoenix_kit/integrations/providers.ex:446
+#: lib/phoenix_kit/integrations/providers.ex:447
 #, elixir-autogen, elixir-format
 msgid "AI model access via Mistral AI (Mistral Large, Codestral, Pixtral)"
 msgstr "Juurdepääs AI mudelitele Mistral AI kaudu (Mistral Large, Codestral, Pixtral)"
 
-#: lib/phoenix_kit/integrations/providers.ex:1218
+#: lib/phoenix_kit/integrations/providers.ex:1290
 #, elixir-autogen, elixir-format
 msgid "Add a client secret"
 msgstr "Lisa kliendi saladus"
 
-#: lib/phoenix_kit/integrations/providers.ex:480
+#: lib/phoenix_kit/integrations/providers.ex:481
 #, elixir-autogen, elixir-format
 msgid "Add a payment method (required)"
 msgstr "Lisa makseviis (kohustuslik)"
 
-#: lib/phoenix_kit/integrations/providers.ex:357
-#: lib/phoenix_kit/integrations/providers.ex:542
-#: lib/phoenix_kit/integrations/providers.ex:611
+#: lib/phoenix_kit/integrations/providers.ex:358
+#: lib/phoenix_kit/integrations/providers.ex:543
+#: lib/phoenix_kit/integrations/providers.ex:612
 #, elixir-autogen, elixir-format
 msgid "Add credits"
 msgstr "Lisa krediite"
 
-#: lib/phoenix_kit/integrations/providers.ex:1233
+#: lib/phoenix_kit/integrations/providers.ex:1305
 #, elixir-autogen, elixir-format
 msgid "Add the permissions your integration needs: `User.Read` is included by default; add `Mail.Read`, `Files.Read.All`, `Calendars.Read`, etc. as required"
 msgstr "Lisa integratsioonile vajalikud õigused: `User.Read` on vaikimisi lisatud; vajadusel lisage `Mail.Read`, `Files.Read.All`, `Calendars.Read` jt"
 
-#: lib/phoenix_kit/integrations/providers.ex:1160
+#: lib/phoenix_kit/integrations/providers.ex:1232
 #, elixir-autogen, elixir-format
 msgid "Application (client) ID"
 msgstr "Rakenduse (kliendi) ID"
@@ -5491,28 +5503,28 @@ msgstr "Rakenduse (kliendi) ID"
 msgid "Clears the OAuth tokens. Credentials and the connection itself stay so you can reconnect with one click."
 msgstr "Tühjendab OAuth tokenid. Mandaadid ja ühendus ise jäävad, nii et saad ühe klõpsuga uuesti ühendada."
 
-#: lib/phoenix_kit/integrations/providers.ex:556
-#: lib/phoenix_kit/integrations/providers.ex:622
+#: lib/phoenix_kit/integrations/providers.ex:557
+#: lib/phoenix_kit/integrations/providers.ex:623
 #, elixir-autogen, elixir-format
 msgid "Click **Create API key**, give it a name"
 msgstr "Klõpsa **Loo API võti**, anna sellele nimi"
 
-#: lib/phoenix_kit/integrations/providers.ex:496
+#: lib/phoenix_kit/integrations/providers.ex:497
 #, elixir-autogen, elixir-format
 msgid "Click **Create new key**, give it a name, set an expiry if desired"
 msgstr "Klõpsa **Loo uus võti**, anna sellele nimi, määra aegumiskuupäev soovi korral"
 
-#: lib/phoenix_kit/integrations/providers.ex:1205
+#: lib/phoenix_kit/integrations/providers.ex:1277
 #, elixir-autogen, elixir-format
 msgid "Click **New registration**, give the app a name"
 msgstr "Klõpsa **Uus registreerimine**, anna rakendusele nimi"
 
-#: lib/phoenix_kit/integrations/providers.ex:1210
+#: lib/phoenix_kit/integrations/providers.ex:1282
 #, elixir-autogen, elixir-format
 msgid "Click **Register**"
 msgstr "Klõpsa **Registreeri**"
 
-#: lib/phoenix_kit/integrations/providers.ex:1228
+#: lib/phoenix_kit/integrations/providers.ex:1300
 #, elixir-autogen, elixir-format
 msgid "Configure API permissions"
 msgstr "Seadista API õigused"
@@ -5533,16 +5545,16 @@ msgstr "Ühenduse nimi ei saa olla tühi."
 msgid "Connection renamed"
 msgstr "Ühendus ümber nimetatud"
 
-#: lib/phoenix_kit/integrations/providers.ex:1222
+#: lib/phoenix_kit/integrations/providers.ex:1294
 #, elixir-autogen, elixir-format
 msgid "Copy the **Value** column (not the Secret ID) into the form above — the value is shown ONCE and disappears on page refresh"
 msgstr "Kopeeri **Väärtus** veerg (mitte Saladuse ID) ülalolevasse vormi — väärtust kuvatakse ÜHEKORDSELT ja see kaob lehe värskendamisel"
 
-#: lib/phoenix_kit/integrations/providers.ex:372
-#: lib/phoenix_kit/integrations/providers.ex:497
-#: lib/phoenix_kit/integrations/providers.ex:557
-#: lib/phoenix_kit/integrations/providers.ex:623
-#: lib/phoenix_kit/integrations/providers.ex:675
+#: lib/phoenix_kit/integrations/providers.ex:373
+#: lib/phoenix_kit/integrations/providers.ex:498
+#: lib/phoenix_kit/integrations/providers.ex:558
+#: lib/phoenix_kit/integrations/providers.ex:624
+#: lib/phoenix_kit/integrations/providers.ex:676
 #, elixir-autogen, elixir-format
 msgid "Copy the key (shown once) and paste it into the form above"
 msgstr "Kopeeri võti (kuvatakse ühekordselt) ja kleebi see ülalolevasse vormi"
@@ -5553,12 +5565,12 @@ msgstr "Kopeeri võti (kuvatakse ühekordselt) ja kleebi see ülalolevasse vormi
 msgid "Create Connection"
 msgstr "Loo ühendus"
 
-#: lib/phoenix_kit/integrations/providers.ex:534
+#: lib/phoenix_kit/integrations/providers.ex:535
 #, elixir-autogen, elixir-format
 msgid "Create a DeepSeek account"
 msgstr "Loo DeepSeeki konto"
 
-#: lib/phoenix_kit/integrations/providers.ex:471
+#: lib/phoenix_kit/integrations/providers.ex:472
 #, elixir-autogen, elixir-format
 msgid "Create a Mistral account"
 msgstr "Loo Mistrali konto"
@@ -5569,12 +5581,12 @@ msgstr "Loo Mistrali konto"
 msgid "Danger Zone"
 msgstr "Ohutsoon"
 
-#: lib/phoenix_kit/integrations/providers.ex:508
+#: lib/phoenix_kit/integrations/providers.ex:509
 #, elixir-autogen, elixir-format
 msgid "DeepSeek"
 msgstr "DeepSeek"
 
-#: lib/phoenix_kit/integrations/providers.ex:547
+#: lib/phoenix_kit/integrations/providers.ex:548
 #, elixir-autogen, elixir-format
 msgid "DeepSeek requires a positive balance before you can call the chat or reasoner endpoints, even on cheap models"
 msgstr "DeepSeek nõuab positiivset jääki enne chat või reasoner lõpp-punktide kutsumist, isegi odavate mudelite puhul"
@@ -5609,82 +5621,82 @@ msgstr "Ühenduse eemaldamine ebaõnnestus."
 msgid "Failed to rename connection."
 msgstr "Ühenduse ümbernimetamine ebaõnnestus."
 
-#: lib/phoenix_kit/integrations/providers.ex:485
+#: lib/phoenix_kit/integrations/providers.ex:486
 #, elixir-autogen, elixir-format
 msgid "Free models still require a billing-enabled workspace"
 msgstr "Tasuta mudelid vajavad ikkagi arveldamisvõimalustega tööruumi"
 
-#: lib/phoenix_kit/integrations/providers.ex:1164
+#: lib/phoenix_kit/integrations/providers.ex:1236
 #, elixir-autogen, elixir-format
 msgid "From Azure Portal → App registrations → your app → Overview"
 msgstr "Azure Portal → Rakenduste registreerimised → teie rakendus → Ülevaade alt"
 
-#: lib/phoenix_kit/integrations/providers.ex:464
+#: lib/phoenix_kit/integrations/providers.ex:465
 #, elixir-autogen, elixir-format
 msgid "From console.mistral.ai/api-keys"
 msgstr "console.mistral.ai/api-keys alt"
 
-#: lib/phoenix_kit/integrations/providers.ex:527
+#: lib/phoenix_kit/integrations/providers.ex:528
 #, elixir-autogen, elixir-format
 msgid "From platform.deepseek.com/api_keys"
 msgstr "platform.deepseek.com/api_keys alt"
 
-#: lib/phoenix_kit/integrations/providers.ex:1174
+#: lib/phoenix_kit/integrations/providers.ex:1246
 #, elixir-autogen, elixir-format
 msgid "From your app → Certificates & secrets → New client secret. Copy the *Value*, not the Secret ID."
 msgstr "Teie rakendus → Sertifikaadid ja saladused → Uus kliendi saladus alt. Kopeeri *Väärtus*, mitte Saladuse ID."
 
-#: lib/phoenix_kit/integrations/providers.ex:1230
+#: lib/phoenix_kit/integrations/providers.ex:1302
 #, elixir-autogen, elixir-format
 msgid "Go to **API permissions → Add a permission → Microsoft Graph → Delegated permissions**"
 msgstr "Mine **API õigused → Lisa luba → Microsoft Graph → Delegeeritud õigused** lehele"
 
-#: lib/phoenix_kit/integrations/providers.ex:1220
+#: lib/phoenix_kit/integrations/providers.ex:1292
 #, elixir-autogen, elixir-format
 msgid "Go to **Certificates & secrets → New client secret**"
 msgstr "Mine **Sertifikaadid ja saladused → Uus kliendi saladus** lehele"
 
-#: lib/phoenix_kit/integrations/providers.ex:495
+#: lib/phoenix_kit/integrations/providers.ex:496
 #, elixir-autogen, elixir-format
 msgid "Go to [API Keys](https://console.mistral.ai/api-keys)"
 msgstr "Mine [API võtmed](https://console.mistral.ai/api-keys) lehele"
 
-#: lib/phoenix_kit/integrations/providers.ex:555
+#: lib/phoenix_kit/integrations/providers.ex:556
 #, elixir-autogen, elixir-format
 msgid "Go to [API Keys](https://platform.deepseek.com/api_keys)"
 msgstr "Mine [API võtmed](https://platform.deepseek.com/api_keys) lehele"
 
-#: lib/phoenix_kit/integrations/providers.ex:544
+#: lib/phoenix_kit/integrations/providers.ex:545
 #, elixir-autogen, elixir-format
 msgid "Go to [Top up](https://platform.deepseek.com/top_up) and add at least the minimum amount"
 msgstr "Mine [Täienda](https://platform.deepseek.com/top_up) lehele ja lisa vähemalt minimaalne summa"
 
-#: lib/phoenix_kit/integrations/providers.ex:482
+#: lib/phoenix_kit/integrations/providers.ex:483
 #, elixir-autogen, elixir-format
 msgid "Go to [Workspace → Billing](https://console.mistral.ai/billing/plans) and choose **Experiment** (pay-as-you-go) or a paid tier"
 msgstr "Mine [Tööruum → Arveldamine](https://console.mistral.ai/billing/plans) lehele ja vali **Eksperiment** (maksa kasutamise järgi) või tasuline tase"
 
-#: lib/phoenix_kit/integrations/providers.ex:473
+#: lib/phoenix_kit/integrations/providers.ex:474
 #, elixir-autogen, elixir-format
 msgid "Go to [console.mistral.ai](https://console.mistral.ai) and sign up or log in"
 msgstr "Mine [console.mistral.ai](https://console.mistral.ai) lehele ja registreeru või logi sisse"
 
-#: lib/phoenix_kit/integrations/providers.ex:536
+#: lib/phoenix_kit/integrations/providers.ex:537
 #, elixir-autogen, elixir-format
 msgid "Go to [platform.deepseek.com](https://platform.deepseek.com) and sign up or log in"
 msgstr "Mine [platform.deepseek.com](https://platform.deepseek.com) lehele ja registreeru või logi sisse"
 
-#: lib/phoenix_kit/integrations/providers.ex:1202
+#: lib/phoenix_kit/integrations/providers.ex:1274
 #, elixir-autogen, elixir-format
 msgid "Go to the [Azure Portal](https://portal.azure.com) and search for **App registrations**"
 msgstr "Mine [Azure Portal](https://portal.azure.com) lehele ja otsi **Rakenduste registreerimised**"
 
-#: lib/phoenix_kit/integrations/providers.ex:1213
+#: lib/phoenix_kit/integrations/providers.ex:1285
 #, elixir-autogen, elixir-format
 msgid "If you picked a single-tenant audience, fill in **Tenant ID** above with your Directory (tenant) ID GUID — leaving it as `common` only works for multi-tenant + personal apps."
 msgstr "Kui valisite ühekordse rentnikuga sihtrühma, täitke **Rentniku ID** ülalpool oma kataloogi (rentniku) ID GUID-iga — `common` jätmine töötab ainult mitme rentnikuga + isiklike rakenduste puhul."
 
-#: lib/phoenix_kit/integrations/providers.ex:1236
+#: lib/phoenix_kit/integrations/providers.ex:1308
 #, elixir-autogen, elixir-format
 msgid "If your tenant requires admin consent, click **Grant admin consent for <tenant>** before the connect flow will work"
 msgstr "Kui teie rentnik nõuab administraatori nõusolekut, klõpsake **Anna administraatori nõusolek <tenant> jaoks** enne kui ühenduse voog töötab"
@@ -5701,32 +5713,32 @@ msgstr "Integratsiooni ei leitud"
 msgid "Last tested"
 msgstr "Viimati testitud"
 
-#: lib/phoenix_kit/integrations/providers.ex:1186
+#: lib/phoenix_kit/integrations/providers.ex:1258
 #, elixir-autogen, elixir-format
 msgid "Leave as `common` for multi-tenant + personal accounts. For single-tenant apps, paste your Directory (tenant) ID GUID. Use `consumers` for personal-only or `organizations` for any work-or-school account."
 msgstr "Jätke `common` mitme rentnikuga + isiklike kontode jaoks. Ühekordse rentnikuga rakenduste jaoks kleepige oma Kataloogi (rentniku) ID GUID. Kasutage `consumers` ainult isiklike või `organizations` töökoha-või kooli kontode jaoks."
 
-#: lib/phoenix_kit/integrations/providers.ex:1131
+#: lib/phoenix_kit/integrations/providers.ex:1203
 #, elixir-autogen, elixir-format
 msgid "Microsoft 365"
 msgstr "Microsoft 365"
 
-#: lib/phoenix_kit/integrations/providers.ex:1132
+#: lib/phoenix_kit/integrations/providers.ex:1204
 #, elixir-autogen, elixir-format
 msgid "Microsoft Graph — Outlook, OneDrive, Teams, Calendar, SharePoint"
 msgstr "Microsoft Graph — Outlook, OneDrive, Teams, Calendar, SharePoint"
 
-#: lib/phoenix_kit/integrations/providers.ex:1249
+#: lib/phoenix_kit/integrations/providers.ex:1321
 #, elixir-autogen, elixir-format
 msgid "Microsoft will show the consent screen — click **Accept** to grant the requested permissions"
 msgstr "Microsoft näitab nõusolekuekraani — klõpsa **Nõustu** taotletud õiguste andmiseks"
 
-#: lib/phoenix_kit/integrations/providers.ex:445
+#: lib/phoenix_kit/integrations/providers.ex:446
 #, elixir-autogen, elixir-format
 msgid "Mistral"
 msgstr "Mistral"
 
-#: lib/phoenix_kit/integrations/providers.ex:488
+#: lib/phoenix_kit/integrations/providers.ex:489
 #, elixir-autogen, elixir-format
 msgid "Mistral does not offer credits without billing setup; this is a hard requirement before keys can be created."
 msgstr "Mistral ei paku krediite ilma arvelduse seadistamiseta; see on kohustuslik nõue enne võtmete loomist."
@@ -5737,7 +5749,7 @@ msgstr "Mistral ei paku krediite ilma arvelduse seadistamiseta; see on kohustusl
 msgid "Permanently delete this connection? This cannot be undone."
 msgstr "Kustutada see ühendus jäädavalt? Seda ei saa tagasi võtta."
 
-#: lib/phoenix_kit/integrations/providers.ex:1200
+#: lib/phoenix_kit/integrations/providers.ex:1272
 #, elixir-autogen, elixir-format
 msgid "Register an application in Microsoft Entra ID (Azure AD)"
 msgstr "Registreerige rakendus Microsoft Entra ID-s (Azure AD)"
@@ -5753,32 +5765,32 @@ msgstr "Eemaldab integratsiooni jäädavalt. Ükski moodul, mis on selle ühendu
 msgid "Search..."
 msgstr "Otsi..."
 
-#: lib/phoenix_kit/integrations/providers.ex:1221
+#: lib/phoenix_kit/integrations/providers.ex:1293
 #, elixir-autogen, elixir-format
 msgid "Set an expiration (24 months is common; renew before it lapses)"
 msgstr "Määrake aegumisaeg (24 kuud on tavaline; uuendage enne aegumist)"
 
-#: lib/phoenix_kit/integrations/providers.ex:1181
+#: lib/phoenix_kit/integrations/providers.ex:1253
 #, elixir-autogen, elixir-format
 msgid "Tenant ID"
 msgstr "Tenant ID"
 
-#: lib/phoenix_kit/integrations/providers.ex:1241
+#: lib/phoenix_kit/integrations/providers.ex:1313
 #, elixir-autogen, elixir-format
 msgid "The `default_scopes` in the provider definition request `openid email profile offline_access User.Read` — extra scopes can be added per-connect by passing `extra_scopes` to `authorization_url/5`."
 msgstr "`default_scopes` teenusepakkuja definitsioonis taotleb `openid email profile offline_access User.Read` — täiendavaid ulatusi saab lisada ühenduse kaupa, edastades `extra_scopes` parameetri `authorization_url/5` funktsioonile."
 
-#: lib/phoenix_kit/integrations/providers.ex:1209
+#: lib/phoenix_kit/integrations/providers.ex:1281
 #, elixir-autogen, elixir-format
 msgid "Under **Redirect URI**, choose **Web** and enter: `{redirect_uri}`"
 msgstr "**Ümbersuunamise URI** all valige **Veebi** ja sisestage: `{redirect_uri}`"
 
-#: lib/phoenix_kit/integrations/providers.ex:1206
+#: lib/phoenix_kit/integrations/providers.ex:1278
 #, elixir-autogen, elixir-format
 msgid "Under **Supported account types**, choose the audience: *Personal Microsoft accounts only*, *Accounts in any organizational directory*, or *Accounts in this organizational directory only* depending on who should sign in"
 msgstr "**Toetatud kontotüübid** all valige sihtrühm: *Ainult isiklikud Microsoft kontod*, *Kontod mis tahes organisatsioonilises kataloogis* või *Kontod ainult selles organisatsioonilises kataloogis* sõltuvalt sellest, kes peaks sisse logima"
 
-#: lib/phoenix_kit/integrations/providers.ex:476
+#: lib/phoenix_kit/integrations/providers.ex:477
 #, elixir-autogen, elixir-format
 msgid "You may need to verify your phone number before creating API keys"
 msgstr "Enne API võtmete loomist võib olla vaja telefoninumber kinnitada"
@@ -6045,14 +6057,14 @@ msgstr "Pole paigaldatud"
 
 #: lib/phoenix_kit_web/live/modules.html.heex:447
 #: lib/phoenix_kit_web/live/settings.html.heex:465
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:289
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:315
 #, elixir-autogen, elixir-format
 msgid "Off"
 msgstr "Väljas"
 
 #: lib/phoenix_kit_web/live/modules.html.heex:447
 #: lib/phoenix_kit_web/live/settings.html.heex:464
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:289
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:315
 #, elixir-autogen, elixir-format
 msgid "On"
 msgstr "Sees"
@@ -7284,8 +7296,8 @@ msgstr "Vasta"
 msgid "Are you sure you want to delete this comment?"
 msgstr "Kas oled kindel, et soovid selle kommentaari kustutada?"
 
-#: lib/phoenix_kit_web/components/media_canvas_viewer.ex:1202
-#: lib/phoenix_kit_web/components/media_canvas_viewer.ex:1203
+#: lib/phoenix_kit_web/components/media_canvas_viewer.ex:1236
+#: lib/phoenix_kit_web/components/media_canvas_viewer.ex:1237
 #, elixir-autogen, elixir-format
 msgid "%b %d, %Y"
 msgstr "%d %b %Y"
@@ -8399,14 +8411,14 @@ msgstr "Kõik väljad on juba valitud"
 msgid "All registered accounts"
 msgstr "Kõik registreeritud kontod"
 
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:185
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:224
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:179
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:218
 #, elixir-autogen, elixir-format
 msgid "Anon"
 msgstr "Anon"
 
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:178
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:245
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:172
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:239
 #, elixir-autogen, elixir-format
 msgid "Anonymous User"
 msgstr "Anonüümne kasutaja"
@@ -8457,8 +8469,8 @@ msgstr "Kas olete kindel, et soovite selle seansi tühistada kasutajale"
 msgid "Are you sure you want to unconfirm this user's email?"
 msgstr "Kas olete kindel, et soovite selle kasutaja e-posti kinnituse tühistada?"
 
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:170
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:220
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:164
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:214
 #, elixir-autogen, elixir-format
 msgid "Auth"
 msgstr "Auth"
@@ -8541,17 +8553,17 @@ msgid "Confirmed Email"
 msgstr "Kinnitatud e-post"
 
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:109
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:195
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Current Page"
 msgstr "Praegune leht"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:251
+#: lib/phoenix_kit_web/live/settings/users.ex:258
 #, elixir-autogen, elixir-format
 msgid "Custom field deleted successfully"
 msgstr "Kohandatud väli edukalt kustutatud"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:171
+#: lib/phoenix_kit_web/live/settings/users.ex:178
 #, elixir-autogen, elixir-format
 msgid "Custom field saved successfully"
 msgstr "Kohandatud väli edukalt salvestatud"
@@ -8566,17 +8578,17 @@ msgstr "Kohanda tabeli veerge"
 msgid "Drag to reorder selected columns above, or add new columns from the options below. Actions column is always included."
 msgstr "Lohistage valitud veergude järjestuse muutmiseks ülalpool või lisage uusi veerge allolevatest valikutest. Toimingute veerg on alati kaasas."
 
-#: lib/phoenix_kit_web/live/settings/users.ex:256
+#: lib/phoenix_kit_web/live/settings/users.ex:263
 #, elixir-autogen, elixir-format
 msgid "Failed to delete custom field"
 msgstr "Kohandatud välja kustutamine ebaõnnestus"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:184
+#: lib/phoenix_kit_web/live/settings/users.ex:191
 #, elixir-autogen, elixir-format
 msgid "Failed to save custom field"
 msgstr "Kohandatud välja salvestamine ebaõnnestus"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:285
+#: lib/phoenix_kit_web/live/settings/users.ex:292
 #, elixir-autogen, elixir-format
 msgid "Failed to update field"
 msgstr "Välja uuendamine ebaõnnestus"
@@ -8609,23 +8621,23 @@ msgstr "Kasutaja rollide uuendamine ebaõnnestus"
 msgid "Failed to update user status"
 msgstr "Kasutaja oleku uuendamine ebaõnnestus"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:278
+#: lib/phoenix_kit_web/live/settings/users.ex:285
 #, elixir-autogen, elixir-format
 msgid "Field '%{label}' disabled"
 msgstr "Väli '%{label}' keelatud"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:277
+#: lib/phoenix_kit_web/live/settings/users.ex:284
 #, elixir-autogen, elixir-format
 msgid "Field '%{label}' enabled"
 msgstr "Väli '%{label}' lubatud"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:289
+#: lib/phoenix_kit_web/live/settings/users.ex:296
 #, elixir-autogen, elixir-format
 msgid "Field not found"
 msgstr "Välja ei leitud"
 
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:108
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:194
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:188
 #, elixir-autogen, elixir-format
 msgid "IP Address"
 msgstr "IP-aadress"
@@ -8657,7 +8669,7 @@ msgstr "Halda kasutajakontosid ja rolle"
 msgid "Monitor and manage active user sessions"
 msgstr "Jälgi ja halda aktiivseid kasutajaseansse"
 
-#: lib/phoenix_kit/integrations/providers.ex:1002
+#: lib/phoenix_kit/integrations/providers.ex:1074
 #: lib/phoenix_kit_web/live/users/users.ex:1048
 #: lib/phoenix_kit_web/live/users/users.html.heex:563
 #, elixir-autogen, elixir-format
@@ -8669,7 +8681,7 @@ msgstr "Mitte kunagi"
 msgid "Next »"
 msgstr "Järgmine"
 
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:208
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:202
 #, elixir-autogen, elixir-format
 msgid "No active sessions"
 msgstr "Aktiivseid seansse ei leitud."
@@ -8821,7 +8833,7 @@ msgstr "Standardväljad"
 msgid "Table columns updated successfully"
 msgstr "Tabeli veerud edukalt uuendatud"
 
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:209
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:203
 #, elixir-autogen, elixir-format
 msgid "There are currently no active sessions to display."
 msgstr "Praegu ei ole kuvamiseks aktiivseid seansse."
@@ -8882,13 +8894,13 @@ msgstr "Kasutaja e-posti kinnitus edukalt tühistatud"
 msgid "User roles updated successfully"
 msgstr "Kasutaja rollid edukalt uuendatud"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:84
+#: lib/phoenix_kit_web/live/settings/users.ex:91
 #, elixir-autogen, elixir-format
 msgid "User settings updated successfully"
 msgstr "Kasutaja seaded edukalt uuendatud"
 
 ## Navigation menu items
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:193
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:187
 #, elixir-autogen, elixir-format
 msgid "User/Session"
 msgstr "Kasutaja/Seanss"
@@ -8922,7 +8934,7 @@ msgstr[1] "Kas soovid kindlasti tühistada kõik %{count} kasutaja %{email} sess
 msgid "Last updated:"
 msgstr "Viimati uuendatud:"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:656
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:671
 #, elixir-autogen, elixir-format
 msgid "Account switcher for signing in to several accounts at once"
 msgstr "Kontovahetaja mitmesse kontosse korraga sisselogimiseks"
@@ -8932,7 +8944,7 @@ msgstr "Kontovahetaja mitmesse kontosse korraga sisselogimiseks"
 msgid "Applying…"
 msgstr "Rakendamine..."
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:662
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:677
 #, elixir-autogen, elixir-format
 msgid "Enable the multi-account switcher in the header"
 msgstr "Luba päises mitme konto vahetaja"
@@ -8950,12 +8962,12 @@ msgstr "Lae rohkem"
 msgid "Loading…"
 msgstr "Laadimine…"
 
-#: lib/phoenix_kit_web/users/session.ex:113
+#: lib/phoenix_kit_web/users/session.ex:115
 #, elixir-autogen, elixir-format
 msgid "Logged out. Now signed in as %{email}."
 msgstr "Välja logitud. Nüüd sisse logitud kui %{email}."
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:653
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:668
 #, elixir-autogen, elixir-format
 msgid "Multiple Sessions"
 msgstr "Mitu sessiooni"
@@ -8991,12 +9003,12 @@ msgstr "Järjesta 1 valitud %{noun} (teised read jäävad paigale)."
 msgid "Showing %{loaded} of %{total} %{noun}"
 msgstr "Kuvatud %{loaded} / %{total} %{noun}"
 
-#: lib/phoenix_kit_web/users/session.ex:268
+#: lib/phoenix_kit_web/users/session.ex:270
 #, elixir-autogen, elixir-format
 msgid "Switched to %{email}."
 msgstr "Vahetatud kontole %{email}."
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:665
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:680
 #, elixir-autogen, elixir-format
 msgid "When on, any signed-in user can add other accounts (with their password) and switch between them from the user menu."
 msgstr "Sisselülitatuna saab iga sisse logitud kasutaja lisada teisi kontosid (nende parooliga) ja nende vahel kasutajamenüüst vahetada."
@@ -9076,7 +9088,7 @@ msgstr "Siia saab lisada ainult lubatud failitüüpe."
 msgid "View background job status and history"
 msgstr "Vaata taustatööde olekut ja ajalugu"
 
-#: lib/phoenix_kit/integrations/providers.ex:312
+#: lib/phoenix_kit/integrations/providers.ex:313
 #, elixir-autogen, elixir-format
 msgid "AI models via OpenAI (GPT, embeddings, images, audio)"
 msgstr "AI mudelid OpenAI kaudu (GPT, vektorid, pildid, heli)"
@@ -9161,12 +9173,12 @@ msgstr "Muuda"
 msgid "Choose"
 msgstr "Vali"
 
-#: lib/phoenix_kit/integrations/providers.ex:674
+#: lib/phoenix_kit/integrations/providers.ex:675
 #, elixir-autogen, elixir-format
 msgid "Click **Create API Key**, give it a name"
 msgstr "Klõpsa **Loo API võti**, anna sellele nimi"
 
-#: lib/phoenix_kit/integrations/providers.ex:371
+#: lib/phoenix_kit/integrations/providers.ex:372
 #, elixir-autogen, elixir-format
 msgid "Click **Create new secret key**, give it a name"
 msgstr "Klõpsa **Create new secret key**, anna sellele nimi"
@@ -9177,12 +9189,12 @@ msgstr "Klõpsa **Create new secret key**, anna sellele nimi"
 msgid "Close search"
 msgstr "Sulge otsing"
 
-#: lib/phoenix_kit/integrations/providers.ex:664
+#: lib/phoenix_kit/integrations/providers.ex:665
 #, elixir-autogen, elixir-format
 msgid "Create an ElevenLabs account"
 msgstr "Loo ElevenLabsi konto"
 
-#: lib/phoenix_kit/integrations/providers.ex:349
+#: lib/phoenix_kit/integrations/providers.ex:350
 #, elixir-autogen, elixir-format
 msgid "Create an OpenAI account"
 msgstr "Loo OpenAI konto"
@@ -9246,7 +9258,7 @@ msgstr "Muuda kirjeldust"
 msgid "Edit header"
 msgstr "Muuda päist"
 
-#: lib/phoenix_kit/integrations/providers.ex:634
+#: lib/phoenix_kit/integrations/providers.ex:635
 #, elixir-autogen, elixir-format
 msgid "ElevenLabs"
 msgstr "ElevenLabs"
@@ -9316,37 +9328,37 @@ msgstr "Kausta nimi ei tohi olla tühi"
 msgid "Forgot password"
 msgstr "Unustasid parooli"
 
-#: lib/phoenix_kit/integrations/providers.ex:657
+#: lib/phoenix_kit/integrations/providers.ex:658
 #, elixir-autogen, elixir-format
 msgid "From elevenlabs.io → Settings → API Keys"
 msgstr "elevenlabs.io kaudu → Seaded → API võtmed"
 
-#: lib/phoenix_kit/integrations/providers.ex:336
+#: lib/phoenix_kit/integrations/providers.ex:337
 #, elixir-autogen, elixir-format
 msgid "From platform.openai.com/api-keys"
 msgstr "platform.openai.com/api-keys alt"
 
-#: lib/phoenix_kit/integrations/providers.ex:370
+#: lib/phoenix_kit/integrations/providers.ex:371
 #, elixir-autogen, elixir-format
 msgid "Go to [API Keys](https://platform.openai.com/api-keys)"
 msgstr "Mine [API võtmed](https://platform.openai.com/api-keys) lehele"
 
-#: lib/phoenix_kit/integrations/providers.ex:359
+#: lib/phoenix_kit/integrations/providers.ex:360
 #, elixir-autogen, elixir-format
 msgid "Go to [Billing](https://platform.openai.com/account/billing/overview) and add a payment method or credits"
 msgstr "Mine [Arveldus](https://platform.openai.com/account/billing/overview) ja lisa makseviis või krediiti"
 
-#: lib/phoenix_kit/integrations/providers.ex:672
+#: lib/phoenix_kit/integrations/providers.ex:673
 #, elixir-autogen, elixir-format
 msgid "Go to [Settings → API Keys](https://elevenlabs.io/app/settings/api-keys)"
 msgstr "Mine [Seaded → API võtmed](https://elevenlabs.io/app/settings/api-keys)"
 
-#: lib/phoenix_kit/integrations/providers.ex:666
+#: lib/phoenix_kit/integrations/providers.ex:667
 #, elixir-autogen, elixir-format
 msgid "Go to [elevenlabs.io](https://elevenlabs.io) and sign up or log in"
 msgstr "Mine [elevenlabs.io](https://elevenlabs.io) ja registreeru või logi sisse"
 
-#: lib/phoenix_kit/integrations/providers.ex:351
+#: lib/phoenix_kit/integrations/providers.ex:352
 #, elixir-autogen, elixir-format
 msgid "Go to [platform.openai.com](https://platform.openai.com) and sign up or log in"
 msgstr "Mine [platform.openai.com](https://platform.openai.com) lehele ja registreeru või logi sisse"
@@ -9375,7 +9387,7 @@ msgstr "Pealkiri %{level}"
 msgid "Icon"
 msgstr "Ikoon"
 
-#: lib/phoenix_kit/integrations/providers.ex:375
+#: lib/phoenix_kit/integrations/providers.ex:376
 #, elixir-autogen, elixir-format
 msgid "If your account belongs to multiple organizations, keys are scoped to the org selected when the key was created."
 msgstr "Kui sinu konto kuulub mitmesse organisatsiooni, on võtmed seotud organisatsiooniga, mis oli võtme loomise ajal valitud."
@@ -9475,12 +9487,12 @@ msgstr "Vanimad enne"
 msgid "Open the media health dashboard to check file redundancy and re-sync files across storage locations."
 msgstr "Ava meedia seisundi töölaud, et kontrollida failide liiasust ja sünkroonida failid salvestuskohtade vahel uuesti."
 
-#: lib/phoenix_kit/integrations/providers.ex:311
+#: lib/phoenix_kit/integrations/providers.ex:312
 #, elixir-autogen, elixir-format
 msgid "OpenAI"
 msgstr "OpenAI"
 
-#: lib/phoenix_kit/integrations/providers.ex:362
+#: lib/phoenix_kit/integrations/providers.ex:363
 #, elixir-autogen, elixir-format
 msgid "OpenAI requires a positive balance before the API will return completions, even on cheaper models"
 msgstr "OpenAI nõuab positiivset saldot, enne kui API tagastab vastuseid, isegi odavamate mudelite puhul"
@@ -9571,12 +9583,12 @@ msgstr "Sorteeri"
 msgid "Stacks"
 msgstr "Virnad"
 
-#: lib/phoenix_kit/integrations/providers.ex:635
+#: lib/phoenix_kit/integrations/providers.ex:636
 #, elixir-autogen, elixir-format
 msgid "Text-to-speech and voice generation via ElevenLabs"
 msgstr "Teksti kõneks muutmine ja hääle genereerimine ElevenLabsi kaudu"
 
-#: lib/phoenix_kit/integrations/providers.ex:678
+#: lib/phoenix_kit/integrations/providers.ex:679
 #, elixir-autogen, elixir-format
 msgid "The free tier includes a monthly character quota; paid plans raise the quota and unlock commercial use and additional voices."
 msgstr "Tasuta tase sisaldab igakuist märkide kvooti; tasulised paketid tõstavad kvooti ning avavad ärilise kasutuse ja lisahääled."
@@ -10459,27 +10471,27 @@ msgstr "Või lisa kaudu"
 msgid "Too many attempts. Please try again shortly."
 msgstr "Liiga palju katseid. Palun proovige veidi hiljem uuesti."
 
-#: lib/phoenix_kit/integrations/providers.ex:569
+#: lib/phoenix_kit/integrations/providers.ex:570
 #, elixir-autogen, elixir-format
 msgid "AI model access via xAI (Grok models)"
 msgstr "Juurdepääs AI mudelitele xAI kaudu (Grok mudelid)"
 
-#: lib/phoenix_kit/integrations/providers.ex:827
+#: lib/phoenix_kit/integrations/providers.ex:828
 #, elixir-autogen, elixir-format
 msgid "AWS Simple Email Service (SMTP credentials via SES API)"
 msgstr "AWS Simple Email Service (SMTP-mandaadid SES API kaudu)"
 
-#: lib/phoenix_kit/integrations/providers.ex:826
+#: lib/phoenix_kit/integrations/providers.ex:827
 #, elixir-autogen, elixir-format
 msgid "Amazon SES"
 msgstr "Amazon SES"
 
-#: lib/phoenix_kit/integrations/providers.ex:1050
+#: lib/phoenix_kit/integrations/providers.ex:1122
 #, elixir-autogen, elixir-format
 msgid "Brevo API"
 msgstr "Brevo API"
 
-#: lib/phoenix_kit/integrations/providers.ex:605
+#: lib/phoenix_kit/integrations/providers.ex:606
 #, elixir-autogen, elixir-format
 msgid "Create an xAI account"
 msgstr "Loo xAI konto"
@@ -10489,37 +10501,37 @@ msgstr "Loo xAI konto"
 msgid "Email users when their account is signed in from a new device"
 msgstr "Saada kasutajale e-kiri, kui tema kontoga logitakse sisse uuest seadmest"
 
-#: lib/phoenix_kit/integrations/providers.ex:961
+#: lib/phoenix_kit/integrations/providers.ex:1033
 #, elixir-autogen, elixir-format
 msgid "For Brevo: the SMTP key starting with xsmtpsib- (SMTP & API → SMTP tab) — not the API key (xkeysib-)."
 msgstr "Brevo puhul: SMTP-võti, mis algab xsmtpsib- (SMTP & API → SMTP vahekaart), mitte API-võti (xkeysib-)."
 
-#: lib/phoenix_kit/integrations/providers.ex:949
+#: lib/phoenix_kit/integrations/providers.ex:1021
 #, elixir-autogen, elixir-format
 msgid "For Brevo: your account's SMTP login, shown as <subaccount>@smtp-brevo.com under SMTP & API → SMTP."
 msgstr "Brevo puhul: teie konto SMTP-kasutajanimi kujul <subaccount>@smtp-brevo.com jaotises SMTP & API → SMTP."
 
-#: lib/phoenix_kit/integrations/providers.ex:1070
+#: lib/phoenix_kit/integrations/providers.ex:1142
 #, elixir-autogen, elixir-format
 msgid "From Brevo → SMTP & API → API Keys. Starts with xkeysib- — not the SMTP key (xsmtpsib-)."
 msgstr "Brevost → SMTP & API → API Keys. Algab xkeysib-, mitte SMTP-võti (xsmtpsib-)."
 
-#: lib/phoenix_kit/integrations/providers.ex:590
+#: lib/phoenix_kit/integrations/providers.ex:591
 #, elixir-autogen, elixir-format
 msgid "From console.x.ai/team/default/api-keys"
 msgstr "console.x.ai/team/default/api-keys alt"
 
-#: lib/phoenix_kit/integrations/providers.ex:621
+#: lib/phoenix_kit/integrations/providers.ex:622
 #, elixir-autogen, elixir-format
 msgid "Go to [API Keys](https://console.x.ai/team/default/api-keys)"
 msgstr "Mine [API võtmed](https://console.x.ai/team/default/api-keys) lehele"
 
-#: lib/phoenix_kit/integrations/providers.ex:607
+#: lib/phoenix_kit/integrations/providers.ex:608
 #, elixir-autogen, elixir-format
 msgid "Go to [accounts.x.ai](https://accounts.x.ai) and sign up or log in"
 msgstr "Minge aadressile [accounts.x.ai](https://accounts.x.ai) ja registreeruge või logige sisse"
 
-#: lib/phoenix_kit/integrations/providers.ex:613
+#: lib/phoenix_kit/integrations/providers.ex:614
 #, elixir-autogen, elixir-format
 msgid "Go to [console.x.ai](https://console.x.ai) → Billing and add credits"
 msgstr "Minge aadressile [console.x.ai](https://console.x.ai) → Billing ja lisage krediiti"
@@ -10529,43 +10541,44 @@ msgstr "Minge aadressile [console.x.ai](https://console.x.ai) → Billing ja lis
 msgid "Login Notifications"
 msgstr "Sisselogimise teavitused"
 
-#: lib/phoenix_kit/integrations/providers.ex:927
+#: lib/phoenix_kit/integrations/providers.ex:999
 #, elixir-autogen, elixir-format
 msgid "Port"
 msgstr "Port"
 
-#: lib/phoenix_kit/integrations/providers.ex:720
-#: lib/phoenix_kit/integrations/providers.ex:860
+#: lib/phoenix_kit/integrations/providers.ex:721
+#: lib/phoenix_kit/integrations/providers.ex:861
+#: lib/phoenix_kit/integrations/providers.ex:945
 #, elixir-autogen, elixir-format
 msgid "Region"
 msgstr "Piirkond"
 
-#: lib/phoenix_kit/integrations/providers.ex:904
+#: lib/phoenix_kit/integrations/providers.ex:976
 #, elixir-autogen, elixir-format
 msgid "SMTP"
 msgstr "SMTP"
 
-#: lib/phoenix_kit/integrations/providers.ex:918
+#: lib/phoenix_kit/integrations/providers.ex:990
 #, elixir-autogen, elixir-format
 msgid "SMTP Host"
 msgstr "SMTP-host"
 
-#: lib/phoenix_kit/integrations/providers.ex:1051
+#: lib/phoenix_kit/integrations/providers.ex:1123
 #, elixir-autogen, elixir-format
 msgid "Send email via the Brevo transactional email API"
 msgstr "Saada e-kirju Brevo tehingukirjade API kaudu"
 
-#: lib/phoenix_kit/integrations/providers.ex:906
+#: lib/phoenix_kit/integrations/providers.ex:978
 #, elixir-autogen, elixir-format
 msgid "Universal SMTP relay — works with any vendor (Brevo, Mailgun, SendGrid, a self-hosted mail server, etc). Add one named connection per relay/account."
 msgstr "Universaalne SMTP-relee — töötab iga teenusepakkujaga (Brevo, Mailgun, SendGrid, oma postiserver jne). Lisage iga relee või konto kohta üks nimeline ühendus."
 
-#: lib/phoenix_kit/integrations/providers.ex:568
+#: lib/phoenix_kit/integrations/providers.ex:569
 #, elixir-autogen, elixir-format
 msgid "xAI"
 msgstr "xAI"
 
-#: lib/phoenix_kit/integrations/providers.ex:615
+#: lib/phoenix_kit/integrations/providers.ex:616
 #, elixir-autogen, elixir-format
 msgid "xAI requires a funded account before the API will return completions"
 msgstr "xAI nõuab krediidiga kontot, muidu API vastuseid ei tagasta"
@@ -10740,12 +10753,12 @@ msgstr "Ühtegi faili ei vasta otsingule."
 msgid "Try a different term or clear the search"
 msgstr "Proovi teist otsingusõna või tühjenda otsing"
 
-#: lib/modules/storage/web/bucket_form.ex:294
+#: lib/modules/storage/web/bucket_form.ex:296
 #, elixir-autogen, elixir-format
 msgid "Add Storage Bucket"
 msgstr "Lisa salvestusbucket"
 
-#: lib/modules/storage/web/bucket_form.ex:295
+#: lib/modules/storage/web/bucket_form.ex:297
 #, elixir-autogen, elixir-format
 msgid "Edit Storage Bucket"
 msgstr "Muuda salvestusbucketit"
@@ -10834,12 +10847,12 @@ msgstr "%{n} min tagasi"
 msgid "%{provider} settings"
 msgstr "%{provider} seaded"
 
-#: lib/phoenix_kit/integrations/validators.ex:643
+#: lib/phoenix_kit/integrations/validators.ex:824
 #, elixir-autogen, elixir-format
 msgid "%{text} · resets %{date}"
 msgstr "%{text} · lähtestub %{date}"
 
-#: lib/phoenix_kit/integrations/validators.ex:632
+#: lib/phoenix_kit/integrations/validators.ex:813
 #, elixir-autogen, elixir-format
 msgid "%{type} · %{credits} credits left"
 msgstr "%{type} · krediiti jäänud: %{credits}"
@@ -10895,12 +10908,12 @@ msgstr "Kogu väljuv süsteemipost — autentimine, teavitused — saadetakse se
 msgid "Allow \"Keep me logged in\" (persistent sessions)"
 msgstr "Luba „Jäta mind meelde“ (püsivad sessioonid)"
 
-#: lib/phoenix_kit/integrations/providers.ex:1001
+#: lib/phoenix_kit/integrations/providers.ex:1073
 #, elixir-autogen, elixir-format
 msgid "Always"
 msgstr "Alati"
 
-#: lib/phoenix_kit_web/users/session.ex:331
+#: lib/phoenix_kit_web/users/session.ex:333
 #, elixir-autogen, elixir-format
 msgid "An owner account cannot be used."
 msgstr "Omaniku kontot ei saa kasutada."
@@ -10910,12 +10923,12 @@ msgstr "Omaniku kontot ei saa kasutada."
 msgid "Applies site-wide wherever the rich-text editor is rendered (posts, comments). Users can still switch modes inside the editor."
 msgstr "Kehtib kogu saidil kõikjal, kus kuvatakse vormindatud teksti redaktor (postitused, kommentaarid). Kasutajad saavad režiimi redaktoris siiski vahetada."
 
-#: lib/phoenix_kit/integrations/providers.ex:982
+#: lib/phoenix_kit/integrations/providers.ex:1054
 #, elixir-autogen, elixir-format
 msgid "Auto (from port)"
 msgstr "Automaatne (pordi järgi)"
 
-#: lib/phoenix_kit/integrations/providers.ex:978
+#: lib/phoenix_kit/integrations/providers.ex:1050
 #, elixir-autogen, elixir-format
 msgid "Auto follows the port: 465 means implicit TLS, anything else STARTTLS (required when a login is set). Choose explicitly for a relay that ignores that convention."
 msgstr "„Automaatne“ lähtub pordist: 465 tähendab kaudset TLS-i, kõik muu STARTTLS-i (nõutav, kui kasutajanimi on määratud). Valige käsitsi, kui relee seda tava ei järgi."
@@ -10930,22 +10943,22 @@ msgstr "Koondage sagedased teavitusetüübid perioodilistesse kokkuvõtetesse �
 msgid "Best,\nThe Team"
 msgstr "Parimate soovidega,\nMeeskond"
 
-#: lib/phoenix_kit/integrations/providers.ex:1098
+#: lib/phoenix_kit/integrations/providers.ex:1170
 #, elixir-autogen, elixir-format
 msgid "Bot Token"
 msgstr "Boti token"
 
-#: lib/phoenix_kit/integrations/providers.ex:1118
+#: lib/phoenix_kit/integrations/providers.ex:1190
 #, elixir-autogen, elixir-format
 msgid "BotFather replies with an HTTP API token like `123456789:ABCdef...` — copy it"
 msgstr "BotFather saadab HTTP API tokeni kujul `123456789:ABCdef...` — kopeerige see"
 
-#: lib/phoenix_kit/integrations/validators.ex:601
+#: lib/phoenix_kit/integrations/validators.ex:782
 #, elixir-autogen, elixir-format
 msgid "Brevo error %{status}"
 msgstr "Brevo viga %{status}"
 
-#: lib/phoenix_kit/integrations/providers.ex:1022
+#: lib/phoenix_kit/integrations/providers.ex:1094
 #, elixir-autogen, elixir-format
 msgid "CA certificate (PEM)"
 msgstr "CA sertifikaat (PEM)"
@@ -10955,7 +10968,7 @@ msgstr "CA sertifikaat (PEM)"
 msgid "Cannot delete send profile"
 msgstr "Saatmisprofiili ei saa kustutada"
 
-#: lib/phoenix_kit/integrations/providers.ex:1007
+#: lib/phoenix_kit/integrations/providers.ex:1079
 #, elixir-autogen, elixir-format
 msgid "Certificate verification"
 msgstr "Sertifikaadi kontroll"
@@ -11000,7 +11013,7 @@ msgstr "Kinnitage oma e-post"
 msgid "Connect your own API keys and services. Only you can see these."
 msgstr "Ühendage oma API-võtmed ja teenused. Neid näete ainult teie."
 
-#: lib/phoenix_kit/integrations/validators.ex:693
+#: lib/phoenix_kit/integrations/validators.ex:874
 #, elixir-autogen, elixir-format
 msgid "Connected as @%{username}"
 msgstr "Ühendatud kasutajana @%{username}"
@@ -11016,7 +11029,7 @@ msgstr "Ühendus töötab"
 msgid "Content Editor"
 msgstr "Sisuredaktor"
 
-#: lib/phoenix_kit/integrations/providers.ex:1116
+#: lib/phoenix_kit/integrations/providers.ex:1188
 #, elixir-autogen, elixir-format
 msgid "Copy the bot token"
 msgstr "Kopeerige boti token"
@@ -11034,12 +11047,12 @@ msgstr "Integratsiooni ei saanud lisada"
 msgid "Could not reach AWS SES"
 msgstr "AWS SES-iga ei saanud ühendust"
 
-#: lib/phoenix_kit/integrations/validators.ex:605
+#: lib/phoenix_kit/integrations/validators.ex:786
 #, elixir-autogen, elixir-format
 msgid "Could not reach Brevo"
 msgstr "Brevoga ei saanud ühendust"
 
-#: lib/phoenix_kit/integrations/validators.ex:705
+#: lib/phoenix_kit/integrations/validators.ex:886
 #, elixir-autogen, elixir-format
 msgid "Could not reach Telegram"
 msgstr "Telegramiga ei saanud ühendust"
@@ -11100,7 +11113,7 @@ msgstr "Koondteadete seadeid ei saanud uuendada."
 msgid "Could not update default send integration"
 msgstr "Vaikimisi saatmisintegratsiooni ei saanud uuendada"
 
-#: lib/phoenix_kit/integrations/providers.ex:1109
+#: lib/phoenix_kit/integrations/providers.ex:1181
 #, elixir-autogen, elixir-format
 msgid "Create a bot with BotFather"
 msgstr "Looge bot BotFatheri abil"
@@ -11176,7 +11189,7 @@ msgstr "Keelatud profiile ei kasutata kunagi saatmiseks, ka mitte vaikimisi prof
 msgid "Dismiss"
 msgstr "Eemalda"
 
-#: lib/phoenix_kit/integrations/providers.ex:1017
+#: lib/phoenix_kit/integrations/providers.ex:1089
 #, elixir-autogen, elixir-format
 msgid "Do not verify"
 msgstr "Ära kontrolli"
@@ -11208,7 +11221,7 @@ msgstr "Saatmisprofiili muutmine: %{name}"
 msgid "Email Sending"
 msgstr "E-posti saatmine"
 
-#: lib/phoenix_kit_web/users/confirmation_instructions.ex:109
+#: lib/phoenix_kit_web/users/confirmation_instructions.ex:111
 #, elixir-autogen, elixir-format
 msgid "Email confirmed. Welcome!"
 msgstr "E-post kinnitatud. Tere tulemast!"
@@ -11218,7 +11231,7 @@ msgstr "E-post kinnitatud. Tere tulemast!"
 msgid "Email-capable integrations"
 msgstr "E-posti toega integratsioonid"
 
-#: lib/phoenix_kit/integrations/providers.ex:973
+#: lib/phoenix_kit/integrations/providers.ex:1045
 #, elixir-autogen, elixir-format
 msgid "Encryption"
 msgstr "Krüpteerimine"
@@ -11238,7 +11251,7 @@ msgstr "Iga 12 tunni järel"
 msgid "Everyone who starts the bot"
 msgstr "Kõigile, kes boti käivitavad"
 
-#: lib/phoenix_kit/integrations/providers.ex:1027
+#: lib/phoenix_kit/integrations/providers.ex:1099
 #, elixir-autogen, elixir-format
 msgid "For a private or self-signed relay certificate. Replaces the system CA store for this connection only."
 msgstr "Privaatse või ise allkirjastatud relee sertifikaadi jaoks. Asendab süsteemi CA-hoidla ainult selle ühenduse puhul."
@@ -11249,7 +11262,7 @@ msgstr "Privaatse või ise allkirjastatud relee sertifikaadi jaoks. Asendab süs
 msgid "From"
 msgstr "Saatja"
 
-#: lib/phoenix_kit/integrations/providers.ex:1102
+#: lib/phoenix_kit/integrations/providers.ex:1174
 #, elixir-autogen, elixir-format
 msgid "From @BotFather → /newbot (or /token for an existing bot)"
 msgstr "@BotFatherilt → /newbot (või /token olemasoleva boti jaoks)"
@@ -11276,7 +11289,7 @@ msgstr "Täielik juurdepääs"
 msgid "Hourly"
 msgstr "Iga tund"
 
-#: lib/phoenix_kit/integrations/providers.ex:1000
+#: lib/phoenix_kit/integrations/providers.ex:1072
 #, elixir-autogen, elixir-format
 msgid "If offered (default)"
 msgstr "Kui pakutakse (vaikimisi)"
@@ -11286,7 +11299,7 @@ msgstr "Kui pakutakse (vaikimisi)"
 msgid "Immediate"
 msgstr "Kohe"
 
-#: lib/phoenix_kit/integrations/providers.ex:983
+#: lib/phoenix_kit/integrations/providers.ex:1055
 #, elixir-autogen, elixir-format
 msgid "Implicit TLS / SMTPS"
 msgstr "Kaudne TLS / SMTPS"
@@ -11304,6 +11317,7 @@ msgid "Incomplete SMTP settings"
 msgstr "Puudulikud SMTP seaded"
 
 #: lib/phoenix_kit/integrations/validators.ex:57
+#: lib/phoenix_kit/integrations/validators.ex:582
 #, elixir-autogen, elixir-format
 msgid "Incomplete credentials"
 msgstr "Puudulikud mandaadid"
@@ -11340,7 +11354,7 @@ msgstr "Vigased SMTP seaded"
 msgid "Invalid SMTP settings: %{reason}"
 msgstr "Vigased SMTP seaded: %{reason}"
 
-#: lib/phoenix_kit/integrations/validators.ex:698
+#: lib/phoenix_kit/integrations/validators.ex:879
 #, elixir-autogen, elixir-format
 msgid "Invalid bot token"
 msgstr "Vigane boti token"
@@ -11360,7 +11374,7 @@ msgstr "Vigane ajalimiit: %{value}"
 msgid "Leave a field blank to fall back to the application config or built-in default."
 msgstr "Jätke väli tühjaks, et kasutada rakenduse seadistust või sisseehitatud vaikeväärtust."
 
-#: lib/phoenix_kit/integrations/providers.ex:1038
+#: lib/phoenix_kit/integrations/providers.ex:1110
 #, elixir-autogen, elixir-format
 msgid "Leave blank for the gen_smtp default."
 msgstr "Jätke tühjaks gen_smtp vaikeväärtuse jaoks."
@@ -11401,7 +11415,7 @@ msgstr "Märgi kõik loetuks"
 msgid "Mark read"
 msgstr "Märgi loetuks"
 
-#: lib/phoenix_kit_web/users/session.ex:340
+#: lib/phoenix_kit_web/users/session.ex:342
 #, elixir-autogen, elixir-format
 msgid "Maximum number of accounts reached — remove one first."
 msgstr "Kontode ülempiir on täis — eemaldage kõigepealt üks."
@@ -11451,7 +11465,7 @@ msgstr "Uus saatmisprofiil"
 msgid "No adapter configured for the static mailer. Set one in your application config, or connect an email-capable integration below and pick it as the default transactional integration."
 msgstr "Staatilisele mailerile pole adapterit seadistatud. Määrake see rakenduse seadistuses või ühendage allpool e-posti toega integratsioon ja valige see vaikimisi tehinguintegratsiooniks."
 
-#: lib/phoenix_kit/integrations/validators.ex:682
+#: lib/phoenix_kit/integrations/validators.ex:863
 #, elixir-autogen, elixir-format
 msgid "No bot token configured"
 msgstr "Boti tokenit pole määratud"
@@ -11491,7 +11505,7 @@ msgstr "Süsteemi CA-sertifikaate ei leitud, seetõttu ei saa relee sertifikaati
 msgid "No unread notifications"
 msgstr "Lugemata teavitusi pole"
 
-#: lib/phoenix_kit/integrations/providers.ex:986
+#: lib/phoenix_kit/integrations/providers.ex:1058
 #, elixir-autogen, elixir-format
 msgid "None — plaintext"
 msgstr "Puudub — krüpteerimata"
@@ -11521,7 +11535,7 @@ msgstr "Saadud teavitused ilmuvad siia."
 msgid "Numeric ID of a verified Brevo sender. Leave empty to send from the From address above."
 msgstr "Kinnitatud Brevo saatja numbriline ID. Jätke tühjaks, et saata ülal määratud aadressilt."
 
-#: lib/phoenix_kit_web/users/session.ex:334
+#: lib/phoenix_kit_web/users/session.ex:336
 #, elixir-autogen, elixir-format
 msgid "Only an owner can sign in as another administrator."
 msgstr "Ainult omanik saab sisse logida teise administraatorina."
@@ -11531,12 +11545,12 @@ msgstr "Ainult omanik saab sisse logida teise administraatorina."
 msgid "Only me"
 msgstr "Ainult mulle"
 
-#: lib/phoenix_kit/integrations/providers.ex:1111
+#: lib/phoenix_kit/integrations/providers.ex:1183
 #, elixir-autogen, elixir-format
 msgid "Open [@BotFather](https://t.me/BotFather) in Telegram"
 msgstr "Avage Telegramis [@BotFather](https://t.me/BotFather)"
 
-#: lib/phoenix_kit/integrations/providers.ex:1121
+#: lib/phoenix_kit/integrations/providers.ex:1193
 #, elixir-autogen, elixir-format
 msgid "Paste the token into the form above and press **Test Connection**"
 msgstr "Kleepige token ülalolevale vormile ja vajutage **Testi ühendust**"
@@ -11556,7 +11570,7 @@ msgstr "Saatja andmed, saatmispiirangud ja teenusepakkuja seaded iga konto kohta
 msgid "Persistent sessions last 60 days. Magic-link and social logins have no checkbox to tick, so they follow the default above. Turning the first option off hides the checkbox everywhere and keeps every login to the browser session."
 msgstr "Püsivad sessioonid kestavad 60 päeva. Võlulingi ja sotsiaalvõrgustike kaudu sisselogimisel linnukest pole, seega järgitakse ülalolevat vaikeväärtust. Esimese valiku väljalülitamine peidab linnukese kõikjal ja piirab iga sisselogimise brauseri sessiooniga."
 
-#: lib/phoenix_kit/integrations/validators.ex:616
+#: lib/phoenix_kit/integrations/validators.ex:797
 #, elixir-autogen, elixir-format
 msgid "Plan: %{entries}"
 msgstr "Pakett: %{entries}"
@@ -11653,12 +11667,12 @@ msgstr "SMTP-l pole profiilipõhiseid teenusepakkuja seadeid — relee, port ja 
 msgid "SMTP server rejected the connection"
 msgstr "SMTP-server lükkas ühenduse tagasi"
 
-#: lib/phoenix_kit/integrations/providers.ex:985
+#: lib/phoenix_kit/integrations/providers.ex:1057
 #, elixir-autogen, elixir-format
 msgid "STARTTLS — if offered"
 msgstr "STARTTLS — kui pakutakse"
 
-#: lib/phoenix_kit/integrations/providers.ex:984
+#: lib/phoenix_kit/integrations/providers.ex:1056
 #, elixir-autogen, elixir-format
 msgid "STARTTLS — required"
 msgstr "STARTTLS — kohustuslik"
@@ -11678,7 +11692,7 @@ msgstr "Salvesta saatja andmed"
 msgid "Select an integration..."
 msgstr "Valige integratsioon…"
 
-#: lib/phoenix_kit/integrations/providers.ex:1112
+#: lib/phoenix_kit/integrations/providers.ex:1184
 #, elixir-autogen, elixir-format
 msgid "Send **/newbot** and follow the prompts to name your bot"
 msgstr "Saatke **/newbot** ja järgige juhiseid, et anda botile nimi"
@@ -11692,7 +11706,7 @@ msgstr "Saatke **/newbot** ja järgige juhiseid, et anda botile nimi"
 msgid "Send Profiles"
 msgstr "Saatmisprofiilid"
 
-#: lib/phoenix_kit/integrations/providers.ex:1087
+#: lib/phoenix_kit/integrations/providers.ex:1159
 #, elixir-autogen, elixir-format
 msgid "Send messages and notifications via your own Telegram bot"
 msgstr "Saada sõnumeid ja teavitusi oma Telegrami boti kaudu"
@@ -11782,13 +11796,13 @@ msgstr "TLS-ühenduse loomine ebaõnnestus"
 msgid "Tags"
 msgstr "Sildid"
 
-#: lib/phoenix_kit/integrations/providers.ex:1086
+#: lib/phoenix_kit/integrations/providers.ex:1158
 #: lib/phoenix_kit/notifications/channels/telegram.ex:36
 #, elixir-autogen, elixir-format
 msgid "Telegram"
 msgstr "Telegram"
 
-#: lib/phoenix_kit/integrations/validators.ex:701
+#: lib/phoenix_kit/integrations/validators.ex:882
 #, elixir-autogen, elixir-format
 msgid "Telegram error %{status}"
 msgstr "Telegrami viga %{status}"
@@ -11808,17 +11822,17 @@ msgstr "Testkiri saidilt %{site}"
 msgid "Test email sent to %{recipient}"
 msgstr "Testkiri saadeti aadressile %{recipient}"
 
-#: lib/phoenix_kit_web/users/session.ex:343
+#: lib/phoenix_kit_web/users/session.ex:345
 #, elixir-autogen, elixir-format
 msgid "That account is already in your session — switch to it instead."
 msgstr "See konto on juba teie sessioonis — lülituge lihtsalt sellele."
 
-#: lib/phoenix_kit_web/users/session.ex:337
+#: lib/phoenix_kit_web/users/session.ex:339
 #, elixir-autogen, elixir-format
 msgid "That account is deactivated."
 msgstr "See konto on deaktiveeritud."
 
-#: lib/phoenix_kit_web/users/session.ex:336
+#: lib/phoenix_kit_web/users/session.ex:338
 #, elixir-autogen, elixir-format
 msgid "That is already your account."
 msgstr "See on juba teie konto."
@@ -11859,7 +11873,7 @@ msgstr "See saatmisprofiil kustutatakse jäädavalt."
 msgid "This sender address cannot be logged"
 msgstr "Seda saatja aadressi ei saa logisse kirjutada"
 
-#: lib/phoenix_kit/integrations/providers.ex:1034
+#: lib/phoenix_kit/integrations/providers.ex:1106
 #, elixir-autogen, elixir-format
 msgid "Timeout (seconds)"
 msgstr "Ajalimiit (sekundites)"
@@ -11869,7 +11883,7 @@ msgstr "Ajalimiit (sekundites)"
 msgid "Transport"
 msgstr "Transport"
 
-#: lib/phoenix_kit/integrations/providers.ex:1012
+#: lib/phoenix_kit/integrations/providers.ex:1084
 #, elixir-autogen, elixir-format
 msgid "Turning verification off means the login travels to whoever answers, including an impostor. Use a CA certificate below instead whenever you can."
 msgstr "Kontrolli väljalülitamine tähendab, et kasutajanimi saadetakse igaühele, kes vastab, sealhulgas petturile. Kasutage võimaluse korral allpool CA sertifikaati."
@@ -11899,12 +11913,12 @@ msgstr "Uuenda saatmisprofiili"
 msgid "Used when no default transactional integration is selected below."
 msgstr "Kasutatakse, kui allpool pole valitud vaikimisi tehinguintegratsiooni."
 
-#: lib/phoenix_kit_web/users/session.ex:309
+#: lib/phoenix_kit_web/users/session.ex:311
 #, elixir-autogen, elixir-format
 msgid "User not found."
 msgstr "Kasutajat ei leitud."
 
-#: lib/phoenix_kit/integrations/providers.ex:1016
+#: lib/phoenix_kit/integrations/providers.ex:1088
 #, elixir-autogen, elixir-format
 msgid "Verify (default)"
 msgstr "Kontrolli (vaikimisi)"
@@ -11924,7 +11938,7 @@ msgstr "Saidi integratsioonid"
 msgid "Where a freshly registered account lands. Empty = after-login path."
 msgstr "Kuhu värskelt registreeritud konto jõuab. Tühi = tee pärast sisselogimist."
 
-#: lib/phoenix_kit/integrations/providers.ex:996
+#: lib/phoenix_kit/integrations/providers.ex:1068
 #, elixir-autogen, elixir-format
 msgid "Whether to send the login at all. “If offered” follows the relay; “Never” is for relays that authenticate by IP."
 msgstr "Kas kasutajanime üldse saata. „Kui pakutakse“ järgib releed; „Mitte kunagi“ on releede jaoks, mis autendivad IP järgi."
@@ -11939,12 +11953,12 @@ msgstr "Kellele see bot kirjutab?"
 msgid "Yesterday"
 msgstr "Eile"
 
-#: lib/phoenix_kit_web/users/session.ex:320
+#: lib/phoenix_kit_web/users/session.ex:322
 #, elixir-autogen, elixir-format
 msgid "You are now signed in as %{email}."
 msgstr "Nüüd olete sisse logitud kui %{email}."
 
-#: lib/phoenix_kit_web/users/session.ex:329
+#: lib/phoenix_kit_web/users/session.ex:331
 #, elixir-autogen, elixir-format
 msgid "You do not have permission to sign in as another user."
 msgstr "Teil pole õigust teise kasutajana sisse logida."
@@ -12060,7 +12074,7 @@ msgstr "Kontrollin…"
 msgid "Continue"
 msgstr "Jätka"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:143
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:169
 #, elixir-autogen, elixir-format
 msgid "Copied!"
 msgstr "Kopeeritud!"
@@ -12070,7 +12084,7 @@ msgstr "Kopeeritud!"
 msgid "Couldn't reach hex.pm, so the package list is unavailable right now."
 msgstr "hex.pm ei ole kättesaadav, seega pakettide nimekiri pole praegu saadaval."
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:119
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:145
 #, elixir-autogen, elixir-format
 msgid "Crawler Instructions"
 msgstr "Juhised otsingurobotitele"
@@ -12124,7 +12138,7 @@ msgstr "Tere tulemast! Sinu soovituskood on vastu võetud."
 msgid "has the robots.txt line that points crawlers here."
 msgstr "sisaldab robots.txt rida, mis suunab otsingurobotid siia."
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:173
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:199
 #, elixir-autogen, elixir-format
 msgid "priv/static/robots.txt points crawlers at your sitemap."
 msgstr "priv/static/robots.txt suunab otsingurobotid sinu saidikaardile."
@@ -12228,17 +12242,17 @@ msgstr "Sul puudub luba seda kasutajat kustutada"
 msgid "You don't have permission to manage this user's credentials"
 msgstr "Sul puudub luba selle kasutaja sisselogimisandmeid hallata"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:190
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:216
 #, elixir-autogen, elixir-format
 msgid "AI Discovery"
 msgstr "AI avastamine"
 
-#: lib/phoenix_kit/integrations/providers.ex:698
+#: lib/phoenix_kit/integrations/providers.ex:699
 #, elixir-autogen, elixir-format
 msgid "AWS Bedrock LLMs via a Bedrock API key (OpenAI-compatible endpoint: gpt-oss models; the rest via native Converse)"
 msgstr "AWS Bedrocki LLM-id Bedrocki API võtme kaudu (OpenAI-ga ühilduv lõpp-punkt: gpt-oss mudelid; ülejäänud natiivse Converse'i kaudu)"
 
-#: lib/phoenix_kit/integrations/providers.ex:715
+#: lib/phoenix_kit/integrations/providers.ex:716
 #, elixir-autogen, elixir-format
 msgid "AWS console → Amazon Bedrock → API keys (long-term key)"
 msgstr "AWS konsool → Amazon Bedrock → API võtmed (pikaajaline võti)"
@@ -12253,22 +12267,22 @@ msgstr "Ligipääsu taotletud."
 msgid "Account %{id}"
 msgstr "Konto %{id}"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:303
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:329
 #, elixir-autogen, elixir-format
 msgid "Advisory-grade: anything can send any User-Agent, so a scraper that lies passes through. Real enforcement belongs at your CDN or reverse proxy — this catches the honest-but-ignorant. Bots identified only by robots.txt tokens (Google-Extended, Applebot-Extended) crawl under their main user agent and are never matched here, so blocking AI training cannot 403 Googlebot."
 msgstr "Nõuandev tase: igaüks võib saata suvalise User-Agenti, seega valetav kraapija pääseb läbi. Tegelik jõustamine käib sinu CDN-i või pöördproksi kaudu — siin püütakse kinni ausad, kuid teadmatud. Botid, keda tuvastatakse ainult robots.txt-i märgendite järgi (Google-Extended, Applebot-Extended), roomavad oma peamise kasutajaagendi all ega satu siin kunagi vastavusse, seega AI-treeningu blokeerimine ei saa Googlebotile 403 vastata."
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:98
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:124
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Allowed"
 msgstr "Kõik"
 
-#: lib/phoenix_kit/integrations/providers.ex:696
+#: lib/phoenix_kit/integrations/providers.ex:697
 #, elixir-autogen, elixir-format
 msgid "Amazon Bedrock"
 msgstr "Amazon Bedrock"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:282
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:308
 #, elixir-autogen, elixir-format
 msgid "Answer 403 to requests whose User-Agent matches a blocked group, for bots that ignore robots.txt."
 msgstr "Vasta 403-ga päringutele, mille User-Agent vastab blokeeritud rühmale — botidele, kes eiravad robots.txt-i."
@@ -12278,7 +12292,7 @@ msgstr "Vasta 403-ga päringutele, mille User-Agent vastab blokeeritud rühmale 
 msgid "Auth mail carries single-use tokens, and /dev/mailbox has no authentication — anyone who can reach this server can read them. Only for closed environments."
 msgstr "Autentimiskirjad sisaldavad ühekordseid tokeneid ja /dev/mailbox ei nõua autentimist — igaüks, kes selle serverini pääseb, saab neid lugeda. Ainult suletud keskkondadeks."
 
-#: lib/phoenix_kit/integrations/providers.ex:711
+#: lib/phoenix_kit/integrations/providers.ex:712
 #, elixir-autogen, elixir-format
 msgid "Bedrock API key"
 msgstr "Bedrocki API võti"
@@ -12288,7 +12302,7 @@ msgstr "Bedrocki API võti"
 msgid "Bedrock error %{status}"
 msgstr "Brevo viga %{status}"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:280
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:306
 #, elixir-autogen, elixir-format
 msgid "Block at the application"
 msgstr "Blokeeri rakenduse tasemel"
@@ -12298,7 +12312,7 @@ msgstr "Blokeeri rakenduse tasemel"
 msgid "Blocked groups"
 msgstr "Blokeeritud"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:77
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:103
 #, elixir-autogen, elixir-format
 msgid "Bot Access"
 msgstr "Botide ligipääs"
@@ -12313,12 +12327,12 @@ msgstr "Vaikimisi näitab mainimine seda, mida ta nimetab, ka ligipääsuta kasu
 msgid "Control how search engines and AI bots crawl and index this site"
 msgstr "Halda, kuidas otsingumootorid ja AI-botid seda saiti roomavad ja indekseerivad"
 
-#: lib/phoenix_kit/integrations/providers.ex:739
+#: lib/phoenix_kit/integrations/providers.ex:740
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Copy the key (shown once, `ABSK…`) and paste it into the form above"
 msgstr "Kopeeri võti (kuvatakse ühekordselt) ja kleebi see ülalolevasse vormi"
 
-#: lib/phoenix_kit/integrations/providers.ex:815
+#: lib/phoenix_kit/integrations/providers.ex:816
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Copy the token and paste it into the form above"
 msgstr "Kopeeri võti ja kleebi see ülalolevasse vormi"
@@ -12359,22 +12373,22 @@ msgstr "Roomajad"
 msgid "Crawlers module is disabled. Enable it from the Modules page to configure settings."
 msgstr "SEO moodul on keelatud. Luba see Moodulite lehelt seadete konfigureerimiseks."
 
-#: lib/phoenix_kit/integrations/providers.ex:731
+#: lib/phoenix_kit/integrations/providers.ex:732
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Create a Bedrock API key"
 msgstr "Loo API võti"
 
-#: lib/phoenix_kit/integrations/providers.ex:807
+#: lib/phoenix_kit/integrations/providers.ex:808
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Create a token"
 msgstr "Loo roll"
 
-#: lib/phoenix_kit/integrations/providers.ex:871
+#: lib/phoenix_kit/integrations/providers.ex:872
 #, elixir-autogen, elixir-format
 msgid "Create an IAM user with SES access"
 msgstr "Loo SES-i ligipääsuga IAM kasutaja"
 
-#: lib/phoenix_kit/integrations/providers.ex:876
+#: lib/phoenix_kit/integrations/providers.ex:877
 #, elixir-autogen, elixir-format
 msgid "Create an access key for that user (Security credentials → Create access key) and paste the ID and secret above"
 msgstr "Loo sellele kasutajale pääsuvõti (Security credentials → Create access key) ja kleebi ID ning saladus ülal"
@@ -12389,41 +12403,42 @@ msgstr "Otsusta, kes tohib seda saiti lugeda — indekseerimisjuhised, botipõhi
 msgid "Deliver development mail to /dev/mailbox"
 msgstr "Toimeta arenduskirjad kausta /dev/mailbox"
 
-#: lib/phoenix_kit/integrations/providers.ex:747
+#: lib/phoenix_kit/integrations/providers.ex:748
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enable model access"
 msgstr "Luba moodul seadetele juurdepääsemiseks"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:278
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:304
 #, elixir-autogen, elixir-format
 msgid "Enforcement"
 msgstr "Jõustamine"
 
 #: lib/phoenix_kit_web/live/settings/crawlers.ex:90
-#: lib/phoenix_kit_web/live/settings/crawlers.ex:109
-#: lib/phoenix_kit_web/live/settings/crawlers.ex:120
-#: lib/phoenix_kit_web/live/settings/crawlers.ex:136
-#: lib/phoenix_kit_web/live/settings/crawlers.ex:149
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:102
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:121
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:132
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:148
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:161
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to update crawler settings"
 msgstr "Seade uuendamine ebaõnnestus"
 
-#: lib/phoenix_kit/integrations/providers.ex:780
+#: lib/phoenix_kit/integrations/providers.ex:781
 #, elixir-autogen, elixir-format, fuzzy
 msgid "GitHub"
 msgstr "GitHub sisselogimine"
 
-#: lib/phoenix_kit/integrations/providers.ex:782
+#: lib/phoenix_kit/integrations/providers.ex:783
 #, elixir-autogen, elixir-format
 msgid "GitHub API token — org statistics, repositories (read-only is enough)"
 msgstr "GitHubi API token — organisatsiooni statistika, repositooriumid (piisab kirjutuskaitstust)"
 
-#: lib/phoenix_kit/integrations/providers.ex:809
+#: lib/phoenix_kit/integrations/providers.ex:810
 #, elixir-autogen, elixir-format
 msgid "Go to [Fine-grained tokens](https://github.com/settings/personal-access-tokens) and click **Generate new token**"
 msgstr "Mine lehele [Fine-grained tokens](https://github.com/settings/personal-access-tokens) ja klõpsa **Generate new token**"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:81
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:107
 #, elixir-autogen, elixir-format
 msgid "Grouped by why they visit. Blocking a group writes it into the generated robots.txt below; everything defaults to allowed."
 msgstr "Rühmitatud külastuse põhjuse järgi. Rühma blokeerimine kirjutab selle allolevasse genereeritud robots.txt-i; vaikimisi on kõik lubatud."
@@ -12433,22 +12448,22 @@ msgstr "Rühmitatud külastuse põhjuse järgi. Rühma blokeerimine kirjutab sel
 msgid "Hide titles of records the reader can't open"
 msgstr "Peida kirjete pealkirjad, mida lugeja ei saa avada"
 
-#: lib/phoenix_kit/integrations/providers.ex:749
+#: lib/phoenix_kit/integrations/providers.ex:750
 #, elixir-autogen, elixir-format
 msgid "In [Bedrock → Model access](https://console.aws.amazon.com/bedrock/home#/modelaccess) enable the models you plan to call — a key with no enabled models validates but cannot complete"
 msgstr "Luba jaotises [Bedrock → Model access](https://console.aws.amazon.com/bedrock/home#/modelaccess) mudelid, mida kavatsed kasutada — ilma lubatud mudeliteta võti valideerub, kuid ei tööta"
 
-#: lib/phoenix_kit/integrations/providers.ex:763
+#: lib/phoenix_kit/integrations/providers.ex:764
 #, elixir-autogen, elixir-format
 msgid "In the AI module, create an endpoint pointing at this connection with a `gpt-oss` model and a base URL in the SAME region as this key"
 msgstr "Loo AI moodulis lõpp-punkt, mis osutab sellele ühendusele `gpt-oss` mudeli ja SAMAS regioonis oleva baas-URL-iga nagu see võti"
 
-#: lib/phoenix_kit/integrations/providers.ex:873
+#: lib/phoenix_kit/integrations/providers.ex:874
 #, elixir-autogen, elixir-format
 msgid "In the [IAM console](https://console.aws.amazon.com/iam/home#/users) create a user for programmatic access and attach an SES policy (least privilege: `ses:SendEmail`/`ses:SendRawEmail`; docs: [SES setup](https://docs.aws.amazon.com/ses/latest/dg/setting-up.html))"
 msgstr "Loo [IAM konsoolis](https://console.aws.amazon.com/iam/home#/users) programmilise ligipääsu kasutaja ja lisa SES-i poliitika (minimaalsed õigused: `ses:SendEmail`/`ses:SendRawEmail`; dokumendid: [SES-i seadistamine](https://docs.aws.amazon.com/ses/latest/dg/setting-up.html))"
 
-#: lib/phoenix_kit/integrations/providers.ex:884
+#: lib/phoenix_kit/integrations/providers.ex:885
 #, elixir-autogen, elixir-format
 msgid "In the [SES console](https://console.aws.amazon.com/ses/home#/identities) verify your domain or sender address — SES refuses to send from unverified identities"
 msgstr "Kinnita [SES konsoolis](https://console.aws.amazon.com/ses/home#/identities) oma domeen või saatja aadress — SES keeldub saatmast kinnitamata identiteetidelt"
@@ -12493,7 +12508,7 @@ msgstr "Mainimised ja kirjeviited"
 msgid "Model catalog in %{region}: %{count} (grants are configured separately)"
 msgstr "Mudelikataloog regioonis %{region}: %{count} (õigused seadistatakse eraldi)"
 
-#: lib/phoenix_kit/integrations/providers.ex:887
+#: lib/phoenix_kit/integrations/providers.ex:888
 #, elixir-autogen, elixir-format
 msgid "New accounts start in the SES sandbox (verified recipients only) — [request production access](https://docs.aws.amazon.com/ses/latest/dg/request-production-access.html) before real sending"
 msgstr "Uued kontod alustavad SES-i liivakastis (ainult kinnitatud saajad) — [taotle tootmisligipääsu](https://docs.aws.amazon.com/ses/latest/dg/request-production-access.html) enne päris saatmist"
@@ -12508,7 +12523,7 @@ msgstr "Selle päringu kohta ei õnnestunud seadme andmeid tuvastada."
 msgid "No longer available"
 msgstr "Pole enam saadaval"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:165
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:191
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No priv/static/robots.txt found. Without one, crawlers assume everything is allowed — and any groups you blocked above are not being told."
 msgstr "Faili priv/static/robots.txt ei leitud. Ilma selleta eeldavad otsingurobotid, et kõik on lubatud — see on enamasti sobiv, kuid nad ei saa teada, kus su saidikaart asub."
@@ -12523,47 +12538,47 @@ msgstr "Sellel lehel ei kuvata"
 msgid "Note (optional)"
 msgstr "Märkus (valikuline)"
 
-#: lib/phoenix_kit/integrations/providers.ex:733
+#: lib/phoenix_kit/integrations/providers.ex:734
 #, elixir-autogen, elixir-format
 msgid "Open the [Bedrock console → API keys](https://console.aws.amazon.com/bedrock/home#/api-keys) and generate a **long-term** key (docs: [Bedrock API keys](https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys.html))"
 msgstr "Ava [Bedrocki konsool → API keys](https://console.aws.amazon.com/bedrock/home#/api-keys) ja genereeri **pikaajaline** võti (dokumendid: [Bedrocki API võtmed](https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys.html))"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:212
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:238
 #, elixir-autogen, elixir-format
 msgid "Optional markdown: a summary paragraph, key links, docs pointers…"
 msgstr "Valikuline markdown: kokkuvõttev lõik, olulised lingid, viited dokumentatsioonile…"
 
-#: lib/phoenix_kit/integrations/providers.ex:736
+#: lib/phoenix_kit/integrations/providers.ex:737
 #, elixir-autogen, elixir-format
 msgid "Or attach one to an existing IAM user: [IAM console](https://console.aws.amazon.com/iam/home#/users) → user → Security credentials → Bedrock API keys"
 msgstr "Või lisa see olemasolevale IAM kasutajale: [IAM konsool](https://console.aws.amazon.com/iam/home#/users) → kasutaja → Security credentials → Bedrock API keys"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:235
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:261
 #, elixir-autogen, elixir-format
 msgid "Paste the verification content Google Search Console or Bing Webmaster Tools gives you — the meta tags are added to every layout head. Pasting the whole <meta> tag also works; the content value is extracted."
 msgstr "Kleebi kinnitussisu, mille Google Search Console või Bing Webmaster Tools annab — meta-sildid lisatakse iga paigutuse päisesse. Töötab ka terve <meta> sildi kleepimine; content-väärtus eraldatakse."
 
-#: lib/phoenix_kit/integrations/providers.ex:796
+#: lib/phoenix_kit/integrations/providers.ex:797
 #, elixir-autogen, elixir-format
 msgid "Personal access token"
 msgstr "Isiklik pääsutoken"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:123
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:149
 #, elixir-autogen, elixir-format
 msgid "PhoenixKit does not serve this file — it is yours, served from priv/static before any route is consulted. This is the complete file your toggles above describe: paste it into priv/static/robots.txt."
 msgstr "PhoenixKit ei serveeri seda faili — see on sinu oma ja serveeritakse kaustast priv/static enne ühegi marsruudi kontrollimist. See on terviklik fail, mida ülalolevad lülitid kirjeldavad: kleebi see faili priv/static/robots.txt."
 
-#: lib/phoenix_kit/integrations/providers.ex:752
+#: lib/phoenix_kit/integrations/providers.ex:753
 #, elixir-autogen, elixir-format
 msgid "Pick the region where access was granted; the AI endpoint's base URL must use the same region"
 msgstr "Vali regioon, kus ligipääs anti; AI lõpp-punkti baas-URL peab kasutama sama regiooni"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:217
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:243
 #, elixir-autogen, elixir-format
 msgid "Preview of the served file:"
 msgstr "Serveeritava faili eelvaade:"
 
-#: lib/phoenix_kit/integrations/providers.ex:812
+#: lib/phoenix_kit/integrations/providers.ex:813
 #, elixir-autogen, elixir-format
 msgid "Repository access: **Public repositories (read-only)** — no extra permissions needed for public-org statistics"
 msgstr "Repositooriumide ligipääs: **Public repositories (read-only)** — avaliku organisatsiooni statistika jaoks lisaõigusi ei ole vaja"
@@ -12573,7 +12588,7 @@ msgstr "Repositooriumide ligipääs: **Public repositories (read-only)** — ava
 msgid "Request access"
 msgstr "Taotletud"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:233
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:259
 #, elixir-autogen, elixir-format
 msgid "Search engine verification"
 msgstr "Otsingumootori kinnitamine"
@@ -12593,12 +12608,12 @@ msgstr "Ootel"
 msgid "Sign in to request access."
 msgstr "Logi sisse kasutajana"
 
-#: lib/phoenix_kit/integrations/providers.ex:760
+#: lib/phoenix_kit/integrations/providers.ex:761
 #, elixir-autogen, elixir-format
 msgid "The OpenAI-compatible endpoint (`…/openai/v1`) currently serves only the `openai.gpt-oss-*` models — Anthropic and the other Bedrock models answer on the native Converse API with the same key"
 msgstr "OpenAI-ga ühilduv lõpp-punkt (`…/openai/v1`) teenindab praegu ainult `openai.gpt-oss-*` mudeleid — Anthropic ja ülejäänud Bedrocki mudelid vastavad sama võtmega natiivses Converse API-s"
 
-#: lib/phoenix_kit/integrations/providers.ex:742
+#: lib/phoenix_kit/integrations/providers.ex:743
 #, elixir-autogen, elixir-format
 msgid "The key's IAM identity must allow the `bedrock:CallWithBearerToken` action — without it every Bearer call answers 403 even when invoke permissions are in place."
 msgstr "Võtme IAM identiteet peab lubama tegevuse `bedrock:CallWithBearerToken` — ilma selleta vastab iga Bearer-päring 403-ga isegi siis, kui väljakutsumisõigused on olemas."
@@ -12608,17 +12623,17 @@ msgstr "Võtme IAM identiteet peab lubama tegevuse `bedrock:CallWithBearerToken`
 msgid "The mailbox is off: outgoing mail is written to the server log instead."
 msgstr "Postkast on välja lülitatud: väljuvad kirjad kirjutatakse selle asemel serveri logisse."
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:179
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:205
 #, elixir-autogen, elixir-format, fuzzy
 msgid "The noindex toggle and robots.txt are separate mechanisms: noindex is a per-page meta tag that tells crawlers not to index what they fetched, while robots.txt tells them what not to fetch at all. A staging site usually wants both."
 msgstr "Ülalolev noindex-lüliti ja robots.txt on eraldi mehhanismid: noindex on lehepõhine metasilt, mis ütleb otsingurobotitele, et allalaaditut ei indekseeritaks, robots.txt aga ütleb, mida üldse mitte alla laadida. Testkeskkond vajab tavaliselt mõlemat."
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:194
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:220
 #, elixir-autogen, elixir-format
 msgid "The other half of bot policy: a markdown summary telling AI assistants what this site is about, served at"
 msgstr "Botipoliitika teine pool: markdown-kokkuvõte, mis ütleb AI-assistentidele, millest see sait räägib; serveeritakse aadressil"
 
-#: lib/phoenix_kit/integrations/providers.ex:892
+#: lib/phoenix_kit/integrations/providers.ex:893
 #, elixir-autogen, elixir-format
 msgid "This connection stores the credential. The full sending pipeline — configuration set, SNS topic, SQS event queue, delivery tracking — is configured in Admin → Settings → Emails, which can select this connection as its credential source."
 msgstr "See ühendus salvestab mandaadi. Kogu saatmiskonveier — konfiguratsioonikomplekt, SNS teema, SQS sündmusejärjekord, kohaletoimetamise jälgimine — seadistatakse jaotises Admin → Seaded → E-kirjad, mis saab valida selle ühenduse mandaadi allikaks."
@@ -12635,22 +12650,22 @@ msgstr "Kirjuta @, et kedagi mainida, ja #, et kirjele viidata."
 msgid "Unread · %{day}"
 msgstr "Lugemata · %{day}"
 
-#: lib/phoenix_kit/integrations/providers.ex:758
+#: lib/phoenix_kit/integrations/providers.ex:759
 #, elixir-autogen, elixir-format
 msgid "Use it from the AI module"
 msgstr "Kasuta seda AI moodulist"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:231
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:257
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Verification"
 msgstr "Teavitused"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.ex:133
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:145
 #, elixir-autogen, elixir-format
 msgid "Verification tags saved."
 msgstr "Kinnitussildid salvestatud."
 
-#: lib/phoenix_kit/integrations/providers.ex:882
+#: lib/phoenix_kit/integrations/providers.ex:883
 #, elixir-autogen, elixir-format
 msgid "Verify a sender in SES"
 msgstr "Kinnita saatja SES-is"
@@ -12665,7 +12680,7 @@ msgstr "Milleks sa seda vajad?"
 msgid "Where development mail goes while the resolved transport is the local adapter."
 msgstr "Kuhu lähevad arenduskirjad, kui lahendatud transport on kohalik adapter."
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:79
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "Who may crawl this site"
 msgstr "Kes tohib seda saiti roomata"
@@ -12685,12 +12700,12 @@ msgstr "Sul puudub ligipääs sellele objektile: %{kind}. Küsi neilt, kellele s
 msgid "You don't have access — click to request it"
 msgstr "Sul puudub ligipääs — klõpsa, et seda taotleda"
 
-#: lib/phoenix_kit/integrations/providers.ex:800
+#: lib/phoenix_kit/integrations/providers.ex:801
 #, elixir-autogen, elixir-format
 msgid "github.com/settings/personal-access-tokens — fine-grained, read-only"
 msgstr "github.com/settings/personal-access-tokens — peeneteraline, kirjutuskaitstud"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.ex:146
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:158
 #, elixir-autogen, elixir-format
 msgid "llms.txt content saved."
 msgstr "llms.txt sisu salvestatud."
@@ -12700,7 +12715,7 @@ msgstr "llms.txt sisu salvestatud."
 msgid "management API: %{services}"
 msgstr "haldus-API: %{services}"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:169
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:195
 #, elixir-autogen, elixir-format, fuzzy
 msgid "priv/static/robots.txt exists but has no Sitemap: line. Paste the file above so crawlers are told where to look."
 msgstr "Fail priv/static/robots.txt on olemas, kuid selles puudub rida Sitemap:. Lisa ülalolev rida, et otsingurobotid teaksid, kust otsida."
@@ -12710,7 +12725,7 @@ msgstr "Fail priv/static/robots.txt on olemas, kuid selles puudub rida Sitemap:.
 msgid "private item"
 msgstr "privaatne kirje"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:200
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:226
 #, elixir-autogen, elixir-format
 msgid "while this module is enabled. The heading comes from your project title; everything below it is yours."
 msgstr "kuni see moodul on sisse lülitatud. Pealkiri tuleb sinu projekti nimest; kõik selle all on sinu oma."
@@ -12764,7 +12779,7 @@ msgstr "Vali helifail"
 msgid "Select Avatar"
 msgstr "Vali avatar"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:701
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:716
 #, elixir-autogen, elixir-format
 msgid "Select Background Image"
 msgstr "Vali taustapilt"
@@ -12781,7 +12796,7 @@ msgstr "Vali pildid"
 
 #: lib/phoenix_kit_web/components/media_browser.html.heex:2469
 #: lib/phoenix_kit_web/live/settings.html.heex:636
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:702
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:717
 #, elixir-autogen, elixir-format
 msgid "Select Logo"
 msgstr "Vali logo"
@@ -12880,3 +12895,422 @@ msgstr "Integratsiooni mandaatide krüpteerimine vajab tähelepanu"
 #, elixir-autogen, elixir-format
 msgid "The current encryption status could not be described by this admin page — it may be newer than what this page recognizes. Check PhoenixKit.Integrations.Encryption.status/0 directly."
 msgstr "Praegust krüpteerimise olekut ei õnnestunud sellel haldusleheküljel kirjeldada — see võib olla uuem kui see lehekülg ära tunneb. Kontrollige otse PhoenixKit.Integrations.Encryption.status/0."
+
+#: lib/phoenix_kit_web/live/settings/authorization.ex:247
+#, elixir-autogen, elixir-format
+msgid "A secret is already configured — leave blank to keep the current value"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:365
+#: lib/phoenix_kit_web/users/session.ex:245
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Account added."
+msgstr "Konto"
+
+#: lib/phoenix_kit_web/users/session.ex:27
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Account created successfully!"
+msgstr "Bucket lubati edukalt"
+
+#: lib/phoenix_kit_web/users/session.ex:356
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Account removed."
+msgstr "Konto"
+
+#: lib/phoenix_kit_web/users/oauth.ex:272
+#, elixir-autogen, elixir-format
+msgid "Account switching is currently disabled."
+msgstr "Konto vahetamine on hetkel keelatud."
+
+#: lib/phoenix_kit_web/users/oauth.ex:316
+#, elixir-autogen, elixir-format
+msgid "An account already exists for that email address. Sign in with your password first, then connect this provider from your account settings."
+msgstr "Selle e-posti aadressiga konto on juba olemas. Logige esmalt sisse parooliga, seejärel ühendage see teenusepakkuja oma konto seadetest."
+
+#: lib/phoenix_kit_web/users/oauth.ex:328
+#, elixir-autogen, elixir-format
+msgid "Authentication failed. Please try again or use a different sign-in method."
+msgstr "Autentimine ebaõnnestus. Palun proovige uuesti või kasutage mõnda muud sisselogimismeetodit."
+
+#: lib/phoenix_kit_web/users/oauth.ex:355
+#: lib/phoenix_kit_web/users/oauth.ex:438
+#: lib/phoenix_kit_web/users/oauth.ex:444
+#, elixir-autogen, elixir-format
+msgid "Authentication failed. Please try again."
+msgstr "Autentimine ebaõnnestus. Palun proovige uuesti."
+
+#: lib/phoenix_kit_web/users/oauth.ex:299
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Authentication failed: %{errors}"
+msgstr "Autentimine"
+
+#: lib/phoenix_kit_web/users/oauth.ex:441
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Authentication failed: %{message}"
+msgstr "Autentimine"
+
+#: lib/phoenix_kit_web/users/session.ex:360
+#, elixir-autogen, elixir-format
+msgid "Cannot remove your primary account."
+msgstr "Teie peamist kontot ei saa eemaldada."
+
+#: lib/phoenix_kit_web/controllers/context_controller.ex:101
+#, elixir-autogen, elixir-format
+msgid "Context switching is not enabled"
+msgstr "Konteksti vahetamine ei ole lubatud"
+
+#: lib/phoenix_kit/integrations/validators.ex:627
+#: lib/phoenix_kit/integrations/validators.ex:634
+#: lib/phoenix_kit/integrations/validators.ex:732
+#: lib/phoenix_kit/integrations/validators.ex:740
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Could not reach the storage endpoint"
+msgstr "Teenusele ei saanud juurde pääseda"
+
+#: lib/phoenix_kit_web/users/session.ex:365
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Could not remove account."
+msgstr "Brevoga ei saanud ühendust"
+
+#: lib/phoenix_kit_web/users/session.ex:274
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Could not switch account."
+msgstr "Vestlusi ei saanud lahti siduda"
+
+#: lib/phoenix_kit/integrations/validators.ex:721
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Credentials are valid, but not authorized to list buckets"
+msgstr "Mandaadid on kehtivad, kuid puudub õigus GetSendQuota jaoks — saatmist ei kontrollitud"
+
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:85
+#, elixir-autogen, elixir-format
+msgid "Exempt"
+msgstr ""
+
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:86
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Follows noindex"
+msgstr "Jälgimised"
+
+#: lib/phoenix_kit_web/users/magic_link.ex:120
+#, elixir-autogen, elixir-format
+msgid "If that email address exists, a magic link has been sent."
+msgstr "Kui see e-posti aadress on olemas, on Magic Link saadetud."
+
+#: lib/phoenix_kit_web/users/confirmation_instructions.ex:89
+#, elixir-autogen, elixir-format
+msgid "If your email is in our system and it has not been confirmed yet, you will receive an email with instructions shortly."
+msgstr "Kui teie e-post on meie süsteemis ja pole veel kinnitatud, saate peagi juhistega e-kirja."
+
+#: lib/phoenix_kit_web/users/forgot_password.ex:49
+#, elixir-autogen, elixir-format
+msgid "If your email is in our system, you will receive instructions to reset your password shortly."
+msgstr "Kui teie e-post on meie süsteemis, saate peagi parooli lähtestamise juhised."
+
+#: lib/phoenix_kit_web/controllers/context_controller.ex:82
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Invalid context"
+msgstr "Vigane boti token"
+
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:110
+#, elixir-autogen, elixir-format
+msgid "Invalid email format"
+msgstr "Vigane e-posti vorming"
+
+#: lib/phoenix_kit_web/users/session.ex:92
+#, elixir-autogen, elixir-format
+msgid "Invalid email/username or password"
+msgstr "Vale e-post/kasutajanimi või parool"
+
+#: lib/phoenix_kit_web/users/session.ex:259
+#, elixir-autogen, elixir-format
+msgid "Invalid email/username or password."
+msgstr "Vale e-post/kasutajanimi või parool."
+
+#: lib/phoenix_kit_web/users/magic_link_verify.ex:40
+#, elixir-autogen, elixir-format
+msgid "Invalid magic link. Please request a new one."
+msgstr "Vigane Magic Link. Palun taotlege uus link."
+
+#: lib/phoenix_kit_web/users/magic_link_registration_verify.ex:32
+#, elixir-autogen, elixir-format
+msgid "Invalid registration link. Please request a new one."
+msgstr "Vigane registreerimislink. Palun taotlege uus link."
+
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:77
+#, elixir-autogen, elixir-format
+msgid "Keep publishing the sitemap's real URLs even while noindex is on, so the feed can be verified without exposing the site to indexing. The noindex meta tag above is unaffected either way."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/session.ex:104
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Logged out of all accounts."
+msgstr "Logi välja kõigilt kontodelt"
+
+#: lib/phoenix_kit_web/users/session.ex:122
+#: lib/phoenix_kit_web/users/session.ex:235
+#, elixir-autogen, elixir-format
+msgid "Logged out successfully."
+msgstr "Välja logitud edukalt."
+
+#: lib/phoenix_kit_web/users/magic_link_verify.ex:63
+#, elixir-autogen, elixir-format
+msgid "Magic link is invalid or has expired. Please request a new one."
+msgstr "Magic Link on kehtetu või aegunud. Palun taotlege uus link."
+
+#: lib/phoenix_kit_web/users/magic_link_registration.ex:41
+#, elixir-autogen, elixir-format
+msgid "Magic link registration is currently disabled."
+msgstr "Magic Linki registreerimine on hetkel keelatud."
+
+#: lib/phoenix_kit_web/users/magic_link.ex:110
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Magic link sent! Check your email."
+msgstr "Magic Link saadetud!"
+
+#: lib/phoenix_kit_web/users/magic_link.ex:39
+#: lib/phoenix_kit_web/users/magic_link_verify.ex:33
+#, elixir-autogen, elixir-format
+msgid "Magic link sign-in is currently disabled."
+msgstr "Magic Linkiga sisselogimine on hetkel keelatud."
+
+#: lib/phoenix_kit_web/users/oauth.ex:370
+#: lib/phoenix_kit_web/users/session.ex:249
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Maximum number of accounts reached."
+msgstr "Kontode ülempiir on täis — eemaldage kõigepealt üks."
+
+#: lib/phoenix_kit_web/users/session.ex:137
+#, elixir-autogen, elixir-format
+msgid "Multi-account switching is not available."
+msgstr "Mitme konto vahel lülitumine ei ole saadaval."
+
+#: lib/phoenix_kit/integrations/providers.ex:950
+#, elixir-autogen, elixir-format
+msgid "Not every S3-compatible provider needs one — leave blank if the endpoint doesn't require it."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:119
+#, elixir-autogen, elixir-format
+msgid "OAuth authentication is currently disabled. Please contact your administrator to enable it."
+msgstr "OAuth autentimine on hetkel keelatud. Palun võtke ühendust administraatoriga selle lubamiseks."
+
+#: lib/phoenix_kit_web/users/oauth.ex:94
+#, elixir-autogen, elixir-format
+msgid "OAuth provider '%{provider}' is currently disabled."
+msgstr "OAuth teenusepakkuja '%{provider}' on hetkel keelatud."
+
+#: lib/phoenix_kit_web/users/oauth.ex:106
+#, elixir-autogen, elixir-format
+msgid "OAuth provider '%{provider}' is not configured. Please contact your administrator."
+msgstr "OAuth teenusepakkuja '%{provider}' ei ole seadistatud. Palun võtke ühendust administraatoriga."
+
+#: lib/phoenix_kit/integrations/providers.ex:913
+#, elixir-autogen, elixir-format
+msgid "Object Storage (S3-compatible)"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/reset_password.ex:41
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Password reset successfully."
+msgstr "Parool muudetud edukalt."
+
+#: lib/phoenix_kit_web/users/session.ex:34
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Password updated successfully!"
+msgstr "Parool muudetud edukalt."
+
+#: lib/phoenix_kit_web/users/magic_link_registration.ex:35
+#: lib/phoenix_kit_web/users/registration.ex:128
+#, elixir-autogen, elixir-format
+msgid "Registration is currently disabled."
+msgstr "Registreerimine on hetkel keelatud."
+
+#: lib/phoenix_kit_web/users/magic_link_registration.ex:92
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Registration link is invalid or has expired."
+msgstr "E-posti muutmise link on kehtetu või aegunud."
+
+#: lib/phoenix_kit_web/users/magic_link_registration.ex:188
+#: lib/phoenix_kit_web/users/magic_link_registration_verify.ex:24
+#, elixir-autogen, elixir-format
+msgid "Registration link is invalid or has expired. Please request a new one."
+msgstr "Registreerimislink on kehtetu või aegunud. Palun taotlege uus link."
+
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:92
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:103
+#, elixir-autogen, elixir-format
+msgid "Registration link sent! Check your email."
+msgstr "Registreerimislink saadetud! Vaata oma e-posti."
+
+#: lib/phoenix_kit/integrations/providers.ex:962
+#, elixir-autogen, elixir-format
+msgid "Required for Cloudflare R2, Backblaze B2, Tigris, and self-hosted S3-compatible storage. Leave blank for AWS S3."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/reset_password.ex:59
+#, elixir-autogen, elixir-format
+msgid "Reset password link is invalid or it has expired."
+msgstr "Parooli lähtestamise link on kehtetu või aegunud."
+
+#: lib/phoenix_kit/integrations/providers.ex:915
+#, elixir-autogen, elixir-format
+msgid "S3-compatible object storage — AWS S3, Cloudflare R2, Backblaze B2, Tigris, or a self-hosted endpoint"
+msgstr ""
+
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:75
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Sitemap Exemption"
+msgstr "Saidikaardi seaded"
+
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:144
+#, elixir-autogen, elixir-format
+msgid "Something went wrong"
+msgstr "Midagi läks valesti"
+
+#: lib/phoenix_kit/integrations/validators.ex:735
+#, elixir-autogen, elixir-format
+msgid "Storage error: %{code}"
+msgstr ""
+
+#: lib/phoenix_kit/integrations/validators.ex:729
+#, elixir-autogen, elixir-format
+msgid "Storage service is busy — try again in a moment"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_verify.ex:56
+#, elixir-autogen, elixir-format
+msgid "Successfully logged in with magic link!"
+msgstr "Sisselogimine Magic Linkiga õnnestus!"
+
+#: lib/phoenix_kit_web/users/oauth.ex:277
+#, elixir-autogen, elixir-format
+msgid "Successfully signed in with %{provider}!"
+msgstr "Sisselogimine teenusepakkujaga '%{provider}' õnnestus!"
+
+#: lib/phoenix_kit_web/users/oauth.ex:375
+#: lib/phoenix_kit_web/users/session.ex:254
+#, elixir-autogen, elixir-format, fuzzy
+msgid "That account is already in your session."
+msgstr "See konto on juba teie sessioonis — lülituge lihtsalt sellele."
+
+#: lib/phoenix_kit_web/users/oauth.ex:380
+#, elixir-autogen, elixir-format, fuzzy
+msgid "That account is inactive."
+msgstr "See konto on deaktiveeritud."
+
+#: lib/phoenix_kit_web/users/magic_link_registration.ex:185
+#, elixir-autogen, elixir-format
+msgid "That email is already registered. Please log in instead."
+msgstr "See e-post on juba registreeritud. Palun logige selle asemel sisse."
+
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:118
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Too many attempts"
+msgstr "Liiga palju faile"
+
+#: lib/phoenix_kit_web/users/session.ex:84
+#, elixir-autogen, elixir-format
+msgid "Too many login attempts. Please try again later."
+msgstr "Liiga palju sisselogimiskatseid. Palun proovige hiljem uuesti."
+
+#: lib/phoenix_kit_web/users/oauth.ex:84
+#: lib/phoenix_kit_web/users/oauth.ex:210
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Unknown OAuth provider: %{provider}"
+msgstr "Tundmatu teenusepakkuja"
+
+#: lib/phoenix_kit_web/users/confirmation.ex:68
+#, elixir-autogen, elixir-format
+msgid "User confirmation link is invalid or it has expired."
+msgstr "Kasutaja kinnituslink on kehtetu või aegunud."
+
+#: lib/phoenix_kit_web/users/confirmation.ex:50
+#, elixir-autogen, elixir-format, fuzzy
+msgid "User confirmed successfully."
+msgstr "Kasutaja edukalt aktiveeritud"
+
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:77
+#, elixir-autogen, elixir-format
+msgid "User registration is currently disabled."
+msgstr "Kasutajate registreerimine on hetkel keelatud."
+
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:51
+#: lib/phoenix_kit_web/users/registration.ex:110
+#, elixir-autogen, elixir-format
+msgid "User registration is currently disabled. Please contact an administrator."
+msgstr "Kasutajate registreerimine on hetkel keelatud. Palun võtke ühendust administraatoriga."
+
+#: lib/phoenix_kit_web/users/session.ex:40
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Welcome back!"
+msgstr "Tere tulemast tagasi"
+
+#: lib/phoenix_kit_web/users/session.ex:66
+#, elixir-autogen, elixir-format
+msgid "Your account is currently inactive. Please contact the team if you believe this is an error."
+msgstr "Teie konto on hetkel mitteaktiivne. Kui arvate, et tegemist on veaga, võtke ühendust meeskonnaga."
+
+#: lib/phoenix_kit_web/users/auth.ex:1873
+#, elixir-autogen, elixir-format
+msgid "%{label} module is not enabled"
+msgstr "%{label} moodul ei ole lubatud"
+
+#: lib/phoenix_kit_web/users/auth.ex:2366
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Enter your referral code to continue."
+msgstr "Sisesta oma soovituskood"
+
+#: lib/phoenix_kit_web/users/auth.ex:2362
+#, elixir-autogen, elixir-format
+msgid "Please confirm your email before accessing the application."
+msgstr "Palun kinnitage oma e-post enne rakenduse kasutamist."
+
+#: lib/phoenix_kit_web/users/auth.ex:111
+#, elixir-autogen, elixir-format
+msgid "This account is not active. Contact an administrator."
+msgstr "See konto ei ole aktiivne. Võtke ühendust administraatoriga."
+
+#: lib/phoenix_kit_web/users/auth.ex:749
+#: lib/phoenix_kit_web/users/auth.ex:1892
+#: lib/phoenix_kit_web/users/auth.ex:2511
+#, elixir-autogen, elixir-format, fuzzy
+msgid "You do not have permission to access this section."
+msgstr "Teil pole õigust teise kasutajana sisse logida."
+
+#: lib/phoenix_kit_web/users/auth.ex:724
+#: lib/phoenix_kit_web/users/auth.ex:878
+#: lib/phoenix_kit_web/users/auth.ex:2460
+#: lib/phoenix_kit_web/users/auth.ex:2496
+#, elixir-autogen, elixir-format, fuzzy
+msgid "You do not have the required permission to access this page."
+msgstr "Teil pole õigust teise kasutajana sisse logida."
+
+#: lib/phoenix_kit_web/users/auth.ex:1417
+#, elixir-autogen, elixir-format
+msgid "You must be an admin to access this page."
+msgstr "Selle lehe vaatamiseks peate olema administraator."
+
+#: lib/phoenix_kit_web/users/auth.ex:679
+#: lib/phoenix_kit_web/users/auth.ex:2423
+#, elixir-autogen, elixir-format
+msgid "You must be an owner to access this page."
+msgstr "Selle lehe vaatamiseks peate olema omanik."
+
+#: lib/phoenix_kit_web/users/auth.ex:2539
+#, elixir-autogen, elixir-format
+msgid "You must have the %{role_name} role to access this page."
+msgstr "Selle lehe vaatamiseks on vajalik %{role_name} roll."
+
+#: lib/phoenix_kit_web/users/auth.ex:903
+#: lib/phoenix_kit_web/users/auth.ex:2292
+#: lib/phoenix_kit_web/users/auth.ex:2329
+#: lib/phoenix_kit_web/users/auth.ex:2467
+#, elixir-autogen, elixir-format
+msgid "You must log in to access this page."
+msgstr "Selle lehe vaatamiseks peate sisse logima."
+
+#: lib/phoenix_kit_web/users/auth.ex:1428
+#, elixir-autogen, elixir-format
+msgid "You no longer have permission to access this section."
+msgstr "Teil ei ole enam õigust seda jaotist vaadata."

--- a/priv/gettext/et/LC_MESSAGES/default.po
+++ b/priv/gettext/et/LC_MESSAGES/default.po
@@ -12263,7 +12263,7 @@ msgid "Access requested."
 msgstr "Ligipääsu taotletud."
 
 #: lib/phoenix_kit/integrations/validators.ex:99
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Account %{id}"
 msgstr "Konto %{id}"
 
@@ -12273,9 +12273,9 @@ msgid "Advisory-grade: anything can send any User-Agent, so a scraper that lies 
 msgstr "Nõuandev tase: igaüks võib saata suvalise User-Agenti, seega valetav kraapija pääseb läbi. Tegelik jõustamine käib sinu CDN-i või pöördproksi kaudu — siin püütakse kinni ausad, kuid teadmatud. Botid, keda tuvastatakse ainult robots.txt-i märgendite järgi (Google-Extended, Applebot-Extended), roomavad oma peamise kasutajaagendi all ega satu siin kunagi vastavusse, seega AI-treeningu blokeerimine ei saa Googlebotile 403 vastata."
 
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:124
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Allowed"
-msgstr "Kõik"
+msgstr ""
 
 #: lib/phoenix_kit/integrations/providers.ex:697
 #, elixir-autogen, elixir-format
@@ -12298,9 +12298,9 @@ msgid "Bedrock API key"
 msgstr "Bedrocki API võti"
 
 #: lib/phoenix_kit/integrations/validators.ex:222
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Bedrock error %{status}"
-msgstr "Brevo viga %{status}"
+msgstr ""
 
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:306
 #, elixir-autogen, elixir-format
@@ -12308,9 +12308,9 @@ msgid "Block at the application"
 msgstr "Blokeeri rakenduse tasemel"
 
 #: lib/phoenix_kit_web/live/modules.html.heex:451
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Blocked groups"
-msgstr "Blokeeritud"
+msgstr ""
 
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:103
 #, elixir-autogen, elixir-format
@@ -12328,17 +12328,17 @@ msgid "Control how search engines and AI bots crawl and index this site"
 msgstr "Halda, kuidas otsingumootorid ja AI-botid seda saiti roomavad ja indekseerivad"
 
 #: lib/phoenix_kit/integrations/providers.ex:740
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Copy the key (shown once, `ABSK…`) and paste it into the form above"
-msgstr "Kopeeri võti (kuvatakse ühekordselt) ja kleebi see ülalolevasse vormi"
+msgstr ""
 
 #: lib/phoenix_kit/integrations/providers.ex:816
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Copy the token and paste it into the form above"
-msgstr "Kopeeri võti ja kleebi see ülalolevasse vormi"
+msgstr ""
 
 #: lib/phoenix_kit/integrations/validators.ex:226
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Could not reach Bedrock in %{region}"
 msgstr "Bedrockiga ei saanud regioonis %{region} ühendust"
 
@@ -12348,20 +12348,20 @@ msgid "Could not send that request."
 msgstr "Päringut ei õnnestunud saata."
 
 #: lib/phoenix_kit_web/live/settings/email_sending.ex:136
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Could not update the mailbox setting"
-msgstr "Vaikimisi saatmisintegratsiooni ei saanud uuendada"
+msgstr ""
 
 #: lib/phoenix_kit_web/live/settings/crawlers.ex:35
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:5
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Crawler Settings"
-msgstr "Juriidilised seaded"
+msgstr ""
 
 #: lib/modules/sitemap/web/settings.html.heex:679
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Crawler settings"
-msgstr "Juhised otsingurobotitele"
+msgstr ""
 
 #: lib/phoenix_kit_web/live/modules.html.heex:406
 #, elixir-autogen, elixir-format
@@ -12369,19 +12369,19 @@ msgid "Crawlers"
 msgstr "Roomajad"
 
 #: lib/phoenix_kit_web/live/settings/crawlers.ex:55
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Crawlers module is disabled. Enable it from the Modules page to configure settings."
-msgstr "SEO moodul on keelatud. Luba see Moodulite lehelt seadete konfigureerimiseks."
+msgstr ""
 
 #: lib/phoenix_kit/integrations/providers.ex:732
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Create a Bedrock API key"
-msgstr "Loo API võti"
+msgstr ""
 
 #: lib/phoenix_kit/integrations/providers.ex:808
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Create a token"
-msgstr "Loo roll"
+msgstr ""
 
 #: lib/phoenix_kit/integrations/providers.ex:872
 #, elixir-autogen, elixir-format
@@ -12404,9 +12404,9 @@ msgid "Deliver development mail to /dev/mailbox"
 msgstr "Toimeta arenduskirjad kausta /dev/mailbox"
 
 #: lib/phoenix_kit/integrations/providers.ex:748
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Enable model access"
-msgstr "Luba moodul seadetele juurdepääsemiseks"
+msgstr ""
 
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:304
 #, elixir-autogen, elixir-format
@@ -12419,14 +12419,14 @@ msgstr "Jõustamine"
 #: lib/phoenix_kit_web/live/settings/crawlers.ex:132
 #: lib/phoenix_kit_web/live/settings/crawlers.ex:148
 #: lib/phoenix_kit_web/live/settings/crawlers.ex:161
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Failed to update crawler settings"
-msgstr "Seade uuendamine ebaõnnestus"
+msgstr ""
 
 #: lib/phoenix_kit/integrations/providers.ex:781
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "GitHub"
-msgstr "GitHub sisselogimine"
+msgstr ""
 
 #: lib/phoenix_kit/integrations/providers.ex:783
 #, elixir-autogen, elixir-format
@@ -12524,9 +12524,9 @@ msgid "No longer available"
 msgstr "Pole enam saadaval"
 
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:191
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "No priv/static/robots.txt found. Without one, crawlers assume everything is allowed — and any groups you blocked above are not being told."
-msgstr "Faili priv/static/robots.txt ei leitud. Ilma selleta eeldavad otsingurobotid, et kõik on lubatud — see on enamasti sobiv, kuid nad ei saa teada, kus su saidikaart asub."
+msgstr ""
 
 #: lib/phoenix_kit_web/components/core/mention_text.ex:152
 #, elixir-autogen, elixir-format
@@ -12584,9 +12584,9 @@ msgid "Repository access: **Public repositories (read-only)** — no extra permi
 msgstr "Repositooriumide ligipääs: **Public repositories (read-only)** — avaliku organisatsiooni statistika jaoks lisaõigusi ei ole vaja"
 
 #: lib/phoenix_kit/mentions/live.ex:227
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Request access"
-msgstr "Taotletud"
+msgstr ""
 
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:259
 #, elixir-autogen, elixir-format
@@ -12599,14 +12599,14 @@ msgid "Send request"
 msgstr "Saada päring"
 
 #: lib/phoenix_kit/mentions/live.ex:254
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Sending…"
-msgstr "Ootel"
+msgstr ""
 
 #: lib/phoenix_kit/mentions/live.ex:76
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Sign in to request access."
-msgstr "Logi sisse kasutajana"
+msgstr ""
 
 #: lib/phoenix_kit/integrations/providers.ex:761
 #, elixir-autogen, elixir-format
@@ -12624,7 +12624,7 @@ msgid "The mailbox is off: outgoing mail is written to the server log instead."
 msgstr "Postkast on välja lülitatud: väljuvad kirjad kirjutatakse selle asemel serveri logisse."
 
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:205
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "The noindex toggle and robots.txt are separate mechanisms: noindex is a per-page meta tag that tells crawlers not to index what they fetched, while robots.txt tells them what not to fetch at all. A staging site usually wants both."
 msgstr "Ülalolev noindex-lüliti ja robots.txt on eraldi mehhanismid: noindex on lehepõhine metasilt, mis ütleb otsingurobotitele, et allalaaditut ei indekseeritaks, robots.txt aga ütleb, mida üldse mitte alla laadida. Testkeskkond vajab tavaliselt mõlemat."
 
@@ -12656,9 +12656,9 @@ msgid "Use it from the AI module"
 msgstr "Kasuta seda AI moodulist"
 
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:257
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Verification"
-msgstr "Teavitused"
+msgstr ""
 
 #: lib/phoenix_kit_web/live/settings/crawlers.ex:145
 #, elixir-autogen, elixir-format
@@ -12716,7 +12716,7 @@ msgid "management API: %{services}"
 msgstr "haldus-API: %{services}"
 
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:195
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "priv/static/robots.txt exists but has no Sitemap: line. Paste the file above so crawlers are told where to look."
 msgstr "Fail priv/static/robots.txt on olemas, kuid selles puudub rida Sitemap:. Lisa ülalolev rida, et otsingurobotid teaksid, kust otsida."
 

--- a/priv/gettext/et/LC_MESSAGES/default.po
+++ b/priv/gettext/et/LC_MESSAGES/default.po
@@ -12903,19 +12903,19 @@ msgstr ""
 
 #: lib/phoenix_kit_web/users/oauth.ex:365
 #: lib/phoenix_kit_web/users/session.ex:245
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Account added."
-msgstr "Konto"
+msgstr "Konto lisatud."
 
 #: lib/phoenix_kit_web/users/session.ex:27
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Account created successfully!"
-msgstr "Bucket lubati edukalt"
+msgstr "Konto loodud edukalt!"
 
 #: lib/phoenix_kit_web/users/session.ex:356
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Account removed."
-msgstr "Konto"
+msgstr "Konto eemaldatud."
 
 #: lib/phoenix_kit_web/users/oauth.ex:272
 #, elixir-autogen, elixir-format
@@ -12940,14 +12940,14 @@ msgid "Authentication failed. Please try again."
 msgstr "Autentimine ebaõnnestus. Palun proovige uuesti."
 
 #: lib/phoenix_kit_web/users/oauth.ex:299
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Authentication failed: %{errors}"
-msgstr "Autentimine"
+msgstr "Autentimine ebaõnnestus: %{errors}"
 
 #: lib/phoenix_kit_web/users/oauth.ex:441
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Authentication failed: %{message}"
-msgstr "Autentimine"
+msgstr "Autentimine ebaõnnestus: %{message}"
 
 #: lib/phoenix_kit_web/users/session.ex:360
 #, elixir-autogen, elixir-format
@@ -12963,24 +12963,24 @@ msgstr "Konteksti vahetamine ei ole lubatud"
 #: lib/phoenix_kit/integrations/validators.ex:634
 #: lib/phoenix_kit/integrations/validators.ex:732
 #: lib/phoenix_kit/integrations/validators.ex:740
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Could not reach the storage endpoint"
-msgstr "Teenusele ei saanud juurde pääseda"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:365
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Could not remove account."
-msgstr "Brevoga ei saanud ühendust"
+msgstr "Konto eemaldamine ebaõnnestus."
 
 #: lib/phoenix_kit_web/users/session.ex:274
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Could not switch account."
-msgstr "Vestlusi ei saanud lahti siduda"
+msgstr "Konto vahetamine ebaõnnestus."
 
 #: lib/phoenix_kit/integrations/validators.ex:721
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Credentials are valid, but not authorized to list buckets"
-msgstr "Mandaadid on kehtivad, kuid puudub õigus GetSendQuota jaoks — saatmist ei kontrollitud"
+msgstr ""
 
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:85
 #, elixir-autogen, elixir-format
@@ -12988,9 +12988,9 @@ msgid "Exempt"
 msgstr ""
 
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:86
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Follows noindex"
-msgstr "Jälgimised"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link.ex:120
 #, elixir-autogen, elixir-format
@@ -13008,9 +13008,9 @@ msgid "If your email is in our system, you will receive instructions to reset yo
 msgstr "Kui teie e-post on meie süsteemis, saate peagi parooli lähtestamise juhised."
 
 #: lib/phoenix_kit_web/controllers/context_controller.ex:82
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Invalid context"
-msgstr "Vigane boti token"
+msgstr "Vigane kontekst"
 
 #: lib/phoenix_kit_web/users/magic_link_registration_request.ex:110
 #, elixir-autogen, elixir-format
@@ -13043,9 +13043,9 @@ msgid "Keep publishing the sitemap's real URLs even while noindex is on, so the 
 msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:104
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Logged out of all accounts."
-msgstr "Logi välja kõigilt kontodelt"
+msgstr "Välja logitud kõikidest kontodest."
 
 #: lib/phoenix_kit_web/users/session.ex:122
 #: lib/phoenix_kit_web/users/session.ex:235
@@ -13064,9 +13064,9 @@ msgid "Magic link registration is currently disabled."
 msgstr "Magic Linki registreerimine on hetkel keelatud."
 
 #: lib/phoenix_kit_web/users/magic_link.ex:110
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Magic link sent! Check your email."
-msgstr "Magic Link saadetud!"
+msgstr "Magic Link saadetud! Vaata oma e-posti."
 
 #: lib/phoenix_kit_web/users/magic_link.ex:39
 #: lib/phoenix_kit_web/users/magic_link_verify.ex:33
@@ -13076,9 +13076,9 @@ msgstr "Magic Linkiga sisselogimine on hetkel keelatud."
 
 #: lib/phoenix_kit_web/users/oauth.ex:370
 #: lib/phoenix_kit_web/users/session.ex:249
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Maximum number of accounts reached."
-msgstr "Kontode ülempiir on täis — eemaldage kõigepealt üks."
+msgstr "Kontode ülempiir on täis."
 
 #: lib/phoenix_kit_web/users/session.ex:137
 #, elixir-autogen, elixir-format
@@ -13111,14 +13111,14 @@ msgid "Object Storage (S3-compatible)"
 msgstr ""
 
 #: lib/phoenix_kit_web/users/reset_password.ex:41
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Password reset successfully."
-msgstr "Parool muudetud edukalt."
+msgstr "Parool lähtestatud edukalt."
 
 #: lib/phoenix_kit_web/users/session.ex:34
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Password updated successfully!"
-msgstr "Parool muudetud edukalt."
+msgstr "Parool uuendatud edukalt!"
 
 #: lib/phoenix_kit_web/users/magic_link_registration.ex:35
 #: lib/phoenix_kit_web/users/registration.ex:128
@@ -13127,9 +13127,9 @@ msgid "Registration is currently disabled."
 msgstr "Registreerimine on hetkel keelatud."
 
 #: lib/phoenix_kit_web/users/magic_link_registration.ex:92
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Registration link is invalid or has expired."
-msgstr "E-posti muutmise link on kehtetu või aegunud."
+msgstr "Registreerimislink on kehtetu või aegunud."
 
 #: lib/phoenix_kit_web/users/magic_link_registration.ex:188
 #: lib/phoenix_kit_web/users/magic_link_registration_verify.ex:24
@@ -13159,9 +13159,9 @@ msgid "S3-compatible object storage — AWS S3, Cloudflare R2, Backblaze B2, Tig
 msgstr ""
 
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:75
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Sitemap Exemption"
-msgstr "Saidikaardi seaded"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link_registration_request.ex:144
 #, elixir-autogen, elixir-format
@@ -13190,14 +13190,14 @@ msgstr "Sisselogimine teenusepakkujaga '%{provider}' õnnestus!"
 
 #: lib/phoenix_kit_web/users/oauth.ex:375
 #: lib/phoenix_kit_web/users/session.ex:254
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "That account is already in your session."
-msgstr "See konto on juba teie sessioonis — lülituge lihtsalt sellele."
+msgstr "See konto on juba teie sessioonis."
 
 #: lib/phoenix_kit_web/users/oauth.ex:380
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "That account is inactive."
-msgstr "See konto on deaktiveeritud."
+msgstr "See konto on mitteaktiivne."
 
 #: lib/phoenix_kit_web/users/magic_link_registration.ex:185
 #, elixir-autogen, elixir-format
@@ -13205,9 +13205,9 @@ msgid "That email is already registered. Please log in instead."
 msgstr "See e-post on juba registreeritud. Palun logige selle asemel sisse."
 
 #: lib/phoenix_kit_web/users/magic_link_registration_request.ex:118
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Too many attempts"
-msgstr "Liiga palju faile"
+msgstr "Liiga palju katseid"
 
 #: lib/phoenix_kit_web/users/session.ex:84
 #, elixir-autogen, elixir-format
@@ -13216,9 +13216,9 @@ msgstr "Liiga palju sisselogimiskatseid. Palun proovige hiljem uuesti."
 
 #: lib/phoenix_kit_web/users/oauth.ex:84
 #: lib/phoenix_kit_web/users/oauth.ex:210
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Unknown OAuth provider: %{provider}"
-msgstr "Tundmatu teenusepakkuja"
+msgstr "Tundmatu OAuth teenusepakkuja: %{provider}"
 
 #: lib/phoenix_kit_web/users/confirmation.ex:68
 #, elixir-autogen, elixir-format
@@ -13226,9 +13226,9 @@ msgid "User confirmation link is invalid or it has expired."
 msgstr "Kasutaja kinnituslink on kehtetu või aegunud."
 
 #: lib/phoenix_kit_web/users/confirmation.ex:50
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "User confirmed successfully."
-msgstr "Kasutaja edukalt aktiveeritud"
+msgstr "Kasutaja kinnitatud edukalt."
 
 #: lib/phoenix_kit_web/users/magic_link_registration_request.ex:77
 #, elixir-autogen, elixir-format
@@ -13242,9 +13242,9 @@ msgid "User registration is currently disabled. Please contact an administrator.
 msgstr "Kasutajate registreerimine on hetkel keelatud. Palun võtke ühendust administraatoriga."
 
 #: lib/phoenix_kit_web/users/session.ex:40
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Welcome back!"
-msgstr "Tere tulemast tagasi"
+msgstr "Tere tulemast tagasi!"
 
 #: lib/phoenix_kit_web/users/session.ex:66
 #, elixir-autogen, elixir-format
@@ -13257,9 +13257,9 @@ msgid "%{label} module is not enabled"
 msgstr "%{label} moodul ei ole lubatud"
 
 #: lib/phoenix_kit_web/users/auth.ex:2366
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Enter your referral code to continue."
-msgstr "Sisesta oma soovituskood"
+msgstr "Jätkamiseks sisestage oma soovituskood."
 
 #: lib/phoenix_kit_web/users/auth.ex:2362
 #, elixir-autogen, elixir-format
@@ -13274,17 +13274,17 @@ msgstr "See konto ei ole aktiivne. Võtke ühendust administraatoriga."
 #: lib/phoenix_kit_web/users/auth.ex:749
 #: lib/phoenix_kit_web/users/auth.ex:1892
 #: lib/phoenix_kit_web/users/auth.ex:2511
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "You do not have permission to access this section."
-msgstr "Teil pole õigust teise kasutajana sisse logida."
+msgstr "Teil ei ole õigust seda jaotist vaadata."
 
 #: lib/phoenix_kit_web/users/auth.ex:724
 #: lib/phoenix_kit_web/users/auth.ex:878
 #: lib/phoenix_kit_web/users/auth.ex:2460
 #: lib/phoenix_kit_web/users/auth.ex:2496
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "You do not have the required permission to access this page."
-msgstr "Teil pole õigust teise kasutajana sisse logida."
+msgstr "Teil ei ole selle lehe vaatamiseks vajalikku õigust."
 
 #: lib/phoenix_kit_web/users/auth.ex:1417
 #, elixir-autogen, elixir-format

--- a/priv/gettext/et/LC_MESSAGES/phoenix_kit.po
+++ b/priv/gettext/et/LC_MESSAGES/phoenix_kit.po
@@ -21,27 +21,27 @@ msgstr "Sellele e-posti aadressile on juba ootel kutse"
 msgid "This user already belongs to an organization"
 msgstr "See kasutaja kuulub juba organisatsiooni"
 
-#: lib/phoenix_kit/users/auth.ex:1064
+#: lib/phoenix_kit/users/auth.ex:1074
 #, elixir-autogen, elixir-format
 msgid "cannot change to person while organization has members"
 msgstr "ei saa muuta isikuks, kuni organisatsioonil on liikmeid"
 
-#: lib/phoenix_kit/users/auth.ex:1044
+#: lib/phoenix_kit/users/auth.ex:1054
 #, elixir-autogen, elixir-format
 msgid "cannot reference self"
 msgstr "ei saa viidata iseendale"
 
-#: lib/phoenix_kit/users/auth.ex:1052
+#: lib/phoenix_kit/users/auth.ex:1062
 #, elixir-autogen, elixir-format
 msgid "only person accounts can join an organization"
 msgstr "organisatsiooniga saavad liituda ainult isikukontod"
 
-#: lib/phoenix_kit/users/auth.ex:1039
+#: lib/phoenix_kit/users/auth.ex:1049
 #, elixir-autogen, elixir-format
 msgid "organization not found"
 msgstr "organisatsiooni ei leitud"
 
-#: lib/phoenix_kit/users/auth.ex:1038
+#: lib/phoenix_kit/users/auth.ex:1048
 #, elixir-autogen, elixir-format
 msgid "target user is not an organization"
 msgstr "sihtkasutaja ei ole organisatsioon"

--- a/priv/gettext/fr/LC_MESSAGES/default.po
+++ b/priv/gettext/fr/LC_MESSAGES/default.po
@@ -69,7 +69,7 @@ msgstr "Gestion des rôles"
 
 #: lib/phoenix_kit/dashboard/admin_tabs.ex:119
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:138
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:647
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:662
 #: lib/phoenix_kit_web/live/settings/users.html.heex:130
 #, elixir-autogen
 msgid "Sessions"
@@ -235,7 +235,7 @@ msgstr "Connexions en temps réel"
 
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:320
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:64
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:144
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:140
 #, elixir-autogen
 msgid "Anonymous"
 msgstr "Anonyme"
@@ -248,7 +248,7 @@ msgstr "Visiteurs non enregistrés"
 
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:331
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:77
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:151
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:144
 #, elixir-autogen
 msgid "Authenticated"
 msgstr "Authentifié"
@@ -345,7 +345,7 @@ msgstr "Niveau d'accès standard"
 msgid "Role System"
 msgstr "Système de rôles"
 
-#: lib/phoenix_kit/integrations/providers.ex:991
+#: lib/phoenix_kit/integrations/providers.ex:1063
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:450
 #, elixir-autogen
 msgid "Authentication"
@@ -357,7 +357,7 @@ msgstr "Authentification"
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:445
 #: lib/phoenix_kit_web/live/modules.html.heex:65
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:114
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:273
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:267
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:145
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:297
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:682
@@ -463,8 +463,8 @@ msgstr "À propos des autorisations"
 msgid "Accept All"
 msgstr "Tout accepter"
 
-#: lib/phoenix_kit/integrations/integrations.ex:1133
-#: lib/phoenix_kit/integrations/validators.ex:598
+#: lib/phoenix_kit/integrations/integrations.ex:1136
+#: lib/phoenix_kit/integrations/validators.ex:779
 #: lib/phoenix_kit_web/live/activity/index.ex:66
 #: lib/phoenix_kit_web/live/activity/show.ex:56
 #, elixir-autogen, elixir-format
@@ -502,7 +502,7 @@ msgid "Actions"
 msgstr "Actions"
 
 #: lib/phoenix_kit_web/components/media_gallery.html.heex:86
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:585
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:600
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:266
 #: lib/phoenix_kit_web/live/settings/users.html.heex:693
 #: lib/phoenix_kit_web/users/user_form.html.heex:719
@@ -610,7 +610,7 @@ msgstr "Informations de base"
 msgid "Billing profiles and payment methods"
 msgstr "Profils de facturation et moyens de paiement"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:98
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:124
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:501
 #, elixir-autogen, elixir-format
 msgid "Blocked"
@@ -1550,7 +1550,7 @@ msgstr "Page générée avec succès"
 msgid "Page published successfully"
 msgstr "Page publiée avec succès"
 
-#: lib/phoenix_kit/integrations/providers.ex:956
+#: lib/phoenix_kit/integrations/providers.ex:1028
 #: lib/phoenix_kit_web/components/user_dashboard_nav.ex:277
 #: lib/phoenix_kit_web/users/login.html.heex:39
 #: lib/phoenix_kit_web/users/magic_link_registration.html.heex:42
@@ -1811,8 +1811,8 @@ msgstr "SWIFT/BIC"
 #: lib/phoenix_kit_web/components/core/markdown_editor.ex:440
 #: lib/phoenix_kit_web/components/media_browser.html.heex:1349
 #: lib/phoenix_kit_web/live/notifications/settings.ex:436
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:219
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:267
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:245
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:293
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr "Enregistrer"
@@ -1855,7 +1855,7 @@ msgstr "Enregistré"
 #: lib/phoenix_kit_web/components/core/markdown_editor.ex:333
 #: lib/phoenix_kit_web/components/core/markdown_editor.ex:417
 #: lib/phoenix_kit_web/live/settings.html.heex:592
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:683
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:698
 #: lib/phoenix_kit_web/live/settings/users.html.heex:546
 #, elixir-autogen, elixir-format
 msgid "Saving..."
@@ -1942,7 +1942,7 @@ msgstr "État/province"
 #: lib/phoenix_kit_web/live/settings/users.html.heex:367
 #: lib/phoenix_kit_web/live/settings/users.html.heex:408
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:114
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:199
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:193
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:247
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:294
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:650
@@ -2048,7 +2048,7 @@ msgstr "Total des rôles"
 #: lib/phoenix_kit_web/live/settings/users.html.heex:361
 #: lib/phoenix_kit_web/live/settings/users.html.heex:404
 #: lib/phoenix_kit_web/live/settings/users.html.heex:602
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:192
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:186
 #: lib/phoenix_kit_web/live/users/roles.html.heex:92
 #: lib/phoenix_kit_web/live/users/roles.html.heex:160
 #, elixir-autogen, elixir-format
@@ -2064,7 +2064,7 @@ msgstr "Non confirmé"
 #: lib/phoenix_kit_web/components/core/time_display.ex:183
 #: lib/phoenix_kit_web/components/language_switcher.ex:832
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:108
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:255
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:249
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr "Inconnu"
@@ -2122,7 +2122,7 @@ msgstr "Utilisateur introuvable"
 msgid "User-defined roles"
 msgstr "Rôles définis par l'utilisateur"
 
-#: lib/phoenix_kit/integrations/providers.ex:944
+#: lib/phoenix_kit/integrations/providers.ex:1016
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:255
 #: lib/phoenix_kit_web/users/magic_link_registration.html.heex:30
 #: lib/phoenix_kit_web/users/registration.html.heex:69
@@ -2440,22 +2440,22 @@ msgstr "(vide)"
 msgid "(registration disabled)"
 msgstr "(inscription désactivée)"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:622
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:637
 #, elixir-autogen, elixir-format
 msgid "1. Enable the provider above and save settings"
 msgstr "1. Activez le fournisseur ci-dessus et enregistrez les paramètres"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:623
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:638
 #, elixir-autogen, elixir-format
 msgid "2. Enter your OAuth credentials in the form that appears"
 msgstr "2. Saisissez vos identifiants OAuth dans le formulaire qui apparaît"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:624
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:639
 #, elixir-autogen, elixir-format
 msgid "3. Save settings again to store credentials"
 msgstr "3. Enregistrez à nouveau les paramètres pour stocker les identifiants"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:625
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:640
 #, elixir-autogen, elixir-format
 msgid "4. Click \"Test Credentials\" to verify configuration"
 msgstr "4. Cliquez sur \"Tester les identifiants\" pour vérifier la configuration"
@@ -2466,7 +2466,8 @@ msgid "Access Credentials"
 msgstr "Identifiants d'accès"
 
 #: lib/modules/storage/web/bucket_form.html.heex:227
-#: lib/phoenix_kit/integrations/providers.ex:842
+#: lib/phoenix_kit/integrations/providers.ex:843
+#: lib/phoenix_kit/integrations/providers.ex:927
 #, elixir-autogen, elixir-format
 msgid "Access Key ID"
 msgstr "ID de clé d'accès"
@@ -2516,9 +2517,9 @@ msgstr "Ajouter une dimension d'image"
 msgid "Add Video Dimension"
 msgstr "Ajouter une dimension vidéo"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:429
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:507
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:592
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:434
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:517
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:607
 #, elixir-autogen, elixir-format
 msgid "Add callback URL above to"
 msgstr "Ajoutez l'URL de rappel ci-dessus à"
@@ -2550,12 +2551,12 @@ msgstr "Tous les nouveaux utilisateurs recevront des privilèges d'administrateu
 msgid "Anyone can register"
 msgstr "Tout le monde peut s'inscrire"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:541
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:551
 #, elixir-autogen, elixir-format
 msgid "App ID"
 msgstr "ID de l'application"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:551
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:561
 #, elixir-autogen, elixir-format
 msgid "App Secret"
 msgstr "Secret de l'application"
@@ -2674,7 +2675,7 @@ msgstr "Les buckets peuvent être des répertoires locaux ou des fournisseurs de
 msgid "CSS color or gradient for auth page background. Ignored if a background image is set."
 msgstr "Couleur ou dégradé CSS pour l'arrière-plan des pages d'authentification. Ignoré si une image d'arrière-plan est définie."
 
-#: lib/phoenix_kit_web/live/settings/authorization.ex:261
+#: lib/phoenix_kit_web/live/settings/authorization.ex:302
 #, elixir-autogen, elixir-format
 msgid "Callback URL"
 msgstr "URL de rappel"
@@ -2684,25 +2685,25 @@ msgstr "URL de rappel"
 msgid "Changes will be saved immediately"
 msgstr "Les modifications seront enregistrées immédiatement"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:434
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:511
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:518
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:609
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:439
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:521
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:528
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:624
 #, elixir-autogen, elixir-format
 msgid "Click"
 msgstr "Cliquez sur"
 
-#: lib/phoenix_kit/integrations/providers.ex:215
+#: lib/phoenix_kit/integrations/providers.ex:216
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:378
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:458
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:463
 #, elixir-autogen, elixir-format
 msgid "Client ID"
 msgstr "ID client"
 
-#: lib/phoenix_kit/integrations/providers.ex:224
-#: lib/phoenix_kit/integrations/providers.ex:1169
+#: lib/phoenix_kit/integrations/providers.ex:225
+#: lib/phoenix_kit/integrations/providers.ex:1241
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:388
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:468
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:473
 #, elixir-autogen, elixir-format
 msgid "Client Secret"
 msgstr "Secret client"
@@ -2733,34 +2734,34 @@ msgstr "Configurez les préférences et options du système"
 msgid "Consider \"User\" for most installations to maintain security."
 msgstr "Envisagez \"Utilisateur\" pour la plupart des installations afin de préserver la sécurité."
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:514
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:599
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:142
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:524
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:614
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:168
 #, elixir-autogen, elixir-format
 msgid "Copy"
 msgstr "Copier"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:432
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:437
 #, elixir-autogen, elixir-format
 msgid "Copy Client ID and Secret to fields above"
 msgstr "Copiez l'ID client et le secret dans les champs ci-dessus"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:568
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:583
 #, elixir-autogen, elixir-format
 msgid "Copy this URL to Facebook App Settings"
 msgstr "Copiez cette URL dans les paramètres de l'application Facebook"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:485
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:495
 #, elixir-autogen, elixir-format
 msgid "Copy this URL to GitHub OAuth Apps"
 msgstr "Copiez cette URL dans GitHub OAuth Apps"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:405
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:410
 #, elixir-autogen, elixir-format
 msgid "Copy this URL to Google Cloud Console"
 msgstr "Copiez cette URL dans Google Cloud Console"
 
-#: lib/phoenix_kit_web/live/settings/authorization.ex:271
+#: lib/phoenix_kit_web/live/settings/authorization.ex:312
 #, elixir-autogen, elixir-format
 msgid "Copy to clipboard"
 msgstr "Copier dans le presse-papiers"
@@ -2785,12 +2786,12 @@ msgstr "Créer le chemin de stockage"
 msgid "Create Your First Bucket"
 msgstr "Créez votre premier bucket"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:582
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:597
 #, elixir-autogen, elixir-format
 msgid "Create a new app or select existing one"
 msgstr "Créez une nouvelle application ou sélectionnez-en une existante"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:418
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:423
 #, elixir-autogen, elixir-format
 msgid "Create project or select existing one"
 msgstr "Créez un projet ou sélectionnez-en un existant"
@@ -2861,11 +2862,12 @@ msgid "Enable OAuth (Master Switch)"
 msgstr "Activer OAuth (interrupteur principal)"
 
 #: lib/modules/storage/web/bucket_form.html.heex:194
+#: lib/phoenix_kit/integrations/providers.ex:957
 #, elixir-autogen, elixir-format
 msgid "Endpoint"
 msgstr "Endpoint"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:503
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:513
 #, elixir-autogen, elixir-format
 msgid "Enter"
 msgstr "Saisissez"
@@ -2900,7 +2902,7 @@ msgstr "FFmpeg non installé"
 msgid "FFmpeg is required for video processing, transcoding, and thumbnail generation."
 msgstr "FFmpeg est requis pour le traitement vidéo, le transcodage et la génération de miniatures."
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:532
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:542
 #, elixir-autogen, elixir-format
 msgid "Facebook OAuth Credentials"
 msgstr "Identifiants OAuth Facebook"
@@ -2943,7 +2945,7 @@ msgstr "Remplacement du format"
 msgid "Format Override:"
 msgstr "Remplacement du format :"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:449
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:454
 #, elixir-autogen, elixir-format
 msgid "GitHub OAuth Credentials"
 msgstr "Identifiants OAuth GitHub"
@@ -2953,10 +2955,10 @@ msgstr "Identifiants OAuth GitHub"
 msgid "GitHub Sign-In"
 msgstr "Connexion avec GitHub"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:420
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:499
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:588
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:596
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:425
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:509
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:603
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:611
 #, elixir-autogen, elixir-format
 msgid "Go to"
 msgstr "Accédez à"
@@ -2986,7 +2988,7 @@ msgstr "Comment les dates sont affichées"
 msgid "How times are displayed"
 msgstr "Comment les heures sont affichées"
 
-#: lib/phoenix_kit_web/live/settings/authorization.ex:296
+#: lib/phoenix_kit_web/live/settings/authorization.ex:337
 #, elixir-autogen, elixir-format
 msgid "If behind nginx/apache, ensure"
 msgstr "Si vous êtes derrière nginx/apache, assurez-vous que"
@@ -3173,7 +3175,7 @@ msgstr "Aucun"
 msgid "Note"
 msgstr "Remarque"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:627
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:642
 #, elixir-autogen, elixir-format
 msgid "Note: OAuth providers require ueberauth dependencies to be installed."
 msgstr "Remarque : les fournisseurs OAuth nécessitent l'installation des dépendances ueberauth."
@@ -3188,7 +3190,7 @@ msgstr "Nombre de copies à conserver"
 msgid "OAuth Providers"
 msgstr "Fournisseurs OAuth"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:620
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:635
 #, elixir-autogen, elixir-format
 msgid "OAuth Setup Instructions"
 msgstr "Instructions de configuration OAuth"
@@ -3261,7 +3263,7 @@ msgstr "Réduisez la redondance ou activez d'autres buckets."
 msgid "Redundancy Copies"
 msgstr "Copies de redondance"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:642
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:657
 #, elixir-autogen, elixir-format
 msgid "Reload OAuth Configuration"
 msgstr "Recharger la configuration OAuth"
@@ -3288,7 +3290,7 @@ msgstr "Réinitialiser aux valeurs par défaut"
 msgid "Resolution"
 msgstr "Résolution"
 
-#: lib/phoenix_kit_web/live/settings/authorization.ex:294
+#: lib/phoenix_kit_web/live/settings/authorization.ex:335
 #, elixir-autogen, elixir-format
 msgid "Reverse Proxy Users:"
 msgstr "Utilisateurs de proxy inverse :"
@@ -3314,7 +3316,7 @@ msgstr "Rôle attribué aux nouvelles inscriptions d'utilisateurs"
 msgid "Save All Settings"
 msgstr "Enregistrer tous les paramètres"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:685
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:700
 #, elixir-autogen, elixir-format
 msgid "Save Authorization Settings"
 msgstr "Enregistrer les paramètres d'autorisation"
@@ -3330,7 +3332,8 @@ msgid "Search engines are instructed to skip this environment. Remove this befor
 msgstr "Les moteurs de recherche sont invités à ignorer cet environnement. Supprimez ceci avant le lancement."
 
 #: lib/modules/storage/web/bucket_form.html.heex:241
-#: lib/phoenix_kit/integrations/providers.ex:851
+#: lib/phoenix_kit/integrations/providers.ex:852
+#: lib/phoenix_kit/integrations/providers.ex:936
 #, elixir-autogen, elixir-format
 msgid "Secret Access Key"
 msgstr "Clé d'accès secrète"
@@ -3347,7 +3350,7 @@ msgstr "Avis de sécurité : risque moyen"
 
 #: lib/phoenix_kit_web/components/media_browser.html.heex:1180
 #: lib/phoenix_kit_web/components/media_browser.html.heex:1182
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:425
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:430
 #, elixir-autogen, elixir-format
 msgid "Select"
 msgstr "Sélectionner"
@@ -3377,7 +3380,7 @@ msgid "Set"
 msgstr "Définir"
 
 #: lib/phoenix_kit_web/components/core/integrations_ui.ex:311
-#: lib/phoenix_kit_web/live/settings/authorization.ex:249
+#: lib/phoenix_kit_web/live/settings/authorization.ex:290
 #: lib/phoenix_kit_web/live/settings/integration_form.html.heex:378
 #, elixir-autogen, elixir-format
 msgid "Setup Instructions"
@@ -3414,7 +3417,7 @@ msgstr "Fournisseur de stockage"
 msgid "Success!"
 msgstr "Succès !"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:604
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:619
 #, elixir-autogen, elixir-format
 msgid "Switch app from"
 msgstr "Faire passer l'application de"
@@ -3439,9 +3442,9 @@ msgstr "Fuseau horaire par défaut du système"
 msgid "Target Width (px)"
 msgstr "Largeur cible (px)"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:400
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:480
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:563
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:405
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:490
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:578
 #, elixir-autogen, elixir-format
 msgid "Test Credentials"
 msgstr "Tester les identifiants"
@@ -3521,7 +3524,7 @@ msgstr "Configuration utilisateur"
 msgid "User Editable"
 msgstr "Modifiable par l'utilisateur"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:35
+#: lib/phoenix_kit_web/live/settings/users.ex:42
 #: lib/phoenix_kit_web/live/settings/users.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "User Settings"
@@ -3563,9 +3566,9 @@ msgstr "Paramètres vidéo :"
 msgid "Videos use CRF 0-51 scale (lower = higher quality)"
 msgstr "Les vidéos utilisent l'échelle CRF 0-51 (plus bas = meilleure qualité)"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:409
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:489
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:572
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:414
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:499
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:587
 #, elixir-autogen, elixir-format
 msgid "Visit"
 msgstr "Visiter"
@@ -3610,22 +3613,22 @@ msgstr "Sans cela, le traitement des fichiers vidéo ne fonctionnera pas."
 msgid "Would you like to create it now?"
 msgstr "Souhaitez-vous le créer maintenant ?"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:542
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:552
 #, elixir-autogen, elixir-format
 msgid "Your Facebook App ID"
 msgstr "Votre ID d'application Facebook"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:552
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:565
 #, elixir-autogen, elixir-format
 msgid "Your Facebook App Secret"
 msgstr "Votre secret d'application Facebook"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:459
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:464
 #, elixir-autogen, elixir-format
 msgid "Your GitHub OAuth Client ID"
 msgstr "Votre ID client OAuth GitHub"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:469
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:477
 #, elixir-autogen, elixir-format
 msgid "Your GitHub OAuth Client Secret"
 msgstr "Votre secret client OAuth GitHub"
@@ -3635,19 +3638,19 @@ msgstr "Votre secret client OAuth GitHub"
 msgid "Your Google OAuth Client ID"
 msgstr "Votre ID client OAuth Google"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:389
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:392
 #, elixir-autogen, elixir-format
 msgid "Your Google OAuth Client Secret"
 msgstr "Votre secret client OAuth Google"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:504
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:600
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:514
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:615
 #: lib/phoenix_kit_web/live/settings/integrations.ex:167
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr "et"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:515
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:525
 #, elixir-autogen, elixir-format
 msgid "and generate/copy"
 msgstr "et générer/copier"
@@ -3668,12 +3671,12 @@ msgstr "par exemple, thumbnail, medium, 720p"
 msgid "files"
 msgstr "fichiers"
 
-#: lib/phoenix_kit_web/live/settings/authorization.ex:300
+#: lib/phoenix_kit_web/live/settings/authorization.ex:341
 #, elixir-autogen, elixir-format
 msgid "header is set to"
 msgstr "l'en-tête est défini sur"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:606
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:621
 #, elixir-autogen, elixir-format
 msgid "mode"
 msgstr "mode"
@@ -3683,12 +3686,12 @@ msgstr "mode"
 msgid "option(s)"
 msgstr "option(s)"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:585
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:600
 #, elixir-autogen, elixir-format
 msgid "product"
 msgstr "produit"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:605
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:620
 #, elixir-autogen, elixir-format
 msgid "to"
 msgstr "à"
@@ -3698,19 +3701,19 @@ msgstr "à"
 msgid "to every PhoenixKit layout, blocking crawlers from indexing or following links."
 msgstr "à chaque mise en page PhoenixKit, bloquant les robots d'indexation et le suivi des liens."
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:601
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:616
 #, elixir-autogen, elixir-format
 msgid "to fields above"
 msgstr "aux champs ci-dessus"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:435
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:519
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:610
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:440
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:529
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:625
 #, elixir-autogen, elixir-format
 msgid "to verify setup"
 msgstr "pour vérifier la configuration"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:426
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:431
 #, elixir-autogen, elixir-format
 msgid "type"
 msgstr "type"
@@ -3845,7 +3848,7 @@ msgstr "Un nom convivial pour identifier cet emplacement de stockage"
 msgid "A unique name to identify this dimension preset"
 msgstr "Un nom unique pour identifier ce préréglage de dimension"
 
-#: lib/phoenix_kit/integrations/providers.ex:388
+#: lib/phoenix_kit/integrations/providers.ex:389
 #, elixir-autogen, elixir-format
 msgid "AI model access via OpenRouter (100+ models)"
 msgstr "Accès aux modèles d'IA via OpenRouter (plus de 100 modèles)"
@@ -3855,13 +3858,13 @@ msgstr "Accès aux modèles d'IA via OpenRouter (plus de 100 modèles)"
 msgid "API Credentials"
 msgstr "Identifiants API"
 
-#: lib/phoenix_kit/integrations/providers.ex:332
-#: lib/phoenix_kit/integrations/providers.ex:402
-#: lib/phoenix_kit/integrations/providers.ex:460
-#: lib/phoenix_kit/integrations/providers.ex:523
-#: lib/phoenix_kit/integrations/providers.ex:586
-#: lib/phoenix_kit/integrations/providers.ex:653
-#: lib/phoenix_kit/integrations/providers.ex:1065
+#: lib/phoenix_kit/integrations/providers.ex:333
+#: lib/phoenix_kit/integrations/providers.ex:403
+#: lib/phoenix_kit/integrations/providers.ex:461
+#: lib/phoenix_kit/integrations/providers.ex:524
+#: lib/phoenix_kit/integrations/providers.ex:587
+#: lib/phoenix_kit/integrations/providers.ex:654
+#: lib/phoenix_kit/integrations/providers.ex:1137
 #, elixir-autogen, elixir-format
 msgid "API Key"
 msgstr "Clé API"
@@ -3922,7 +3925,7 @@ msgstr "Actif en raison de la fenêtre planifiée."
 msgid "Add Integration"
 msgstr "Ajouter une intégration"
 
-#: lib/phoenix_kit/integrations/providers.ex:431
+#: lib/phoenix_kit/integrations/providers.ex:432
 #, elixir-autogen, elixir-format
 msgid "Add credits (optional)"
 msgstr "Ajouter des crédits (facultatif)"
@@ -3957,7 +3960,7 @@ msgstr "Tous les fichiers atteignent l'objectif de redondance de %{n} copies."
 msgid "Alternative Formats"
 msgstr "Formats alternatifs"
 
-#: lib/phoenix_kit/integrations/providers.ex:285
+#: lib/phoenix_kit/integrations/providers.ex:286
 #, elixir-autogen, elixir-format
 msgid "Application type: **Web application** (do not select \"Desktop app\" — it won't support redirect URIs)"
 msgstr "Type d'application : **Application web** (ne sélectionnez pas « Application de bureau » — elle ne prend pas en charge les URI de redirection)"
@@ -4079,18 +4082,18 @@ msgstr "Choisir un service à connecter"
 msgid "Clear Schedule"
 msgstr "Effacer la planification"
 
-#: lib/phoenix_kit/integrations/providers.ex:284
+#: lib/phoenix_kit/integrations/providers.ex:285
 #, elixir-autogen, elixir-format
 msgid "Click **Create Credentials → OAuth client ID**"
 msgstr "Cliquez sur **Créer des identifiants → ID client OAuth**"
 
-#: lib/phoenix_kit/integrations/providers.ex:425
+#: lib/phoenix_kit/integrations/providers.ex:426
 #, elixir-autogen, elixir-format
 msgid "Click **Create Key**"
 msgstr "Cliquez sur **Créer une clé**"
 
-#: lib/phoenix_kit/integrations/providers.ex:295
-#: lib/phoenix_kit/integrations/providers.ex:1248
+#: lib/phoenix_kit/integrations/providers.ex:296
+#: lib/phoenix_kit/integrations/providers.ex:1320
 #, elixir-autogen, elixir-format
 msgid "Click **Save**, then **Connect Account**"
 msgstr "Cliquez sur **Enregistrer**, puis sur **Connecter le compte**"
@@ -4140,8 +4143,8 @@ msgstr "Connecter le compte %{provider}"
 msgid "Connect Account"
 msgstr "Connecter le compte"
 
-#: lib/phoenix_kit/integrations/providers.ex:293
-#: lib/phoenix_kit/integrations/providers.ex:1246
+#: lib/phoenix_kit/integrations/providers.ex:294
+#: lib/phoenix_kit/integrations/providers.ex:1318
 #, elixir-autogen, elixir-format
 msgid "Connect and authorize"
 msgstr "Connecter et autoriser"
@@ -4161,7 +4164,7 @@ msgstr "Connectez des services externes à utiliser dans tous les modules"
 #: lib/phoenix_kit_web/live/settings/integration_form.html.heex:327
 #: lib/phoenix_kit_web/live/settings/integrations.ex:181
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:111
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:197
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:191
 #, elixir-autogen, elixir-format
 msgid "Connected"
 msgstr "Connecté"
@@ -4202,48 +4205,48 @@ msgstr "Connexion réussie"
 msgid "Connection verified"
 msgstr "Connexion vérifiée"
 
-#: lib/phoenix_kit/integrations/providers.ex:289
+#: lib/phoenix_kit/integrations/providers.ex:290
 #, elixir-autogen, elixir-format
 msgid "Copy the **Client ID** and **Client Secret** into the form above"
 msgstr "Copiez l'**ID client** et le **secret client** dans le formulaire ci-dessus"
 
-#: lib/phoenix_kit/integrations/providers.ex:427
+#: lib/phoenix_kit/integrations/providers.ex:428
 #, elixir-autogen, elixir-format
 msgid "Copy the key and paste it into the form above"
 msgstr "Copiez la clé et collez-la dans le formulaire ci-dessus"
 
-#: lib/phoenix_kit/integrations/integrations.ex:1135
+#: lib/phoenix_kit/integrations/integrations.ex:1138
 #: lib/phoenix_kit/integrations/probe.ex:102
 #, elixir-autogen, elixir-format
 msgid "Could not reach the service"
 msgstr "Impossible de joindre le service"
 
-#: lib/phoenix_kit/integrations/providers.ex:235
+#: lib/phoenix_kit/integrations/providers.ex:236
 #, elixir-autogen, elixir-format
 msgid "Create a Google Cloud project"
 msgstr "Créer un projet Google Cloud"
 
-#: lib/phoenix_kit/integrations/providers.ex:238
+#: lib/phoenix_kit/integrations/providers.ex:239
 #, elixir-autogen, elixir-format
 msgid "Create a new project or select an existing one"
 msgstr "Créer un nouveau projet ou en sélectionner un existant"
 
-#: lib/phoenix_kit/integrations/providers.ex:368
-#: lib/phoenix_kit/integrations/providers.ex:423
-#: lib/phoenix_kit/integrations/providers.ex:493
-#: lib/phoenix_kit/integrations/providers.ex:553
-#: lib/phoenix_kit/integrations/providers.ex:619
-#: lib/phoenix_kit/integrations/providers.ex:670
+#: lib/phoenix_kit/integrations/providers.ex:369
+#: lib/phoenix_kit/integrations/providers.ex:424
+#: lib/phoenix_kit/integrations/providers.ex:494
+#: lib/phoenix_kit/integrations/providers.ex:554
+#: lib/phoenix_kit/integrations/providers.ex:620
+#: lib/phoenix_kit/integrations/providers.ex:671
 #, elixir-autogen, elixir-format
 msgid "Create an API key"
 msgstr "Créer une clé API"
 
-#: lib/phoenix_kit/integrations/providers.ex:279
+#: lib/phoenix_kit/integrations/providers.ex:280
 #, elixir-autogen, elixir-format
 msgid "Create an OAuth Client"
 msgstr "Créer un client OAuth"
 
-#: lib/phoenix_kit/integrations/providers.ex:416
+#: lib/phoenix_kit/integrations/providers.ex:417
 #, elixir-autogen, elixir-format
 msgid "Create an OpenRouter account"
 msgstr "Créer un compte OpenRouter"
@@ -4312,7 +4315,7 @@ msgstr "Déconnecter ?"
 msgid "Disconnected"
 msgstr "Déconnecté"
 
-#: lib/phoenix_kit/integrations/providers.ex:253
+#: lib/phoenix_kit/integrations/providers.ex:254
 #, elixir-autogen, elixir-format
 msgid "Drive API handles file listing, creation, copying, and PDF export. Docs API is used for reading document content and substituting template variables."
 msgstr "L'API Drive gère la liste, la création, la copie et l'export PDF des fichiers. L'API Docs sert à lire le contenu des documents et à substituer les variables de modèle."
@@ -4342,7 +4345,7 @@ msgstr "Activer le bucket"
 msgid "Enable organization accounts"
 msgstr "Activer les comptes d'organisation"
 
-#: lib/phoenix_kit/integrations/providers.ex:242
+#: lib/phoenix_kit/integrations/providers.ex:243
 #, elixir-autogen, elixir-format
 msgid "Enable required APIs"
 msgstr "Activer les API requises"
@@ -4475,12 +4478,12 @@ msgstr "Les fichiers sont suivis dans PostgreSQL avec la prise en charge de plus
 msgid "Files with completed variants"
 msgstr "Fichiers avec variantes terminées"
 
-#: lib/phoenix_kit/integrations/providers.ex:219
+#: lib/phoenix_kit/integrations/providers.ex:220
 #, elixir-autogen, elixir-format
 msgid "From Google Cloud Console → APIs & Services → Credentials"
 msgstr "Depuis Google Cloud Console → API et services → Identifiants"
 
-#: lib/phoenix_kit/integrations/providers.ex:406
+#: lib/phoenix_kit/integrations/providers.ex:407
 #, elixir-autogen, elixir-format
 msgid "From openrouter.ai/keys"
 msgstr "Depuis openrouter.ai/keys"
@@ -4490,72 +4493,72 @@ msgstr "Depuis openrouter.ai/keys"
 msgid "Generate additional format variants alongside the primary format. Modern formats like WebP and AVIF offer better compression."
 msgstr "Génère des variantes de format supplémentaires en plus du format principal. Les formats modernes comme WebP et AVIF offrent une meilleure compression."
 
-#: lib/phoenix_kit/integrations/providers.ex:426
+#: lib/phoenix_kit/integrations/providers.ex:427
 #, elixir-autogen, elixir-format
 msgid "Give it a name (e.g., your app name)"
 msgstr "Donnez-lui un nom (par ex., le nom de votre application)"
 
-#: lib/phoenix_kit/integrations/providers.ex:248
+#: lib/phoenix_kit/integrations/providers.ex:249
 #, elixir-autogen, elixir-format
 msgid "Go back to the Library and search for **Google Docs API**, click it, then click **Enable**"
 msgstr "Retournez dans la Bibliothèque et recherchez **Google Docs API**, cliquez dessus, puis cliquez sur **Activer**"
 
-#: lib/phoenix_kit/integrations/providers.ex:281
+#: lib/phoenix_kit/integrations/providers.ex:282
 #, elixir-autogen, elixir-format
 msgid "Go to [APIs & Services → Credentials](https://console.cloud.google.com/apis/credentials)"
 msgstr "Accédez à [API et services → Identifiants](https://console.cloud.google.com/apis/credentials)"
 
-#: lib/phoenix_kit/integrations/providers.ex:244
+#: lib/phoenix_kit/integrations/providers.ex:245
 #, elixir-autogen, elixir-format
 msgid "Go to [APIs & Services → Library](https://console.cloud.google.com/apis/library)"
 msgstr "Accédez à [API et services → Bibliothèque](https://console.cloud.google.com/apis/library)"
 
-#: lib/phoenix_kit/integrations/providers.ex:263
+#: lib/phoenix_kit/integrations/providers.ex:264
 #, elixir-autogen, elixir-format
 msgid "Go to [Audience](https://console.cloud.google.com/auth/audience) — set user type to **External** (or Internal for Google Workspace)"
 msgstr "Accédez à [Audience](https://console.cloud.google.com/auth/audience) — définissez le type d'utilisateur sur **Externe** (ou Interne pour Google Workspace)"
 
-#: lib/phoenix_kit/integrations/providers.ex:260
+#: lib/phoenix_kit/integrations/providers.ex:261
 #, elixir-autogen, elixir-format
 msgid "Go to [Branding](https://console.cloud.google.com/auth/branding) in the sidebar — fill in the **App name** and **User support email**, then save"
 msgstr "Accédez à [Image de marque](https://console.cloud.google.com/auth/branding) dans la barre latérale — renseignez le **Nom de l'application** et l'**E-mail d'assistance utilisateur**, puis enregistrez"
 
-#: lib/phoenix_kit/integrations/providers.ex:434
+#: lib/phoenix_kit/integrations/providers.ex:435
 #, elixir-autogen, elixir-format
 msgid "Go to [Credits](https://openrouter.ai/credits) to add funds"
 msgstr "Accédez à [Crédits](https://openrouter.ai/credits) pour ajouter des fonds"
 
-#: lib/phoenix_kit/integrations/providers.ex:269
+#: lib/phoenix_kit/integrations/providers.ex:270
 #, elixir-autogen, elixir-format
 msgid "Go to [Data Access](https://console.cloud.google.com/auth/scopes) — click **Add or Remove Scopes** and add the Drive and Docs scopes. This step may not be required — the app requests the needed scopes at connect time regardless."
 msgstr "Accédez à [Accès aux données](https://console.cloud.google.com/auth/scopes) — cliquez sur **Ajouter ou supprimer des champs d'application** et ajoutez les champs d'application Drive et Docs. Cette étape n'est peut-être pas nécessaire — l'application demande de toute façon les champs d'application requis lors de la connexion."
 
-#: lib/phoenix_kit/integrations/providers.ex:418
+#: lib/phoenix_kit/integrations/providers.ex:419
 #, elixir-autogen, elixir-format
 msgid "Go to [openrouter.ai](https://openrouter.ai) and sign up or log in"
 msgstr "Accédez à [openrouter.ai](https://openrouter.ai) et inscrivez-vous ou connectez-vous"
 
-#: lib/phoenix_kit/integrations/providers.ex:237
+#: lib/phoenix_kit/integrations/providers.ex:238
 #, elixir-autogen, elixir-format
 msgid "Go to the [Google Cloud Console](https://console.cloud.google.com)"
 msgstr "Accédez à la [Google Cloud Console](https://console.cloud.google.com)"
 
-#: lib/phoenix_kit/integrations/providers.ex:200
+#: lib/phoenix_kit/integrations/providers.ex:201
 #, elixir-autogen, elixir-format
 msgid "Google"
 msgstr "Google"
 
-#: lib/phoenix_kit/integrations/providers.ex:201
+#: lib/phoenix_kit/integrations/providers.ex:202
 #, elixir-autogen, elixir-format
 msgid "Google Docs, Drive, Calendar, Sheets, Gmail"
 msgstr "Google Docs, Drive, Calendar, Sheets, Gmail"
 
-#: lib/phoenix_kit/integrations/providers.ex:296
+#: lib/phoenix_kit/integrations/providers.ex:297
 #, elixir-autogen, elixir-format
 msgid "Google will show an \"unverified app\" warning — click **Advanced → Go to (app name)** to proceed"
 msgstr "Google affichera un avertissement \"application non validée\" — cliquez sur **Avancé → Accéder à (nom de l'application)** pour continuer"
 
-#: lib/phoenix_kit/integrations/providers.ex:299
+#: lib/phoenix_kit/integrations/providers.ex:300
 #, elixir-autogen, elixir-format
 msgid "Grant access to Google Docs and Google Drive"
 msgstr "Accordez l'accès à Google Docs et Google Drive"
@@ -4591,11 +4594,12 @@ msgstr "Intégration supprimée"
 msgid "Integrations"
 msgstr "Intégrations"
 
-#: lib/phoenix_kit/integrations/integrations.ex:1132
+#: lib/phoenix_kit/integrations/integrations.ex:1135
 #: lib/phoenix_kit/integrations/validators.ex:208
 #: lib/phoenix_kit/integrations/validators.ex:378
 #: lib/phoenix_kit/integrations/validators.ex:412
-#: lib/phoenix_kit/integrations/validators.ex:595
+#: lib/phoenix_kit/integrations/validators.ex:608
+#: lib/phoenix_kit/integrations/validators.ex:776
 #, elixir-autogen, elixir-format
 msgid "Invalid credentials"
 msgstr "Identifiants invalides"
@@ -4809,12 +4813,12 @@ msgstr "%{n} manquant(s)"
 msgid "Missing %{n} copies"
 msgstr "%{n} copies manquantes"
 
-#: lib/phoenix_kit/integrations/providers.ex:419
+#: lib/phoenix_kit/integrations/providers.ex:420
 #, elixir-autogen, elixir-format
 msgid "Navigate to [Keys](https://openrouter.ai/keys)"
 msgstr "Accédez à [Clés](https://openrouter.ai/keys)"
 
-#: lib/phoenix_kit/integrations/providers.ex:274
+#: lib/phoenix_kit/integrations/providers.ex:275
 #, elixir-autogen, elixir-format
 msgid "Navigate to the OAuth section using the search bar or the hamburger menu: search for \"OAuth\", or go to the sidebar: **APIs & Services → OAuth consent screen**. This opens a different section with its own sidebar."
 msgstr "Accédez à la section OAuth à l'aide de la barre de recherche ou du menu hamburger : recherchez \"OAuth\", ou allez dans la barre latérale : **API et services → Écran de consentement OAuth**. Cela ouvre une section différente avec sa propre barre latérale."
@@ -4835,9 +4839,9 @@ msgstr "Aucun jeton d'accès"
 msgid "No copies"
 msgstr "Aucune copie"
 
-#: lib/phoenix_kit/integrations/integrations.ex:1115
+#: lib/phoenix_kit/integrations/integrations.ex:1118
 #: lib/phoenix_kit/integrations/validators.ex:170
-#: lib/phoenix_kit/integrations/validators.ex:577
+#: lib/phoenix_kit/integrations/validators.ex:758
 #, elixir-autogen, elixir-format
 msgid "No credentials configured"
 msgstr "Aucun identifiant configuré"
@@ -4918,7 +4922,7 @@ msgstr "Seuls les buckets activés reçoivent les nouveaux téléversements"
 msgid "Only width is used, height is calculated automatically"
 msgstr "Seule la largeur est utilisée, la hauteur est calculée automatiquement"
 
-#: lib/phoenix_kit/integrations/providers.ex:387
+#: lib/phoenix_kit/integrations/providers.ex:388
 #, elixir-autogen, elixir-format
 msgid "OpenRouter"
 msgstr "OpenRouter"
@@ -5099,7 +5103,7 @@ msgstr "Maintenance planifiée"
 msgid "Scheduled window is currently active"
 msgstr "La fenêtre planifiée est actuellement active"
 
-#: lib/phoenix_kit/integrations/providers.ex:247
+#: lib/phoenix_kit/integrations/providers.ex:248
 #, elixir-autogen, elixir-format
 msgid "Search for **Google Drive API**, click it, then click **Enable**"
 msgstr "Recherchez **Google Drive API**, cliquez dessus, puis cliquez sur **Activer**"
@@ -5126,7 +5130,7 @@ msgstr "Sélectionnez un utilisateur à ajouter..."
 msgid "Service"
 msgstr "Service"
 
-#: lib/phoenix_kit/integrations/integrations.ex:1134
+#: lib/phoenix_kit/integrations/integrations.ex:1137
 #, elixir-autogen, elixir-format
 msgid "Service error %{status}"
 msgstr "Erreur de service %{status}"
@@ -5136,7 +5140,7 @@ msgstr "Erreur de service %{status}"
 msgid "Set a time window for automatic maintenance activation."
 msgstr "Définissez une plage horaire pour l'activation automatique de la maintenance."
 
-#: lib/phoenix_kit/integrations/providers.ex:258
+#: lib/phoenix_kit/integrations/providers.ex:259
 #, elixir-autogen, elixir-format
 msgid "Set up OAuth consent"
 msgstr "Configurer le consentement OAuth"
@@ -5146,7 +5150,7 @@ msgstr "Configurer le consentement OAuth"
 msgid "Size Configuration"
 msgstr "Configuration de la taille"
 
-#: lib/phoenix_kit/integrations/providers.ex:433
+#: lib/phoenix_kit/integrations/providers.ex:434
 #, elixir-autogen, elixir-format
 msgid "Some models are free, but most require credits"
 msgstr "Certains modèles sont gratuits, mais la plupart nécessitent des crédits"
@@ -5176,7 +5180,7 @@ msgstr "Étape 1"
 msgid "Step 2"
 msgstr "Étape 2"
 
-#: lib/phoenix_kit/integrations/providers.ex:266
+#: lib/phoenix_kit/integrations/providers.ex:267
 #, elixir-autogen, elixir-format
 msgid "Still on Audience — while the app is in **Testing** status, add the Google account you will connect as a **Test user** (this must be the same account whose Drive will store your files)"
 msgstr "Toujours dans Audience — tant que l'application est au statut **Testing**, ajoutez le compte Google que vous allez connecter en tant que **Test user** (ce doit être le même compte dont le Drive stockera vos fichiers)"
@@ -5311,7 +5315,7 @@ msgstr "Région Tigris"
 msgid "Total Files"
 msgstr "Total des fichiers"
 
-#: lib/phoenix_kit/integrations/providers.ex:288
+#: lib/phoenix_kit/integrations/providers.ex:289
 #, elixir-autogen, elixir-format
 msgid "Under **Authorized redirect URIs**, add: `{redirect_uri}`"
 msgstr "Sous **Authorized redirect URIs**, ajoutez : `{redirect_uri}`"
@@ -5368,8 +5372,8 @@ msgstr "Vous avez rejoint l'organisation !"
 msgid "You need to create at least one media bucket before files can be uploaded."
 msgstr "Vous devez créer au moins un bucket de médias avant de pouvoir envoyer des fichiers."
 
-#: lib/phoenix_kit/integrations/providers.ex:300
-#: lib/phoenix_kit/integrations/providers.ex:1252
+#: lib/phoenix_kit/integrations/providers.ex:301
+#: lib/phoenix_kit/integrations/providers.ex:1324
 #, elixir-autogen, elixir-format
 msgid "You'll be redirected back here once connected"
 msgstr "Vous serez redirigé ici une fois connecté"
@@ -5436,39 +5440,39 @@ msgstr "il y a 1 heure"
 msgid "1 minute ago"
 msgstr "il y a 1 minute"
 
-#: lib/phoenix_kit/integrations/providers.ex:509
+#: lib/phoenix_kit/integrations/providers.ex:510
 #, elixir-autogen, elixir-format
 msgid "AI model access via DeepSeek (deepseek-chat, deepseek-reasoner)"
 msgstr "Accès aux modèles d'IA via DeepSeek (deepseek-chat, deepseek-reasoner)"
 
-#: lib/phoenix_kit/integrations/providers.ex:446
+#: lib/phoenix_kit/integrations/providers.ex:447
 #, elixir-autogen, elixir-format
 msgid "AI model access via Mistral AI (Mistral Large, Codestral, Pixtral)"
 msgstr "Accès aux modèles d'IA via Mistral AI (Mistral Large, Codestral, Pixtral)"
 
-#: lib/phoenix_kit/integrations/providers.ex:1218
+#: lib/phoenix_kit/integrations/providers.ex:1290
 #, elixir-autogen, elixir-format
 msgid "Add a client secret"
 msgstr "Ajouter un secret client"
 
-#: lib/phoenix_kit/integrations/providers.ex:480
+#: lib/phoenix_kit/integrations/providers.ex:481
 #, elixir-autogen, elixir-format
 msgid "Add a payment method (required)"
 msgstr "Ajouter un moyen de paiement (obligatoire)"
 
-#: lib/phoenix_kit/integrations/providers.ex:357
-#: lib/phoenix_kit/integrations/providers.ex:542
-#: lib/phoenix_kit/integrations/providers.ex:611
+#: lib/phoenix_kit/integrations/providers.ex:358
+#: lib/phoenix_kit/integrations/providers.ex:543
+#: lib/phoenix_kit/integrations/providers.ex:612
 #, elixir-autogen, elixir-format
 msgid "Add credits"
 msgstr "Ajouter des crédits"
 
-#: lib/phoenix_kit/integrations/providers.ex:1233
+#: lib/phoenix_kit/integrations/providers.ex:1305
 #, elixir-autogen, elixir-format
 msgid "Add the permissions your integration needs: `User.Read` is included by default; add `Mail.Read`, `Files.Read.All`, `Calendars.Read`, etc. as required"
 msgstr "Ajoutez les autorisations dont votre intégration a besoin : `User.Read` est inclus par défaut ; ajoutez `Mail.Read`, `Files.Read.All`, `Calendars.Read`, etc. selon vos besoins"
 
-#: lib/phoenix_kit/integrations/providers.ex:1160
+#: lib/phoenix_kit/integrations/providers.ex:1232
 #, elixir-autogen, elixir-format
 msgid "Application (client) ID"
 msgstr "ID d'application (client)"
@@ -5478,28 +5482,28 @@ msgstr "ID d'application (client)"
 msgid "Clears the OAuth tokens. Credentials and the connection itself stay so you can reconnect with one click."
 msgstr "Efface les jetons OAuth. Les identifiants et la connexion elle-même sont conservés afin de pouvoir vous reconnecter en un clic."
 
-#: lib/phoenix_kit/integrations/providers.ex:556
-#: lib/phoenix_kit/integrations/providers.ex:622
+#: lib/phoenix_kit/integrations/providers.ex:557
+#: lib/phoenix_kit/integrations/providers.ex:623
 #, elixir-autogen, elixir-format
 msgid "Click **Create API key**, give it a name"
 msgstr "Cliquez sur **Create API key**, puis donnez-lui un nom"
 
-#: lib/phoenix_kit/integrations/providers.ex:496
+#: lib/phoenix_kit/integrations/providers.ex:497
 #, elixir-autogen, elixir-format
 msgid "Click **Create new key**, give it a name, set an expiry if desired"
 msgstr "Cliquez sur **Create new key**, donnez-lui un nom, puis définissez une date d'expiration si vous le souhaitez"
 
-#: lib/phoenix_kit/integrations/providers.ex:1205
+#: lib/phoenix_kit/integrations/providers.ex:1277
 #, elixir-autogen, elixir-format
 msgid "Click **New registration**, give the app a name"
 msgstr "Cliquez sur **New registration**, puis donnez un nom à l'application"
 
-#: lib/phoenix_kit/integrations/providers.ex:1210
+#: lib/phoenix_kit/integrations/providers.ex:1282
 #, elixir-autogen, elixir-format
 msgid "Click **Register**"
 msgstr "Cliquez sur **Register**"
 
-#: lib/phoenix_kit/integrations/providers.ex:1228
+#: lib/phoenix_kit/integrations/providers.ex:1300
 #, elixir-autogen, elixir-format
 msgid "Configure API permissions"
 msgstr "Configurer les autorisations de l'API"
@@ -5520,16 +5524,16 @@ msgstr "Le nom de la connexion ne peut pas être vide."
 msgid "Connection renamed"
 msgstr "Connexion renommée"
 
-#: lib/phoenix_kit/integrations/providers.ex:1222
+#: lib/phoenix_kit/integrations/providers.ex:1294
 #, elixir-autogen, elixir-format
 msgid "Copy the **Value** column (not the Secret ID) into the form above — the value is shown ONCE and disappears on page refresh"
 msgstr "Copiez la colonne **Value** (pas le Secret ID) dans le formulaire ci-dessus — la valeur ne s'affiche qu'UNE SEULE FOIS et disparaît après actualisation de la page"
 
-#: lib/phoenix_kit/integrations/providers.ex:372
-#: lib/phoenix_kit/integrations/providers.ex:497
-#: lib/phoenix_kit/integrations/providers.ex:557
-#: lib/phoenix_kit/integrations/providers.ex:623
-#: lib/phoenix_kit/integrations/providers.ex:675
+#: lib/phoenix_kit/integrations/providers.ex:373
+#: lib/phoenix_kit/integrations/providers.ex:498
+#: lib/phoenix_kit/integrations/providers.ex:558
+#: lib/phoenix_kit/integrations/providers.ex:624
+#: lib/phoenix_kit/integrations/providers.ex:676
 #, elixir-autogen, elixir-format
 msgid "Copy the key (shown once) and paste it into the form above"
 msgstr "Copiez la clé (affichée une seule fois) et collez-la dans le formulaire ci-dessus"
@@ -5540,12 +5544,12 @@ msgstr "Copiez la clé (affichée une seule fois) et collez-la dans le formulair
 msgid "Create Connection"
 msgstr "Créer une connexion"
 
-#: lib/phoenix_kit/integrations/providers.ex:534
+#: lib/phoenix_kit/integrations/providers.ex:535
 #, elixir-autogen, elixir-format
 msgid "Create a DeepSeek account"
 msgstr "Créer un compte DeepSeek"
 
-#: lib/phoenix_kit/integrations/providers.ex:471
+#: lib/phoenix_kit/integrations/providers.ex:472
 #, elixir-autogen, elixir-format
 msgid "Create a Mistral account"
 msgstr "Créer un compte Mistral"
@@ -5556,12 +5560,12 @@ msgstr "Créer un compte Mistral"
 msgid "Danger Zone"
 msgstr "Zone de danger"
 
-#: lib/phoenix_kit/integrations/providers.ex:508
+#: lib/phoenix_kit/integrations/providers.ex:509
 #, elixir-autogen, elixir-format
 msgid "DeepSeek"
 msgstr "DeepSeek"
 
-#: lib/phoenix_kit/integrations/providers.ex:547
+#: lib/phoenix_kit/integrations/providers.ex:548
 #, elixir-autogen, elixir-format
 msgid "DeepSeek requires a positive balance before you can call the chat or reasoner endpoints, even on cheap models"
 msgstr "DeepSeek exige un solde positif avant de pouvoir appeler les points de terminaison chat ou reasoner, même sur les modèles bon marché"
@@ -5596,82 +5600,82 @@ msgstr "Échec de la suppression de la connexion."
 msgid "Failed to rename connection."
 msgstr "Échec du renommage de la connexion."
 
-#: lib/phoenix_kit/integrations/providers.ex:485
+#: lib/phoenix_kit/integrations/providers.ex:486
 #, elixir-autogen, elixir-format
 msgid "Free models still require a billing-enabled workspace"
 msgstr "Les modèles gratuits nécessitent tout de même un espace de travail avec facturation activée"
 
-#: lib/phoenix_kit/integrations/providers.ex:1164
+#: lib/phoenix_kit/integrations/providers.ex:1236
 #, elixir-autogen, elixir-format
 msgid "From Azure Portal → App registrations → your app → Overview"
 msgstr "Depuis Azure Portal → App registrations → votre application → Overview"
 
-#: lib/phoenix_kit/integrations/providers.ex:464
+#: lib/phoenix_kit/integrations/providers.ex:465
 #, elixir-autogen, elixir-format
 msgid "From console.mistral.ai/api-keys"
 msgstr "Depuis console.mistral.ai/api-keys"
 
-#: lib/phoenix_kit/integrations/providers.ex:527
+#: lib/phoenix_kit/integrations/providers.ex:528
 #, elixir-autogen, elixir-format
 msgid "From platform.deepseek.com/api_keys"
 msgstr "Depuis platform.deepseek.com/api_keys"
 
-#: lib/phoenix_kit/integrations/providers.ex:1174
+#: lib/phoenix_kit/integrations/providers.ex:1246
 #, elixir-autogen, elixir-format
 msgid "From your app → Certificates & secrets → New client secret. Copy the *Value*, not the Secret ID."
 msgstr "Depuis votre application → Certificates & secrets → New client secret. Copiez la *Value*, pas le Secret ID."
 
-#: lib/phoenix_kit/integrations/providers.ex:1230
+#: lib/phoenix_kit/integrations/providers.ex:1302
 #, elixir-autogen, elixir-format
 msgid "Go to **API permissions → Add a permission → Microsoft Graph → Delegated permissions**"
 msgstr "Allez dans **API permissions → Add a permission → Microsoft Graph → Delegated permissions**"
 
-#: lib/phoenix_kit/integrations/providers.ex:1220
+#: lib/phoenix_kit/integrations/providers.ex:1292
 #, elixir-autogen, elixir-format
 msgid "Go to **Certificates & secrets → New client secret**"
 msgstr "Allez dans **Certificates & secrets → New client secret**"
 
-#: lib/phoenix_kit/integrations/providers.ex:495
+#: lib/phoenix_kit/integrations/providers.ex:496
 #, elixir-autogen, elixir-format
 msgid "Go to [API Keys](https://console.mistral.ai/api-keys)"
 msgstr "Allez dans [API Keys](https://console.mistral.ai/api-keys)"
 
-#: lib/phoenix_kit/integrations/providers.ex:555
+#: lib/phoenix_kit/integrations/providers.ex:556
 #, elixir-autogen, elixir-format
 msgid "Go to [API Keys](https://platform.deepseek.com/api_keys)"
 msgstr "Allez dans [API Keys](https://platform.deepseek.com/api_keys)"
 
-#: lib/phoenix_kit/integrations/providers.ex:544
+#: lib/phoenix_kit/integrations/providers.ex:545
 #, elixir-autogen, elixir-format
 msgid "Go to [Top up](https://platform.deepseek.com/top_up) and add at least the minimum amount"
 msgstr "Allez dans [Top up](https://platform.deepseek.com/top_up) et ajoutez au moins le montant minimum"
 
-#: lib/phoenix_kit/integrations/providers.ex:482
+#: lib/phoenix_kit/integrations/providers.ex:483
 #, elixir-autogen, elixir-format
 msgid "Go to [Workspace → Billing](https://console.mistral.ai/billing/plans) and choose **Experiment** (pay-as-you-go) or a paid tier"
 msgstr "Allez dans [Workspace → Billing](https://console.mistral.ai/billing/plans) et choisissez **Experiment** (paiement à l'usage) ou une offre payante"
 
-#: lib/phoenix_kit/integrations/providers.ex:473
+#: lib/phoenix_kit/integrations/providers.ex:474
 #, elixir-autogen, elixir-format
 msgid "Go to [console.mistral.ai](https://console.mistral.ai) and sign up or log in"
 msgstr "Allez sur [console.mistral.ai](https://console.mistral.ai) et inscrivez-vous ou connectez-vous"
 
-#: lib/phoenix_kit/integrations/providers.ex:536
+#: lib/phoenix_kit/integrations/providers.ex:537
 #, elixir-autogen, elixir-format
 msgid "Go to [platform.deepseek.com](https://platform.deepseek.com) and sign up or log in"
 msgstr "Allez sur [platform.deepseek.com](https://platform.deepseek.com) et inscrivez-vous ou connectez-vous"
 
-#: lib/phoenix_kit/integrations/providers.ex:1202
+#: lib/phoenix_kit/integrations/providers.ex:1274
 #, elixir-autogen, elixir-format
 msgid "Go to the [Azure Portal](https://portal.azure.com) and search for **App registrations**"
 msgstr "Allez sur [Azure Portal](https://portal.azure.com) et recherchez **App registrations**"
 
-#: lib/phoenix_kit/integrations/providers.ex:1213
+#: lib/phoenix_kit/integrations/providers.ex:1285
 #, elixir-autogen, elixir-format
 msgid "If you picked a single-tenant audience, fill in **Tenant ID** above with your Directory (tenant) ID GUID — leaving it as `common` only works for multi-tenant + personal apps."
 msgstr "Si vous avez choisi une audience à locataire unique (single-tenant), renseignez le champ **Tenant ID** ci-dessus avec le GUID de votre ID de répertoire (tenant) — laisser la valeur `common` ne fonctionne que pour les applications multi-locataires + personnelles."
 
-#: lib/phoenix_kit/integrations/providers.ex:1236
+#: lib/phoenix_kit/integrations/providers.ex:1308
 #, elixir-autogen, elixir-format
 msgid "If your tenant requires admin consent, click **Grant admin consent for <tenant>** before the connect flow will work"
 msgstr "Si votre locataire (tenant) exige un consentement administrateur, cliquez sur **Grant admin consent for <tenant>** avant que le processus de connexion ne fonctionne"
@@ -5688,32 +5692,32 @@ msgstr "Intégration introuvable"
 msgid "Last tested"
 msgstr "Dernier test"
 
-#: lib/phoenix_kit/integrations/providers.ex:1186
+#: lib/phoenix_kit/integrations/providers.ex:1258
 #, elixir-autogen, elixir-format
 msgid "Leave as `common` for multi-tenant + personal accounts. For single-tenant apps, paste your Directory (tenant) ID GUID. Use `consumers` for personal-only or `organizations` for any work-or-school account."
 msgstr "Laissez `common` pour les comptes multi-locataires + personnels. Pour les applications à locataire unique, collez le GUID de votre ID de répertoire (tenant). Utilisez `consumers` pour les comptes personnels uniquement ou `organizations` pour tout compte professionnel ou scolaire."
 
-#: lib/phoenix_kit/integrations/providers.ex:1131
+#: lib/phoenix_kit/integrations/providers.ex:1203
 #, elixir-autogen, elixir-format
 msgid "Microsoft 365"
 msgstr "Microsoft 365"
 
-#: lib/phoenix_kit/integrations/providers.ex:1132
+#: lib/phoenix_kit/integrations/providers.ex:1204
 #, elixir-autogen, elixir-format
 msgid "Microsoft Graph — Outlook, OneDrive, Teams, Calendar, SharePoint"
 msgstr "Microsoft Graph — Outlook, OneDrive, Teams, Calendrier, SharePoint"
 
-#: lib/phoenix_kit/integrations/providers.ex:1249
+#: lib/phoenix_kit/integrations/providers.ex:1321
 #, elixir-autogen, elixir-format
 msgid "Microsoft will show the consent screen — click **Accept** to grant the requested permissions"
 msgstr "Microsoft affichera l'écran de consentement — cliquez sur **Accept** pour accorder les autorisations demandées"
 
-#: lib/phoenix_kit/integrations/providers.ex:445
+#: lib/phoenix_kit/integrations/providers.ex:446
 #, elixir-autogen, elixir-format
 msgid "Mistral"
 msgstr "Mistral"
 
-#: lib/phoenix_kit/integrations/providers.ex:488
+#: lib/phoenix_kit/integrations/providers.ex:489
 #, elixir-autogen, elixir-format
 msgid "Mistral does not offer credits without billing setup; this is a hard requirement before keys can be created."
 msgstr "Mistral n'offre pas de crédits sans configuration de facturation ; c'est une exigence stricte avant de pouvoir créer des clés."
@@ -5724,7 +5728,7 @@ msgstr "Mistral n'offre pas de crédits sans configuration de facturation ; c'es
 msgid "Permanently delete this connection? This cannot be undone."
 msgstr "Supprimer définitivement cette connexion ? Cette action est irréversible."
 
-#: lib/phoenix_kit/integrations/providers.ex:1200
+#: lib/phoenix_kit/integrations/providers.ex:1272
 #, elixir-autogen, elixir-format
 msgid "Register an application in Microsoft Entra ID (Azure AD)"
 msgstr "Enregistrer une application dans Microsoft Entra ID (Azure AD)"
@@ -5740,32 +5744,32 @@ msgstr "Supprime définitivement l'intégration. Tout module lié à cette conne
 msgid "Search..."
 msgstr "Rechercher..."
 
-#: lib/phoenix_kit/integrations/providers.ex:1221
+#: lib/phoenix_kit/integrations/providers.ex:1293
 #, elixir-autogen, elixir-format
 msgid "Set an expiration (24 months is common; renew before it lapses)"
 msgstr "Définissez une expiration (24 mois est courant ; renouvelez avant l'échéance)"
 
-#: lib/phoenix_kit/integrations/providers.ex:1181
+#: lib/phoenix_kit/integrations/providers.ex:1253
 #, elixir-autogen, elixir-format
 msgid "Tenant ID"
 msgstr "ID du locataire"
 
-#: lib/phoenix_kit/integrations/providers.ex:1241
+#: lib/phoenix_kit/integrations/providers.ex:1313
 #, elixir-autogen, elixir-format
 msgid "The `default_scopes` in the provider definition request `openid email profile offline_access User.Read` — extra scopes can be added per-connect by passing `extra_scopes` to `authorization_url/5`."
 msgstr "Les `default_scopes` définis dans le fournisseur demandent `openid email profile offline_access User.Read` — des scopes supplémentaires peuvent être ajoutés par connexion en passant `extra_scopes` à `authorization_url/5`."
 
-#: lib/phoenix_kit/integrations/providers.ex:1209
+#: lib/phoenix_kit/integrations/providers.ex:1281
 #, elixir-autogen, elixir-format
 msgid "Under **Redirect URI**, choose **Web** and enter: `{redirect_uri}`"
 msgstr "Sous **Redirect URI**, choisissez **Web** et saisissez : `{redirect_uri}`"
 
-#: lib/phoenix_kit/integrations/providers.ex:1206
+#: lib/phoenix_kit/integrations/providers.ex:1278
 #, elixir-autogen, elixir-format
 msgid "Under **Supported account types**, choose the audience: *Personal Microsoft accounts only*, *Accounts in any organizational directory*, or *Accounts in this organizational directory only* depending on who should sign in"
 msgstr "Sous **Supported account types**, choisissez l'audience : *Personal Microsoft accounts only*, *Accounts in any organizational directory*, ou *Accounts in this organizational directory only* selon qui doit pouvoir se connecter"
 
-#: lib/phoenix_kit/integrations/providers.ex:476
+#: lib/phoenix_kit/integrations/providers.ex:477
 #, elixir-autogen, elixir-format
 msgid "You may need to verify your phone number before creating API keys"
 msgstr "Il se peut que vous deviez vérifier votre numéro de téléphone avant de créer des clés API"
@@ -6032,14 +6036,14 @@ msgstr "Non installé"
 
 #: lib/phoenix_kit_web/live/modules.html.heex:447
 #: lib/phoenix_kit_web/live/settings.html.heex:465
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:289
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:315
 #, elixir-autogen, elixir-format
 msgid "Off"
 msgstr "Désactivé"
 
 #: lib/phoenix_kit_web/live/modules.html.heex:447
 #: lib/phoenix_kit_web/live/settings.html.heex:464
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:289
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:315
 #, elixir-autogen, elixir-format
 msgid "On"
 msgstr "Activé"
@@ -7271,8 +7275,8 @@ msgstr "Répondre"
 msgid "Are you sure you want to delete this comment?"
 msgstr "Êtes-vous sûr de vouloir supprimer ce commentaire ?"
 
-#: lib/phoenix_kit_web/components/media_canvas_viewer.ex:1202
-#: lib/phoenix_kit_web/components/media_canvas_viewer.ex:1203
+#: lib/phoenix_kit_web/components/media_canvas_viewer.ex:1236
+#: lib/phoenix_kit_web/components/media_canvas_viewer.ex:1237
 #, elixir-autogen, elixir-format
 msgid "%b %d, %Y"
 msgstr "%d %b %Y"
@@ -8386,14 +8390,14 @@ msgstr "Tous les champs sont déjà sélectionnés"
 msgid "All registered accounts"
 msgstr "Tous les comptes enregistrés"
 
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:185
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:224
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:179
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:218
 #, elixir-autogen, elixir-format
 msgid "Anon"
 msgstr "Anon."
 
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:178
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:245
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:172
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:239
 #, elixir-autogen, elixir-format
 msgid "Anonymous User"
 msgstr "Utilisateur anonyme"
@@ -8444,8 +8448,8 @@ msgstr "Voulez-vous vraiment révoquer cette session pour"
 msgid "Are you sure you want to unconfirm this user's email?"
 msgstr "Voulez-vous vraiment annuler la confirmation de l'e-mail de cet utilisateur ?"
 
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:170
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:220
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:164
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:214
 #, elixir-autogen, elixir-format
 msgid "Auth"
 msgstr "Auth."
@@ -8528,17 +8532,17 @@ msgid "Confirmed Email"
 msgstr "E-mail confirmé"
 
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:109
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:195
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Current Page"
 msgstr "Page actuelle"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:251
+#: lib/phoenix_kit_web/live/settings/users.ex:258
 #, elixir-autogen, elixir-format
 msgid "Custom field deleted successfully"
 msgstr "Champ personnalisé supprimé avec succès"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:171
+#: lib/phoenix_kit_web/live/settings/users.ex:178
 #, elixir-autogen, elixir-format
 msgid "Custom field saved successfully"
 msgstr "Champ personnalisé enregistré avec succès"
@@ -8553,17 +8557,17 @@ msgstr "Personnaliser les colonnes du tableau"
 msgid "Drag to reorder selected columns above, or add new columns from the options below. Actions column is always included."
 msgstr "Faites glisser pour réorganiser les colonnes sélectionnées ci-dessus, ou ajoutez de nouvelles colonnes à partir des options ci-dessous. La colonne Actions est toujours incluse."
 
-#: lib/phoenix_kit_web/live/settings/users.ex:256
+#: lib/phoenix_kit_web/live/settings/users.ex:263
 #, elixir-autogen, elixir-format
 msgid "Failed to delete custom field"
 msgstr "Échec de la suppression du champ personnalisé"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:184
+#: lib/phoenix_kit_web/live/settings/users.ex:191
 #, elixir-autogen, elixir-format
 msgid "Failed to save custom field"
 msgstr "Échec de l'enregistrement du champ personnalisé"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:285
+#: lib/phoenix_kit_web/live/settings/users.ex:292
 #, elixir-autogen, elixir-format
 msgid "Failed to update field"
 msgstr "Impossible de mettre à jour le champ"
@@ -8596,23 +8600,23 @@ msgstr "Impossible de mettre à jour les rôles de l'utilisateur"
 msgid "Failed to update user status"
 msgstr "Impossible de mettre à jour le statut de l'utilisateur"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:278
+#: lib/phoenix_kit_web/live/settings/users.ex:285
 #, elixir-autogen, elixir-format
 msgid "Field '%{label}' disabled"
 msgstr "Champ '%{label}' désactivé"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:277
+#: lib/phoenix_kit_web/live/settings/users.ex:284
 #, elixir-autogen, elixir-format
 msgid "Field '%{label}' enabled"
 msgstr "Champ '%{label}' activé"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:289
+#: lib/phoenix_kit_web/live/settings/users.ex:296
 #, elixir-autogen, elixir-format
 msgid "Field not found"
 msgstr "Champ introuvable"
 
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:108
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:194
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:188
 #, elixir-autogen, elixir-format
 msgid "IP Address"
 msgstr "Adresse IP"
@@ -8644,7 +8648,7 @@ msgstr "Gérer les comptes utilisateurs et les rôles"
 msgid "Monitor and manage active user sessions"
 msgstr "Surveiller et gérer les sessions utilisateur actives"
 
-#: lib/phoenix_kit/integrations/providers.ex:1002
+#: lib/phoenix_kit/integrations/providers.ex:1074
 #: lib/phoenix_kit_web/live/users/users.ex:1048
 #: lib/phoenix_kit_web/live/users/users.html.heex:563
 #, elixir-autogen, elixir-format
@@ -8656,7 +8660,7 @@ msgstr "Jamais"
 msgid "Next »"
 msgstr "Suivant »"
 
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:208
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:202
 #, elixir-autogen, elixir-format
 msgid "No active sessions"
 msgstr "Aucune session active"
@@ -8808,7 +8812,7 @@ msgstr "Champs standard"
 msgid "Table columns updated successfully"
 msgstr "Colonnes du tableau mises à jour avec succès"
 
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:209
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:203
 #, elixir-autogen, elixir-format
 msgid "There are currently no active sessions to display."
 msgstr "Il n'y a actuellement aucune session active à afficher."
@@ -8869,12 +8873,12 @@ msgstr "Confirmation de l'e-mail de l'utilisateur annulée avec succès"
 msgid "User roles updated successfully"
 msgstr "Rôles de l'utilisateur mis à jour avec succès"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:84
+#: lib/phoenix_kit_web/live/settings/users.ex:91
 #, elixir-autogen, elixir-format
 msgid "User settings updated successfully"
 msgstr "Paramètres utilisateur mis à jour avec succès"
 
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:193
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:187
 #, elixir-autogen, elixir-format
 msgid "User/Session"
 msgstr "Utilisateur/Session"
@@ -8908,7 +8912,7 @@ msgstr[1] "Voulez-vous vraiment révoquer les %{count} sessions de l'utilisateur
 msgid "Last updated:"
 msgstr "Dernière mise à jour :"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:656
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:671
 #, elixir-autogen, elixir-format
 msgid "Account switcher for signing in to several accounts at once"
 msgstr "Sélecteur de comptes pour se connecter à plusieurs comptes à la fois"
@@ -8918,7 +8922,7 @@ msgstr "Sélecteur de comptes pour se connecter à plusieurs comptes à la fois"
 msgid "Applying…"
 msgstr "Application en cours…"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:662
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:677
 #, elixir-autogen, elixir-format
 msgid "Enable the multi-account switcher in the header"
 msgstr "Activer le sélecteur multi-comptes dans l'en-tête"
@@ -8936,12 +8940,12 @@ msgstr "Charger plus"
 msgid "Loading…"
 msgstr "Chargement…"
 
-#: lib/phoenix_kit_web/users/session.ex:113
+#: lib/phoenix_kit_web/users/session.ex:115
 #, elixir-autogen, elixir-format
 msgid "Logged out. Now signed in as %{email}."
 msgstr "Déconnecté. Vous êtes maintenant connecté en tant que %{email}."
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:653
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:668
 #, elixir-autogen, elixir-format
 msgid "Multiple Sessions"
 msgstr "Sessions multiples"
@@ -8977,12 +8981,12 @@ msgstr "Réorganiser le 1 %{noun} sélectionné (les autres lignes restent en pl
 msgid "Showing %{loaded} of %{total} %{noun}"
 msgstr "Affichage de %{loaded} sur %{total} %{noun}"
 
-#: lib/phoenix_kit_web/users/session.ex:268
+#: lib/phoenix_kit_web/users/session.ex:270
 #, elixir-autogen, elixir-format
 msgid "Switched to %{email}."
 msgstr "Basculé vers %{email}."
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:665
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:680
 #, elixir-autogen, elixir-format
 msgid "When on, any signed-in user can add other accounts (with their password) and switch between them from the user menu."
 msgstr "Lorsque cette option est activée, tout utilisateur connecté peut ajouter d'autres comptes (avec leur mot de passe) et basculer entre eux depuis le menu utilisateur."
@@ -9062,7 +9066,7 @@ msgstr "Seuls les types de fichiers autorisés peuvent être ajoutés ici."
 msgid "View background job status and history"
 msgstr "Consulter l'état et l'historique des tâches en arrière-plan"
 
-#: lib/phoenix_kit/integrations/providers.ex:312
+#: lib/phoenix_kit/integrations/providers.ex:313
 #, elixir-autogen, elixir-format
 msgid "AI models via OpenAI (GPT, embeddings, images, audio)"
 msgstr "Modèles d'IA via OpenAI (GPT, embeddings, images, audio)"
@@ -9147,12 +9151,12 @@ msgstr "Modifier"
 msgid "Choose"
 msgstr "Choisir"
 
-#: lib/phoenix_kit/integrations/providers.ex:674
+#: lib/phoenix_kit/integrations/providers.ex:675
 #, elixir-autogen, elixir-format
 msgid "Click **Create API Key**, give it a name"
 msgstr "Cliquez sur **Créer une clé API**, donnez-lui un nom"
 
-#: lib/phoenix_kit/integrations/providers.ex:371
+#: lib/phoenix_kit/integrations/providers.ex:372
 #, elixir-autogen, elixir-format
 msgid "Click **Create new secret key**, give it a name"
 msgstr "Cliquez sur **Créer une nouvelle clé secrète**, donnez-lui un nom"
@@ -9163,12 +9167,12 @@ msgstr "Cliquez sur **Créer une nouvelle clé secrète**, donnez-lui un nom"
 msgid "Close search"
 msgstr "Fermer la recherche"
 
-#: lib/phoenix_kit/integrations/providers.ex:664
+#: lib/phoenix_kit/integrations/providers.ex:665
 #, elixir-autogen, elixir-format
 msgid "Create an ElevenLabs account"
 msgstr "Créer un compte ElevenLabs"
 
-#: lib/phoenix_kit/integrations/providers.ex:349
+#: lib/phoenix_kit/integrations/providers.ex:350
 #, elixir-autogen, elixir-format
 msgid "Create an OpenAI account"
 msgstr "Créer un compte OpenAI"
@@ -9232,7 +9236,7 @@ msgstr "Modifier la description"
 msgid "Edit header"
 msgstr "Modifier l'en-tête"
 
-#: lib/phoenix_kit/integrations/providers.ex:634
+#: lib/phoenix_kit/integrations/providers.ex:635
 #, elixir-autogen, elixir-format
 msgid "ElevenLabs"
 msgstr "ElevenLabs"
@@ -9302,37 +9306,37 @@ msgstr "Le nom du dossier ne peut pas être vide"
 msgid "Forgot password"
 msgstr "Mot de passe oublié"
 
-#: lib/phoenix_kit/integrations/providers.ex:657
+#: lib/phoenix_kit/integrations/providers.ex:658
 #, elixir-autogen, elixir-format
 msgid "From elevenlabs.io → Settings → API Keys"
 msgstr "Depuis elevenlabs.io → Paramètres → Clés API"
 
-#: lib/phoenix_kit/integrations/providers.ex:336
+#: lib/phoenix_kit/integrations/providers.ex:337
 #, elixir-autogen, elixir-format
 msgid "From platform.openai.com/api-keys"
 msgstr "Depuis platform.openai.com/api-keys"
 
-#: lib/phoenix_kit/integrations/providers.ex:370
+#: lib/phoenix_kit/integrations/providers.ex:371
 #, elixir-autogen, elixir-format
 msgid "Go to [API Keys](https://platform.openai.com/api-keys)"
 msgstr "Accédez à [Clés API](https://platform.openai.com/api-keys)"
 
-#: lib/phoenix_kit/integrations/providers.ex:359
+#: lib/phoenix_kit/integrations/providers.ex:360
 #, elixir-autogen, elixir-format
 msgid "Go to [Billing](https://platform.openai.com/account/billing/overview) and add a payment method or credits"
 msgstr "Accédez à [Facturation](https://platform.openai.com/account/billing/overview) et ajoutez un moyen de paiement ou des crédits"
 
-#: lib/phoenix_kit/integrations/providers.ex:672
+#: lib/phoenix_kit/integrations/providers.ex:673
 #, elixir-autogen, elixir-format
 msgid "Go to [Settings → API Keys](https://elevenlabs.io/app/settings/api-keys)"
 msgstr "Accédez à [Paramètres → Clés API](https://elevenlabs.io/app/settings/api-keys)"
 
-#: lib/phoenix_kit/integrations/providers.ex:666
+#: lib/phoenix_kit/integrations/providers.ex:667
 #, elixir-autogen, elixir-format
 msgid "Go to [elevenlabs.io](https://elevenlabs.io) and sign up or log in"
 msgstr "Accédez à [elevenlabs.io](https://elevenlabs.io) et inscrivez-vous ou connectez-vous"
 
-#: lib/phoenix_kit/integrations/providers.ex:351
+#: lib/phoenix_kit/integrations/providers.ex:352
 #, elixir-autogen, elixir-format
 msgid "Go to [platform.openai.com](https://platform.openai.com) and sign up or log in"
 msgstr "Accédez à [platform.openai.com](https://platform.openai.com) et inscrivez-vous ou connectez-vous"
@@ -9361,7 +9365,7 @@ msgstr "Titre %{level}"
 msgid "Icon"
 msgstr "Icône"
 
-#: lib/phoenix_kit/integrations/providers.ex:375
+#: lib/phoenix_kit/integrations/providers.ex:376
 #, elixir-autogen, elixir-format
 msgid "If your account belongs to multiple organizations, keys are scoped to the org selected when the key was created."
 msgstr "Si votre compte appartient à plusieurs organisations, les clés sont limitées à l'organisation sélectionnée au moment de leur création."
@@ -9461,12 +9465,12 @@ msgstr "Plus anciens en premier"
 msgid "Open the media health dashboard to check file redundancy and re-sync files across storage locations."
 msgstr "Ouvrez le tableau de bord d'intégrité des médias pour vérifier la redondance des fichiers et resynchroniser les fichiers entre les emplacements de stockage."
 
-#: lib/phoenix_kit/integrations/providers.ex:311
+#: lib/phoenix_kit/integrations/providers.ex:312
 #, elixir-autogen, elixir-format
 msgid "OpenAI"
 msgstr "OpenAI"
 
-#: lib/phoenix_kit/integrations/providers.ex:362
+#: lib/phoenix_kit/integrations/providers.ex:363
 #, elixir-autogen, elixir-format
 msgid "OpenAI requires a positive balance before the API will return completions, even on cheaper models"
 msgstr "OpenAI exige un solde positif avant que l'API ne renvoie des complétions, même avec les modèles les moins chers"
@@ -9556,12 +9560,12 @@ msgstr "Trier"
 msgid "Stacks"
 msgstr "Piles"
 
-#: lib/phoenix_kit/integrations/providers.ex:635
+#: lib/phoenix_kit/integrations/providers.ex:636
 #, elixir-autogen, elixir-format
 msgid "Text-to-speech and voice generation via ElevenLabs"
 msgstr "Synthèse vocale et génération de voix via ElevenLabs"
 
-#: lib/phoenix_kit/integrations/providers.ex:678
+#: lib/phoenix_kit/integrations/providers.ex:679
 #, elixir-autogen, elixir-format
 msgid "The free tier includes a monthly character quota; paid plans raise the quota and unlock commercial use and additional voices."
 msgstr "L'offre gratuite inclut un quota mensuel de caractères ; les offres payantes augmentent ce quota et débloquent l'usage commercial ainsi que des voix supplémentaires."
@@ -10443,27 +10447,27 @@ msgstr "Ou ajouter via"
 msgid "Too many attempts. Please try again shortly."
 msgstr "Trop de tentatives. Veuillez réessayer dans un instant."
 
-#: lib/phoenix_kit/integrations/providers.ex:569
+#: lib/phoenix_kit/integrations/providers.ex:570
 #, elixir-autogen, elixir-format
 msgid "AI model access via xAI (Grok models)"
 msgstr "Accès aux modèles d'IA via xAI (modèles Grok)"
 
-#: lib/phoenix_kit/integrations/providers.ex:827
+#: lib/phoenix_kit/integrations/providers.ex:828
 #, elixir-autogen, elixir-format
 msgid "AWS Simple Email Service (SMTP credentials via SES API)"
 msgstr "AWS Simple Email Service (identifiants SMTP via l'API SES)"
 
-#: lib/phoenix_kit/integrations/providers.ex:826
+#: lib/phoenix_kit/integrations/providers.ex:827
 #, elixir-autogen, elixir-format
 msgid "Amazon SES"
 msgstr "Amazon SES"
 
-#: lib/phoenix_kit/integrations/providers.ex:1050
+#: lib/phoenix_kit/integrations/providers.ex:1122
 #, elixir-autogen, elixir-format
 msgid "Brevo API"
 msgstr "API Brevo"
 
-#: lib/phoenix_kit/integrations/providers.ex:605
+#: lib/phoenix_kit/integrations/providers.ex:606
 #, elixir-autogen, elixir-format
 msgid "Create an xAI account"
 msgstr "Créer un compte xAI"
@@ -10473,37 +10477,37 @@ msgstr "Créer un compte xAI"
 msgid "Email users when their account is signed in from a new device"
 msgstr "Envoyer un e-mail aux utilisateurs lors d'une connexion depuis un nouvel appareil"
 
-#: lib/phoenix_kit/integrations/providers.ex:961
+#: lib/phoenix_kit/integrations/providers.ex:1033
 #, elixir-autogen, elixir-format
 msgid "For Brevo: the SMTP key starting with xsmtpsib- (SMTP & API → SMTP tab) — not the API key (xkeysib-)."
 msgstr "Pour Brevo : la clé SMTP commençant par xsmtpsib- (SMTP & API → onglet SMTP), et non la clé API (xkeysib-)."
 
-#: lib/phoenix_kit/integrations/providers.ex:949
+#: lib/phoenix_kit/integrations/providers.ex:1021
 #, elixir-autogen, elixir-format
 msgid "For Brevo: your account's SMTP login, shown as <subaccount>@smtp-brevo.com under SMTP & API → SMTP."
 msgstr "Pour Brevo : l'identifiant SMTP de votre compte, affiché sous la forme <subaccount>@smtp-brevo.com dans SMTP & API → SMTP."
 
-#: lib/phoenix_kit/integrations/providers.ex:1070
+#: lib/phoenix_kit/integrations/providers.ex:1142
 #, elixir-autogen, elixir-format
 msgid "From Brevo → SMTP & API → API Keys. Starts with xkeysib- — not the SMTP key (xsmtpsib-)."
 msgstr "Depuis Brevo → SMTP & API → API Keys. Commence par xkeysib-, et non la clé SMTP (xsmtpsib-)."
 
-#: lib/phoenix_kit/integrations/providers.ex:590
+#: lib/phoenix_kit/integrations/providers.ex:591
 #, elixir-autogen, elixir-format
 msgid "From console.x.ai/team/default/api-keys"
 msgstr "Depuis console.x.ai/team/default/api-keys"
 
-#: lib/phoenix_kit/integrations/providers.ex:621
+#: lib/phoenix_kit/integrations/providers.ex:622
 #, elixir-autogen, elixir-format
 msgid "Go to [API Keys](https://console.x.ai/team/default/api-keys)"
 msgstr "Allez dans [API Keys](https://console.x.ai/team/default/api-keys)"
 
-#: lib/phoenix_kit/integrations/providers.ex:607
+#: lib/phoenix_kit/integrations/providers.ex:608
 #, elixir-autogen, elixir-format
 msgid "Go to [accounts.x.ai](https://accounts.x.ai) and sign up or log in"
 msgstr "Rendez-vous sur [accounts.x.ai](https://accounts.x.ai) et inscrivez-vous ou connectez-vous"
 
-#: lib/phoenix_kit/integrations/providers.ex:613
+#: lib/phoenix_kit/integrations/providers.ex:614
 #, elixir-autogen, elixir-format
 msgid "Go to [console.x.ai](https://console.x.ai) → Billing and add credits"
 msgstr "Rendez-vous sur [console.x.ai](https://console.x.ai) → Billing et ajoutez des crédits"
@@ -10513,43 +10517,44 @@ msgstr "Rendez-vous sur [console.x.ai](https://console.x.ai) → Billing et ajou
 msgid "Login Notifications"
 msgstr "Notifications de connexion"
 
-#: lib/phoenix_kit/integrations/providers.ex:927
+#: lib/phoenix_kit/integrations/providers.ex:999
 #, elixir-autogen, elixir-format
 msgid "Port"
 msgstr "Port"
 
-#: lib/phoenix_kit/integrations/providers.ex:720
-#: lib/phoenix_kit/integrations/providers.ex:860
+#: lib/phoenix_kit/integrations/providers.ex:721
+#: lib/phoenix_kit/integrations/providers.ex:861
+#: lib/phoenix_kit/integrations/providers.ex:945
 #, elixir-autogen, elixir-format
 msgid "Region"
 msgstr "Région"
 
-#: lib/phoenix_kit/integrations/providers.ex:904
+#: lib/phoenix_kit/integrations/providers.ex:976
 #, elixir-autogen, elixir-format
 msgid "SMTP"
 msgstr "SMTP"
 
-#: lib/phoenix_kit/integrations/providers.ex:918
+#: lib/phoenix_kit/integrations/providers.ex:990
 #, elixir-autogen, elixir-format
 msgid "SMTP Host"
 msgstr "Hôte SMTP"
 
-#: lib/phoenix_kit/integrations/providers.ex:1051
+#: lib/phoenix_kit/integrations/providers.ex:1123
 #, elixir-autogen, elixir-format
 msgid "Send email via the Brevo transactional email API"
 msgstr "Envoyer les e-mails via l'API d'e-mails transactionnels de Brevo"
 
-#: lib/phoenix_kit/integrations/providers.ex:906
+#: lib/phoenix_kit/integrations/providers.ex:978
 #, elixir-autogen, elixir-format
 msgid "Universal SMTP relay — works with any vendor (Brevo, Mailgun, SendGrid, a self-hosted mail server, etc). Add one named connection per relay/account."
 msgstr "Relais SMTP universel — fonctionne avec n'importe quel fournisseur (Brevo, Mailgun, SendGrid, un serveur de messagerie auto-hébergé, etc.). Ajoutez une connexion nommée par relais ou par compte."
 
-#: lib/phoenix_kit/integrations/providers.ex:568
+#: lib/phoenix_kit/integrations/providers.ex:569
 #, elixir-autogen, elixir-format
 msgid "xAI"
 msgstr "xAI"
 
-#: lib/phoenix_kit/integrations/providers.ex:615
+#: lib/phoenix_kit/integrations/providers.ex:616
 #, elixir-autogen, elixir-format
 msgid "xAI requires a funded account before the API will return completions"
 msgstr "xAI exige un compte crédité avant que l'API ne renvoie des complétions"
@@ -10723,12 +10728,12 @@ msgstr "Aucun fichier ne correspond à votre recherche."
 msgid "Try a different term or clear the search"
 msgstr "Essayez un autre terme ou effacez la recherche"
 
-#: lib/modules/storage/web/bucket_form.ex:294
+#: lib/modules/storage/web/bucket_form.ex:296
 #, elixir-autogen, elixir-format
 msgid "Add Storage Bucket"
 msgstr "Ajouter un bucket de stockage"
 
-#: lib/modules/storage/web/bucket_form.ex:295
+#: lib/modules/storage/web/bucket_form.ex:297
 #, elixir-autogen, elixir-format
 msgid "Edit Storage Bucket"
 msgstr "Modifier le bucket de stockage"
@@ -10817,12 +10822,12 @@ msgstr "il y a %{n} min"
 msgid "%{provider} settings"
 msgstr "Paramètres %{provider}"
 
-#: lib/phoenix_kit/integrations/validators.ex:643
+#: lib/phoenix_kit/integrations/validators.ex:824
 #, elixir-autogen, elixir-format
 msgid "%{text} · resets %{date}"
 msgstr "%{text} · réinitialisation le %{date}"
 
-#: lib/phoenix_kit/integrations/validators.ex:632
+#: lib/phoenix_kit/integrations/validators.ex:813
 #, elixir-autogen, elixir-format
 msgid "%{type} · %{credits} credits left"
 msgstr "%{type} · %{credits} crédits restants"
@@ -10878,12 +10883,12 @@ msgstr "Tout le courrier système sortant — authentification, notifications �
 msgid "Allow \"Keep me logged in\" (persistent sessions)"
 msgstr "Autoriser « Rester connecté » (sessions persistantes)"
 
-#: lib/phoenix_kit/integrations/providers.ex:1001
+#: lib/phoenix_kit/integrations/providers.ex:1073
 #, elixir-autogen, elixir-format
 msgid "Always"
 msgstr "Toujours"
 
-#: lib/phoenix_kit_web/users/session.ex:331
+#: lib/phoenix_kit_web/users/session.ex:333
 #, elixir-autogen, elixir-format
 msgid "An owner account cannot be used."
 msgstr "Un compte propriétaire ne peut pas être utilisé."
@@ -10893,12 +10898,12 @@ msgstr "Un compte propriétaire ne peut pas être utilisé."
 msgid "Applies site-wide wherever the rich-text editor is rendered (posts, comments). Users can still switch modes inside the editor."
 msgstr "S'applique à tout le site partout où l'éditeur de texte enrichi est affiché (publications, commentaires). Les utilisateurs peuvent toujours changer de mode dans l'éditeur."
 
-#: lib/phoenix_kit/integrations/providers.ex:982
+#: lib/phoenix_kit/integrations/providers.ex:1054
 #, elixir-autogen, elixir-format
 msgid "Auto (from port)"
 msgstr "Automatique (d'après le port)"
 
-#: lib/phoenix_kit/integrations/providers.ex:978
+#: lib/phoenix_kit/integrations/providers.ex:1050
 #, elixir-autogen, elixir-format
 msgid "Auto follows the port: 465 means implicit TLS, anything else STARTTLS (required when a login is set). Choose explicitly for a relay that ignores that convention."
 msgstr "« Automatique » suit le port : 465 signifie TLS implicite, tout autre port STARTTLS (obligatoire si un identifiant est défini). Choisissez explicitement pour un relais qui ne respecte pas cette convention."
@@ -10913,22 +10918,22 @@ msgstr "Regroupez les types à fort volume dans des résumés périodiques — d
 msgid "Best,\nThe Team"
 msgstr "Cordialement,\nL'équipe"
 
-#: lib/phoenix_kit/integrations/providers.ex:1098
+#: lib/phoenix_kit/integrations/providers.ex:1170
 #, elixir-autogen, elixir-format
 msgid "Bot Token"
 msgstr "Jeton du bot"
 
-#: lib/phoenix_kit/integrations/providers.ex:1118
+#: lib/phoenix_kit/integrations/providers.ex:1190
 #, elixir-autogen, elixir-format
 msgid "BotFather replies with an HTTP API token like `123456789:ABCdef...` — copy it"
 msgstr "BotFather répond avec un jeton d'API HTTP du type `123456789:ABCdef...` — copiez-le"
 
-#: lib/phoenix_kit/integrations/validators.ex:601
+#: lib/phoenix_kit/integrations/validators.ex:782
 #, elixir-autogen, elixir-format
 msgid "Brevo error %{status}"
 msgstr "Erreur Brevo %{status}"
 
-#: lib/phoenix_kit/integrations/providers.ex:1022
+#: lib/phoenix_kit/integrations/providers.ex:1094
 #, elixir-autogen, elixir-format
 msgid "CA certificate (PEM)"
 msgstr "Certificat CA (PEM)"
@@ -10938,7 +10943,7 @@ msgstr "Certificat CA (PEM)"
 msgid "Cannot delete send profile"
 msgstr "Impossible de supprimer le profil d'envoi"
 
-#: lib/phoenix_kit/integrations/providers.ex:1007
+#: lib/phoenix_kit/integrations/providers.ex:1079
 #, elixir-autogen, elixir-format
 msgid "Certificate verification"
 msgstr "Vérification du certificat"
@@ -10983,7 +10988,7 @@ msgstr "Confirmez votre e-mail"
 msgid "Connect your own API keys and services. Only you can see these."
 msgstr "Connectez vos propres clés API et services. Vous seul pouvez les voir."
 
-#: lib/phoenix_kit/integrations/validators.ex:693
+#: lib/phoenix_kit/integrations/validators.ex:874
 #, elixir-autogen, elixir-format
 msgid "Connected as @%{username}"
 msgstr "Connecté en tant que @%{username}"
@@ -10999,7 +11004,7 @@ msgstr "La connexion fonctionne"
 msgid "Content Editor"
 msgstr "Éditeur de contenu"
 
-#: lib/phoenix_kit/integrations/providers.ex:1116
+#: lib/phoenix_kit/integrations/providers.ex:1188
 #, elixir-autogen, elixir-format
 msgid "Copy the bot token"
 msgstr "Copiez le jeton du bot"
@@ -11017,12 +11022,12 @@ msgstr "Impossible d'ajouter l'intégration"
 msgid "Could not reach AWS SES"
 msgstr "Impossible de joindre AWS SES"
 
-#: lib/phoenix_kit/integrations/validators.ex:605
+#: lib/phoenix_kit/integrations/validators.ex:786
 #, elixir-autogen, elixir-format
 msgid "Could not reach Brevo"
 msgstr "Impossible de joindre Brevo"
 
-#: lib/phoenix_kit/integrations/validators.ex:705
+#: lib/phoenix_kit/integrations/validators.ex:886
 #, elixir-autogen, elixir-format
 msgid "Could not reach Telegram"
 msgstr "Impossible de joindre Telegram"
@@ -11083,7 +11088,7 @@ msgstr "Impossible de mettre à jour le regroupement."
 msgid "Could not update default send integration"
 msgstr "Impossible de mettre à jour l'intégration d'envoi par défaut"
 
-#: lib/phoenix_kit/integrations/providers.ex:1109
+#: lib/phoenix_kit/integrations/providers.ex:1181
 #, elixir-autogen, elixir-format
 msgid "Create a bot with BotFather"
 msgstr "Créez un bot avec BotFather"
@@ -11159,7 +11164,7 @@ msgstr "Les profils désactivés ne sont jamais utilisés pour l'envoi, même co
 msgid "Dismiss"
 msgstr "Ignorer"
 
-#: lib/phoenix_kit/integrations/providers.ex:1017
+#: lib/phoenix_kit/integrations/providers.ex:1089
 #, elixir-autogen, elixir-format
 msgid "Do not verify"
 msgstr "Ne pas vérifier"
@@ -11191,7 +11196,7 @@ msgstr "Modification du profil d'envoi : %{name}"
 msgid "Email Sending"
 msgstr "Envoi d'e-mails"
 
-#: lib/phoenix_kit_web/users/confirmation_instructions.ex:109
+#: lib/phoenix_kit_web/users/confirmation_instructions.ex:111
 #, elixir-autogen, elixir-format
 msgid "Email confirmed. Welcome!"
 msgstr "E-mail confirmé. Bienvenue !"
@@ -11201,7 +11206,7 @@ msgstr "E-mail confirmé. Bienvenue !"
 msgid "Email-capable integrations"
 msgstr "Intégrations prenant en charge l'e-mail"
 
-#: lib/phoenix_kit/integrations/providers.ex:973
+#: lib/phoenix_kit/integrations/providers.ex:1045
 #, elixir-autogen, elixir-format
 msgid "Encryption"
 msgstr "Chiffrement"
@@ -11221,7 +11226,7 @@ msgstr "Toutes les 12 heures"
 msgid "Everyone who starts the bot"
 msgstr "À tous ceux qui démarrent le bot"
 
-#: lib/phoenix_kit/integrations/providers.ex:1027
+#: lib/phoenix_kit/integrations/providers.ex:1099
 #, elixir-autogen, elixir-format
 msgid "For a private or self-signed relay certificate. Replaces the system CA store for this connection only."
 msgstr "Pour un certificat de relais privé ou auto-signé. Remplace le magasin de CA du système pour cette connexion uniquement."
@@ -11232,7 +11237,7 @@ msgstr "Pour un certificat de relais privé ou auto-signé. Remplace le magasin 
 msgid "From"
 msgstr "Expéditeur"
 
-#: lib/phoenix_kit/integrations/providers.ex:1102
+#: lib/phoenix_kit/integrations/providers.ex:1174
 #, elixir-autogen, elixir-format
 msgid "From @BotFather → /newbot (or /token for an existing bot)"
 msgstr "Depuis @BotFather → /newbot (ou /token pour un bot existant)"
@@ -11259,7 +11264,7 @@ msgstr "Accès complet"
 msgid "Hourly"
 msgstr "Toutes les heures"
 
-#: lib/phoenix_kit/integrations/providers.ex:1000
+#: lib/phoenix_kit/integrations/providers.ex:1072
 #, elixir-autogen, elixir-format
 msgid "If offered (default)"
 msgstr "Si proposé (par défaut)"
@@ -11269,7 +11274,7 @@ msgstr "Si proposé (par défaut)"
 msgid "Immediate"
 msgstr "Immédiat"
 
-#: lib/phoenix_kit/integrations/providers.ex:983
+#: lib/phoenix_kit/integrations/providers.ex:1055
 #, elixir-autogen, elixir-format
 msgid "Implicit TLS / SMTPS"
 msgstr "TLS implicite / SMTPS"
@@ -11287,6 +11292,7 @@ msgid "Incomplete SMTP settings"
 msgstr "Paramètres SMTP incomplets"
 
 #: lib/phoenix_kit/integrations/validators.ex:57
+#: lib/phoenix_kit/integrations/validators.ex:582
 #, elixir-autogen, elixir-format
 msgid "Incomplete credentials"
 msgstr "Identifiants incomplets"
@@ -11323,7 +11329,7 @@ msgstr "Paramètres SMTP invalides"
 msgid "Invalid SMTP settings: %{reason}"
 msgstr "Paramètres SMTP invalides : %{reason}"
 
-#: lib/phoenix_kit/integrations/validators.ex:698
+#: lib/phoenix_kit/integrations/validators.ex:879
 #, elixir-autogen, elixir-format
 msgid "Invalid bot token"
 msgstr "Jeton de bot invalide"
@@ -11343,7 +11349,7 @@ msgstr "Délai d'attente invalide : %{value}"
 msgid "Leave a field blank to fall back to the application config or built-in default."
 msgstr "Laissez un champ vide pour utiliser la configuration de l'application ou la valeur par défaut intégrée."
 
-#: lib/phoenix_kit/integrations/providers.ex:1038
+#: lib/phoenix_kit/integrations/providers.ex:1110
 #, elixir-autogen, elixir-format
 msgid "Leave blank for the gen_smtp default."
 msgstr "Laissez vide pour la valeur par défaut de gen_smtp."
@@ -11384,7 +11390,7 @@ msgstr "Tout marquer comme lu"
 msgid "Mark read"
 msgstr "Marquer comme lu"
 
-#: lib/phoenix_kit_web/users/session.ex:340
+#: lib/phoenix_kit_web/users/session.ex:342
 #, elixir-autogen, elixir-format
 msgid "Maximum number of accounts reached — remove one first."
 msgstr "Nombre maximal de comptes atteint — supprimez-en un d'abord."
@@ -11434,7 +11440,7 @@ msgstr "Nouveau profil d'envoi"
 msgid "No adapter configured for the static mailer. Set one in your application config, or connect an email-capable integration below and pick it as the default transactional integration."
 msgstr "Aucun adaptateur configuré pour le mailer statique. Définissez-en un dans la configuration de votre application, ou connectez ci-dessous une intégration prenant en charge l'e-mail et choisissez-la comme intégration transactionnelle par défaut."
 
-#: lib/phoenix_kit/integrations/validators.ex:682
+#: lib/phoenix_kit/integrations/validators.ex:863
 #, elixir-autogen, elixir-format
 msgid "No bot token configured"
 msgstr "Aucun jeton de bot configuré"
@@ -11474,7 +11480,7 @@ msgstr "Aucun certificat CA système trouvé, le certificat du relais ne peut do
 msgid "No unread notifications"
 msgstr "Aucune notification non lue"
 
-#: lib/phoenix_kit/integrations/providers.ex:986
+#: lib/phoenix_kit/integrations/providers.ex:1058
 #, elixir-autogen, elixir-format
 msgid "None — plaintext"
 msgstr "Aucun — en clair"
@@ -11504,7 +11510,7 @@ msgstr "Les notifications que vous recevez apparaîtront ici."
 msgid "Numeric ID of a verified Brevo sender. Leave empty to send from the From address above."
 msgstr "ID numérique d'un expéditeur Brevo vérifié. Laissez vide pour envoyer depuis l'adresse indiquée ci-dessus."
 
-#: lib/phoenix_kit_web/users/session.ex:334
+#: lib/phoenix_kit_web/users/session.ex:336
 #, elixir-autogen, elixir-format
 msgid "Only an owner can sign in as another administrator."
 msgstr "Seul un propriétaire peut se connecter en tant qu'autre administrateur."
@@ -11514,12 +11520,12 @@ msgstr "Seul un propriétaire peut se connecter en tant qu'autre administrateur.
 msgid "Only me"
 msgstr "Moi uniquement"
 
-#: lib/phoenix_kit/integrations/providers.ex:1111
+#: lib/phoenix_kit/integrations/providers.ex:1183
 #, elixir-autogen, elixir-format
 msgid "Open [@BotFather](https://t.me/BotFather) in Telegram"
 msgstr "Ouvrez [@BotFather](https://t.me/BotFather) dans Telegram"
 
-#: lib/phoenix_kit/integrations/providers.ex:1121
+#: lib/phoenix_kit/integrations/providers.ex:1193
 #, elixir-autogen, elixir-format
 msgid "Paste the token into the form above and press **Test Connection**"
 msgstr "Collez le jeton dans le formulaire ci-dessus et appuyez sur **Tester la connexion**"
@@ -11539,7 +11545,7 @@ msgstr "Identité de l'expéditeur, limites de débit et options propres au four
 msgid "Persistent sessions last 60 days. Magic-link and social logins have no checkbox to tick, so they follow the default above. Turning the first option off hides the checkbox everywhere and keeps every login to the browser session."
 msgstr "Les sessions persistantes durent 60 jours. Les connexions par lien magique et via les réseaux sociaux n'ont pas de case à cocher et suivent donc la valeur par défaut ci-dessus. Désactiver la première option masque la case partout et limite chaque connexion à la session du navigateur."
 
-#: lib/phoenix_kit/integrations/validators.ex:616
+#: lib/phoenix_kit/integrations/validators.ex:797
 #, elixir-autogen, elixir-format
 msgid "Plan: %{entries}"
 msgstr "Forfait : %{entries}"
@@ -11636,12 +11642,12 @@ msgstr "SMTP n'a pas de paramètres de fournisseur par profil — le relais, le 
 msgid "SMTP server rejected the connection"
 msgstr "Le serveur SMTP a rejeté la connexion"
 
-#: lib/phoenix_kit/integrations/providers.ex:985
+#: lib/phoenix_kit/integrations/providers.ex:1057
 #, elixir-autogen, elixir-format
 msgid "STARTTLS — if offered"
 msgstr "STARTTLS — si proposé"
 
-#: lib/phoenix_kit/integrations/providers.ex:984
+#: lib/phoenix_kit/integrations/providers.ex:1056
 #, elixir-autogen, elixir-format
 msgid "STARTTLS — required"
 msgstr "STARTTLS — obligatoire"
@@ -11661,7 +11667,7 @@ msgstr "Enregistrer l'identité de l'expéditeur"
 msgid "Select an integration..."
 msgstr "Sélectionnez une intégration…"
 
-#: lib/phoenix_kit/integrations/providers.ex:1112
+#: lib/phoenix_kit/integrations/providers.ex:1184
 #, elixir-autogen, elixir-format
 msgid "Send **/newbot** and follow the prompts to name your bot"
 msgstr "Envoyez **/newbot** et suivez les instructions pour nommer votre bot"
@@ -11675,7 +11681,7 @@ msgstr "Envoyez **/newbot** et suivez les instructions pour nommer votre bot"
 msgid "Send Profiles"
 msgstr "Profils d'envoi"
 
-#: lib/phoenix_kit/integrations/providers.ex:1087
+#: lib/phoenix_kit/integrations/providers.ex:1159
 #, elixir-autogen, elixir-format
 msgid "Send messages and notifications via your own Telegram bot"
 msgstr "Envoyer des messages et des notifications via votre propre bot Telegram"
@@ -11765,13 +11771,13 @@ msgstr "La négociation TLS a échoué"
 msgid "Tags"
 msgstr "Tags"
 
-#: lib/phoenix_kit/integrations/providers.ex:1086
+#: lib/phoenix_kit/integrations/providers.ex:1158
 #: lib/phoenix_kit/notifications/channels/telegram.ex:36
 #, elixir-autogen, elixir-format
 msgid "Telegram"
 msgstr "Telegram"
 
-#: lib/phoenix_kit/integrations/validators.ex:701
+#: lib/phoenix_kit/integrations/validators.ex:882
 #, elixir-autogen, elixir-format
 msgid "Telegram error %{status}"
 msgstr "Erreur Telegram %{status}"
@@ -11791,17 +11797,17 @@ msgstr "E-mail de test depuis %{site}"
 msgid "Test email sent to %{recipient}"
 msgstr "E-mail de test envoyé à %{recipient}"
 
-#: lib/phoenix_kit_web/users/session.ex:343
+#: lib/phoenix_kit_web/users/session.ex:345
 #, elixir-autogen, elixir-format
 msgid "That account is already in your session — switch to it instead."
 msgstr "Ce compte est déjà dans votre session — basculez plutôt vers celui-ci."
 
-#: lib/phoenix_kit_web/users/session.ex:337
+#: lib/phoenix_kit_web/users/session.ex:339
 #, elixir-autogen, elixir-format
 msgid "That account is deactivated."
 msgstr "Ce compte est désactivé."
 
-#: lib/phoenix_kit_web/users/session.ex:336
+#: lib/phoenix_kit_web/users/session.ex:338
 #, elixir-autogen, elixir-format
 msgid "That is already your account."
 msgstr "C'est déjà votre compte."
@@ -11842,7 +11848,7 @@ msgstr "Ce profil d'envoi sera définitivement supprimé."
 msgid "This sender address cannot be logged"
 msgstr "Cette adresse d'expéditeur ne peut pas être journalisée"
 
-#: lib/phoenix_kit/integrations/providers.ex:1034
+#: lib/phoenix_kit/integrations/providers.ex:1106
 #, elixir-autogen, elixir-format
 msgid "Timeout (seconds)"
 msgstr "Délai d'attente (secondes)"
@@ -11852,7 +11858,7 @@ msgstr "Délai d'attente (secondes)"
 msgid "Transport"
 msgstr "Transport"
 
-#: lib/phoenix_kit/integrations/providers.ex:1012
+#: lib/phoenix_kit/integrations/providers.ex:1084
 #, elixir-autogen, elixir-format
 msgid "Turning verification off means the login travels to whoever answers, including an impostor. Use a CA certificate below instead whenever you can."
 msgstr "Désactiver la vérification signifie que l'identifiant est transmis à quiconque répond, y compris à un imposteur. Utilisez plutôt un certificat CA ci-dessous dès que possible."
@@ -11882,12 +11888,12 @@ msgstr "Mettre à jour le profil d'envoi"
 msgid "Used when no default transactional integration is selected below."
 msgstr "Utilisé lorsqu'aucune intégration transactionnelle par défaut n'est sélectionnée ci-dessous."
 
-#: lib/phoenix_kit_web/users/session.ex:309
+#: lib/phoenix_kit_web/users/session.ex:311
 #, elixir-autogen, elixir-format
 msgid "User not found."
 msgstr "Utilisateur introuvable."
 
-#: lib/phoenix_kit/integrations/providers.ex:1016
+#: lib/phoenix_kit/integrations/providers.ex:1088
 #, elixir-autogen, elixir-format
 msgid "Verify (default)"
 msgstr "Vérifier (par défaut)"
@@ -11907,7 +11913,7 @@ msgstr "Intégrations du site"
 msgid "Where a freshly registered account lands. Empty = after-login path."
 msgstr "Où arrive un compte fraîchement inscrit. Vide = chemin après connexion."
 
-#: lib/phoenix_kit/integrations/providers.ex:996
+#: lib/phoenix_kit/integrations/providers.ex:1068
 #, elixir-autogen, elixir-format
 msgid "Whether to send the login at all. “If offered” follows the relay; “Never” is for relays that authenticate by IP."
 msgstr "Faut-il envoyer l'identifiant du tout. « Si proposé » suit le relais ; « Jamais » est destiné aux relais qui authentifient par IP."
@@ -11922,12 +11928,12 @@ msgstr "À qui ce bot écrit-il ?"
 msgid "Yesterday"
 msgstr "Hier"
 
-#: lib/phoenix_kit_web/users/session.ex:320
+#: lib/phoenix_kit_web/users/session.ex:322
 #, elixir-autogen, elixir-format
 msgid "You are now signed in as %{email}."
 msgstr "Vous êtes maintenant connecté en tant que %{email}."
 
-#: lib/phoenix_kit_web/users/session.ex:329
+#: lib/phoenix_kit_web/users/session.ex:331
 #, elixir-autogen, elixir-format
 msgid "You do not have permission to sign in as another user."
 msgstr "Vous n'avez pas la permission de vous connecter en tant qu'autre utilisateur."
@@ -12043,7 +12049,7 @@ msgstr "Vérification…"
 msgid "Continue"
 msgstr "Continuer"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:143
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:169
 #, elixir-autogen, elixir-format
 msgid "Copied!"
 msgstr "Copié !"
@@ -12053,7 +12059,7 @@ msgstr "Copié !"
 msgid "Couldn't reach hex.pm, so the package list is unavailable right now."
 msgstr "hex.pm est injoignable, la liste des paquets est donc indisponible pour le moment."
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:119
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:145
 #, elixir-autogen, elixir-format
 msgid "Crawler Instructions"
 msgstr "Instructions pour les robots d'indexation"
@@ -12107,7 +12113,7 @@ msgstr "Bienvenue ! Votre code de parrainage a été accepté."
 msgid "has the robots.txt line that points crawlers here."
 msgstr "contient la ligne robots.txt qui dirige les robots d'indexation ici."
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:173
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:199
 #, elixir-autogen, elixir-format
 msgid "priv/static/robots.txt points crawlers at your sitemap."
 msgstr "priv/static/robots.txt dirige les robots d'indexation vers votre plan du site."
@@ -12211,17 +12217,17 @@ msgstr "Vous n'avez pas la permission de supprimer cet utilisateur"
 msgid "You don't have permission to manage this user's credentials"
 msgstr "Vous n'avez pas la permission de gérer les identifiants de cet utilisateur"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:190
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:216
 #, elixir-autogen, elixir-format
 msgid "AI Discovery"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:698
+#: lib/phoenix_kit/integrations/providers.ex:699
 #, elixir-autogen, elixir-format
 msgid "AWS Bedrock LLMs via a Bedrock API key (OpenAI-compatible endpoint: gpt-oss models; the rest via native Converse)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:715
+#: lib/phoenix_kit/integrations/providers.ex:716
 #, elixir-autogen, elixir-format
 msgid "AWS console → Amazon Bedrock → API keys (long-term key)"
 msgstr ""
@@ -12236,22 +12242,22 @@ msgstr ""
 msgid "Account %{id}"
 msgstr "Compte"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:303
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:329
 #, elixir-autogen, elixir-format
 msgid "Advisory-grade: anything can send any User-Agent, so a scraper that lies passes through. Real enforcement belongs at your CDN or reverse proxy — this catches the honest-but-ignorant. Bots identified only by robots.txt tokens (Google-Extended, Applebot-Extended) crawl under their main user agent and are never matched here, so blocking AI training cannot 403 Googlebot."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:98
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:124
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Allowed"
 msgstr "Tous"
 
-#: lib/phoenix_kit/integrations/providers.ex:696
+#: lib/phoenix_kit/integrations/providers.ex:697
 #, elixir-autogen, elixir-format
 msgid "Amazon Bedrock"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:282
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:308
 #, elixir-autogen, elixir-format
 msgid "Answer 403 to requests whose User-Agent matches a blocked group, for bots that ignore robots.txt."
 msgstr ""
@@ -12261,7 +12267,7 @@ msgstr ""
 msgid "Auth mail carries single-use tokens, and /dev/mailbox has no authentication — anyone who can reach this server can read them. Only for closed environments."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:711
+#: lib/phoenix_kit/integrations/providers.ex:712
 #, elixir-autogen, elixir-format
 msgid "Bedrock API key"
 msgstr ""
@@ -12271,7 +12277,7 @@ msgstr ""
 msgid "Bedrock error %{status}"
 msgstr "Erreur Brevo %{status}"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:280
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:306
 #, elixir-autogen, elixir-format
 msgid "Block at the application"
 msgstr ""
@@ -12281,7 +12287,7 @@ msgstr ""
 msgid "Blocked groups"
 msgstr "Bloqué"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:77
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:103
 #, elixir-autogen, elixir-format
 msgid "Bot Access"
 msgstr ""
@@ -12296,12 +12302,12 @@ msgstr ""
 msgid "Control how search engines and AI bots crawl and index this site"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:739
+#: lib/phoenix_kit/integrations/providers.ex:740
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Copy the key (shown once, `ABSK…`) and paste it into the form above"
 msgstr "Copiez la clé (affichée une seule fois) et collez-la dans le formulaire ci-dessus"
 
-#: lib/phoenix_kit/integrations/providers.ex:815
+#: lib/phoenix_kit/integrations/providers.ex:816
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Copy the token and paste it into the form above"
 msgstr "Copiez la clé et collez-la dans le formulaire ci-dessus"
@@ -12342,22 +12348,22 @@ msgstr ""
 msgid "Crawlers module is disabled. Enable it from the Modules page to configure settings."
 msgstr "Le module SEO est désactivé. Activez-le depuis la page Modules pour configurer les paramètres."
 
-#: lib/phoenix_kit/integrations/providers.ex:731
+#: lib/phoenix_kit/integrations/providers.ex:732
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Create a Bedrock API key"
 msgstr "Créer une clé API"
 
-#: lib/phoenix_kit/integrations/providers.ex:807
+#: lib/phoenix_kit/integrations/providers.ex:808
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Create a token"
 msgstr "Créer le rôle"
 
-#: lib/phoenix_kit/integrations/providers.ex:871
+#: lib/phoenix_kit/integrations/providers.ex:872
 #, elixir-autogen, elixir-format
 msgid "Create an IAM user with SES access"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:876
+#: lib/phoenix_kit/integrations/providers.ex:877
 #, elixir-autogen, elixir-format
 msgid "Create an access key for that user (Security credentials → Create access key) and paste the ID and secret above"
 msgstr ""
@@ -12372,41 +12378,42 @@ msgstr ""
 msgid "Deliver development mail to /dev/mailbox"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:747
+#: lib/phoenix_kit/integrations/providers.ex:748
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enable model access"
 msgstr "Activez le module pour accéder aux paramètres"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:278
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:304
 #, elixir-autogen, elixir-format
 msgid "Enforcement"
 msgstr ""
 
 #: lib/phoenix_kit_web/live/settings/crawlers.ex:90
-#: lib/phoenix_kit_web/live/settings/crawlers.ex:109
-#: lib/phoenix_kit_web/live/settings/crawlers.ex:120
-#: lib/phoenix_kit_web/live/settings/crawlers.ex:136
-#: lib/phoenix_kit_web/live/settings/crawlers.ex:149
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:102
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:121
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:132
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:148
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:161
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to update crawler settings"
 msgstr "Impossible de mettre à jour le paramètre"
 
-#: lib/phoenix_kit/integrations/providers.ex:780
+#: lib/phoenix_kit/integrations/providers.ex:781
 #, elixir-autogen, elixir-format, fuzzy
 msgid "GitHub"
 msgstr "Connexion avec GitHub"
 
-#: lib/phoenix_kit/integrations/providers.ex:782
+#: lib/phoenix_kit/integrations/providers.ex:783
 #, elixir-autogen, elixir-format
 msgid "GitHub API token — org statistics, repositories (read-only is enough)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:809
+#: lib/phoenix_kit/integrations/providers.ex:810
 #, elixir-autogen, elixir-format
 msgid "Go to [Fine-grained tokens](https://github.com/settings/personal-access-tokens) and click **Generate new token**"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:81
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:107
 #, elixir-autogen, elixir-format
 msgid "Grouped by why they visit. Blocking a group writes it into the generated robots.txt below; everything defaults to allowed."
 msgstr ""
@@ -12416,22 +12423,22 @@ msgstr ""
 msgid "Hide titles of records the reader can't open"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:749
+#: lib/phoenix_kit/integrations/providers.ex:750
 #, elixir-autogen, elixir-format
 msgid "In [Bedrock → Model access](https://console.aws.amazon.com/bedrock/home#/modelaccess) enable the models you plan to call — a key with no enabled models validates but cannot complete"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:763
+#: lib/phoenix_kit/integrations/providers.ex:764
 #, elixir-autogen, elixir-format
 msgid "In the AI module, create an endpoint pointing at this connection with a `gpt-oss` model and a base URL in the SAME region as this key"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:873
+#: lib/phoenix_kit/integrations/providers.ex:874
 #, elixir-autogen, elixir-format
 msgid "In the [IAM console](https://console.aws.amazon.com/iam/home#/users) create a user for programmatic access and attach an SES policy (least privilege: `ses:SendEmail`/`ses:SendRawEmail`; docs: [SES setup](https://docs.aws.amazon.com/ses/latest/dg/setting-up.html))"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:884
+#: lib/phoenix_kit/integrations/providers.ex:885
 #, elixir-autogen, elixir-format
 msgid "In the [SES console](https://console.aws.amazon.com/ses/home#/identities) verify your domain or sender address — SES refuses to send from unverified identities"
 msgstr ""
@@ -12476,7 +12483,7 @@ msgstr ""
 msgid "Model catalog in %{region}: %{count} (grants are configured separately)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:887
+#: lib/phoenix_kit/integrations/providers.ex:888
 #, elixir-autogen, elixir-format
 msgid "New accounts start in the SES sandbox (verified recipients only) — [request production access](https://docs.aws.amazon.com/ses/latest/dg/request-production-access.html) before real sending"
 msgstr ""
@@ -12491,7 +12498,7 @@ msgstr ""
 msgid "No longer available"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:165
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:191
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No priv/static/robots.txt found. Without one, crawlers assume everything is allowed — and any groups you blocked above are not being told."
 msgstr "Aucun fichier priv/static/robots.txt trouvé. Sans lui, les robots d'indexation considèrent que tout est autorisé — ce qui convient généralement, mais ils ne sauront pas où se trouve votre plan du site."
@@ -12506,47 +12513,47 @@ msgstr ""
 msgid "Note (optional)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:733
+#: lib/phoenix_kit/integrations/providers.ex:734
 #, elixir-autogen, elixir-format
 msgid "Open the [Bedrock console → API keys](https://console.aws.amazon.com/bedrock/home#/api-keys) and generate a **long-term** key (docs: [Bedrock API keys](https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys.html))"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:212
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:238
 #, elixir-autogen, elixir-format
 msgid "Optional markdown: a summary paragraph, key links, docs pointers…"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:736
+#: lib/phoenix_kit/integrations/providers.ex:737
 #, elixir-autogen, elixir-format
 msgid "Or attach one to an existing IAM user: [IAM console](https://console.aws.amazon.com/iam/home#/users) → user → Security credentials → Bedrock API keys"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:235
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:261
 #, elixir-autogen, elixir-format
 msgid "Paste the verification content Google Search Console or Bing Webmaster Tools gives you — the meta tags are added to every layout head. Pasting the whole <meta> tag also works; the content value is extracted."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:796
+#: lib/phoenix_kit/integrations/providers.ex:797
 #, elixir-autogen, elixir-format
 msgid "Personal access token"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:123
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:149
 #, elixir-autogen, elixir-format
 msgid "PhoenixKit does not serve this file — it is yours, served from priv/static before any route is consulted. This is the complete file your toggles above describe: paste it into priv/static/robots.txt."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:752
+#: lib/phoenix_kit/integrations/providers.ex:753
 #, elixir-autogen, elixir-format
 msgid "Pick the region where access was granted; the AI endpoint's base URL must use the same region"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:217
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:243
 #, elixir-autogen, elixir-format
 msgid "Preview of the served file:"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:812
+#: lib/phoenix_kit/integrations/providers.ex:813
 #, elixir-autogen, elixir-format
 msgid "Repository access: **Public repositories (read-only)** — no extra permissions needed for public-org statistics"
 msgstr ""
@@ -12556,7 +12563,7 @@ msgstr ""
 msgid "Request access"
 msgstr "Demandé"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:233
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:259
 #, elixir-autogen, elixir-format
 msgid "Search engine verification"
 msgstr ""
@@ -12576,12 +12583,12 @@ msgstr "En attente"
 msgid "Sign in to request access."
 msgstr "Se connecter en tant qu'utilisateur"
 
-#: lib/phoenix_kit/integrations/providers.ex:760
+#: lib/phoenix_kit/integrations/providers.ex:761
 #, elixir-autogen, elixir-format
 msgid "The OpenAI-compatible endpoint (`…/openai/v1`) currently serves only the `openai.gpt-oss-*` models — Anthropic and the other Bedrock models answer on the native Converse API with the same key"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:742
+#: lib/phoenix_kit/integrations/providers.ex:743
 #, elixir-autogen, elixir-format
 msgid "The key's IAM identity must allow the `bedrock:CallWithBearerToken` action — without it every Bearer call answers 403 even when invoke permissions are in place."
 msgstr ""
@@ -12591,17 +12598,17 @@ msgstr ""
 msgid "The mailbox is off: outgoing mail is written to the server log instead."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:179
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:205
 #, elixir-autogen, elixir-format, fuzzy
 msgid "The noindex toggle and robots.txt are separate mechanisms: noindex is a per-page meta tag that tells crawlers not to index what they fetched, while robots.txt tells them what not to fetch at all. A staging site usually wants both."
 msgstr "L'option noindex ci-dessus et robots.txt sont deux mécanismes distincts : noindex est une balise meta par page qui demande aux robots de ne pas indexer ce qu'ils ont récupéré, tandis que robots.txt leur indique ce qu'il ne faut pas récupérer du tout. Un site de préproduction a généralement besoin des deux."
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:194
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:220
 #, elixir-autogen, elixir-format
 msgid "The other half of bot policy: a markdown summary telling AI assistants what this site is about, served at"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:892
+#: lib/phoenix_kit/integrations/providers.ex:893
 #, elixir-autogen, elixir-format
 msgid "This connection stores the credential. The full sending pipeline — configuration set, SNS topic, SQS event queue, delivery tracking — is configured in Admin → Settings → Emails, which can select this connection as its credential source."
 msgstr ""
@@ -12618,22 +12625,22 @@ msgstr ""
 msgid "Unread · %{day}"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:758
+#: lib/phoenix_kit/integrations/providers.ex:759
 #, elixir-autogen, elixir-format
 msgid "Use it from the AI module"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:231
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:257
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Verification"
 msgstr "Notifications"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.ex:133
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:145
 #, elixir-autogen, elixir-format
 msgid "Verification tags saved."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:882
+#: lib/phoenix_kit/integrations/providers.ex:883
 #, elixir-autogen, elixir-format
 msgid "Verify a sender in SES"
 msgstr ""
@@ -12648,7 +12655,7 @@ msgstr ""
 msgid "Where development mail goes while the resolved transport is the local adapter."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:79
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "Who may crawl this site"
 msgstr ""
@@ -12668,12 +12675,12 @@ msgstr ""
 msgid "You don't have access — click to request it"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:800
+#: lib/phoenix_kit/integrations/providers.ex:801
 #, elixir-autogen, elixir-format
 msgid "github.com/settings/personal-access-tokens — fine-grained, read-only"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.ex:146
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:158
 #, elixir-autogen, elixir-format
 msgid "llms.txt content saved."
 msgstr ""
@@ -12683,7 +12690,7 @@ msgstr ""
 msgid "management API: %{services}"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:169
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:195
 #, elixir-autogen, elixir-format, fuzzy
 msgid "priv/static/robots.txt exists but has no Sitemap: line. Paste the file above so crawlers are told where to look."
 msgstr "priv/static/robots.txt existe mais ne contient pas de ligne Sitemap:. Ajoutez la ligne ci-dessus pour indiquer aux robots où chercher."
@@ -12693,7 +12700,7 @@ msgstr "priv/static/robots.txt existe mais ne contient pas de ligne Sitemap:. Aj
 msgid "private item"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:200
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:226
 #, elixir-autogen, elixir-format
 msgid "while this module is enabled. The heading comes from your project title; everything below it is yours."
 msgstr ""
@@ -12747,7 +12754,7 @@ msgstr "Sélectionner un fichier audio"
 msgid "Select Avatar"
 msgstr "Sélectionner un avatar"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:701
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:716
 #, elixir-autogen, elixir-format
 msgid "Select Background Image"
 msgstr "Sélectionner une image de fond"
@@ -12764,7 +12771,7 @@ msgstr "Sélectionner des images"
 
 #: lib/phoenix_kit_web/components/media_browser.html.heex:2469
 #: lib/phoenix_kit_web/live/settings.html.heex:636
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:702
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:717
 #, elixir-autogen, elixir-format
 msgid "Select Logo"
 msgstr "Sélectionner un logo"
@@ -12863,3 +12870,422 @@ msgstr "Le chiffrement des identifiants d'intégration nécessite une attention"
 #, elixir-autogen, elixir-format
 msgid "The current encryption status could not be described by this admin page — it may be newer than what this page recognizes. Check PhoenixKit.Integrations.Encryption.status/0 directly."
 msgstr "Le statut de chiffrement actuel n'a pas pu être décrit par cette page d'administration — il pourrait être plus récent que ce que cette page reconnaît. Vérifiez directement PhoenixKit.Integrations.Encryption.status/0."
+
+#: lib/phoenix_kit_web/live/settings/authorization.ex:247
+#, elixir-autogen, elixir-format
+msgid "A secret is already configured — leave blank to keep the current value"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:365
+#: lib/phoenix_kit_web/users/session.ex:245
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Account added."
+msgstr "Compte"
+
+#: lib/phoenix_kit_web/users/session.ex:27
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Account created successfully!"
+msgstr "Bucket activé avec succès"
+
+#: lib/phoenix_kit_web/users/session.ex:356
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Account removed."
+msgstr "Compte"
+
+#: lib/phoenix_kit_web/users/oauth.ex:272
+#, elixir-autogen, elixir-format
+msgid "Account switching is currently disabled."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:316
+#, elixir-autogen, elixir-format
+msgid "An account already exists for that email address. Sign in with your password first, then connect this provider from your account settings."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:328
+#, elixir-autogen, elixir-format
+msgid "Authentication failed. Please try again or use a different sign-in method."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:355
+#: lib/phoenix_kit_web/users/oauth.ex:438
+#: lib/phoenix_kit_web/users/oauth.ex:444
+#, elixir-autogen, elixir-format
+msgid "Authentication failed. Please try again."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:299
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Authentication failed: %{errors}"
+msgstr "Authentification"
+
+#: lib/phoenix_kit_web/users/oauth.ex:441
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Authentication failed: %{message}"
+msgstr "Authentification"
+
+#: lib/phoenix_kit_web/users/session.ex:360
+#, elixir-autogen, elixir-format
+msgid "Cannot remove your primary account."
+msgstr ""
+
+#: lib/phoenix_kit_web/controllers/context_controller.ex:101
+#, elixir-autogen, elixir-format
+msgid "Context switching is not enabled"
+msgstr ""
+
+#: lib/phoenix_kit/integrations/validators.ex:627
+#: lib/phoenix_kit/integrations/validators.ex:634
+#: lib/phoenix_kit/integrations/validators.ex:732
+#: lib/phoenix_kit/integrations/validators.ex:740
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Could not reach the storage endpoint"
+msgstr "Impossible de joindre le service"
+
+#: lib/phoenix_kit_web/users/session.ex:365
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Could not remove account."
+msgstr "Impossible de joindre Brevo"
+
+#: lib/phoenix_kit_web/users/session.ex:274
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Could not switch account."
+msgstr "Impossible de dissocier les conversations"
+
+#: lib/phoenix_kit/integrations/validators.ex:721
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Credentials are valid, but not authorized to list buckets"
+msgstr "Les identifiants sont valides mais non autorisés pour GetSendQuota — l'envoi n'a pas été vérifié"
+
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:85
+#, elixir-autogen, elixir-format
+msgid "Exempt"
+msgstr ""
+
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:86
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Follows noindex"
+msgstr "Abonnements"
+
+#: lib/phoenix_kit_web/users/magic_link.ex:120
+#, elixir-autogen, elixir-format
+msgid "If that email address exists, a magic link has been sent."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/confirmation_instructions.ex:89
+#, elixir-autogen, elixir-format
+msgid "If your email is in our system and it has not been confirmed yet, you will receive an email with instructions shortly."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/forgot_password.ex:49
+#, elixir-autogen, elixir-format
+msgid "If your email is in our system, you will receive instructions to reset your password shortly."
+msgstr ""
+
+#: lib/phoenix_kit_web/controllers/context_controller.ex:82
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Invalid context"
+msgstr "Jeton de bot invalide"
+
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:110
+#, elixir-autogen, elixir-format
+msgid "Invalid email format"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/session.ex:92
+#, elixir-autogen, elixir-format
+msgid "Invalid email/username or password"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/session.ex:259
+#, elixir-autogen, elixir-format
+msgid "Invalid email/username or password."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_verify.ex:40
+#, elixir-autogen, elixir-format
+msgid "Invalid magic link. Please request a new one."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration_verify.ex:32
+#, elixir-autogen, elixir-format
+msgid "Invalid registration link. Please request a new one."
+msgstr ""
+
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:77
+#, elixir-autogen, elixir-format
+msgid "Keep publishing the sitemap's real URLs even while noindex is on, so the feed can be verified without exposing the site to indexing. The noindex meta tag above is unaffected either way."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/session.ex:104
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Logged out of all accounts."
+msgstr "Se déconnecter de tous les comptes"
+
+#: lib/phoenix_kit_web/users/session.ex:122
+#: lib/phoenix_kit_web/users/session.ex:235
+#, elixir-autogen, elixir-format
+msgid "Logged out successfully."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_verify.ex:63
+#, elixir-autogen, elixir-format
+msgid "Magic link is invalid or has expired. Please request a new one."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration.ex:41
+#, elixir-autogen, elixir-format
+msgid "Magic link registration is currently disabled."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link.ex:110
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Magic link sent! Check your email."
+msgstr "Lien magique envoyé !"
+
+#: lib/phoenix_kit_web/users/magic_link.ex:39
+#: lib/phoenix_kit_web/users/magic_link_verify.ex:33
+#, elixir-autogen, elixir-format
+msgid "Magic link sign-in is currently disabled."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:370
+#: lib/phoenix_kit_web/users/session.ex:249
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Maximum number of accounts reached."
+msgstr "Nombre maximal de comptes atteint — supprimez-en un d'abord."
+
+#: lib/phoenix_kit_web/users/session.ex:137
+#, elixir-autogen, elixir-format
+msgid "Multi-account switching is not available."
+msgstr ""
+
+#: lib/phoenix_kit/integrations/providers.ex:950
+#, elixir-autogen, elixir-format
+msgid "Not every S3-compatible provider needs one — leave blank if the endpoint doesn't require it."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:119
+#, elixir-autogen, elixir-format
+msgid "OAuth authentication is currently disabled. Please contact your administrator to enable it."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:94
+#, elixir-autogen, elixir-format
+msgid "OAuth provider '%{provider}' is currently disabled."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:106
+#, elixir-autogen, elixir-format
+msgid "OAuth provider '%{provider}' is not configured. Please contact your administrator."
+msgstr ""
+
+#: lib/phoenix_kit/integrations/providers.ex:913
+#, elixir-autogen, elixir-format
+msgid "Object Storage (S3-compatible)"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/reset_password.ex:41
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Password reset successfully."
+msgstr "Mot de passe modifié avec succès."
+
+#: lib/phoenix_kit_web/users/session.ex:34
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Password updated successfully!"
+msgstr "Mot de passe modifié avec succès."
+
+#: lib/phoenix_kit_web/users/magic_link_registration.ex:35
+#: lib/phoenix_kit_web/users/registration.ex:128
+#, elixir-autogen, elixir-format
+msgid "Registration is currently disabled."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration.ex:92
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Registration link is invalid or has expired."
+msgstr "Le lien de changement d'e-mail n'est pas valide ou a expiré."
+
+#: lib/phoenix_kit_web/users/magic_link_registration.ex:188
+#: lib/phoenix_kit_web/users/magic_link_registration_verify.ex:24
+#, elixir-autogen, elixir-format
+msgid "Registration link is invalid or has expired. Please request a new one."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:92
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:103
+#, elixir-autogen, elixir-format
+msgid "Registration link sent! Check your email."
+msgstr ""
+
+#: lib/phoenix_kit/integrations/providers.ex:962
+#, elixir-autogen, elixir-format
+msgid "Required for Cloudflare R2, Backblaze B2, Tigris, and self-hosted S3-compatible storage. Leave blank for AWS S3."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/reset_password.ex:59
+#, elixir-autogen, elixir-format
+msgid "Reset password link is invalid or it has expired."
+msgstr ""
+
+#: lib/phoenix_kit/integrations/providers.ex:915
+#, elixir-autogen, elixir-format
+msgid "S3-compatible object storage — AWS S3, Cloudflare R2, Backblaze B2, Tigris, or a self-hosted endpoint"
+msgstr ""
+
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:75
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Sitemap Exemption"
+msgstr "Paramètres du plan du site"
+
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:144
+#, elixir-autogen, elixir-format
+msgid "Something went wrong"
+msgstr ""
+
+#: lib/phoenix_kit/integrations/validators.ex:735
+#, elixir-autogen, elixir-format
+msgid "Storage error: %{code}"
+msgstr ""
+
+#: lib/phoenix_kit/integrations/validators.ex:729
+#, elixir-autogen, elixir-format
+msgid "Storage service is busy — try again in a moment"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_verify.ex:56
+#, elixir-autogen, elixir-format
+msgid "Successfully logged in with magic link!"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:277
+#, elixir-autogen, elixir-format
+msgid "Successfully signed in with %{provider}!"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:375
+#: lib/phoenix_kit_web/users/session.ex:254
+#, elixir-autogen, elixir-format, fuzzy
+msgid "That account is already in your session."
+msgstr "Ce compte est déjà dans votre session — basculez plutôt vers celui-ci."
+
+#: lib/phoenix_kit_web/users/oauth.ex:380
+#, elixir-autogen, elixir-format, fuzzy
+msgid "That account is inactive."
+msgstr "Ce compte est désactivé."
+
+#: lib/phoenix_kit_web/users/magic_link_registration.ex:185
+#, elixir-autogen, elixir-format
+msgid "That email is already registered. Please log in instead."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:118
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Too many attempts"
+msgstr "Trop de fichiers"
+
+#: lib/phoenix_kit_web/users/session.ex:84
+#, elixir-autogen, elixir-format
+msgid "Too many login attempts. Please try again later."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:84
+#: lib/phoenix_kit_web/users/oauth.ex:210
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Unknown OAuth provider: %{provider}"
+msgstr "Fournisseur inconnu"
+
+#: lib/phoenix_kit_web/users/confirmation.ex:68
+#, elixir-autogen, elixir-format
+msgid "User confirmation link is invalid or it has expired."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/confirmation.ex:50
+#, elixir-autogen, elixir-format, fuzzy
+msgid "User confirmed successfully."
+msgstr "Utilisateur activé avec succès"
+
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:77
+#, elixir-autogen, elixir-format
+msgid "User registration is currently disabled."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:51
+#: lib/phoenix_kit_web/users/registration.ex:110
+#, elixir-autogen, elixir-format
+msgid "User registration is currently disabled. Please contact an administrator."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/session.ex:40
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Welcome back!"
+msgstr "Bon retour"
+
+#: lib/phoenix_kit_web/users/session.ex:66
+#, elixir-autogen, elixir-format
+msgid "Your account is currently inactive. Please contact the team if you believe this is an error."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:1873
+#, elixir-autogen, elixir-format
+msgid "%{label} module is not enabled"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:2366
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Enter your referral code to continue."
+msgstr "Saisissez votre code de parrainage"
+
+#: lib/phoenix_kit_web/users/auth.ex:2362
+#, elixir-autogen, elixir-format
+msgid "Please confirm your email before accessing the application."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:111
+#, elixir-autogen, elixir-format
+msgid "This account is not active. Contact an administrator."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:749
+#: lib/phoenix_kit_web/users/auth.ex:1892
+#: lib/phoenix_kit_web/users/auth.ex:2511
+#, elixir-autogen, elixir-format, fuzzy
+msgid "You do not have permission to access this section."
+msgstr "Vous n'avez pas la permission de vous connecter en tant qu'autre utilisateur."
+
+#: lib/phoenix_kit_web/users/auth.ex:724
+#: lib/phoenix_kit_web/users/auth.ex:878
+#: lib/phoenix_kit_web/users/auth.ex:2460
+#: lib/phoenix_kit_web/users/auth.ex:2496
+#, elixir-autogen, elixir-format, fuzzy
+msgid "You do not have the required permission to access this page."
+msgstr "Vous n'avez pas la permission de vous connecter en tant qu'autre utilisateur."
+
+#: lib/phoenix_kit_web/users/auth.ex:1417
+#, elixir-autogen, elixir-format
+msgid "You must be an admin to access this page."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:679
+#: lib/phoenix_kit_web/users/auth.ex:2423
+#, elixir-autogen, elixir-format
+msgid "You must be an owner to access this page."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:2539
+#, elixir-autogen, elixir-format
+msgid "You must have the %{role_name} role to access this page."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:903
+#: lib/phoenix_kit_web/users/auth.ex:2292
+#: lib/phoenix_kit_web/users/auth.ex:2329
+#: lib/phoenix_kit_web/users/auth.ex:2467
+#, elixir-autogen, elixir-format
+msgid "You must log in to access this page."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:1428
+#, elixir-autogen, elixir-format
+msgid "You no longer have permission to access this section."
+msgstr ""

--- a/priv/gettext/fr/LC_MESSAGES/default.po
+++ b/priv/gettext/fr/LC_MESSAGES/default.po
@@ -12878,19 +12878,19 @@ msgstr ""
 
 #: lib/phoenix_kit_web/users/oauth.ex:365
 #: lib/phoenix_kit_web/users/session.ex:245
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Account added."
-msgstr "Compte"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:27
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Account created successfully!"
-msgstr "Bucket activé avec succès"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:356
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Account removed."
-msgstr "Compte"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/oauth.ex:272
 #, elixir-autogen, elixir-format
@@ -12915,14 +12915,14 @@ msgid "Authentication failed. Please try again."
 msgstr ""
 
 #: lib/phoenix_kit_web/users/oauth.ex:299
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Authentication failed: %{errors}"
-msgstr "Authentification"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/oauth.ex:441
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Authentication failed: %{message}"
-msgstr "Authentification"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:360
 #, elixir-autogen, elixir-format
@@ -12938,24 +12938,24 @@ msgstr ""
 #: lib/phoenix_kit/integrations/validators.ex:634
 #: lib/phoenix_kit/integrations/validators.ex:732
 #: lib/phoenix_kit/integrations/validators.ex:740
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Could not reach the storage endpoint"
-msgstr "Impossible de joindre le service"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:365
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Could not remove account."
-msgstr "Impossible de joindre Brevo"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:274
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Could not switch account."
-msgstr "Impossible de dissocier les conversations"
+msgstr ""
 
 #: lib/phoenix_kit/integrations/validators.ex:721
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Credentials are valid, but not authorized to list buckets"
-msgstr "Les identifiants sont valides mais non autorisés pour GetSendQuota — l'envoi n'a pas été vérifié"
+msgstr ""
 
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:85
 #, elixir-autogen, elixir-format
@@ -12963,9 +12963,9 @@ msgid "Exempt"
 msgstr ""
 
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:86
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Follows noindex"
-msgstr "Abonnements"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link.ex:120
 #, elixir-autogen, elixir-format
@@ -12983,9 +12983,9 @@ msgid "If your email is in our system, you will receive instructions to reset yo
 msgstr ""
 
 #: lib/phoenix_kit_web/controllers/context_controller.ex:82
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Invalid context"
-msgstr "Jeton de bot invalide"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link_registration_request.ex:110
 #, elixir-autogen, elixir-format
@@ -13018,9 +13018,9 @@ msgid "Keep publishing the sitemap's real URLs even while noindex is on, so the 
 msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:104
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Logged out of all accounts."
-msgstr "Se déconnecter de tous les comptes"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:122
 #: lib/phoenix_kit_web/users/session.ex:235
@@ -13039,9 +13039,9 @@ msgid "Magic link registration is currently disabled."
 msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link.ex:110
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Magic link sent! Check your email."
-msgstr "Lien magique envoyé !"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link.ex:39
 #: lib/phoenix_kit_web/users/magic_link_verify.ex:33
@@ -13051,9 +13051,9 @@ msgstr ""
 
 #: lib/phoenix_kit_web/users/oauth.ex:370
 #: lib/phoenix_kit_web/users/session.ex:249
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Maximum number of accounts reached."
-msgstr "Nombre maximal de comptes atteint — supprimez-en un d'abord."
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:137
 #, elixir-autogen, elixir-format
@@ -13086,14 +13086,14 @@ msgid "Object Storage (S3-compatible)"
 msgstr ""
 
 #: lib/phoenix_kit_web/users/reset_password.ex:41
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Password reset successfully."
-msgstr "Mot de passe modifié avec succès."
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:34
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Password updated successfully!"
-msgstr "Mot de passe modifié avec succès."
+msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link_registration.ex:35
 #: lib/phoenix_kit_web/users/registration.ex:128
@@ -13102,9 +13102,9 @@ msgid "Registration is currently disabled."
 msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link_registration.ex:92
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Registration link is invalid or has expired."
-msgstr "Le lien de changement d'e-mail n'est pas valide ou a expiré."
+msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link_registration.ex:188
 #: lib/phoenix_kit_web/users/magic_link_registration_verify.ex:24
@@ -13134,9 +13134,9 @@ msgid "S3-compatible object storage — AWS S3, Cloudflare R2, Backblaze B2, Tig
 msgstr ""
 
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:75
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Sitemap Exemption"
-msgstr "Paramètres du plan du site"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link_registration_request.ex:144
 #, elixir-autogen, elixir-format
@@ -13165,14 +13165,14 @@ msgstr ""
 
 #: lib/phoenix_kit_web/users/oauth.ex:375
 #: lib/phoenix_kit_web/users/session.ex:254
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "That account is already in your session."
-msgstr "Ce compte est déjà dans votre session — basculez plutôt vers celui-ci."
+msgstr ""
 
 #: lib/phoenix_kit_web/users/oauth.ex:380
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "That account is inactive."
-msgstr "Ce compte est désactivé."
+msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link_registration.ex:185
 #, elixir-autogen, elixir-format
@@ -13180,9 +13180,9 @@ msgid "That email is already registered. Please log in instead."
 msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link_registration_request.ex:118
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Too many attempts"
-msgstr "Trop de fichiers"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:84
 #, elixir-autogen, elixir-format
@@ -13191,9 +13191,9 @@ msgstr ""
 
 #: lib/phoenix_kit_web/users/oauth.ex:84
 #: lib/phoenix_kit_web/users/oauth.ex:210
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Unknown OAuth provider: %{provider}"
-msgstr "Fournisseur inconnu"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/confirmation.ex:68
 #, elixir-autogen, elixir-format
@@ -13201,9 +13201,9 @@ msgid "User confirmation link is invalid or it has expired."
 msgstr ""
 
 #: lib/phoenix_kit_web/users/confirmation.ex:50
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "User confirmed successfully."
-msgstr "Utilisateur activé avec succès"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link_registration_request.ex:77
 #, elixir-autogen, elixir-format
@@ -13217,9 +13217,9 @@ msgid "User registration is currently disabled. Please contact an administrator.
 msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:40
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Welcome back!"
-msgstr "Bon retour"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:66
 #, elixir-autogen, elixir-format
@@ -13232,9 +13232,9 @@ msgid "%{label} module is not enabled"
 msgstr ""
 
 #: lib/phoenix_kit_web/users/auth.ex:2366
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Enter your referral code to continue."
-msgstr "Saisissez votre code de parrainage"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/auth.ex:2362
 #, elixir-autogen, elixir-format
@@ -13249,17 +13249,17 @@ msgstr ""
 #: lib/phoenix_kit_web/users/auth.ex:749
 #: lib/phoenix_kit_web/users/auth.ex:1892
 #: lib/phoenix_kit_web/users/auth.ex:2511
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "You do not have permission to access this section."
-msgstr "Vous n'avez pas la permission de vous connecter en tant qu'autre utilisateur."
+msgstr ""
 
 #: lib/phoenix_kit_web/users/auth.ex:724
 #: lib/phoenix_kit_web/users/auth.ex:878
 #: lib/phoenix_kit_web/users/auth.ex:2460
 #: lib/phoenix_kit_web/users/auth.ex:2496
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "You do not have the required permission to access this page."
-msgstr "Vous n'avez pas la permission de vous connecter en tant qu'autre utilisateur."
+msgstr ""
 
 #: lib/phoenix_kit_web/users/auth.ex:1417
 #, elixir-autogen, elixir-format

--- a/priv/gettext/fr/LC_MESSAGES/phoenix_kit.po
+++ b/priv/gettext/fr/LC_MESSAGES/phoenix_kit.po
@@ -21,27 +21,27 @@ msgstr "Une invitation en attente existe déjà pour cet e-mail"
 msgid "This user already belongs to an organization"
 msgstr "Cet utilisateur appartient déjà à une organisation"
 
-#: lib/phoenix_kit/users/auth.ex:1064
+#: lib/phoenix_kit/users/auth.ex:1074
 #, elixir-autogen, elixir-format
 msgid "cannot change to person while organization has members"
 msgstr "ne peut pas passer en compte personnel tant que l'organisation a des membres"
 
-#: lib/phoenix_kit/users/auth.ex:1044
+#: lib/phoenix_kit/users/auth.ex:1054
 #, elixir-autogen, elixir-format
 msgid "cannot reference self"
 msgstr "ne peut pas faire référence à lui-même"
 
-#: lib/phoenix_kit/users/auth.ex:1052
+#: lib/phoenix_kit/users/auth.ex:1062
 #, elixir-autogen, elixir-format
 msgid "only person accounts can join an organization"
 msgstr "seuls les comptes personnels peuvent rejoindre une organisation"
 
-#: lib/phoenix_kit/users/auth.ex:1039
+#: lib/phoenix_kit/users/auth.ex:1049
 #, elixir-autogen, elixir-format
 msgid "organization not found"
 msgstr "organisation introuvable"
 
-#: lib/phoenix_kit/users/auth.ex:1038
+#: lib/phoenix_kit/users/auth.ex:1048
 #, elixir-autogen, elixir-format
 msgid "target user is not an organization"
 msgstr "l'utilisateur cible n'est pas une organisation"

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -69,7 +69,7 @@ msgstr "Gestione ruoli"
 
 #: lib/phoenix_kit/dashboard/admin_tabs.ex:119
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:138
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:647
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:662
 #: lib/phoenix_kit_web/live/settings/users.html.heex:130
 #, elixir-autogen
 msgid "Sessions"
@@ -235,7 +235,7 @@ msgstr "Connessioni in tempo reale"
 
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:320
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:64
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:144
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:140
 #, elixir-autogen
 msgid "Anonymous"
 msgstr "Anonimi"
@@ -248,7 +248,7 @@ msgstr "Visitatori non registrati"
 
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:331
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:77
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:151
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:144
 #, elixir-autogen
 msgid "Authenticated"
 msgstr "Autenticati"
@@ -345,7 +345,7 @@ msgstr "Livello di accesso standard"
 msgid "Role System"
 msgstr "Sistema dei ruoli"
 
-#: lib/phoenix_kit/integrations/providers.ex:991
+#: lib/phoenix_kit/integrations/providers.ex:1063
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:450
 #, elixir-autogen
 msgid "Authentication"
@@ -357,7 +357,7 @@ msgstr "Autenticazione"
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:445
 #: lib/phoenix_kit_web/live/modules.html.heex:65
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:114
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:273
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:267
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:145
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:297
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:682
@@ -463,8 +463,8 @@ msgstr "Informazioni sui permessi"
 msgid "Accept All"
 msgstr "Accetta tutti"
 
-#: lib/phoenix_kit/integrations/integrations.ex:1133
-#: lib/phoenix_kit/integrations/validators.ex:598
+#: lib/phoenix_kit/integrations/integrations.ex:1136
+#: lib/phoenix_kit/integrations/validators.ex:779
 #: lib/phoenix_kit_web/live/activity/index.ex:66
 #: lib/phoenix_kit_web/live/activity/show.ex:56
 #, elixir-autogen, elixir-format
@@ -502,7 +502,7 @@ msgid "Actions"
 msgstr "Azioni"
 
 #: lib/phoenix_kit_web/components/media_gallery.html.heex:86
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:585
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:600
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:266
 #: lib/phoenix_kit_web/live/settings/users.html.heex:693
 #: lib/phoenix_kit_web/users/user_form.html.heex:719
@@ -610,7 +610,7 @@ msgstr "Informazioni di base"
 msgid "Billing profiles and payment methods"
 msgstr "Profili di fatturazione e metodi di pagamento"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:98
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:124
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:501
 #, elixir-autogen, elixir-format
 msgid "Blocked"
@@ -1550,7 +1550,7 @@ msgstr "Pagina generata con successo"
 msgid "Page published successfully"
 msgstr "Pagina pubblicata con successo"
 
-#: lib/phoenix_kit/integrations/providers.ex:956
+#: lib/phoenix_kit/integrations/providers.ex:1028
 #: lib/phoenix_kit_web/components/user_dashboard_nav.ex:277
 #: lib/phoenix_kit_web/users/login.html.heex:39
 #: lib/phoenix_kit_web/users/magic_link_registration.html.heex:42
@@ -1811,8 +1811,8 @@ msgstr "SWIFT/BIC"
 #: lib/phoenix_kit_web/components/core/markdown_editor.ex:440
 #: lib/phoenix_kit_web/components/media_browser.html.heex:1349
 #: lib/phoenix_kit_web/live/notifications/settings.ex:436
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:219
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:267
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:245
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:293
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr "Salva"
@@ -1855,7 +1855,7 @@ msgstr "Salvato"
 #: lib/phoenix_kit_web/components/core/markdown_editor.ex:333
 #: lib/phoenix_kit_web/components/core/markdown_editor.ex:417
 #: lib/phoenix_kit_web/live/settings.html.heex:592
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:683
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:698
 #: lib/phoenix_kit_web/live/settings/users.html.heex:546
 #, elixir-autogen, elixir-format
 msgid "Saving..."
@@ -1942,7 +1942,7 @@ msgstr "Stato/Provincia"
 #: lib/phoenix_kit_web/live/settings/users.html.heex:367
 #: lib/phoenix_kit_web/live/settings/users.html.heex:408
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:114
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:199
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:193
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:247
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:294
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:650
@@ -2048,7 +2048,7 @@ msgstr "Ruoli totali"
 #: lib/phoenix_kit_web/live/settings/users.html.heex:361
 #: lib/phoenix_kit_web/live/settings/users.html.heex:404
 #: lib/phoenix_kit_web/live/settings/users.html.heex:602
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:192
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:186
 #: lib/phoenix_kit_web/live/users/roles.html.heex:92
 #: lib/phoenix_kit_web/live/users/roles.html.heex:160
 #, elixir-autogen, elixir-format
@@ -2064,7 +2064,7 @@ msgstr "Non confermato"
 #: lib/phoenix_kit_web/components/core/time_display.ex:183
 #: lib/phoenix_kit_web/components/language_switcher.ex:832
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:108
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:255
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:249
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr "Sconosciuto"
@@ -2122,7 +2122,7 @@ msgstr "Utente non trovato"
 msgid "User-defined roles"
 msgstr "Ruoli definiti dall'utente"
 
-#: lib/phoenix_kit/integrations/providers.ex:944
+#: lib/phoenix_kit/integrations/providers.ex:1016
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:255
 #: lib/phoenix_kit_web/users/magic_link_registration.html.heex:30
 #: lib/phoenix_kit_web/users/registration.html.heex:69
@@ -2440,22 +2440,22 @@ msgstr "(vuoto)"
 msgid "(registration disabled)"
 msgstr "(registrazione disattivata)"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:622
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:637
 #, elixir-autogen, elixir-format
 msgid "1. Enable the provider above and save settings"
 msgstr "1. Attiva il provider qui sopra e salva le impostazioni"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:623
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:638
 #, elixir-autogen, elixir-format
 msgid "2. Enter your OAuth credentials in the form that appears"
 msgstr "2. Inserisci le tue credenziali OAuth nel modulo che appare"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:624
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:639
 #, elixir-autogen, elixir-format
 msgid "3. Save settings again to store credentials"
 msgstr "3. Salva di nuovo le impostazioni per memorizzare le credenziali"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:625
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:640
 #, elixir-autogen, elixir-format
 msgid "4. Click \"Test Credentials\" to verify configuration"
 msgstr "4. Fai clic su «Verifica credenziali» per controllare la configurazione"
@@ -2466,7 +2466,8 @@ msgid "Access Credentials"
 msgstr "Credenziali di accesso"
 
 #: lib/modules/storage/web/bucket_form.html.heex:227
-#: lib/phoenix_kit/integrations/providers.ex:842
+#: lib/phoenix_kit/integrations/providers.ex:843
+#: lib/phoenix_kit/integrations/providers.ex:927
 #, elixir-autogen, elixir-format
 msgid "Access Key ID"
 msgstr "ID chiave di accesso"
@@ -2516,9 +2517,9 @@ msgstr "Aggiungi dimensione immagine"
 msgid "Add Video Dimension"
 msgstr "Aggiungi dimensione video"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:429
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:507
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:592
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:434
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:517
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:607
 #, elixir-autogen, elixir-format
 msgid "Add callback URL above to"
 msgstr "Aggiungi sopra l'URL di callback per"
@@ -2550,12 +2551,12 @@ msgstr "Tutti i nuovi utenti riceveranno privilegi amministrativi e l'accesso al
 msgid "Anyone can register"
 msgstr "Chiunque può registrarsi"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:541
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:551
 #, elixir-autogen, elixir-format
 msgid "App ID"
 msgstr "ID dell'app"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:551
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:561
 #, elixir-autogen, elixir-format
 msgid "App Secret"
 msgstr "Secret dell'app"
@@ -2674,7 +2675,7 @@ msgstr "I bucket possono essere directory locali o provider di archiviazione clo
 msgid "CSS color or gradient for auth page background. Ignored if a background image is set."
 msgstr "Colore o gradiente CSS per lo sfondo della pagina di autenticazione. Ignorato se è impostata un'immagine di sfondo."
 
-#: lib/phoenix_kit_web/live/settings/authorization.ex:261
+#: lib/phoenix_kit_web/live/settings/authorization.ex:302
 #, elixir-autogen, elixir-format
 msgid "Callback URL"
 msgstr "URL di callback"
@@ -2684,25 +2685,25 @@ msgstr "URL di callback"
 msgid "Changes will be saved immediately"
 msgstr "Le modifiche verranno salvate immediatamente"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:434
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:511
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:518
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:609
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:439
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:521
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:528
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:624
 #, elixir-autogen, elixir-format
 msgid "Click"
 msgstr "Fai clic"
 
-#: lib/phoenix_kit/integrations/providers.ex:215
+#: lib/phoenix_kit/integrations/providers.ex:216
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:378
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:458
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:463
 #, elixir-autogen, elixir-format
 msgid "Client ID"
 msgstr "ID client"
 
-#: lib/phoenix_kit/integrations/providers.ex:224
-#: lib/phoenix_kit/integrations/providers.ex:1169
+#: lib/phoenix_kit/integrations/providers.ex:225
+#: lib/phoenix_kit/integrations/providers.ex:1241
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:388
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:468
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:473
 #, elixir-autogen, elixir-format
 msgid "Client Secret"
 msgstr "Secret client"
@@ -2733,34 +2734,34 @@ msgstr "Configura preferenze e opzioni di sistema"
 msgid "Consider \"User\" for most installations to maintain security."
 msgstr "Per la maggior parte delle installazioni valuta «Utente» per mantenere la sicurezza."
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:514
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:599
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:142
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:524
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:614
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:168
 #, elixir-autogen, elixir-format
 msgid "Copy"
 msgstr "Copia"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:432
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:437
 #, elixir-autogen, elixir-format
 msgid "Copy Client ID and Secret to fields above"
 msgstr "Copia l'ID client e il secret nei campi qui sopra"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:568
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:583
 #, elixir-autogen, elixir-format
 msgid "Copy this URL to Facebook App Settings"
 msgstr "Copia questo URL nelle impostazioni dell'app Facebook"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:485
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:495
 #, elixir-autogen, elixir-format
 msgid "Copy this URL to GitHub OAuth Apps"
 msgstr "Copia questo URL nelle app OAuth di GitHub"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:405
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:410
 #, elixir-autogen, elixir-format
 msgid "Copy this URL to Google Cloud Console"
 msgstr "Copia questo URL nella Google Cloud Console"
 
-#: lib/phoenix_kit_web/live/settings/authorization.ex:271
+#: lib/phoenix_kit_web/live/settings/authorization.ex:312
 #, elixir-autogen, elixir-format
 msgid "Copy to clipboard"
 msgstr "Copia negli appunti"
@@ -2785,12 +2786,12 @@ msgstr "Crea percorso di archiviazione"
 msgid "Create Your First Bucket"
 msgstr "Crea il tuo primo bucket"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:582
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:597
 #, elixir-autogen, elixir-format
 msgid "Create a new app or select existing one"
 msgstr "Crea una nuova app o selezionane una esistente"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:418
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:423
 #, elixir-autogen, elixir-format
 msgid "Create project or select existing one"
 msgstr "Crea un progetto o selezionane uno esistente"
@@ -2861,11 +2862,12 @@ msgid "Enable OAuth (Master Switch)"
 msgstr "Abilita OAuth (interruttore principale)"
 
 #: lib/modules/storage/web/bucket_form.html.heex:194
+#: lib/phoenix_kit/integrations/providers.ex:957
 #, elixir-autogen, elixir-format
 msgid "Endpoint"
 msgstr "Endpoint"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:503
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:513
 #, elixir-autogen, elixir-format
 msgid "Enter"
 msgstr "Inserisci"
@@ -2900,7 +2902,7 @@ msgstr "FFmpeg non installato"
 msgid "FFmpeg is required for video processing, transcoding, and thumbnail generation."
 msgstr "FFmpeg è necessario per l'elaborazione video, la transcodifica e la generazione delle anteprime."
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:532
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:542
 #, elixir-autogen, elixir-format
 msgid "Facebook OAuth Credentials"
 msgstr "Credenziali OAuth di Facebook"
@@ -2943,7 +2945,7 @@ msgstr "Sovrascrivi formato"
 msgid "Format Override:"
 msgstr "Sovrascrivi formato:"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:449
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:454
 #, elixir-autogen, elixir-format
 msgid "GitHub OAuth Credentials"
 msgstr "Credenziali OAuth di GitHub"
@@ -2953,10 +2955,10 @@ msgstr "Credenziali OAuth di GitHub"
 msgid "GitHub Sign-In"
 msgstr "Accesso con GitHub"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:420
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:499
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:588
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:596
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:425
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:509
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:603
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:611
 #, elixir-autogen, elixir-format
 msgid "Go to"
 msgstr "Vai a"
@@ -2986,7 +2988,7 @@ msgstr "Come vengono visualizzate le date"
 msgid "How times are displayed"
 msgstr "Come vengono visualizzate le ore"
 
-#: lib/phoenix_kit_web/live/settings/authorization.ex:296
+#: lib/phoenix_kit_web/live/settings/authorization.ex:337
 #, elixir-autogen, elixir-format
 msgid "If behind nginx/apache, ensure"
 msgstr "Se dietro nginx/apache, assicurati che"
@@ -3173,7 +3175,7 @@ msgstr "Nessuno"
 msgid "Note"
 msgstr "Nota"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:627
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:642
 #, elixir-autogen, elixir-format
 msgid "Note: OAuth providers require ueberauth dependencies to be installed."
 msgstr "Nota: i provider OAuth richiedono l'installazione delle dipendenze ueberauth."
@@ -3188,7 +3190,7 @@ msgstr "Numero di copie da archiviare"
 msgid "OAuth Providers"
 msgstr "Provider OAuth"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:620
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:635
 #, elixir-autogen, elixir-format
 msgid "OAuth Setup Instructions"
 msgstr "Istruzioni per la configurazione di OAuth"
@@ -3261,7 +3263,7 @@ msgstr "Riduci la ridondanza o attiva altri bucket."
 msgid "Redundancy Copies"
 msgstr "Copie di ridondanza"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:642
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:657
 #, elixir-autogen, elixir-format
 msgid "Reload OAuth Configuration"
 msgstr "Ricarica la configurazione OAuth"
@@ -3288,7 +3290,7 @@ msgstr "Ripristina i valori predefiniti"
 msgid "Resolution"
 msgstr "Risoluzione"
 
-#: lib/phoenix_kit_web/live/settings/authorization.ex:294
+#: lib/phoenix_kit_web/live/settings/authorization.ex:335
 #, elixir-autogen, elixir-format
 msgid "Reverse Proxy Users:"
 msgstr "Utenti con reverse proxy:"
@@ -3314,7 +3316,7 @@ msgstr "Ruolo assegnato alle nuove registrazioni"
 msgid "Save All Settings"
 msgstr "Salva tutte le impostazioni"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:685
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:700
 #, elixir-autogen, elixir-format
 msgid "Save Authorization Settings"
 msgstr "Salva le impostazioni di autorizzazione"
@@ -3330,7 +3332,8 @@ msgid "Search engines are instructed to skip this environment. Remove this befor
 msgstr "Ai motori di ricerca viene indicato di ignorare questo ambiente. Rimuovilo prima del lancio."
 
 #: lib/modules/storage/web/bucket_form.html.heex:241
-#: lib/phoenix_kit/integrations/providers.ex:851
+#: lib/phoenix_kit/integrations/providers.ex:852
+#: lib/phoenix_kit/integrations/providers.ex:936
 #, elixir-autogen, elixir-format
 msgid "Secret Access Key"
 msgstr "Chiave di accesso segreta"
@@ -3347,7 +3350,7 @@ msgstr "Avviso di sicurezza: rischio medio"
 
 #: lib/phoenix_kit_web/components/media_browser.html.heex:1180
 #: lib/phoenix_kit_web/components/media_browser.html.heex:1182
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:425
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:430
 #, elixir-autogen, elixir-format
 msgid "Select"
 msgstr "Seleziona"
@@ -3377,7 +3380,7 @@ msgid "Set"
 msgstr "Imposta"
 
 #: lib/phoenix_kit_web/components/core/integrations_ui.ex:311
-#: lib/phoenix_kit_web/live/settings/authorization.ex:249
+#: lib/phoenix_kit_web/live/settings/authorization.ex:290
 #: lib/phoenix_kit_web/live/settings/integration_form.html.heex:378
 #, elixir-autogen, elixir-format
 msgid "Setup Instructions"
@@ -3414,7 +3417,7 @@ msgstr "Provider di archiviazione"
 msgid "Success!"
 msgstr "Operazione riuscita!"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:604
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:619
 #, elixir-autogen, elixir-format
 msgid "Switch app from"
 msgstr "Cambia app da"
@@ -3439,9 +3442,9 @@ msgstr "Fuso orario predefinito del sistema"
 msgid "Target Width (px)"
 msgstr "Larghezza di destinazione (px)"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:400
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:480
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:563
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:405
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:490
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:578
 #, elixir-autogen, elixir-format
 msgid "Test Credentials"
 msgstr "Verifica credenziali"
@@ -3521,7 +3524,7 @@ msgstr "Configurazione utente"
 msgid "User Editable"
 msgstr "Modificabile dall'utente"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:35
+#: lib/phoenix_kit_web/live/settings/users.ex:42
 #: lib/phoenix_kit_web/live/settings/users.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "User Settings"
@@ -3563,9 +3566,9 @@ msgstr "Impostazioni video:"
 msgid "Videos use CRF 0-51 scale (lower = higher quality)"
 msgstr "I video usano la scala CRF da 0 a 51 (più basso = qualità più alta)"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:409
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:489
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:572
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:414
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:499
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:587
 #, elixir-autogen, elixir-format
 msgid "Visit"
 msgstr "Visita"
@@ -3610,22 +3613,22 @@ msgstr "Senza di esso, l'elaborazione dei file video non funzionerà."
 msgid "Would you like to create it now?"
 msgstr "Vuoi crearlo ora?"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:542
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:552
 #, elixir-autogen, elixir-format
 msgid "Your Facebook App ID"
 msgstr "Il tuo ID app Facebook"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:552
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:565
 #, elixir-autogen, elixir-format
 msgid "Your Facebook App Secret"
 msgstr "Il tuo secret app Facebook"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:459
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:464
 #, elixir-autogen, elixir-format
 msgid "Your GitHub OAuth Client ID"
 msgstr "Il tuo ID client OAuth GitHub"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:469
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:477
 #, elixir-autogen, elixir-format
 msgid "Your GitHub OAuth Client Secret"
 msgstr "Il tuo secret client OAuth GitHub"
@@ -3635,19 +3638,19 @@ msgstr "Il tuo secret client OAuth GitHub"
 msgid "Your Google OAuth Client ID"
 msgstr "Il tuo ID client OAuth Google"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:389
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:392
 #, elixir-autogen, elixir-format
 msgid "Your Google OAuth Client Secret"
 msgstr "Il tuo secret client OAuth Google"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:504
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:600
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:514
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:615
 #: lib/phoenix_kit_web/live/settings/integrations.ex:167
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr "e"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:515
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:525
 #, elixir-autogen, elixir-format
 msgid "and generate/copy"
 msgstr "e genera/copia"
@@ -3668,12 +3671,12 @@ msgstr "es. thumbnail, medium, 720p"
 msgid "files"
 msgstr "file"
 
-#: lib/phoenix_kit_web/live/settings/authorization.ex:300
+#: lib/phoenix_kit_web/live/settings/authorization.ex:341
 #, elixir-autogen, elixir-format
 msgid "header is set to"
 msgstr "l'header è impostato su"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:606
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:621
 #, elixir-autogen, elixir-format
 msgid "mode"
 msgstr "modalità"
@@ -3683,12 +3686,12 @@ msgstr "modalità"
 msgid "option(s)"
 msgstr "opzione/i"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:585
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:600
 #, elixir-autogen, elixir-format
 msgid "product"
 msgstr "prodotto"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:605
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:620
 #, elixir-autogen, elixir-format
 msgid "to"
 msgstr "a"
@@ -3698,19 +3701,19 @@ msgstr "a"
 msgid "to every PhoenixKit layout, blocking crawlers from indexing or following links."
 msgstr "a ogni layout di PhoenixKit, impedendo ai crawler di indicizzare o seguire i link."
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:601
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:616
 #, elixir-autogen, elixir-format
 msgid "to fields above"
 msgstr "nei campi qui sopra"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:435
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:519
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:610
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:440
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:529
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:625
 #, elixir-autogen, elixir-format
 msgid "to verify setup"
 msgstr "per verificare la configurazione"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:426
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:431
 #, elixir-autogen, elixir-format
 msgid "type"
 msgstr "tipo"
@@ -3845,7 +3848,7 @@ msgstr "Un nome descrittivo per identificare questa posizione di archiviazione"
 msgid "A unique name to identify this dimension preset"
 msgstr "Un nome univoco per identificare questo preset di dimensioni"
 
-#: lib/phoenix_kit/integrations/providers.ex:388
+#: lib/phoenix_kit/integrations/providers.ex:389
 #, elixir-autogen, elixir-format
 msgid "AI model access via OpenRouter (100+ models)"
 msgstr "Accesso ai modelli di IA tramite OpenRouter (oltre 100 modelli)"
@@ -3855,13 +3858,13 @@ msgstr "Accesso ai modelli di IA tramite OpenRouter (oltre 100 modelli)"
 msgid "API Credentials"
 msgstr "Credenziali API"
 
-#: lib/phoenix_kit/integrations/providers.ex:332
-#: lib/phoenix_kit/integrations/providers.ex:402
-#: lib/phoenix_kit/integrations/providers.ex:460
-#: lib/phoenix_kit/integrations/providers.ex:523
-#: lib/phoenix_kit/integrations/providers.ex:586
-#: lib/phoenix_kit/integrations/providers.ex:653
-#: lib/phoenix_kit/integrations/providers.ex:1065
+#: lib/phoenix_kit/integrations/providers.ex:333
+#: lib/phoenix_kit/integrations/providers.ex:403
+#: lib/phoenix_kit/integrations/providers.ex:461
+#: lib/phoenix_kit/integrations/providers.ex:524
+#: lib/phoenix_kit/integrations/providers.ex:587
+#: lib/phoenix_kit/integrations/providers.ex:654
+#: lib/phoenix_kit/integrations/providers.ex:1137
 #, elixir-autogen, elixir-format
 msgid "API Key"
 msgstr "Chiave API"
@@ -3922,7 +3925,7 @@ msgstr "Attivo per la finestra programmata."
 msgid "Add Integration"
 msgstr "Aggiungi integrazione"
 
-#: lib/phoenix_kit/integrations/providers.ex:431
+#: lib/phoenix_kit/integrations/providers.ex:432
 #, elixir-autogen, elixir-format
 msgid "Add credits (optional)"
 msgstr "Aggiungi crediti (opzionale)"
@@ -3957,7 +3960,7 @@ msgstr "Tutti i file soddisfano l'obiettivo di ridondanza di %{n} copie."
 msgid "Alternative Formats"
 msgstr "Formati alternativi"
 
-#: lib/phoenix_kit/integrations/providers.ex:285
+#: lib/phoenix_kit/integrations/providers.ex:286
 #, elixir-autogen, elixir-format
 msgid "Application type: **Web application** (do not select \"Desktop app\" — it won't support redirect URIs)"
 msgstr "Tipo di applicazione: **applicazione web** (non selezionare «app desktop» — non supporta gli URI di reindirizzamento)"
@@ -4079,18 +4082,18 @@ msgstr "Scegli un servizio da collegare"
 msgid "Clear Schedule"
 msgstr "Cancella la pianificazione"
 
-#: lib/phoenix_kit/integrations/providers.ex:284
+#: lib/phoenix_kit/integrations/providers.ex:285
 #, elixir-autogen, elixir-format
 msgid "Click **Create Credentials → OAuth client ID**"
 msgstr "Fai clic su **Crea credenziali → ID client OAuth**"
 
-#: lib/phoenix_kit/integrations/providers.ex:425
+#: lib/phoenix_kit/integrations/providers.ex:426
 #, elixir-autogen, elixir-format
 msgid "Click **Create Key**"
 msgstr "Fai clic su **Crea chiave**"
 
-#: lib/phoenix_kit/integrations/providers.ex:295
-#: lib/phoenix_kit/integrations/providers.ex:1248
+#: lib/phoenix_kit/integrations/providers.ex:296
+#: lib/phoenix_kit/integrations/providers.ex:1320
 #, elixir-autogen, elixir-format
 msgid "Click **Save**, then **Connect Account**"
 msgstr "Fai clic su **Salva**, poi su **Collega account**"
@@ -4140,8 +4143,8 @@ msgstr "Collega l'account %{provider}"
 msgid "Connect Account"
 msgstr "Collega account"
 
-#: lib/phoenix_kit/integrations/providers.ex:293
-#: lib/phoenix_kit/integrations/providers.ex:1246
+#: lib/phoenix_kit/integrations/providers.ex:294
+#: lib/phoenix_kit/integrations/providers.ex:1318
 #, elixir-autogen, elixir-format
 msgid "Connect and authorize"
 msgstr "Collega e autorizza"
@@ -4161,7 +4164,7 @@ msgstr "Collega servizi esterni per usarli in tutti i moduli"
 #: lib/phoenix_kit_web/live/settings/integration_form.html.heex:327
 #: lib/phoenix_kit_web/live/settings/integrations.ex:181
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:111
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:197
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:191
 #, elixir-autogen, elixir-format
 msgid "Connected"
 msgstr "Collegato"
@@ -4202,48 +4205,48 @@ msgstr "Connessione riuscita"
 msgid "Connection verified"
 msgstr "Connessione verificata"
 
-#: lib/phoenix_kit/integrations/providers.ex:289
+#: lib/phoenix_kit/integrations/providers.ex:290
 #, elixir-autogen, elixir-format
 msgid "Copy the **Client ID** and **Client Secret** into the form above"
 msgstr "Copia l'**ID client** e il **secret client** nel modulo qui sopra"
 
-#: lib/phoenix_kit/integrations/providers.ex:427
+#: lib/phoenix_kit/integrations/providers.ex:428
 #, elixir-autogen, elixir-format
 msgid "Copy the key and paste it into the form above"
 msgstr "Copia la chiave e incollala nel modulo qui sopra"
 
-#: lib/phoenix_kit/integrations/integrations.ex:1135
+#: lib/phoenix_kit/integrations/integrations.ex:1138
 #: lib/phoenix_kit/integrations/probe.ex:102
 #, elixir-autogen, elixir-format
 msgid "Could not reach the service"
 msgstr "Impossibile raggiungere il servizio"
 
-#: lib/phoenix_kit/integrations/providers.ex:235
+#: lib/phoenix_kit/integrations/providers.ex:236
 #, elixir-autogen, elixir-format
 msgid "Create a Google Cloud project"
 msgstr "Crea un progetto Google Cloud"
 
-#: lib/phoenix_kit/integrations/providers.ex:238
+#: lib/phoenix_kit/integrations/providers.ex:239
 #, elixir-autogen, elixir-format
 msgid "Create a new project or select an existing one"
 msgstr "Crea un nuovo progetto o selezionane uno esistente"
 
-#: lib/phoenix_kit/integrations/providers.ex:368
-#: lib/phoenix_kit/integrations/providers.ex:423
-#: lib/phoenix_kit/integrations/providers.ex:493
-#: lib/phoenix_kit/integrations/providers.ex:553
-#: lib/phoenix_kit/integrations/providers.ex:619
-#: lib/phoenix_kit/integrations/providers.ex:670
+#: lib/phoenix_kit/integrations/providers.ex:369
+#: lib/phoenix_kit/integrations/providers.ex:424
+#: lib/phoenix_kit/integrations/providers.ex:494
+#: lib/phoenix_kit/integrations/providers.ex:554
+#: lib/phoenix_kit/integrations/providers.ex:620
+#: lib/phoenix_kit/integrations/providers.ex:671
 #, elixir-autogen, elixir-format
 msgid "Create an API key"
 msgstr "Crea una chiave API"
 
-#: lib/phoenix_kit/integrations/providers.ex:279
+#: lib/phoenix_kit/integrations/providers.ex:280
 #, elixir-autogen, elixir-format
 msgid "Create an OAuth Client"
 msgstr "Crea un client OAuth"
 
-#: lib/phoenix_kit/integrations/providers.ex:416
+#: lib/phoenix_kit/integrations/providers.ex:417
 #, elixir-autogen, elixir-format
 msgid "Create an OpenRouter account"
 msgstr "Crea un account OpenRouter"
@@ -4312,7 +4315,7 @@ msgstr "Disconnettere?"
 msgid "Disconnected"
 msgstr "Disconnesso"
 
-#: lib/phoenix_kit/integrations/providers.ex:253
+#: lib/phoenix_kit/integrations/providers.ex:254
 #, elixir-autogen, elixir-format
 msgid "Drive API handles file listing, creation, copying, and PDF export. Docs API is used for reading document content and substituting template variables."
 msgstr "L'API Drive gestisce l'elenco, la creazione, la copia e l'esportazione in PDF dei file. L'API Docs viene usata per leggere il contenuto dei documenti e sostituire le variabili dei modelli."
@@ -4342,7 +4345,7 @@ msgstr "Attiva bucket"
 msgid "Enable organization accounts"
 msgstr "Attiva gli account organizzazione"
 
-#: lib/phoenix_kit/integrations/providers.ex:242
+#: lib/phoenix_kit/integrations/providers.ex:243
 #, elixir-autogen, elixir-format
 msgid "Enable required APIs"
 msgstr "Attiva le API necessarie"
@@ -4475,12 +4478,12 @@ msgstr "I file sono tracciati in PostgreSQL con supporto per più posizioni mult
 msgid "Files with completed variants"
 msgstr "File con varianti completate"
 
-#: lib/phoenix_kit/integrations/providers.ex:219
+#: lib/phoenix_kit/integrations/providers.ex:220
 #, elixir-autogen, elixir-format
 msgid "From Google Cloud Console → APIs & Services → Credentials"
 msgstr "Dalla Google Cloud Console → API e servizi → Credenziali"
 
-#: lib/phoenix_kit/integrations/providers.ex:406
+#: lib/phoenix_kit/integrations/providers.ex:407
 #, elixir-autogen, elixir-format
 msgid "From openrouter.ai/keys"
 msgstr "Da openrouter.ai/keys"
@@ -4490,72 +4493,72 @@ msgstr "Da openrouter.ai/keys"
 msgid "Generate additional format variants alongside the primary format. Modern formats like WebP and AVIF offer better compression."
 msgstr "Genera varianti di formato aggiuntive oltre al formato principale. I formati moderni come WebP e AVIF offrono una compressione migliore."
 
-#: lib/phoenix_kit/integrations/providers.ex:426
+#: lib/phoenix_kit/integrations/providers.ex:427
 #, elixir-autogen, elixir-format
 msgid "Give it a name (e.g., your app name)"
 msgstr "Dagli un nome (es. il nome della tua app)"
 
-#: lib/phoenix_kit/integrations/providers.ex:248
+#: lib/phoenix_kit/integrations/providers.ex:249
 #, elixir-autogen, elixir-format
 msgid "Go back to the Library and search for **Google Docs API**, click it, then click **Enable**"
 msgstr "Torna alla Libreria, cerca **Google Docs API**, fai clic su di essa e poi su **Abilita**"
 
-#: lib/phoenix_kit/integrations/providers.ex:281
+#: lib/phoenix_kit/integrations/providers.ex:282
 #, elixir-autogen, elixir-format
 msgid "Go to [APIs & Services → Credentials](https://console.cloud.google.com/apis/credentials)"
 msgstr "Vai a [API e servizi → Credenziali](https://console.cloud.google.com/apis/credentials)"
 
-#: lib/phoenix_kit/integrations/providers.ex:244
+#: lib/phoenix_kit/integrations/providers.ex:245
 #, elixir-autogen, elixir-format
 msgid "Go to [APIs & Services → Library](https://console.cloud.google.com/apis/library)"
 msgstr "Vai a [API e servizi → Libreria](https://console.cloud.google.com/apis/library)"
 
-#: lib/phoenix_kit/integrations/providers.ex:263
+#: lib/phoenix_kit/integrations/providers.ex:264
 #, elixir-autogen, elixir-format
 msgid "Go to [Audience](https://console.cloud.google.com/auth/audience) — set user type to **External** (or Internal for Google Workspace)"
 msgstr "Vai a [Pubblico](https://console.cloud.google.com/auth/audience) — imposta il tipo di utente su **Esterno** (o Interno per Google Workspace)"
 
-#: lib/phoenix_kit/integrations/providers.ex:260
+#: lib/phoenix_kit/integrations/providers.ex:261
 #, elixir-autogen, elixir-format
 msgid "Go to [Branding](https://console.cloud.google.com/auth/branding) in the sidebar — fill in the **App name** and **User support email**, then save"
 msgstr "Vai a [Branding](https://console.cloud.google.com/auth/branding) nella barra laterale — compila **Nome app** ed **Email di supporto**, poi salva"
 
-#: lib/phoenix_kit/integrations/providers.ex:434
+#: lib/phoenix_kit/integrations/providers.ex:435
 #, elixir-autogen, elixir-format
 msgid "Go to [Credits](https://openrouter.ai/credits) to add funds"
 msgstr "Vai a [Credits](https://openrouter.ai/credits) per aggiungere fondi"
 
-#: lib/phoenix_kit/integrations/providers.ex:269
+#: lib/phoenix_kit/integrations/providers.ex:270
 #, elixir-autogen, elixir-format
 msgid "Go to [Data Access](https://console.cloud.google.com/auth/scopes) — click **Add or Remove Scopes** and add the Drive and Docs scopes. This step may not be required — the app requests the needed scopes at connect time regardless."
 msgstr "Vai a [Accesso ai dati](https://console.cloud.google.com/auth/scopes) — fai clic su **Aggiungi o rimuovi ambiti** e aggiungi gli ambiti Drive e Docs. Questo passaggio potrebbe non essere necessario: l'app richiede comunque gli ambiti necessari al momento del collegamento."
 
-#: lib/phoenix_kit/integrations/providers.ex:418
+#: lib/phoenix_kit/integrations/providers.ex:419
 #, elixir-autogen, elixir-format
 msgid "Go to [openrouter.ai](https://openrouter.ai) and sign up or log in"
 msgstr "Vai su [openrouter.ai](https://openrouter.ai) e registrati o accedi"
 
-#: lib/phoenix_kit/integrations/providers.ex:237
+#: lib/phoenix_kit/integrations/providers.ex:238
 #, elixir-autogen, elixir-format
 msgid "Go to the [Google Cloud Console](https://console.cloud.google.com)"
 msgstr "Vai alla [Google Cloud Console](https://console.cloud.google.com)"
 
-#: lib/phoenix_kit/integrations/providers.ex:200
+#: lib/phoenix_kit/integrations/providers.ex:201
 #, elixir-autogen, elixir-format
 msgid "Google"
 msgstr "Google"
 
-#: lib/phoenix_kit/integrations/providers.ex:201
+#: lib/phoenix_kit/integrations/providers.ex:202
 #, elixir-autogen, elixir-format
 msgid "Google Docs, Drive, Calendar, Sheets, Gmail"
 msgstr "Google Documenti, Drive, Calendar, Fogli, Gmail"
 
-#: lib/phoenix_kit/integrations/providers.ex:296
+#: lib/phoenix_kit/integrations/providers.ex:297
 #, elixir-autogen, elixir-format
 msgid "Google will show an \"unverified app\" warning — click **Advanced → Go to (app name)** to proceed"
 msgstr "Google mostrerà un avviso «app non verificata» — fai clic su **Avanzate → Vai a (nome app)** per procedere"
 
-#: lib/phoenix_kit/integrations/providers.ex:299
+#: lib/phoenix_kit/integrations/providers.ex:300
 #, elixir-autogen, elixir-format
 msgid "Grant access to Google Docs and Google Drive"
 msgstr "Concedi l'accesso a Google Documenti e Google Drive"
@@ -4591,11 +4594,12 @@ msgstr "Integrazione eliminata"
 msgid "Integrations"
 msgstr "Integrazioni"
 
-#: lib/phoenix_kit/integrations/integrations.ex:1132
+#: lib/phoenix_kit/integrations/integrations.ex:1135
 #: lib/phoenix_kit/integrations/validators.ex:208
 #: lib/phoenix_kit/integrations/validators.ex:378
 #: lib/phoenix_kit/integrations/validators.ex:412
-#: lib/phoenix_kit/integrations/validators.ex:595
+#: lib/phoenix_kit/integrations/validators.ex:608
+#: lib/phoenix_kit/integrations/validators.ex:776
 #, elixir-autogen, elixir-format
 msgid "Invalid credentials"
 msgstr "Credenziali non valide"
@@ -4809,12 +4813,12 @@ msgstr "Mancanti %{n}"
 msgid "Missing %{n} copies"
 msgstr "Mancano %{n} copie"
 
-#: lib/phoenix_kit/integrations/providers.ex:419
+#: lib/phoenix_kit/integrations/providers.ex:420
 #, elixir-autogen, elixir-format
 msgid "Navigate to [Keys](https://openrouter.ai/keys)"
 msgstr "Vai a [Keys](https://openrouter.ai/keys)"
 
-#: lib/phoenix_kit/integrations/providers.ex:274
+#: lib/phoenix_kit/integrations/providers.ex:275
 #, elixir-autogen, elixir-format
 msgid "Navigate to the OAuth section using the search bar or the hamburger menu: search for \"OAuth\", or go to the sidebar: **APIs & Services → OAuth consent screen**. This opens a different section with its own sidebar."
 msgstr "Vai alla sezione OAuth usando la barra di ricerca o il menu hamburger: cerca «OAuth», oppure vai nella barra laterale: **API e servizi → Schermata consenso OAuth**. Si aprirà una sezione diversa con una propria barra laterale."
@@ -4835,9 +4839,9 @@ msgstr "Nessun token di accesso"
 msgid "No copies"
 msgstr "Nessuna copia"
 
-#: lib/phoenix_kit/integrations/integrations.ex:1115
+#: lib/phoenix_kit/integrations/integrations.ex:1118
 #: lib/phoenix_kit/integrations/validators.ex:170
-#: lib/phoenix_kit/integrations/validators.ex:577
+#: lib/phoenix_kit/integrations/validators.ex:758
 #, elixir-autogen, elixir-format
 msgid "No credentials configured"
 msgstr "Nessuna credenziale configurata"
@@ -4918,7 +4922,7 @@ msgstr "Solo i bucket attivi ricevono nuovi caricamenti"
 msgid "Only width is used, height is calculated automatically"
 msgstr "Viene usata solo la larghezza, l'altezza è calcolata automaticamente"
 
-#: lib/phoenix_kit/integrations/providers.ex:387
+#: lib/phoenix_kit/integrations/providers.ex:388
 #, elixir-autogen, elixir-format
 msgid "OpenRouter"
 msgstr "OpenRouter"
@@ -5099,7 +5103,7 @@ msgstr "Manutenzione programmata"
 msgid "Scheduled window is currently active"
 msgstr "La finestra programmata è attualmente attiva"
 
-#: lib/phoenix_kit/integrations/providers.ex:247
+#: lib/phoenix_kit/integrations/providers.ex:248
 #, elixir-autogen, elixir-format
 msgid "Search for **Google Drive API**, click it, then click **Enable**"
 msgstr "Cerca **Google Drive API**, fai clic su di essa e poi su **Abilita**"
@@ -5126,7 +5130,7 @@ msgstr "Seleziona un utente da aggiungere…"
 msgid "Service"
 msgstr "Servizio"
 
-#: lib/phoenix_kit/integrations/integrations.ex:1134
+#: lib/phoenix_kit/integrations/integrations.ex:1137
 #, elixir-autogen, elixir-format
 msgid "Service error %{status}"
 msgstr "Errore del servizio %{status}"
@@ -5136,7 +5140,7 @@ msgstr "Errore del servizio %{status}"
 msgid "Set a time window for automatic maintenance activation."
 msgstr "Imposta una finestra temporale per l'attivazione automatica della manutenzione."
 
-#: lib/phoenix_kit/integrations/providers.ex:258
+#: lib/phoenix_kit/integrations/providers.ex:259
 #, elixir-autogen, elixir-format
 msgid "Set up OAuth consent"
 msgstr "Configura il consenso OAuth"
@@ -5146,7 +5150,7 @@ msgstr "Configura il consenso OAuth"
 msgid "Size Configuration"
 msgstr "Configurazione delle dimensioni"
 
-#: lib/phoenix_kit/integrations/providers.ex:433
+#: lib/phoenix_kit/integrations/providers.ex:434
 #, elixir-autogen, elixir-format
 msgid "Some models are free, but most require credits"
 msgstr "Alcuni modelli sono gratuiti, ma la maggior parte richiede crediti"
@@ -5176,7 +5180,7 @@ msgstr "Passaggio 1"
 msgid "Step 2"
 msgstr "Passaggio 2"
 
-#: lib/phoenix_kit/integrations/providers.ex:266
+#: lib/phoenix_kit/integrations/providers.ex:267
 #, elixir-autogen, elixir-format
 msgid "Still on Audience — while the app is in **Testing** status, add the Google account you will connect as a **Test user** (this must be the same account whose Drive will store your files)"
 msgstr "Sempre in Pubblico — finché l'app è in stato **Test**, aggiungi l'account Google che collegherai come **utente di test** (deve essere lo stesso account il cui Drive conserverà i tuoi file)"
@@ -5311,7 +5315,7 @@ msgstr "Regione Tigris"
 msgid "Total Files"
 msgstr "File totali"
 
-#: lib/phoenix_kit/integrations/providers.ex:288
+#: lib/phoenix_kit/integrations/providers.ex:289
 #, elixir-autogen, elixir-format
 msgid "Under **Authorized redirect URIs**, add: `{redirect_uri}`"
 msgstr "In **URI di reindirizzamento autorizzati**, aggiungi: `{redirect_uri}`"
@@ -5368,8 +5372,8 @@ msgstr "Ti sei unito all'organizzazione!"
 msgid "You need to create at least one media bucket before files can be uploaded."
 msgstr "Devi creare almeno un bucket multimediale prima di poter caricare file."
 
-#: lib/phoenix_kit/integrations/providers.ex:300
-#: lib/phoenix_kit/integrations/providers.ex:1252
+#: lib/phoenix_kit/integrations/providers.ex:301
+#: lib/phoenix_kit/integrations/providers.ex:1324
 #, elixir-autogen, elixir-format
 msgid "You'll be redirected back here once connected"
 msgstr "Verrai reindirizzato qui una volta collegato"
@@ -5436,39 +5440,39 @@ msgstr "1 ora fa"
 msgid "1 minute ago"
 msgstr "1 minuto fa"
 
-#: lib/phoenix_kit/integrations/providers.ex:509
+#: lib/phoenix_kit/integrations/providers.ex:510
 #, elixir-autogen, elixir-format
 msgid "AI model access via DeepSeek (deepseek-chat, deepseek-reasoner)"
 msgstr "Accesso ai modelli di IA tramite DeepSeek (deepseek-chat, deepseek-reasoner)"
 
-#: lib/phoenix_kit/integrations/providers.ex:446
+#: lib/phoenix_kit/integrations/providers.ex:447
 #, elixir-autogen, elixir-format
 msgid "AI model access via Mistral AI (Mistral Large, Codestral, Pixtral)"
 msgstr "Accesso ai modelli di IA tramite Mistral AI (Mistral Large, Codestral, Pixtral)"
 
-#: lib/phoenix_kit/integrations/providers.ex:1218
+#: lib/phoenix_kit/integrations/providers.ex:1290
 #, elixir-autogen, elixir-format
 msgid "Add a client secret"
 msgstr "Aggiungi un secret client"
 
-#: lib/phoenix_kit/integrations/providers.ex:480
+#: lib/phoenix_kit/integrations/providers.ex:481
 #, elixir-autogen, elixir-format
 msgid "Add a payment method (required)"
 msgstr "Aggiungi un metodo di pagamento (obbligatorio)"
 
-#: lib/phoenix_kit/integrations/providers.ex:357
-#: lib/phoenix_kit/integrations/providers.ex:542
-#: lib/phoenix_kit/integrations/providers.ex:611
+#: lib/phoenix_kit/integrations/providers.ex:358
+#: lib/phoenix_kit/integrations/providers.ex:543
+#: lib/phoenix_kit/integrations/providers.ex:612
 #, elixir-autogen, elixir-format
 msgid "Add credits"
 msgstr "Aggiungi crediti"
 
-#: lib/phoenix_kit/integrations/providers.ex:1233
+#: lib/phoenix_kit/integrations/providers.ex:1305
 #, elixir-autogen, elixir-format
 msgid "Add the permissions your integration needs: `User.Read` is included by default; add `Mail.Read`, `Files.Read.All`, `Calendars.Read`, etc. as required"
 msgstr "Aggiungi i permessi necessari alla tua integrazione: `User.Read` è incluso per impostazione predefinita; aggiungi `Mail.Read`, `Files.Read.All`, `Calendars.Read` ecc. secondo necessità"
 
-#: lib/phoenix_kit/integrations/providers.ex:1160
+#: lib/phoenix_kit/integrations/providers.ex:1232
 #, elixir-autogen, elixir-format
 msgid "Application (client) ID"
 msgstr "ID applicazione (client)"
@@ -5478,28 +5482,28 @@ msgstr "ID applicazione (client)"
 msgid "Clears the OAuth tokens. Credentials and the connection itself stay so you can reconnect with one click."
 msgstr "Cancella i token OAuth. Le credenziali e la connessione stessa rimangono, così puoi ricollegarti con un clic."
 
-#: lib/phoenix_kit/integrations/providers.ex:556
-#: lib/phoenix_kit/integrations/providers.ex:622
+#: lib/phoenix_kit/integrations/providers.ex:557
+#: lib/phoenix_kit/integrations/providers.ex:623
 #, elixir-autogen, elixir-format
 msgid "Click **Create API key**, give it a name"
 msgstr "Fai clic su **Crea chiave API** e dagli un nome"
 
-#: lib/phoenix_kit/integrations/providers.ex:496
+#: lib/phoenix_kit/integrations/providers.ex:497
 #, elixir-autogen, elixir-format
 msgid "Click **Create new key**, give it a name, set an expiry if desired"
 msgstr "Fai clic su **Crea nuova chiave**, dagli un nome e imposta una scadenza se desideri"
 
-#: lib/phoenix_kit/integrations/providers.ex:1205
+#: lib/phoenix_kit/integrations/providers.ex:1277
 #, elixir-autogen, elixir-format
 msgid "Click **New registration**, give the app a name"
 msgstr "Fai clic su **Nuova registrazione** e dai un nome all'app"
 
-#: lib/phoenix_kit/integrations/providers.ex:1210
+#: lib/phoenix_kit/integrations/providers.ex:1282
 #, elixir-autogen, elixir-format
 msgid "Click **Register**"
 msgstr "Fai clic su **Registra**"
 
-#: lib/phoenix_kit/integrations/providers.ex:1228
+#: lib/phoenix_kit/integrations/providers.ex:1300
 #, elixir-autogen, elixir-format
 msgid "Configure API permissions"
 msgstr "Configura i permessi API"
@@ -5520,16 +5524,16 @@ msgstr "Il nome della connessione non può essere vuoto."
 msgid "Connection renamed"
 msgstr "Connessione rinominata"
 
-#: lib/phoenix_kit/integrations/providers.ex:1222
+#: lib/phoenix_kit/integrations/providers.ex:1294
 #, elixir-autogen, elixir-format
 msgid "Copy the **Value** column (not the Secret ID) into the form above — the value is shown ONCE and disappears on page refresh"
 msgstr "Copia la colonna **Valore** (non il Secret ID) nel modulo qui sopra — il valore è mostrato UNA SOLA volta e scompare al ricaricamento della pagina"
 
-#: lib/phoenix_kit/integrations/providers.ex:372
-#: lib/phoenix_kit/integrations/providers.ex:497
-#: lib/phoenix_kit/integrations/providers.ex:557
-#: lib/phoenix_kit/integrations/providers.ex:623
-#: lib/phoenix_kit/integrations/providers.ex:675
+#: lib/phoenix_kit/integrations/providers.ex:373
+#: lib/phoenix_kit/integrations/providers.ex:498
+#: lib/phoenix_kit/integrations/providers.ex:558
+#: lib/phoenix_kit/integrations/providers.ex:624
+#: lib/phoenix_kit/integrations/providers.ex:676
 #, elixir-autogen, elixir-format
 msgid "Copy the key (shown once) and paste it into the form above"
 msgstr "Copia la chiave (mostrata una sola volta) e incollala nel modulo qui sopra"
@@ -5540,12 +5544,12 @@ msgstr "Copia la chiave (mostrata una sola volta) e incollala nel modulo qui sop
 msgid "Create Connection"
 msgstr "Crea connessione"
 
-#: lib/phoenix_kit/integrations/providers.ex:534
+#: lib/phoenix_kit/integrations/providers.ex:535
 #, elixir-autogen, elixir-format
 msgid "Create a DeepSeek account"
 msgstr "Crea un account DeepSeek"
 
-#: lib/phoenix_kit/integrations/providers.ex:471
+#: lib/phoenix_kit/integrations/providers.ex:472
 #, elixir-autogen, elixir-format
 msgid "Create a Mistral account"
 msgstr "Crea un account Mistral"
@@ -5556,12 +5560,12 @@ msgstr "Crea un account Mistral"
 msgid "Danger Zone"
 msgstr "Zona a rischio"
 
-#: lib/phoenix_kit/integrations/providers.ex:508
+#: lib/phoenix_kit/integrations/providers.ex:509
 #, elixir-autogen, elixir-format
 msgid "DeepSeek"
 msgstr "DeepSeek"
 
-#: lib/phoenix_kit/integrations/providers.ex:547
+#: lib/phoenix_kit/integrations/providers.ex:548
 #, elixir-autogen, elixir-format
 msgid "DeepSeek requires a positive balance before you can call the chat or reasoner endpoints, even on cheap models"
 msgstr "DeepSeek richiede un saldo positivo prima di poter chiamare gli endpoint chat o reasoner, anche con modelli economici"
@@ -5596,82 +5600,82 @@ msgstr "Impossibile rimuovere la connessione."
 msgid "Failed to rename connection."
 msgstr "Impossibile rinominare la connessione."
 
-#: lib/phoenix_kit/integrations/providers.ex:485
+#: lib/phoenix_kit/integrations/providers.ex:486
 #, elixir-autogen, elixir-format
 msgid "Free models still require a billing-enabled workspace"
 msgstr "Anche i modelli gratuiti richiedono un workspace con fatturazione attiva"
 
-#: lib/phoenix_kit/integrations/providers.ex:1164
+#: lib/phoenix_kit/integrations/providers.ex:1236
 #, elixir-autogen, elixir-format
 msgid "From Azure Portal → App registrations → your app → Overview"
 msgstr "Dal portale Azure → Registrazioni app → la tua app → Panoramica"
 
-#: lib/phoenix_kit/integrations/providers.ex:464
+#: lib/phoenix_kit/integrations/providers.ex:465
 #, elixir-autogen, elixir-format
 msgid "From console.mistral.ai/api-keys"
 msgstr "Da console.mistral.ai/api-keys"
 
-#: lib/phoenix_kit/integrations/providers.ex:527
+#: lib/phoenix_kit/integrations/providers.ex:528
 #, elixir-autogen, elixir-format
 msgid "From platform.deepseek.com/api_keys"
 msgstr "Da platform.deepseek.com/api_keys"
 
-#: lib/phoenix_kit/integrations/providers.ex:1174
+#: lib/phoenix_kit/integrations/providers.ex:1246
 #, elixir-autogen, elixir-format
 msgid "From your app → Certificates & secrets → New client secret. Copy the *Value*, not the Secret ID."
 msgstr "Dalla tua app → Certificati e segreti → Nuovo secret client. Copia il *Valore*, non il Secret ID."
 
-#: lib/phoenix_kit/integrations/providers.ex:1230
+#: lib/phoenix_kit/integrations/providers.ex:1302
 #, elixir-autogen, elixir-format
 msgid "Go to **API permissions → Add a permission → Microsoft Graph → Delegated permissions**"
 msgstr "Vai a **Autorizzazioni API → Aggiungi un'autorizzazione → Microsoft Graph → Autorizzazioni delegate**"
 
-#: lib/phoenix_kit/integrations/providers.ex:1220
+#: lib/phoenix_kit/integrations/providers.ex:1292
 #, elixir-autogen, elixir-format
 msgid "Go to **Certificates & secrets → New client secret**"
 msgstr "Vai a **Certificati e segreti → Nuovo secret client**"
 
-#: lib/phoenix_kit/integrations/providers.ex:495
+#: lib/phoenix_kit/integrations/providers.ex:496
 #, elixir-autogen, elixir-format
 msgid "Go to [API Keys](https://console.mistral.ai/api-keys)"
 msgstr "Vai a [API Keys](https://console.mistral.ai/api-keys)"
 
-#: lib/phoenix_kit/integrations/providers.ex:555
+#: lib/phoenix_kit/integrations/providers.ex:556
 #, elixir-autogen, elixir-format
 msgid "Go to [API Keys](https://platform.deepseek.com/api_keys)"
 msgstr "Vai a [API Keys](https://platform.deepseek.com/api_keys)"
 
-#: lib/phoenix_kit/integrations/providers.ex:544
+#: lib/phoenix_kit/integrations/providers.ex:545
 #, elixir-autogen, elixir-format
 msgid "Go to [Top up](https://platform.deepseek.com/top_up) and add at least the minimum amount"
 msgstr "Vai a [Top up](https://platform.deepseek.com/top_up) e aggiungi almeno l'importo minimo"
 
-#: lib/phoenix_kit/integrations/providers.ex:482
+#: lib/phoenix_kit/integrations/providers.ex:483
 #, elixir-autogen, elixir-format
 msgid "Go to [Workspace → Billing](https://console.mistral.ai/billing/plans) and choose **Experiment** (pay-as-you-go) or a paid tier"
 msgstr "Vai a [Workspace → Billing](https://console.mistral.ai/billing/plans) e scegli **Experiment** (pagamento a consumo) o un piano a pagamento"
 
-#: lib/phoenix_kit/integrations/providers.ex:473
+#: lib/phoenix_kit/integrations/providers.ex:474
 #, elixir-autogen, elixir-format
 msgid "Go to [console.mistral.ai](https://console.mistral.ai) and sign up or log in"
 msgstr "Vai su [console.mistral.ai](https://console.mistral.ai) e registrati o accedi"
 
-#: lib/phoenix_kit/integrations/providers.ex:536
+#: lib/phoenix_kit/integrations/providers.ex:537
 #, elixir-autogen, elixir-format
 msgid "Go to [platform.deepseek.com](https://platform.deepseek.com) and sign up or log in"
 msgstr "Vai su [platform.deepseek.com](https://platform.deepseek.com) e registrati o accedi"
 
-#: lib/phoenix_kit/integrations/providers.ex:1202
+#: lib/phoenix_kit/integrations/providers.ex:1274
 #, elixir-autogen, elixir-format
 msgid "Go to the [Azure Portal](https://portal.azure.com) and search for **App registrations**"
 msgstr "Vai al [portale Azure](https://portal.azure.com) e cerca **Registrazioni app**"
 
-#: lib/phoenix_kit/integrations/providers.ex:1213
+#: lib/phoenix_kit/integrations/providers.ex:1285
 #, elixir-autogen, elixir-format
 msgid "If you picked a single-tenant audience, fill in **Tenant ID** above with your Directory (tenant) ID GUID — leaving it as `common` only works for multi-tenant + personal apps."
 msgstr "Se hai scelto un pubblico single-tenant, inserisci sopra in **Tenant ID** il GUID dell'ID directory (tenant) — lasciarlo su `common` funziona solo per app multi-tenant e personali."
 
-#: lib/phoenix_kit/integrations/providers.ex:1236
+#: lib/phoenix_kit/integrations/providers.ex:1308
 #, elixir-autogen, elixir-format
 msgid "If your tenant requires admin consent, click **Grant admin consent for <tenant>** before the connect flow will work"
 msgstr "Se il tuo tenant richiede il consenso dell'amministratore, fai clic su **Concedi consenso amministratore per <tenant>** prima che il flusso di collegamento funzioni"
@@ -5688,32 +5692,32 @@ msgstr "Integrazione non trovata"
 msgid "Last tested"
 msgstr "Ultimo test"
 
-#: lib/phoenix_kit/integrations/providers.ex:1186
+#: lib/phoenix_kit/integrations/providers.ex:1258
 #, elixir-autogen, elixir-format
 msgid "Leave as `common` for multi-tenant + personal accounts. For single-tenant apps, paste your Directory (tenant) ID GUID. Use `consumers` for personal-only or `organizations` for any work-or-school account."
 msgstr "Lascia `common` per account multi-tenant e personali. Per app single-tenant, incolla il GUID dell'ID directory (tenant). Usa `consumers` solo per account personali oppure `organizations` per qualsiasi account aziendale o scolastico."
 
-#: lib/phoenix_kit/integrations/providers.ex:1131
+#: lib/phoenix_kit/integrations/providers.ex:1203
 #, elixir-autogen, elixir-format
 msgid "Microsoft 365"
 msgstr "Microsoft 365"
 
-#: lib/phoenix_kit/integrations/providers.ex:1132
+#: lib/phoenix_kit/integrations/providers.ex:1204
 #, elixir-autogen, elixir-format
 msgid "Microsoft Graph — Outlook, OneDrive, Teams, Calendar, SharePoint"
 msgstr "Microsoft Graph — Outlook, OneDrive, Teams, Calendario, SharePoint"
 
-#: lib/phoenix_kit/integrations/providers.ex:1249
+#: lib/phoenix_kit/integrations/providers.ex:1321
 #, elixir-autogen, elixir-format
 msgid "Microsoft will show the consent screen — click **Accept** to grant the requested permissions"
 msgstr "Microsoft mostrerà la schermata di consenso — fai clic su **Accetta** per concedere i permessi richiesti"
 
-#: lib/phoenix_kit/integrations/providers.ex:445
+#: lib/phoenix_kit/integrations/providers.ex:446
 #, elixir-autogen, elixir-format
 msgid "Mistral"
 msgstr "Mistral"
 
-#: lib/phoenix_kit/integrations/providers.ex:488
+#: lib/phoenix_kit/integrations/providers.ex:489
 #, elixir-autogen, elixir-format
 msgid "Mistral does not offer credits without billing setup; this is a hard requirement before keys can be created."
 msgstr "Mistral non offre crediti senza configurare la fatturazione; è un requisito obbligatorio prima di poter creare le chiavi."
@@ -5724,7 +5728,7 @@ msgstr "Mistral non offre crediti senza configurare la fatturazione; è un requi
 msgid "Permanently delete this connection? This cannot be undone."
 msgstr "Eliminare definitivamente questa connessione? L'azione non può essere annullata."
 
-#: lib/phoenix_kit/integrations/providers.ex:1200
+#: lib/phoenix_kit/integrations/providers.ex:1272
 #, elixir-autogen, elixir-format
 msgid "Register an application in Microsoft Entra ID (Azure AD)"
 msgstr "Registra un'applicazione in Microsoft Entra ID (Azure AD)"
@@ -5740,32 +5744,32 @@ msgstr "Rimuove definitivamente l'integrazione. Ogni modulo collegato a questa c
 msgid "Search..."
 msgstr "Cerca…"
 
-#: lib/phoenix_kit/integrations/providers.ex:1221
+#: lib/phoenix_kit/integrations/providers.ex:1293
 #, elixir-autogen, elixir-format
 msgid "Set an expiration (24 months is common; renew before it lapses)"
 msgstr "Imposta una scadenza (24 mesi è comune; rinnovala prima che scada)"
 
-#: lib/phoenix_kit/integrations/providers.ex:1181
+#: lib/phoenix_kit/integrations/providers.ex:1253
 #, elixir-autogen, elixir-format
 msgid "Tenant ID"
 msgstr "ID tenant"
 
-#: lib/phoenix_kit/integrations/providers.ex:1241
+#: lib/phoenix_kit/integrations/providers.ex:1313
 #, elixir-autogen, elixir-format
 msgid "The `default_scopes` in the provider definition request `openid email profile offline_access User.Read` — extra scopes can be added per-connect by passing `extra_scopes` to `authorization_url/5`."
 msgstr "I `default_scopes` nella definizione del provider richiedono `openid email profile offline_access User.Read` — è possibile aggiungere ambiti extra per singolo collegamento passando `extra_scopes` a `authorization_url/5`."
 
-#: lib/phoenix_kit/integrations/providers.ex:1209
+#: lib/phoenix_kit/integrations/providers.ex:1281
 #, elixir-autogen, elixir-format
 msgid "Under **Redirect URI**, choose **Web** and enter: `{redirect_uri}`"
 msgstr "In **URI di reindirizzamento**, scegli **Web** e inserisci: `{redirect_uri}`"
 
-#: lib/phoenix_kit/integrations/providers.ex:1206
+#: lib/phoenix_kit/integrations/providers.ex:1278
 #, elixir-autogen, elixir-format
 msgid "Under **Supported account types**, choose the audience: *Personal Microsoft accounts only*, *Accounts in any organizational directory*, or *Accounts in this organizational directory only* depending on who should sign in"
 msgstr "In **Tipi di account supportati**, scegli il pubblico: *Solo account Microsoft personali*, *Account in qualsiasi directory organizzativa* oppure *Solo account in questa directory organizzativa*, in base a chi deve accedere"
 
-#: lib/phoenix_kit/integrations/providers.ex:476
+#: lib/phoenix_kit/integrations/providers.ex:477
 #, elixir-autogen, elixir-format
 msgid "You may need to verify your phone number before creating API keys"
 msgstr "Potrebbe essere necessario verificare il numero di telefono prima di creare le chiavi API"
@@ -6032,14 +6036,14 @@ msgstr "Non installato"
 
 #: lib/phoenix_kit_web/live/modules.html.heex:447
 #: lib/phoenix_kit_web/live/settings.html.heex:465
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:289
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:315
 #, elixir-autogen, elixir-format
 msgid "Off"
 msgstr "Off"
 
 #: lib/phoenix_kit_web/live/modules.html.heex:447
 #: lib/phoenix_kit_web/live/settings.html.heex:464
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:289
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:315
 #, elixir-autogen, elixir-format
 msgid "On"
 msgstr "On"
@@ -7271,8 +7275,8 @@ msgstr "Rispondi"
 msgid "Are you sure you want to delete this comment?"
 msgstr "Vuoi davvero eliminare questo commento?"
 
-#: lib/phoenix_kit_web/components/media_canvas_viewer.ex:1202
-#: lib/phoenix_kit_web/components/media_canvas_viewer.ex:1203
+#: lib/phoenix_kit_web/components/media_canvas_viewer.ex:1236
+#: lib/phoenix_kit_web/components/media_canvas_viewer.ex:1237
 #, elixir-autogen, elixir-format
 msgid "%b %d, %Y"
 msgstr "%d %b %Y"
@@ -8386,14 +8390,14 @@ msgstr "Tutti i campi sono già selezionati"
 msgid "All registered accounts"
 msgstr "Tutti gli account registrati"
 
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:185
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:224
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:179
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:218
 #, elixir-autogen, elixir-format
 msgid "Anon"
 msgstr "Anon."
 
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:178
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:245
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:172
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:239
 #, elixir-autogen, elixir-format
 msgid "Anonymous User"
 msgstr "Utente anonimo"
@@ -8444,8 +8448,8 @@ msgstr "Vuoi davvero revocare questa sessione per"
 msgid "Are you sure you want to unconfirm this user's email?"
 msgstr "Vuoi davvero annullare la conferma dell'email di questo utente?"
 
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:170
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:220
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:164
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:214
 #, elixir-autogen, elixir-format
 msgid "Auth"
 msgstr "Autenticazione"
@@ -8528,17 +8532,17 @@ msgid "Confirmed Email"
 msgstr "Email confermata"
 
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:109
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:195
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Current Page"
 msgstr "Pagina attuale"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:251
+#: lib/phoenix_kit_web/live/settings/users.ex:258
 #, elixir-autogen, elixir-format
 msgid "Custom field deleted successfully"
 msgstr "Campo personalizzato eliminato con successo"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:171
+#: lib/phoenix_kit_web/live/settings/users.ex:178
 #, elixir-autogen, elixir-format
 msgid "Custom field saved successfully"
 msgstr "Campo personalizzato salvato con successo"
@@ -8553,17 +8557,17 @@ msgstr "Personalizza le colonne della tabella"
 msgid "Drag to reorder selected columns above, or add new columns from the options below. Actions column is always included."
 msgstr "Trascina per riordinare le colonne selezionate qui sopra, oppure aggiungi nuove colonne dalle opzioni qui sotto. La colonna Azioni è sempre inclusa."
 
-#: lib/phoenix_kit_web/live/settings/users.ex:256
+#: lib/phoenix_kit_web/live/settings/users.ex:263
 #, elixir-autogen, elixir-format
 msgid "Failed to delete custom field"
 msgstr "Impossibile eliminare il campo personalizzato"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:184
+#: lib/phoenix_kit_web/live/settings/users.ex:191
 #, elixir-autogen, elixir-format
 msgid "Failed to save custom field"
 msgstr "Impossibile salvare il campo personalizzato"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:285
+#: lib/phoenix_kit_web/live/settings/users.ex:292
 #, elixir-autogen, elixir-format
 msgid "Failed to update field"
 msgstr "Impossibile aggiornare il campo"
@@ -8596,23 +8600,23 @@ msgstr "Impossibile aggiornare i ruoli dell'utente"
 msgid "Failed to update user status"
 msgstr "Impossibile aggiornare lo stato dell'utente"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:278
+#: lib/phoenix_kit_web/live/settings/users.ex:285
 #, elixir-autogen, elixir-format
 msgid "Field '%{label}' disabled"
 msgstr "Campo «%{label}» disattivato"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:277
+#: lib/phoenix_kit_web/live/settings/users.ex:284
 #, elixir-autogen, elixir-format
 msgid "Field '%{label}' enabled"
 msgstr "Campo «%{label}» attivato"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:289
+#: lib/phoenix_kit_web/live/settings/users.ex:296
 #, elixir-autogen, elixir-format
 msgid "Field not found"
 msgstr "Campo non trovato"
 
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:108
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:194
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:188
 #, elixir-autogen, elixir-format
 msgid "IP Address"
 msgstr "Indirizzo IP"
@@ -8644,7 +8648,7 @@ msgstr "Gestisci gli account utente e i ruoli"
 msgid "Monitor and manage active user sessions"
 msgstr "Monitora e gestisci le sessioni utente attive"
 
-#: lib/phoenix_kit/integrations/providers.ex:1002
+#: lib/phoenix_kit/integrations/providers.ex:1074
 #: lib/phoenix_kit_web/live/users/users.ex:1048
 #: lib/phoenix_kit_web/live/users/users.html.heex:563
 #, elixir-autogen, elixir-format
@@ -8656,7 +8660,7 @@ msgstr "Mai"
 msgid "Next »"
 msgstr "Avanti »"
 
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:208
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:202
 #, elixir-autogen, elixir-format
 msgid "No active sessions"
 msgstr "Nessuna sessione attiva"
@@ -8808,7 +8812,7 @@ msgstr "Campi standard"
 msgid "Table columns updated successfully"
 msgstr "Colonne della tabella aggiornate con successo"
 
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:209
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:203
 #, elixir-autogen, elixir-format
 msgid "There are currently no active sessions to display."
 msgstr "Attualmente non ci sono sessioni attive da mostrare."
@@ -8869,12 +8873,12 @@ msgstr "Conferma dell'email dell'utente annullata con successo"
 msgid "User roles updated successfully"
 msgstr "Ruoli dell'utente aggiornati con successo"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:84
+#: lib/phoenix_kit_web/live/settings/users.ex:91
 #, elixir-autogen, elixir-format
 msgid "User settings updated successfully"
 msgstr "Impostazioni utente aggiornate con successo"
 
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:193
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:187
 #, elixir-autogen, elixir-format
 msgid "User/Session"
 msgstr "Utente/Sessione"
@@ -8908,7 +8912,7 @@ msgstr[1] "Vuoi davvero revocare tutte le %{count} sessioni dell'utente %{email}
 msgid "Last updated:"
 msgstr "Ultimo aggiornamento:"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:656
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:671
 #, elixir-autogen, elixir-format
 msgid "Account switcher for signing in to several accounts at once"
 msgstr "Selettore di account per accedere a più account contemporaneamente"
@@ -8918,7 +8922,7 @@ msgstr "Selettore di account per accedere a più account contemporaneamente"
 msgid "Applying…"
 msgstr "Applicazione…"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:662
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:677
 #, elixir-autogen, elixir-format
 msgid "Enable the multi-account switcher in the header"
 msgstr "Attiva il selettore multi-account nell'intestazione"
@@ -8936,12 +8940,12 @@ msgstr "Carica altri"
 msgid "Loading…"
 msgstr "Caricamento…"
 
-#: lib/phoenix_kit_web/users/session.ex:113
+#: lib/phoenix_kit_web/users/session.ex:115
 #, elixir-autogen, elixir-format
 msgid "Logged out. Now signed in as %{email}."
 msgstr "Disconnesso. Ora sei connesso come %{email}."
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:653
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:668
 #, elixir-autogen, elixir-format
 msgid "Multiple Sessions"
 msgstr "Più sessioni"
@@ -8977,12 +8981,12 @@ msgstr "Riordina l'unico %{noun} selezionato (le altre righe restano al loro pos
 msgid "Showing %{loaded} of %{total} %{noun}"
 msgstr "Visualizzazione di %{loaded} su %{total} %{noun}"
 
-#: lib/phoenix_kit_web/users/session.ex:268
+#: lib/phoenix_kit_web/users/session.ex:270
 #, elixir-autogen, elixir-format
 msgid "Switched to %{email}."
 msgstr "Passato a %{email}."
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:665
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:680
 #, elixir-autogen, elixir-format
 msgid "When on, any signed-in user can add other accounts (with their password) and switch between them from the user menu."
 msgstr "Se attivo, qualsiasi utente connesso può aggiungere altri account (con la relativa password) e passare da uno all'altro dal menu utente."
@@ -9062,7 +9066,7 @@ msgstr "Qui è possibile aggiungere solo i tipi di file consentiti."
 msgid "View background job status and history"
 msgstr "Visualizza stato e cronologia dei job in background"
 
-#: lib/phoenix_kit/integrations/providers.ex:312
+#: lib/phoenix_kit/integrations/providers.ex:313
 #, elixir-autogen, elixir-format
 msgid "AI models via OpenAI (GPT, embeddings, images, audio)"
 msgstr "Modelli di IA tramite OpenAI (GPT, embedding, immagini, audio)"
@@ -9147,12 +9151,12 @@ msgstr "Cambia"
 msgid "Choose"
 msgstr "Scegli"
 
-#: lib/phoenix_kit/integrations/providers.ex:674
+#: lib/phoenix_kit/integrations/providers.ex:675
 #, elixir-autogen, elixir-format
 msgid "Click **Create API Key**, give it a name"
 msgstr "Fai clic su **Crea chiave API** e dagli un nome"
 
-#: lib/phoenix_kit/integrations/providers.ex:371
+#: lib/phoenix_kit/integrations/providers.ex:372
 #, elixir-autogen, elixir-format
 msgid "Click **Create new secret key**, give it a name"
 msgstr "Fai clic su **Create new secret key** e dagli un nome"
@@ -9163,12 +9167,12 @@ msgstr "Fai clic su **Create new secret key** e dagli un nome"
 msgid "Close search"
 msgstr "Chiudi la ricerca"
 
-#: lib/phoenix_kit/integrations/providers.ex:664
+#: lib/phoenix_kit/integrations/providers.ex:665
 #, elixir-autogen, elixir-format
 msgid "Create an ElevenLabs account"
 msgstr "Crea un account ElevenLabs"
 
-#: lib/phoenix_kit/integrations/providers.ex:349
+#: lib/phoenix_kit/integrations/providers.ex:350
 #, elixir-autogen, elixir-format
 msgid "Create an OpenAI account"
 msgstr "Crea un account OpenAI"
@@ -9232,7 +9236,7 @@ msgstr "Modifica la descrizione"
 msgid "Edit header"
 msgstr "Modifica l'intestazione"
 
-#: lib/phoenix_kit/integrations/providers.ex:634
+#: lib/phoenix_kit/integrations/providers.ex:635
 #, elixir-autogen, elixir-format
 msgid "ElevenLabs"
 msgstr "ElevenLabs"
@@ -9302,37 +9306,37 @@ msgstr "Il nome della cartella non può essere vuoto"
 msgid "Forgot password"
 msgstr "Password dimenticata"
 
-#: lib/phoenix_kit/integrations/providers.ex:657
+#: lib/phoenix_kit/integrations/providers.ex:658
 #, elixir-autogen, elixir-format
 msgid "From elevenlabs.io → Settings → API Keys"
 msgstr "Da elevenlabs.io → Impostazioni → API Keys"
 
-#: lib/phoenix_kit/integrations/providers.ex:336
+#: lib/phoenix_kit/integrations/providers.ex:337
 #, elixir-autogen, elixir-format
 msgid "From platform.openai.com/api-keys"
 msgstr "Da platform.openai.com/api-keys"
 
-#: lib/phoenix_kit/integrations/providers.ex:370
+#: lib/phoenix_kit/integrations/providers.ex:371
 #, elixir-autogen, elixir-format
 msgid "Go to [API Keys](https://platform.openai.com/api-keys)"
 msgstr "Vai a [API Keys](https://platform.openai.com/api-keys)"
 
-#: lib/phoenix_kit/integrations/providers.ex:359
+#: lib/phoenix_kit/integrations/providers.ex:360
 #, elixir-autogen, elixir-format
 msgid "Go to [Billing](https://platform.openai.com/account/billing/overview) and add a payment method or credits"
 msgstr "Vai a [Billing](https://platform.openai.com/account/billing/overview) e aggiungi un metodo di pagamento o dei crediti"
 
-#: lib/phoenix_kit/integrations/providers.ex:672
+#: lib/phoenix_kit/integrations/providers.ex:673
 #, elixir-autogen, elixir-format
 msgid "Go to [Settings → API Keys](https://elevenlabs.io/app/settings/api-keys)"
 msgstr "Vai a [Settings → API Keys](https://elevenlabs.io/app/settings/api-keys)"
 
-#: lib/phoenix_kit/integrations/providers.ex:666
+#: lib/phoenix_kit/integrations/providers.ex:667
 #, elixir-autogen, elixir-format
 msgid "Go to [elevenlabs.io](https://elevenlabs.io) and sign up or log in"
 msgstr "Vai su [elevenlabs.io](https://elevenlabs.io) e registrati o accedi"
 
-#: lib/phoenix_kit/integrations/providers.ex:351
+#: lib/phoenix_kit/integrations/providers.ex:352
 #, elixir-autogen, elixir-format
 msgid "Go to [platform.openai.com](https://platform.openai.com) and sign up or log in"
 msgstr "Vai su [platform.openai.com](https://platform.openai.com) e registrati o accedi"
@@ -9361,7 +9365,7 @@ msgstr "Titolo %{level}"
 msgid "Icon"
 msgstr "Icona"
 
-#: lib/phoenix_kit/integrations/providers.ex:375
+#: lib/phoenix_kit/integrations/providers.ex:376
 #, elixir-autogen, elixir-format
 msgid "If your account belongs to multiple organizations, keys are scoped to the org selected when the key was created."
 msgstr "Se il tuo account appartiene a più organizzazioni, le chiavi sono limitate all'organizzazione selezionata al momento della creazione."
@@ -9461,12 +9465,12 @@ msgstr "Prima i più vecchi"
 msgid "Open the media health dashboard to check file redundancy and re-sync files across storage locations."
 msgstr "Apri la dashboard dell'integrità dei media per verificare la ridondanza dei file e risincronizzarli tra le posizioni di archiviazione."
 
-#: lib/phoenix_kit/integrations/providers.ex:311
+#: lib/phoenix_kit/integrations/providers.ex:312
 #, elixir-autogen, elixir-format
 msgid "OpenAI"
 msgstr "OpenAI"
 
-#: lib/phoenix_kit/integrations/providers.ex:362
+#: lib/phoenix_kit/integrations/providers.ex:363
 #, elixir-autogen, elixir-format
 msgid "OpenAI requires a positive balance before the API will return completions, even on cheaper models"
 msgstr "OpenAI richiede un saldo positivo prima che l'API restituisca completion, anche con modelli più economici"
@@ -9556,12 +9560,12 @@ msgstr "Ordina"
 msgid "Stacks"
 msgstr "Pile"
 
-#: lib/phoenix_kit/integrations/providers.ex:635
+#: lib/phoenix_kit/integrations/providers.ex:636
 #, elixir-autogen, elixir-format
 msgid "Text-to-speech and voice generation via ElevenLabs"
 msgstr "Sintesi vocale e generazione di voci tramite ElevenLabs"
 
-#: lib/phoenix_kit/integrations/providers.ex:678
+#: lib/phoenix_kit/integrations/providers.ex:679
 #, elixir-autogen, elixir-format
 msgid "The free tier includes a monthly character quota; paid plans raise the quota and unlock commercial use and additional voices."
 msgstr "Il piano gratuito include una quota mensile di caratteri; i piani a pagamento aumentano la quota e sbloccano l'uso commerciale e voci aggiuntive."
@@ -10443,27 +10447,27 @@ msgstr "Oppure aggiungi con"
 msgid "Too many attempts. Please try again shortly."
 msgstr "Troppi tentativi. Riprova a breve."
 
-#: lib/phoenix_kit/integrations/providers.ex:569
+#: lib/phoenix_kit/integrations/providers.ex:570
 #, elixir-autogen, elixir-format
 msgid "AI model access via xAI (Grok models)"
 msgstr "Accesso ai modelli di IA tramite xAI (modelli Grok)"
 
-#: lib/phoenix_kit/integrations/providers.ex:827
+#: lib/phoenix_kit/integrations/providers.ex:828
 #, elixir-autogen, elixir-format
 msgid "AWS Simple Email Service (SMTP credentials via SES API)"
 msgstr "AWS Simple Email Service (credenziali SMTP tramite API SES)"
 
-#: lib/phoenix_kit/integrations/providers.ex:826
+#: lib/phoenix_kit/integrations/providers.ex:827
 #, elixir-autogen, elixir-format
 msgid "Amazon SES"
 msgstr "Amazon SES"
 
-#: lib/phoenix_kit/integrations/providers.ex:1050
+#: lib/phoenix_kit/integrations/providers.ex:1122
 #, elixir-autogen, elixir-format
 msgid "Brevo API"
 msgstr "API Brevo"
 
-#: lib/phoenix_kit/integrations/providers.ex:605
+#: lib/phoenix_kit/integrations/providers.ex:606
 #, elixir-autogen, elixir-format
 msgid "Create an xAI account"
 msgstr "Crea un account xAI"
@@ -10473,37 +10477,37 @@ msgstr "Crea un account xAI"
 msgid "Email users when their account is signed in from a new device"
 msgstr "Invia un'email agli utenti quando il loro account accede da un nuovo dispositivo"
 
-#: lib/phoenix_kit/integrations/providers.ex:961
+#: lib/phoenix_kit/integrations/providers.ex:1033
 #, elixir-autogen, elixir-format
 msgid "For Brevo: the SMTP key starting with xsmtpsib- (SMTP & API → SMTP tab) — not the API key (xkeysib-)."
 msgstr "Per Brevo: la chiave SMTP che inizia con xsmtpsib- (SMTP & API → scheda SMTP), non la chiave API (xkeysib-)."
 
-#: lib/phoenix_kit/integrations/providers.ex:949
+#: lib/phoenix_kit/integrations/providers.ex:1021
 #, elixir-autogen, elixir-format
 msgid "For Brevo: your account's SMTP login, shown as <subaccount>@smtp-brevo.com under SMTP & API → SMTP."
 msgstr "Per Brevo: il nome utente SMTP del tuo account, mostrato come <subaccount>@smtp-brevo.com in SMTP & API → SMTP."
 
-#: lib/phoenix_kit/integrations/providers.ex:1070
+#: lib/phoenix_kit/integrations/providers.ex:1142
 #, elixir-autogen, elixir-format
 msgid "From Brevo → SMTP & API → API Keys. Starts with xkeysib- — not the SMTP key (xsmtpsib-)."
 msgstr "Da Brevo → SMTP & API → API Keys. Inizia con xkeysib-, non la chiave SMTP (xsmtpsib-)."
 
-#: lib/phoenix_kit/integrations/providers.ex:590
+#: lib/phoenix_kit/integrations/providers.ex:591
 #, elixir-autogen, elixir-format
 msgid "From console.x.ai/team/default/api-keys"
 msgstr "Da console.x.ai/team/default/api-keys"
 
-#: lib/phoenix_kit/integrations/providers.ex:621
+#: lib/phoenix_kit/integrations/providers.ex:622
 #, elixir-autogen, elixir-format
 msgid "Go to [API Keys](https://console.x.ai/team/default/api-keys)"
 msgstr "Vai a [API Keys](https://console.x.ai/team/default/api-keys)"
 
-#: lib/phoenix_kit/integrations/providers.ex:607
+#: lib/phoenix_kit/integrations/providers.ex:608
 #, elixir-autogen, elixir-format
 msgid "Go to [accounts.x.ai](https://accounts.x.ai) and sign up or log in"
 msgstr "Vai su [accounts.x.ai](https://accounts.x.ai) e registrati o accedi"
 
-#: lib/phoenix_kit/integrations/providers.ex:613
+#: lib/phoenix_kit/integrations/providers.ex:614
 #, elixir-autogen, elixir-format
 msgid "Go to [console.x.ai](https://console.x.ai) → Billing and add credits"
 msgstr "Vai a [console.x.ai](https://console.x.ai) → Billing e aggiungi crediti"
@@ -10513,43 +10517,44 @@ msgstr "Vai a [console.x.ai](https://console.x.ai) → Billing e aggiungi credit
 msgid "Login Notifications"
 msgstr "Notifiche di accesso"
 
-#: lib/phoenix_kit/integrations/providers.ex:927
+#: lib/phoenix_kit/integrations/providers.ex:999
 #, elixir-autogen, elixir-format
 msgid "Port"
 msgstr "Porta"
 
-#: lib/phoenix_kit/integrations/providers.ex:720
-#: lib/phoenix_kit/integrations/providers.ex:860
+#: lib/phoenix_kit/integrations/providers.ex:721
+#: lib/phoenix_kit/integrations/providers.ex:861
+#: lib/phoenix_kit/integrations/providers.ex:945
 #, elixir-autogen, elixir-format
 msgid "Region"
 msgstr "Regione"
 
-#: lib/phoenix_kit/integrations/providers.ex:904
+#: lib/phoenix_kit/integrations/providers.ex:976
 #, elixir-autogen, elixir-format
 msgid "SMTP"
 msgstr "SMTP"
 
-#: lib/phoenix_kit/integrations/providers.ex:918
+#: lib/phoenix_kit/integrations/providers.ex:990
 #, elixir-autogen, elixir-format
 msgid "SMTP Host"
 msgstr "Host SMTP"
 
-#: lib/phoenix_kit/integrations/providers.ex:1051
+#: lib/phoenix_kit/integrations/providers.ex:1123
 #, elixir-autogen, elixir-format
 msgid "Send email via the Brevo transactional email API"
 msgstr "Invia email tramite l'API per email transazionali di Brevo"
 
-#: lib/phoenix_kit/integrations/providers.ex:906
+#: lib/phoenix_kit/integrations/providers.ex:978
 #, elixir-autogen, elixir-format
 msgid "Universal SMTP relay — works with any vendor (Brevo, Mailgun, SendGrid, a self-hosted mail server, etc). Add one named connection per relay/account."
 msgstr "Relay SMTP universale — funziona con qualsiasi fornitore (Brevo, Mailgun, SendGrid, un server di posta autogestito, ecc.). Aggiungi una connessione con nome per ogni relay o account."
 
-#: lib/phoenix_kit/integrations/providers.ex:568
+#: lib/phoenix_kit/integrations/providers.ex:569
 #, elixir-autogen, elixir-format
 msgid "xAI"
 msgstr "xAI"
 
-#: lib/phoenix_kit/integrations/providers.ex:615
+#: lib/phoenix_kit/integrations/providers.ex:616
 #, elixir-autogen, elixir-format
 msgid "xAI requires a funded account before the API will return completions"
 msgstr "xAI richiede un account con credito prima che l'API restituisca completion"
@@ -10723,12 +10728,12 @@ msgstr "Nessun file corrisponde alla ricerca."
 msgid "Try a different term or clear the search"
 msgstr "Prova un altro termine oppure cancella la ricerca"
 
-#: lib/modules/storage/web/bucket_form.ex:294
+#: lib/modules/storage/web/bucket_form.ex:296
 #, elixir-autogen, elixir-format
 msgid "Add Storage Bucket"
 msgstr "Aggiungi bucket di archiviazione"
 
-#: lib/modules/storage/web/bucket_form.ex:295
+#: lib/modules/storage/web/bucket_form.ex:297
 #, elixir-autogen, elixir-format
 msgid "Edit Storage Bucket"
 msgstr "Modifica il bucket di archiviazione"
@@ -10817,12 +10822,12 @@ msgstr "%{n} min fa"
 msgid "%{provider} settings"
 msgstr "Impostazioni di %{provider}"
 
-#: lib/phoenix_kit/integrations/validators.ex:643
+#: lib/phoenix_kit/integrations/validators.ex:824
 #, elixir-autogen, elixir-format
 msgid "%{text} · resets %{date}"
 msgstr "%{text} · si azzera il %{date}"
 
-#: lib/phoenix_kit/integrations/validators.ex:632
+#: lib/phoenix_kit/integrations/validators.ex:813
 #, elixir-autogen, elixir-format
 msgid "%{type} · %{credits} credits left"
 msgstr "%{type} · %{credits} crediti rimasti"
@@ -10878,12 +10883,12 @@ msgstr "Tutta la posta di sistema in uscita — autenticazione, notifiche — pa
 msgid "Allow \"Keep me logged in\" (persistent sessions)"
 msgstr "Consenti «Ricordami» (sessioni persistenti)"
 
-#: lib/phoenix_kit/integrations/providers.ex:1001
+#: lib/phoenix_kit/integrations/providers.ex:1073
 #, elixir-autogen, elixir-format
 msgid "Always"
 msgstr "Sempre"
 
-#: lib/phoenix_kit_web/users/session.ex:331
+#: lib/phoenix_kit_web/users/session.ex:333
 #, elixir-autogen, elixir-format
 msgid "An owner account cannot be used."
 msgstr "Non è possibile usare un account proprietario."
@@ -10893,12 +10898,12 @@ msgstr "Non è possibile usare un account proprietario."
 msgid "Applies site-wide wherever the rich-text editor is rendered (posts, comments). Users can still switch modes inside the editor."
 msgstr "Si applica in tutto il sito dove viene mostrato l'editor di testo formattato (post, commenti). Gli utenti possono comunque cambiare modalità nell'editor."
 
-#: lib/phoenix_kit/integrations/providers.ex:982
+#: lib/phoenix_kit/integrations/providers.ex:1054
 #, elixir-autogen, elixir-format
 msgid "Auto (from port)"
 msgstr "Automatico (in base alla porta)"
 
-#: lib/phoenix_kit/integrations/providers.ex:978
+#: lib/phoenix_kit/integrations/providers.ex:1050
 #, elixir-autogen, elixir-format
 msgid "Auto follows the port: 465 means implicit TLS, anything else STARTTLS (required when a login is set). Choose explicitly for a relay that ignores that convention."
 msgstr "«Automatico» segue la porta: 465 significa TLS implicito, qualsiasi altra STARTTLS (obbligatorio se è impostato un nome utente). Scegli manualmente per un relay che ignora questa convenzione."
@@ -10913,22 +10918,22 @@ msgstr "Raggruppa i tipi ad alto volume in riepiloghi periodici — imposta una 
 msgid "Best,\nThe Team"
 msgstr "Cordiali saluti,\nil team"
 
-#: lib/phoenix_kit/integrations/providers.ex:1098
+#: lib/phoenix_kit/integrations/providers.ex:1170
 #, elixir-autogen, elixir-format
 msgid "Bot Token"
 msgstr "Token del bot"
 
-#: lib/phoenix_kit/integrations/providers.ex:1118
+#: lib/phoenix_kit/integrations/providers.ex:1190
 #, elixir-autogen, elixir-format
 msgid "BotFather replies with an HTTP API token like `123456789:ABCdef...` — copy it"
 msgstr "BotFather risponde con un token API HTTP tipo `123456789:ABCdef...` — copialo"
 
-#: lib/phoenix_kit/integrations/validators.ex:601
+#: lib/phoenix_kit/integrations/validators.ex:782
 #, elixir-autogen, elixir-format
 msgid "Brevo error %{status}"
 msgstr "Errore Brevo %{status}"
 
-#: lib/phoenix_kit/integrations/providers.ex:1022
+#: lib/phoenix_kit/integrations/providers.ex:1094
 #, elixir-autogen, elixir-format
 msgid "CA certificate (PEM)"
 msgstr "Certificato CA (PEM)"
@@ -10938,7 +10943,7 @@ msgstr "Certificato CA (PEM)"
 msgid "Cannot delete send profile"
 msgstr "Impossibile eliminare il profilo di invio"
 
-#: lib/phoenix_kit/integrations/providers.ex:1007
+#: lib/phoenix_kit/integrations/providers.ex:1079
 #, elixir-autogen, elixir-format
 msgid "Certificate verification"
 msgstr "Verifica del certificato"
@@ -10983,7 +10988,7 @@ msgstr "Conferma la tua email"
 msgid "Connect your own API keys and services. Only you can see these."
 msgstr "Collega le tue chiavi API e i tuoi servizi. Solo tu puoi vederli."
 
-#: lib/phoenix_kit/integrations/validators.ex:693
+#: lib/phoenix_kit/integrations/validators.ex:874
 #, elixir-autogen, elixir-format
 msgid "Connected as @%{username}"
 msgstr "Collegato come @%{username}"
@@ -10999,7 +11004,7 @@ msgstr "La connessione funziona"
 msgid "Content Editor"
 msgstr "Editor dei contenuti"
 
-#: lib/phoenix_kit/integrations/providers.ex:1116
+#: lib/phoenix_kit/integrations/providers.ex:1188
 #, elixir-autogen, elixir-format
 msgid "Copy the bot token"
 msgstr "Copia il token del bot"
@@ -11017,12 +11022,12 @@ msgstr "Impossibile aggiungere l'integrazione"
 msgid "Could not reach AWS SES"
 msgstr "Impossibile raggiungere AWS SES"
 
-#: lib/phoenix_kit/integrations/validators.ex:605
+#: lib/phoenix_kit/integrations/validators.ex:786
 #, elixir-autogen, elixir-format
 msgid "Could not reach Brevo"
 msgstr "Impossibile raggiungere Brevo"
 
-#: lib/phoenix_kit/integrations/validators.ex:705
+#: lib/phoenix_kit/integrations/validators.ex:886
 #, elixir-autogen, elixir-format
 msgid "Could not reach Telegram"
 msgstr "Impossibile raggiungere Telegram"
@@ -11083,7 +11088,7 @@ msgstr "Impossibile aggiornare le impostazioni di aggregazione."
 msgid "Could not update default send integration"
 msgstr "Impossibile aggiornare l'integrazione di invio predefinita"
 
-#: lib/phoenix_kit/integrations/providers.ex:1109
+#: lib/phoenix_kit/integrations/providers.ex:1181
 #, elixir-autogen, elixir-format
 msgid "Create a bot with BotFather"
 msgstr "Crea un bot con BotFather"
@@ -11159,7 +11164,7 @@ msgstr "I profili disattivati non vengono mai usati per l'invio, nemmeno come pr
 msgid "Dismiss"
 msgstr "Ignora"
 
-#: lib/phoenix_kit/integrations/providers.ex:1017
+#: lib/phoenix_kit/integrations/providers.ex:1089
 #, elixir-autogen, elixir-format
 msgid "Do not verify"
 msgstr "Non verificare"
@@ -11191,7 +11196,7 @@ msgstr "Modifica profilo di invio: %{name}"
 msgid "Email Sending"
 msgstr "Invio delle email"
 
-#: lib/phoenix_kit_web/users/confirmation_instructions.ex:109
+#: lib/phoenix_kit_web/users/confirmation_instructions.ex:111
 #, elixir-autogen, elixir-format
 msgid "Email confirmed. Welcome!"
 msgstr "Email confermata. Benvenuto!"
@@ -11201,7 +11206,7 @@ msgstr "Email confermata. Benvenuto!"
 msgid "Email-capable integrations"
 msgstr "Integrazioni con supporto email"
 
-#: lib/phoenix_kit/integrations/providers.ex:973
+#: lib/phoenix_kit/integrations/providers.ex:1045
 #, elixir-autogen, elixir-format
 msgid "Encryption"
 msgstr "Crittografia"
@@ -11221,7 +11226,7 @@ msgstr "Ogni 12 ore"
 msgid "Everyone who starts the bot"
 msgstr "Tutti coloro che avviano il bot"
 
-#: lib/phoenix_kit/integrations/providers.ex:1027
+#: lib/phoenix_kit/integrations/providers.ex:1099
 #, elixir-autogen, elixir-format
 msgid "For a private or self-signed relay certificate. Replaces the system CA store for this connection only."
 msgstr "Per un certificato di relay privato o autofirmato. Sostituisce l'archivio CA di sistema solo per questa connessione."
@@ -11232,7 +11237,7 @@ msgstr "Per un certificato di relay privato o autofirmato. Sostituisce l'archivi
 msgid "From"
 msgstr "Mittente"
 
-#: lib/phoenix_kit/integrations/providers.ex:1102
+#: lib/phoenix_kit/integrations/providers.ex:1174
 #, elixir-autogen, elixir-format
 msgid "From @BotFather → /newbot (or /token for an existing bot)"
 msgstr "Da @BotFather → /newbot (o /token per un bot esistente)"
@@ -11259,7 +11264,7 @@ msgstr "Accesso completo"
 msgid "Hourly"
 msgstr "Ogni ora"
 
-#: lib/phoenix_kit/integrations/providers.ex:1000
+#: lib/phoenix_kit/integrations/providers.ex:1072
 #, elixir-autogen, elixir-format
 msgid "If offered (default)"
 msgstr "Se offerto (predefinito)"
@@ -11269,7 +11274,7 @@ msgstr "Se offerto (predefinito)"
 msgid "Immediate"
 msgstr "Immediato"
 
-#: lib/phoenix_kit/integrations/providers.ex:983
+#: lib/phoenix_kit/integrations/providers.ex:1055
 #, elixir-autogen, elixir-format
 msgid "Implicit TLS / SMTPS"
 msgstr "TLS implicito / SMTPS"
@@ -11287,6 +11292,7 @@ msgid "Incomplete SMTP settings"
 msgstr "Impostazioni SMTP incomplete"
 
 #: lib/phoenix_kit/integrations/validators.ex:57
+#: lib/phoenix_kit/integrations/validators.ex:582
 #, elixir-autogen, elixir-format
 msgid "Incomplete credentials"
 msgstr "Credenziali incomplete"
@@ -11323,7 +11329,7 @@ msgstr "Impostazioni SMTP non valide"
 msgid "Invalid SMTP settings: %{reason}"
 msgstr "Impostazioni SMTP non valide: %{reason}"
 
-#: lib/phoenix_kit/integrations/validators.ex:698
+#: lib/phoenix_kit/integrations/validators.ex:879
 #, elixir-autogen, elixir-format
 msgid "Invalid bot token"
 msgstr "Token del bot non valido"
@@ -11343,7 +11349,7 @@ msgstr "Timeout non valido: %{value}"
 msgid "Leave a field blank to fall back to the application config or built-in default."
 msgstr "Lascia un campo vuoto per usare la configurazione dell'applicazione o il valore predefinito integrato."
 
-#: lib/phoenix_kit/integrations/providers.ex:1038
+#: lib/phoenix_kit/integrations/providers.ex:1110
 #, elixir-autogen, elixir-format
 msgid "Leave blank for the gen_smtp default."
 msgstr "Lascia vuoto per il valore predefinito di gen_smtp."
@@ -11384,7 +11390,7 @@ msgstr "Segna tutto come letto"
 msgid "Mark read"
 msgstr "Segna come letto"
 
-#: lib/phoenix_kit_web/users/session.ex:340
+#: lib/phoenix_kit_web/users/session.ex:342
 #, elixir-autogen, elixir-format
 msgid "Maximum number of accounts reached — remove one first."
 msgstr "Numero massimo di account raggiunto — rimuovine prima uno."
@@ -11434,7 +11440,7 @@ msgstr "Nuovo profilo di invio"
 msgid "No adapter configured for the static mailer. Set one in your application config, or connect an email-capable integration below and pick it as the default transactional integration."
 msgstr "Nessun adapter configurato per il mailer statico. Impostane uno nella configurazione dell'applicazione oppure collega qui sotto un'integrazione con supporto email e scegliela come integrazione transazionale predefinita."
 
-#: lib/phoenix_kit/integrations/validators.ex:682
+#: lib/phoenix_kit/integrations/validators.ex:863
 #, elixir-autogen, elixir-format
 msgid "No bot token configured"
 msgstr "Nessun token del bot configurato"
@@ -11474,7 +11480,7 @@ msgstr "Nessun certificato CA di sistema trovato, quindi il certificato del rela
 msgid "No unread notifications"
 msgstr "Nessuna notifica non letta"
 
-#: lib/phoenix_kit/integrations/providers.ex:986
+#: lib/phoenix_kit/integrations/providers.ex:1058
 #, elixir-autogen, elixir-format
 msgid "None — plaintext"
 msgstr "Nessuna — non cifrato"
@@ -11504,7 +11510,7 @@ msgstr "Le notifiche che ricevi appariranno qui."
 msgid "Numeric ID of a verified Brevo sender. Leave empty to send from the From address above."
 msgstr "ID numerico di un mittente Brevo verificato. Lascia vuoto per inviare dall'indirizzo indicato sopra."
 
-#: lib/phoenix_kit_web/users/session.ex:334
+#: lib/phoenix_kit_web/users/session.ex:336
 #, elixir-autogen, elixir-format
 msgid "Only an owner can sign in as another administrator."
 msgstr "Solo un proprietario può accedere come un altro amministratore."
@@ -11514,12 +11520,12 @@ msgstr "Solo un proprietario può accedere come un altro amministratore."
 msgid "Only me"
 msgstr "Solo io"
 
-#: lib/phoenix_kit/integrations/providers.ex:1111
+#: lib/phoenix_kit/integrations/providers.ex:1183
 #, elixir-autogen, elixir-format
 msgid "Open [@BotFather](https://t.me/BotFather) in Telegram"
 msgstr "Apri [@BotFather](https://t.me/BotFather) in Telegram"
 
-#: lib/phoenix_kit/integrations/providers.ex:1121
+#: lib/phoenix_kit/integrations/providers.ex:1193
 #, elixir-autogen, elixir-format
 msgid "Paste the token into the form above and press **Test Connection**"
 msgstr "Incolla il token nel modulo qui sopra e premi **Verifica la connessione**"
@@ -11539,7 +11545,7 @@ msgstr "Identità del mittente, limiti di frequenza e opzioni specifiche del pro
 msgid "Persistent sessions last 60 days. Magic-link and social logins have no checkbox to tick, so they follow the default above. Turning the first option off hides the checkbox everywhere and keeps every login to the browser session."
 msgstr "Le sessioni persistenti durano 60 giorni. Gli accessi con Magic Link e tramite social non hanno una casella da selezionare, quindi seguono il valore predefinito qui sopra. Disattivando la prima opzione la casella scompare in ogni punto e ogni accesso resta limitato alla sessione del browser."
 
-#: lib/phoenix_kit/integrations/validators.ex:616
+#: lib/phoenix_kit/integrations/validators.ex:797
 #, elixir-autogen, elixir-format
 msgid "Plan: %{entries}"
 msgstr "Piano: %{entries}"
@@ -11636,12 +11642,12 @@ msgstr "SMTP non ha impostazioni del provider per profilo — relay, porta e TLS
 msgid "SMTP server rejected the connection"
 msgstr "Il server SMTP ha rifiutato la connessione"
 
-#: lib/phoenix_kit/integrations/providers.ex:985
+#: lib/phoenix_kit/integrations/providers.ex:1057
 #, elixir-autogen, elixir-format
 msgid "STARTTLS — if offered"
 msgstr "STARTTLS — se offerto"
 
-#: lib/phoenix_kit/integrations/providers.ex:984
+#: lib/phoenix_kit/integrations/providers.ex:1056
 #, elixir-autogen, elixir-format
 msgid "STARTTLS — required"
 msgstr "STARTTLS — obbligatorio"
@@ -11661,7 +11667,7 @@ msgstr "Salva l'identità del mittente"
 msgid "Select an integration..."
 msgstr "Seleziona un'integrazione…"
 
-#: lib/phoenix_kit/integrations/providers.ex:1112
+#: lib/phoenix_kit/integrations/providers.ex:1184
 #, elixir-autogen, elixir-format
 msgid "Send **/newbot** and follow the prompts to name your bot"
 msgstr "Invia **/newbot** e segui le istruzioni per dare un nome al tuo bot"
@@ -11675,7 +11681,7 @@ msgstr "Invia **/newbot** e segui le istruzioni per dare un nome al tuo bot"
 msgid "Send Profiles"
 msgstr "Profili di invio"
 
-#: lib/phoenix_kit/integrations/providers.ex:1087
+#: lib/phoenix_kit/integrations/providers.ex:1159
 #, elixir-autogen, elixir-format
 msgid "Send messages and notifications via your own Telegram bot"
 msgstr "Invia messaggi e notifiche tramite il tuo bot Telegram"
@@ -11765,13 +11771,13 @@ msgstr "Handshake TLS non riuscito"
 msgid "Tags"
 msgstr "Tag"
 
-#: lib/phoenix_kit/integrations/providers.ex:1086
+#: lib/phoenix_kit/integrations/providers.ex:1158
 #: lib/phoenix_kit/notifications/channels/telegram.ex:36
 #, elixir-autogen, elixir-format
 msgid "Telegram"
 msgstr "Telegram"
 
-#: lib/phoenix_kit/integrations/validators.ex:701
+#: lib/phoenix_kit/integrations/validators.ex:882
 #, elixir-autogen, elixir-format
 msgid "Telegram error %{status}"
 msgstr "Errore Telegram %{status}"
@@ -11791,17 +11797,17 @@ msgstr "Email di test da %{site}"
 msgid "Test email sent to %{recipient}"
 msgstr "Email di test inviata a %{recipient}"
 
-#: lib/phoenix_kit_web/users/session.ex:343
+#: lib/phoenix_kit_web/users/session.ex:345
 #, elixir-autogen, elixir-format
 msgid "That account is already in your session — switch to it instead."
 msgstr "Quell'account è già nella tua sessione — passa direttamente a esso."
 
-#: lib/phoenix_kit_web/users/session.ex:337
+#: lib/phoenix_kit_web/users/session.ex:339
 #, elixir-autogen, elixir-format
 msgid "That account is deactivated."
 msgstr "Quell'account è disattivato."
 
-#: lib/phoenix_kit_web/users/session.ex:336
+#: lib/phoenix_kit_web/users/session.ex:338
 #, elixir-autogen, elixir-format
 msgid "That is already your account."
 msgstr "Quello è già il tuo account."
@@ -11842,7 +11848,7 @@ msgstr "Questo profilo di invio verrà eliminato definitivamente."
 msgid "This sender address cannot be logged"
 msgstr "Questo indirizzo del mittente non può essere registrato"
 
-#: lib/phoenix_kit/integrations/providers.ex:1034
+#: lib/phoenix_kit/integrations/providers.ex:1106
 #, elixir-autogen, elixir-format
 msgid "Timeout (seconds)"
 msgstr "Timeout (secondi)"
@@ -11852,7 +11858,7 @@ msgstr "Timeout (secondi)"
 msgid "Transport"
 msgstr "Trasporto"
 
-#: lib/phoenix_kit/integrations/providers.ex:1012
+#: lib/phoenix_kit/integrations/providers.ex:1084
 #, elixir-autogen, elixir-format
 msgid "Turning verification off means the login travels to whoever answers, including an impostor. Use a CA certificate below instead whenever you can."
 msgstr "Disattivare la verifica significa che le credenziali vanno a chiunque risponda, incluso un impostore. Quando possibile, usa invece un certificato CA qui sotto."
@@ -11882,12 +11888,12 @@ msgstr "Aggiorna il profilo di invio"
 msgid "Used when no default transactional integration is selected below."
 msgstr "Usato quando qui sotto non è selezionata alcuna integrazione transazionale predefinita."
 
-#: lib/phoenix_kit_web/users/session.ex:309
+#: lib/phoenix_kit_web/users/session.ex:311
 #, elixir-autogen, elixir-format
 msgid "User not found."
 msgstr "Utente non trovato."
 
-#: lib/phoenix_kit/integrations/providers.ex:1016
+#: lib/phoenix_kit/integrations/providers.ex:1088
 #, elixir-autogen, elixir-format
 msgid "Verify (default)"
 msgstr "Verifica (predefinito)"
@@ -11907,7 +11913,7 @@ msgstr "Integrazioni del sito"
 msgid "Where a freshly registered account lands. Empty = after-login path."
 msgstr "Dove arriva un account appena registrato. Vuoto = percorso dopo l'accesso."
 
-#: lib/phoenix_kit/integrations/providers.ex:996
+#: lib/phoenix_kit/integrations/providers.ex:1068
 #, elixir-autogen, elixir-format
 msgid "Whether to send the login at all. “If offered” follows the relay; “Never” is for relays that authenticate by IP."
 msgstr "Se inviare o no le credenziali. «Se offerto» segue il relay; «Mai» è per i relay che autenticano tramite IP."
@@ -11922,12 +11928,12 @@ msgstr "A chi scrive questo bot?"
 msgid "Yesterday"
 msgstr "Ieri"
 
-#: lib/phoenix_kit_web/users/session.ex:320
+#: lib/phoenix_kit_web/users/session.ex:322
 #, elixir-autogen, elixir-format
 msgid "You are now signed in as %{email}."
 msgstr "Ora sei connesso come %{email}."
 
-#: lib/phoenix_kit_web/users/session.ex:329
+#: lib/phoenix_kit_web/users/session.ex:331
 #, elixir-autogen, elixir-format
 msgid "You do not have permission to sign in as another user."
 msgstr "Non hai il permesso di accedere come un altro utente."
@@ -12043,7 +12049,7 @@ msgstr "Verifica in corso…"
 msgid "Continue"
 msgstr "Continua"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:143
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:169
 #, elixir-autogen, elixir-format
 msgid "Copied!"
 msgstr "Copiato!"
@@ -12053,7 +12059,7 @@ msgstr "Copiato!"
 msgid "Couldn't reach hex.pm, so the package list is unavailable right now."
 msgstr "Impossibile raggiungere hex.pm, quindi l'elenco dei pacchetti non è disponibile al momento."
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:119
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:145
 #, elixir-autogen, elixir-format
 msgid "Crawler Instructions"
 msgstr "Istruzioni per i crawler"
@@ -12107,7 +12113,7 @@ msgstr "Benvenuto! Il tuo codice di invito è stato accettato."
 msgid "has the robots.txt line that points crawlers here."
 msgstr "contiene la riga robots.txt che indirizza qui i crawler."
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:173
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:199
 #, elixir-autogen, elixir-format
 msgid "priv/static/robots.txt points crawlers at your sitemap."
 msgstr "priv/static/robots.txt indirizza i crawler alla tua sitemap."
@@ -12211,17 +12217,17 @@ msgstr "Non hai il permesso di eliminare questo utente"
 msgid "You don't have permission to manage this user's credentials"
 msgstr "Non hai il permesso di gestire le credenziali di questo utente"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:190
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:216
 #, elixir-autogen, elixir-format
 msgid "AI Discovery"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:698
+#: lib/phoenix_kit/integrations/providers.ex:699
 #, elixir-autogen, elixir-format
 msgid "AWS Bedrock LLMs via a Bedrock API key (OpenAI-compatible endpoint: gpt-oss models; the rest via native Converse)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:715
+#: lib/phoenix_kit/integrations/providers.ex:716
 #, elixir-autogen, elixir-format
 msgid "AWS console → Amazon Bedrock → API keys (long-term key)"
 msgstr ""
@@ -12236,22 +12242,22 @@ msgstr ""
 msgid "Account %{id}"
 msgstr "Account"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:303
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:329
 #, elixir-autogen, elixir-format
 msgid "Advisory-grade: anything can send any User-Agent, so a scraper that lies passes through. Real enforcement belongs at your CDN or reverse proxy — this catches the honest-but-ignorant. Bots identified only by robots.txt tokens (Google-Extended, Applebot-Extended) crawl under their main user agent and are never matched here, so blocking AI training cannot 403 Googlebot."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:98
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:124
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Allowed"
 msgstr "Tutti"
 
-#: lib/phoenix_kit/integrations/providers.ex:696
+#: lib/phoenix_kit/integrations/providers.ex:697
 #, elixir-autogen, elixir-format
 msgid "Amazon Bedrock"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:282
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:308
 #, elixir-autogen, elixir-format
 msgid "Answer 403 to requests whose User-Agent matches a blocked group, for bots that ignore robots.txt."
 msgstr ""
@@ -12261,7 +12267,7 @@ msgstr ""
 msgid "Auth mail carries single-use tokens, and /dev/mailbox has no authentication — anyone who can reach this server can read them. Only for closed environments."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:711
+#: lib/phoenix_kit/integrations/providers.ex:712
 #, elixir-autogen, elixir-format
 msgid "Bedrock API key"
 msgstr ""
@@ -12271,7 +12277,7 @@ msgstr ""
 msgid "Bedrock error %{status}"
 msgstr "Errore Brevo %{status}"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:280
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:306
 #, elixir-autogen, elixir-format
 msgid "Block at the application"
 msgstr ""
@@ -12281,7 +12287,7 @@ msgstr ""
 msgid "Blocked groups"
 msgstr "Bloccato"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:77
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:103
 #, elixir-autogen, elixir-format
 msgid "Bot Access"
 msgstr ""
@@ -12296,12 +12302,12 @@ msgstr ""
 msgid "Control how search engines and AI bots crawl and index this site"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:739
+#: lib/phoenix_kit/integrations/providers.ex:740
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Copy the key (shown once, `ABSK…`) and paste it into the form above"
 msgstr "Copia la chiave (mostrata una sola volta) e incollala nel modulo qui sopra"
 
-#: lib/phoenix_kit/integrations/providers.ex:815
+#: lib/phoenix_kit/integrations/providers.ex:816
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Copy the token and paste it into the form above"
 msgstr "Copia la chiave e incollala nel modulo qui sopra"
@@ -12342,22 +12348,22 @@ msgstr ""
 msgid "Crawlers module is disabled. Enable it from the Modules page to configure settings."
 msgstr "Il modulo SEO è disattivato. Attivalo dalla pagina Moduli per configurare le impostazioni."
 
-#: lib/phoenix_kit/integrations/providers.ex:731
+#: lib/phoenix_kit/integrations/providers.ex:732
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Create a Bedrock API key"
 msgstr "Crea una chiave API"
 
-#: lib/phoenix_kit/integrations/providers.ex:807
+#: lib/phoenix_kit/integrations/providers.ex:808
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Create a token"
 msgstr "Crea ruolo"
 
-#: lib/phoenix_kit/integrations/providers.ex:871
+#: lib/phoenix_kit/integrations/providers.ex:872
 #, elixir-autogen, elixir-format
 msgid "Create an IAM user with SES access"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:876
+#: lib/phoenix_kit/integrations/providers.ex:877
 #, elixir-autogen, elixir-format
 msgid "Create an access key for that user (Security credentials → Create access key) and paste the ID and secret above"
 msgstr ""
@@ -12372,41 +12378,42 @@ msgstr ""
 msgid "Deliver development mail to /dev/mailbox"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:747
+#: lib/phoenix_kit/integrations/providers.ex:748
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enable model access"
 msgstr "Attiva il modulo per accedere alle impostazioni"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:278
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:304
 #, elixir-autogen, elixir-format
 msgid "Enforcement"
 msgstr ""
 
 #: lib/phoenix_kit_web/live/settings/crawlers.ex:90
-#: lib/phoenix_kit_web/live/settings/crawlers.ex:109
-#: lib/phoenix_kit_web/live/settings/crawlers.ex:120
-#: lib/phoenix_kit_web/live/settings/crawlers.ex:136
-#: lib/phoenix_kit_web/live/settings/crawlers.ex:149
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:102
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:121
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:132
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:148
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:161
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to update crawler settings"
 msgstr "Impossibile aggiornare l'impostazione"
 
-#: lib/phoenix_kit/integrations/providers.ex:780
+#: lib/phoenix_kit/integrations/providers.ex:781
 #, elixir-autogen, elixir-format, fuzzy
 msgid "GitHub"
 msgstr "Accesso con GitHub"
 
-#: lib/phoenix_kit/integrations/providers.ex:782
+#: lib/phoenix_kit/integrations/providers.ex:783
 #, elixir-autogen, elixir-format
 msgid "GitHub API token — org statistics, repositories (read-only is enough)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:809
+#: lib/phoenix_kit/integrations/providers.ex:810
 #, elixir-autogen, elixir-format
 msgid "Go to [Fine-grained tokens](https://github.com/settings/personal-access-tokens) and click **Generate new token**"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:81
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:107
 #, elixir-autogen, elixir-format
 msgid "Grouped by why they visit. Blocking a group writes it into the generated robots.txt below; everything defaults to allowed."
 msgstr ""
@@ -12416,22 +12423,22 @@ msgstr ""
 msgid "Hide titles of records the reader can't open"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:749
+#: lib/phoenix_kit/integrations/providers.ex:750
 #, elixir-autogen, elixir-format
 msgid "In [Bedrock → Model access](https://console.aws.amazon.com/bedrock/home#/modelaccess) enable the models you plan to call — a key with no enabled models validates but cannot complete"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:763
+#: lib/phoenix_kit/integrations/providers.ex:764
 #, elixir-autogen, elixir-format
 msgid "In the AI module, create an endpoint pointing at this connection with a `gpt-oss` model and a base URL in the SAME region as this key"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:873
+#: lib/phoenix_kit/integrations/providers.ex:874
 #, elixir-autogen, elixir-format
 msgid "In the [IAM console](https://console.aws.amazon.com/iam/home#/users) create a user for programmatic access and attach an SES policy (least privilege: `ses:SendEmail`/`ses:SendRawEmail`; docs: [SES setup](https://docs.aws.amazon.com/ses/latest/dg/setting-up.html))"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:884
+#: lib/phoenix_kit/integrations/providers.ex:885
 #, elixir-autogen, elixir-format
 msgid "In the [SES console](https://console.aws.amazon.com/ses/home#/identities) verify your domain or sender address — SES refuses to send from unverified identities"
 msgstr ""
@@ -12476,7 +12483,7 @@ msgstr ""
 msgid "Model catalog in %{region}: %{count} (grants are configured separately)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:887
+#: lib/phoenix_kit/integrations/providers.ex:888
 #, elixir-autogen, elixir-format
 msgid "New accounts start in the SES sandbox (verified recipients only) — [request production access](https://docs.aws.amazon.com/ses/latest/dg/request-production-access.html) before real sending"
 msgstr ""
@@ -12491,7 +12498,7 @@ msgstr ""
 msgid "No longer available"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:165
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:191
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No priv/static/robots.txt found. Without one, crawlers assume everything is allowed — and any groups you blocked above are not being told."
 msgstr "Nessun file priv/static/robots.txt trovato. Senza di esso i crawler presumono che tutto sia consentito — di solito va bene, ma non sapranno dove si trova la tua sitemap."
@@ -12506,47 +12513,47 @@ msgstr ""
 msgid "Note (optional)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:733
+#: lib/phoenix_kit/integrations/providers.ex:734
 #, elixir-autogen, elixir-format
 msgid "Open the [Bedrock console → API keys](https://console.aws.amazon.com/bedrock/home#/api-keys) and generate a **long-term** key (docs: [Bedrock API keys](https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys.html))"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:212
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:238
 #, elixir-autogen, elixir-format
 msgid "Optional markdown: a summary paragraph, key links, docs pointers…"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:736
+#: lib/phoenix_kit/integrations/providers.ex:737
 #, elixir-autogen, elixir-format
 msgid "Or attach one to an existing IAM user: [IAM console](https://console.aws.amazon.com/iam/home#/users) → user → Security credentials → Bedrock API keys"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:235
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:261
 #, elixir-autogen, elixir-format
 msgid "Paste the verification content Google Search Console or Bing Webmaster Tools gives you — the meta tags are added to every layout head. Pasting the whole <meta> tag also works; the content value is extracted."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:796
+#: lib/phoenix_kit/integrations/providers.ex:797
 #, elixir-autogen, elixir-format
 msgid "Personal access token"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:123
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:149
 #, elixir-autogen, elixir-format
 msgid "PhoenixKit does not serve this file — it is yours, served from priv/static before any route is consulted. This is the complete file your toggles above describe: paste it into priv/static/robots.txt."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:752
+#: lib/phoenix_kit/integrations/providers.ex:753
 #, elixir-autogen, elixir-format
 msgid "Pick the region where access was granted; the AI endpoint's base URL must use the same region"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:217
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:243
 #, elixir-autogen, elixir-format
 msgid "Preview of the served file:"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:812
+#: lib/phoenix_kit/integrations/providers.ex:813
 #, elixir-autogen, elixir-format
 msgid "Repository access: **Public repositories (read-only)** — no extra permissions needed for public-org statistics"
 msgstr ""
@@ -12556,7 +12563,7 @@ msgstr ""
 msgid "Request access"
 msgstr "Richiesto"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:233
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:259
 #, elixir-autogen, elixir-format
 msgid "Search engine verification"
 msgstr ""
@@ -12576,12 +12583,12 @@ msgstr "In attesa"
 msgid "Sign in to request access."
 msgstr "Accedi come utente"
 
-#: lib/phoenix_kit/integrations/providers.ex:760
+#: lib/phoenix_kit/integrations/providers.ex:761
 #, elixir-autogen, elixir-format
 msgid "The OpenAI-compatible endpoint (`…/openai/v1`) currently serves only the `openai.gpt-oss-*` models — Anthropic and the other Bedrock models answer on the native Converse API with the same key"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:742
+#: lib/phoenix_kit/integrations/providers.ex:743
 #, elixir-autogen, elixir-format
 msgid "The key's IAM identity must allow the `bedrock:CallWithBearerToken` action — without it every Bearer call answers 403 even when invoke permissions are in place."
 msgstr ""
@@ -12591,17 +12598,17 @@ msgstr ""
 msgid "The mailbox is off: outgoing mail is written to the server log instead."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:179
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:205
 #, elixir-autogen, elixir-format, fuzzy
 msgid "The noindex toggle and robots.txt are separate mechanisms: noindex is a per-page meta tag that tells crawlers not to index what they fetched, while robots.txt tells them what not to fetch at all. A staging site usually wants both."
 msgstr "L'interruttore noindex qui sopra e robots.txt sono meccanismi distinti: noindex è un meta tag per pagina che dice ai crawler di non indicizzare ciò che hanno scaricato, mentre robots.txt dice loro cosa non scaricare affatto. Un sito di staging di solito ha bisogno di entrambi."
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:194
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:220
 #, elixir-autogen, elixir-format
 msgid "The other half of bot policy: a markdown summary telling AI assistants what this site is about, served at"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:892
+#: lib/phoenix_kit/integrations/providers.ex:893
 #, elixir-autogen, elixir-format
 msgid "This connection stores the credential. The full sending pipeline — configuration set, SNS topic, SQS event queue, delivery tracking — is configured in Admin → Settings → Emails, which can select this connection as its credential source."
 msgstr ""
@@ -12618,22 +12625,22 @@ msgstr ""
 msgid "Unread · %{day}"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:758
+#: lib/phoenix_kit/integrations/providers.ex:759
 #, elixir-autogen, elixir-format
 msgid "Use it from the AI module"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:231
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:257
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Verification"
 msgstr "Notifiche"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.ex:133
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:145
 #, elixir-autogen, elixir-format
 msgid "Verification tags saved."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:882
+#: lib/phoenix_kit/integrations/providers.ex:883
 #, elixir-autogen, elixir-format
 msgid "Verify a sender in SES"
 msgstr ""
@@ -12648,7 +12655,7 @@ msgstr ""
 msgid "Where development mail goes while the resolved transport is the local adapter."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:79
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "Who may crawl this site"
 msgstr ""
@@ -12668,12 +12675,12 @@ msgstr ""
 msgid "You don't have access — click to request it"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:800
+#: lib/phoenix_kit/integrations/providers.ex:801
 #, elixir-autogen, elixir-format
 msgid "github.com/settings/personal-access-tokens — fine-grained, read-only"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.ex:146
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:158
 #, elixir-autogen, elixir-format
 msgid "llms.txt content saved."
 msgstr ""
@@ -12683,7 +12690,7 @@ msgstr ""
 msgid "management API: %{services}"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:169
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:195
 #, elixir-autogen, elixir-format, fuzzy
 msgid "priv/static/robots.txt exists but has no Sitemap: line. Paste the file above so crawlers are told where to look."
 msgstr "priv/static/robots.txt esiste ma non contiene una riga Sitemap:. Aggiungi la riga qui sopra così i crawler sapranno dove cercare."
@@ -12693,7 +12700,7 @@ msgstr "priv/static/robots.txt esiste ma non contiene una riga Sitemap:. Aggiung
 msgid "private item"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:200
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:226
 #, elixir-autogen, elixir-format
 msgid "while this module is enabled. The heading comes from your project title; everything below it is yours."
 msgstr ""
@@ -12747,7 +12754,7 @@ msgstr "Seleziona audio"
 msgid "Select Avatar"
 msgstr "Seleziona avatar"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:701
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:716
 #, elixir-autogen, elixir-format
 msgid "Select Background Image"
 msgstr "Seleziona immagine di sfondo"
@@ -12764,7 +12771,7 @@ msgstr "Seleziona immagini"
 
 #: lib/phoenix_kit_web/components/media_browser.html.heex:2469
 #: lib/phoenix_kit_web/live/settings.html.heex:636
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:702
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:717
 #, elixir-autogen, elixir-format
 msgid "Select Logo"
 msgstr "Seleziona logo"
@@ -12863,3 +12870,422 @@ msgstr "La crittografia delle credenziali di integrazione richiede attenzione"
 #, elixir-autogen, elixir-format
 msgid "The current encryption status could not be described by this admin page — it may be newer than what this page recognizes. Check PhoenixKit.Integrations.Encryption.status/0 directly."
 msgstr "Lo stato di crittografia attuale non ha potuto essere descritto da questa pagina di amministrazione — potrebbe essere più recente di quanto questa pagina riconosca. Controllare direttamente PhoenixKit.Integrations.Encryption.status/0."
+
+#: lib/phoenix_kit_web/live/settings/authorization.ex:247
+#, elixir-autogen, elixir-format
+msgid "A secret is already configured — leave blank to keep the current value"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:365
+#: lib/phoenix_kit_web/users/session.ex:245
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Account added."
+msgstr "Account"
+
+#: lib/phoenix_kit_web/users/session.ex:27
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Account created successfully!"
+msgstr "Bucket attivato con successo"
+
+#: lib/phoenix_kit_web/users/session.ex:356
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Account removed."
+msgstr "Account"
+
+#: lib/phoenix_kit_web/users/oauth.ex:272
+#, elixir-autogen, elixir-format
+msgid "Account switching is currently disabled."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:316
+#, elixir-autogen, elixir-format
+msgid "An account already exists for that email address. Sign in with your password first, then connect this provider from your account settings."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:328
+#, elixir-autogen, elixir-format
+msgid "Authentication failed. Please try again or use a different sign-in method."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:355
+#: lib/phoenix_kit_web/users/oauth.ex:438
+#: lib/phoenix_kit_web/users/oauth.ex:444
+#, elixir-autogen, elixir-format
+msgid "Authentication failed. Please try again."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:299
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Authentication failed: %{errors}"
+msgstr "Autenticazione"
+
+#: lib/phoenix_kit_web/users/oauth.ex:441
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Authentication failed: %{message}"
+msgstr "Autenticazione"
+
+#: lib/phoenix_kit_web/users/session.ex:360
+#, elixir-autogen, elixir-format
+msgid "Cannot remove your primary account."
+msgstr ""
+
+#: lib/phoenix_kit_web/controllers/context_controller.ex:101
+#, elixir-autogen, elixir-format
+msgid "Context switching is not enabled"
+msgstr ""
+
+#: lib/phoenix_kit/integrations/validators.ex:627
+#: lib/phoenix_kit/integrations/validators.ex:634
+#: lib/phoenix_kit/integrations/validators.ex:732
+#: lib/phoenix_kit/integrations/validators.ex:740
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Could not reach the storage endpoint"
+msgstr "Impossibile raggiungere il servizio"
+
+#: lib/phoenix_kit_web/users/session.ex:365
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Could not remove account."
+msgstr "Impossibile raggiungere Brevo"
+
+#: lib/phoenix_kit_web/users/session.ex:274
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Could not switch account."
+msgstr "Impossibile scollegare le chat"
+
+#: lib/phoenix_kit/integrations/validators.ex:721
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Credentials are valid, but not authorized to list buckets"
+msgstr "Le credenziali sono valide ma non autorizzate per GetSendQuota — l'invio non è stato verificato"
+
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:85
+#, elixir-autogen, elixir-format
+msgid "Exempt"
+msgstr ""
+
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:86
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Follows noindex"
+msgstr "Seguiti"
+
+#: lib/phoenix_kit_web/users/magic_link.ex:120
+#, elixir-autogen, elixir-format
+msgid "If that email address exists, a magic link has been sent."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/confirmation_instructions.ex:89
+#, elixir-autogen, elixir-format
+msgid "If your email is in our system and it has not been confirmed yet, you will receive an email with instructions shortly."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/forgot_password.ex:49
+#, elixir-autogen, elixir-format
+msgid "If your email is in our system, you will receive instructions to reset your password shortly."
+msgstr ""
+
+#: lib/phoenix_kit_web/controllers/context_controller.ex:82
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Invalid context"
+msgstr "Token del bot non valido"
+
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:110
+#, elixir-autogen, elixir-format
+msgid "Invalid email format"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/session.ex:92
+#, elixir-autogen, elixir-format
+msgid "Invalid email/username or password"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/session.ex:259
+#, elixir-autogen, elixir-format
+msgid "Invalid email/username or password."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_verify.ex:40
+#, elixir-autogen, elixir-format
+msgid "Invalid magic link. Please request a new one."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration_verify.ex:32
+#, elixir-autogen, elixir-format
+msgid "Invalid registration link. Please request a new one."
+msgstr ""
+
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:77
+#, elixir-autogen, elixir-format
+msgid "Keep publishing the sitemap's real URLs even while noindex is on, so the feed can be verified without exposing the site to indexing. The noindex meta tag above is unaffected either way."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/session.ex:104
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Logged out of all accounts."
+msgstr "Esci da tutti gli account"
+
+#: lib/phoenix_kit_web/users/session.ex:122
+#: lib/phoenix_kit_web/users/session.ex:235
+#, elixir-autogen, elixir-format
+msgid "Logged out successfully."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_verify.ex:63
+#, elixir-autogen, elixir-format
+msgid "Magic link is invalid or has expired. Please request a new one."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration.ex:41
+#, elixir-autogen, elixir-format
+msgid "Magic link registration is currently disabled."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link.ex:110
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Magic link sent! Check your email."
+msgstr "Magic Link inviato!"
+
+#: lib/phoenix_kit_web/users/magic_link.ex:39
+#: lib/phoenix_kit_web/users/magic_link_verify.ex:33
+#, elixir-autogen, elixir-format
+msgid "Magic link sign-in is currently disabled."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:370
+#: lib/phoenix_kit_web/users/session.ex:249
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Maximum number of accounts reached."
+msgstr "Numero massimo di account raggiunto — rimuovine prima uno."
+
+#: lib/phoenix_kit_web/users/session.ex:137
+#, elixir-autogen, elixir-format
+msgid "Multi-account switching is not available."
+msgstr ""
+
+#: lib/phoenix_kit/integrations/providers.ex:950
+#, elixir-autogen, elixir-format
+msgid "Not every S3-compatible provider needs one — leave blank if the endpoint doesn't require it."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:119
+#, elixir-autogen, elixir-format
+msgid "OAuth authentication is currently disabled. Please contact your administrator to enable it."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:94
+#, elixir-autogen, elixir-format
+msgid "OAuth provider '%{provider}' is currently disabled."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:106
+#, elixir-autogen, elixir-format
+msgid "OAuth provider '%{provider}' is not configured. Please contact your administrator."
+msgstr ""
+
+#: lib/phoenix_kit/integrations/providers.ex:913
+#, elixir-autogen, elixir-format
+msgid "Object Storage (S3-compatible)"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/reset_password.ex:41
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Password reset successfully."
+msgstr "Password modificata con successo."
+
+#: lib/phoenix_kit_web/users/session.ex:34
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Password updated successfully!"
+msgstr "Password modificata con successo."
+
+#: lib/phoenix_kit_web/users/magic_link_registration.ex:35
+#: lib/phoenix_kit_web/users/registration.ex:128
+#, elixir-autogen, elixir-format
+msgid "Registration is currently disabled."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration.ex:92
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Registration link is invalid or has expired."
+msgstr "Il link per la modifica dell'email non è valido o è scaduto."
+
+#: lib/phoenix_kit_web/users/magic_link_registration.ex:188
+#: lib/phoenix_kit_web/users/magic_link_registration_verify.ex:24
+#, elixir-autogen, elixir-format
+msgid "Registration link is invalid or has expired. Please request a new one."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:92
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:103
+#, elixir-autogen, elixir-format
+msgid "Registration link sent! Check your email."
+msgstr ""
+
+#: lib/phoenix_kit/integrations/providers.ex:962
+#, elixir-autogen, elixir-format
+msgid "Required for Cloudflare R2, Backblaze B2, Tigris, and self-hosted S3-compatible storage. Leave blank for AWS S3."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/reset_password.ex:59
+#, elixir-autogen, elixir-format
+msgid "Reset password link is invalid or it has expired."
+msgstr ""
+
+#: lib/phoenix_kit/integrations/providers.ex:915
+#, elixir-autogen, elixir-format
+msgid "S3-compatible object storage — AWS S3, Cloudflare R2, Backblaze B2, Tigris, or a self-hosted endpoint"
+msgstr ""
+
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:75
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Sitemap Exemption"
+msgstr "Impostazioni della sitemap"
+
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:144
+#, elixir-autogen, elixir-format
+msgid "Something went wrong"
+msgstr ""
+
+#: lib/phoenix_kit/integrations/validators.ex:735
+#, elixir-autogen, elixir-format
+msgid "Storage error: %{code}"
+msgstr ""
+
+#: lib/phoenix_kit/integrations/validators.ex:729
+#, elixir-autogen, elixir-format
+msgid "Storage service is busy — try again in a moment"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_verify.ex:56
+#, elixir-autogen, elixir-format
+msgid "Successfully logged in with magic link!"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:277
+#, elixir-autogen, elixir-format
+msgid "Successfully signed in with %{provider}!"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:375
+#: lib/phoenix_kit_web/users/session.ex:254
+#, elixir-autogen, elixir-format, fuzzy
+msgid "That account is already in your session."
+msgstr "Quell'account è già nella tua sessione — passa direttamente a esso."
+
+#: lib/phoenix_kit_web/users/oauth.ex:380
+#, elixir-autogen, elixir-format, fuzzy
+msgid "That account is inactive."
+msgstr "Quell'account è disattivato."
+
+#: lib/phoenix_kit_web/users/magic_link_registration.ex:185
+#, elixir-autogen, elixir-format
+msgid "That email is already registered. Please log in instead."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:118
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Too many attempts"
+msgstr "Troppi file"
+
+#: lib/phoenix_kit_web/users/session.ex:84
+#, elixir-autogen, elixir-format
+msgid "Too many login attempts. Please try again later."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:84
+#: lib/phoenix_kit_web/users/oauth.ex:210
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Unknown OAuth provider: %{provider}"
+msgstr "Provider sconosciuto"
+
+#: lib/phoenix_kit_web/users/confirmation.ex:68
+#, elixir-autogen, elixir-format
+msgid "User confirmation link is invalid or it has expired."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/confirmation.ex:50
+#, elixir-autogen, elixir-format, fuzzy
+msgid "User confirmed successfully."
+msgstr "Utente attivato con successo"
+
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:77
+#, elixir-autogen, elixir-format
+msgid "User registration is currently disabled."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:51
+#: lib/phoenix_kit_web/users/registration.ex:110
+#, elixir-autogen, elixir-format
+msgid "User registration is currently disabled. Please contact an administrator."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/session.ex:40
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Welcome back!"
+msgstr "Bentornato"
+
+#: lib/phoenix_kit_web/users/session.ex:66
+#, elixir-autogen, elixir-format
+msgid "Your account is currently inactive. Please contact the team if you believe this is an error."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:1873
+#, elixir-autogen, elixir-format
+msgid "%{label} module is not enabled"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:2366
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Enter your referral code to continue."
+msgstr "Inserisci il tuo codice di invito"
+
+#: lib/phoenix_kit_web/users/auth.ex:2362
+#, elixir-autogen, elixir-format
+msgid "Please confirm your email before accessing the application."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:111
+#, elixir-autogen, elixir-format
+msgid "This account is not active. Contact an administrator."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:749
+#: lib/phoenix_kit_web/users/auth.ex:1892
+#: lib/phoenix_kit_web/users/auth.ex:2511
+#, elixir-autogen, elixir-format, fuzzy
+msgid "You do not have permission to access this section."
+msgstr "Non hai il permesso di accedere come un altro utente."
+
+#: lib/phoenix_kit_web/users/auth.ex:724
+#: lib/phoenix_kit_web/users/auth.ex:878
+#: lib/phoenix_kit_web/users/auth.ex:2460
+#: lib/phoenix_kit_web/users/auth.ex:2496
+#, elixir-autogen, elixir-format, fuzzy
+msgid "You do not have the required permission to access this page."
+msgstr "Non hai il permesso di accedere come un altro utente."
+
+#: lib/phoenix_kit_web/users/auth.ex:1417
+#, elixir-autogen, elixir-format
+msgid "You must be an admin to access this page."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:679
+#: lib/phoenix_kit_web/users/auth.ex:2423
+#, elixir-autogen, elixir-format
+msgid "You must be an owner to access this page."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:2539
+#, elixir-autogen, elixir-format
+msgid "You must have the %{role_name} role to access this page."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:903
+#: lib/phoenix_kit_web/users/auth.ex:2292
+#: lib/phoenix_kit_web/users/auth.ex:2329
+#: lib/phoenix_kit_web/users/auth.ex:2467
+#, elixir-autogen, elixir-format
+msgid "You must log in to access this page."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:1428
+#, elixir-autogen, elixir-format
+msgid "You no longer have permission to access this section."
+msgstr ""

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -12878,19 +12878,19 @@ msgstr ""
 
 #: lib/phoenix_kit_web/users/oauth.ex:365
 #: lib/phoenix_kit_web/users/session.ex:245
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Account added."
-msgstr "Account"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:27
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Account created successfully!"
-msgstr "Bucket attivato con successo"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:356
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Account removed."
-msgstr "Account"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/oauth.ex:272
 #, elixir-autogen, elixir-format
@@ -12915,14 +12915,14 @@ msgid "Authentication failed. Please try again."
 msgstr ""
 
 #: lib/phoenix_kit_web/users/oauth.ex:299
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Authentication failed: %{errors}"
-msgstr "Autenticazione"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/oauth.ex:441
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Authentication failed: %{message}"
-msgstr "Autenticazione"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:360
 #, elixir-autogen, elixir-format
@@ -12938,24 +12938,24 @@ msgstr ""
 #: lib/phoenix_kit/integrations/validators.ex:634
 #: lib/phoenix_kit/integrations/validators.ex:732
 #: lib/phoenix_kit/integrations/validators.ex:740
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Could not reach the storage endpoint"
-msgstr "Impossibile raggiungere il servizio"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:365
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Could not remove account."
-msgstr "Impossibile raggiungere Brevo"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:274
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Could not switch account."
-msgstr "Impossibile scollegare le chat"
+msgstr ""
 
 #: lib/phoenix_kit/integrations/validators.ex:721
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Credentials are valid, but not authorized to list buckets"
-msgstr "Le credenziali sono valide ma non autorizzate per GetSendQuota — l'invio non è stato verificato"
+msgstr ""
 
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:85
 #, elixir-autogen, elixir-format
@@ -12963,9 +12963,9 @@ msgid "Exempt"
 msgstr ""
 
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:86
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Follows noindex"
-msgstr "Seguiti"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link.ex:120
 #, elixir-autogen, elixir-format
@@ -12983,9 +12983,9 @@ msgid "If your email is in our system, you will receive instructions to reset yo
 msgstr ""
 
 #: lib/phoenix_kit_web/controllers/context_controller.ex:82
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Invalid context"
-msgstr "Token del bot non valido"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link_registration_request.ex:110
 #, elixir-autogen, elixir-format
@@ -13018,9 +13018,9 @@ msgid "Keep publishing the sitemap's real URLs even while noindex is on, so the 
 msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:104
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Logged out of all accounts."
-msgstr "Esci da tutti gli account"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:122
 #: lib/phoenix_kit_web/users/session.ex:235
@@ -13039,9 +13039,9 @@ msgid "Magic link registration is currently disabled."
 msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link.ex:110
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Magic link sent! Check your email."
-msgstr "Magic Link inviato!"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link.ex:39
 #: lib/phoenix_kit_web/users/magic_link_verify.ex:33
@@ -13051,9 +13051,9 @@ msgstr ""
 
 #: lib/phoenix_kit_web/users/oauth.ex:370
 #: lib/phoenix_kit_web/users/session.ex:249
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Maximum number of accounts reached."
-msgstr "Numero massimo di account raggiunto — rimuovine prima uno."
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:137
 #, elixir-autogen, elixir-format
@@ -13086,14 +13086,14 @@ msgid "Object Storage (S3-compatible)"
 msgstr ""
 
 #: lib/phoenix_kit_web/users/reset_password.ex:41
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Password reset successfully."
-msgstr "Password modificata con successo."
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:34
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Password updated successfully!"
-msgstr "Password modificata con successo."
+msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link_registration.ex:35
 #: lib/phoenix_kit_web/users/registration.ex:128
@@ -13102,9 +13102,9 @@ msgid "Registration is currently disabled."
 msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link_registration.ex:92
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Registration link is invalid or has expired."
-msgstr "Il link per la modifica dell'email non è valido o è scaduto."
+msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link_registration.ex:188
 #: lib/phoenix_kit_web/users/magic_link_registration_verify.ex:24
@@ -13134,9 +13134,9 @@ msgid "S3-compatible object storage — AWS S3, Cloudflare R2, Backblaze B2, Tig
 msgstr ""
 
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:75
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Sitemap Exemption"
-msgstr "Impostazioni della sitemap"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link_registration_request.ex:144
 #, elixir-autogen, elixir-format
@@ -13165,14 +13165,14 @@ msgstr ""
 
 #: lib/phoenix_kit_web/users/oauth.ex:375
 #: lib/phoenix_kit_web/users/session.ex:254
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "That account is already in your session."
-msgstr "Quell'account è già nella tua sessione — passa direttamente a esso."
+msgstr ""
 
 #: lib/phoenix_kit_web/users/oauth.ex:380
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "That account is inactive."
-msgstr "Quell'account è disattivato."
+msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link_registration.ex:185
 #, elixir-autogen, elixir-format
@@ -13180,9 +13180,9 @@ msgid "That email is already registered. Please log in instead."
 msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link_registration_request.ex:118
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Too many attempts"
-msgstr "Troppi file"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:84
 #, elixir-autogen, elixir-format
@@ -13191,9 +13191,9 @@ msgstr ""
 
 #: lib/phoenix_kit_web/users/oauth.ex:84
 #: lib/phoenix_kit_web/users/oauth.ex:210
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Unknown OAuth provider: %{provider}"
-msgstr "Provider sconosciuto"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/confirmation.ex:68
 #, elixir-autogen, elixir-format
@@ -13201,9 +13201,9 @@ msgid "User confirmation link is invalid or it has expired."
 msgstr ""
 
 #: lib/phoenix_kit_web/users/confirmation.ex:50
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "User confirmed successfully."
-msgstr "Utente attivato con successo"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link_registration_request.ex:77
 #, elixir-autogen, elixir-format
@@ -13217,9 +13217,9 @@ msgid "User registration is currently disabled. Please contact an administrator.
 msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:40
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Welcome back!"
-msgstr "Bentornato"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:66
 #, elixir-autogen, elixir-format
@@ -13232,9 +13232,9 @@ msgid "%{label} module is not enabled"
 msgstr ""
 
 #: lib/phoenix_kit_web/users/auth.ex:2366
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Enter your referral code to continue."
-msgstr "Inserisci il tuo codice di invito"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/auth.ex:2362
 #, elixir-autogen, elixir-format
@@ -13249,17 +13249,17 @@ msgstr ""
 #: lib/phoenix_kit_web/users/auth.ex:749
 #: lib/phoenix_kit_web/users/auth.ex:1892
 #: lib/phoenix_kit_web/users/auth.ex:2511
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "You do not have permission to access this section."
-msgstr "Non hai il permesso di accedere come un altro utente."
+msgstr ""
 
 #: lib/phoenix_kit_web/users/auth.ex:724
 #: lib/phoenix_kit_web/users/auth.ex:878
 #: lib/phoenix_kit_web/users/auth.ex:2460
 #: lib/phoenix_kit_web/users/auth.ex:2496
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "You do not have the required permission to access this page."
-msgstr "Non hai il permesso di accedere come un altro utente."
+msgstr ""
 
 #: lib/phoenix_kit_web/users/auth.ex:1417
 #, elixir-autogen, elixir-format

--- a/priv/gettext/it/LC_MESSAGES/phoenix_kit.po
+++ b/priv/gettext/it/LC_MESSAGES/phoenix_kit.po
@@ -21,27 +21,27 @@ msgstr "Esiste già un invito in attesa per questa email"
 msgid "This user already belongs to an organization"
 msgstr "Questo utente appartiene già a un'organizzazione"
 
-#: lib/phoenix_kit/users/auth.ex:1064
+#: lib/phoenix_kit/users/auth.ex:1074
 #, elixir-autogen, elixir-format
 msgid "cannot change to person while organization has members"
 msgstr "non può essere cambiato in persona finché l'organizzazione ha membri"
 
-#: lib/phoenix_kit/users/auth.ex:1044
+#: lib/phoenix_kit/users/auth.ex:1054
 #, elixir-autogen, elixir-format
 msgid "cannot reference self"
 msgstr "non può fare riferimento a sé stesso"
 
-#: lib/phoenix_kit/users/auth.ex:1052
+#: lib/phoenix_kit/users/auth.ex:1062
 #, elixir-autogen, elixir-format
 msgid "only person accounts can join an organization"
 msgstr "solo gli account persona possono unirsi a un'organizzazione"
 
-#: lib/phoenix_kit/users/auth.ex:1039
+#: lib/phoenix_kit/users/auth.ex:1049
 #, elixir-autogen, elixir-format
 msgid "organization not found"
 msgstr "organizzazione non trovata"
 
-#: lib/phoenix_kit/users/auth.ex:1038
+#: lib/phoenix_kit/users/auth.ex:1048
 #, elixir-autogen, elixir-format
 msgid "target user is not an organization"
 msgstr "l'utente di destinazione non è un'organizzazione"

--- a/priv/gettext/phoenix_kit.pot
+++ b/priv/gettext/phoenix_kit.pot
@@ -21,27 +21,27 @@ msgstr ""
 msgid "This user already belongs to an organization"
 msgstr ""
 
-#: lib/phoenix_kit/users/auth.ex:1064
+#: lib/phoenix_kit/users/auth.ex:1074
 #, elixir-autogen, elixir-format
 msgid "cannot change to person while organization has members"
 msgstr ""
 
-#: lib/phoenix_kit/users/auth.ex:1044
+#: lib/phoenix_kit/users/auth.ex:1054
 #, elixir-autogen, elixir-format
 msgid "cannot reference self"
 msgstr ""
 
-#: lib/phoenix_kit/users/auth.ex:1052
+#: lib/phoenix_kit/users/auth.ex:1062
 #, elixir-autogen, elixir-format
 msgid "only person accounts can join an organization"
 msgstr ""
 
-#: lib/phoenix_kit/users/auth.ex:1039
+#: lib/phoenix_kit/users/auth.ex:1049
 #, elixir-autogen, elixir-format
 msgid "organization not found"
 msgstr ""
 
-#: lib/phoenix_kit/users/auth.ex:1038
+#: lib/phoenix_kit/users/auth.ex:1048
 #, elixir-autogen, elixir-format
 msgid "target user is not an organization"
 msgstr ""

--- a/priv/gettext/pl/LC_MESSAGES/default.po
+++ b/priv/gettext/pl/LC_MESSAGES/default.po
@@ -69,7 +69,7 @@ msgstr "Zarządzanie rolami"
 
 #: lib/phoenix_kit/dashboard/admin_tabs.ex:119
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:138
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:647
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:662
 #: lib/phoenix_kit_web/live/settings/users.html.heex:130
 #, elixir-autogen
 msgid "Sessions"
@@ -235,7 +235,7 @@ msgstr "Połączenia w czasie rzeczywistym"
 
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:320
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:64
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:144
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:140
 #, elixir-autogen
 msgid "Anonymous"
 msgstr "Anonimowi"
@@ -248,7 +248,7 @@ msgstr "Niezarejestrowani odwiedzający"
 
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:331
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:77
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:151
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:144
 #, elixir-autogen
 msgid "Authenticated"
 msgstr "Uwierzytelnieni"
@@ -345,7 +345,7 @@ msgstr "Standardowy poziom dostępu"
 msgid "Role System"
 msgstr "System ról"
 
-#: lib/phoenix_kit/integrations/providers.ex:991
+#: lib/phoenix_kit/integrations/providers.ex:1063
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:450
 #, elixir-autogen
 msgid "Authentication"
@@ -357,7 +357,7 @@ msgstr "Uwierzytelnianie"
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:445
 #: lib/phoenix_kit_web/live/modules.html.heex:65
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:114
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:273
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:267
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:145
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:297
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:682
@@ -463,8 +463,8 @@ msgstr "O uprawnieniach"
 msgid "Accept All"
 msgstr "Akceptuj wszystkie"
 
-#: lib/phoenix_kit/integrations/integrations.ex:1133
-#: lib/phoenix_kit/integrations/validators.ex:598
+#: lib/phoenix_kit/integrations/integrations.ex:1136
+#: lib/phoenix_kit/integrations/validators.ex:779
 #: lib/phoenix_kit_web/live/activity/index.ex:66
 #: lib/phoenix_kit_web/live/activity/show.ex:56
 #, elixir-autogen, elixir-format
@@ -502,7 +502,7 @@ msgid "Actions"
 msgstr "Akcje"
 
 #: lib/phoenix_kit_web/components/media_gallery.html.heex:86
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:585
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:600
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:266
 #: lib/phoenix_kit_web/live/settings/users.html.heex:693
 #: lib/phoenix_kit_web/users/user_form.html.heex:719
@@ -610,7 +610,7 @@ msgstr "Informacje podstawowe"
 msgid "Billing profiles and payment methods"
 msgstr "Profile rozliczeniowe i metody płatności"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:98
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:124
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:501
 #, elixir-autogen, elixir-format
 msgid "Blocked"
@@ -1550,7 +1550,7 @@ msgstr "Strona została wygenerowana pomyślnie"
 msgid "Page published successfully"
 msgstr "Strona została opublikowana pomyślnie"
 
-#: lib/phoenix_kit/integrations/providers.ex:956
+#: lib/phoenix_kit/integrations/providers.ex:1028
 #: lib/phoenix_kit_web/components/user_dashboard_nav.ex:277
 #: lib/phoenix_kit_web/users/login.html.heex:39
 #: lib/phoenix_kit_web/users/magic_link_registration.html.heex:42
@@ -1811,8 +1811,8 @@ msgstr "SWIFT/BIC"
 #: lib/phoenix_kit_web/components/core/markdown_editor.ex:440
 #: lib/phoenix_kit_web/components/media_browser.html.heex:1349
 #: lib/phoenix_kit_web/live/notifications/settings.ex:436
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:219
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:267
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:245
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:293
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr "Zapisz"
@@ -1855,7 +1855,7 @@ msgstr "Zapisano"
 #: lib/phoenix_kit_web/components/core/markdown_editor.ex:333
 #: lib/phoenix_kit_web/components/core/markdown_editor.ex:417
 #: lib/phoenix_kit_web/live/settings.html.heex:592
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:683
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:698
 #: lib/phoenix_kit_web/live/settings/users.html.heex:546
 #, elixir-autogen, elixir-format
 msgid "Saving..."
@@ -1942,7 +1942,7 @@ msgstr "Województwo/Region"
 #: lib/phoenix_kit_web/live/settings/users.html.heex:367
 #: lib/phoenix_kit_web/live/settings/users.html.heex:408
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:114
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:199
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:193
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:247
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:294
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:650
@@ -2048,7 +2048,7 @@ msgstr "Łącznie ról"
 #: lib/phoenix_kit_web/live/settings/users.html.heex:361
 #: lib/phoenix_kit_web/live/settings/users.html.heex:404
 #: lib/phoenix_kit_web/live/settings/users.html.heex:602
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:192
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:186
 #: lib/phoenix_kit_web/live/users/roles.html.heex:92
 #: lib/phoenix_kit_web/live/users/roles.html.heex:160
 #, elixir-autogen, elixir-format
@@ -2064,7 +2064,7 @@ msgstr "Niepotwierdzony"
 #: lib/phoenix_kit_web/components/core/time_display.ex:183
 #: lib/phoenix_kit_web/components/language_switcher.ex:832
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:108
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:255
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:249
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr "Nieznany"
@@ -2122,7 +2122,7 @@ msgstr "Nie znaleziono użytkownika"
 msgid "User-defined roles"
 msgstr "Role zdefiniowane przez użytkownika"
 
-#: lib/phoenix_kit/integrations/providers.ex:944
+#: lib/phoenix_kit/integrations/providers.ex:1016
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:255
 #: lib/phoenix_kit_web/users/magic_link_registration.html.heex:30
 #: lib/phoenix_kit_web/users/registration.html.heex:69
@@ -2440,22 +2440,22 @@ msgstr "(puste)"
 msgid "(registration disabled)"
 msgstr "(rejestracja wyłączona)"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:622
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:637
 #, elixir-autogen, elixir-format
 msgid "1. Enable the provider above and save settings"
 msgstr "1. Włącz dostawcę powyżej i zapisz ustawienia"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:623
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:638
 #, elixir-autogen, elixir-format
 msgid "2. Enter your OAuth credentials in the form that appears"
 msgstr "2. Wprowadź swoje dane OAuth w wyświetlonym formularzu"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:624
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:639
 #, elixir-autogen, elixir-format
 msgid "3. Save settings again to store credentials"
 msgstr "3. Zapisz ustawienia ponownie, aby zachować dane logowania"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:625
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:640
 #, elixir-autogen, elixir-format
 msgid "4. Click \"Test Credentials\" to verify configuration"
 msgstr "4. Kliknij „Testuj dane logowania”, aby sprawdzić konfigurację"
@@ -2466,7 +2466,8 @@ msgid "Access Credentials"
 msgstr "Dane dostępowe"
 
 #: lib/modules/storage/web/bucket_form.html.heex:227
-#: lib/phoenix_kit/integrations/providers.ex:842
+#: lib/phoenix_kit/integrations/providers.ex:843
+#: lib/phoenix_kit/integrations/providers.ex:927
 #, elixir-autogen, elixir-format
 msgid "Access Key ID"
 msgstr "Identyfikator klucza dostępu"
@@ -2516,9 +2517,9 @@ msgstr "Dodaj wymiar obrazu"
 msgid "Add Video Dimension"
 msgstr "Dodaj wymiar wideo"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:429
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:507
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:592
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:434
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:517
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:607
 #, elixir-autogen, elixir-format
 msgid "Add callback URL above to"
 msgstr "Dodaj powyżej adres URL wywołania zwrotnego, aby"
@@ -2550,12 +2551,12 @@ msgstr "Wszyscy nowi użytkownicy otrzymają uprawnienia administracyjne i dost�
 msgid "Anyone can register"
 msgstr "Każdy może się zarejestrować"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:541
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:551
 #, elixir-autogen, elixir-format
 msgid "App ID"
 msgstr "Identyfikator aplikacji"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:551
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:561
 #, elixir-autogen, elixir-format
 msgid "App Secret"
 msgstr "Sekret aplikacji"
@@ -2674,7 +2675,7 @@ msgstr "Zasobniki mogą być katalogami lokalnymi lub dostawcami chmury (AWS S3,
 msgid "CSS color or gradient for auth page background. Ignored if a background image is set."
 msgstr "Kolor lub gradient CSS tła strony uwierzytelniania. Ignorowany, gdy ustawiono obraz tła."
 
-#: lib/phoenix_kit_web/live/settings/authorization.ex:261
+#: lib/phoenix_kit_web/live/settings/authorization.ex:302
 #, elixir-autogen, elixir-format
 msgid "Callback URL"
 msgstr "Adres URL wywołania zwrotnego"
@@ -2684,25 +2685,25 @@ msgstr "Adres URL wywołania zwrotnego"
 msgid "Changes will be saved immediately"
 msgstr "Zmiany zostaną zapisane natychmiast"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:434
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:511
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:518
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:609
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:439
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:521
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:528
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:624
 #, elixir-autogen, elixir-format
 msgid "Click"
 msgstr "Kliknij"
 
-#: lib/phoenix_kit/integrations/providers.ex:215
+#: lib/phoenix_kit/integrations/providers.ex:216
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:378
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:458
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:463
 #, elixir-autogen, elixir-format
 msgid "Client ID"
 msgstr "Identyfikator klienta"
 
-#: lib/phoenix_kit/integrations/providers.ex:224
-#: lib/phoenix_kit/integrations/providers.ex:1169
+#: lib/phoenix_kit/integrations/providers.ex:225
+#: lib/phoenix_kit/integrations/providers.ex:1241
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:388
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:468
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:473
 #, elixir-autogen, elixir-format
 msgid "Client Secret"
 msgstr "Sekret klienta"
@@ -2733,34 +2734,34 @@ msgstr "Skonfiguruj preferencje i opcje systemu"
 msgid "Consider \"User\" for most installations to maintain security."
 msgstr "W większości instalacji rozważ „Użytkownik”, aby zachować bezpieczeństwo."
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:514
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:599
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:142
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:524
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:614
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:168
 #, elixir-autogen, elixir-format
 msgid "Copy"
 msgstr "Kopiuj"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:432
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:437
 #, elixir-autogen, elixir-format
 msgid "Copy Client ID and Secret to fields above"
 msgstr "Skopiuj identyfikator i sekret klienta do pól powyżej"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:568
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:583
 #, elixir-autogen, elixir-format
 msgid "Copy this URL to Facebook App Settings"
 msgstr "Skopiuj ten adres URL do ustawień aplikacji Facebook"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:485
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:495
 #, elixir-autogen, elixir-format
 msgid "Copy this URL to GitHub OAuth Apps"
 msgstr "Skopiuj ten adres URL do aplikacji OAuth GitHub"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:405
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:410
 #, elixir-autogen, elixir-format
 msgid "Copy this URL to Google Cloud Console"
 msgstr "Skopiuj ten adres URL do Google Cloud Console"
 
-#: lib/phoenix_kit_web/live/settings/authorization.ex:271
+#: lib/phoenix_kit_web/live/settings/authorization.ex:312
 #, elixir-autogen, elixir-format
 msgid "Copy to clipboard"
 msgstr "Kopiuj do schowka"
@@ -2785,12 +2786,12 @@ msgstr "Utwórz ścieżkę magazynu"
 msgid "Create Your First Bucket"
 msgstr "Utwórz swój pierwszy zasobnik"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:582
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:597
 #, elixir-autogen, elixir-format
 msgid "Create a new app or select existing one"
 msgstr "Utwórz nową aplikację lub wybierz istniejącą"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:418
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:423
 #, elixir-autogen, elixir-format
 msgid "Create project or select existing one"
 msgstr "Utwórz projekt lub wybierz istniejący"
@@ -2861,11 +2862,12 @@ msgid "Enable OAuth (Master Switch)"
 msgstr "Włącz OAuth (przełącznik główny)"
 
 #: lib/modules/storage/web/bucket_form.html.heex:194
+#: lib/phoenix_kit/integrations/providers.ex:957
 #, elixir-autogen, elixir-format
 msgid "Endpoint"
 msgstr "Punkt końcowy"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:503
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:513
 #, elixir-autogen, elixir-format
 msgid "Enter"
 msgstr "Wprowadź"
@@ -2900,7 +2902,7 @@ msgstr "FFmpeg nie jest zainstalowany"
 msgid "FFmpeg is required for video processing, transcoding, and thumbnail generation."
 msgstr "FFmpeg jest wymagany do przetwarzania wideo, transkodowania i generowania miniatur."
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:532
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:542
 #, elixir-autogen, elixir-format
 msgid "Facebook OAuth Credentials"
 msgstr "Dane OAuth Facebooka"
@@ -2943,7 +2945,7 @@ msgstr "Nadpisanie formatu"
 msgid "Format Override:"
 msgstr "Nadpisanie formatu:"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:449
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:454
 #, elixir-autogen, elixir-format
 msgid "GitHub OAuth Credentials"
 msgstr "Dane OAuth GitHuba"
@@ -2953,10 +2955,10 @@ msgstr "Dane OAuth GitHuba"
 msgid "GitHub Sign-In"
 msgstr "Logowanie przez GitHuba"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:420
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:499
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:588
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:596
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:425
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:509
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:603
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:611
 #, elixir-autogen, elixir-format
 msgid "Go to"
 msgstr "Przejdź do"
@@ -2986,7 +2988,7 @@ msgstr "Sposób wyświetlania dat"
 msgid "How times are displayed"
 msgstr "Sposób wyświetlania godzin"
 
-#: lib/phoenix_kit_web/live/settings/authorization.ex:296
+#: lib/phoenix_kit_web/live/settings/authorization.ex:337
 #, elixir-autogen, elixir-format
 msgid "If behind nginx/apache, ensure"
 msgstr "Jeśli za nginx/apache, upewnij się, że"
@@ -3173,7 +3175,7 @@ msgstr "Brak"
 msgid "Note"
 msgstr "Uwaga"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:627
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:642
 #, elixir-autogen, elixir-format
 msgid "Note: OAuth providers require ueberauth dependencies to be installed."
 msgstr "Uwaga: dostawcy OAuth wymagają zainstalowania zależności ueberauth."
@@ -3188,7 +3190,7 @@ msgstr "Liczba przechowywanych kopii"
 msgid "OAuth Providers"
 msgstr "Dostawcy OAuth"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:620
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:635
 #, elixir-autogen, elixir-format
 msgid "OAuth Setup Instructions"
 msgstr "Instrukcje konfiguracji OAuth"
@@ -3261,7 +3263,7 @@ msgstr "Zmniejsz nadmiarowość lub włącz więcej zasobników."
 msgid "Redundancy Copies"
 msgstr "Kopie nadmiarowe"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:642
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:657
 #, elixir-autogen, elixir-format
 msgid "Reload OAuth Configuration"
 msgstr "Wczytaj ponownie konfigurację OAuth"
@@ -3288,7 +3290,7 @@ msgstr "Przywróć wartości domyślne"
 msgid "Resolution"
 msgstr "Rozdzielczość"
 
-#: lib/phoenix_kit_web/live/settings/authorization.ex:294
+#: lib/phoenix_kit_web/live/settings/authorization.ex:335
 #, elixir-autogen, elixir-format
 msgid "Reverse Proxy Users:"
 msgstr "Użytkownicy odwrotnego proxy:"
@@ -3314,7 +3316,7 @@ msgstr "Rola przypisywana nowym rejestracjom"
 msgid "Save All Settings"
 msgstr "Zapisz wszystkie ustawienia"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:685
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:700
 #, elixir-autogen, elixir-format
 msgid "Save Authorization Settings"
 msgstr "Zapisz ustawienia autoryzacji"
@@ -3330,7 +3332,8 @@ msgid "Search engines are instructed to skip this environment. Remove this befor
 msgstr "Wyszukiwarki mają pomijać to środowisko. Usuń to przed uruchomieniem."
 
 #: lib/modules/storage/web/bucket_form.html.heex:241
-#: lib/phoenix_kit/integrations/providers.ex:851
+#: lib/phoenix_kit/integrations/providers.ex:852
+#: lib/phoenix_kit/integrations/providers.ex:936
 #, elixir-autogen, elixir-format
 msgid "Secret Access Key"
 msgstr "Tajny klucz dostępu"
@@ -3347,7 +3350,7 @@ msgstr "Uwaga dotycząca bezpieczeństwa: średnie ryzyko"
 
 #: lib/phoenix_kit_web/components/media_browser.html.heex:1180
 #: lib/phoenix_kit_web/components/media_browser.html.heex:1182
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:425
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:430
 #, elixir-autogen, elixir-format
 msgid "Select"
 msgstr "Wybierz"
@@ -3377,7 +3380,7 @@ msgid "Set"
 msgstr "Ustaw"
 
 #: lib/phoenix_kit_web/components/core/integrations_ui.ex:311
-#: lib/phoenix_kit_web/live/settings/authorization.ex:249
+#: lib/phoenix_kit_web/live/settings/authorization.ex:290
 #: lib/phoenix_kit_web/live/settings/integration_form.html.heex:378
 #, elixir-autogen, elixir-format
 msgid "Setup Instructions"
@@ -3414,7 +3417,7 @@ msgstr "Dostawca magazynu"
 msgid "Success!"
 msgstr "Sukces!"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:604
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:619
 #, elixir-autogen, elixir-format
 msgid "Switch app from"
 msgstr "Przełącz aplikację z"
@@ -3439,9 +3442,9 @@ msgstr "Domyślna strefa czasowa systemu"
 msgid "Target Width (px)"
 msgstr "Docelowa szerokość (px)"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:400
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:480
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:563
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:405
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:490
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:578
 #, elixir-autogen, elixir-format
 msgid "Test Credentials"
 msgstr "Testuj dane logowania"
@@ -3521,7 +3524,7 @@ msgstr "Konfiguracja użytkowników"
 msgid "User Editable"
 msgstr "Edytowalne przez użytkownika"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:35
+#: lib/phoenix_kit_web/live/settings/users.ex:42
 #: lib/phoenix_kit_web/live/settings/users.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "User Settings"
@@ -3563,9 +3566,9 @@ msgstr "Ustawienia wideo:"
 msgid "Videos use CRF 0-51 scale (lower = higher quality)"
 msgstr "Wideo używa skali CRF 0–51 (niżej = wyższa jakość)"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:409
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:489
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:572
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:414
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:499
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:587
 #, elixir-autogen, elixir-format
 msgid "Visit"
 msgstr "Odwiedź"
@@ -3610,22 +3613,22 @@ msgstr "Bez niego przetwarzanie plików wideo nie będzie działać."
 msgid "Would you like to create it now?"
 msgstr "Czy chcesz go teraz utworzyć?"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:542
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:552
 #, elixir-autogen, elixir-format
 msgid "Your Facebook App ID"
 msgstr "Twój identyfikator aplikacji Facebook"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:552
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:565
 #, elixir-autogen, elixir-format
 msgid "Your Facebook App Secret"
 msgstr "Twój sekret aplikacji Facebook"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:459
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:464
 #, elixir-autogen, elixir-format
 msgid "Your GitHub OAuth Client ID"
 msgstr "Twój identyfikator klienta OAuth GitHub"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:469
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:477
 #, elixir-autogen, elixir-format
 msgid "Your GitHub OAuth Client Secret"
 msgstr "Twój sekret klienta OAuth GitHub"
@@ -3635,19 +3638,19 @@ msgstr "Twój sekret klienta OAuth GitHub"
 msgid "Your Google OAuth Client ID"
 msgstr "Twój identyfikator klienta OAuth Google"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:389
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:392
 #, elixir-autogen, elixir-format
 msgid "Your Google OAuth Client Secret"
 msgstr "Twój sekret klienta OAuth Google"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:504
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:600
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:514
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:615
 #: lib/phoenix_kit_web/live/settings/integrations.ex:167
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr "i"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:515
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:525
 #, elixir-autogen, elixir-format
 msgid "and generate/copy"
 msgstr "i wygeneruj/skopiuj"
@@ -3668,12 +3671,12 @@ msgstr "np. thumbnail, medium, 720p"
 msgid "files"
 msgstr "pliki"
 
-#: lib/phoenix_kit_web/live/settings/authorization.ex:300
+#: lib/phoenix_kit_web/live/settings/authorization.ex:341
 #, elixir-autogen, elixir-format
 msgid "header is set to"
 msgstr "nagłówek jest ustawiony na"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:606
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:621
 #, elixir-autogen, elixir-format
 msgid "mode"
 msgstr "tryb"
@@ -3683,12 +3686,12 @@ msgstr "tryb"
 msgid "option(s)"
 msgstr "opcja/opcje"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:585
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:600
 #, elixir-autogen, elixir-format
 msgid "product"
 msgstr "produkt"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:605
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:620
 #, elixir-autogen, elixir-format
 msgid "to"
 msgstr "do"
@@ -3698,19 +3701,19 @@ msgstr "do"
 msgid "to every PhoenixKit layout, blocking crawlers from indexing or following links."
 msgstr "do każdego układu PhoenixKit, blokując robotom indeksowanie i podążanie za linkami."
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:601
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:616
 #, elixir-autogen, elixir-format
 msgid "to fields above"
 msgstr "do pól powyżej"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:435
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:519
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:610
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:440
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:529
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:625
 #, elixir-autogen, elixir-format
 msgid "to verify setup"
 msgstr "aby sprawdzić konfigurację"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:426
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:431
 #, elixir-autogen, elixir-format
 msgid "type"
 msgstr "typ"
@@ -3845,7 +3848,7 @@ msgstr "Przyjazna nazwa identyfikująca tę lokalizację magazynu"
 msgid "A unique name to identify this dimension preset"
 msgstr "Unikalna nazwa identyfikująca ten szablon wymiarów"
 
-#: lib/phoenix_kit/integrations/providers.ex:388
+#: lib/phoenix_kit/integrations/providers.ex:389
 #, elixir-autogen, elixir-format
 msgid "AI model access via OpenRouter (100+ models)"
 msgstr "Dostęp do modeli AI przez OpenRouter (ponad 100 modeli)"
@@ -3855,13 +3858,13 @@ msgstr "Dostęp do modeli AI przez OpenRouter (ponad 100 modeli)"
 msgid "API Credentials"
 msgstr "Dane dostępowe API"
 
-#: lib/phoenix_kit/integrations/providers.ex:332
-#: lib/phoenix_kit/integrations/providers.ex:402
-#: lib/phoenix_kit/integrations/providers.ex:460
-#: lib/phoenix_kit/integrations/providers.ex:523
-#: lib/phoenix_kit/integrations/providers.ex:586
-#: lib/phoenix_kit/integrations/providers.ex:653
-#: lib/phoenix_kit/integrations/providers.ex:1065
+#: lib/phoenix_kit/integrations/providers.ex:333
+#: lib/phoenix_kit/integrations/providers.ex:403
+#: lib/phoenix_kit/integrations/providers.ex:461
+#: lib/phoenix_kit/integrations/providers.ex:524
+#: lib/phoenix_kit/integrations/providers.ex:587
+#: lib/phoenix_kit/integrations/providers.ex:654
+#: lib/phoenix_kit/integrations/providers.ex:1137
 #, elixir-autogen, elixir-format
 msgid "API Key"
 msgstr "Klucz API"
@@ -3922,7 +3925,7 @@ msgstr "Aktywne z powodu zaplanowanego okna."
 msgid "Add Integration"
 msgstr "Dodaj integrację"
 
-#: lib/phoenix_kit/integrations/providers.ex:431
+#: lib/phoenix_kit/integrations/providers.ex:432
 #, elixir-autogen, elixir-format
 msgid "Add credits (optional)"
 msgstr "Dodaj kredyty (opcjonalnie)"
@@ -3957,7 +3960,7 @@ msgstr "Wszystkie pliki spełniają docelową nadmiarowość %{n} kopii."
 msgid "Alternative Formats"
 msgstr "Formaty alternatywne"
 
-#: lib/phoenix_kit/integrations/providers.ex:285
+#: lib/phoenix_kit/integrations/providers.ex:286
 #, elixir-autogen, elixir-format
 msgid "Application type: **Web application** (do not select \"Desktop app\" — it won't support redirect URIs)"
 msgstr "Typ aplikacji: **aplikacja internetowa** (nie wybieraj „aplikacja desktopowa” — nie obsługuje adresów URI przekierowania)"
@@ -4079,18 +4082,18 @@ msgstr "Wybierz usługę do połączenia"
 msgid "Clear Schedule"
 msgstr "Wyczyść harmonogram"
 
-#: lib/phoenix_kit/integrations/providers.ex:284
+#: lib/phoenix_kit/integrations/providers.ex:285
 #, elixir-autogen, elixir-format
 msgid "Click **Create Credentials → OAuth client ID**"
 msgstr "Kliknij **Utwórz dane logowania → Identyfikator klienta OAuth**"
 
-#: lib/phoenix_kit/integrations/providers.ex:425
+#: lib/phoenix_kit/integrations/providers.ex:426
 #, elixir-autogen, elixir-format
 msgid "Click **Create Key**"
 msgstr "Kliknij **Utwórz klucz**"
 
-#: lib/phoenix_kit/integrations/providers.ex:295
-#: lib/phoenix_kit/integrations/providers.ex:1248
+#: lib/phoenix_kit/integrations/providers.ex:296
+#: lib/phoenix_kit/integrations/providers.ex:1320
 #, elixir-autogen, elixir-format
 msgid "Click **Save**, then **Connect Account**"
 msgstr "Kliknij **Zapisz**, a następnie **Połącz konto**"
@@ -4140,8 +4143,8 @@ msgstr "Połącz konto %{provider}"
 msgid "Connect Account"
 msgstr "Połącz konto"
 
-#: lib/phoenix_kit/integrations/providers.ex:293
-#: lib/phoenix_kit/integrations/providers.ex:1246
+#: lib/phoenix_kit/integrations/providers.ex:294
+#: lib/phoenix_kit/integrations/providers.ex:1318
 #, elixir-autogen, elixir-format
 msgid "Connect and authorize"
 msgstr "Połącz i autoryzuj"
@@ -4161,7 +4164,7 @@ msgstr "Połącz usługi zewnętrzne do użytku w modułach"
 #: lib/phoenix_kit_web/live/settings/integration_form.html.heex:327
 #: lib/phoenix_kit_web/live/settings/integrations.ex:181
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:111
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:197
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:191
 #, elixir-autogen, elixir-format
 msgid "Connected"
 msgstr "Połączone"
@@ -4202,48 +4205,48 @@ msgstr "Połączenie udane"
 msgid "Connection verified"
 msgstr "Połączenie zweryfikowane"
 
-#: lib/phoenix_kit/integrations/providers.ex:289
+#: lib/phoenix_kit/integrations/providers.ex:290
 #, elixir-autogen, elixir-format
 msgid "Copy the **Client ID** and **Client Secret** into the form above"
 msgstr "Skopiuj **identyfikator klienta** i **sekret klienta** do formularza powyżej"
 
-#: lib/phoenix_kit/integrations/providers.ex:427
+#: lib/phoenix_kit/integrations/providers.ex:428
 #, elixir-autogen, elixir-format
 msgid "Copy the key and paste it into the form above"
 msgstr "Skopiuj klucz i wklej go do formularza powyżej"
 
-#: lib/phoenix_kit/integrations/integrations.ex:1135
+#: lib/phoenix_kit/integrations/integrations.ex:1138
 #: lib/phoenix_kit/integrations/probe.ex:102
 #, elixir-autogen, elixir-format
 msgid "Could not reach the service"
 msgstr "Nie udało się połączyć z usługą"
 
-#: lib/phoenix_kit/integrations/providers.ex:235
+#: lib/phoenix_kit/integrations/providers.ex:236
 #, elixir-autogen, elixir-format
 msgid "Create a Google Cloud project"
 msgstr "Utwórz projekt Google Cloud"
 
-#: lib/phoenix_kit/integrations/providers.ex:238
+#: lib/phoenix_kit/integrations/providers.ex:239
 #, elixir-autogen, elixir-format
 msgid "Create a new project or select an existing one"
 msgstr "Utwórz nowy projekt lub wybierz istniejący"
 
-#: lib/phoenix_kit/integrations/providers.ex:368
-#: lib/phoenix_kit/integrations/providers.ex:423
-#: lib/phoenix_kit/integrations/providers.ex:493
-#: lib/phoenix_kit/integrations/providers.ex:553
-#: lib/phoenix_kit/integrations/providers.ex:619
-#: lib/phoenix_kit/integrations/providers.ex:670
+#: lib/phoenix_kit/integrations/providers.ex:369
+#: lib/phoenix_kit/integrations/providers.ex:424
+#: lib/phoenix_kit/integrations/providers.ex:494
+#: lib/phoenix_kit/integrations/providers.ex:554
+#: lib/phoenix_kit/integrations/providers.ex:620
+#: lib/phoenix_kit/integrations/providers.ex:671
 #, elixir-autogen, elixir-format
 msgid "Create an API key"
 msgstr "Utwórz klucz API"
 
-#: lib/phoenix_kit/integrations/providers.ex:279
+#: lib/phoenix_kit/integrations/providers.ex:280
 #, elixir-autogen, elixir-format
 msgid "Create an OAuth Client"
 msgstr "Utwórz klienta OAuth"
 
-#: lib/phoenix_kit/integrations/providers.ex:416
+#: lib/phoenix_kit/integrations/providers.ex:417
 #, elixir-autogen, elixir-format
 msgid "Create an OpenRouter account"
 msgstr "Utwórz konto OpenRouter"
@@ -4312,7 +4315,7 @@ msgstr "Odłączyć?"
 msgid "Disconnected"
 msgstr "Odłączone"
 
-#: lib/phoenix_kit/integrations/providers.ex:253
+#: lib/phoenix_kit/integrations/providers.ex:254
 #, elixir-autogen, elixir-format
 msgid "Drive API handles file listing, creation, copying, and PDF export. Docs API is used for reading document content and substituting template variables."
 msgstr "API Drive obsługuje listowanie, tworzenie, kopiowanie i eksport plików do PDF. API Docs służy do odczytu treści dokumentów i podstawiania zmiennych szablonu."
@@ -4342,7 +4345,7 @@ msgstr "Włącz zasobnik"
 msgid "Enable organization accounts"
 msgstr "Włącz konta organizacji"
 
-#: lib/phoenix_kit/integrations/providers.ex:242
+#: lib/phoenix_kit/integrations/providers.ex:243
 #, elixir-autogen, elixir-format
 msgid "Enable required APIs"
 msgstr "Włącz wymagane API"
@@ -4475,12 +4478,12 @@ msgstr "Pliki są rejestrowane w PostgreSQL z obsługą wielu lokalizacji medió
 msgid "Files with completed variants"
 msgstr "Pliki z ukończonymi wariantami"
 
-#: lib/phoenix_kit/integrations/providers.ex:219
+#: lib/phoenix_kit/integrations/providers.ex:220
 #, elixir-autogen, elixir-format
 msgid "From Google Cloud Console → APIs & Services → Credentials"
 msgstr "Z Google Cloud Console → Interfejsy API i usługi → Dane logowania"
 
-#: lib/phoenix_kit/integrations/providers.ex:406
+#: lib/phoenix_kit/integrations/providers.ex:407
 #, elixir-autogen, elixir-format
 msgid "From openrouter.ai/keys"
 msgstr "Z openrouter.ai/keys"
@@ -4490,72 +4493,72 @@ msgstr "Z openrouter.ai/keys"
 msgid "Generate additional format variants alongside the primary format. Modern formats like WebP and AVIF offer better compression."
 msgstr "Generuj dodatkowe warianty formatu obok formatu głównego. Nowoczesne formaty jak WebP i AVIF zapewniają lepszą kompresję."
 
-#: lib/phoenix_kit/integrations/providers.ex:426
+#: lib/phoenix_kit/integrations/providers.ex:427
 #, elixir-autogen, elixir-format
 msgid "Give it a name (e.g., your app name)"
 msgstr "Nadaj mu nazwę (np. nazwę Twojej aplikacji)"
 
-#: lib/phoenix_kit/integrations/providers.ex:248
+#: lib/phoenix_kit/integrations/providers.ex:249
 #, elixir-autogen, elixir-format
 msgid "Go back to the Library and search for **Google Docs API**, click it, then click **Enable**"
 msgstr "Wróć do biblioteki, wyszukaj **Google Docs API**, kliknij ją, a następnie kliknij **Włącz**"
 
-#: lib/phoenix_kit/integrations/providers.ex:281
+#: lib/phoenix_kit/integrations/providers.ex:282
 #, elixir-autogen, elixir-format
 msgid "Go to [APIs & Services → Credentials](https://console.cloud.google.com/apis/credentials)"
 msgstr "Przejdź do [Interfejsy API i usługi → Dane logowania](https://console.cloud.google.com/apis/credentials)"
 
-#: lib/phoenix_kit/integrations/providers.ex:244
+#: lib/phoenix_kit/integrations/providers.ex:245
 #, elixir-autogen, elixir-format
 msgid "Go to [APIs & Services → Library](https://console.cloud.google.com/apis/library)"
 msgstr "Przejdź do [Interfejsy API i usługi → Biblioteka](https://console.cloud.google.com/apis/library)"
 
-#: lib/phoenix_kit/integrations/providers.ex:263
+#: lib/phoenix_kit/integrations/providers.ex:264
 #, elixir-autogen, elixir-format
 msgid "Go to [Audience](https://console.cloud.google.com/auth/audience) — set user type to **External** (or Internal for Google Workspace)"
 msgstr "Przejdź do [Odbiorcy](https://console.cloud.google.com/auth/audience) — ustaw typ użytkownika na **Zewnętrzny** (lub Wewnętrzny dla Google Workspace)"
 
-#: lib/phoenix_kit/integrations/providers.ex:260
+#: lib/phoenix_kit/integrations/providers.ex:261
 #, elixir-autogen, elixir-format
 msgid "Go to [Branding](https://console.cloud.google.com/auth/branding) in the sidebar — fill in the **App name** and **User support email**, then save"
 msgstr "Przejdź do [Branding](https://console.cloud.google.com/auth/branding) na pasku bocznym — wypełnij **nazwę aplikacji** i **e-mail wsparcia**, a następnie zapisz"
 
-#: lib/phoenix_kit/integrations/providers.ex:434
+#: lib/phoenix_kit/integrations/providers.ex:435
 #, elixir-autogen, elixir-format
 msgid "Go to [Credits](https://openrouter.ai/credits) to add funds"
 msgstr "Przejdź do [Credits](https://openrouter.ai/credits), aby dodać środki"
 
-#: lib/phoenix_kit/integrations/providers.ex:269
+#: lib/phoenix_kit/integrations/providers.ex:270
 #, elixir-autogen, elixir-format
 msgid "Go to [Data Access](https://console.cloud.google.com/auth/scopes) — click **Add or Remove Scopes** and add the Drive and Docs scopes. This step may not be required — the app requests the needed scopes at connect time regardless."
 msgstr "Przejdź do [Dostęp do danych](https://console.cloud.google.com/auth/scopes) — kliknij **Dodaj lub usuń zakresy** i dodaj zakresy Drive i Docs. Ten krok może nie być konieczny — aplikacja i tak żąda potrzebnych zakresów przy łączeniu."
 
-#: lib/phoenix_kit/integrations/providers.ex:418
+#: lib/phoenix_kit/integrations/providers.ex:419
 #, elixir-autogen, elixir-format
 msgid "Go to [openrouter.ai](https://openrouter.ai) and sign up or log in"
 msgstr "Przejdź na [openrouter.ai](https://openrouter.ai) i zarejestruj się lub zaloguj"
 
-#: lib/phoenix_kit/integrations/providers.ex:237
+#: lib/phoenix_kit/integrations/providers.ex:238
 #, elixir-autogen, elixir-format
 msgid "Go to the [Google Cloud Console](https://console.cloud.google.com)"
 msgstr "Przejdź do [Google Cloud Console](https://console.cloud.google.com)"
 
-#: lib/phoenix_kit/integrations/providers.ex:200
+#: lib/phoenix_kit/integrations/providers.ex:201
 #, elixir-autogen, elixir-format
 msgid "Google"
 msgstr "Google"
 
-#: lib/phoenix_kit/integrations/providers.ex:201
+#: lib/phoenix_kit/integrations/providers.ex:202
 #, elixir-autogen, elixir-format
 msgid "Google Docs, Drive, Calendar, Sheets, Gmail"
 msgstr "Google Docs, Drive, Kalendarz, Arkusze, Gmail"
 
-#: lib/phoenix_kit/integrations/providers.ex:296
+#: lib/phoenix_kit/integrations/providers.ex:297
 #, elixir-autogen, elixir-format
 msgid "Google will show an \"unverified app\" warning — click **Advanced → Go to (app name)** to proceed"
 msgstr "Google wyświetli ostrzeżenie o „niezweryfikowanej aplikacji” — kliknij **Zaawansowane → Przejdź do (nazwa aplikacji)**, aby kontynuować"
 
-#: lib/phoenix_kit/integrations/providers.ex:299
+#: lib/phoenix_kit/integrations/providers.ex:300
 #, elixir-autogen, elixir-format
 msgid "Grant access to Google Docs and Google Drive"
 msgstr "Udziel dostępu do Google Docs i Google Drive"
@@ -4591,11 +4594,12 @@ msgstr "Integracja usunięta"
 msgid "Integrations"
 msgstr "Integracje"
 
-#: lib/phoenix_kit/integrations/integrations.ex:1132
+#: lib/phoenix_kit/integrations/integrations.ex:1135
 #: lib/phoenix_kit/integrations/validators.ex:208
 #: lib/phoenix_kit/integrations/validators.ex:378
 #: lib/phoenix_kit/integrations/validators.ex:412
-#: lib/phoenix_kit/integrations/validators.ex:595
+#: lib/phoenix_kit/integrations/validators.ex:608
+#: lib/phoenix_kit/integrations/validators.ex:776
 #, elixir-autogen, elixir-format
 msgid "Invalid credentials"
 msgstr "Nieprawidłowe dane logowania"
@@ -4809,12 +4813,12 @@ msgstr "Brakuje %{n}"
 msgid "Missing %{n} copies"
 msgstr "Brakuje %{n} kopii"
 
-#: lib/phoenix_kit/integrations/providers.ex:419
+#: lib/phoenix_kit/integrations/providers.ex:420
 #, elixir-autogen, elixir-format
 msgid "Navigate to [Keys](https://openrouter.ai/keys)"
 msgstr "Przejdź do [Keys](https://openrouter.ai/keys)"
 
-#: lib/phoenix_kit/integrations/providers.ex:274
+#: lib/phoenix_kit/integrations/providers.ex:275
 #, elixir-autogen, elixir-format
 msgid "Navigate to the OAuth section using the search bar or the hamburger menu: search for \"OAuth\", or go to the sidebar: **APIs & Services → OAuth consent screen**. This opens a different section with its own sidebar."
 msgstr "Przejdź do sekcji OAuth za pomocą paska wyszukiwania lub menu hamburger: wyszukaj „OAuth” albo wybierz na pasku bocznym **Interfejsy API i usługi → Ekran zgody OAuth**. Otworzy się inna sekcja z własnym paskiem bocznym."
@@ -4835,9 +4839,9 @@ msgstr "Brak tokenu dostępu"
 msgid "No copies"
 msgstr "Brak kopii"
 
-#: lib/phoenix_kit/integrations/integrations.ex:1115
+#: lib/phoenix_kit/integrations/integrations.ex:1118
 #: lib/phoenix_kit/integrations/validators.ex:170
-#: lib/phoenix_kit/integrations/validators.ex:577
+#: lib/phoenix_kit/integrations/validators.ex:758
 #, elixir-autogen, elixir-format
 msgid "No credentials configured"
 msgstr "Brak skonfigurowanych danych logowania"
@@ -4918,7 +4922,7 @@ msgstr "Tylko włączone zasobniki otrzymują nowe przesłania"
 msgid "Only width is used, height is calculated automatically"
 msgstr "Używana jest tylko szerokość, wysokość jest obliczana automatycznie"
 
-#: lib/phoenix_kit/integrations/providers.ex:387
+#: lib/phoenix_kit/integrations/providers.ex:388
 #, elixir-autogen, elixir-format
 msgid "OpenRouter"
 msgstr "OpenRouter"
@@ -5099,7 +5103,7 @@ msgstr "Zaplanowana konserwacja"
 msgid "Scheduled window is currently active"
 msgstr "Zaplanowane okno jest obecnie aktywne"
 
-#: lib/phoenix_kit/integrations/providers.ex:247
+#: lib/phoenix_kit/integrations/providers.ex:248
 #, elixir-autogen, elixir-format
 msgid "Search for **Google Drive API**, click it, then click **Enable**"
 msgstr "Wyszukaj **Google Drive API**, kliknij ją, a następnie kliknij **Włącz**"
@@ -5126,7 +5130,7 @@ msgstr "Wybierz użytkownika do dodania…"
 msgid "Service"
 msgstr "Usługa"
 
-#: lib/phoenix_kit/integrations/integrations.ex:1134
+#: lib/phoenix_kit/integrations/integrations.ex:1137
 #, elixir-autogen, elixir-format
 msgid "Service error %{status}"
 msgstr "Błąd usługi %{status}"
@@ -5136,7 +5140,7 @@ msgstr "Błąd usługi %{status}"
 msgid "Set a time window for automatic maintenance activation."
 msgstr "Ustaw przedział czasowy automatycznego włączania konserwacji."
 
-#: lib/phoenix_kit/integrations/providers.ex:258
+#: lib/phoenix_kit/integrations/providers.ex:259
 #, elixir-autogen, elixir-format
 msgid "Set up OAuth consent"
 msgstr "Skonfiguruj zgodę OAuth"
@@ -5146,7 +5150,7 @@ msgstr "Skonfiguruj zgodę OAuth"
 msgid "Size Configuration"
 msgstr "Konfiguracja rozmiarów"
 
-#: lib/phoenix_kit/integrations/providers.ex:433
+#: lib/phoenix_kit/integrations/providers.ex:434
 #, elixir-autogen, elixir-format
 msgid "Some models are free, but most require credits"
 msgstr "Niektóre modele są darmowe, ale większość wymaga kredytów"
@@ -5176,7 +5180,7 @@ msgstr "Krok 1"
 msgid "Step 2"
 msgstr "Krok 2"
 
-#: lib/phoenix_kit/integrations/providers.ex:266
+#: lib/phoenix_kit/integrations/providers.ex:267
 #, elixir-autogen, elixir-format
 msgid "Still on Audience — while the app is in **Testing** status, add the Google account you will connect as a **Test user** (this must be the same account whose Drive will store your files)"
 msgstr "Nadal w sekcji Odbiorcy — dopóki aplikacja ma status **Testowanie**, dodaj konto Google, które podłączysz, jako **użytkownika testowego** (musi to być to samo konto, na którego Dysku będą przechowywane pliki)"
@@ -5311,7 +5315,7 @@ msgstr "Region Tigris"
 msgid "Total Files"
 msgstr "Łącznie plików"
 
-#: lib/phoenix_kit/integrations/providers.ex:288
+#: lib/phoenix_kit/integrations/providers.ex:289
 #, elixir-autogen, elixir-format
 msgid "Under **Authorized redirect URIs**, add: `{redirect_uri}`"
 msgstr "W sekcji **Autoryzowane adresy URI przekierowania** dodaj: `{redirect_uri}`"
@@ -5368,8 +5372,8 @@ msgstr "Dołączyłeś do organizacji!"
 msgid "You need to create at least one media bucket before files can be uploaded."
 msgstr "Musisz utworzyć co najmniej jeden zasobnik mediów, aby móc przesyłać pliki."
 
-#: lib/phoenix_kit/integrations/providers.ex:300
-#: lib/phoenix_kit/integrations/providers.ex:1252
+#: lib/phoenix_kit/integrations/providers.ex:301
+#: lib/phoenix_kit/integrations/providers.ex:1324
 #, elixir-autogen, elixir-format
 msgid "You'll be redirected back here once connected"
 msgstr "Po połączeniu wrócisz tutaj"
@@ -5436,39 +5440,39 @@ msgstr "1 godzinę temu"
 msgid "1 minute ago"
 msgstr "1 minutę temu"
 
-#: lib/phoenix_kit/integrations/providers.ex:509
+#: lib/phoenix_kit/integrations/providers.ex:510
 #, elixir-autogen, elixir-format
 msgid "AI model access via DeepSeek (deepseek-chat, deepseek-reasoner)"
 msgstr "Dostęp do modeli AI przez DeepSeek (deepseek-chat, deepseek-reasoner)"
 
-#: lib/phoenix_kit/integrations/providers.ex:446
+#: lib/phoenix_kit/integrations/providers.ex:447
 #, elixir-autogen, elixir-format
 msgid "AI model access via Mistral AI (Mistral Large, Codestral, Pixtral)"
 msgstr "Dostęp do modeli AI przez Mistral AI (Mistral Large, Codestral, Pixtral)"
 
-#: lib/phoenix_kit/integrations/providers.ex:1218
+#: lib/phoenix_kit/integrations/providers.ex:1290
 #, elixir-autogen, elixir-format
 msgid "Add a client secret"
 msgstr "Dodaj sekret klienta"
 
-#: lib/phoenix_kit/integrations/providers.ex:480
+#: lib/phoenix_kit/integrations/providers.ex:481
 #, elixir-autogen, elixir-format
 msgid "Add a payment method (required)"
 msgstr "Dodaj metodę płatności (wymagane)"
 
-#: lib/phoenix_kit/integrations/providers.ex:357
-#: lib/phoenix_kit/integrations/providers.ex:542
-#: lib/phoenix_kit/integrations/providers.ex:611
+#: lib/phoenix_kit/integrations/providers.ex:358
+#: lib/phoenix_kit/integrations/providers.ex:543
+#: lib/phoenix_kit/integrations/providers.ex:612
 #, elixir-autogen, elixir-format
 msgid "Add credits"
 msgstr "Dodaj kredyty"
 
-#: lib/phoenix_kit/integrations/providers.ex:1233
+#: lib/phoenix_kit/integrations/providers.ex:1305
 #, elixir-autogen, elixir-format
 msgid "Add the permissions your integration needs: `User.Read` is included by default; add `Mail.Read`, `Files.Read.All`, `Calendars.Read`, etc. as required"
 msgstr "Dodaj uprawnienia potrzebne integracji: `User.Read` jest domyślnie uwzględnione; w razie potrzeby dodaj `Mail.Read`, `Files.Read.All`, `Calendars.Read` itd."
 
-#: lib/phoenix_kit/integrations/providers.ex:1160
+#: lib/phoenix_kit/integrations/providers.ex:1232
 #, elixir-autogen, elixir-format
 msgid "Application (client) ID"
 msgstr "Identyfikator aplikacji (klienta)"
@@ -5478,28 +5482,28 @@ msgstr "Identyfikator aplikacji (klienta)"
 msgid "Clears the OAuth tokens. Credentials and the connection itself stay so you can reconnect with one click."
 msgstr "Usuwa tokeny OAuth. Dane logowania i samo połączenie pozostają, więc możesz połączyć się ponownie jednym kliknięciem."
 
-#: lib/phoenix_kit/integrations/providers.ex:556
-#: lib/phoenix_kit/integrations/providers.ex:622
+#: lib/phoenix_kit/integrations/providers.ex:557
+#: lib/phoenix_kit/integrations/providers.ex:623
 #, elixir-autogen, elixir-format
 msgid "Click **Create API key**, give it a name"
 msgstr "Kliknij **Utwórz klucz API** i nadaj mu nazwę"
 
-#: lib/phoenix_kit/integrations/providers.ex:496
+#: lib/phoenix_kit/integrations/providers.ex:497
 #, elixir-autogen, elixir-format
 msgid "Click **Create new key**, give it a name, set an expiry if desired"
 msgstr "Kliknij **Utwórz nowy klucz**, nadaj mu nazwę i w razie potrzeby ustaw datę wygaśnięcia"
 
-#: lib/phoenix_kit/integrations/providers.ex:1205
+#: lib/phoenix_kit/integrations/providers.ex:1277
 #, elixir-autogen, elixir-format
 msgid "Click **New registration**, give the app a name"
 msgstr "Kliknij **Nowa rejestracja** i nadaj aplikacji nazwę"
 
-#: lib/phoenix_kit/integrations/providers.ex:1210
+#: lib/phoenix_kit/integrations/providers.ex:1282
 #, elixir-autogen, elixir-format
 msgid "Click **Register**"
 msgstr "Kliknij **Zarejestruj**"
 
-#: lib/phoenix_kit/integrations/providers.ex:1228
+#: lib/phoenix_kit/integrations/providers.ex:1300
 #, elixir-autogen, elixir-format
 msgid "Configure API permissions"
 msgstr "Skonfiguruj uprawnienia API"
@@ -5520,16 +5524,16 @@ msgstr "Nazwa połączenia nie może być pusta."
 msgid "Connection renamed"
 msgstr "Połączenie zmieniło nazwę"
 
-#: lib/phoenix_kit/integrations/providers.ex:1222
+#: lib/phoenix_kit/integrations/providers.ex:1294
 #, elixir-autogen, elixir-format
 msgid "Copy the **Value** column (not the Secret ID) into the form above — the value is shown ONCE and disappears on page refresh"
 msgstr "Skopiuj kolumnę **Wartość** (nie identyfikator sekretu) do formularza powyżej — wartość jest pokazywana TYLKO RAZ i znika po odświeżeniu strony"
 
-#: lib/phoenix_kit/integrations/providers.ex:372
-#: lib/phoenix_kit/integrations/providers.ex:497
-#: lib/phoenix_kit/integrations/providers.ex:557
-#: lib/phoenix_kit/integrations/providers.ex:623
-#: lib/phoenix_kit/integrations/providers.ex:675
+#: lib/phoenix_kit/integrations/providers.ex:373
+#: lib/phoenix_kit/integrations/providers.ex:498
+#: lib/phoenix_kit/integrations/providers.ex:558
+#: lib/phoenix_kit/integrations/providers.ex:624
+#: lib/phoenix_kit/integrations/providers.ex:676
 #, elixir-autogen, elixir-format
 msgid "Copy the key (shown once) and paste it into the form above"
 msgstr "Skopiuj klucz (pokazywany raz) i wklej go do formularza powyżej"
@@ -5540,12 +5544,12 @@ msgstr "Skopiuj klucz (pokazywany raz) i wklej go do formularza powyżej"
 msgid "Create Connection"
 msgstr "Utwórz połączenie"
 
-#: lib/phoenix_kit/integrations/providers.ex:534
+#: lib/phoenix_kit/integrations/providers.ex:535
 #, elixir-autogen, elixir-format
 msgid "Create a DeepSeek account"
 msgstr "Utwórz konto DeepSeek"
 
-#: lib/phoenix_kit/integrations/providers.ex:471
+#: lib/phoenix_kit/integrations/providers.ex:472
 #, elixir-autogen, elixir-format
 msgid "Create a Mistral account"
 msgstr "Utwórz konto Mistral"
@@ -5556,12 +5560,12 @@ msgstr "Utwórz konto Mistral"
 msgid "Danger Zone"
 msgstr "Strefa zagrożenia"
 
-#: lib/phoenix_kit/integrations/providers.ex:508
+#: lib/phoenix_kit/integrations/providers.ex:509
 #, elixir-autogen, elixir-format
 msgid "DeepSeek"
 msgstr "DeepSeek"
 
-#: lib/phoenix_kit/integrations/providers.ex:547
+#: lib/phoenix_kit/integrations/providers.ex:548
 #, elixir-autogen, elixir-format
 msgid "DeepSeek requires a positive balance before you can call the chat or reasoner endpoints, even on cheap models"
 msgstr "DeepSeek wymaga dodatniego salda, aby móc wywołać punkty końcowe chat lub reasoner, nawet dla tanich modeli"
@@ -5596,82 +5600,82 @@ msgstr "Nie udało się usunąć połączenia."
 msgid "Failed to rename connection."
 msgstr "Nie udało się zmienić nazwy połączenia."
 
-#: lib/phoenix_kit/integrations/providers.ex:485
+#: lib/phoenix_kit/integrations/providers.ex:486
 #, elixir-autogen, elixir-format
 msgid "Free models still require a billing-enabled workspace"
 msgstr "Darmowe modele również wymagają obszaru roboczego z włączonymi rozliczeniami"
 
-#: lib/phoenix_kit/integrations/providers.ex:1164
+#: lib/phoenix_kit/integrations/providers.ex:1236
 #, elixir-autogen, elixir-format
 msgid "From Azure Portal → App registrations → your app → Overview"
 msgstr "Z portalu Azure → Rejestracje aplikacji → Twoja aplikacja → Przegląd"
 
-#: lib/phoenix_kit/integrations/providers.ex:464
+#: lib/phoenix_kit/integrations/providers.ex:465
 #, elixir-autogen, elixir-format
 msgid "From console.mistral.ai/api-keys"
 msgstr "Z console.mistral.ai/api-keys"
 
-#: lib/phoenix_kit/integrations/providers.ex:527
+#: lib/phoenix_kit/integrations/providers.ex:528
 #, elixir-autogen, elixir-format
 msgid "From platform.deepseek.com/api_keys"
 msgstr "Z platform.deepseek.com/api_keys"
 
-#: lib/phoenix_kit/integrations/providers.ex:1174
+#: lib/phoenix_kit/integrations/providers.ex:1246
 #, elixir-autogen, elixir-format
 msgid "From your app → Certificates & secrets → New client secret. Copy the *Value*, not the Secret ID."
 msgstr "Z Twojej aplikacji → Certyfikaty i wpisy tajne → Nowy sekret klienta. Skopiuj *Wartość*, nie identyfikator sekretu."
 
-#: lib/phoenix_kit/integrations/providers.ex:1230
+#: lib/phoenix_kit/integrations/providers.ex:1302
 #, elixir-autogen, elixir-format
 msgid "Go to **API permissions → Add a permission → Microsoft Graph → Delegated permissions**"
 msgstr "Przejdź do **Uprawnienia interfejsu API → Dodaj uprawnienie → Microsoft Graph → Uprawnienia delegowane**"
 
-#: lib/phoenix_kit/integrations/providers.ex:1220
+#: lib/phoenix_kit/integrations/providers.ex:1292
 #, elixir-autogen, elixir-format
 msgid "Go to **Certificates & secrets → New client secret**"
 msgstr "Przejdź do **Certyfikaty i wpisy tajne → Nowy sekret klienta**"
 
-#: lib/phoenix_kit/integrations/providers.ex:495
+#: lib/phoenix_kit/integrations/providers.ex:496
 #, elixir-autogen, elixir-format
 msgid "Go to [API Keys](https://console.mistral.ai/api-keys)"
 msgstr "Przejdź do [API Keys](https://console.mistral.ai/api-keys)"
 
-#: lib/phoenix_kit/integrations/providers.ex:555
+#: lib/phoenix_kit/integrations/providers.ex:556
 #, elixir-autogen, elixir-format
 msgid "Go to [API Keys](https://platform.deepseek.com/api_keys)"
 msgstr "Przejdź do [API Keys](https://platform.deepseek.com/api_keys)"
 
-#: lib/phoenix_kit/integrations/providers.ex:544
+#: lib/phoenix_kit/integrations/providers.ex:545
 #, elixir-autogen, elixir-format
 msgid "Go to [Top up](https://platform.deepseek.com/top_up) and add at least the minimum amount"
 msgstr "Przejdź do [Top up](https://platform.deepseek.com/top_up) i wpłać co najmniej minimalną kwotę"
 
-#: lib/phoenix_kit/integrations/providers.ex:482
+#: lib/phoenix_kit/integrations/providers.ex:483
 #, elixir-autogen, elixir-format
 msgid "Go to [Workspace → Billing](https://console.mistral.ai/billing/plans) and choose **Experiment** (pay-as-you-go) or a paid tier"
 msgstr "Przejdź do [Workspace → Billing](https://console.mistral.ai/billing/plans) i wybierz **Experiment** (płatność za użycie) lub plan płatny"
 
-#: lib/phoenix_kit/integrations/providers.ex:473
+#: lib/phoenix_kit/integrations/providers.ex:474
 #, elixir-autogen, elixir-format
 msgid "Go to [console.mistral.ai](https://console.mistral.ai) and sign up or log in"
 msgstr "Przejdź na [console.mistral.ai](https://console.mistral.ai) i zarejestruj się lub zaloguj"
 
-#: lib/phoenix_kit/integrations/providers.ex:536
+#: lib/phoenix_kit/integrations/providers.ex:537
 #, elixir-autogen, elixir-format
 msgid "Go to [platform.deepseek.com](https://platform.deepseek.com) and sign up or log in"
 msgstr "Przejdź na [platform.deepseek.com](https://platform.deepseek.com) i zarejestruj się lub zaloguj"
 
-#: lib/phoenix_kit/integrations/providers.ex:1202
+#: lib/phoenix_kit/integrations/providers.ex:1274
 #, elixir-autogen, elixir-format
 msgid "Go to the [Azure Portal](https://portal.azure.com) and search for **App registrations**"
 msgstr "Przejdź do [portalu Azure](https://portal.azure.com) i wyszukaj **Rejestracje aplikacji**"
 
-#: lib/phoenix_kit/integrations/providers.ex:1213
+#: lib/phoenix_kit/integrations/providers.ex:1285
 #, elixir-autogen, elixir-format
 msgid "If you picked a single-tenant audience, fill in **Tenant ID** above with your Directory (tenant) ID GUID — leaving it as `common` only works for multi-tenant + personal apps."
 msgstr "Jeśli wybrano odbiorców jednodostępowych, wpisz powyżej w **Tenant ID** identyfikator GUID katalogu (dzierżawcy) — wartość `common` działa tylko dla aplikacji wielodostępowych i osobistych."
 
-#: lib/phoenix_kit/integrations/providers.ex:1236
+#: lib/phoenix_kit/integrations/providers.ex:1308
 #, elixir-autogen, elixir-format
 msgid "If your tenant requires admin consent, click **Grant admin consent for <tenant>** before the connect flow will work"
 msgstr "Jeśli Twój dzierżawca wymaga zgody administratora, kliknij **Udziel zgody administratora dla <tenant>**, aby proces łączenia działał"
@@ -5688,32 +5692,32 @@ msgstr "Nie znaleziono integracji"
 msgid "Last tested"
 msgstr "Ostatni test"
 
-#: lib/phoenix_kit/integrations/providers.ex:1186
+#: lib/phoenix_kit/integrations/providers.ex:1258
 #, elixir-autogen, elixir-format
 msgid "Leave as `common` for multi-tenant + personal accounts. For single-tenant apps, paste your Directory (tenant) ID GUID. Use `consumers` for personal-only or `organizations` for any work-or-school account."
 msgstr "Pozostaw `common` dla kont wielodostępowych i osobistych. Dla aplikacji jednodostępowych wklej identyfikator GUID katalogu (dzierżawcy). Użyj `consumers` tylko dla kont osobistych lub `organizations` dla kont służbowych i szkolnych."
 
-#: lib/phoenix_kit/integrations/providers.ex:1131
+#: lib/phoenix_kit/integrations/providers.ex:1203
 #, elixir-autogen, elixir-format
 msgid "Microsoft 365"
 msgstr "Microsoft 365"
 
-#: lib/phoenix_kit/integrations/providers.ex:1132
+#: lib/phoenix_kit/integrations/providers.ex:1204
 #, elixir-autogen, elixir-format
 msgid "Microsoft Graph — Outlook, OneDrive, Teams, Calendar, SharePoint"
 msgstr "Microsoft Graph — Outlook, OneDrive, Teams, Kalendarz, SharePoint"
 
-#: lib/phoenix_kit/integrations/providers.ex:1249
+#: lib/phoenix_kit/integrations/providers.ex:1321
 #, elixir-autogen, elixir-format
 msgid "Microsoft will show the consent screen — click **Accept** to grant the requested permissions"
 msgstr "Microsoft wyświetli ekran zgody — kliknij **Akceptuj**, aby przyznać żądane uprawnienia"
 
-#: lib/phoenix_kit/integrations/providers.ex:445
+#: lib/phoenix_kit/integrations/providers.ex:446
 #, elixir-autogen, elixir-format
 msgid "Mistral"
 msgstr "Mistral"
 
-#: lib/phoenix_kit/integrations/providers.ex:488
+#: lib/phoenix_kit/integrations/providers.ex:489
 #, elixir-autogen, elixir-format
 msgid "Mistral does not offer credits without billing setup; this is a hard requirement before keys can be created."
 msgstr "Mistral nie oferuje kredytów bez skonfigurowanych rozliczeń; to bezwzględny wymóg przed utworzeniem kluczy."
@@ -5724,7 +5728,7 @@ msgstr "Mistral nie oferuje kredytów bez skonfigurowanych rozliczeń; to bezwzg
 msgid "Permanently delete this connection? This cannot be undone."
 msgstr "Trwale usunąć to połączenie? Tej operacji nie można cofnąć."
 
-#: lib/phoenix_kit/integrations/providers.ex:1200
+#: lib/phoenix_kit/integrations/providers.ex:1272
 #, elixir-autogen, elixir-format
 msgid "Register an application in Microsoft Entra ID (Azure AD)"
 msgstr "Zarejestruj aplikację w Microsoft Entra ID (Azure AD)"
@@ -5740,32 +5744,32 @@ msgstr "Trwale usuwa integrację. Każdy moduł przypisany do tego połączenia 
 msgid "Search..."
 msgstr "Szukaj…"
 
-#: lib/phoenix_kit/integrations/providers.ex:1221
+#: lib/phoenix_kit/integrations/providers.ex:1293
 #, elixir-autogen, elixir-format
 msgid "Set an expiration (24 months is common; renew before it lapses)"
 msgstr "Ustaw datę wygaśnięcia (typowo 24 miesiące; odnów przed jej upływem)"
 
-#: lib/phoenix_kit/integrations/providers.ex:1181
+#: lib/phoenix_kit/integrations/providers.ex:1253
 #, elixir-autogen, elixir-format
 msgid "Tenant ID"
 msgstr "Identyfikator dzierżawcy"
 
-#: lib/phoenix_kit/integrations/providers.ex:1241
+#: lib/phoenix_kit/integrations/providers.ex:1313
 #, elixir-autogen, elixir-format
 msgid "The `default_scopes` in the provider definition request `openid email profile offline_access User.Read` — extra scopes can be added per-connect by passing `extra_scopes` to `authorization_url/5`."
 msgstr "`default_scopes` w definicji dostawcy żądają `openid email profile offline_access User.Read` — dodatkowe zakresy można dodać przy każdym łączeniu, przekazując `extra_scopes` do `authorization_url/5`."
 
-#: lib/phoenix_kit/integrations/providers.ex:1209
+#: lib/phoenix_kit/integrations/providers.ex:1281
 #, elixir-autogen, elixir-format
 msgid "Under **Redirect URI**, choose **Web** and enter: `{redirect_uri}`"
 msgstr "W sekcji **Identyfikator URI przekierowania** wybierz **Web** i wpisz: `{redirect_uri}`"
 
-#: lib/phoenix_kit/integrations/providers.ex:1206
+#: lib/phoenix_kit/integrations/providers.ex:1278
 #, elixir-autogen, elixir-format
 msgid "Under **Supported account types**, choose the audience: *Personal Microsoft accounts only*, *Accounts in any organizational directory*, or *Accounts in this organizational directory only* depending on who should sign in"
 msgstr "W sekcji **Obsługiwane typy kont** wybierz odbiorców: *Tylko osobiste konta Microsoft*, *Konta w dowolnym katalogu organizacyjnym* lub *Tylko konta w tym katalogu organizacyjnym*, zależnie od tego, kto ma się logować"
 
-#: lib/phoenix_kit/integrations/providers.ex:476
+#: lib/phoenix_kit/integrations/providers.ex:477
 #, elixir-autogen, elixir-format
 msgid "You may need to verify your phone number before creating API keys"
 msgstr "Może być konieczne potwierdzenie numeru telefonu przed utworzeniem kluczy API"
@@ -6032,14 +6036,14 @@ msgstr "Nie zainstalowano"
 
 #: lib/phoenix_kit_web/live/modules.html.heex:447
 #: lib/phoenix_kit_web/live/settings.html.heex:465
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:289
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:315
 #, elixir-autogen, elixir-format
 msgid "Off"
 msgstr "Wyłączone"
 
 #: lib/phoenix_kit_web/live/modules.html.heex:447
 #: lib/phoenix_kit_web/live/settings.html.heex:464
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:289
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:315
 #, elixir-autogen, elixir-format
 msgid "On"
 msgstr "Włączone"
@@ -7290,8 +7294,8 @@ msgstr "Odpowiedz"
 msgid "Are you sure you want to delete this comment?"
 msgstr "Czy na pewno chcesz usunąć ten komentarz?"
 
-#: lib/phoenix_kit_web/components/media_canvas_viewer.ex:1202
-#: lib/phoenix_kit_web/components/media_canvas_viewer.ex:1203
+#: lib/phoenix_kit_web/components/media_canvas_viewer.ex:1236
+#: lib/phoenix_kit_web/components/media_canvas_viewer.ex:1237
 #, elixir-autogen, elixir-format
 msgid "%b %d, %Y"
 msgstr "%d %b %Y"
@@ -8409,14 +8413,14 @@ msgstr "Wszystkie pola są już wybrane"
 msgid "All registered accounts"
 msgstr "Wszystkie zarejestrowane konta"
 
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:185
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:224
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:179
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:218
 #, elixir-autogen, elixir-format
 msgid "Anon"
 msgstr "Anon."
 
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:178
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:245
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:172
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:239
 #, elixir-autogen, elixir-format
 msgid "Anonymous User"
 msgstr "Anonimowy użytkownik"
@@ -8467,8 +8471,8 @@ msgstr "Czy na pewno chcesz unieważnić tę sesję dla"
 msgid "Are you sure you want to unconfirm this user's email?"
 msgstr "Czy na pewno chcesz anulować potwierdzenie adresu e-mail tego użytkownika?"
 
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:170
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:220
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:164
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:214
 #, elixir-autogen, elixir-format
 msgid "Auth"
 msgstr "Uwierzytelnianie"
@@ -8551,17 +8555,17 @@ msgid "Confirmed Email"
 msgstr "Potwierdzony e-mail"
 
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:109
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:195
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Current Page"
 msgstr "Bieżąca strona"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:251
+#: lib/phoenix_kit_web/live/settings/users.ex:258
 #, elixir-autogen, elixir-format
 msgid "Custom field deleted successfully"
 msgstr "Pole niestandardowe zostało usunięte"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:171
+#: lib/phoenix_kit_web/live/settings/users.ex:178
 #, elixir-autogen, elixir-format
 msgid "Custom field saved successfully"
 msgstr "Pole niestandardowe zostało zapisane"
@@ -8576,17 +8580,17 @@ msgstr "Dostosuj kolumny tabeli"
 msgid "Drag to reorder selected columns above, or add new columns from the options below. Actions column is always included."
 msgstr "Przeciągnij, aby zmienić kolejność wybranych kolumn powyżej, lub dodaj nowe kolumny z opcji poniżej. Kolumna Akcje jest zawsze uwzględniona."
 
-#: lib/phoenix_kit_web/live/settings/users.ex:256
+#: lib/phoenix_kit_web/live/settings/users.ex:263
 #, elixir-autogen, elixir-format
 msgid "Failed to delete custom field"
 msgstr "Nie udało się usunąć pola niestandardowego"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:184
+#: lib/phoenix_kit_web/live/settings/users.ex:191
 #, elixir-autogen, elixir-format
 msgid "Failed to save custom field"
 msgstr "Nie udało się zapisać pola niestandardowego"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:285
+#: lib/phoenix_kit_web/live/settings/users.ex:292
 #, elixir-autogen, elixir-format
 msgid "Failed to update field"
 msgstr "Nie udało się zaktualizować pola"
@@ -8619,23 +8623,23 @@ msgstr "Nie udało się zaktualizować ról użytkownika"
 msgid "Failed to update user status"
 msgstr "Nie udało się zaktualizować statusu użytkownika"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:278
+#: lib/phoenix_kit_web/live/settings/users.ex:285
 #, elixir-autogen, elixir-format
 msgid "Field '%{label}' disabled"
 msgstr "Pole „%{label}” wyłączone"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:277
+#: lib/phoenix_kit_web/live/settings/users.ex:284
 #, elixir-autogen, elixir-format
 msgid "Field '%{label}' enabled"
 msgstr "Pole „%{label}” włączone"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:289
+#: lib/phoenix_kit_web/live/settings/users.ex:296
 #, elixir-autogen, elixir-format
 msgid "Field not found"
 msgstr "Nie znaleziono pola"
 
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:108
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:194
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:188
 #, elixir-autogen, elixir-format
 msgid "IP Address"
 msgstr "Adres IP"
@@ -8667,7 +8671,7 @@ msgstr "Zarządzaj kontami użytkowników i rolami"
 msgid "Monitor and manage active user sessions"
 msgstr "Monitoruj aktywne sesje użytkowników i zarządzaj nimi"
 
-#: lib/phoenix_kit/integrations/providers.ex:1002
+#: lib/phoenix_kit/integrations/providers.ex:1074
 #: lib/phoenix_kit_web/live/users/users.ex:1048
 #: lib/phoenix_kit_web/live/users/users.html.heex:563
 #, elixir-autogen, elixir-format
@@ -8679,7 +8683,7 @@ msgstr "Nigdy"
 msgid "Next »"
 msgstr "Dalej »"
 
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:208
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:202
 #, elixir-autogen, elixir-format
 msgid "No active sessions"
 msgstr "Brak aktywnych sesji"
@@ -8831,7 +8835,7 @@ msgstr "Pola standardowe"
 msgid "Table columns updated successfully"
 msgstr "Kolumny tabeli zostały zaktualizowane"
 
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:209
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:203
 #, elixir-autogen, elixir-format
 msgid "There are currently no active sessions to display."
 msgstr "Obecnie nie ma aktywnych sesji do wyświetlenia."
@@ -8892,12 +8896,12 @@ msgstr "Potwierdzenie adresu e-mail użytkownika zostało anulowane"
 msgid "User roles updated successfully"
 msgstr "Role użytkownika zostały zaktualizowane"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:84
+#: lib/phoenix_kit_web/live/settings/users.ex:91
 #, elixir-autogen, elixir-format
 msgid "User settings updated successfully"
 msgstr "Ustawienia użytkownika zostały zaktualizowane"
 
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:193
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:187
 #, elixir-autogen, elixir-format
 msgid "User/Session"
 msgstr "Użytkownik/Sesja"
@@ -8932,7 +8936,7 @@ msgstr[2] "Czy na pewno chcesz unieważnić %{count} sesji użytkownika %{email}
 msgid "Last updated:"
 msgstr "Ostatnia aktualizacja:"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:656
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:671
 #, elixir-autogen, elixir-format
 msgid "Account switcher for signing in to several accounts at once"
 msgstr "Przełącznik kont do logowania się na kilka kont jednocześnie"
@@ -8942,7 +8946,7 @@ msgstr "Przełącznik kont do logowania się na kilka kont jednocześnie"
 msgid "Applying…"
 msgstr "Stosowanie…"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:662
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:677
 #, elixir-autogen, elixir-format
 msgid "Enable the multi-account switcher in the header"
 msgstr "Włącz przełącznik wielu kont w nagłówku"
@@ -8960,12 +8964,12 @@ msgstr "Wczytaj więcej"
 msgid "Loading…"
 msgstr "Wczytywanie…"
 
-#: lib/phoenix_kit_web/users/session.ex:113
+#: lib/phoenix_kit_web/users/session.ex:115
 #, elixir-autogen, elixir-format
 msgid "Logged out. Now signed in as %{email}."
 msgstr "Wylogowano. Teraz jesteś zalogowany jako %{email}."
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:653
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:668
 #, elixir-autogen, elixir-format
 msgid "Multiple Sessions"
 msgstr "Wiele sesji"
@@ -9001,12 +9005,12 @@ msgstr "Zmień kolejność 1 wybranego %{noun} (pozostałe wiersze zostają na m
 msgid "Showing %{loaded} of %{total} %{noun}"
 msgstr "Wyświetlanie %{loaded} z %{total} %{noun}"
 
-#: lib/phoenix_kit_web/users/session.ex:268
+#: lib/phoenix_kit_web/users/session.ex:270
 #, elixir-autogen, elixir-format
 msgid "Switched to %{email}."
 msgstr "Przełączono na %{email}."
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:665
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:680
 #, elixir-autogen, elixir-format
 msgid "When on, any signed-in user can add other accounts (with their password) and switch between them from the user menu."
 msgstr "Gdy włączone, każdy zalogowany użytkownik może dodać inne konta (podając ich hasło) i przełączać się między nimi z menu użytkownika."
@@ -9086,7 +9090,7 @@ msgstr "Tutaj można dodawać tylko dozwolone typy plików."
 msgid "View background job status and history"
 msgstr "Wyświetl status i historię zadań w tle"
 
-#: lib/phoenix_kit/integrations/providers.ex:312
+#: lib/phoenix_kit/integrations/providers.ex:313
 #, elixir-autogen, elixir-format
 msgid "AI models via OpenAI (GPT, embeddings, images, audio)"
 msgstr "Modele AI przez OpenAI (GPT, embeddingi, obrazy, audio)"
@@ -9171,12 +9175,12 @@ msgstr "Zmień"
 msgid "Choose"
 msgstr "Wybierz"
 
-#: lib/phoenix_kit/integrations/providers.ex:674
+#: lib/phoenix_kit/integrations/providers.ex:675
 #, elixir-autogen, elixir-format
 msgid "Click **Create API Key**, give it a name"
 msgstr "Kliknij **Utwórz klucz API** i nadaj mu nazwę"
 
-#: lib/phoenix_kit/integrations/providers.ex:371
+#: lib/phoenix_kit/integrations/providers.ex:372
 #, elixir-autogen, elixir-format
 msgid "Click **Create new secret key**, give it a name"
 msgstr "Kliknij **Create new secret key** i nadaj mu nazwę"
@@ -9187,12 +9191,12 @@ msgstr "Kliknij **Create new secret key** i nadaj mu nazwę"
 msgid "Close search"
 msgstr "Zamknij wyszukiwanie"
 
-#: lib/phoenix_kit/integrations/providers.ex:664
+#: lib/phoenix_kit/integrations/providers.ex:665
 #, elixir-autogen, elixir-format
 msgid "Create an ElevenLabs account"
 msgstr "Utwórz konto ElevenLabs"
 
-#: lib/phoenix_kit/integrations/providers.ex:349
+#: lib/phoenix_kit/integrations/providers.ex:350
 #, elixir-autogen, elixir-format
 msgid "Create an OpenAI account"
 msgstr "Utwórz konto OpenAI"
@@ -9256,7 +9260,7 @@ msgstr "Edytuj opis"
 msgid "Edit header"
 msgstr "Edytuj nagłówek"
 
-#: lib/phoenix_kit/integrations/providers.ex:634
+#: lib/phoenix_kit/integrations/providers.ex:635
 #, elixir-autogen, elixir-format
 msgid "ElevenLabs"
 msgstr "ElevenLabs"
@@ -9326,37 +9330,37 @@ msgstr "Nazwa folderu nie może być pusta"
 msgid "Forgot password"
 msgstr "Nie pamiętam hasła"
 
-#: lib/phoenix_kit/integrations/providers.ex:657
+#: lib/phoenix_kit/integrations/providers.ex:658
 #, elixir-autogen, elixir-format
 msgid "From elevenlabs.io → Settings → API Keys"
 msgstr "Z elevenlabs.io → Ustawienia → API Keys"
 
-#: lib/phoenix_kit/integrations/providers.ex:336
+#: lib/phoenix_kit/integrations/providers.ex:337
 #, elixir-autogen, elixir-format
 msgid "From platform.openai.com/api-keys"
 msgstr "Z platform.openai.com/api-keys"
 
-#: lib/phoenix_kit/integrations/providers.ex:370
+#: lib/phoenix_kit/integrations/providers.ex:371
 #, elixir-autogen, elixir-format
 msgid "Go to [API Keys](https://platform.openai.com/api-keys)"
 msgstr "Przejdź do [API Keys](https://platform.openai.com/api-keys)"
 
-#: lib/phoenix_kit/integrations/providers.ex:359
+#: lib/phoenix_kit/integrations/providers.ex:360
 #, elixir-autogen, elixir-format
 msgid "Go to [Billing](https://platform.openai.com/account/billing/overview) and add a payment method or credits"
 msgstr "Przejdź do [Billing](https://platform.openai.com/account/billing/overview) i dodaj metodę płatności lub kredyty"
 
-#: lib/phoenix_kit/integrations/providers.ex:672
+#: lib/phoenix_kit/integrations/providers.ex:673
 #, elixir-autogen, elixir-format
 msgid "Go to [Settings → API Keys](https://elevenlabs.io/app/settings/api-keys)"
 msgstr "Przejdź do [Settings → API Keys](https://elevenlabs.io/app/settings/api-keys)"
 
-#: lib/phoenix_kit/integrations/providers.ex:666
+#: lib/phoenix_kit/integrations/providers.ex:667
 #, elixir-autogen, elixir-format
 msgid "Go to [elevenlabs.io](https://elevenlabs.io) and sign up or log in"
 msgstr "Przejdź na [elevenlabs.io](https://elevenlabs.io) i zarejestruj się lub zaloguj"
 
-#: lib/phoenix_kit/integrations/providers.ex:351
+#: lib/phoenix_kit/integrations/providers.ex:352
 #, elixir-autogen, elixir-format
 msgid "Go to [platform.openai.com](https://platform.openai.com) and sign up or log in"
 msgstr "Przejdź na [platform.openai.com](https://platform.openai.com) i zarejestruj się lub zaloguj"
@@ -9385,7 +9389,7 @@ msgstr "Nagłówek %{level}"
 msgid "Icon"
 msgstr "Ikona"
 
-#: lib/phoenix_kit/integrations/providers.ex:375
+#: lib/phoenix_kit/integrations/providers.ex:376
 #, elixir-autogen, elixir-format
 msgid "If your account belongs to multiple organizations, keys are scoped to the org selected when the key was created."
 msgstr "Jeśli Twoje konto należy do wielu organizacji, klucze są ograniczone do organizacji wybranej przy ich tworzeniu."
@@ -9485,12 +9489,12 @@ msgstr "Najstarsze najpierw"
 msgid "Open the media health dashboard to check file redundancy and re-sync files across storage locations."
 msgstr "Otwórz panel stanu mediów, aby sprawdzić nadmiarowość plików i ponownie zsynchronizować je między lokalizacjami magazynu."
 
-#: lib/phoenix_kit/integrations/providers.ex:311
+#: lib/phoenix_kit/integrations/providers.ex:312
 #, elixir-autogen, elixir-format
 msgid "OpenAI"
 msgstr "OpenAI"
 
-#: lib/phoenix_kit/integrations/providers.ex:362
+#: lib/phoenix_kit/integrations/providers.ex:363
 #, elixir-autogen, elixir-format
 msgid "OpenAI requires a positive balance before the API will return completions, even on cheaper models"
 msgstr "OpenAI wymaga dodatniego salda, aby API zwracało uzupełnienia, nawet dla tańszych modeli"
@@ -9580,12 +9584,12 @@ msgstr "Sortowanie"
 msgid "Stacks"
 msgstr "Stosy"
 
-#: lib/phoenix_kit/integrations/providers.ex:635
+#: lib/phoenix_kit/integrations/providers.ex:636
 #, elixir-autogen, elixir-format
 msgid "Text-to-speech and voice generation via ElevenLabs"
 msgstr "Zamiana tekstu na mowę i generowanie głosu przez ElevenLabs"
 
-#: lib/phoenix_kit/integrations/providers.ex:678
+#: lib/phoenix_kit/integrations/providers.ex:679
 #, elixir-autogen, elixir-format
 msgid "The free tier includes a monthly character quota; paid plans raise the quota and unlock commercial use and additional voices."
 msgstr "Plan darmowy obejmuje miesięczny limit znaków; plany płatne zwiększają limit oraz udostępniają użycie komercyjne i dodatkowe głosy."
@@ -10468,27 +10472,27 @@ msgstr "Lub dodaj przez"
 msgid "Too many attempts. Please try again shortly."
 msgstr "Zbyt wiele prób. Spróbuj ponownie za chwilę."
 
-#: lib/phoenix_kit/integrations/providers.ex:569
+#: lib/phoenix_kit/integrations/providers.ex:570
 #, elixir-autogen, elixir-format
 msgid "AI model access via xAI (Grok models)"
 msgstr "Dostęp do modeli AI przez xAI (modele Grok)"
 
-#: lib/phoenix_kit/integrations/providers.ex:827
+#: lib/phoenix_kit/integrations/providers.ex:828
 #, elixir-autogen, elixir-format
 msgid "AWS Simple Email Service (SMTP credentials via SES API)"
 msgstr "AWS Simple Email Service (dane SMTP przez API SES)"
 
-#: lib/phoenix_kit/integrations/providers.ex:826
+#: lib/phoenix_kit/integrations/providers.ex:827
 #, elixir-autogen, elixir-format
 msgid "Amazon SES"
 msgstr "Amazon SES"
 
-#: lib/phoenix_kit/integrations/providers.ex:1050
+#: lib/phoenix_kit/integrations/providers.ex:1122
 #, elixir-autogen, elixir-format
 msgid "Brevo API"
 msgstr "API Brevo"
 
-#: lib/phoenix_kit/integrations/providers.ex:605
+#: lib/phoenix_kit/integrations/providers.ex:606
 #, elixir-autogen, elixir-format
 msgid "Create an xAI account"
 msgstr "Utwórz konto xAI"
@@ -10498,37 +10502,37 @@ msgstr "Utwórz konto xAI"
 msgid "Email users when their account is signed in from a new device"
 msgstr "Wysyłaj e-mail do użytkowników, gdy ich konto zaloguje się z nowego urządzenia"
 
-#: lib/phoenix_kit/integrations/providers.ex:961
+#: lib/phoenix_kit/integrations/providers.ex:1033
 #, elixir-autogen, elixir-format
 msgid "For Brevo: the SMTP key starting with xsmtpsib- (SMTP & API → SMTP tab) — not the API key (xkeysib-)."
 msgstr "Dla Brevo: klucz SMTP zaczynający się od xsmtpsib- (SMTP & API → zakładka SMTP), a nie klucz API (xkeysib-)."
 
-#: lib/phoenix_kit/integrations/providers.ex:949
+#: lib/phoenix_kit/integrations/providers.ex:1021
 #, elixir-autogen, elixir-format
 msgid "For Brevo: your account's SMTP login, shown as <subaccount>@smtp-brevo.com under SMTP & API → SMTP."
 msgstr "Dla Brevo: login SMTP Twojego konta, pokazywany jako <subaccount>@smtp-brevo.com w SMTP & API → SMTP."
 
-#: lib/phoenix_kit/integrations/providers.ex:1070
+#: lib/phoenix_kit/integrations/providers.ex:1142
 #, elixir-autogen, elixir-format
 msgid "From Brevo → SMTP & API → API Keys. Starts with xkeysib- — not the SMTP key (xsmtpsib-)."
 msgstr "Z Brevo → SMTP & API → API Keys. Zaczyna się od xkeysib-, a nie klucz SMTP (xsmtpsib-)."
 
-#: lib/phoenix_kit/integrations/providers.ex:590
+#: lib/phoenix_kit/integrations/providers.ex:591
 #, elixir-autogen, elixir-format
 msgid "From console.x.ai/team/default/api-keys"
 msgstr "Z console.x.ai/team/default/api-keys"
 
-#: lib/phoenix_kit/integrations/providers.ex:621
+#: lib/phoenix_kit/integrations/providers.ex:622
 #, elixir-autogen, elixir-format
 msgid "Go to [API Keys](https://console.x.ai/team/default/api-keys)"
 msgstr "Przejdź do [API Keys](https://console.x.ai/team/default/api-keys)"
 
-#: lib/phoenix_kit/integrations/providers.ex:607
+#: lib/phoenix_kit/integrations/providers.ex:608
 #, elixir-autogen, elixir-format
 msgid "Go to [accounts.x.ai](https://accounts.x.ai) and sign up or log in"
 msgstr "Przejdź na [accounts.x.ai](https://accounts.x.ai) i zarejestruj się lub zaloguj"
 
-#: lib/phoenix_kit/integrations/providers.ex:613
+#: lib/phoenix_kit/integrations/providers.ex:614
 #, elixir-autogen, elixir-format
 msgid "Go to [console.x.ai](https://console.x.ai) → Billing and add credits"
 msgstr "Przejdź do [console.x.ai](https://console.x.ai) → Billing i dodaj kredyty"
@@ -10538,43 +10542,44 @@ msgstr "Przejdź do [console.x.ai](https://console.x.ai) → Billing i dodaj kre
 msgid "Login Notifications"
 msgstr "Powiadomienia o logowaniu"
 
-#: lib/phoenix_kit/integrations/providers.ex:927
+#: lib/phoenix_kit/integrations/providers.ex:999
 #, elixir-autogen, elixir-format
 msgid "Port"
 msgstr "Port"
 
-#: lib/phoenix_kit/integrations/providers.ex:720
-#: lib/phoenix_kit/integrations/providers.ex:860
+#: lib/phoenix_kit/integrations/providers.ex:721
+#: lib/phoenix_kit/integrations/providers.ex:861
+#: lib/phoenix_kit/integrations/providers.ex:945
 #, elixir-autogen, elixir-format
 msgid "Region"
 msgstr "Region"
 
-#: lib/phoenix_kit/integrations/providers.ex:904
+#: lib/phoenix_kit/integrations/providers.ex:976
 #, elixir-autogen, elixir-format
 msgid "SMTP"
 msgstr "SMTP"
 
-#: lib/phoenix_kit/integrations/providers.ex:918
+#: lib/phoenix_kit/integrations/providers.ex:990
 #, elixir-autogen, elixir-format
 msgid "SMTP Host"
 msgstr "Host SMTP"
 
-#: lib/phoenix_kit/integrations/providers.ex:1051
+#: lib/phoenix_kit/integrations/providers.ex:1123
 #, elixir-autogen, elixir-format
 msgid "Send email via the Brevo transactional email API"
 msgstr "Wysyłaj e-maile przez API e-maili transakcyjnych Brevo"
 
-#: lib/phoenix_kit/integrations/providers.ex:906
+#: lib/phoenix_kit/integrations/providers.ex:978
 #, elixir-autogen, elixir-format
 msgid "Universal SMTP relay — works with any vendor (Brevo, Mailgun, SendGrid, a self-hosted mail server, etc). Add one named connection per relay/account."
 msgstr "Uniwersalny przekaźnik SMTP — działa z każdym dostawcą (Brevo, Mailgun, SendGrid, własny serwer poczty itd.). Dodaj jedno nazwane połączenie na przekaźnik lub konto."
 
-#: lib/phoenix_kit/integrations/providers.ex:568
+#: lib/phoenix_kit/integrations/providers.ex:569
 #, elixir-autogen, elixir-format
 msgid "xAI"
 msgstr "xAI"
 
-#: lib/phoenix_kit/integrations/providers.ex:615
+#: lib/phoenix_kit/integrations/providers.ex:616
 #, elixir-autogen, elixir-format
 msgid "xAI requires a funded account before the API will return completions"
 msgstr "xAI wymaga zasilonego konta, aby API zwracało uzupełnienia"
@@ -10750,12 +10755,12 @@ msgstr "Żaden plik nie odpowiada wyszukiwaniu."
 msgid "Try a different term or clear the search"
 msgstr "Spróbuj innego hasła lub wyczyść wyszukiwanie"
 
-#: lib/modules/storage/web/bucket_form.ex:294
+#: lib/modules/storage/web/bucket_form.ex:296
 #, elixir-autogen, elixir-format
 msgid "Add Storage Bucket"
 msgstr "Dodaj zasobnik magazynu"
 
-#: lib/modules/storage/web/bucket_form.ex:295
+#: lib/modules/storage/web/bucket_form.ex:297
 #, elixir-autogen, elixir-format
 msgid "Edit Storage Bucket"
 msgstr "Edytuj zasobnik magazynu"
@@ -10845,12 +10850,12 @@ msgstr "%{n} min temu"
 msgid "%{provider} settings"
 msgstr "Ustawienia %{provider}"
 
-#: lib/phoenix_kit/integrations/validators.ex:643
+#: lib/phoenix_kit/integrations/validators.ex:824
 #, elixir-autogen, elixir-format
 msgid "%{text} · resets %{date}"
 msgstr "%{text} · reset %{date}"
 
-#: lib/phoenix_kit/integrations/validators.ex:632
+#: lib/phoenix_kit/integrations/validators.ex:813
 #, elixir-autogen, elixir-format
 msgid "%{type} · %{credits} credits left"
 msgstr "%{type} · pozostało %{credits} kredytów"
@@ -10906,12 +10911,12 @@ msgstr "Cała wychodząca poczta systemowa — uwierzytelnianie, powiadomienia �
 msgid "Allow \"Keep me logged in\" (persistent sessions)"
 msgstr "Zezwól na „Nie wylogowuj mnie” (sesje trwałe)"
 
-#: lib/phoenix_kit/integrations/providers.ex:1001
+#: lib/phoenix_kit/integrations/providers.ex:1073
 #, elixir-autogen, elixir-format
 msgid "Always"
 msgstr "Zawsze"
 
-#: lib/phoenix_kit_web/users/session.ex:331
+#: lib/phoenix_kit_web/users/session.ex:333
 #, elixir-autogen, elixir-format
 msgid "An owner account cannot be used."
 msgstr "Nie można użyć konta właściciela."
@@ -10921,12 +10926,12 @@ msgstr "Nie można użyć konta właściciela."
 msgid "Applies site-wide wherever the rich-text editor is rendered (posts, comments). Users can still switch modes inside the editor."
 msgstr "Obowiązuje w całej witrynie wszędzie, gdzie wyświetlany jest edytor tekstu sformatowanego (wpisy, komentarze). Użytkownicy nadal mogą zmieniać tryb w edytorze."
 
-#: lib/phoenix_kit/integrations/providers.ex:982
+#: lib/phoenix_kit/integrations/providers.ex:1054
 #, elixir-autogen, elixir-format
 msgid "Auto (from port)"
 msgstr "Automatycznie (na podstawie portu)"
 
-#: lib/phoenix_kit/integrations/providers.ex:978
+#: lib/phoenix_kit/integrations/providers.ex:1050
 #, elixir-autogen, elixir-format
 msgid "Auto follows the port: 465 means implicit TLS, anything else STARTTLS (required when a login is set). Choose explicitly for a relay that ignores that convention."
 msgstr "„Automatycznie” zależy od portu: 465 oznacza niejawny TLS, każdy inny STARTTLS (wymagany, gdy ustawiono login). Wybierz ręcznie dla przekaźnika, który nie stosuje tej konwencji."
@@ -10941,22 +10946,22 @@ msgstr "Grupuj częste typy w okresowe podsumowania — ustaw częstotliwość d
 msgid "Best,\nThe Team"
 msgstr "Z poważaniem,\nzespół"
 
-#: lib/phoenix_kit/integrations/providers.ex:1098
+#: lib/phoenix_kit/integrations/providers.ex:1170
 #, elixir-autogen, elixir-format
 msgid "Bot Token"
 msgstr "Token bota"
 
-#: lib/phoenix_kit/integrations/providers.ex:1118
+#: lib/phoenix_kit/integrations/providers.ex:1190
 #, elixir-autogen, elixir-format
 msgid "BotFather replies with an HTTP API token like `123456789:ABCdef...` — copy it"
 msgstr "BotFather odpowie tokenem API HTTP w postaci `123456789:ABCdef...` — skopiuj go"
 
-#: lib/phoenix_kit/integrations/validators.ex:601
+#: lib/phoenix_kit/integrations/validators.ex:782
 #, elixir-autogen, elixir-format
 msgid "Brevo error %{status}"
 msgstr "Błąd Brevo %{status}"
 
-#: lib/phoenix_kit/integrations/providers.ex:1022
+#: lib/phoenix_kit/integrations/providers.ex:1094
 #, elixir-autogen, elixir-format
 msgid "CA certificate (PEM)"
 msgstr "Certyfikat CA (PEM)"
@@ -10966,7 +10971,7 @@ msgstr "Certyfikat CA (PEM)"
 msgid "Cannot delete send profile"
 msgstr "Nie można usunąć profilu wysyłki"
 
-#: lib/phoenix_kit/integrations/providers.ex:1007
+#: lib/phoenix_kit/integrations/providers.ex:1079
 #, elixir-autogen, elixir-format
 msgid "Certificate verification"
 msgstr "Weryfikacja certyfikatu"
@@ -11011,7 +11016,7 @@ msgstr "Potwierdź swój adres e-mail"
 msgid "Connect your own API keys and services. Only you can see these."
 msgstr "Połącz własne klucze API i usługi. Widzisz je tylko Ty."
 
-#: lib/phoenix_kit/integrations/validators.ex:693
+#: lib/phoenix_kit/integrations/validators.ex:874
 #, elixir-autogen, elixir-format
 msgid "Connected as @%{username}"
 msgstr "Połączono jako @%{username}"
@@ -11027,7 +11032,7 @@ msgstr "Połączenie działa"
 msgid "Content Editor"
 msgstr "Edytor treści"
 
-#: lib/phoenix_kit/integrations/providers.ex:1116
+#: lib/phoenix_kit/integrations/providers.ex:1188
 #, elixir-autogen, elixir-format
 msgid "Copy the bot token"
 msgstr "Skopiuj token bota"
@@ -11045,12 +11050,12 @@ msgstr "Nie udało się dodać integracji"
 msgid "Could not reach AWS SES"
 msgstr "Nie udało się połączyć z AWS SES"
 
-#: lib/phoenix_kit/integrations/validators.ex:605
+#: lib/phoenix_kit/integrations/validators.ex:786
 #, elixir-autogen, elixir-format
 msgid "Could not reach Brevo"
 msgstr "Nie udało się połączyć z Brevo"
 
-#: lib/phoenix_kit/integrations/validators.ex:705
+#: lib/phoenix_kit/integrations/validators.ex:886
 #, elixir-autogen, elixir-format
 msgid "Could not reach Telegram"
 msgstr "Nie udało się połączyć z Telegramem"
@@ -11111,7 +11116,7 @@ msgstr "Nie udało się zaktualizować ustawień podsumowań."
 msgid "Could not update default send integration"
 msgstr "Nie udało się zaktualizować domyślnej integracji wysyłki"
 
-#: lib/phoenix_kit/integrations/providers.ex:1109
+#: lib/phoenix_kit/integrations/providers.ex:1181
 #, elixir-autogen, elixir-format
 msgid "Create a bot with BotFather"
 msgstr "Utwórz bota za pomocą BotFather"
@@ -11187,7 +11192,7 @@ msgstr "Wyłączone profile nigdy nie są używane do wysyłki, nawet jako domy�
 msgid "Dismiss"
 msgstr "Odrzuć"
 
-#: lib/phoenix_kit/integrations/providers.ex:1017
+#: lib/phoenix_kit/integrations/providers.ex:1089
 #, elixir-autogen, elixir-format
 msgid "Do not verify"
 msgstr "Nie weryfikuj"
@@ -11219,7 +11224,7 @@ msgstr "Edycja profilu wysyłki: %{name}"
 msgid "Email Sending"
 msgstr "Wysyłka e-maili"
 
-#: lib/phoenix_kit_web/users/confirmation_instructions.ex:109
+#: lib/phoenix_kit_web/users/confirmation_instructions.ex:111
 #, elixir-autogen, elixir-format
 msgid "Email confirmed. Welcome!"
 msgstr "E-mail potwierdzony. Witamy!"
@@ -11229,7 +11234,7 @@ msgstr "E-mail potwierdzony. Witamy!"
 msgid "Email-capable integrations"
 msgstr "Integracje z obsługą e-maili"
 
-#: lib/phoenix_kit/integrations/providers.ex:973
+#: lib/phoenix_kit/integrations/providers.ex:1045
 #, elixir-autogen, elixir-format
 msgid "Encryption"
 msgstr "Szyfrowanie"
@@ -11249,7 +11254,7 @@ msgstr "Co 12 godzin"
 msgid "Everyone who starts the bot"
 msgstr "Wszyscy, którzy uruchomią bota"
 
-#: lib/phoenix_kit/integrations/providers.ex:1027
+#: lib/phoenix_kit/integrations/providers.ex:1099
 #, elixir-autogen, elixir-format
 msgid "For a private or self-signed relay certificate. Replaces the system CA store for this connection only."
 msgstr "Dla prywatnego lub samopodpisanego certyfikatu przekaźnika. Zastępuje systemowy magazyn CA tylko dla tego połączenia."
@@ -11260,7 +11265,7 @@ msgstr "Dla prywatnego lub samopodpisanego certyfikatu przekaźnika. Zastępuje 
 msgid "From"
 msgstr "Nadawca"
 
-#: lib/phoenix_kit/integrations/providers.ex:1102
+#: lib/phoenix_kit/integrations/providers.ex:1174
 #, elixir-autogen, elixir-format
 msgid "From @BotFather → /newbot (or /token for an existing bot)"
 msgstr "Od @BotFather → /newbot (lub /token dla istniejącego bota)"
@@ -11287,7 +11292,7 @@ msgstr "Pełny dostęp"
 msgid "Hourly"
 msgstr "Co godzinę"
 
-#: lib/phoenix_kit/integrations/providers.ex:1000
+#: lib/phoenix_kit/integrations/providers.ex:1072
 #, elixir-autogen, elixir-format
 msgid "If offered (default)"
 msgstr "Jeśli oferowane (domyślnie)"
@@ -11297,7 +11302,7 @@ msgstr "Jeśli oferowane (domyślnie)"
 msgid "Immediate"
 msgstr "Natychmiast"
 
-#: lib/phoenix_kit/integrations/providers.ex:983
+#: lib/phoenix_kit/integrations/providers.ex:1055
 #, elixir-autogen, elixir-format
 msgid "Implicit TLS / SMTPS"
 msgstr "Niejawny TLS / SMTPS"
@@ -11315,6 +11320,7 @@ msgid "Incomplete SMTP settings"
 msgstr "Niepełne ustawienia SMTP"
 
 #: lib/phoenix_kit/integrations/validators.ex:57
+#: lib/phoenix_kit/integrations/validators.ex:582
 #, elixir-autogen, elixir-format
 msgid "Incomplete credentials"
 msgstr "Niepełne dane logowania"
@@ -11351,7 +11357,7 @@ msgstr "Nieprawidłowe ustawienia SMTP"
 msgid "Invalid SMTP settings: %{reason}"
 msgstr "Nieprawidłowe ustawienia SMTP: %{reason}"
 
-#: lib/phoenix_kit/integrations/validators.ex:698
+#: lib/phoenix_kit/integrations/validators.ex:879
 #, elixir-autogen, elixir-format
 msgid "Invalid bot token"
 msgstr "Nieprawidłowy token bota"
@@ -11371,7 +11377,7 @@ msgstr "Nieprawidłowy limit czasu: %{value}"
 msgid "Leave a field blank to fall back to the application config or built-in default."
 msgstr "Pozostaw pole puste, aby użyć konfiguracji aplikacji lub wbudowanej wartości domyślnej."
 
-#: lib/phoenix_kit/integrations/providers.ex:1038
+#: lib/phoenix_kit/integrations/providers.ex:1110
 #, elixir-autogen, elixir-format
 msgid "Leave blank for the gen_smtp default."
 msgstr "Pozostaw puste, aby użyć domyślnej wartości gen_smtp."
@@ -11412,7 +11418,7 @@ msgstr "Oznacz wszystkie jako przeczytane"
 msgid "Mark read"
 msgstr "Oznacz jako przeczytane"
 
-#: lib/phoenix_kit_web/users/session.ex:340
+#: lib/phoenix_kit_web/users/session.ex:342
 #, elixir-autogen, elixir-format
 msgid "Maximum number of accounts reached — remove one first."
 msgstr "Osiągnięto maksymalną liczbę kont — najpierw usuń jedno."
@@ -11462,7 +11468,7 @@ msgstr "Nowy profil wysyłki"
 msgid "No adapter configured for the static mailer. Set one in your application config, or connect an email-capable integration below and pick it as the default transactional integration."
 msgstr "Nie skonfigurowano adaptera dla statycznego mailera. Ustaw go w konfiguracji aplikacji lub połącz poniżej integrację z obsługą e-maili i wybierz ją jako domyślną integrację transakcyjną."
 
-#: lib/phoenix_kit/integrations/validators.ex:682
+#: lib/phoenix_kit/integrations/validators.ex:863
 #, elixir-autogen, elixir-format
 msgid "No bot token configured"
 msgstr "Nie skonfigurowano tokenu bota"
@@ -11502,7 +11508,7 @@ msgstr "Nie znaleziono systemowych certyfikatów CA, więc nie można zweryfikow
 msgid "No unread notifications"
 msgstr "Brak nieprzeczytanych powiadomień"
 
-#: lib/phoenix_kit/integrations/providers.ex:986
+#: lib/phoenix_kit/integrations/providers.ex:1058
 #, elixir-autogen, elixir-format
 msgid "None — plaintext"
 msgstr "Brak — bez szyfrowania"
@@ -11532,7 +11538,7 @@ msgstr "Otrzymane powiadomienia pojawią się tutaj."
 msgid "Numeric ID of a verified Brevo sender. Leave empty to send from the From address above."
 msgstr "Numeryczny identyfikator zweryfikowanego nadawcy Brevo. Pozostaw puste, aby wysyłać z adresu podanego powyżej."
 
-#: lib/phoenix_kit_web/users/session.ex:334
+#: lib/phoenix_kit_web/users/session.ex:336
 #, elixir-autogen, elixir-format
 msgid "Only an owner can sign in as another administrator."
 msgstr "Tylko właściciel może zalogować się jako inny administrator."
@@ -11542,12 +11548,12 @@ msgstr "Tylko właściciel może zalogować się jako inny administrator."
 msgid "Only me"
 msgstr "Tylko ja"
 
-#: lib/phoenix_kit/integrations/providers.ex:1111
+#: lib/phoenix_kit/integrations/providers.ex:1183
 #, elixir-autogen, elixir-format
 msgid "Open [@BotFather](https://t.me/BotFather) in Telegram"
 msgstr "Otwórz [@BotFather](https://t.me/BotFather) w Telegramie"
 
-#: lib/phoenix_kit/integrations/providers.ex:1121
+#: lib/phoenix_kit/integrations/providers.ex:1193
 #, elixir-autogen, elixir-format
 msgid "Paste the token into the form above and press **Test Connection**"
 msgstr "Wklej token do formularza powyżej i naciśnij **Testuj połączenie**"
@@ -11567,7 +11573,7 @@ msgstr "Dane nadawcy, limity częstotliwości i opcje dostawcy dla każdego kont
 msgid "Persistent sessions last 60 days. Magic-link and social logins have no checkbox to tick, so they follow the default above. Turning the first option off hides the checkbox everywhere and keeps every login to the browser session."
 msgstr "Sesje trwałe działają 60 dni. Logowanie magicznym linkiem i przez media społecznościowe nie ma pola wyboru, więc korzysta z wartości domyślnej powyżej. Wyłączenie pierwszej opcji ukrywa pole wszędzie i ogranicza każde logowanie do sesji przeglądarki."
 
-#: lib/phoenix_kit/integrations/validators.ex:616
+#: lib/phoenix_kit/integrations/validators.ex:797
 #, elixir-autogen, elixir-format
 msgid "Plan: %{entries}"
 msgstr "Plan: %{entries}"
@@ -11664,12 +11670,12 @@ msgstr "SMTP nie ma ustawień dostawcy na poziomie profilu — przekaźnik, port
 msgid "SMTP server rejected the connection"
 msgstr "Serwer SMTP odrzucił połączenie"
 
-#: lib/phoenix_kit/integrations/providers.ex:985
+#: lib/phoenix_kit/integrations/providers.ex:1057
 #, elixir-autogen, elixir-format
 msgid "STARTTLS — if offered"
 msgstr "STARTTLS — jeśli oferowane"
 
-#: lib/phoenix_kit/integrations/providers.ex:984
+#: lib/phoenix_kit/integrations/providers.ex:1056
 #, elixir-autogen, elixir-format
 msgid "STARTTLS — required"
 msgstr "STARTTLS — wymagane"
@@ -11689,7 +11695,7 @@ msgstr "Zapisz dane nadawcy"
 msgid "Select an integration..."
 msgstr "Wybierz integrację…"
 
-#: lib/phoenix_kit/integrations/providers.ex:1112
+#: lib/phoenix_kit/integrations/providers.ex:1184
 #, elixir-autogen, elixir-format
 msgid "Send **/newbot** and follow the prompts to name your bot"
 msgstr "Wyślij **/newbot** i podążaj za instrukcjami, aby nazwać bota"
@@ -11703,7 +11709,7 @@ msgstr "Wyślij **/newbot** i podążaj za instrukcjami, aby nazwać bota"
 msgid "Send Profiles"
 msgstr "Profile wysyłki"
 
-#: lib/phoenix_kit/integrations/providers.ex:1087
+#: lib/phoenix_kit/integrations/providers.ex:1159
 #, elixir-autogen, elixir-format
 msgid "Send messages and notifications via your own Telegram bot"
 msgstr "Wysyłaj wiadomości i powiadomienia przez własnego bota Telegram"
@@ -11793,13 +11799,13 @@ msgstr "Uzgadnianie TLS nie powiodło się"
 msgid "Tags"
 msgstr "Tagi"
 
-#: lib/phoenix_kit/integrations/providers.ex:1086
+#: lib/phoenix_kit/integrations/providers.ex:1158
 #: lib/phoenix_kit/notifications/channels/telegram.ex:36
 #, elixir-autogen, elixir-format
 msgid "Telegram"
 msgstr "Telegram"
 
-#: lib/phoenix_kit/integrations/validators.ex:701
+#: lib/phoenix_kit/integrations/validators.ex:882
 #, elixir-autogen, elixir-format
 msgid "Telegram error %{status}"
 msgstr "Błąd Telegrama %{status}"
@@ -11819,17 +11825,17 @@ msgstr "E-mail testowy z %{site}"
 msgid "Test email sent to %{recipient}"
 msgstr "E-mail testowy wysłany na %{recipient}"
 
-#: lib/phoenix_kit_web/users/session.ex:343
+#: lib/phoenix_kit_web/users/session.ex:345
 #, elixir-autogen, elixir-format
 msgid "That account is already in your session — switch to it instead."
 msgstr "To konto jest już w Twojej sesji — po prostu przełącz się na nie."
 
-#: lib/phoenix_kit_web/users/session.ex:337
+#: lib/phoenix_kit_web/users/session.ex:339
 #, elixir-autogen, elixir-format
 msgid "That account is deactivated."
 msgstr "To konto jest dezaktywowane."
 
-#: lib/phoenix_kit_web/users/session.ex:336
+#: lib/phoenix_kit_web/users/session.ex:338
 #, elixir-autogen, elixir-format
 msgid "That is already your account."
 msgstr "To już jest Twoje konto."
@@ -11870,7 +11876,7 @@ msgstr "Ten profil wysyłki zostanie trwale usunięty."
 msgid "This sender address cannot be logged"
 msgstr "Tego adresu nadawcy nie można zapisać w dzienniku"
 
-#: lib/phoenix_kit/integrations/providers.ex:1034
+#: lib/phoenix_kit/integrations/providers.ex:1106
 #, elixir-autogen, elixir-format
 msgid "Timeout (seconds)"
 msgstr "Limit czasu (sekundy)"
@@ -11880,7 +11886,7 @@ msgstr "Limit czasu (sekundy)"
 msgid "Transport"
 msgstr "Transport"
 
-#: lib/phoenix_kit/integrations/providers.ex:1012
+#: lib/phoenix_kit/integrations/providers.ex:1084
 #, elixir-autogen, elixir-format
 msgid "Turning verification off means the login travels to whoever answers, including an impostor. Use a CA certificate below instead whenever you can."
 msgstr "Wyłączenie weryfikacji oznacza, że dane logowania trafią do każdego, kto odpowie, także do oszusta. Gdy tylko możesz, użyj zamiast tego certyfikatu CA poniżej."
@@ -11910,12 +11916,12 @@ msgstr "Zaktualizuj profil wysyłki"
 msgid "Used when no default transactional integration is selected below."
 msgstr "Używane, gdy poniżej nie wybrano domyślnej integracji transakcyjnej."
 
-#: lib/phoenix_kit_web/users/session.ex:309
+#: lib/phoenix_kit_web/users/session.ex:311
 #, elixir-autogen, elixir-format
 msgid "User not found."
 msgstr "Nie znaleziono użytkownika."
 
-#: lib/phoenix_kit/integrations/providers.ex:1016
+#: lib/phoenix_kit/integrations/providers.ex:1088
 #, elixir-autogen, elixir-format
 msgid "Verify (default)"
 msgstr "Weryfikuj (domyślnie)"
@@ -11935,7 +11941,7 @@ msgstr "Integracje witryny"
 msgid "Where a freshly registered account lands. Empty = after-login path."
 msgstr "Gdzie trafia świeżo zarejestrowane konto. Puste = ścieżka po zalogowaniu."
 
-#: lib/phoenix_kit/integrations/providers.ex:996
+#: lib/phoenix_kit/integrations/providers.ex:1068
 #, elixir-autogen, elixir-format
 msgid "Whether to send the login at all. “If offered” follows the relay; “Never” is for relays that authenticate by IP."
 msgstr "Czy w ogóle wysyłać dane logowania. „Jeśli oferowane” zależy od przekaźnika; „Nigdy” dotyczy przekaźników uwierzytelniających po IP."
@@ -11950,12 +11956,12 @@ msgstr "Do kogo pisze ten bot?"
 msgid "Yesterday"
 msgstr "Wczoraj"
 
-#: lib/phoenix_kit_web/users/session.ex:320
+#: lib/phoenix_kit_web/users/session.ex:322
 #, elixir-autogen, elixir-format
 msgid "You are now signed in as %{email}."
 msgstr "Jesteś teraz zalogowany jako %{email}."
 
-#: lib/phoenix_kit_web/users/session.ex:329
+#: lib/phoenix_kit_web/users/session.ex:331
 #, elixir-autogen, elixir-format
 msgid "You do not have permission to sign in as another user."
 msgstr "Nie masz uprawnień, aby zalogować się jako inny użytkownik."
@@ -12071,7 +12077,7 @@ msgstr "Sprawdzanie…"
 msgid "Continue"
 msgstr "Kontynuuj"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:143
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:169
 #, elixir-autogen, elixir-format
 msgid "Copied!"
 msgstr "Skopiowano!"
@@ -12081,7 +12087,7 @@ msgstr "Skopiowano!"
 msgid "Couldn't reach hex.pm, so the package list is unavailable right now."
 msgstr "Nie udało się połączyć z hex.pm, więc lista pakietów jest teraz niedostępna."
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:119
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:145
 #, elixir-autogen, elixir-format
 msgid "Crawler Instructions"
 msgstr "Instrukcje dla robotów indeksujących"
@@ -12135,7 +12141,7 @@ msgstr "Witamy! Twój kod polecający został zaakceptowany."
 msgid "has the robots.txt line that points crawlers here."
 msgstr "zawiera wiersz robots.txt, który kieruje tu roboty indeksujące."
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:173
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:199
 #, elixir-autogen, elixir-format
 msgid "priv/static/robots.txt points crawlers at your sitemap."
 msgstr "priv/static/robots.txt kieruje roboty indeksujące do mapy witryny."
@@ -12239,17 +12245,17 @@ msgstr "Nie masz uprawnień do usunięcia tego użytkownika"
 msgid "You don't have permission to manage this user's credentials"
 msgstr "Nie masz uprawnień do zarządzania danymi logowania tego użytkownika"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:190
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:216
 #, elixir-autogen, elixir-format
 msgid "AI Discovery"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:698
+#: lib/phoenix_kit/integrations/providers.ex:699
 #, elixir-autogen, elixir-format
 msgid "AWS Bedrock LLMs via a Bedrock API key (OpenAI-compatible endpoint: gpt-oss models; the rest via native Converse)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:715
+#: lib/phoenix_kit/integrations/providers.ex:716
 #, elixir-autogen, elixir-format
 msgid "AWS console → Amazon Bedrock → API keys (long-term key)"
 msgstr ""
@@ -12264,22 +12270,22 @@ msgstr ""
 msgid "Account %{id}"
 msgstr "Konto"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:303
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:329
 #, elixir-autogen, elixir-format
 msgid "Advisory-grade: anything can send any User-Agent, so a scraper that lies passes through. Real enforcement belongs at your CDN or reverse proxy — this catches the honest-but-ignorant. Bots identified only by robots.txt tokens (Google-Extended, Applebot-Extended) crawl under their main user agent and are never matched here, so blocking AI training cannot 403 Googlebot."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:98
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:124
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Allowed"
 msgstr "Wszystkie"
 
-#: lib/phoenix_kit/integrations/providers.ex:696
+#: lib/phoenix_kit/integrations/providers.ex:697
 #, elixir-autogen, elixir-format
 msgid "Amazon Bedrock"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:282
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:308
 #, elixir-autogen, elixir-format
 msgid "Answer 403 to requests whose User-Agent matches a blocked group, for bots that ignore robots.txt."
 msgstr ""
@@ -12289,7 +12295,7 @@ msgstr ""
 msgid "Auth mail carries single-use tokens, and /dev/mailbox has no authentication — anyone who can reach this server can read them. Only for closed environments."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:711
+#: lib/phoenix_kit/integrations/providers.ex:712
 #, elixir-autogen, elixir-format
 msgid "Bedrock API key"
 msgstr ""
@@ -12299,7 +12305,7 @@ msgstr ""
 msgid "Bedrock error %{status}"
 msgstr "Błąd Brevo %{status}"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:280
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:306
 #, elixir-autogen, elixir-format
 msgid "Block at the application"
 msgstr ""
@@ -12309,7 +12315,7 @@ msgstr ""
 msgid "Blocked groups"
 msgstr "Zablokowany"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:77
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:103
 #, elixir-autogen, elixir-format
 msgid "Bot Access"
 msgstr ""
@@ -12324,12 +12330,12 @@ msgstr ""
 msgid "Control how search engines and AI bots crawl and index this site"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:739
+#: lib/phoenix_kit/integrations/providers.ex:740
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Copy the key (shown once, `ABSK…`) and paste it into the form above"
 msgstr "Skopiuj klucz (pokazywany raz) i wklej go do formularza powyżej"
 
-#: lib/phoenix_kit/integrations/providers.ex:815
+#: lib/phoenix_kit/integrations/providers.ex:816
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Copy the token and paste it into the form above"
 msgstr "Skopiuj klucz i wklej go do formularza powyżej"
@@ -12370,22 +12376,22 @@ msgstr ""
 msgid "Crawlers module is disabled. Enable it from the Modules page to configure settings."
 msgstr "Moduł SEO jest wyłączony. Włącz go na stronie Moduły, aby skonfigurować ustawienia."
 
-#: lib/phoenix_kit/integrations/providers.ex:731
+#: lib/phoenix_kit/integrations/providers.ex:732
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Create a Bedrock API key"
 msgstr "Utwórz klucz API"
 
-#: lib/phoenix_kit/integrations/providers.ex:807
+#: lib/phoenix_kit/integrations/providers.ex:808
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Create a token"
 msgstr "Utwórz rolę"
 
-#: lib/phoenix_kit/integrations/providers.ex:871
+#: lib/phoenix_kit/integrations/providers.ex:872
 #, elixir-autogen, elixir-format
 msgid "Create an IAM user with SES access"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:876
+#: lib/phoenix_kit/integrations/providers.ex:877
 #, elixir-autogen, elixir-format
 msgid "Create an access key for that user (Security credentials → Create access key) and paste the ID and secret above"
 msgstr ""
@@ -12400,41 +12406,42 @@ msgstr ""
 msgid "Deliver development mail to /dev/mailbox"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:747
+#: lib/phoenix_kit/integrations/providers.ex:748
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enable model access"
 msgstr "Włącz moduł, aby uzyskać dostęp do ustawień"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:278
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:304
 #, elixir-autogen, elixir-format
 msgid "Enforcement"
 msgstr ""
 
 #: lib/phoenix_kit_web/live/settings/crawlers.ex:90
-#: lib/phoenix_kit_web/live/settings/crawlers.ex:109
-#: lib/phoenix_kit_web/live/settings/crawlers.ex:120
-#: lib/phoenix_kit_web/live/settings/crawlers.ex:136
-#: lib/phoenix_kit_web/live/settings/crawlers.ex:149
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:102
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:121
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:132
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:148
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:161
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to update crawler settings"
 msgstr "Nie udało się zaktualizować ustawienia"
 
-#: lib/phoenix_kit/integrations/providers.ex:780
+#: lib/phoenix_kit/integrations/providers.ex:781
 #, elixir-autogen, elixir-format, fuzzy
 msgid "GitHub"
 msgstr "Logowanie przez GitHuba"
 
-#: lib/phoenix_kit/integrations/providers.ex:782
+#: lib/phoenix_kit/integrations/providers.ex:783
 #, elixir-autogen, elixir-format
 msgid "GitHub API token — org statistics, repositories (read-only is enough)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:809
+#: lib/phoenix_kit/integrations/providers.ex:810
 #, elixir-autogen, elixir-format
 msgid "Go to [Fine-grained tokens](https://github.com/settings/personal-access-tokens) and click **Generate new token**"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:81
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:107
 #, elixir-autogen, elixir-format
 msgid "Grouped by why they visit. Blocking a group writes it into the generated robots.txt below; everything defaults to allowed."
 msgstr ""
@@ -12444,22 +12451,22 @@ msgstr ""
 msgid "Hide titles of records the reader can't open"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:749
+#: lib/phoenix_kit/integrations/providers.ex:750
 #, elixir-autogen, elixir-format
 msgid "In [Bedrock → Model access](https://console.aws.amazon.com/bedrock/home#/modelaccess) enable the models you plan to call — a key with no enabled models validates but cannot complete"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:763
+#: lib/phoenix_kit/integrations/providers.ex:764
 #, elixir-autogen, elixir-format
 msgid "In the AI module, create an endpoint pointing at this connection with a `gpt-oss` model and a base URL in the SAME region as this key"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:873
+#: lib/phoenix_kit/integrations/providers.ex:874
 #, elixir-autogen, elixir-format
 msgid "In the [IAM console](https://console.aws.amazon.com/iam/home#/users) create a user for programmatic access and attach an SES policy (least privilege: `ses:SendEmail`/`ses:SendRawEmail`; docs: [SES setup](https://docs.aws.amazon.com/ses/latest/dg/setting-up.html))"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:884
+#: lib/phoenix_kit/integrations/providers.ex:885
 #, elixir-autogen, elixir-format
 msgid "In the [SES console](https://console.aws.amazon.com/ses/home#/identities) verify your domain or sender address — SES refuses to send from unverified identities"
 msgstr ""
@@ -12504,7 +12511,7 @@ msgstr ""
 msgid "Model catalog in %{region}: %{count} (grants are configured separately)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:887
+#: lib/phoenix_kit/integrations/providers.ex:888
 #, elixir-autogen, elixir-format
 msgid "New accounts start in the SES sandbox (verified recipients only) — [request production access](https://docs.aws.amazon.com/ses/latest/dg/request-production-access.html) before real sending"
 msgstr ""
@@ -12519,7 +12526,7 @@ msgstr ""
 msgid "No longer available"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:165
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:191
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No priv/static/robots.txt found. Without one, crawlers assume everything is allowed — and any groups you blocked above are not being told."
 msgstr "Nie znaleziono pliku priv/static/robots.txt. Bez niego roboty indeksujące zakładają, że wszystko jest dozwolone — zwykle to nie problem, ale nie dowiedzą się, gdzie jest mapa witryny."
@@ -12534,47 +12541,47 @@ msgstr ""
 msgid "Note (optional)"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:733
+#: lib/phoenix_kit/integrations/providers.ex:734
 #, elixir-autogen, elixir-format
 msgid "Open the [Bedrock console → API keys](https://console.aws.amazon.com/bedrock/home#/api-keys) and generate a **long-term** key (docs: [Bedrock API keys](https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys.html))"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:212
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:238
 #, elixir-autogen, elixir-format
 msgid "Optional markdown: a summary paragraph, key links, docs pointers…"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:736
+#: lib/phoenix_kit/integrations/providers.ex:737
 #, elixir-autogen, elixir-format
 msgid "Or attach one to an existing IAM user: [IAM console](https://console.aws.amazon.com/iam/home#/users) → user → Security credentials → Bedrock API keys"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:235
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:261
 #, elixir-autogen, elixir-format
 msgid "Paste the verification content Google Search Console or Bing Webmaster Tools gives you — the meta tags are added to every layout head. Pasting the whole <meta> tag also works; the content value is extracted."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:796
+#: lib/phoenix_kit/integrations/providers.ex:797
 #, elixir-autogen, elixir-format
 msgid "Personal access token"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:123
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:149
 #, elixir-autogen, elixir-format
 msgid "PhoenixKit does not serve this file — it is yours, served from priv/static before any route is consulted. This is the complete file your toggles above describe: paste it into priv/static/robots.txt."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:752
+#: lib/phoenix_kit/integrations/providers.ex:753
 #, elixir-autogen, elixir-format
 msgid "Pick the region where access was granted; the AI endpoint's base URL must use the same region"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:217
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:243
 #, elixir-autogen, elixir-format
 msgid "Preview of the served file:"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:812
+#: lib/phoenix_kit/integrations/providers.ex:813
 #, elixir-autogen, elixir-format
 msgid "Repository access: **Public repositories (read-only)** — no extra permissions needed for public-org statistics"
 msgstr ""
@@ -12584,7 +12591,7 @@ msgstr ""
 msgid "Request access"
 msgstr "Zażądano"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:233
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:259
 #, elixir-autogen, elixir-format
 msgid "Search engine verification"
 msgstr ""
@@ -12604,12 +12611,12 @@ msgstr "Oczekujące"
 msgid "Sign in to request access."
 msgstr "Zaloguj się jako użytkownik"
 
-#: lib/phoenix_kit/integrations/providers.ex:760
+#: lib/phoenix_kit/integrations/providers.ex:761
 #, elixir-autogen, elixir-format
 msgid "The OpenAI-compatible endpoint (`…/openai/v1`) currently serves only the `openai.gpt-oss-*` models — Anthropic and the other Bedrock models answer on the native Converse API with the same key"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:742
+#: lib/phoenix_kit/integrations/providers.ex:743
 #, elixir-autogen, elixir-format
 msgid "The key's IAM identity must allow the `bedrock:CallWithBearerToken` action — without it every Bearer call answers 403 even when invoke permissions are in place."
 msgstr ""
@@ -12619,17 +12626,17 @@ msgstr ""
 msgid "The mailbox is off: outgoing mail is written to the server log instead."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:179
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:205
 #, elixir-autogen, elixir-format, fuzzy
 msgid "The noindex toggle and robots.txt are separate mechanisms: noindex is a per-page meta tag that tells crawlers not to index what they fetched, while robots.txt tells them what not to fetch at all. A staging site usually wants both."
 msgstr "Przełącznik noindex powyżej i robots.txt to osobne mechanizmy: noindex to metatag na stronie, który mówi robotom, by nie indeksowały tego, co pobrały, a robots.txt mówi im, czego w ogóle nie pobierać. Środowisko testowe zwykle potrzebuje obu."
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:194
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:220
 #, elixir-autogen, elixir-format
 msgid "The other half of bot policy: a markdown summary telling AI assistants what this site is about, served at"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:892
+#: lib/phoenix_kit/integrations/providers.ex:893
 #, elixir-autogen, elixir-format
 msgid "This connection stores the credential. The full sending pipeline — configuration set, SNS topic, SQS event queue, delivery tracking — is configured in Admin → Settings → Emails, which can select this connection as its credential source."
 msgstr ""
@@ -12646,22 +12653,22 @@ msgstr ""
 msgid "Unread · %{day}"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:758
+#: lib/phoenix_kit/integrations/providers.ex:759
 #, elixir-autogen, elixir-format
 msgid "Use it from the AI module"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:231
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:257
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Verification"
 msgstr "Powiadomienia"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.ex:133
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:145
 #, elixir-autogen, elixir-format
 msgid "Verification tags saved."
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:882
+#: lib/phoenix_kit/integrations/providers.ex:883
 #, elixir-autogen, elixir-format
 msgid "Verify a sender in SES"
 msgstr ""
@@ -12676,7 +12683,7 @@ msgstr ""
 msgid "Where development mail goes while the resolved transport is the local adapter."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:79
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "Who may crawl this site"
 msgstr ""
@@ -12696,12 +12703,12 @@ msgstr ""
 msgid "You don't have access — click to request it"
 msgstr ""
 
-#: lib/phoenix_kit/integrations/providers.ex:800
+#: lib/phoenix_kit/integrations/providers.ex:801
 #, elixir-autogen, elixir-format
 msgid "github.com/settings/personal-access-tokens — fine-grained, read-only"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.ex:146
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:158
 #, elixir-autogen, elixir-format
 msgid "llms.txt content saved."
 msgstr ""
@@ -12711,7 +12718,7 @@ msgstr ""
 msgid "management API: %{services}"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:169
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:195
 #, elixir-autogen, elixir-format, fuzzy
 msgid "priv/static/robots.txt exists but has no Sitemap: line. Paste the file above so crawlers are told where to look."
 msgstr "Plik priv/static/robots.txt istnieje, ale nie zawiera wiersza Sitemap:. Dodaj powyższy wiersz, aby roboty wiedziały, gdzie szukać."
@@ -12721,7 +12728,7 @@ msgstr "Plik priv/static/robots.txt istnieje, ale nie zawiera wiersza Sitemap:. 
 msgid "private item"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:200
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:226
 #, elixir-autogen, elixir-format
 msgid "while this module is enabled. The heading comes from your project title; everything below it is yours."
 msgstr ""
@@ -12775,7 +12782,7 @@ msgstr "Wybierz audio"
 msgid "Select Avatar"
 msgstr "Wybierz awatar"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:701
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:716
 #, elixir-autogen, elixir-format
 msgid "Select Background Image"
 msgstr "Wybierz obraz tła"
@@ -12792,7 +12799,7 @@ msgstr "Wybierz obrazy"
 
 #: lib/phoenix_kit_web/components/media_browser.html.heex:2469
 #: lib/phoenix_kit_web/live/settings.html.heex:636
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:702
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:717
 #, elixir-autogen, elixir-format
 msgid "Select Logo"
 msgstr "Wybierz logo"
@@ -12891,3 +12898,422 @@ msgstr "Szyfrowanie danych integracji wymaga uwagi"
 #, elixir-autogen, elixir-format
 msgid "The current encryption status could not be described by this admin page — it may be newer than what this page recognizes. Check PhoenixKit.Integrations.Encryption.status/0 directly."
 msgstr "Bieżącego stanu szyfrowania nie można opisać na tej stronie administracyjnej — może być nowszy niż rozpoznaje ta strona. Sprawdź bezpośrednio PhoenixKit.Integrations.Encryption.status/0."
+
+#: lib/phoenix_kit_web/live/settings/authorization.ex:247
+#, elixir-autogen, elixir-format
+msgid "A secret is already configured — leave blank to keep the current value"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:365
+#: lib/phoenix_kit_web/users/session.ex:245
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Account added."
+msgstr "Konto"
+
+#: lib/phoenix_kit_web/users/session.ex:27
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Account created successfully!"
+msgstr "Zasobnik został włączony"
+
+#: lib/phoenix_kit_web/users/session.ex:356
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Account removed."
+msgstr "Konto"
+
+#: lib/phoenix_kit_web/users/oauth.ex:272
+#, elixir-autogen, elixir-format
+msgid "Account switching is currently disabled."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:316
+#, elixir-autogen, elixir-format
+msgid "An account already exists for that email address. Sign in with your password first, then connect this provider from your account settings."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:328
+#, elixir-autogen, elixir-format
+msgid "Authentication failed. Please try again or use a different sign-in method."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:355
+#: lib/phoenix_kit_web/users/oauth.ex:438
+#: lib/phoenix_kit_web/users/oauth.ex:444
+#, elixir-autogen, elixir-format
+msgid "Authentication failed. Please try again."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:299
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Authentication failed: %{errors}"
+msgstr "Uwierzytelnianie"
+
+#: lib/phoenix_kit_web/users/oauth.ex:441
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Authentication failed: %{message}"
+msgstr "Uwierzytelnianie"
+
+#: lib/phoenix_kit_web/users/session.ex:360
+#, elixir-autogen, elixir-format
+msgid "Cannot remove your primary account."
+msgstr ""
+
+#: lib/phoenix_kit_web/controllers/context_controller.ex:101
+#, elixir-autogen, elixir-format
+msgid "Context switching is not enabled"
+msgstr ""
+
+#: lib/phoenix_kit/integrations/validators.ex:627
+#: lib/phoenix_kit/integrations/validators.ex:634
+#: lib/phoenix_kit/integrations/validators.ex:732
+#: lib/phoenix_kit/integrations/validators.ex:740
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Could not reach the storage endpoint"
+msgstr "Nie udało się połączyć z usługą"
+
+#: lib/phoenix_kit_web/users/session.ex:365
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Could not remove account."
+msgstr "Nie udało się połączyć z Brevo"
+
+#: lib/phoenix_kit_web/users/session.ex:274
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Could not switch account."
+msgstr "Nie udało się odłączyć czatów"
+
+#: lib/phoenix_kit/integrations/validators.ex:721
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Credentials are valid, but not authorized to list buckets"
+msgstr "Dane logowania są prawidłowe, ale brak uprawnienia do GetSendQuota — wysyłka nie została sprawdzona"
+
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:85
+#, elixir-autogen, elixir-format
+msgid "Exempt"
+msgstr ""
+
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:86
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Follows noindex"
+msgstr "Obserwowani"
+
+#: lib/phoenix_kit_web/users/magic_link.ex:120
+#, elixir-autogen, elixir-format
+msgid "If that email address exists, a magic link has been sent."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/confirmation_instructions.ex:89
+#, elixir-autogen, elixir-format
+msgid "If your email is in our system and it has not been confirmed yet, you will receive an email with instructions shortly."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/forgot_password.ex:49
+#, elixir-autogen, elixir-format
+msgid "If your email is in our system, you will receive instructions to reset your password shortly."
+msgstr ""
+
+#: lib/phoenix_kit_web/controllers/context_controller.ex:82
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Invalid context"
+msgstr "Nieprawidłowy token bota"
+
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:110
+#, elixir-autogen, elixir-format
+msgid "Invalid email format"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/session.ex:92
+#, elixir-autogen, elixir-format
+msgid "Invalid email/username or password"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/session.ex:259
+#, elixir-autogen, elixir-format
+msgid "Invalid email/username or password."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_verify.ex:40
+#, elixir-autogen, elixir-format
+msgid "Invalid magic link. Please request a new one."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration_verify.ex:32
+#, elixir-autogen, elixir-format
+msgid "Invalid registration link. Please request a new one."
+msgstr ""
+
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:77
+#, elixir-autogen, elixir-format
+msgid "Keep publishing the sitemap's real URLs even while noindex is on, so the feed can be verified without exposing the site to indexing. The noindex meta tag above is unaffected either way."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/session.ex:104
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Logged out of all accounts."
+msgstr "Wyloguj się ze wszystkich kont"
+
+#: lib/phoenix_kit_web/users/session.ex:122
+#: lib/phoenix_kit_web/users/session.ex:235
+#, elixir-autogen, elixir-format
+msgid "Logged out successfully."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_verify.ex:63
+#, elixir-autogen, elixir-format
+msgid "Magic link is invalid or has expired. Please request a new one."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration.ex:41
+#, elixir-autogen, elixir-format
+msgid "Magic link registration is currently disabled."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link.ex:110
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Magic link sent! Check your email."
+msgstr "Magiczny link wysłany!"
+
+#: lib/phoenix_kit_web/users/magic_link.ex:39
+#: lib/phoenix_kit_web/users/magic_link_verify.ex:33
+#, elixir-autogen, elixir-format
+msgid "Magic link sign-in is currently disabled."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:370
+#: lib/phoenix_kit_web/users/session.ex:249
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Maximum number of accounts reached."
+msgstr "Osiągnięto maksymalną liczbę kont — najpierw usuń jedno."
+
+#: lib/phoenix_kit_web/users/session.ex:137
+#, elixir-autogen, elixir-format
+msgid "Multi-account switching is not available."
+msgstr ""
+
+#: lib/phoenix_kit/integrations/providers.ex:950
+#, elixir-autogen, elixir-format
+msgid "Not every S3-compatible provider needs one — leave blank if the endpoint doesn't require it."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:119
+#, elixir-autogen, elixir-format
+msgid "OAuth authentication is currently disabled. Please contact your administrator to enable it."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:94
+#, elixir-autogen, elixir-format
+msgid "OAuth provider '%{provider}' is currently disabled."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:106
+#, elixir-autogen, elixir-format
+msgid "OAuth provider '%{provider}' is not configured. Please contact your administrator."
+msgstr ""
+
+#: lib/phoenix_kit/integrations/providers.ex:913
+#, elixir-autogen, elixir-format
+msgid "Object Storage (S3-compatible)"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/reset_password.ex:41
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Password reset successfully."
+msgstr "Hasło zostało zmienione."
+
+#: lib/phoenix_kit_web/users/session.ex:34
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Password updated successfully!"
+msgstr "Hasło zostało zmienione."
+
+#: lib/phoenix_kit_web/users/magic_link_registration.ex:35
+#: lib/phoenix_kit_web/users/registration.ex:128
+#, elixir-autogen, elixir-format
+msgid "Registration is currently disabled."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration.ex:92
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Registration link is invalid or has expired."
+msgstr "Link zmiany adresu e-mail jest nieprawidłowy lub wygasł."
+
+#: lib/phoenix_kit_web/users/magic_link_registration.ex:188
+#: lib/phoenix_kit_web/users/magic_link_registration_verify.ex:24
+#, elixir-autogen, elixir-format
+msgid "Registration link is invalid or has expired. Please request a new one."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:92
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:103
+#, elixir-autogen, elixir-format
+msgid "Registration link sent! Check your email."
+msgstr ""
+
+#: lib/phoenix_kit/integrations/providers.ex:962
+#, elixir-autogen, elixir-format
+msgid "Required for Cloudflare R2, Backblaze B2, Tigris, and self-hosted S3-compatible storage. Leave blank for AWS S3."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/reset_password.ex:59
+#, elixir-autogen, elixir-format
+msgid "Reset password link is invalid or it has expired."
+msgstr ""
+
+#: lib/phoenix_kit/integrations/providers.ex:915
+#, elixir-autogen, elixir-format
+msgid "S3-compatible object storage — AWS S3, Cloudflare R2, Backblaze B2, Tigris, or a self-hosted endpoint"
+msgstr ""
+
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:75
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Sitemap Exemption"
+msgstr "Ustawienia mapy witryny"
+
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:144
+#, elixir-autogen, elixir-format
+msgid "Something went wrong"
+msgstr ""
+
+#: lib/phoenix_kit/integrations/validators.ex:735
+#, elixir-autogen, elixir-format
+msgid "Storage error: %{code}"
+msgstr ""
+
+#: lib/phoenix_kit/integrations/validators.ex:729
+#, elixir-autogen, elixir-format
+msgid "Storage service is busy — try again in a moment"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_verify.ex:56
+#, elixir-autogen, elixir-format
+msgid "Successfully logged in with magic link!"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:277
+#, elixir-autogen, elixir-format
+msgid "Successfully signed in with %{provider}!"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:375
+#: lib/phoenix_kit_web/users/session.ex:254
+#, elixir-autogen, elixir-format, fuzzy
+msgid "That account is already in your session."
+msgstr "To konto jest już w Twojej sesji — po prostu przełącz się na nie."
+
+#: lib/phoenix_kit_web/users/oauth.ex:380
+#, elixir-autogen, elixir-format, fuzzy
+msgid "That account is inactive."
+msgstr "To konto jest dezaktywowane."
+
+#: lib/phoenix_kit_web/users/magic_link_registration.ex:185
+#, elixir-autogen, elixir-format
+msgid "That email is already registered. Please log in instead."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:118
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Too many attempts"
+msgstr "Zbyt wiele plików"
+
+#: lib/phoenix_kit_web/users/session.ex:84
+#, elixir-autogen, elixir-format
+msgid "Too many login attempts. Please try again later."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:84
+#: lib/phoenix_kit_web/users/oauth.ex:210
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Unknown OAuth provider: %{provider}"
+msgstr "Nieznany dostawca"
+
+#: lib/phoenix_kit_web/users/confirmation.ex:68
+#, elixir-autogen, elixir-format
+msgid "User confirmation link is invalid or it has expired."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/confirmation.ex:50
+#, elixir-autogen, elixir-format, fuzzy
+msgid "User confirmed successfully."
+msgstr "Użytkownik został aktywowany"
+
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:77
+#, elixir-autogen, elixir-format
+msgid "User registration is currently disabled."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:51
+#: lib/phoenix_kit_web/users/registration.ex:110
+#, elixir-autogen, elixir-format
+msgid "User registration is currently disabled. Please contact an administrator."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/session.ex:40
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Welcome back!"
+msgstr "Witamy ponownie"
+
+#: lib/phoenix_kit_web/users/session.ex:66
+#, elixir-autogen, elixir-format
+msgid "Your account is currently inactive. Please contact the team if you believe this is an error."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:1873
+#, elixir-autogen, elixir-format
+msgid "%{label} module is not enabled"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:2366
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Enter your referral code to continue."
+msgstr "Wpisz swój kod polecający"
+
+#: lib/phoenix_kit_web/users/auth.ex:2362
+#, elixir-autogen, elixir-format
+msgid "Please confirm your email before accessing the application."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:111
+#, elixir-autogen, elixir-format
+msgid "This account is not active. Contact an administrator."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:749
+#: lib/phoenix_kit_web/users/auth.ex:1892
+#: lib/phoenix_kit_web/users/auth.ex:2511
+#, elixir-autogen, elixir-format, fuzzy
+msgid "You do not have permission to access this section."
+msgstr "Nie masz uprawnień, aby zalogować się jako inny użytkownik."
+
+#: lib/phoenix_kit_web/users/auth.ex:724
+#: lib/phoenix_kit_web/users/auth.ex:878
+#: lib/phoenix_kit_web/users/auth.ex:2460
+#: lib/phoenix_kit_web/users/auth.ex:2496
+#, elixir-autogen, elixir-format, fuzzy
+msgid "You do not have the required permission to access this page."
+msgstr "Nie masz uprawnień, aby zalogować się jako inny użytkownik."
+
+#: lib/phoenix_kit_web/users/auth.ex:1417
+#, elixir-autogen, elixir-format
+msgid "You must be an admin to access this page."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:679
+#: lib/phoenix_kit_web/users/auth.ex:2423
+#, elixir-autogen, elixir-format
+msgid "You must be an owner to access this page."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:2539
+#, elixir-autogen, elixir-format
+msgid "You must have the %{role_name} role to access this page."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:903
+#: lib/phoenix_kit_web/users/auth.ex:2292
+#: lib/phoenix_kit_web/users/auth.ex:2329
+#: lib/phoenix_kit_web/users/auth.ex:2467
+#, elixir-autogen, elixir-format
+msgid "You must log in to access this page."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:1428
+#, elixir-autogen, elixir-format
+msgid "You no longer have permission to access this section."
+msgstr ""

--- a/priv/gettext/pl/LC_MESSAGES/default.po
+++ b/priv/gettext/pl/LC_MESSAGES/default.po
@@ -12906,19 +12906,19 @@ msgstr ""
 
 #: lib/phoenix_kit_web/users/oauth.ex:365
 #: lib/phoenix_kit_web/users/session.ex:245
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Account added."
-msgstr "Konto"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:27
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Account created successfully!"
-msgstr "Zasobnik został włączony"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:356
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Account removed."
-msgstr "Konto"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/oauth.ex:272
 #, elixir-autogen, elixir-format
@@ -12943,14 +12943,14 @@ msgid "Authentication failed. Please try again."
 msgstr ""
 
 #: lib/phoenix_kit_web/users/oauth.ex:299
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Authentication failed: %{errors}"
-msgstr "Uwierzytelnianie"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/oauth.ex:441
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Authentication failed: %{message}"
-msgstr "Uwierzytelnianie"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:360
 #, elixir-autogen, elixir-format
@@ -12966,24 +12966,24 @@ msgstr ""
 #: lib/phoenix_kit/integrations/validators.ex:634
 #: lib/phoenix_kit/integrations/validators.ex:732
 #: lib/phoenix_kit/integrations/validators.ex:740
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Could not reach the storage endpoint"
-msgstr "Nie udało się połączyć z usługą"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:365
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Could not remove account."
-msgstr "Nie udało się połączyć z Brevo"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:274
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Could not switch account."
-msgstr "Nie udało się odłączyć czatów"
+msgstr ""
 
 #: lib/phoenix_kit/integrations/validators.ex:721
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Credentials are valid, but not authorized to list buckets"
-msgstr "Dane logowania są prawidłowe, ale brak uprawnienia do GetSendQuota — wysyłka nie została sprawdzona"
+msgstr ""
 
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:85
 #, elixir-autogen, elixir-format
@@ -12991,9 +12991,9 @@ msgid "Exempt"
 msgstr ""
 
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:86
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Follows noindex"
-msgstr "Obserwowani"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link.ex:120
 #, elixir-autogen, elixir-format
@@ -13011,9 +13011,9 @@ msgid "If your email is in our system, you will receive instructions to reset yo
 msgstr ""
 
 #: lib/phoenix_kit_web/controllers/context_controller.ex:82
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Invalid context"
-msgstr "Nieprawidłowy token bota"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link_registration_request.ex:110
 #, elixir-autogen, elixir-format
@@ -13046,9 +13046,9 @@ msgid "Keep publishing the sitemap's real URLs even while noindex is on, so the 
 msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:104
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Logged out of all accounts."
-msgstr "Wyloguj się ze wszystkich kont"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:122
 #: lib/phoenix_kit_web/users/session.ex:235
@@ -13067,9 +13067,9 @@ msgid "Magic link registration is currently disabled."
 msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link.ex:110
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Magic link sent! Check your email."
-msgstr "Magiczny link wysłany!"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link.ex:39
 #: lib/phoenix_kit_web/users/magic_link_verify.ex:33
@@ -13079,9 +13079,9 @@ msgstr ""
 
 #: lib/phoenix_kit_web/users/oauth.ex:370
 #: lib/phoenix_kit_web/users/session.ex:249
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Maximum number of accounts reached."
-msgstr "Osiągnięto maksymalną liczbę kont — najpierw usuń jedno."
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:137
 #, elixir-autogen, elixir-format
@@ -13114,14 +13114,14 @@ msgid "Object Storage (S3-compatible)"
 msgstr ""
 
 #: lib/phoenix_kit_web/users/reset_password.ex:41
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Password reset successfully."
-msgstr "Hasło zostało zmienione."
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:34
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Password updated successfully!"
-msgstr "Hasło zostało zmienione."
+msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link_registration.ex:35
 #: lib/phoenix_kit_web/users/registration.ex:128
@@ -13130,9 +13130,9 @@ msgid "Registration is currently disabled."
 msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link_registration.ex:92
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Registration link is invalid or has expired."
-msgstr "Link zmiany adresu e-mail jest nieprawidłowy lub wygasł."
+msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link_registration.ex:188
 #: lib/phoenix_kit_web/users/magic_link_registration_verify.ex:24
@@ -13162,9 +13162,9 @@ msgid "S3-compatible object storage — AWS S3, Cloudflare R2, Backblaze B2, Tig
 msgstr ""
 
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:75
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Sitemap Exemption"
-msgstr "Ustawienia mapy witryny"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link_registration_request.ex:144
 #, elixir-autogen, elixir-format
@@ -13193,14 +13193,14 @@ msgstr ""
 
 #: lib/phoenix_kit_web/users/oauth.ex:375
 #: lib/phoenix_kit_web/users/session.ex:254
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "That account is already in your session."
-msgstr "To konto jest już w Twojej sesji — po prostu przełącz się na nie."
+msgstr ""
 
 #: lib/phoenix_kit_web/users/oauth.ex:380
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "That account is inactive."
-msgstr "To konto jest dezaktywowane."
+msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link_registration.ex:185
 #, elixir-autogen, elixir-format
@@ -13208,9 +13208,9 @@ msgid "That email is already registered. Please log in instead."
 msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link_registration_request.ex:118
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Too many attempts"
-msgstr "Zbyt wiele plików"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:84
 #, elixir-autogen, elixir-format
@@ -13219,9 +13219,9 @@ msgstr ""
 
 #: lib/phoenix_kit_web/users/oauth.ex:84
 #: lib/phoenix_kit_web/users/oauth.ex:210
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Unknown OAuth provider: %{provider}"
-msgstr "Nieznany dostawca"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/confirmation.ex:68
 #, elixir-autogen, elixir-format
@@ -13229,9 +13229,9 @@ msgid "User confirmation link is invalid or it has expired."
 msgstr ""
 
 #: lib/phoenix_kit_web/users/confirmation.ex:50
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "User confirmed successfully."
-msgstr "Użytkownik został aktywowany"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link_registration_request.ex:77
 #, elixir-autogen, elixir-format
@@ -13245,9 +13245,9 @@ msgid "User registration is currently disabled. Please contact an administrator.
 msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:40
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Welcome back!"
-msgstr "Witamy ponownie"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:66
 #, elixir-autogen, elixir-format
@@ -13260,9 +13260,9 @@ msgid "%{label} module is not enabled"
 msgstr ""
 
 #: lib/phoenix_kit_web/users/auth.ex:2366
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Enter your referral code to continue."
-msgstr "Wpisz swój kod polecający"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/auth.ex:2362
 #, elixir-autogen, elixir-format
@@ -13277,17 +13277,17 @@ msgstr ""
 #: lib/phoenix_kit_web/users/auth.ex:749
 #: lib/phoenix_kit_web/users/auth.ex:1892
 #: lib/phoenix_kit_web/users/auth.ex:2511
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "You do not have permission to access this section."
-msgstr "Nie masz uprawnień, aby zalogować się jako inny użytkownik."
+msgstr ""
 
 #: lib/phoenix_kit_web/users/auth.ex:724
 #: lib/phoenix_kit_web/users/auth.ex:878
 #: lib/phoenix_kit_web/users/auth.ex:2460
 #: lib/phoenix_kit_web/users/auth.ex:2496
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "You do not have the required permission to access this page."
-msgstr "Nie masz uprawnień, aby zalogować się jako inny użytkownik."
+msgstr ""
 
 #: lib/phoenix_kit_web/users/auth.ex:1417
 #, elixir-autogen, elixir-format

--- a/priv/gettext/pl/LC_MESSAGES/phoenix_kit.po
+++ b/priv/gettext/pl/LC_MESSAGES/phoenix_kit.po
@@ -21,27 +21,27 @@ msgstr "Dla tego adresu e-mail istnieje już oczekujące zaproszenie"
 msgid "This user already belongs to an organization"
 msgstr "Ten użytkownik już należy do organizacji"
 
-#: lib/phoenix_kit/users/auth.ex:1064
+#: lib/phoenix_kit/users/auth.ex:1074
 #, elixir-autogen, elixir-format
 msgid "cannot change to person while organization has members"
 msgstr "nie można zmienić na osobę, dopóki organizacja ma członków"
 
-#: lib/phoenix_kit/users/auth.ex:1044
+#: lib/phoenix_kit/users/auth.ex:1054
 #, elixir-autogen, elixir-format
 msgid "cannot reference self"
 msgstr "nie może odnosić się do siebie"
 
-#: lib/phoenix_kit/users/auth.ex:1052
+#: lib/phoenix_kit/users/auth.ex:1062
 #, elixir-autogen, elixir-format
 msgid "only person accounts can join an organization"
 msgstr "tylko konta osób mogą dołączyć do organizacji"
 
-#: lib/phoenix_kit/users/auth.ex:1039
+#: lib/phoenix_kit/users/auth.ex:1049
 #, elixir-autogen, elixir-format
 msgid "organization not found"
 msgstr "nie znaleziono organizacji"
 
-#: lib/phoenix_kit/users/auth.ex:1038
+#: lib/phoenix_kit/users/auth.ex:1048
 #, elixir-autogen, elixir-format
 msgid "target user is not an organization"
 msgstr "użytkownik docelowy nie jest organizacją"

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -70,7 +70,7 @@ msgstr "Управление ролями"
 
 #: lib/phoenix_kit/dashboard/admin_tabs.ex:119
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:138
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:647
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:662
 #: lib/phoenix_kit_web/live/settings/users.html.heex:130
 #, elixir-autogen
 msgid "Sessions"
@@ -237,7 +237,7 @@ msgstr "Соединения в реальном времени"
 
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:320
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:64
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:144
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:140
 #, elixir-autogen
 msgid "Anonymous"
 msgstr "Анонимные"
@@ -250,7 +250,7 @@ msgstr "Незарегистрированные посетители"
 
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:331
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:77
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:151
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:144
 #, elixir-autogen
 msgid "Authenticated"
 msgstr "Аутентифицированные"
@@ -347,7 +347,7 @@ msgstr "Стандартный уровень доступа"
 msgid "Role System"
 msgstr "Система ролей"
 
-#: lib/phoenix_kit/integrations/providers.ex:991
+#: lib/phoenix_kit/integrations/providers.ex:1063
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:450
 #, elixir-autogen
 msgid "Authentication"
@@ -359,7 +359,7 @@ msgstr "Аутентификация"
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:445
 #: lib/phoenix_kit_web/live/modules.html.heex:65
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:114
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:273
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:267
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:145
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:297
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:682
@@ -466,8 +466,8 @@ msgstr "О правах доступа"
 msgid "Accept All"
 msgstr "Принять все"
 
-#: lib/phoenix_kit/integrations/integrations.ex:1133
-#: lib/phoenix_kit/integrations/validators.ex:598
+#: lib/phoenix_kit/integrations/integrations.ex:1136
+#: lib/phoenix_kit/integrations/validators.ex:779
 #: lib/phoenix_kit_web/live/activity/index.ex:66
 #: lib/phoenix_kit_web/live/activity/show.ex:56
 #, elixir-autogen, elixir-format
@@ -505,7 +505,7 @@ msgid "Actions"
 msgstr "Действия"
 
 #: lib/phoenix_kit_web/components/media_gallery.html.heex:86
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:585
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:600
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:266
 #: lib/phoenix_kit_web/live/settings/users.html.heex:693
 #: lib/phoenix_kit_web/users/user_form.html.heex:719
@@ -613,7 +613,7 @@ msgstr "Основная информация"
 msgid "Billing profiles and payment methods"
 msgstr "Профили выставления счетов и способы оплаты"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:98
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:124
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:501
 #, elixir-autogen, elixir-format
 msgid "Blocked"
@@ -1553,7 +1553,7 @@ msgstr "Страница успешно создана"
 msgid "Page published successfully"
 msgstr "Страница успешно опубликована"
 
-#: lib/phoenix_kit/integrations/providers.ex:956
+#: lib/phoenix_kit/integrations/providers.ex:1028
 #: lib/phoenix_kit_web/components/user_dashboard_nav.ex:277
 #: lib/phoenix_kit_web/users/login.html.heex:39
 #: lib/phoenix_kit_web/users/magic_link_registration.html.heex:42
@@ -1814,8 +1814,8 @@ msgstr "SWIFT/BIC"
 #: lib/phoenix_kit_web/components/core/markdown_editor.ex:440
 #: lib/phoenix_kit_web/components/media_browser.html.heex:1349
 #: lib/phoenix_kit_web/live/notifications/settings.ex:436
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:219
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:267
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:245
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:293
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr "Сохранить"
@@ -1858,7 +1858,7 @@ msgstr "Сохранено"
 #: lib/phoenix_kit_web/components/core/markdown_editor.ex:333
 #: lib/phoenix_kit_web/components/core/markdown_editor.ex:417
 #: lib/phoenix_kit_web/live/settings.html.heex:592
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:683
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:698
 #: lib/phoenix_kit_web/live/settings/users.html.heex:546
 #, elixir-autogen, elixir-format
 msgid "Saving..."
@@ -1946,7 +1946,7 @@ msgstr "Регион/Область"
 #: lib/phoenix_kit_web/live/settings/users.html.heex:367
 #: lib/phoenix_kit_web/live/settings/users.html.heex:408
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:114
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:199
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:193
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:247
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:294
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:650
@@ -2053,7 +2053,7 @@ msgstr "Всего ролей"
 #: lib/phoenix_kit_web/live/settings/users.html.heex:361
 #: lib/phoenix_kit_web/live/settings/users.html.heex:404
 #: lib/phoenix_kit_web/live/settings/users.html.heex:602
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:192
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:186
 #: lib/phoenix_kit_web/live/users/roles.html.heex:92
 #: lib/phoenix_kit_web/live/users/roles.html.heex:160
 #, elixir-autogen, elixir-format
@@ -2069,7 +2069,7 @@ msgstr "Не подтверждён"
 #: lib/phoenix_kit_web/components/core/time_display.ex:183
 #: lib/phoenix_kit_web/components/language_switcher.ex:832
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:108
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:255
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:249
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr "Неизвестно"
@@ -2127,7 +2127,7 @@ msgstr "Пользователь не найден"
 msgid "User-defined roles"
 msgstr "Роли, определённые пользователем"
 
-#: lib/phoenix_kit/integrations/providers.ex:944
+#: lib/phoenix_kit/integrations/providers.ex:1016
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:255
 #: lib/phoenix_kit_web/users/magic_link_registration.html.heex:30
 #: lib/phoenix_kit_web/users/registration.html.heex:69
@@ -2447,22 +2447,22 @@ msgstr "(пусто)"
 msgid "(registration disabled)"
 msgstr "(регистрация отключена)"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:622
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:637
 #, elixir-autogen, elixir-format
 msgid "1. Enable the provider above and save settings"
 msgstr "1. Включите провайдера выше и сохраните настройки"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:623
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:638
 #, elixir-autogen, elixir-format
 msgid "2. Enter your OAuth credentials in the form that appears"
 msgstr "2. Введите учётные данные OAuth в появившейся форме"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:624
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:639
 #, elixir-autogen, elixir-format
 msgid "3. Save settings again to store credentials"
 msgstr "3. Снова сохраните настройки для сохранения учётных данных"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:625
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:640
 #, elixir-autogen, elixir-format
 msgid "4. Click \"Test Credentials\" to verify configuration"
 msgstr "4. Нажмите «Проверить учётные данные», чтобы проверить конфигурацию"
@@ -2473,7 +2473,8 @@ msgid "Access Credentials"
 msgstr "Учётные данные доступа"
 
 #: lib/modules/storage/web/bucket_form.html.heex:227
-#: lib/phoenix_kit/integrations/providers.ex:842
+#: lib/phoenix_kit/integrations/providers.ex:843
+#: lib/phoenix_kit/integrations/providers.ex:927
 #, elixir-autogen, elixir-format
 msgid "Access Key ID"
 msgstr "ID ключа доступа"
@@ -2523,9 +2524,9 @@ msgstr "Добавить размер изображения"
 msgid "Add Video Dimension"
 msgstr "Добавить размер видео"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:429
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:507
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:592
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:434
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:517
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:607
 #, elixir-autogen, elixir-format
 msgid "Add callback URL above to"
 msgstr "Добавьте URL обратного вызова выше в"
@@ -2557,12 +2558,12 @@ msgstr "Все новые пользователи получат админис
 msgid "Anyone can register"
 msgstr "Кто угодно может зарегистрироваться"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:541
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:551
 #, elixir-autogen, elixir-format
 msgid "App ID"
 msgstr "ID приложения"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:551
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:561
 #, elixir-autogen, elixir-format
 msgid "App Secret"
 msgstr "Секрет приложения"
@@ -2681,7 +2682,7 @@ msgstr "Бакеты могут быть локальными директори
 msgid "CSS color or gradient for auth page background. Ignored if a background image is set."
 msgstr "Цвет CSS или градиент для фона страницы аутентификации. Игнорируется, если задано фоновое изображение."
 
-#: lib/phoenix_kit_web/live/settings/authorization.ex:261
+#: lib/phoenix_kit_web/live/settings/authorization.ex:302
 #, elixir-autogen, elixir-format
 msgid "Callback URL"
 msgstr "URL обратного вызова"
@@ -2691,25 +2692,25 @@ msgstr "URL обратного вызова"
 msgid "Changes will be saved immediately"
 msgstr "Изменения будут сохранены немедленно"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:434
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:511
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:518
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:609
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:439
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:521
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:528
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:624
 #, elixir-autogen, elixir-format
 msgid "Click"
 msgstr "Нажмите"
 
-#: lib/phoenix_kit/integrations/providers.ex:215
+#: lib/phoenix_kit/integrations/providers.ex:216
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:378
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:458
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:463
 #, elixir-autogen, elixir-format
 msgid "Client ID"
 msgstr "ID клиента"
 
-#: lib/phoenix_kit/integrations/providers.ex:224
-#: lib/phoenix_kit/integrations/providers.ex:1169
+#: lib/phoenix_kit/integrations/providers.ex:225
+#: lib/phoenix_kit/integrations/providers.ex:1241
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:388
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:468
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:473
 #, elixir-autogen, elixir-format
 msgid "Client Secret"
 msgstr "Секрет клиента"
@@ -2740,34 +2741,34 @@ msgstr "Настройте системные параметры и опции"
 msgid "Consider \"User\" for most installations to maintain security."
 msgstr "Для большинства установок используйте «Пользователь» в целях безопасности."
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:514
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:599
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:142
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:524
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:614
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:168
 #, elixir-autogen, elixir-format
 msgid "Copy"
 msgstr "Копировать"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:432
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:437
 #, elixir-autogen, elixir-format
 msgid "Copy Client ID and Secret to fields above"
 msgstr "Скопировать ID клиента и Секрет в поля выше"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:568
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:583
 #, elixir-autogen, elixir-format
 msgid "Copy this URL to Facebook App Settings"
 msgstr "Скопируйте этот URL в настройки приложения Facebook"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:485
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:495
 #, elixir-autogen, elixir-format
 msgid "Copy this URL to GitHub OAuth Apps"
 msgstr "Скопируйте этот URL в OAuth Apps GitHub"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:405
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:410
 #, elixir-autogen, elixir-format
 msgid "Copy this URL to Google Cloud Console"
 msgstr "Скопируйте этот URL в Google Cloud Console"
 
-#: lib/phoenix_kit_web/live/settings/authorization.ex:271
+#: lib/phoenix_kit_web/live/settings/authorization.ex:312
 #, elixir-autogen, elixir-format
 msgid "Copy to clipboard"
 msgstr "Скопировать в буфер обмена"
@@ -2792,12 +2793,12 @@ msgstr "Создать путь хранилища"
 msgid "Create Your First Bucket"
 msgstr "Создайте первый бакет"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:582
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:597
 #, elixir-autogen, elixir-format
 msgid "Create a new app or select existing one"
 msgstr "Создайте новое приложение или выберите существующее"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:418
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:423
 #, elixir-autogen, elixir-format
 msgid "Create project or select existing one"
 msgstr "Создайте проект или выберите существующий"
@@ -2868,11 +2869,12 @@ msgid "Enable OAuth (Master Switch)"
 msgstr "Включить OAuth (главный переключатель)"
 
 #: lib/modules/storage/web/bucket_form.html.heex:194
+#: lib/phoenix_kit/integrations/providers.ex:957
 #, elixir-autogen, elixir-format
 msgid "Endpoint"
 msgstr "Конечная точка"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:503
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:513
 #, elixir-autogen, elixir-format
 msgid "Enter"
 msgstr "Введите"
@@ -2907,7 +2909,7 @@ msgstr "FFmpeg не установлен"
 msgid "FFmpeg is required for video processing, transcoding, and thumbnail generation."
 msgstr "FFmpeg необходим для обработки видео, перекодирования и создания миниатюр."
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:532
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:542
 #, elixir-autogen, elixir-format
 msgid "Facebook OAuth Credentials"
 msgstr "Учётные данные Facebook OAuth"
@@ -2950,7 +2952,7 @@ msgstr "Переопределение формата"
 msgid "Format Override:"
 msgstr "Переопределение формата:"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:449
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:454
 #, elixir-autogen, elixir-format
 msgid "GitHub OAuth Credentials"
 msgstr "Учётные данные GitHub OAuth"
@@ -2960,10 +2962,10 @@ msgstr "Учётные данные GitHub OAuth"
 msgid "GitHub Sign-In"
 msgstr "Вход через GitHub"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:420
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:499
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:588
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:596
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:425
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:509
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:603
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:611
 #, elixir-autogen, elixir-format
 msgid "Go to"
 msgstr "Перейти в"
@@ -2993,7 +2995,7 @@ msgstr "Как отображаются даты"
 msgid "How times are displayed"
 msgstr "Как отображается время"
 
-#: lib/phoenix_kit_web/live/settings/authorization.ex:296
+#: lib/phoenix_kit_web/live/settings/authorization.ex:337
 #, elixir-autogen, elixir-format
 msgid "If behind nginx/apache, ensure"
 msgstr "При использовании nginx/apache убедитесь, что"
@@ -3180,7 +3182,7 @@ msgstr "Нет"
 msgid "Note"
 msgstr "Примечание"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:627
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:642
 #, elixir-autogen, elixir-format
 msgid "Note: OAuth providers require ueberauth dependencies to be installed."
 msgstr "Примечание: провайдеры OAuth требуют установки зависимостей ueberauth."
@@ -3195,7 +3197,7 @@ msgstr "Количество хранимых копий"
 msgid "OAuth Providers"
 msgstr "Провайдеры OAuth"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:620
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:635
 #, elixir-autogen, elixir-format
 msgid "OAuth Setup Instructions"
 msgstr "Инструкции по настройке OAuth"
@@ -3268,7 +3270,7 @@ msgstr "Уменьшите резервирование или включите 
 msgid "Redundancy Copies"
 msgstr "Копии резервирования"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:642
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:657
 #, elixir-autogen, elixir-format
 msgid "Reload OAuth Configuration"
 msgstr "Перезагрузить конфигурацию OAuth"
@@ -3295,7 +3297,7 @@ msgstr "Сбросить к настройкам по умолчанию"
 msgid "Resolution"
 msgstr "Разрешение"
 
-#: lib/phoenix_kit_web/live/settings/authorization.ex:294
+#: lib/phoenix_kit_web/live/settings/authorization.ex:335
 #, elixir-autogen, elixir-format
 msgid "Reverse Proxy Users:"
 msgstr "Пользователи обратного прокси:"
@@ -3321,7 +3323,7 @@ msgstr "Роль, назначаемая при регистрации новы�
 msgid "Save All Settings"
 msgstr "Сохранить все настройки"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:685
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:700
 #, elixir-autogen, elixir-format
 msgid "Save Authorization Settings"
 msgstr "Сохранить настройки авторизации"
@@ -3337,7 +3339,8 @@ msgid "Search engines are instructed to skip this environment. Remove this befor
 msgstr "Поисковые системы не будут индексировать эту среду. Снимите это ограничение перед запуском."
 
 #: lib/modules/storage/web/bucket_form.html.heex:241
-#: lib/phoenix_kit/integrations/providers.ex:851
+#: lib/phoenix_kit/integrations/providers.ex:852
+#: lib/phoenix_kit/integrations/providers.ex:936
 #, elixir-autogen, elixir-format
 msgid "Secret Access Key"
 msgstr "Секретный ключ доступа"
@@ -3354,7 +3357,7 @@ msgstr "Уведомление безопасности: средний риск
 
 #: lib/phoenix_kit_web/components/media_browser.html.heex:1180
 #: lib/phoenix_kit_web/components/media_browser.html.heex:1182
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:425
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:430
 #, elixir-autogen, elixir-format
 msgid "Select"
 msgstr "Выбрать"
@@ -3384,7 +3387,7 @@ msgid "Set"
 msgstr "Установить"
 
 #: lib/phoenix_kit_web/components/core/integrations_ui.ex:311
-#: lib/phoenix_kit_web/live/settings/authorization.ex:249
+#: lib/phoenix_kit_web/live/settings/authorization.ex:290
 #: lib/phoenix_kit_web/live/settings/integration_form.html.heex:378
 #, elixir-autogen, elixir-format
 msgid "Setup Instructions"
@@ -3421,7 +3424,7 @@ msgstr "Провайдер хранилища"
 msgid "Success!"
 msgstr "Успешно!"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:604
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:619
 #, elixir-autogen, elixir-format
 msgid "Switch app from"
 msgstr "Переключить приложение с"
@@ -3446,9 +3449,9 @@ msgstr "Часовой пояс системы по умолчанию"
 msgid "Target Width (px)"
 msgstr "Целевая ширина (пкс)"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:400
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:480
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:563
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:405
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:490
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:578
 #, elixir-autogen, elixir-format
 msgid "Test Credentials"
 msgstr "Проверить учётные данные"
@@ -3529,7 +3532,7 @@ msgstr "Конфигурация пользователей"
 msgid "User Editable"
 msgstr "Редактируется пользователем"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:35
+#: lib/phoenix_kit_web/live/settings/users.ex:42
 #: lib/phoenix_kit_web/live/settings/users.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "User Settings"
@@ -3571,9 +3574,9 @@ msgstr "Настройки видео:"
 msgid "Videos use CRF 0-51 scale (lower = higher quality)"
 msgstr "Видео использует шкалу CRF 0–51 (ниже = лучше качество)"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:409
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:489
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:572
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:414
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:499
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:587
 #, elixir-autogen, elixir-format
 msgid "Visit"
 msgstr "Перейти"
@@ -3618,22 +3621,22 @@ msgstr "Без него обработка видеофайлов не буде�
 msgid "Would you like to create it now?"
 msgstr "Вы хотите создать его сейчас?"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:542
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:552
 #, elixir-autogen, elixir-format
 msgid "Your Facebook App ID"
 msgstr "Ваш Facebook App ID"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:552
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:565
 #, elixir-autogen, elixir-format
 msgid "Your Facebook App Secret"
 msgstr "Ваш Facebook App Secret"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:459
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:464
 #, elixir-autogen, elixir-format
 msgid "Your GitHub OAuth Client ID"
 msgstr "Ваш GitHub OAuth Client ID"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:469
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:477
 #, elixir-autogen, elixir-format
 msgid "Your GitHub OAuth Client Secret"
 msgstr "Ваш GitHub OAuth Client Secret"
@@ -3643,19 +3646,19 @@ msgstr "Ваш GitHub OAuth Client Secret"
 msgid "Your Google OAuth Client ID"
 msgstr "Ваш Google OAuth Client ID"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:389
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:392
 #, elixir-autogen, elixir-format
 msgid "Your Google OAuth Client Secret"
 msgstr "Ваш Google OAuth Client Secret"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:504
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:600
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:514
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:615
 #: lib/phoenix_kit_web/live/settings/integrations.ex:167
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr "и"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:515
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:525
 #, elixir-autogen, elixir-format
 msgid "and generate/copy"
 msgstr "и сгенерируйте/скопируйте"
@@ -3676,12 +3679,12 @@ msgstr "например, thumbnail, medium, 720p"
 msgid "files"
 msgstr "файлы"
 
-#: lib/phoenix_kit_web/live/settings/authorization.ex:300
+#: lib/phoenix_kit_web/live/settings/authorization.ex:341
 #, elixir-autogen, elixir-format
 msgid "header is set to"
 msgstr "заголовок установлен в"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:606
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:621
 #, elixir-autogen, elixir-format
 msgid "mode"
 msgstr "режим"
@@ -3691,12 +3694,12 @@ msgstr "режим"
 msgid "option(s)"
 msgstr "вариант(ов)"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:585
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:600
 #, elixir-autogen, elixir-format
 msgid "product"
 msgstr "продукт"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:605
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:620
 #, elixir-autogen, elixir-format
 msgid "to"
 msgstr "в"
@@ -3706,19 +3709,19 @@ msgstr "в"
 msgid "to every PhoenixKit layout, blocking crawlers from indexing or following links."
 msgstr "во все макеты PhoenixKit, запрещая роботам индексировать или переходить по ссылкам."
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:601
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:616
 #, elixir-autogen, elixir-format
 msgid "to fields above"
 msgstr "в поля выше"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:435
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:519
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:610
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:440
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:529
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:625
 #, elixir-autogen, elixir-format
 msgid "to verify setup"
 msgstr "для проверки настройки"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:426
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:431
 #, elixir-autogen, elixir-format
 msgid "type"
 msgstr "тип"
@@ -3853,7 +3856,7 @@ msgstr "Понятное название для идентификации эт
 msgid "A unique name to identify this dimension preset"
 msgstr "Уникальное название для идентификации этого пресета размера"
 
-#: lib/phoenix_kit/integrations/providers.ex:388
+#: lib/phoenix_kit/integrations/providers.ex:389
 #, elixir-autogen, elixir-format
 msgid "AI model access via OpenRouter (100+ models)"
 msgstr "Доступ к AI-моделям через OpenRouter (100+ моделей)"
@@ -3863,13 +3866,13 @@ msgstr "Доступ к AI-моделям через OpenRouter (100+ модел
 msgid "API Credentials"
 msgstr "Учётные данные API"
 
-#: lib/phoenix_kit/integrations/providers.ex:332
-#: lib/phoenix_kit/integrations/providers.ex:402
-#: lib/phoenix_kit/integrations/providers.ex:460
-#: lib/phoenix_kit/integrations/providers.ex:523
-#: lib/phoenix_kit/integrations/providers.ex:586
-#: lib/phoenix_kit/integrations/providers.ex:653
-#: lib/phoenix_kit/integrations/providers.ex:1065
+#: lib/phoenix_kit/integrations/providers.ex:333
+#: lib/phoenix_kit/integrations/providers.ex:403
+#: lib/phoenix_kit/integrations/providers.ex:461
+#: lib/phoenix_kit/integrations/providers.ex:524
+#: lib/phoenix_kit/integrations/providers.ex:587
+#: lib/phoenix_kit/integrations/providers.ex:654
+#: lib/phoenix_kit/integrations/providers.ex:1137
 #, elixir-autogen, elixir-format
 msgid "API Key"
 msgstr "API-ключ"
@@ -3930,7 +3933,7 @@ msgstr "Активно из-за запланированного окна."
 msgid "Add Integration"
 msgstr "Добавить интеграцию"
 
-#: lib/phoenix_kit/integrations/providers.ex:431
+#: lib/phoenix_kit/integrations/providers.ex:432
 #, elixir-autogen, elixir-format
 msgid "Add credits (optional)"
 msgstr "Добавить кредиты (необязательно)"
@@ -3965,7 +3968,7 @@ msgstr "Все файлы соответствуют цели резервиро
 msgid "Alternative Formats"
 msgstr "Альтернативные форматы"
 
-#: lib/phoenix_kit/integrations/providers.ex:285
+#: lib/phoenix_kit/integrations/providers.ex:286
 #, elixir-autogen, elixir-format
 msgid "Application type: **Web application** (do not select \"Desktop app\" — it won't support redirect URIs)"
 msgstr "Тип приложения: **Веб-приложение** (не выбирайте «Десктопное приложение» — оно не поддерживает URI перенаправления)"
@@ -4087,18 +4090,18 @@ msgstr "Выберите сервис для подключения"
 msgid "Clear Schedule"
 msgstr "Очистить расписание"
 
-#: lib/phoenix_kit/integrations/providers.ex:284
+#: lib/phoenix_kit/integrations/providers.ex:285
 #, elixir-autogen, elixir-format
 msgid "Click **Create Credentials → OAuth client ID**"
 msgstr "Нажмите **Создать учётные данные → OAuth client ID**"
 
-#: lib/phoenix_kit/integrations/providers.ex:425
+#: lib/phoenix_kit/integrations/providers.ex:426
 #, elixir-autogen, elixir-format
 msgid "Click **Create Key**"
 msgstr "Нажмите **Создать ключ**"
 
-#: lib/phoenix_kit/integrations/providers.ex:295
-#: lib/phoenix_kit/integrations/providers.ex:1248
+#: lib/phoenix_kit/integrations/providers.ex:296
+#: lib/phoenix_kit/integrations/providers.ex:1320
 #, elixir-autogen, elixir-format
 msgid "Click **Save**, then **Connect Account**"
 msgstr "Нажмите **Сохранить**, затем **Подключить аккаунт**"
@@ -4148,8 +4151,8 @@ msgstr "Подключить аккаунт %{provider}"
 msgid "Connect Account"
 msgstr "Подключить аккаунт"
 
-#: lib/phoenix_kit/integrations/providers.ex:293
-#: lib/phoenix_kit/integrations/providers.ex:1246
+#: lib/phoenix_kit/integrations/providers.ex:294
+#: lib/phoenix_kit/integrations/providers.ex:1318
 #, elixir-autogen, elixir-format
 msgid "Connect and authorize"
 msgstr "Подключить и авторизовать"
@@ -4169,7 +4172,7 @@ msgstr "Подключайте внешние сервисы для исполь
 #: lib/phoenix_kit_web/live/settings/integration_form.html.heex:327
 #: lib/phoenix_kit_web/live/settings/integrations.ex:181
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:111
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:197
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:191
 #, elixir-autogen, elixir-format
 msgid "Connected"
 msgstr "Подключено"
@@ -4210,48 +4213,48 @@ msgstr "Соединение успешно"
 msgid "Connection verified"
 msgstr "Соединение подтверждено"
 
-#: lib/phoenix_kit/integrations/providers.ex:289
+#: lib/phoenix_kit/integrations/providers.ex:290
 #, elixir-autogen, elixir-format
 msgid "Copy the **Client ID** and **Client Secret** into the form above"
 msgstr "Скопируйте **ID клиента** и **Секрет клиента** в форму выше"
 
-#: lib/phoenix_kit/integrations/providers.ex:427
+#: lib/phoenix_kit/integrations/providers.ex:428
 #, elixir-autogen, elixir-format
 msgid "Copy the key and paste it into the form above"
 msgstr "Скопируйте ключ и вставьте его в форму выше"
 
-#: lib/phoenix_kit/integrations/integrations.ex:1135
+#: lib/phoenix_kit/integrations/integrations.ex:1138
 #: lib/phoenix_kit/integrations/probe.ex:102
 #, elixir-autogen, elixir-format
 msgid "Could not reach the service"
 msgstr "Не удалось связаться с сервисом"
 
-#: lib/phoenix_kit/integrations/providers.ex:235
+#: lib/phoenix_kit/integrations/providers.ex:236
 #, elixir-autogen, elixir-format
 msgid "Create a Google Cloud project"
 msgstr "Создайте проект Google Cloud"
 
-#: lib/phoenix_kit/integrations/providers.ex:238
+#: lib/phoenix_kit/integrations/providers.ex:239
 #, elixir-autogen, elixir-format
 msgid "Create a new project or select an existing one"
 msgstr "Создайте новый проект или выберите существующий"
 
-#: lib/phoenix_kit/integrations/providers.ex:368
-#: lib/phoenix_kit/integrations/providers.ex:423
-#: lib/phoenix_kit/integrations/providers.ex:493
-#: lib/phoenix_kit/integrations/providers.ex:553
-#: lib/phoenix_kit/integrations/providers.ex:619
-#: lib/phoenix_kit/integrations/providers.ex:670
+#: lib/phoenix_kit/integrations/providers.ex:369
+#: lib/phoenix_kit/integrations/providers.ex:424
+#: lib/phoenix_kit/integrations/providers.ex:494
+#: lib/phoenix_kit/integrations/providers.ex:554
+#: lib/phoenix_kit/integrations/providers.ex:620
+#: lib/phoenix_kit/integrations/providers.ex:671
 #, elixir-autogen, elixir-format
 msgid "Create an API key"
 msgstr "Создайте API-ключ"
 
-#: lib/phoenix_kit/integrations/providers.ex:279
+#: lib/phoenix_kit/integrations/providers.ex:280
 #, elixir-autogen, elixir-format
 msgid "Create an OAuth Client"
 msgstr "Создайте OAuth-клиент"
 
-#: lib/phoenix_kit/integrations/providers.ex:416
+#: lib/phoenix_kit/integrations/providers.ex:417
 #, elixir-autogen, elixir-format
 msgid "Create an OpenRouter account"
 msgstr "Создайте аккаунт OpenRouter"
@@ -4320,7 +4323,7 @@ msgstr "Отключить?"
 msgid "Disconnected"
 msgstr "Отключено"
 
-#: lib/phoenix_kit/integrations/providers.ex:253
+#: lib/phoenix_kit/integrations/providers.ex:254
 #, elixir-autogen, elixir-format
 msgid "Drive API handles file listing, creation, copying, and PDF export. Docs API is used for reading document content and substituting template variables."
 msgstr "Drive API обрабатывает перечисление, создание, копирование файлов и экспорт PDF. Docs API используется для чтения содержимого документов и подстановки переменных шаблона."
@@ -4350,7 +4353,7 @@ msgstr "Включить бакет"
 msgid "Enable organization accounts"
 msgstr "Включить аккаунты организаций"
 
-#: lib/phoenix_kit/integrations/providers.ex:242
+#: lib/phoenix_kit/integrations/providers.ex:243
 #, elixir-autogen, elixir-format
 msgid "Enable required APIs"
 msgstr "Включить необходимые API"
@@ -4483,12 +4486,12 @@ msgstr "Файлы отслеживаются в PostgreSQL с поддержк�
 msgid "Files with completed variants"
 msgstr "Файлы с готовыми вариантами"
 
-#: lib/phoenix_kit/integrations/providers.ex:219
+#: lib/phoenix_kit/integrations/providers.ex:220
 #, elixir-autogen, elixir-format
 msgid "From Google Cloud Console → APIs & Services → Credentials"
 msgstr "Из Google Cloud Console → APIs & Services → Credentials"
 
-#: lib/phoenix_kit/integrations/providers.ex:406
+#: lib/phoenix_kit/integrations/providers.ex:407
 #, elixir-autogen, elixir-format
 msgid "From openrouter.ai/keys"
 msgstr "С openrouter.ai/keys"
@@ -4498,72 +4501,72 @@ msgstr "С openrouter.ai/keys"
 msgid "Generate additional format variants alongside the primary format. Modern formats like WebP and AVIF offer better compression."
 msgstr "Создавайте дополнительные форматные варианты вместе с основным форматом. Современные форматы, такие как WebP и AVIF, обеспечивают лучшее сжатие."
 
-#: lib/phoenix_kit/integrations/providers.ex:426
+#: lib/phoenix_kit/integrations/providers.ex:427
 #, elixir-autogen, elixir-format
 msgid "Give it a name (e.g., your app name)"
 msgstr "Дайте ему название (например, название вашего приложения)"
 
-#: lib/phoenix_kit/integrations/providers.ex:248
+#: lib/phoenix_kit/integrations/providers.ex:249
 #, elixir-autogen, elixir-format
 msgid "Go back to the Library and search for **Google Docs API**, click it, then click **Enable**"
 msgstr "Вернитесь в Библиотеку и найдите **Google Docs API**, нажмите на него, затем нажмите **Включить**"
 
-#: lib/phoenix_kit/integrations/providers.ex:281
+#: lib/phoenix_kit/integrations/providers.ex:282
 #, elixir-autogen, elixir-format
 msgid "Go to [APIs & Services → Credentials](https://console.cloud.google.com/apis/credentials)"
 msgstr "Перейдите в [APIs & Services → Credentials](https://console.cloud.google.com/apis/credentials)"
 
-#: lib/phoenix_kit/integrations/providers.ex:244
+#: lib/phoenix_kit/integrations/providers.ex:245
 #, elixir-autogen, elixir-format
 msgid "Go to [APIs & Services → Library](https://console.cloud.google.com/apis/library)"
 msgstr "Перейдите в [APIs & Services → Library](https://console.cloud.google.com/apis/library)"
 
-#: lib/phoenix_kit/integrations/providers.ex:263
+#: lib/phoenix_kit/integrations/providers.ex:264
 #, elixir-autogen, elixir-format
 msgid "Go to [Audience](https://console.cloud.google.com/auth/audience) — set user type to **External** (or Internal for Google Workspace)"
 msgstr "Перейдите в [Audience](https://console.cloud.google.com/auth/audience) — установите тип пользователей **External** (или Internal для Google Workspace)"
 
-#: lib/phoenix_kit/integrations/providers.ex:260
+#: lib/phoenix_kit/integrations/providers.ex:261
 #, elixir-autogen, elixir-format
 msgid "Go to [Branding](https://console.cloud.google.com/auth/branding) in the sidebar — fill in the **App name** and **User support email**, then save"
 msgstr "В боковой панели перейдите в [Branding](https://console.cloud.google.com/auth/branding) — заполните **Название приложения** и **Email поддержки пользователей**, затем сохраните"
 
-#: lib/phoenix_kit/integrations/providers.ex:434
+#: lib/phoenix_kit/integrations/providers.ex:435
 #, elixir-autogen, elixir-format
 msgid "Go to [Credits](https://openrouter.ai/credits) to add funds"
 msgstr "Перейдите на [Credits](https://openrouter.ai/credits) для пополнения"
 
-#: lib/phoenix_kit/integrations/providers.ex:269
+#: lib/phoenix_kit/integrations/providers.ex:270
 #, elixir-autogen, elixir-format
 msgid "Go to [Data Access](https://console.cloud.google.com/auth/scopes) — click **Add or Remove Scopes** and add the Drive and Docs scopes. This step may not be required — the app requests the needed scopes at connect time regardless."
 msgstr "Перейдите в [Data Access](https://console.cloud.google.com/auth/scopes) — нажмите **Добавить или удалить области** и добавьте области Drive и Docs. Этот шаг может быть необязателен — приложение запрашивает необходимые области при подключении."
 
-#: lib/phoenix_kit/integrations/providers.ex:418
+#: lib/phoenix_kit/integrations/providers.ex:419
 #, elixir-autogen, elixir-format
 msgid "Go to [openrouter.ai](https://openrouter.ai) and sign up or log in"
 msgstr "Перейдите на [openrouter.ai](https://openrouter.ai) и зарегистрируйтесь или войдите"
 
-#: lib/phoenix_kit/integrations/providers.ex:237
+#: lib/phoenix_kit/integrations/providers.ex:238
 #, elixir-autogen, elixir-format
 msgid "Go to the [Google Cloud Console](https://console.cloud.google.com)"
 msgstr "Перейдите в [Google Cloud Console](https://console.cloud.google.com)"
 
-#: lib/phoenix_kit/integrations/providers.ex:200
+#: lib/phoenix_kit/integrations/providers.ex:201
 #, elixir-autogen, elixir-format
 msgid "Google"
 msgstr "Google"
 
-#: lib/phoenix_kit/integrations/providers.ex:201
+#: lib/phoenix_kit/integrations/providers.ex:202
 #, elixir-autogen, elixir-format
 msgid "Google Docs, Drive, Calendar, Sheets, Gmail"
 msgstr "Google Docs, Drive, Calendar, Sheets, Gmail"
 
-#: lib/phoenix_kit/integrations/providers.ex:296
+#: lib/phoenix_kit/integrations/providers.ex:297
 #, elixir-autogen, elixir-format
 msgid "Google will show an \"unverified app\" warning — click **Advanced → Go to (app name)** to proceed"
 msgstr "Google покажет предупреждение «неверифицированное приложение» — нажмите **Дополнительно → Перейти в (название приложения)** для продолжения"
 
-#: lib/phoenix_kit/integrations/providers.ex:299
+#: lib/phoenix_kit/integrations/providers.ex:300
 #, elixir-autogen, elixir-format
 msgid "Grant access to Google Docs and Google Drive"
 msgstr "Предоставьте доступ к Google Docs и Google Drive"
@@ -4599,11 +4602,12 @@ msgstr "Интеграция удалена"
 msgid "Integrations"
 msgstr "Интеграции"
 
-#: lib/phoenix_kit/integrations/integrations.ex:1132
+#: lib/phoenix_kit/integrations/integrations.ex:1135
 #: lib/phoenix_kit/integrations/validators.ex:208
 #: lib/phoenix_kit/integrations/validators.ex:378
 #: lib/phoenix_kit/integrations/validators.ex:412
-#: lib/phoenix_kit/integrations/validators.ex:595
+#: lib/phoenix_kit/integrations/validators.ex:608
+#: lib/phoenix_kit/integrations/validators.ex:776
 #, elixir-autogen, elixir-format
 msgid "Invalid credentials"
 msgstr "Неверные учётные данные"
@@ -4817,12 +4821,12 @@ msgstr "Отсутствует %{n}"
 msgid "Missing %{n} copies"
 msgstr "Отсутствует %{n} копий"
 
-#: lib/phoenix_kit/integrations/providers.ex:419
+#: lib/phoenix_kit/integrations/providers.ex:420
 #, elixir-autogen, elixir-format
 msgid "Navigate to [Keys](https://openrouter.ai/keys)"
 msgstr "Перейдите в [Keys](https://openrouter.ai/keys)"
 
-#: lib/phoenix_kit/integrations/providers.ex:274
+#: lib/phoenix_kit/integrations/providers.ex:275
 #, elixir-autogen, elixir-format
 msgid "Navigate to the OAuth section using the search bar or the hamburger menu: search for \"OAuth\", or go to the sidebar: **APIs & Services → OAuth consent screen**. This opens a different section with its own sidebar."
 msgstr "Перейдите в раздел OAuth с помощью строки поиска или меню-гамбургера: введите «OAuth» в поиске или откройте боковую панель: **APIs & Services → OAuth consent screen**. Это откроет отдельный раздел со своей боковой панелью."
@@ -4843,9 +4847,9 @@ msgstr "Токен доступа отсутствует"
 msgid "No copies"
 msgstr "Нет копий"
 
-#: lib/phoenix_kit/integrations/integrations.ex:1115
+#: lib/phoenix_kit/integrations/integrations.ex:1118
 #: lib/phoenix_kit/integrations/validators.ex:170
-#: lib/phoenix_kit/integrations/validators.ex:577
+#: lib/phoenix_kit/integrations/validators.ex:758
 #, elixir-autogen, elixir-format
 msgid "No credentials configured"
 msgstr "Учётные данные не настроены"
@@ -4926,7 +4930,7 @@ msgstr "Только включённые бакеты принимают нов
 msgid "Only width is used, height is calculated automatically"
 msgstr "Используется только ширина, высота рассчитывается автоматически"
 
-#: lib/phoenix_kit/integrations/providers.ex:387
+#: lib/phoenix_kit/integrations/providers.ex:388
 #, elixir-autogen, elixir-format
 msgid "OpenRouter"
 msgstr "OpenRouter"
@@ -5107,7 +5111,7 @@ msgstr "Плановое обслуживание"
 msgid "Scheduled window is currently active"
 msgstr "Запланированное окно в настоящее время активно"
 
-#: lib/phoenix_kit/integrations/providers.ex:247
+#: lib/phoenix_kit/integrations/providers.ex:248
 #, elixir-autogen, elixir-format
 msgid "Search for **Google Drive API**, click it, then click **Enable**"
 msgstr "Найдите **Google Drive API**, нажмите на него, затем нажмите **Включить**"
@@ -5134,7 +5138,7 @@ msgstr "Выберите пользователя для добавления...
 msgid "Service"
 msgstr "Сервис"
 
-#: lib/phoenix_kit/integrations/integrations.ex:1134
+#: lib/phoenix_kit/integrations/integrations.ex:1137
 #, elixir-autogen, elixir-format
 msgid "Service error %{status}"
 msgstr "Ошибка сервиса %{status}"
@@ -5144,7 +5148,7 @@ msgstr "Ошибка сервиса %{status}"
 msgid "Set a time window for automatic maintenance activation."
 msgstr "Установите временное окно для автоматической активации режима обслуживания."
 
-#: lib/phoenix_kit/integrations/providers.ex:258
+#: lib/phoenix_kit/integrations/providers.ex:259
 #, elixir-autogen, elixir-format
 msgid "Set up OAuth consent"
 msgstr "Настройте согласие OAuth"
@@ -5154,7 +5158,7 @@ msgstr "Настройте согласие OAuth"
 msgid "Size Configuration"
 msgstr "Конфигурация размера"
 
-#: lib/phoenix_kit/integrations/providers.ex:433
+#: lib/phoenix_kit/integrations/providers.ex:434
 #, elixir-autogen, elixir-format
 msgid "Some models are free, but most require credits"
 msgstr "Некоторые модели бесплатны, но большинству требуются кредиты"
@@ -5184,7 +5188,7 @@ msgstr "Шаг 1"
 msgid "Step 2"
 msgstr "Шаг 2"
 
-#: lib/phoenix_kit/integrations/providers.ex:266
+#: lib/phoenix_kit/integrations/providers.ex:267
 #, elixir-autogen, elixir-format
 msgid "Still on Audience — while the app is in **Testing** status, add the Google account you will connect as a **Test user** (this must be the same account whose Drive will store your files)"
 msgstr "Оставаясь на Audience — пока приложение находится в статусе **Тестирование**, добавьте аккаунт Google, который будете подключать, как **Тестового пользователя** (это должен быть тот же аккаунт, Drive которого будет хранить ваши файлы)"
@@ -5319,7 +5323,7 @@ msgstr "Регион Tigris"
 msgid "Total Files"
 msgstr "Всего файлов"
 
-#: lib/phoenix_kit/integrations/providers.ex:288
+#: lib/phoenix_kit/integrations/providers.ex:289
 #, elixir-autogen, elixir-format
 msgid "Under **Authorized redirect URIs**, add: `{redirect_uri}`"
 msgstr "В разделе **Авторизованные URI перенаправления** добавьте: `{redirect_uri}`"
@@ -5376,8 +5380,8 @@ msgstr "Вы вступили в организацию!"
 msgid "You need to create at least one media bucket before files can be uploaded."
 msgstr "Вам нужно создать хотя бы один медиа-бакет, прежде чем загружать файлы."
 
-#: lib/phoenix_kit/integrations/providers.ex:300
-#: lib/phoenix_kit/integrations/providers.ex:1252
+#: lib/phoenix_kit/integrations/providers.ex:301
+#: lib/phoenix_kit/integrations/providers.ex:1324
 #, elixir-autogen, elixir-format
 msgid "You'll be redirected back here once connected"
 msgstr "После подключения вы будете перенаправлены обратно"
@@ -5444,39 +5448,39 @@ msgstr "1 час назад"
 msgid "1 minute ago"
 msgstr "1 минуту назад"
 
-#: lib/phoenix_kit/integrations/providers.ex:509
+#: lib/phoenix_kit/integrations/providers.ex:510
 #, elixir-autogen, elixir-format
 msgid "AI model access via DeepSeek (deepseek-chat, deepseek-reasoner)"
 msgstr "Доступ к AI-моделям через DeepSeek (deepseek-chat, deepseek-reasoner)"
 
-#: lib/phoenix_kit/integrations/providers.ex:446
+#: lib/phoenix_kit/integrations/providers.ex:447
 #, elixir-autogen, elixir-format
 msgid "AI model access via Mistral AI (Mistral Large, Codestral, Pixtral)"
 msgstr "Доступ к AI-моделям через Mistral AI (Mistral Large, Codestral, Pixtral)"
 
-#: lib/phoenix_kit/integrations/providers.ex:1218
+#: lib/phoenix_kit/integrations/providers.ex:1290
 #, elixir-autogen, elixir-format
 msgid "Add a client secret"
 msgstr "Добавьте секрет клиента"
 
-#: lib/phoenix_kit/integrations/providers.ex:480
+#: lib/phoenix_kit/integrations/providers.ex:481
 #, elixir-autogen, elixir-format
 msgid "Add a payment method (required)"
 msgstr "Добавьте способ оплаты (обязательно)"
 
-#: lib/phoenix_kit/integrations/providers.ex:357
-#: lib/phoenix_kit/integrations/providers.ex:542
-#: lib/phoenix_kit/integrations/providers.ex:611
+#: lib/phoenix_kit/integrations/providers.ex:358
+#: lib/phoenix_kit/integrations/providers.ex:543
+#: lib/phoenix_kit/integrations/providers.ex:612
 #, elixir-autogen, elixir-format
 msgid "Add credits"
 msgstr "Добавить кредиты"
 
-#: lib/phoenix_kit/integrations/providers.ex:1233
+#: lib/phoenix_kit/integrations/providers.ex:1305
 #, elixir-autogen, elixir-format
 msgid "Add the permissions your integration needs: `User.Read` is included by default; add `Mail.Read`, `Files.Read.All`, `Calendars.Read`, etc. as required"
 msgstr "Добавьте необходимые разрешения: `User.Read` включён по умолчанию; добавьте `Mail.Read`, `Files.Read.All`, `Calendars.Read` и другие по мере необходимости"
 
-#: lib/phoenix_kit/integrations/providers.ex:1160
+#: lib/phoenix_kit/integrations/providers.ex:1232
 #, elixir-autogen, elixir-format
 msgid "Application (client) ID"
 msgstr "ID приложения (клиента)"
@@ -5486,28 +5490,28 @@ msgstr "ID приложения (клиента)"
 msgid "Clears the OAuth tokens. Credentials and the connection itself stay so you can reconnect with one click."
 msgstr "Очищает токены OAuth. Учётные данные и само соединение остаются, поэтому вы можете переподключиться одним нажатием."
 
-#: lib/phoenix_kit/integrations/providers.ex:556
-#: lib/phoenix_kit/integrations/providers.ex:622
+#: lib/phoenix_kit/integrations/providers.ex:557
+#: lib/phoenix_kit/integrations/providers.ex:623
 #, elixir-autogen, elixir-format
 msgid "Click **Create API key**, give it a name"
 msgstr "Нажмите **Создать API-ключ**, дайте ему имя"
 
-#: lib/phoenix_kit/integrations/providers.ex:496
+#: lib/phoenix_kit/integrations/providers.ex:497
 #, elixir-autogen, elixir-format
 msgid "Click **Create new key**, give it a name, set an expiry if desired"
 msgstr "Нажмите **Создать новый ключ**, дайте ему имя, при желании установите срок действия"
 
-#: lib/phoenix_kit/integrations/providers.ex:1205
+#: lib/phoenix_kit/integrations/providers.ex:1277
 #, elixir-autogen, elixir-format
 msgid "Click **New registration**, give the app a name"
 msgstr "Нажмите **Новая регистрация**, дайте приложению имя"
 
-#: lib/phoenix_kit/integrations/providers.ex:1210
+#: lib/phoenix_kit/integrations/providers.ex:1282
 #, elixir-autogen, elixir-format
 msgid "Click **Register**"
 msgstr "Нажмите **Зарегистрировать**"
 
-#: lib/phoenix_kit/integrations/providers.ex:1228
+#: lib/phoenix_kit/integrations/providers.ex:1300
 #, elixir-autogen, elixir-format
 msgid "Configure API permissions"
 msgstr "Настройте разрешения API"
@@ -5528,16 +5532,16 @@ msgstr "Название соединения не может быть пуст�
 msgid "Connection renamed"
 msgstr "Соединение переименовано"
 
-#: lib/phoenix_kit/integrations/providers.ex:1222
+#: lib/phoenix_kit/integrations/providers.ex:1294
 #, elixir-autogen, elixir-format
 msgid "Copy the **Value** column (not the Secret ID) into the form above — the value is shown ONCE and disappears on page refresh"
 msgstr "Скопируйте столбец **Значение** (не Secret ID) в форму выше — значение отображается ОДИН РАЗ и исчезает при обновлении страницы"
 
-#: lib/phoenix_kit/integrations/providers.ex:372
-#: lib/phoenix_kit/integrations/providers.ex:497
-#: lib/phoenix_kit/integrations/providers.ex:557
-#: lib/phoenix_kit/integrations/providers.ex:623
-#: lib/phoenix_kit/integrations/providers.ex:675
+#: lib/phoenix_kit/integrations/providers.ex:373
+#: lib/phoenix_kit/integrations/providers.ex:498
+#: lib/phoenix_kit/integrations/providers.ex:558
+#: lib/phoenix_kit/integrations/providers.ex:624
+#: lib/phoenix_kit/integrations/providers.ex:676
 #, elixir-autogen, elixir-format
 msgid "Copy the key (shown once) and paste it into the form above"
 msgstr "Скопируйте ключ (показывается один раз) и вставьте его в форму выше"
@@ -5548,12 +5552,12 @@ msgstr "Скопируйте ключ (показывается один раз)
 msgid "Create Connection"
 msgstr "Создать соединение"
 
-#: lib/phoenix_kit/integrations/providers.ex:534
+#: lib/phoenix_kit/integrations/providers.ex:535
 #, elixir-autogen, elixir-format
 msgid "Create a DeepSeek account"
 msgstr "Создайте аккаунт DeepSeek"
 
-#: lib/phoenix_kit/integrations/providers.ex:471
+#: lib/phoenix_kit/integrations/providers.ex:472
 #, elixir-autogen, elixir-format
 msgid "Create a Mistral account"
 msgstr "Создайте аккаунт Mistral"
@@ -5564,12 +5568,12 @@ msgstr "Создайте аккаунт Mistral"
 msgid "Danger Zone"
 msgstr "Опасная зона"
 
-#: lib/phoenix_kit/integrations/providers.ex:508
+#: lib/phoenix_kit/integrations/providers.ex:509
 #, elixir-autogen, elixir-format
 msgid "DeepSeek"
 msgstr "DeepSeek"
 
-#: lib/phoenix_kit/integrations/providers.ex:547
+#: lib/phoenix_kit/integrations/providers.ex:548
 #, elixir-autogen, elixir-format
 msgid "DeepSeek requires a positive balance before you can call the chat or reasoner endpoints, even on cheap models"
 msgstr "DeepSeek требует положительного баланса перед вызовом конечных точек чата или рассуждателя, даже для дешёвых моделей"
@@ -5604,82 +5608,82 @@ msgstr "Не удалось удалить соединение."
 msgid "Failed to rename connection."
 msgstr "Не удалось переименовать соединение."
 
-#: lib/phoenix_kit/integrations/providers.ex:485
+#: lib/phoenix_kit/integrations/providers.ex:486
 #, elixir-autogen, elixir-format
 msgid "Free models still require a billing-enabled workspace"
 msgstr "Бесплатные модели по-прежнему требуют рабочего пространства с включённой оплатой"
 
-#: lib/phoenix_kit/integrations/providers.ex:1164
+#: lib/phoenix_kit/integrations/providers.ex:1236
 #, elixir-autogen, elixir-format
 msgid "From Azure Portal → App registrations → your app → Overview"
 msgstr "Из Azure Portal → Регистрация приложений → ваше приложение → Обзор"
 
-#: lib/phoenix_kit/integrations/providers.ex:464
+#: lib/phoenix_kit/integrations/providers.ex:465
 #, elixir-autogen, elixir-format
 msgid "From console.mistral.ai/api-keys"
 msgstr "С console.mistral.ai/api-keys"
 
-#: lib/phoenix_kit/integrations/providers.ex:527
+#: lib/phoenix_kit/integrations/providers.ex:528
 #, elixir-autogen, elixir-format
 msgid "From platform.deepseek.com/api_keys"
 msgstr "С platform.deepseek.com/api_keys"
 
-#: lib/phoenix_kit/integrations/providers.ex:1174
+#: lib/phoenix_kit/integrations/providers.ex:1246
 #, elixir-autogen, elixir-format
 msgid "From your app → Certificates & secrets → New client secret. Copy the *Value*, not the Secret ID."
 msgstr "Из вашего приложения → Сертификаты и секреты → Новый секрет клиента. Скопируйте *Значение*, а не Secret ID."
 
-#: lib/phoenix_kit/integrations/providers.ex:1230
+#: lib/phoenix_kit/integrations/providers.ex:1302
 #, elixir-autogen, elixir-format
 msgid "Go to **API permissions → Add a permission → Microsoft Graph → Delegated permissions**"
 msgstr "Перейдите в **Разрешения API → Добавить разрешение → Microsoft Graph → Делегированные разрешения**"
 
-#: lib/phoenix_kit/integrations/providers.ex:1220
+#: lib/phoenix_kit/integrations/providers.ex:1292
 #, elixir-autogen, elixir-format
 msgid "Go to **Certificates & secrets → New client secret**"
 msgstr "Перейдите в **Сертификаты и секреты → Новый секрет клиента**"
 
-#: lib/phoenix_kit/integrations/providers.ex:495
+#: lib/phoenix_kit/integrations/providers.ex:496
 #, elixir-autogen, elixir-format
 msgid "Go to [API Keys](https://console.mistral.ai/api-keys)"
 msgstr "Перейдите в [API Keys](https://console.mistral.ai/api-keys)"
 
-#: lib/phoenix_kit/integrations/providers.ex:555
+#: lib/phoenix_kit/integrations/providers.ex:556
 #, elixir-autogen, elixir-format
 msgid "Go to [API Keys](https://platform.deepseek.com/api_keys)"
 msgstr "Перейдите в [API Keys](https://platform.deepseek.com/api_keys)"
 
-#: lib/phoenix_kit/integrations/providers.ex:544
+#: lib/phoenix_kit/integrations/providers.ex:545
 #, elixir-autogen, elixir-format
 msgid "Go to [Top up](https://platform.deepseek.com/top_up) and add at least the minimum amount"
 msgstr "Перейдите на [Пополнение](https://platform.deepseek.com/top_up) и добавьте хотя бы минимальную сумму"
 
-#: lib/phoenix_kit/integrations/providers.ex:482
+#: lib/phoenix_kit/integrations/providers.ex:483
 #, elixir-autogen, elixir-format
 msgid "Go to [Workspace → Billing](https://console.mistral.ai/billing/plans) and choose **Experiment** (pay-as-you-go) or a paid tier"
 msgstr "Перейдите в [Workspace → Billing](https://console.mistral.ai/billing/plans) и выберите **Experiment** (pay-as-you-go) или платный тариф"
 
-#: lib/phoenix_kit/integrations/providers.ex:473
+#: lib/phoenix_kit/integrations/providers.ex:474
 #, elixir-autogen, elixir-format
 msgid "Go to [console.mistral.ai](https://console.mistral.ai) and sign up or log in"
 msgstr "Перейдите на [console.mistral.ai](https://console.mistral.ai) и зарегистрируйтесь или войдите"
 
-#: lib/phoenix_kit/integrations/providers.ex:536
+#: lib/phoenix_kit/integrations/providers.ex:537
 #, elixir-autogen, elixir-format
 msgid "Go to [platform.deepseek.com](https://platform.deepseek.com) and sign up or log in"
 msgstr "Перейдите на [platform.deepseek.com](https://platform.deepseek.com) и зарегистрируйтесь или войдите"
 
-#: lib/phoenix_kit/integrations/providers.ex:1202
+#: lib/phoenix_kit/integrations/providers.ex:1274
 #, elixir-autogen, elixir-format
 msgid "Go to the [Azure Portal](https://portal.azure.com) and search for **App registrations**"
 msgstr "Перейдите на [Azure Portal](https://portal.azure.com) и найдите **Регистрация приложений**"
 
-#: lib/phoenix_kit/integrations/providers.ex:1213
+#: lib/phoenix_kit/integrations/providers.ex:1285
 #, elixir-autogen, elixir-format
 msgid "If you picked a single-tenant audience, fill in **Tenant ID** above with your Directory (tenant) ID GUID — leaving it as `common` only works for multi-tenant + personal apps."
 msgstr "Если вы выбрали аудиторию одного тенанта, заполните **Tenant ID** выше вашим Directory (tenant) ID GUID — оставление как `common` работает только для мультитенантных + личных приложений."
 
-#: lib/phoenix_kit/integrations/providers.ex:1236
+#: lib/phoenix_kit/integrations/providers.ex:1308
 #, elixir-autogen, elixir-format
 msgid "If your tenant requires admin consent, click **Grant admin consent for <tenant>** before the connect flow will work"
 msgstr "Если ваш тенант требует согласия администратора, нажмите **Предоставить согласие администратора для <tenant>** перед тем, как процесс подключения заработает"
@@ -5696,32 +5700,32 @@ msgstr "Интеграция не найдена"
 msgid "Last tested"
 msgstr "Последняя проверка"
 
-#: lib/phoenix_kit/integrations/providers.ex:1186
+#: lib/phoenix_kit/integrations/providers.ex:1258
 #, elixir-autogen, elixir-format
 msgid "Leave as `common` for multi-tenant + personal accounts. For single-tenant apps, paste your Directory (tenant) ID GUID. Use `consumers` for personal-only or `organizations` for any work-or-school account."
 msgstr "Оставьте как `common` для мультитенантных + личных аккаунтов. Для однотенантных приложений вставьте ваш Directory (tenant) ID GUID. Используйте `consumers` только для личных или `organizations` для рабочих/учебных аккаунтов."
 
-#: lib/phoenix_kit/integrations/providers.ex:1131
+#: lib/phoenix_kit/integrations/providers.ex:1203
 #, elixir-autogen, elixir-format
 msgid "Microsoft 365"
 msgstr "Microsoft 365"
 
-#: lib/phoenix_kit/integrations/providers.ex:1132
+#: lib/phoenix_kit/integrations/providers.ex:1204
 #, elixir-autogen, elixir-format
 msgid "Microsoft Graph — Outlook, OneDrive, Teams, Calendar, SharePoint"
 msgstr "Microsoft Graph — Outlook, OneDrive, Teams, Calendar, SharePoint"
 
-#: lib/phoenix_kit/integrations/providers.ex:1249
+#: lib/phoenix_kit/integrations/providers.ex:1321
 #, elixir-autogen, elixir-format
 msgid "Microsoft will show the consent screen — click **Accept** to grant the requested permissions"
 msgstr "Microsoft покажет экран согласия — нажмите **Принять** для предоставления запрошенных разрешений"
 
-#: lib/phoenix_kit/integrations/providers.ex:445
+#: lib/phoenix_kit/integrations/providers.ex:446
 #, elixir-autogen, elixir-format
 msgid "Mistral"
 msgstr "Mistral"
 
-#: lib/phoenix_kit/integrations/providers.ex:488
+#: lib/phoenix_kit/integrations/providers.ex:489
 #, elixir-autogen, elixir-format
 msgid "Mistral does not offer credits without billing setup; this is a hard requirement before keys can be created."
 msgstr "Mistral не предоставляет кредиты без настройки оплаты; это обязательное требование перед созданием ключей."
@@ -5732,7 +5736,7 @@ msgstr "Mistral не предоставляет кредиты без настр
 msgid "Permanently delete this connection? This cannot be undone."
 msgstr "Окончательно удалить это соединение? Это нельзя отменить."
 
-#: lib/phoenix_kit/integrations/providers.ex:1200
+#: lib/phoenix_kit/integrations/providers.ex:1272
 #, elixir-autogen, elixir-format
 msgid "Register an application in Microsoft Entra ID (Azure AD)"
 msgstr "Зарегистрируйте приложение в Microsoft Entra ID (Azure AD)"
@@ -5748,32 +5752,32 @@ msgstr "Удаляет интеграцию навсегда. Любой мод�
 msgid "Search..."
 msgstr "Поиск..."
 
-#: lib/phoenix_kit/integrations/providers.ex:1221
+#: lib/phoenix_kit/integrations/providers.ex:1293
 #, elixir-autogen, elixir-format
 msgid "Set an expiration (24 months is common; renew before it lapses)"
 msgstr "Установите срок действия (обычно 24 месяца; обновляйте до истечения)"
 
-#: lib/phoenix_kit/integrations/providers.ex:1181
+#: lib/phoenix_kit/integrations/providers.ex:1253
 #, elixir-autogen, elixir-format
 msgid "Tenant ID"
 msgstr "ID тенанта"
 
-#: lib/phoenix_kit/integrations/providers.ex:1241
+#: lib/phoenix_kit/integrations/providers.ex:1313
 #, elixir-autogen, elixir-format
 msgid "The `default_scopes` in the provider definition request `openid email profile offline_access User.Read` — extra scopes can be added per-connect by passing `extra_scopes` to `authorization_url/5`."
 msgstr "`default_scopes` в определении провайдера запрашивают `openid email profile offline_access User.Read` — дополнительные области можно добавить при подключении, передав `extra_scopes` в `authorization_url/5`."
 
-#: lib/phoenix_kit/integrations/providers.ex:1209
+#: lib/phoenix_kit/integrations/providers.ex:1281
 #, elixir-autogen, elixir-format
 msgid "Under **Redirect URI**, choose **Web** and enter: `{redirect_uri}`"
 msgstr "В разделе **URI перенаправления** выберите **Web** и введите: `{redirect_uri}`"
 
-#: lib/phoenix_kit/integrations/providers.ex:1206
+#: lib/phoenix_kit/integrations/providers.ex:1278
 #, elixir-autogen, elixir-format
 msgid "Under **Supported account types**, choose the audience: *Personal Microsoft accounts only*, *Accounts in any organizational directory*, or *Accounts in this organizational directory only* depending on who should sign in"
 msgstr "В разделе **Поддерживаемые типы аккаунтов** выберите аудиторию: *Только личные аккаунты Microsoft*, *Аккаунты в любом организационном каталоге* или *Аккаунты только в этом организационном каталоге* в зависимости от того, кто должен входить"
 
-#: lib/phoenix_kit/integrations/providers.ex:476
+#: lib/phoenix_kit/integrations/providers.ex:477
 #, elixir-autogen, elixir-format
 msgid "You may need to verify your phone number before creating API keys"
 msgstr "Перед созданием API-ключей может потребоваться подтверждение номера телефона"
@@ -6040,14 +6044,14 @@ msgstr "Не установлен"
 
 #: lib/phoenix_kit_web/live/modules.html.heex:447
 #: lib/phoenix_kit_web/live/settings.html.heex:465
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:289
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:315
 #, elixir-autogen, elixir-format
 msgid "Off"
 msgstr "Выкл."
 
 #: lib/phoenix_kit_web/live/modules.html.heex:447
 #: lib/phoenix_kit_web/live/settings.html.heex:464
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:289
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:315
 #, elixir-autogen, elixir-format
 msgid "On"
 msgstr "Вкл."
@@ -7298,8 +7302,8 @@ msgstr "Ответить"
 msgid "Are you sure you want to delete this comment?"
 msgstr "Точно удалить этот комментарий?"
 
-#: lib/phoenix_kit_web/components/media_canvas_viewer.ex:1202
-#: lib/phoenix_kit_web/components/media_canvas_viewer.ex:1203
+#: lib/phoenix_kit_web/components/media_canvas_viewer.ex:1236
+#: lib/phoenix_kit_web/components/media_canvas_viewer.ex:1237
 #, elixir-autogen, elixir-format
 msgid "%b %d, %Y"
 msgstr "%d %b %Y"
@@ -8417,14 +8421,14 @@ msgstr "Все поля уже выбраны"
 msgid "All registered accounts"
 msgstr "Все зарегистрированные аккаунты"
 
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:185
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:224
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:179
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:218
 #, elixir-autogen, elixir-format
 msgid "Anon"
 msgstr "Аноним"
 
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:178
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:245
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:172
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:239
 #, elixir-autogen, elixir-format
 msgid "Anonymous User"
 msgstr "Анонимный пользователь"
@@ -8475,8 +8479,8 @@ msgstr "Вы уверены, что хотите отозвать эту сес�
 msgid "Are you sure you want to unconfirm this user's email?"
 msgstr "Вы уверены, что хотите отменить подтверждение email этого пользователя?"
 
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:170
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:220
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:164
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:214
 #, elixir-autogen, elixir-format
 msgid "Auth"
 msgstr "Авт."
@@ -8559,17 +8563,17 @@ msgid "Confirmed Email"
 msgstr "Подтверждённый email"
 
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:109
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:195
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Current Page"
 msgstr "Текущая страница"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:251
+#: lib/phoenix_kit_web/live/settings/users.ex:258
 #, elixir-autogen, elixir-format
 msgid "Custom field deleted successfully"
 msgstr "Пользовательское поле успешно удалено"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:171
+#: lib/phoenix_kit_web/live/settings/users.ex:178
 #, elixir-autogen, elixir-format
 msgid "Custom field saved successfully"
 msgstr "Пользовательское поле успешно сохранено"
@@ -8584,17 +8588,17 @@ msgstr "Настройка столбцов таблицы"
 msgid "Drag to reorder selected columns above, or add new columns from the options below. Actions column is always included."
 msgstr "Перетащите для изменения порядка выбранных столбцов выше или добавьте новые из вариантов ниже. Столбец действий всегда включён."
 
-#: lib/phoenix_kit_web/live/settings/users.ex:256
+#: lib/phoenix_kit_web/live/settings/users.ex:263
 #, elixir-autogen, elixir-format
 msgid "Failed to delete custom field"
 msgstr "Не удалось удалить пользовательское поле"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:184
+#: lib/phoenix_kit_web/live/settings/users.ex:191
 #, elixir-autogen, elixir-format
 msgid "Failed to save custom field"
 msgstr "Не удалось сохранить пользовательское поле"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:285
+#: lib/phoenix_kit_web/live/settings/users.ex:292
 #, elixir-autogen, elixir-format
 msgid "Failed to update field"
 msgstr "Не удалось обновить поле"
@@ -8627,23 +8631,23 @@ msgstr "Не удалось обновить роли пользователя"
 msgid "Failed to update user status"
 msgstr "Не удалось обновить статус пользователя"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:278
+#: lib/phoenix_kit_web/live/settings/users.ex:285
 #, elixir-autogen, elixir-format
 msgid "Field '%{label}' disabled"
 msgstr "Поле «%{label}» отключено"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:277
+#: lib/phoenix_kit_web/live/settings/users.ex:284
 #, elixir-autogen, elixir-format
 msgid "Field '%{label}' enabled"
 msgstr "Поле «%{label}» включено"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:289
+#: lib/phoenix_kit_web/live/settings/users.ex:296
 #, elixir-autogen, elixir-format
 msgid "Field not found"
 msgstr "Поле не найдено"
 
 #: lib/phoenix_kit_web/live/users/live_sessions.html.heex:108
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:194
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:188
 #, elixir-autogen, elixir-format
 msgid "IP Address"
 msgstr "IP-адрес"
@@ -8675,7 +8679,7 @@ msgstr "Управление учётными записями и ролями �
 msgid "Monitor and manage active user sessions"
 msgstr "Мониторинг и управление активными сессиями пользователей"
 
-#: lib/phoenix_kit/integrations/providers.ex:1002
+#: lib/phoenix_kit/integrations/providers.ex:1074
 #: lib/phoenix_kit_web/live/users/users.ex:1048
 #: lib/phoenix_kit_web/live/users/users.html.heex:563
 #, elixir-autogen, elixir-format
@@ -8687,7 +8691,7 @@ msgstr "Никогда"
 msgid "Next »"
 msgstr "Вперёд"
 
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:208
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:202
 #, elixir-autogen, elixir-format
 msgid "No active sessions"
 msgstr "Активные сессии не найдены."
@@ -8839,7 +8843,7 @@ msgstr "Стандартные поля"
 msgid "Table columns updated successfully"
 msgstr "Столбцы таблицы успешно обновлены"
 
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:209
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:203
 #, elixir-autogen, elixir-format
 msgid "There are currently no active sessions to display."
 msgstr "В данный момент нет активных сессий для отображения."
@@ -8900,13 +8904,13 @@ msgstr "Подтверждение email пользователя успешно
 msgid "User roles updated successfully"
 msgstr "Роли пользователя успешно обновлены"
 
-#: lib/phoenix_kit_web/live/settings/users.ex:84
+#: lib/phoenix_kit_web/live/settings/users.ex:91
 #, elixir-autogen, elixir-format
 msgid "User settings updated successfully"
 msgstr "Настройки пользователя успешно обновлены"
 
 ## Navigation menu items
-#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:193
+#: lib/phoenix_kit_web/live/users/live_sessions.html.heex:187
 #, elixir-autogen, elixir-format
 msgid "User/Session"
 msgstr "Пользователь/Сессия"
@@ -8941,7 +8945,7 @@ msgstr[2] "Вы уверены, что хотите отозвать %{count} с
 msgid "Last updated:"
 msgstr "Обновлено:"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:656
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:671
 #, elixir-autogen, elixir-format
 msgid "Account switcher for signing in to several accounts at once"
 msgstr "Переключатель аккаунтов для входа в несколько аккаунтов одновременно"
@@ -8951,7 +8955,7 @@ msgstr "Переключатель аккаунтов для входа в не�
 msgid "Applying…"
 msgstr "Применение..."
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:662
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:677
 #, elixir-autogen, elixir-format
 msgid "Enable the multi-account switcher in the header"
 msgstr "Включить переключатель нескольких аккаунтов в шапке"
@@ -8969,12 +8973,12 @@ msgstr "Загрузить ещё"
 msgid "Loading…"
 msgstr "Загрузка…"
 
-#: lib/phoenix_kit_web/users/session.ex:113
+#: lib/phoenix_kit_web/users/session.ex:115
 #, elixir-autogen, elixir-format
 msgid "Logged out. Now signed in as %{email}."
 msgstr "Выполнен выход. Теперь вы вошли как %{email}."
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:653
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:668
 #, elixir-autogen, elixir-format
 msgid "Multiple Sessions"
 msgstr "Несколько сессий"
@@ -9010,12 +9014,12 @@ msgstr "Изменить порядок 1 выбранного %{noun} (оста
 msgid "Showing %{loaded} of %{total} %{noun}"
 msgstr "Показано %{loaded} из %{total} %{noun}"
 
-#: lib/phoenix_kit_web/users/session.ex:268
+#: lib/phoenix_kit_web/users/session.ex:270
 #, elixir-autogen, elixir-format
 msgid "Switched to %{email}."
 msgstr "Переключено на %{email}."
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:665
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:680
 #, elixir-autogen, elixir-format
 msgid "When on, any signed-in user can add other accounts (with their password) and switch between them from the user menu."
 msgstr "Когда включено, любой вошедший пользователь может добавлять другие аккаунты (с их паролем) и переключаться между ними из меню пользователя."
@@ -9095,7 +9099,7 @@ msgstr "Сюда можно добавлять только разрешённы
 msgid "View background job status and history"
 msgstr "Просмотр статуса и истории фоновых задач"
 
-#: lib/phoenix_kit/integrations/providers.ex:312
+#: lib/phoenix_kit/integrations/providers.ex:313
 #, elixir-autogen, elixir-format
 msgid "AI models via OpenAI (GPT, embeddings, images, audio)"
 msgstr "ИИ-модели через OpenAI (GPT, эмбеддинги, изображения, аудио)"
@@ -9180,12 +9184,12 @@ msgstr "Изменить"
 msgid "Choose"
 msgstr "Выбрать"
 
-#: lib/phoenix_kit/integrations/providers.ex:674
+#: lib/phoenix_kit/integrations/providers.ex:675
 #, elixir-autogen, elixir-format
 msgid "Click **Create API Key**, give it a name"
 msgstr "Нажмите **Создать API-ключ**, дайте ему имя"
 
-#: lib/phoenix_kit/integrations/providers.ex:371
+#: lib/phoenix_kit/integrations/providers.ex:372
 #, elixir-autogen, elixir-format
 msgid "Click **Create new secret key**, give it a name"
 msgstr "Нажмите **Create new secret key**, дайте ему имя"
@@ -9196,12 +9200,12 @@ msgstr "Нажмите **Create new secret key**, дайте ему имя"
 msgid "Close search"
 msgstr "Закрыть поиск"
 
-#: lib/phoenix_kit/integrations/providers.ex:664
+#: lib/phoenix_kit/integrations/providers.ex:665
 #, elixir-autogen, elixir-format
 msgid "Create an ElevenLabs account"
 msgstr "Создайте аккаунт ElevenLabs"
 
-#: lib/phoenix_kit/integrations/providers.ex:349
+#: lib/phoenix_kit/integrations/providers.ex:350
 #, elixir-autogen, elixir-format
 msgid "Create an OpenAI account"
 msgstr "Создайте аккаунт OpenAI"
@@ -9265,7 +9269,7 @@ msgstr "Изменить описание"
 msgid "Edit header"
 msgstr "Изменить заголовок"
 
-#: lib/phoenix_kit/integrations/providers.ex:634
+#: lib/phoenix_kit/integrations/providers.ex:635
 #, elixir-autogen, elixir-format
 msgid "ElevenLabs"
 msgstr "ElevenLabs"
@@ -9335,37 +9339,37 @@ msgstr "Имя папки не может быть пустым"
 msgid "Forgot password"
 msgstr "Забыли пароль"
 
-#: lib/phoenix_kit/integrations/providers.ex:657
+#: lib/phoenix_kit/integrations/providers.ex:658
 #, elixir-autogen, elixir-format
 msgid "From elevenlabs.io → Settings → API Keys"
 msgstr "Из elevenlabs.io → Настройки → API-ключи"
 
-#: lib/phoenix_kit/integrations/providers.ex:336
+#: lib/phoenix_kit/integrations/providers.ex:337
 #, elixir-autogen, elixir-format
 msgid "From platform.openai.com/api-keys"
 msgstr "С platform.openai.com/api-keys"
 
-#: lib/phoenix_kit/integrations/providers.ex:370
+#: lib/phoenix_kit/integrations/providers.ex:371
 #, elixir-autogen, elixir-format
 msgid "Go to [API Keys](https://platform.openai.com/api-keys)"
 msgstr "Перейдите в [API Keys](https://platform.openai.com/api-keys)"
 
-#: lib/phoenix_kit/integrations/providers.ex:359
+#: lib/phoenix_kit/integrations/providers.ex:360
 #, elixir-autogen, elixir-format
 msgid "Go to [Billing](https://platform.openai.com/account/billing/overview) and add a payment method or credits"
 msgstr "Перейдите в [Биллинг](https://platform.openai.com/account/billing/overview) и добавьте способ оплаты или кредиты"
 
-#: lib/phoenix_kit/integrations/providers.ex:672
+#: lib/phoenix_kit/integrations/providers.ex:673
 #, elixir-autogen, elixir-format
 msgid "Go to [Settings → API Keys](https://elevenlabs.io/app/settings/api-keys)"
 msgstr "Перейдите в [Настройки → API-ключи](https://elevenlabs.io/app/settings/api-keys)"
 
-#: lib/phoenix_kit/integrations/providers.ex:666
+#: lib/phoenix_kit/integrations/providers.ex:667
 #, elixir-autogen, elixir-format
 msgid "Go to [elevenlabs.io](https://elevenlabs.io) and sign up or log in"
 msgstr "Перейдите на [elevenlabs.io](https://elevenlabs.io) и зарегистрируйтесь или войдите"
 
-#: lib/phoenix_kit/integrations/providers.ex:351
+#: lib/phoenix_kit/integrations/providers.ex:352
 #, elixir-autogen, elixir-format
 msgid "Go to [platform.openai.com](https://platform.openai.com) and sign up or log in"
 msgstr "Перейдите на [platform.openai.com](https://platform.openai.com) и зарегистрируйтесь или войдите"
@@ -9394,7 +9398,7 @@ msgstr "Заголовок %{level}"
 msgid "Icon"
 msgstr "Значок"
 
-#: lib/phoenix_kit/integrations/providers.ex:375
+#: lib/phoenix_kit/integrations/providers.ex:376
 #, elixir-autogen, elixir-format
 msgid "If your account belongs to multiple organizations, keys are scoped to the org selected when the key was created."
 msgstr "Если ваш аккаунт принадлежит нескольким организациям, ключи привязаны к организации, выбранной при создании ключа."
@@ -9494,12 +9498,12 @@ msgstr "Сначала старые"
 msgid "Open the media health dashboard to check file redundancy and re-sync files across storage locations."
 msgstr "Откройте панель состояния медиа, чтобы проверить избыточность файлов и повторно синхронизировать файлы между хранилищами."
 
-#: lib/phoenix_kit/integrations/providers.ex:311
+#: lib/phoenix_kit/integrations/providers.ex:312
 #, elixir-autogen, elixir-format
 msgid "OpenAI"
 msgstr "OpenAI"
 
-#: lib/phoenix_kit/integrations/providers.ex:362
+#: lib/phoenix_kit/integrations/providers.ex:363
 #, elixir-autogen, elixir-format
 msgid "OpenAI requires a positive balance before the API will return completions, even on cheaper models"
 msgstr "OpenAI требует положительного баланса, прежде чем API начнёт возвращать ответы, даже на более дешёвых моделях"
@@ -9590,12 +9594,12 @@ msgstr "Сортировка"
 msgid "Stacks"
 msgstr "Стопки"
 
-#: lib/phoenix_kit/integrations/providers.ex:635
+#: lib/phoenix_kit/integrations/providers.ex:636
 #, elixir-autogen, elixir-format
 msgid "Text-to-speech and voice generation via ElevenLabs"
 msgstr "Преобразование текста в речь и генерация голоса через ElevenLabs"
 
-#: lib/phoenix_kit/integrations/providers.ex:678
+#: lib/phoenix_kit/integrations/providers.ex:679
 #, elixir-autogen, elixir-format
 msgid "The free tier includes a monthly character quota; paid plans raise the quota and unlock commercial use and additional voices."
 msgstr "Бесплатный тариф включает ежемесячную квоту символов; платные планы увеличивают квоту и открывают коммерческое использование и дополнительные голоса."
@@ -10479,27 +10483,27 @@ msgstr "Или добавить через"
 msgid "Too many attempts. Please try again shortly."
 msgstr "Слишком много попыток. Повторите чуть позже."
 
-#: lib/phoenix_kit/integrations/providers.ex:569
+#: lib/phoenix_kit/integrations/providers.ex:570
 #, elixir-autogen, elixir-format
 msgid "AI model access via xAI (Grok models)"
 msgstr "Доступ к AI-моделям через xAI (модели Grok)"
 
-#: lib/phoenix_kit/integrations/providers.ex:827
+#: lib/phoenix_kit/integrations/providers.ex:828
 #, elixir-autogen, elixir-format
 msgid "AWS Simple Email Service (SMTP credentials via SES API)"
 msgstr "AWS Simple Email Service (учётные данные SMTP через SES API)"
 
-#: lib/phoenix_kit/integrations/providers.ex:826
+#: lib/phoenix_kit/integrations/providers.ex:827
 #, elixir-autogen, elixir-format
 msgid "Amazon SES"
 msgstr "Amazon SES"
 
-#: lib/phoenix_kit/integrations/providers.ex:1050
+#: lib/phoenix_kit/integrations/providers.ex:1122
 #, elixir-autogen, elixir-format
 msgid "Brevo API"
 msgstr "Brevo API"
 
-#: lib/phoenix_kit/integrations/providers.ex:605
+#: lib/phoenix_kit/integrations/providers.ex:606
 #, elixir-autogen, elixir-format
 msgid "Create an xAI account"
 msgstr "Создайте аккаунт xAI"
@@ -10509,37 +10513,37 @@ msgstr "Создайте аккаунт xAI"
 msgid "Email users when their account is signed in from a new device"
 msgstr "Отправлять пользователям письмо при входе в их аккаунт с нового устройства"
 
-#: lib/phoenix_kit/integrations/providers.ex:961
+#: lib/phoenix_kit/integrations/providers.ex:1033
 #, elixir-autogen, elixir-format
 msgid "For Brevo: the SMTP key starting with xsmtpsib- (SMTP & API → SMTP tab) — not the API key (xkeysib-)."
 msgstr "Для Brevo: ключ SMTP, начинающийся с xsmtpsib- (SMTP & API → вкладка SMTP), а не ключ API (xkeysib-)."
 
-#: lib/phoenix_kit/integrations/providers.ex:949
+#: lib/phoenix_kit/integrations/providers.ex:1021
 #, elixir-autogen, elixir-format
 msgid "For Brevo: your account's SMTP login, shown as <subaccount>@smtp-brevo.com under SMTP & API → SMTP."
 msgstr "Для Brevo: SMTP-логин вашего аккаунта, показанный как <subaccount>@smtp-brevo.com в разделе SMTP & API → SMTP."
 
-#: lib/phoenix_kit/integrations/providers.ex:1070
+#: lib/phoenix_kit/integrations/providers.ex:1142
 #, elixir-autogen, elixir-format
 msgid "From Brevo → SMTP & API → API Keys. Starts with xkeysib- — not the SMTP key (xsmtpsib-)."
 msgstr "Из Brevo → SMTP & API → API Keys. Начинается с xkeysib-, а не ключ SMTP (xsmtpsib-)."
 
-#: lib/phoenix_kit/integrations/providers.ex:590
+#: lib/phoenix_kit/integrations/providers.ex:591
 #, elixir-autogen, elixir-format
 msgid "From console.x.ai/team/default/api-keys"
 msgstr "С console.x.ai/team/default/api-keys"
 
-#: lib/phoenix_kit/integrations/providers.ex:621
+#: lib/phoenix_kit/integrations/providers.ex:622
 #, elixir-autogen, elixir-format
 msgid "Go to [API Keys](https://console.x.ai/team/default/api-keys)"
 msgstr "Перейдите в [API Keys](https://console.x.ai/team/default/api-keys)"
 
-#: lib/phoenix_kit/integrations/providers.ex:607
+#: lib/phoenix_kit/integrations/providers.ex:608
 #, elixir-autogen, elixir-format
 msgid "Go to [accounts.x.ai](https://accounts.x.ai) and sign up or log in"
 msgstr "Перейдите на [accounts.x.ai](https://accounts.x.ai) и зарегистрируйтесь или войдите"
 
-#: lib/phoenix_kit/integrations/providers.ex:613
+#: lib/phoenix_kit/integrations/providers.ex:614
 #, elixir-autogen, elixir-format
 msgid "Go to [console.x.ai](https://console.x.ai) → Billing and add credits"
 msgstr "Перейдите на [console.x.ai](https://console.x.ai) → Billing и добавьте кредиты"
@@ -10549,43 +10553,44 @@ msgstr "Перейдите на [console.x.ai](https://console.x.ai) → Billing
 msgid "Login Notifications"
 msgstr "Уведомления о входе"
 
-#: lib/phoenix_kit/integrations/providers.ex:927
+#: lib/phoenix_kit/integrations/providers.ex:999
 #, elixir-autogen, elixir-format
 msgid "Port"
 msgstr "Порт"
 
-#: lib/phoenix_kit/integrations/providers.ex:720
-#: lib/phoenix_kit/integrations/providers.ex:860
+#: lib/phoenix_kit/integrations/providers.ex:721
+#: lib/phoenix_kit/integrations/providers.ex:861
+#: lib/phoenix_kit/integrations/providers.ex:945
 #, elixir-autogen, elixir-format
 msgid "Region"
 msgstr "Регион"
 
-#: lib/phoenix_kit/integrations/providers.ex:904
+#: lib/phoenix_kit/integrations/providers.ex:976
 #, elixir-autogen, elixir-format
 msgid "SMTP"
 msgstr "SMTP"
 
-#: lib/phoenix_kit/integrations/providers.ex:918
+#: lib/phoenix_kit/integrations/providers.ex:990
 #, elixir-autogen, elixir-format
 msgid "SMTP Host"
 msgstr "SMTP-хост"
 
-#: lib/phoenix_kit/integrations/providers.ex:1051
+#: lib/phoenix_kit/integrations/providers.ex:1123
 #, elixir-autogen, elixir-format
 msgid "Send email via the Brevo transactional email API"
 msgstr "Отправка писем через транзакционный API Brevo"
 
-#: lib/phoenix_kit/integrations/providers.ex:906
+#: lib/phoenix_kit/integrations/providers.ex:978
 #, elixir-autogen, elixir-format
 msgid "Universal SMTP relay — works with any vendor (Brevo, Mailgun, SendGrid, a self-hosted mail server, etc). Add one named connection per relay/account."
 msgstr "Универсальный SMTP-релей — работает с любым поставщиком (Brevo, Mailgun, SendGrid, собственный почтовый сервер и т. д.). Добавьте по одному именованному подключению на каждый релей или аккаунт."
 
-#: lib/phoenix_kit/integrations/providers.ex:568
+#: lib/phoenix_kit/integrations/providers.ex:569
 #, elixir-autogen, elixir-format
 msgid "xAI"
 msgstr "xAI"
 
-#: lib/phoenix_kit/integrations/providers.ex:615
+#: lib/phoenix_kit/integrations/providers.ex:616
 #, elixir-autogen, elixir-format
 msgid "xAI requires a funded account before the API will return completions"
 msgstr "xAI требует пополненного аккаунта, иначе API не будет возвращать ответы"
@@ -10762,12 +10767,12 @@ msgstr "Ни один файл не соответствует поиску."
 msgid "Try a different term or clear the search"
 msgstr "Попробуйте другой запрос или очистите поиск"
 
-#: lib/modules/storage/web/bucket_form.ex:294
+#: lib/modules/storage/web/bucket_form.ex:296
 #, elixir-autogen, elixir-format
 msgid "Add Storage Bucket"
 msgstr "Добавить бакет хранилища"
 
-#: lib/modules/storage/web/bucket_form.ex:295
+#: lib/modules/storage/web/bucket_form.ex:297
 #, elixir-autogen, elixir-format
 msgid "Edit Storage Bucket"
 msgstr "Изменить бакет хранилища"
@@ -10857,12 +10862,12 @@ msgstr "%{n} мин назад"
 msgid "%{provider} settings"
 msgstr "Настройки %{provider}"
 
-#: lib/phoenix_kit/integrations/validators.ex:643
+#: lib/phoenix_kit/integrations/validators.ex:824
 #, elixir-autogen, elixir-format
 msgid "%{text} · resets %{date}"
 msgstr "%{text} · сброс %{date}"
 
-#: lib/phoenix_kit/integrations/validators.ex:632
+#: lib/phoenix_kit/integrations/validators.ex:813
 #, elixir-autogen, elixir-format
 msgid "%{type} · %{credits} credits left"
 msgstr "%{type} · осталось кредитов: %{credits}"
@@ -10918,12 +10923,12 @@ msgstr "Вся исходящая системная почта — аутент
 msgid "Allow \"Keep me logged in\" (persistent sessions)"
 msgstr "Разрешить «Запомнить меня» (постоянные сессии)"
 
-#: lib/phoenix_kit/integrations/providers.ex:1001
+#: lib/phoenix_kit/integrations/providers.ex:1073
 #, elixir-autogen, elixir-format
 msgid "Always"
 msgstr "Всегда"
 
-#: lib/phoenix_kit_web/users/session.ex:331
+#: lib/phoenix_kit_web/users/session.ex:333
 #, elixir-autogen, elixir-format
 msgid "An owner account cannot be used."
 msgstr "Нельзя использовать аккаунт владельца."
@@ -10933,12 +10938,12 @@ msgstr "Нельзя использовать аккаунт владельца.
 msgid "Applies site-wide wherever the rich-text editor is rendered (posts, comments). Users can still switch modes inside the editor."
 msgstr "Действует на всём сайте везде, где отображается визуальный редактор (записи, комментарии). Пользователи по-прежнему могут переключать режим внутри редактора."
 
-#: lib/phoenix_kit/integrations/providers.ex:982
+#: lib/phoenix_kit/integrations/providers.ex:1054
 #, elixir-autogen, elixir-format
 msgid "Auto (from port)"
 msgstr "Автоматически (по порту)"
 
-#: lib/phoenix_kit/integrations/providers.ex:978
+#: lib/phoenix_kit/integrations/providers.ex:1050
 #, elixir-autogen, elixir-format
 msgid "Auto follows the port: 465 means implicit TLS, anything else STARTTLS (required when a login is set). Choose explicitly for a relay that ignores that convention."
 msgstr "«Автоматически» ориентируется на порт: 465 означает неявный TLS, любой другой — STARTTLS (обязателен, если задан логин). Выберите значение вручную, если релей не следует этому соглашению."
@@ -10953,22 +10958,22 @@ msgstr "Объединяйте частые типы уведомлений в �
 msgid "Best,\nThe Team"
 msgstr "С уважением,\nКоманда"
 
-#: lib/phoenix_kit/integrations/providers.ex:1098
+#: lib/phoenix_kit/integrations/providers.ex:1170
 #, elixir-autogen, elixir-format
 msgid "Bot Token"
 msgstr "Токен бота"
 
-#: lib/phoenix_kit/integrations/providers.ex:1118
+#: lib/phoenix_kit/integrations/providers.ex:1190
 #, elixir-autogen, elixir-format
 msgid "BotFather replies with an HTTP API token like `123456789:ABCdef...` — copy it"
 msgstr "BotFather пришлёт токен HTTP API вида `123456789:ABCdef...` — скопируйте его"
 
-#: lib/phoenix_kit/integrations/validators.ex:601
+#: lib/phoenix_kit/integrations/validators.ex:782
 #, elixir-autogen, elixir-format
 msgid "Brevo error %{status}"
 msgstr "Ошибка Brevo %{status}"
 
-#: lib/phoenix_kit/integrations/providers.ex:1022
+#: lib/phoenix_kit/integrations/providers.ex:1094
 #, elixir-autogen, elixir-format
 msgid "CA certificate (PEM)"
 msgstr "Сертификат CA (PEM)"
@@ -10978,7 +10983,7 @@ msgstr "Сертификат CA (PEM)"
 msgid "Cannot delete send profile"
 msgstr "Невозможно удалить профиль отправки"
 
-#: lib/phoenix_kit/integrations/providers.ex:1007
+#: lib/phoenix_kit/integrations/providers.ex:1079
 #, elixir-autogen, elixir-format
 msgid "Certificate verification"
 msgstr "Проверка сертификата"
@@ -11023,7 +11028,7 @@ msgstr "Подтвердите ваш email"
 msgid "Connect your own API keys and services. Only you can see these."
 msgstr "Подключите свои ключи API и сервисы. Их видите только вы."
 
-#: lib/phoenix_kit/integrations/validators.ex:693
+#: lib/phoenix_kit/integrations/validators.ex:874
 #, elixir-autogen, elixir-format
 msgid "Connected as @%{username}"
 msgstr "Подключено как @%{username}"
@@ -11039,7 +11044,7 @@ msgstr "Соединение работает"
 msgid "Content Editor"
 msgstr "Редактор контента"
 
-#: lib/phoenix_kit/integrations/providers.ex:1116
+#: lib/phoenix_kit/integrations/providers.ex:1188
 #, elixir-autogen, elixir-format
 msgid "Copy the bot token"
 msgstr "Скопируйте токен бота"
@@ -11057,12 +11062,12 @@ msgstr "Не удалось добавить интеграцию"
 msgid "Could not reach AWS SES"
 msgstr "Не удалось связаться с AWS SES"
 
-#: lib/phoenix_kit/integrations/validators.ex:605
+#: lib/phoenix_kit/integrations/validators.ex:786
 #, elixir-autogen, elixir-format
 msgid "Could not reach Brevo"
 msgstr "Не удалось связаться с Brevo"
 
-#: lib/phoenix_kit/integrations/validators.ex:705
+#: lib/phoenix_kit/integrations/validators.ex:886
 #, elixir-autogen, elixir-format
 msgid "Could not reach Telegram"
 msgstr "Не удалось связаться с Telegram"
@@ -11123,7 +11128,7 @@ msgstr "Не удалось обновить настройки сводок."
 msgid "Could not update default send integration"
 msgstr "Не удалось обновить интеграцию отправки по умолчанию"
 
-#: lib/phoenix_kit/integrations/providers.ex:1109
+#: lib/phoenix_kit/integrations/providers.ex:1181
 #, elixir-autogen, elixir-format
 msgid "Create a bot with BotFather"
 msgstr "Создайте бота через BotFather"
@@ -11199,7 +11204,7 @@ msgstr "Отключённые профили никогда не использ
 msgid "Dismiss"
 msgstr "Отклонить"
 
-#: lib/phoenix_kit/integrations/providers.ex:1017
+#: lib/phoenix_kit/integrations/providers.ex:1089
 #, elixir-autogen, elixir-format
 msgid "Do not verify"
 msgstr "Не проверять"
@@ -11231,7 +11236,7 @@ msgstr "Изменение профиля отправки: %{name}"
 msgid "Email Sending"
 msgstr "Отправка почты"
 
-#: lib/phoenix_kit_web/users/confirmation_instructions.ex:109
+#: lib/phoenix_kit_web/users/confirmation_instructions.ex:111
 #, elixir-autogen, elixir-format
 msgid "Email confirmed. Welcome!"
 msgstr "Email подтверждён. Добро пожаловать!"
@@ -11241,7 +11246,7 @@ msgstr "Email подтверждён. Добро пожаловать!"
 msgid "Email-capable integrations"
 msgstr "Интеграции с поддержкой почты"
 
-#: lib/phoenix_kit/integrations/providers.ex:973
+#: lib/phoenix_kit/integrations/providers.ex:1045
 #, elixir-autogen, elixir-format
 msgid "Encryption"
 msgstr "Шифрование"
@@ -11261,7 +11266,7 @@ msgstr "Каждые 12 часов"
 msgid "Everyone who starts the bot"
 msgstr "Всем, кто запустил бота"
 
-#: lib/phoenix_kit/integrations/providers.ex:1027
+#: lib/phoenix_kit/integrations/providers.ex:1099
 #, elixir-autogen, elixir-format
 msgid "For a private or self-signed relay certificate. Replaces the system CA store for this connection only."
 msgstr "Для частного или самоподписанного сертификата релея. Заменяет системное хранилище CA только для этого подключения."
@@ -11272,7 +11277,7 @@ msgstr "Для частного или самоподписанного серт
 msgid "From"
 msgstr "Отправитель"
 
-#: lib/phoenix_kit/integrations/providers.ex:1102
+#: lib/phoenix_kit/integrations/providers.ex:1174
 #, elixir-autogen, elixir-format
 msgid "From @BotFather → /newbot (or /token for an existing bot)"
 msgstr "От @BotFather → /newbot (или /token для существующего бота)"
@@ -11299,7 +11304,7 @@ msgstr "Полный доступ"
 msgid "Hourly"
 msgstr "Каждый час"
 
-#: lib/phoenix_kit/integrations/providers.ex:1000
+#: lib/phoenix_kit/integrations/providers.ex:1072
 #, elixir-autogen, elixir-format
 msgid "If offered (default)"
 msgstr "Если предлагается (по умолчанию)"
@@ -11309,7 +11314,7 @@ msgstr "Если предлагается (по умолчанию)"
 msgid "Immediate"
 msgstr "Сразу"
 
-#: lib/phoenix_kit/integrations/providers.ex:983
+#: lib/phoenix_kit/integrations/providers.ex:1055
 #, elixir-autogen, elixir-format
 msgid "Implicit TLS / SMTPS"
 msgstr "Неявный TLS / SMTPS"
@@ -11327,6 +11332,7 @@ msgid "Incomplete SMTP settings"
 msgstr "Неполные настройки SMTP"
 
 #: lib/phoenix_kit/integrations/validators.ex:57
+#: lib/phoenix_kit/integrations/validators.ex:582
 #, elixir-autogen, elixir-format
 msgid "Incomplete credentials"
 msgstr "Неполные учётные данные"
@@ -11363,7 +11369,7 @@ msgstr "Некорректные настройки SMTP"
 msgid "Invalid SMTP settings: %{reason}"
 msgstr "Некорректные настройки SMTP: %{reason}"
 
-#: lib/phoenix_kit/integrations/validators.ex:698
+#: lib/phoenix_kit/integrations/validators.ex:879
 #, elixir-autogen, elixir-format
 msgid "Invalid bot token"
 msgstr "Некорректный токен бота"
@@ -11383,7 +11389,7 @@ msgstr "Некорректный тайм-аут: %{value}"
 msgid "Leave a field blank to fall back to the application config or built-in default."
 msgstr "Оставьте поле пустым, чтобы использовать конфигурацию приложения или встроенное значение по умолчанию."
 
-#: lib/phoenix_kit/integrations/providers.ex:1038
+#: lib/phoenix_kit/integrations/providers.ex:1110
 #, elixir-autogen, elixir-format
 msgid "Leave blank for the gen_smtp default."
 msgstr "Оставьте пустым для значения gen_smtp по умолчанию."
@@ -11424,7 +11430,7 @@ msgstr "Отметить все прочитанными"
 msgid "Mark read"
 msgstr "Отметить прочитанным"
 
-#: lib/phoenix_kit_web/users/session.ex:340
+#: lib/phoenix_kit_web/users/session.ex:342
 #, elixir-autogen, elixir-format
 msgid "Maximum number of accounts reached — remove one first."
 msgstr "Достигнуто максимальное число аккаунтов — сначала удалите один."
@@ -11474,7 +11480,7 @@ msgstr "Новый профиль отправки"
 msgid "No adapter configured for the static mailer. Set one in your application config, or connect an email-capable integration below and pick it as the default transactional integration."
 msgstr "Для статического mailer не настроен адаптер. Задайте его в конфигурации приложения или подключите ниже интеграцию с поддержкой почты и выберите её как транзакционную интеграцию по умолчанию."
 
-#: lib/phoenix_kit/integrations/validators.ex:682
+#: lib/phoenix_kit/integrations/validators.ex:863
 #, elixir-autogen, elixir-format
 msgid "No bot token configured"
 msgstr "Токен бота не задан"
@@ -11514,7 +11520,7 @@ msgstr "Системные сертификаты CA не найдены, поэ
 msgid "No unread notifications"
 msgstr "Нет непрочитанных уведомлений"
 
-#: lib/phoenix_kit/integrations/providers.ex:986
+#: lib/phoenix_kit/integrations/providers.ex:1058
 #, elixir-autogen, elixir-format
 msgid "None — plaintext"
 msgstr "Нет — без шифрования"
@@ -11544,7 +11550,7 @@ msgstr "Полученные уведомления появятся здесь.
 msgid "Numeric ID of a verified Brevo sender. Leave empty to send from the From address above."
 msgstr "Числовой ID подтверждённого отправителя Brevo. Оставьте пустым, чтобы отправлять с адреса, указанного выше."
 
-#: lib/phoenix_kit_web/users/session.ex:334
+#: lib/phoenix_kit_web/users/session.ex:336
 #, elixir-autogen, elixir-format
 msgid "Only an owner can sign in as another administrator."
 msgstr "Только владелец может войти от имени другого администратора."
@@ -11554,12 +11560,12 @@ msgstr "Только владелец может войти от имени др
 msgid "Only me"
 msgstr "Только мне"
 
-#: lib/phoenix_kit/integrations/providers.ex:1111
+#: lib/phoenix_kit/integrations/providers.ex:1183
 #, elixir-autogen, elixir-format
 msgid "Open [@BotFather](https://t.me/BotFather) in Telegram"
 msgstr "Откройте [@BotFather](https://t.me/BotFather) в Telegram"
 
-#: lib/phoenix_kit/integrations/providers.ex:1121
+#: lib/phoenix_kit/integrations/providers.ex:1193
 #, elixir-autogen, elixir-format
 msgid "Paste the token into the form above and press **Test Connection**"
 msgstr "Вставьте токен в форму выше и нажмите **Проверить соединение**"
@@ -11579,7 +11585,7 @@ msgstr "Данные отправителя, ограничения частот
 msgid "Persistent sessions last 60 days. Magic-link and social logins have no checkbox to tick, so they follow the default above. Turning the first option off hides the checkbox everywhere and keeps every login to the browser session."
 msgstr "Постоянные сессии живут 60 дней. При входе по волшебной ссылке и через соцсети галочки нет, поэтому используется значение по умолчанию выше. Если отключить первый параметр, галочка исчезнет везде, а любой вход будет ограничен сессией браузера."
 
-#: lib/phoenix_kit/integrations/validators.ex:616
+#: lib/phoenix_kit/integrations/validators.ex:797
 #, elixir-autogen, elixir-format
 msgid "Plan: %{entries}"
 msgstr "Тариф: %{entries}"
@@ -11676,12 +11682,12 @@ msgstr "У SMTP нет настроек провайдера на уровне �
 msgid "SMTP server rejected the connection"
 msgstr "SMTP-сервер отклонил подключение"
 
-#: lib/phoenix_kit/integrations/providers.ex:985
+#: lib/phoenix_kit/integrations/providers.ex:1057
 #, elixir-autogen, elixir-format
 msgid "STARTTLS — if offered"
 msgstr "STARTTLS — если предлагается"
 
-#: lib/phoenix_kit/integrations/providers.ex:984
+#: lib/phoenix_kit/integrations/providers.ex:1056
 #, elixir-autogen, elixir-format
 msgid "STARTTLS — required"
 msgstr "STARTTLS — обязательно"
@@ -11701,7 +11707,7 @@ msgstr "Сохранить данные отправителя"
 msgid "Select an integration..."
 msgstr "Выберите интеграцию…"
 
-#: lib/phoenix_kit/integrations/providers.ex:1112
+#: lib/phoenix_kit/integrations/providers.ex:1184
 #, elixir-autogen, elixir-format
 msgid "Send **/newbot** and follow the prompts to name your bot"
 msgstr "Отправьте **/newbot** и следуйте подсказкам, чтобы задать имя бота"
@@ -11715,7 +11721,7 @@ msgstr "Отправьте **/newbot** и следуйте подсказкам,
 msgid "Send Profiles"
 msgstr "Профили отправки"
 
-#: lib/phoenix_kit/integrations/providers.ex:1087
+#: lib/phoenix_kit/integrations/providers.ex:1159
 #, elixir-autogen, elixir-format
 msgid "Send messages and notifications via your own Telegram bot"
 msgstr "Отправка сообщений и уведомлений через ваш собственный бот Telegram"
@@ -11805,13 +11811,13 @@ msgstr "Не удалось установить TLS-соединение"
 msgid "Tags"
 msgstr "Теги"
 
-#: lib/phoenix_kit/integrations/providers.ex:1086
+#: lib/phoenix_kit/integrations/providers.ex:1158
 #: lib/phoenix_kit/notifications/channels/telegram.ex:36
 #, elixir-autogen, elixir-format
 msgid "Telegram"
 msgstr "Telegram"
 
-#: lib/phoenix_kit/integrations/validators.ex:701
+#: lib/phoenix_kit/integrations/validators.ex:882
 #, elixir-autogen, elixir-format
 msgid "Telegram error %{status}"
 msgstr "Ошибка Telegram %{status}"
@@ -11831,17 +11837,17 @@ msgstr "Тестовое письмо от %{site}"
 msgid "Test email sent to %{recipient}"
 msgstr "Тестовое письмо отправлено на %{recipient}"
 
-#: lib/phoenix_kit_web/users/session.ex:343
+#: lib/phoenix_kit_web/users/session.ex:345
 #, elixir-autogen, elixir-format
 msgid "That account is already in your session — switch to it instead."
 msgstr "Этот аккаунт уже есть в вашей сессии — просто переключитесь на него."
 
-#: lib/phoenix_kit_web/users/session.ex:337
+#: lib/phoenix_kit_web/users/session.ex:339
 #, elixir-autogen, elixir-format
 msgid "That account is deactivated."
 msgstr "Этот аккаунт деактивирован."
 
-#: lib/phoenix_kit_web/users/session.ex:336
+#: lib/phoenix_kit_web/users/session.ex:338
 #, elixir-autogen, elixir-format
 msgid "That is already your account."
 msgstr "Это и есть ваш аккаунт."
@@ -11882,7 +11888,7 @@ msgstr "Этот профиль отправки будет удалён без�
 msgid "This sender address cannot be logged"
 msgstr "Этот адрес отправителя нельзя записать в журнал"
 
-#: lib/phoenix_kit/integrations/providers.ex:1034
+#: lib/phoenix_kit/integrations/providers.ex:1106
 #, elixir-autogen, elixir-format
 msgid "Timeout (seconds)"
 msgstr "Тайм-аут (секунды)"
@@ -11892,7 +11898,7 @@ msgstr "Тайм-аут (секунды)"
 msgid "Transport"
 msgstr "Транспорт"
 
-#: lib/phoenix_kit/integrations/providers.ex:1012
+#: lib/phoenix_kit/integrations/providers.ex:1084
 #, elixir-autogen, elixir-format
 msgid "Turning verification off means the login travels to whoever answers, including an impostor. Use a CA certificate below instead whenever you can."
 msgstr "Если отключить проверку, логин будет отправлен любому, кто ответит, включая подставной сервер. По возможности используйте сертификат CA ниже."
@@ -11922,12 +11928,12 @@ msgstr "Обновить профиль отправки"
 msgid "Used when no default transactional integration is selected below."
 msgstr "Используется, если ниже не выбрана транзакционная интеграция по умолчанию."
 
-#: lib/phoenix_kit_web/users/session.ex:309
+#: lib/phoenix_kit_web/users/session.ex:311
 #, elixir-autogen, elixir-format
 msgid "User not found."
 msgstr "Пользователь не найден."
 
-#: lib/phoenix_kit/integrations/providers.ex:1016
+#: lib/phoenix_kit/integrations/providers.ex:1088
 #, elixir-autogen, elixir-format
 msgid "Verify (default)"
 msgstr "Проверять (по умолчанию)"
@@ -11947,7 +11953,7 @@ msgstr "Интеграции сайта"
 msgid "Where a freshly registered account lands. Empty = after-login path."
 msgstr "Куда попадает только что зарегистрированный аккаунт. Пусто — путь после входа."
 
-#: lib/phoenix_kit/integrations/providers.ex:996
+#: lib/phoenix_kit/integrations/providers.ex:1068
 #, elixir-autogen, elixir-format
 msgid "Whether to send the login at all. “If offered” follows the relay; “Never” is for relays that authenticate by IP."
 msgstr "Отправлять ли логин вообще. «Если предлагается» следует за релеем; «Никогда» — для релеев, которые проверяют подлинность по IP."
@@ -11962,12 +11968,12 @@ msgstr "Кому пишет этот бот?"
 msgid "Yesterday"
 msgstr "Вчера"
 
-#: lib/phoenix_kit_web/users/session.ex:320
+#: lib/phoenix_kit_web/users/session.ex:322
 #, elixir-autogen, elixir-format
 msgid "You are now signed in as %{email}."
 msgstr "Теперь вы вошли как %{email}."
 
-#: lib/phoenix_kit_web/users/session.ex:329
+#: lib/phoenix_kit_web/users/session.ex:331
 #, elixir-autogen, elixir-format
 msgid "You do not have permission to sign in as another user."
 msgstr "У вас нет права входить от имени другого пользователя."
@@ -12083,7 +12089,7 @@ msgstr "Проверка…"
 msgid "Continue"
 msgstr "Продолжить"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:143
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:169
 #, elixir-autogen, elixir-format
 msgid "Copied!"
 msgstr "Скопировано!"
@@ -12093,7 +12099,7 @@ msgstr "Скопировано!"
 msgid "Couldn't reach hex.pm, so the package list is unavailable right now."
 msgstr "Не удалось связаться с hex.pm, поэтому список пакетов сейчас недоступен."
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:119
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:145
 #, elixir-autogen, elixir-format
 msgid "Crawler Instructions"
 msgstr "Инструкции для поисковых роботов"
@@ -12147,7 +12153,7 @@ msgstr "Добро пожаловать! Ваш реферальный код п
 msgid "has the robots.txt line that points crawlers here."
 msgstr "содержит строку robots.txt, которая направляет сюда поисковых роботов."
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:173
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:199
 #, elixir-autogen, elixir-format
 msgid "priv/static/robots.txt points crawlers at your sitemap."
 msgstr "priv/static/robots.txt направляет поисковых роботов к карте сайта."
@@ -12251,17 +12257,17 @@ msgstr "У вас нет прав для удаления этого польз�
 msgid "You don't have permission to manage this user's credentials"
 msgstr "У вас нет прав для управления учётными данными этого пользователя"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:190
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:216
 #, elixir-autogen, elixir-format
 msgid "AI Discovery"
 msgstr "Обнаружение ИИ"
 
-#: lib/phoenix_kit/integrations/providers.ex:698
+#: lib/phoenix_kit/integrations/providers.ex:699
 #, elixir-autogen, elixir-format
 msgid "AWS Bedrock LLMs via a Bedrock API key (OpenAI-compatible endpoint: gpt-oss models; the rest via native Converse)"
 msgstr "LLM-модели AWS Bedrock через API-ключ Bedrock (эндпоинт, совместимый с OpenAI: модели gpt-oss; остальные через нативный Converse)"
 
-#: lib/phoenix_kit/integrations/providers.ex:715
+#: lib/phoenix_kit/integrations/providers.ex:716
 #, elixir-autogen, elixir-format
 msgid "AWS console → Amazon Bedrock → API keys (long-term key)"
 msgstr "Консоль AWS → Amazon Bedrock → API-ключи (долгосрочный ключ)"
@@ -12276,22 +12282,22 @@ msgstr "Запрос на доступ отправлен."
 msgid "Account %{id}"
 msgstr "Аккаунт %{id}"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:303
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:329
 #, elixir-autogen, elixir-format
 msgid "Advisory-grade: anything can send any User-Agent, so a scraper that lies passes through. Real enforcement belongs at your CDN or reverse proxy — this catches the honest-but-ignorant. Bots identified only by robots.txt tokens (Google-Extended, Applebot-Extended) crawl under their main user agent and are never matched here, so blocking AI training cannot 403 Googlebot."
 msgstr "Рекомендательный уровень: любой может отправить произвольный User-Agent, поэтому лгущий парсер пройдёт. Реальное принуждение — на вашем CDN или обратном прокси; здесь ловятся честные, но неосведомлённые. Боты, определяемые только по токенам robots.txt (Google-Extended, Applebot-Extended), обходят сайт под своим основным user agent и здесь никогда не совпадают, поэтому блокировка обучения ИИ не может вернуть 403 для Googlebot."
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:98
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:124
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Allowed"
 msgstr "Все"
 
-#: lib/phoenix_kit/integrations/providers.ex:696
+#: lib/phoenix_kit/integrations/providers.ex:697
 #, elixir-autogen, elixir-format
 msgid "Amazon Bedrock"
 msgstr "Amazon Bedrock"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:282
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:308
 #, elixir-autogen, elixir-format
 msgid "Answer 403 to requests whose User-Agent matches a blocked group, for bots that ignore robots.txt."
 msgstr "Отвечать 403 на запросы, чей User-Agent совпадает с заблокированной группой — для ботов, игнорирующих robots.txt."
@@ -12301,7 +12307,7 @@ msgstr "Отвечать 403 на запросы, чей User-Agent совпад
 msgid "Auth mail carries single-use tokens, and /dev/mailbox has no authentication — anyone who can reach this server can read them. Only for closed environments."
 msgstr "Письма аутентификации содержат одноразовые токены, а /dev/mailbox не требует аутентификации — любой, кто имеет доступ к этому серверу, сможет их прочитать. Только для закрытых окружений."
 
-#: lib/phoenix_kit/integrations/providers.ex:711
+#: lib/phoenix_kit/integrations/providers.ex:712
 #, elixir-autogen, elixir-format
 msgid "Bedrock API key"
 msgstr "API-ключ Bedrock"
@@ -12311,7 +12317,7 @@ msgstr "API-ключ Bedrock"
 msgid "Bedrock error %{status}"
 msgstr "Ошибка Brevo %{status}"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:280
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:306
 #, elixir-autogen, elixir-format
 msgid "Block at the application"
 msgstr "Блокировать на уровне приложения"
@@ -12321,7 +12327,7 @@ msgstr "Блокировать на уровне приложения"
 msgid "Blocked groups"
 msgstr "Заблокирован"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:77
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:103
 #, elixir-autogen, elixir-format
 msgid "Bot Access"
 msgstr "Доступ ботов"
@@ -12336,12 +12342,12 @@ msgstr "По умолчанию упоминание показывает то, 
 msgid "Control how search engines and AI bots crawl and index this site"
 msgstr "Управление тем, как поисковые системы и ИИ-боты сканируют и индексируют этот сайт"
 
-#: lib/phoenix_kit/integrations/providers.ex:739
+#: lib/phoenix_kit/integrations/providers.ex:740
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Copy the key (shown once, `ABSK…`) and paste it into the form above"
 msgstr "Скопируйте ключ (показывается один раз) и вставьте его в форму выше"
 
-#: lib/phoenix_kit/integrations/providers.ex:815
+#: lib/phoenix_kit/integrations/providers.ex:816
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Copy the token and paste it into the form above"
 msgstr "Скопируйте ключ и вставьте его в форму выше"
@@ -12382,22 +12388,22 @@ msgstr "Сканеры"
 msgid "Crawlers module is disabled. Enable it from the Modules page to configure settings."
 msgstr "Модуль SEO отключён. Включите его на странице Модулей для настройки."
 
-#: lib/phoenix_kit/integrations/providers.ex:731
+#: lib/phoenix_kit/integrations/providers.ex:732
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Create a Bedrock API key"
 msgstr "Создайте API-ключ"
 
-#: lib/phoenix_kit/integrations/providers.ex:807
+#: lib/phoenix_kit/integrations/providers.ex:808
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Create a token"
 msgstr "Создать роль"
 
-#: lib/phoenix_kit/integrations/providers.ex:871
+#: lib/phoenix_kit/integrations/providers.ex:872
 #, elixir-autogen, elixir-format
 msgid "Create an IAM user with SES access"
 msgstr "Создайте пользователя IAM с доступом к SES"
 
-#: lib/phoenix_kit/integrations/providers.ex:876
+#: lib/phoenix_kit/integrations/providers.ex:877
 #, elixir-autogen, elixir-format
 msgid "Create an access key for that user (Security credentials → Create access key) and paste the ID and secret above"
 msgstr "Создайте ключ доступа для этого пользователя (Security credentials → Create access key) и вставьте ID и секрет выше"
@@ -12412,41 +12418,42 @@ msgstr "Решите, кто может читать этот сайт — ди�
 msgid "Deliver development mail to /dev/mailbox"
 msgstr "Доставлять письма разработки в /dev/mailbox"
 
-#: lib/phoenix_kit/integrations/providers.ex:747
+#: lib/phoenix_kit/integrations/providers.ex:748
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enable model access"
 msgstr "Включите модуль для доступа к настройкам"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:278
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:304
 #, elixir-autogen, elixir-format
 msgid "Enforcement"
 msgstr "Принуждение"
 
 #: lib/phoenix_kit_web/live/settings/crawlers.ex:90
-#: lib/phoenix_kit_web/live/settings/crawlers.ex:109
-#: lib/phoenix_kit_web/live/settings/crawlers.ex:120
-#: lib/phoenix_kit_web/live/settings/crawlers.ex:136
-#: lib/phoenix_kit_web/live/settings/crawlers.ex:149
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:102
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:121
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:132
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:148
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:161
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to update crawler settings"
 msgstr "Не удалось обновить настройку"
 
-#: lib/phoenix_kit/integrations/providers.ex:780
+#: lib/phoenix_kit/integrations/providers.ex:781
 #, elixir-autogen, elixir-format, fuzzy
 msgid "GitHub"
 msgstr "Вход через GitHub"
 
-#: lib/phoenix_kit/integrations/providers.ex:782
+#: lib/phoenix_kit/integrations/providers.ex:783
 #, elixir-autogen, elixir-format
 msgid "GitHub API token — org statistics, repositories (read-only is enough)"
 msgstr "API-токен GitHub — статистика организации, репозитории (достаточно только чтения)"
 
-#: lib/phoenix_kit/integrations/providers.ex:809
+#: lib/phoenix_kit/integrations/providers.ex:810
 #, elixir-autogen, elixir-format
 msgid "Go to [Fine-grained tokens](https://github.com/settings/personal-access-tokens) and click **Generate new token**"
 msgstr "Перейдите на [Fine-grained tokens](https://github.com/settings/personal-access-tokens) и нажмите **Generate new token**"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:81
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:107
 #, elixir-autogen, elixir-format
 msgid "Grouped by why they visit. Blocking a group writes it into the generated robots.txt below; everything defaults to allowed."
 msgstr "Сгруппированы по причине посещения. Блокировка группы записывается в генерируемый ниже robots.txt; по умолчанию разрешено всё."
@@ -12456,22 +12463,22 @@ msgstr "Сгруппированы по причине посещения. Бл�
 msgid "Hide titles of records the reader can't open"
 msgstr "Скрывать заголовки записей, которые читатель не может открыть"
 
-#: lib/phoenix_kit/integrations/providers.ex:749
+#: lib/phoenix_kit/integrations/providers.ex:750
 #, elixir-autogen, elixir-format
 msgid "In [Bedrock → Model access](https://console.aws.amazon.com/bedrock/home#/modelaccess) enable the models you plan to call — a key with no enabled models validates but cannot complete"
 msgstr "В [Bedrock → Model access](https://console.aws.amazon.com/bedrock/home#/modelaccess) включите модели, которые планируете вызывать — ключ без включённых моделей проходит проверку, но не работает"
 
-#: lib/phoenix_kit/integrations/providers.ex:763
+#: lib/phoenix_kit/integrations/providers.ex:764
 #, elixir-autogen, elixir-format
 msgid "In the AI module, create an endpoint pointing at this connection with a `gpt-oss` model and a base URL in the SAME region as this key"
 msgstr "В модуле AI создайте эндпоинт, указывающий на это подключение, с моделью `gpt-oss` и базовым URL в ТОМ ЖЕ регионе, что и ключ"
 
-#: lib/phoenix_kit/integrations/providers.ex:873
+#: lib/phoenix_kit/integrations/providers.ex:874
 #, elixir-autogen, elixir-format
 msgid "In the [IAM console](https://console.aws.amazon.com/iam/home#/users) create a user for programmatic access and attach an SES policy (least privilege: `ses:SendEmail`/`ses:SendRawEmail`; docs: [SES setup](https://docs.aws.amazon.com/ses/latest/dg/setting-up.html))"
 msgstr "В [консоли IAM](https://console.aws.amazon.com/iam/home#/users) создайте пользователя для программного доступа и приложите политику SES (минимальные права: `ses:SendEmail`/`ses:SendRawEmail`; документация: [настройка SES](https://docs.aws.amazon.com/ses/latest/dg/setting-up.html))"
 
-#: lib/phoenix_kit/integrations/providers.ex:884
+#: lib/phoenix_kit/integrations/providers.ex:885
 #, elixir-autogen, elixir-format
 msgid "In the [SES console](https://console.aws.amazon.com/ses/home#/identities) verify your domain or sender address — SES refuses to send from unverified identities"
 msgstr "В [консоли SES](https://console.aws.amazon.com/ses/home#/identities) подтвердите домен или адрес отправителя — SES не отправляет с неподтверждённых идентификаторов"
@@ -12516,7 +12523,7 @@ msgstr "Упоминания и ссылки на записи"
 msgid "Model catalog in %{region}: %{count} (grants are configured separately)"
 msgstr "Каталог моделей в регионе %{region}: %{count} (права настраиваются отдельно)"
 
-#: lib/phoenix_kit/integrations/providers.ex:887
+#: lib/phoenix_kit/integrations/providers.ex:888
 #, elixir-autogen, elixir-format
 msgid "New accounts start in the SES sandbox (verified recipients only) — [request production access](https://docs.aws.amazon.com/ses/latest/dg/request-production-access.html) before real sending"
 msgstr "Новые аккаунты начинают в песочнице SES (только подтверждённые получатели) — [запросите производственный доступ](https://docs.aws.amazon.com/ses/latest/dg/request-production-access.html) перед реальной отправкой"
@@ -12531,7 +12538,7 @@ msgstr "Не удалось определить данные устройств
 msgid "No longer available"
 msgstr "Больше недоступно"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:165
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:191
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No priv/static/robots.txt found. Without one, crawlers assume everything is allowed — and any groups you blocked above are not being told."
 msgstr "Файл priv/static/robots.txt не найден. Без него поисковые роботы считают, что разрешено всё — обычно это не проблема, но они не узнают, где находится карта сайта."
@@ -12546,47 +12553,47 @@ msgstr "Не показано на этой странице"
 msgid "Note (optional)"
 msgstr "Примечание (необязательно)"
 
-#: lib/phoenix_kit/integrations/providers.ex:733
+#: lib/phoenix_kit/integrations/providers.ex:734
 #, elixir-autogen, elixir-format
 msgid "Open the [Bedrock console → API keys](https://console.aws.amazon.com/bedrock/home#/api-keys) and generate a **long-term** key (docs: [Bedrock API keys](https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys.html))"
 msgstr "Откройте [консоль Bedrock → API keys](https://console.aws.amazon.com/bedrock/home#/api-keys) и создайте **долгосрочный** ключ (документация: [API-ключи Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys.html))"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:212
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:238
 #, elixir-autogen, elixir-format
 msgid "Optional markdown: a summary paragraph, key links, docs pointers…"
 msgstr "Необязательный markdown: краткий абзац, ключевые ссылки, указатели на документацию…"
 
-#: lib/phoenix_kit/integrations/providers.ex:736
+#: lib/phoenix_kit/integrations/providers.ex:737
 #, elixir-autogen, elixir-format
 msgid "Or attach one to an existing IAM user: [IAM console](https://console.aws.amazon.com/iam/home#/users) → user → Security credentials → Bedrock API keys"
 msgstr "Либо привяжите его к существующему пользователю IAM: [консоль IAM](https://console.aws.amazon.com/iam/home#/users) → пользователь → Security credentials → Bedrock API keys"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:235
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:261
 #, elixir-autogen, elixir-format
 msgid "Paste the verification content Google Search Console or Bing Webmaster Tools gives you — the meta tags are added to every layout head. Pasting the whole <meta> tag also works; the content value is extracted."
 msgstr "Вставьте содержимое подтверждения, которое выдаёт Google Search Console или Bing Webmaster Tools — meta-теги добавляются в head каждого макета. Можно вставить и весь тег <meta>; значение content будет извлечено."
 
-#: lib/phoenix_kit/integrations/providers.ex:796
+#: lib/phoenix_kit/integrations/providers.ex:797
 #, elixir-autogen, elixir-format
 msgid "Personal access token"
 msgstr "Персональный токен доступа"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:123
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:149
 #, elixir-autogen, elixir-format
 msgid "PhoenixKit does not serve this file — it is yours, served from priv/static before any route is consulted. This is the complete file your toggles above describe: paste it into priv/static/robots.txt."
 msgstr "PhoenixKit не отдаёт этот файл — он ваш и отдаётся из priv/static до обработки маршрутов. Это полный файл, который описывают переключатели выше: вставьте его в priv/static/robots.txt."
 
-#: lib/phoenix_kit/integrations/providers.ex:752
+#: lib/phoenix_kit/integrations/providers.ex:753
 #, elixir-autogen, elixir-format
 msgid "Pick the region where access was granted; the AI endpoint's base URL must use the same region"
 msgstr "Выберите регион, в котором выдан доступ; базовый URL эндпоинта AI должен использовать тот же регион"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:217
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:243
 #, elixir-autogen, elixir-format
 msgid "Preview of the served file:"
 msgstr "Предпросмотр отдаваемого файла:"
 
-#: lib/phoenix_kit/integrations/providers.ex:812
+#: lib/phoenix_kit/integrations/providers.ex:813
 #, elixir-autogen, elixir-format
 msgid "Repository access: **Public repositories (read-only)** — no extra permissions needed for public-org statistics"
 msgstr "Доступ к репозиториям: **Public repositories (read-only)** — для статистики публичной организации дополнительные права не нужны"
@@ -12596,7 +12603,7 @@ msgstr "Доступ к репозиториям: **Public repositories (read-on
 msgid "Request access"
 msgstr "Запрошено"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:233
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:259
 #, elixir-autogen, elixir-format
 msgid "Search engine verification"
 msgstr "Подтверждение в поисковых системах"
@@ -12616,12 +12623,12 @@ msgstr "Ожидает"
 msgid "Sign in to request access."
 msgstr "Войти под пользователем"
 
-#: lib/phoenix_kit/integrations/providers.ex:760
+#: lib/phoenix_kit/integrations/providers.ex:761
 #, elixir-autogen, elixir-format
 msgid "The OpenAI-compatible endpoint (`…/openai/v1`) currently serves only the `openai.gpt-oss-*` models — Anthropic and the other Bedrock models answer on the native Converse API with the same key"
 msgstr "Совместимый с OpenAI эндпоинт (`…/openai/v1`) сейчас обслуживает только модели `openai.gpt-oss-*` — Anthropic и остальные модели Bedrock отвечают тем же ключом через нативный Converse API"
 
-#: lib/phoenix_kit/integrations/providers.ex:742
+#: lib/phoenix_kit/integrations/providers.ex:743
 #, elixir-autogen, elixir-format
 msgid "The key's IAM identity must allow the `bedrock:CallWithBearerToken` action — without it every Bearer call answers 403 even when invoke permissions are in place."
 msgstr "IAM-идентификатор ключа должен разрешать действие `bedrock:CallWithBearerToken` — без него каждый вызов с Bearer отвечает 403, даже если права на вызов есть."
@@ -12631,17 +12638,17 @@ msgstr "IAM-идентификатор ключа должен разрешат�
 msgid "The mailbox is off: outgoing mail is written to the server log instead."
 msgstr "Почтовый ящик выключен: исходящие письма вместо этого пишутся в лог сервера."
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:179
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:205
 #, elixir-autogen, elixir-format, fuzzy
 msgid "The noindex toggle and robots.txt are separate mechanisms: noindex is a per-page meta tag that tells crawlers not to index what they fetched, while robots.txt tells them what not to fetch at all. A staging site usually wants both."
 msgstr "Переключатель noindex выше и robots.txt — разные механизмы: noindex это метатег на странице, который говорит роботам не индексировать загруженное, а robots.txt говорит им, что вообще не нужно загружать. Тестовому сайту обычно нужны оба."
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:194
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:220
 #, elixir-autogen, elixir-format
 msgid "The other half of bot policy: a markdown summary telling AI assistants what this site is about, served at"
 msgstr "Вторая половина политики ботов: markdown-описание, сообщающее ИИ-ассистентам, о чём этот сайт; отдаётся по адресу"
 
-#: lib/phoenix_kit/integrations/providers.ex:892
+#: lib/phoenix_kit/integrations/providers.ex:893
 #, elixir-autogen, elixir-format
 msgid "This connection stores the credential. The full sending pipeline — configuration set, SNS topic, SQS event queue, delivery tracking — is configured in Admin → Settings → Emails, which can select this connection as its credential source."
 msgstr "Это подключение хранит учётные данные. Весь конвейер отправки — configuration set, тема SNS, очередь событий SQS, отслеживание доставки — настраивается в Админ → Настройки → Письма, где это подключение можно выбрать источником учётных данных."
@@ -12658,22 +12665,22 @@ msgstr "Введите @, чтобы упомянуть человека, и #, 
 msgid "Unread · %{day}"
 msgstr "Непрочитано · %{day}"
 
-#: lib/phoenix_kit/integrations/providers.ex:758
+#: lib/phoenix_kit/integrations/providers.ex:759
 #, elixir-autogen, elixir-format
 msgid "Use it from the AI module"
 msgstr "Используйте его из модуля AI"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:231
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:257
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Verification"
 msgstr "Уведомления"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.ex:133
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:145
 #, elixir-autogen, elixir-format
 msgid "Verification tags saved."
 msgstr "Теги подтверждения сохранены."
 
-#: lib/phoenix_kit/integrations/providers.ex:882
+#: lib/phoenix_kit/integrations/providers.ex:883
 #, elixir-autogen, elixir-format
 msgid "Verify a sender in SES"
 msgstr "Подтвердите отправителя в SES"
@@ -12688,7 +12695,7 @@ msgstr "Для чего это вам нужно?"
 msgid "Where development mail goes while the resolved transport is the local adapter."
 msgstr "Куда попадают письма разработки, пока используется локальный адаптер."
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:79
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "Who may crawl this site"
 msgstr "Кто может сканировать этот сайт"
@@ -12708,12 +12715,12 @@ msgstr "У вас нет доступа к этому объекту: %{kind}. �
 msgid "You don't have access — click to request it"
 msgstr "У вас нет доступа — нажмите, чтобы запросить"
 
-#: lib/phoenix_kit/integrations/providers.ex:800
+#: lib/phoenix_kit/integrations/providers.ex:801
 #, elixir-autogen, elixir-format
 msgid "github.com/settings/personal-access-tokens — fine-grained, read-only"
 msgstr "github.com/settings/personal-access-tokens — детализированный, только чтение"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.ex:146
+#: lib/phoenix_kit_web/live/settings/crawlers.ex:158
 #, elixir-autogen, elixir-format
 msgid "llms.txt content saved."
 msgstr "Содержимое llms.txt сохранено."
@@ -12723,7 +12730,7 @@ msgstr "Содержимое llms.txt сохранено."
 msgid "management API: %{services}"
 msgstr "API управления: %{services}"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:169
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:195
 #, elixir-autogen, elixir-format, fuzzy
 msgid "priv/static/robots.txt exists but has no Sitemap: line. Paste the file above so crawlers are told where to look."
 msgstr "Файл priv/static/robots.txt существует, но в нём нет строки Sitemap:. Добавьте строку выше, чтобы роботы знали, где искать."
@@ -12733,7 +12740,7 @@ msgstr "Файл priv/static/robots.txt существует, но в нём н�
 msgid "private item"
 msgstr "приватная запись"
 
-#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:200
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:226
 #, elixir-autogen, elixir-format
 msgid "while this module is enabled. The heading comes from your project title; everything below it is yours."
 msgstr "пока этот модуль включён. Заголовок берётся из названия проекта; всё под ним — ваше."
@@ -12787,7 +12794,7 @@ msgstr "Выбрать аудио"
 msgid "Select Avatar"
 msgstr "Выбрать аватар"
 
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:701
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:716
 #, elixir-autogen, elixir-format
 msgid "Select Background Image"
 msgstr "Выбрать фоновое изображение"
@@ -12804,7 +12811,7 @@ msgstr "Выбрать изображения"
 
 #: lib/phoenix_kit_web/components/media_browser.html.heex:2469
 #: lib/phoenix_kit_web/live/settings.html.heex:636
-#: lib/phoenix_kit_web/live/settings/authorization.html.heex:702
+#: lib/phoenix_kit_web/live/settings/authorization.html.heex:717
 #, elixir-autogen, elixir-format
 msgid "Select Logo"
 msgstr "Выбрать логотип"
@@ -12903,3 +12910,422 @@ msgstr "Шифрование учётных данных интеграций т
 #, elixir-autogen, elixir-format
 msgid "The current encryption status could not be described by this admin page — it may be newer than what this page recognizes. Check PhoenixKit.Integrations.Encryption.status/0 directly."
 msgstr "Текущий статус шифрования не удалось описать на этой странице администрирования — возможно, он новее, чем распознаёт эта страница. Проверьте PhoenixKit.Integrations.Encryption.status/0 напрямую."
+
+#: lib/phoenix_kit_web/live/settings/authorization.ex:247
+#, elixir-autogen, elixir-format
+msgid "A secret is already configured — leave blank to keep the current value"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:365
+#: lib/phoenix_kit_web/users/session.ex:245
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Account added."
+msgstr "Аккаунт"
+
+#: lib/phoenix_kit_web/users/session.ex:27
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Account created successfully!"
+msgstr "Бакет успешно включён"
+
+#: lib/phoenix_kit_web/users/session.ex:356
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Account removed."
+msgstr "Аккаунт"
+
+#: lib/phoenix_kit_web/users/oauth.ex:272
+#, elixir-autogen, elixir-format
+msgid "Account switching is currently disabled."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:316
+#, elixir-autogen, elixir-format
+msgid "An account already exists for that email address. Sign in with your password first, then connect this provider from your account settings."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:328
+#, elixir-autogen, elixir-format
+msgid "Authentication failed. Please try again or use a different sign-in method."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:355
+#: lib/phoenix_kit_web/users/oauth.ex:438
+#: lib/phoenix_kit_web/users/oauth.ex:444
+#, elixir-autogen, elixir-format
+msgid "Authentication failed. Please try again."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:299
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Authentication failed: %{errors}"
+msgstr "Аутентификация"
+
+#: lib/phoenix_kit_web/users/oauth.ex:441
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Authentication failed: %{message}"
+msgstr "Аутентификация"
+
+#: lib/phoenix_kit_web/users/session.ex:360
+#, elixir-autogen, elixir-format
+msgid "Cannot remove your primary account."
+msgstr ""
+
+#: lib/phoenix_kit_web/controllers/context_controller.ex:101
+#, elixir-autogen, elixir-format
+msgid "Context switching is not enabled"
+msgstr ""
+
+#: lib/phoenix_kit/integrations/validators.ex:627
+#: lib/phoenix_kit/integrations/validators.ex:634
+#: lib/phoenix_kit/integrations/validators.ex:732
+#: lib/phoenix_kit/integrations/validators.ex:740
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Could not reach the storage endpoint"
+msgstr "Не удалось связаться с сервисом"
+
+#: lib/phoenix_kit_web/users/session.ex:365
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Could not remove account."
+msgstr "Не удалось связаться с Brevo"
+
+#: lib/phoenix_kit_web/users/session.ex:274
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Could not switch account."
+msgstr "Не удалось отвязать чаты"
+
+#: lib/phoenix_kit/integrations/validators.ex:721
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Credentials are valid, but not authorized to list buckets"
+msgstr "Учётные данные верны, но нет доступа к GetSendQuota — отправка не проверена"
+
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:85
+#, elixir-autogen, elixir-format
+msgid "Exempt"
+msgstr ""
+
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:86
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Follows noindex"
+msgstr "Подписки"
+
+#: lib/phoenix_kit_web/users/magic_link.ex:120
+#, elixir-autogen, elixir-format
+msgid "If that email address exists, a magic link has been sent."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/confirmation_instructions.ex:89
+#, elixir-autogen, elixir-format
+msgid "If your email is in our system and it has not been confirmed yet, you will receive an email with instructions shortly."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/forgot_password.ex:49
+#, elixir-autogen, elixir-format
+msgid "If your email is in our system, you will receive instructions to reset your password shortly."
+msgstr ""
+
+#: lib/phoenix_kit_web/controllers/context_controller.ex:82
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Invalid context"
+msgstr "Некорректный токен бота"
+
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:110
+#, elixir-autogen, elixir-format
+msgid "Invalid email format"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/session.ex:92
+#, elixir-autogen, elixir-format
+msgid "Invalid email/username or password"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/session.ex:259
+#, elixir-autogen, elixir-format
+msgid "Invalid email/username or password."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_verify.ex:40
+#, elixir-autogen, elixir-format
+msgid "Invalid magic link. Please request a new one."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration_verify.ex:32
+#, elixir-autogen, elixir-format
+msgid "Invalid registration link. Please request a new one."
+msgstr ""
+
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:77
+#, elixir-autogen, elixir-format
+msgid "Keep publishing the sitemap's real URLs even while noindex is on, so the feed can be verified without exposing the site to indexing. The noindex meta tag above is unaffected either way."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/session.ex:104
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Logged out of all accounts."
+msgstr "Выйти из всех аккаунтов"
+
+#: lib/phoenix_kit_web/users/session.ex:122
+#: lib/phoenix_kit_web/users/session.ex:235
+#, elixir-autogen, elixir-format
+msgid "Logged out successfully."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_verify.ex:63
+#, elixir-autogen, elixir-format
+msgid "Magic link is invalid or has expired. Please request a new one."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration.ex:41
+#, elixir-autogen, elixir-format
+msgid "Magic link registration is currently disabled."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link.ex:110
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Magic link sent! Check your email."
+msgstr "Magic Link отправлен!"
+
+#: lib/phoenix_kit_web/users/magic_link.ex:39
+#: lib/phoenix_kit_web/users/magic_link_verify.ex:33
+#, elixir-autogen, elixir-format
+msgid "Magic link sign-in is currently disabled."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:370
+#: lib/phoenix_kit_web/users/session.ex:249
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Maximum number of accounts reached."
+msgstr "Достигнуто максимальное число аккаунтов — сначала удалите один."
+
+#: lib/phoenix_kit_web/users/session.ex:137
+#, elixir-autogen, elixir-format
+msgid "Multi-account switching is not available."
+msgstr ""
+
+#: lib/phoenix_kit/integrations/providers.ex:950
+#, elixir-autogen, elixir-format
+msgid "Not every S3-compatible provider needs one — leave blank if the endpoint doesn't require it."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:119
+#, elixir-autogen, elixir-format
+msgid "OAuth authentication is currently disabled. Please contact your administrator to enable it."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:94
+#, elixir-autogen, elixir-format
+msgid "OAuth provider '%{provider}' is currently disabled."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:106
+#, elixir-autogen, elixir-format
+msgid "OAuth provider '%{provider}' is not configured. Please contact your administrator."
+msgstr ""
+
+#: lib/phoenix_kit/integrations/providers.ex:913
+#, elixir-autogen, elixir-format
+msgid "Object Storage (S3-compatible)"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/reset_password.ex:41
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Password reset successfully."
+msgstr "Пароль успешно изменён."
+
+#: lib/phoenix_kit_web/users/session.ex:34
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Password updated successfully!"
+msgstr "Пароль успешно изменён."
+
+#: lib/phoenix_kit_web/users/magic_link_registration.ex:35
+#: lib/phoenix_kit_web/users/registration.ex:128
+#, elixir-autogen, elixir-format
+msgid "Registration is currently disabled."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration.ex:92
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Registration link is invalid or has expired."
+msgstr "Ссылка для смены email недействительна или устарела."
+
+#: lib/phoenix_kit_web/users/magic_link_registration.ex:188
+#: lib/phoenix_kit_web/users/magic_link_registration_verify.ex:24
+#, elixir-autogen, elixir-format
+msgid "Registration link is invalid or has expired. Please request a new one."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:92
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:103
+#, elixir-autogen, elixir-format
+msgid "Registration link sent! Check your email."
+msgstr ""
+
+#: lib/phoenix_kit/integrations/providers.ex:962
+#, elixir-autogen, elixir-format
+msgid "Required for Cloudflare R2, Backblaze B2, Tigris, and self-hosted S3-compatible storage. Leave blank for AWS S3."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/reset_password.ex:59
+#, elixir-autogen, elixir-format
+msgid "Reset password link is invalid or it has expired."
+msgstr ""
+
+#: lib/phoenix_kit/integrations/providers.ex:915
+#, elixir-autogen, elixir-format
+msgid "S3-compatible object storage — AWS S3, Cloudflare R2, Backblaze B2, Tigris, or a self-hosted endpoint"
+msgstr ""
+
+#: lib/phoenix_kit_web/live/settings/crawlers.html.heex:75
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Sitemap Exemption"
+msgstr "Настройки карты сайта"
+
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:144
+#, elixir-autogen, elixir-format
+msgid "Something went wrong"
+msgstr ""
+
+#: lib/phoenix_kit/integrations/validators.ex:735
+#, elixir-autogen, elixir-format
+msgid "Storage error: %{code}"
+msgstr ""
+
+#: lib/phoenix_kit/integrations/validators.ex:729
+#, elixir-autogen, elixir-format
+msgid "Storage service is busy — try again in a moment"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_verify.ex:56
+#, elixir-autogen, elixir-format
+msgid "Successfully logged in with magic link!"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:277
+#, elixir-autogen, elixir-format
+msgid "Successfully signed in with %{provider}!"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:375
+#: lib/phoenix_kit_web/users/session.ex:254
+#, elixir-autogen, elixir-format, fuzzy
+msgid "That account is already in your session."
+msgstr "Этот аккаунт уже есть в вашей сессии — просто переключитесь на него."
+
+#: lib/phoenix_kit_web/users/oauth.ex:380
+#, elixir-autogen, elixir-format, fuzzy
+msgid "That account is inactive."
+msgstr "Этот аккаунт деактивирован."
+
+#: lib/phoenix_kit_web/users/magic_link_registration.ex:185
+#, elixir-autogen, elixir-format
+msgid "That email is already registered. Please log in instead."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:118
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Too many attempts"
+msgstr "Слишком много файлов"
+
+#: lib/phoenix_kit_web/users/session.ex:84
+#, elixir-autogen, elixir-format
+msgid "Too many login attempts. Please try again later."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/oauth.ex:84
+#: lib/phoenix_kit_web/users/oauth.ex:210
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Unknown OAuth provider: %{provider}"
+msgstr "Неизвестный провайдер"
+
+#: lib/phoenix_kit_web/users/confirmation.ex:68
+#, elixir-autogen, elixir-format
+msgid "User confirmation link is invalid or it has expired."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/confirmation.ex:50
+#, elixir-autogen, elixir-format, fuzzy
+msgid "User confirmed successfully."
+msgstr "Пользователь успешно активирован"
+
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:77
+#, elixir-autogen, elixir-format
+msgid "User registration is currently disabled."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/magic_link_registration_request.ex:51
+#: lib/phoenix_kit_web/users/registration.ex:110
+#, elixir-autogen, elixir-format
+msgid "User registration is currently disabled. Please contact an administrator."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/session.ex:40
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Welcome back!"
+msgstr "С возвращением"
+
+#: lib/phoenix_kit_web/users/session.ex:66
+#, elixir-autogen, elixir-format
+msgid "Your account is currently inactive. Please contact the team if you believe this is an error."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:1873
+#, elixir-autogen, elixir-format
+msgid "%{label} module is not enabled"
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:2366
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Enter your referral code to continue."
+msgstr "Введите реферальный код"
+
+#: lib/phoenix_kit_web/users/auth.ex:2362
+#, elixir-autogen, elixir-format
+msgid "Please confirm your email before accessing the application."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:111
+#, elixir-autogen, elixir-format
+msgid "This account is not active. Contact an administrator."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:749
+#: lib/phoenix_kit_web/users/auth.ex:1892
+#: lib/phoenix_kit_web/users/auth.ex:2511
+#, elixir-autogen, elixir-format, fuzzy
+msgid "You do not have permission to access this section."
+msgstr "У вас нет права входить от имени другого пользователя."
+
+#: lib/phoenix_kit_web/users/auth.ex:724
+#: lib/phoenix_kit_web/users/auth.ex:878
+#: lib/phoenix_kit_web/users/auth.ex:2460
+#: lib/phoenix_kit_web/users/auth.ex:2496
+#, elixir-autogen, elixir-format, fuzzy
+msgid "You do not have the required permission to access this page."
+msgstr "У вас нет права входить от имени другого пользователя."
+
+#: lib/phoenix_kit_web/users/auth.ex:1417
+#, elixir-autogen, elixir-format
+msgid "You must be an admin to access this page."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:679
+#: lib/phoenix_kit_web/users/auth.ex:2423
+#, elixir-autogen, elixir-format
+msgid "You must be an owner to access this page."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:2539
+#, elixir-autogen, elixir-format
+msgid "You must have the %{role_name} role to access this page."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:903
+#: lib/phoenix_kit_web/users/auth.ex:2292
+#: lib/phoenix_kit_web/users/auth.ex:2329
+#: lib/phoenix_kit_web/users/auth.ex:2467
+#, elixir-autogen, elixir-format
+msgid "You must log in to access this page."
+msgstr ""
+
+#: lib/phoenix_kit_web/users/auth.ex:1428
+#, elixir-autogen, elixir-format
+msgid "You no longer have permission to access this section."
+msgstr ""

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -12918,19 +12918,19 @@ msgstr ""
 
 #: lib/phoenix_kit_web/users/oauth.ex:365
 #: lib/phoenix_kit_web/users/session.ex:245
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Account added."
-msgstr "Аккаунт"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:27
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Account created successfully!"
-msgstr "Бакет успешно включён"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:356
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Account removed."
-msgstr "Аккаунт"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/oauth.ex:272
 #, elixir-autogen, elixir-format
@@ -12955,14 +12955,14 @@ msgid "Authentication failed. Please try again."
 msgstr ""
 
 #: lib/phoenix_kit_web/users/oauth.ex:299
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Authentication failed: %{errors}"
-msgstr "Аутентификация"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/oauth.ex:441
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Authentication failed: %{message}"
-msgstr "Аутентификация"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:360
 #, elixir-autogen, elixir-format
@@ -12978,24 +12978,24 @@ msgstr ""
 #: lib/phoenix_kit/integrations/validators.ex:634
 #: lib/phoenix_kit/integrations/validators.ex:732
 #: lib/phoenix_kit/integrations/validators.ex:740
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Could not reach the storage endpoint"
-msgstr "Не удалось связаться с сервисом"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:365
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Could not remove account."
-msgstr "Не удалось связаться с Brevo"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:274
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Could not switch account."
-msgstr "Не удалось отвязать чаты"
+msgstr ""
 
 #: lib/phoenix_kit/integrations/validators.ex:721
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Credentials are valid, but not authorized to list buckets"
-msgstr "Учётные данные верны, но нет доступа к GetSendQuota — отправка не проверена"
+msgstr ""
 
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:85
 #, elixir-autogen, elixir-format
@@ -13003,9 +13003,9 @@ msgid "Exempt"
 msgstr ""
 
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:86
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Follows noindex"
-msgstr "Подписки"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link.ex:120
 #, elixir-autogen, elixir-format
@@ -13023,9 +13023,9 @@ msgid "If your email is in our system, you will receive instructions to reset yo
 msgstr ""
 
 #: lib/phoenix_kit_web/controllers/context_controller.ex:82
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Invalid context"
-msgstr "Некорректный токен бота"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link_registration_request.ex:110
 #, elixir-autogen, elixir-format
@@ -13058,9 +13058,9 @@ msgid "Keep publishing the sitemap's real URLs even while noindex is on, so the 
 msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:104
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Logged out of all accounts."
-msgstr "Выйти из всех аккаунтов"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:122
 #: lib/phoenix_kit_web/users/session.ex:235
@@ -13079,9 +13079,9 @@ msgid "Magic link registration is currently disabled."
 msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link.ex:110
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Magic link sent! Check your email."
-msgstr "Magic Link отправлен!"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link.ex:39
 #: lib/phoenix_kit_web/users/magic_link_verify.ex:33
@@ -13091,9 +13091,9 @@ msgstr ""
 
 #: lib/phoenix_kit_web/users/oauth.ex:370
 #: lib/phoenix_kit_web/users/session.ex:249
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Maximum number of accounts reached."
-msgstr "Достигнуто максимальное число аккаунтов — сначала удалите один."
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:137
 #, elixir-autogen, elixir-format
@@ -13126,14 +13126,14 @@ msgid "Object Storage (S3-compatible)"
 msgstr ""
 
 #: lib/phoenix_kit_web/users/reset_password.ex:41
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Password reset successfully."
-msgstr "Пароль успешно изменён."
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:34
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Password updated successfully!"
-msgstr "Пароль успешно изменён."
+msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link_registration.ex:35
 #: lib/phoenix_kit_web/users/registration.ex:128
@@ -13142,9 +13142,9 @@ msgid "Registration is currently disabled."
 msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link_registration.ex:92
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Registration link is invalid or has expired."
-msgstr "Ссылка для смены email недействительна или устарела."
+msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link_registration.ex:188
 #: lib/phoenix_kit_web/users/magic_link_registration_verify.ex:24
@@ -13174,9 +13174,9 @@ msgid "S3-compatible object storage — AWS S3, Cloudflare R2, Backblaze B2, Tig
 msgstr ""
 
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:75
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Sitemap Exemption"
-msgstr "Настройки карты сайта"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link_registration_request.ex:144
 #, elixir-autogen, elixir-format
@@ -13205,14 +13205,14 @@ msgstr ""
 
 #: lib/phoenix_kit_web/users/oauth.ex:375
 #: lib/phoenix_kit_web/users/session.ex:254
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "That account is already in your session."
-msgstr "Этот аккаунт уже есть в вашей сессии — просто переключитесь на него."
+msgstr ""
 
 #: lib/phoenix_kit_web/users/oauth.ex:380
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "That account is inactive."
-msgstr "Этот аккаунт деактивирован."
+msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link_registration.ex:185
 #, elixir-autogen, elixir-format
@@ -13220,9 +13220,9 @@ msgid "That email is already registered. Please log in instead."
 msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link_registration_request.ex:118
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Too many attempts"
-msgstr "Слишком много файлов"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:84
 #, elixir-autogen, elixir-format
@@ -13231,9 +13231,9 @@ msgstr ""
 
 #: lib/phoenix_kit_web/users/oauth.ex:84
 #: lib/phoenix_kit_web/users/oauth.ex:210
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Unknown OAuth provider: %{provider}"
-msgstr "Неизвестный провайдер"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/confirmation.ex:68
 #, elixir-autogen, elixir-format
@@ -13241,9 +13241,9 @@ msgid "User confirmation link is invalid or it has expired."
 msgstr ""
 
 #: lib/phoenix_kit_web/users/confirmation.ex:50
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "User confirmed successfully."
-msgstr "Пользователь успешно активирован"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/magic_link_registration_request.ex:77
 #, elixir-autogen, elixir-format
@@ -13257,9 +13257,9 @@ msgid "User registration is currently disabled. Please contact an administrator.
 msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:40
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Welcome back!"
-msgstr "С возвращением"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/session.ex:66
 #, elixir-autogen, elixir-format
@@ -13272,9 +13272,9 @@ msgid "%{label} module is not enabled"
 msgstr ""
 
 #: lib/phoenix_kit_web/users/auth.ex:2366
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Enter your referral code to continue."
-msgstr "Введите реферальный код"
+msgstr ""
 
 #: lib/phoenix_kit_web/users/auth.ex:2362
 #, elixir-autogen, elixir-format
@@ -13289,17 +13289,17 @@ msgstr ""
 #: lib/phoenix_kit_web/users/auth.ex:749
 #: lib/phoenix_kit_web/users/auth.ex:1892
 #: lib/phoenix_kit_web/users/auth.ex:2511
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "You do not have permission to access this section."
-msgstr "У вас нет права входить от имени другого пользователя."
+msgstr ""
 
 #: lib/phoenix_kit_web/users/auth.ex:724
 #: lib/phoenix_kit_web/users/auth.ex:878
 #: lib/phoenix_kit_web/users/auth.ex:2460
 #: lib/phoenix_kit_web/users/auth.ex:2496
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "You do not have the required permission to access this page."
-msgstr "У вас нет права входить от имени другого пользователя."
+msgstr ""
 
 #: lib/phoenix_kit_web/users/auth.ex:1417
 #, elixir-autogen, elixir-format

--- a/priv/gettext/ru/LC_MESSAGES/phoenix_kit.po
+++ b/priv/gettext/ru/LC_MESSAGES/phoenix_kit.po
@@ -21,27 +21,27 @@ msgstr "Для этого адреса уже есть ожидающее при
 msgid "This user already belongs to an organization"
 msgstr "Этот пользователь уже входит в организацию"
 
-#: lib/phoenix_kit/users/auth.ex:1064
+#: lib/phoenix_kit/users/auth.ex:1074
 #, elixir-autogen, elixir-format
 msgid "cannot change to person while organization has members"
 msgstr "нельзя сменить на «физическое лицо», пока в организации есть участники"
 
-#: lib/phoenix_kit/users/auth.ex:1044
+#: lib/phoenix_kit/users/auth.ex:1054
 #, elixir-autogen, elixir-format
 msgid "cannot reference self"
 msgstr "не может ссылаться на себя"
 
-#: lib/phoenix_kit/users/auth.ex:1052
+#: lib/phoenix_kit/users/auth.ex:1062
 #, elixir-autogen, elixir-format
 msgid "only person accounts can join an organization"
 msgstr "присоединиться к организации могут только аккаунты физических лиц"
 
-#: lib/phoenix_kit/users/auth.ex:1039
+#: lib/phoenix_kit/users/auth.ex:1049
 #, elixir-autogen, elixir-format
 msgid "organization not found"
 msgstr "организация не найдена"
 
-#: lib/phoenix_kit/users/auth.ex:1038
+#: lib/phoenix_kit/users/auth.ex:1048
 #, elixir-autogen, elixir-format
 msgid "target user is not an organization"
 msgstr "указанный пользователь не является организацией"


### PR DESCRIPTION
## Summary

Login, registration, magic-link, password-reset, and OAuth flash messages
were built as plain string literals instead of routing through gettext, so
non-English users got a mix of translated and raw-English notifications —
most visibly right after a successful sign-in.

Two shapes of the same bug:

- A literal string passed directly to `put_flash/2,3`.
- A message built once — a local variable, or a small helper like
  `format_ueberauth_failure/1` or the shared `account_gate/1` check used by
  three different auth gates — and only then handed to `put_flash`. This
  form doesn't show up in a naive grep of `put_flash` call sites, since no
  literal string appears at the call itself.

## Changes

- Wrapped every plain-literal and indirected flash message found in the
  authentication/session controllers and LiveViews (login, logout,
  multi-account switching/impersonation, OAuth, magic link, registration,
  email confirmation, password reset) in `gettext`/`dgettext`.
- Converted `#{}` string interpolation to named `%{}` bindings everywhere
  it appeared in a translatable string — raw interpolation breaks
  extraction and can't carry a translation.
- `PhoenixKitWeb.Users.Auth` builds its plugs via `use PhoenixKitWeb,
  :verified_routes`, which (unlike `:controller`/`:live_view`) doesn't pull
  in the Gettext macros. Added `use Gettext, backend: PhoenixKitWeb.Gettext`
  there. While in that file, also fixed one pre-existing case where a
  message was already going through `Gettext.dgettext/3` — the plain
  runtime function, not the macro — which meant `mix gettext.extract` had
  never picked it up and it had no translation in any locale.
- Added Estonian translations for every string this introduces, matching
  the terminology and register already established in the existing
  catalog rather than inventing new phrasing.
- Two of the newly-wrapped strings live in the fallback OAuth controller
  module that only compiles when Ueberauth is *not* an installed
  dependency, so `mix gettext.extract` can never see them in a normal
  build (Ueberauth is always present here). Added their Estonian catalog
  entries by hand — the `.po` header itself names this as the supported
  path for a translation that can't be statically extracted.

## Why storage/sitemap strings appear in this diff

`mix gettext.extract` scans the whole project, not just the files this
change touches — it can't be scoped. That surfaced pre-existing, unrelated
gaps already sitting in `lib/phoenix_kit/integrations/{providers,
validators}.ex` and `lib/phoenix_kit_web/live/settings/crawlers.html.heex`
(an S3-compatible object storage integration added 2026-08-17/18, never
synced into the catalog since): 13 msgids that had no catalog entry before
this branch. Left untranslated (empty `msgstr`) — same as they'd have
rendered before, raw English via gettext's fallback. None are storage/
sitemap changes on this branch's part; left for whichever queue picks up
that area.

## Two translation-correctness passes, both driven by review

**Pass 1 — this branch's own new entries.** `mix gettext.extract --merge`
fuzzy-matches a newly-added msgid against some structurally similar
existing (often orphaned) entry and carries over *its* translation,
flagging the result `fuzzy` — gettext's own signal that the pairing is a
guess, not a confirmed translation. The first version of this PR trusted
"this msgid already has a non-empty msgstr" as good enough without
checking that flag. It wasn't: 27 of the strings this PR introduces had
been fuzzy-matched to an unrelated message — e.g. `"Account created
successfully!"` had picked up the translation of `"Bucket enabled
successfully"`, `"Unknown OAuth provider: %{provider}"` had picked up a
translation missing the `%{provider}` binding entirely. Fixed by replacing
23 (the ones belonging to this PR) with the actual intended translation,
and leaving 4 empty (unrelated storage/sitemap strings caught in the same
pass, folded into the 13 above). The same fuzzy-matching hit every other
locale's extraction too (27 newly-fuzzy entries each, in
`de`/`en`/`es`/`fr`/`it`/`pl`/`ru`, none of them this PR's to translate) —
all cleared to empty rather than ship an unverifiable guess in a language
nobody here checked.

**Pass 2 — pre-existing entries sitting at this branch's tip.** 23 more
`fuzzy` entries exist in the catalog, identical in content and count on
`upstream/main` — not introduced by this branch, spanning crawlers/sitemap
settings, the Bedrock integration, and the mentions feature. Went through
each against its actual source call site: 4 were faithful, complete
translations (kept, flag cleared) and 19 didn't hold up (wrong service
name, a status label swapped in for an action button, one word standing in
for a full sentence, content from a neighboring but different message) —
cleared to empty, same as the storage/sitemap entries above.

Every one of the 68 Estonian strings this PR translates, plus the 4 kept
pre-existing entries, was re-verified by resolving it at runtime with the
locale set to `et`, including the interpolated ones with a real bound
value — not just confirming a `msgstr` was present.

## Test plan

- [x] `mix compile --force --warnings-as-errors` — clean, whole project.
- [x] `mix format --check-formatted` — clean.
- [x] Runtime check: all 68 introduced strings + the 4 kept pre-existing
      ones resolved with the locale set to `et`, interpolated ones with
      real values bound — all render the correct Estonian text, none
      empty, none leaking `%{...}`.
- [x] Confirmed zero `fuzzy`-flagged entries remain anywhere in
      `et/default.po` (was 23 pre-existing + 27 introduced by this
      branch's extraction, now 0).
- [x] Confirmed zero *new* `fuzzy`-flagged entries remain in the other
      seven locales (fuzzy counts match the pre-branch baseline exactly).
- [ ] Manual click-through of the affected pages in a running app (not
      done here).
