### PR TITLE
Stop echoing saved integration secrets into the setup form

### DIFF
--- a/lib/phoenix_kit_web/components/core/integrations_ui.ex
+++ b/lib/phoenix_kit_web/components/core/integrations_ui.ex
@@ -223,11 +223,35 @@ defmodule PhoenixKitWeb.Components.Core.IntegrationsUI do
   should list its default first (that is how the SMTP `security` / `auth` /
   `verify_cert` fields keep their historical behavior on connections created
   before they existed).
+
+  `:password` fields never echo a saved secret back into the markup (D011 —
+  it used to round-trip in plain text on every `Edit` render). Resolution is
+  three-way, in priority order:
+
+    1. `typed_value` present — the operator just typed this (a dry-run Test
+       re-render, `/new` flow) — show it verbatim, unmasked.
+    2. No typed value, `saved_value` present, and the field is `:password` —
+       show an empty input with the same "already configured" placeholder
+       `Authorization` uses for its OAuth secrets (S009, `oauth_secret_placeholder/2`
+       in `authorization.ex`) — same class of leak, same wording, so an
+       operator doesn't see two phrasings of "a secret is already saved" in
+       the same admin. An empty submit for an untouched password field is
+       already read as "keep the existing credential" on the save side
+       (`extract_setup_attrs/2` and its mirror in `MyIntegrationForm`), so
+       this empty render is exactly what that save path expects.
+    3. Otherwise — plain fields, or a `:password` field with nothing saved
+       yet — show `saved_value` as before.
   """
   attr :field, :map, required: true
-  attr :value, :string, default: ""
+  attr :typed_value, :string, default: ""
+  attr :saved_value, :string, default: ""
 
   def setup_field(assigns) do
+    assigns =
+      assigns
+      |> assign(:value, setup_field_value(assigns))
+      |> assign(:placeholder, setup_field_placeholder(assigns))
+
     ~H"""
     <div class="fieldset">
       <label class="label" for={"field-#{@field.key}"}>
@@ -263,7 +287,7 @@ defmodule PhoenixKitWeb.Components.Core.IntegrationsUI do
         id={"field-#{@field.key}"}
         class="textarea w-full font-mono text-xs"
         rows="5"
-        placeholder={Map.get(@field, :placeholder) || ""}
+        placeholder={@placeholder}
         required={@field.required}
         autocomplete="off"
       >{@value}</textarea>
@@ -275,7 +299,7 @@ defmodule PhoenixKitWeb.Components.Core.IntegrationsUI do
         id={"field-#{@field.key}"}
         value={@value}
         class="input w-full"
-        placeholder={Map.get(@field, :placeholder) || ""}
+        placeholder={@placeholder}
         required={@field.required}
         autocomplete="off"
       />
@@ -288,6 +312,26 @@ defmodule PhoenixKitWeb.Components.Core.IntegrationsUI do
   end
 
   defp field_type(field), do: Map.get(field, :type) || :text
+
+  defp setup_field_value(%{typed_value: typed, saved_value: saved, field: field}) do
+    cond do
+      typed != "" -> typed
+      field_type(field) == :password and saved != "" -> ""
+      true -> saved
+    end
+  end
+
+  defp setup_field_placeholder(%{typed_value: typed, saved_value: saved, field: field}) do
+    if typed == "" and field_type(field) == :password and saved != "" do
+      # Same string as `Authorization`'s `oauth_secret_placeholder/2` (S009) —
+      # not a call to it, since this core component shouldn't depend on a
+      # LiveView module. The shared string is what matters: one wording for
+      # "a secret is already saved", not two.
+      gettext("A secret is already configured — leave blank to keep the current value")
+    else
+      Map.get(field, :placeholder) || ""
+    end
+  end
 
   @doc """
   Collapsible provider setup instructions (from the provider definition).

--- a/lib/phoenix_kit_web/live/integrations/my_integration_form.ex
+++ b/lib/phoenix_kit_web/live/integrations/my_integration_form.ex
@@ -413,7 +413,8 @@ defmodule PhoenixKitWeb.Live.Integrations.MyIntegrationForm do
                 <.setup_field
                   :for={field <- @provider.setup_fields}
                   field={field}
-                  value={Map.get(@form_values, field.key) || to_string(@data[field.key] || "")}
+                  typed_value={to_string(Map.get(@form_values, field.key) || "")}
+                  saved_value={to_string(@data[field.key] || "")}
                 />
 
                 <div class="flex flex-wrap gap-2 items-center pt-2">

--- a/lib/phoenix_kit_web/live/settings/integration_form.html.heex
+++ b/lib/phoenix_kit_web/live/settings/integration_form.html.heex
@@ -219,18 +219,17 @@
                  which silently dropped every :select / :textarea / :number
                  field a provider declared.
 
-                 Value resolution order:
-                 1. `@form_values` — user-typed values captured
-                    during a dry-run test (`/new` flow). Without
-                    this, a failed test would re-render with empty
-                    inputs and look like the form ate the user's
-                    input.
-                 2. `@data` — the saved credential, edit mode.
-                 3. `""` — fresh /new, untouched. --%>
+                 `typed_value` (from `@form_values`, a dry-run test re-render
+                 on `/new`) and `saved_value` (`@data`, edit mode) go in
+                 separately — `setup_field/1` itself decides whether
+                 `saved_value` is safe to echo, masking it for `:password`
+                 fields instead of round-tripping a decrypted secret into the
+                 markup (D011). --%>
             <.setup_field
               :for={field <- @provider.setup_fields}
               field={field}
-              value={to_string(Map.get(@form_values, field.key) || @data[field.key] || "")}
+              typed_value={to_string(Map.get(@form_values, field.key) || "")}
+              saved_value={to_string(@data[field.key] || "")}
             />
 
             <%!-- Action row at the bottom of the same card body.

--- a/test/integration/phoenix_kit_web/live/integrations/my_integration_form_secret_masking_test.exs
+++ b/test/integration/phoenix_kit_web/live/integrations/my_integration_form_secret_masking_test.exs
@@ -1,0 +1,90 @@
+defmodule PhoenixKitWeb.Live.Integrations.MyIntegrationFormSecretMaskingTest do
+  @moduledoc """
+  D011: the PERSONAL integration setup form
+  (`/admin/settings/integrations/:uuid`) shares `setup_field/1` with the
+  system form, but has its own render call site and its own duplicate
+  save-side "empty password = keep existing" logic (`setup_attrs/2`) — so it
+  needs its own proof the fix landed here too, not just on the system form.
+
+  Uses `telegram` — personal-offered, single `:password` field (`bot_token`).
+  """
+
+  use PhoenixKitWeb.ConnCase, async: true
+
+  alias PhoenixKit.Integrations
+  alias PhoenixKit.Users.Permissions
+  alias PhoenixKit.Users.Roles
+  alias PhoenixKit.Utils.Routes
+
+  @new_path Routes.path("/admin/settings/integrations/new")
+
+  defp setup_admin(%{conn: conn}) do
+    {user, _token} = create_admin_user()
+
+    # Personal integrations are gated by the "integrations" key (independent
+    # of the system form's "integrations_system") — same auto-grant-runs-at-
+    # boot-not-here situation as `integrations_test.exs`.
+    admin_role = Roles.get_role_by_name("Admin")
+    {:ok, _} = Permissions.grant_permission(admin_role.uuid, "integrations")
+
+    conn = log_in_user(conn, user)
+    %{conn: conn, user: user}
+  end
+
+  defp seed_telegram(user, secret) do
+    {:ok, %{uuid: uuid}} =
+      Integrations.add_connection("telegram", "my bot", user.uuid, owner: {:user, user.uuid})
+
+    {:ok, _} =
+      Integrations.save_setup(uuid, %{"bot_token" => secret}, user.uuid,
+        owner: {:user, user.uuid}
+      )
+
+    uuid
+  end
+
+  describe "editing a personal connection with a saved secret" do
+    setup :setup_admin
+
+    test "the saved bot token never appears in the rendered HTML", %{conn: conn, user: user} do
+      secret = "telegram-token-#{System.unique_integer([:positive])}"
+      uuid = seed_telegram(user, secret)
+
+      {:ok, _view, html} = live(conn, Routes.path("/admin/settings/integrations/#{uuid}"))
+
+      refute html =~ secret
+    end
+
+    test "the operator sees the S009 'already configured' placeholder instead of the token",
+         %{conn: conn, user: user} do
+      secret = "telegram-token-#{System.unique_integer([:positive])}"
+      uuid = seed_telegram(user, secret)
+
+      {:ok, _view, html} = live(conn, Routes.path("/admin/settings/integrations/#{uuid}"))
+
+      assert html =~ "A secret is already configured — leave blank to keep the current value"
+      assert html =~ ~s(name="bot_token" id="field-bot_token" value="")
+    end
+  end
+
+  describe "a failed dry-run test on /new preserves what the operator typed" do
+    setup :setup_admin
+
+    test "the just-typed token is NOT swallowed by masking when the test fails", %{conn: conn} do
+      typed_token = "just-typed-token-#{System.unique_integer([:positive])}"
+
+      {:ok, view, _html} = live(conn, @new_path)
+
+      view
+      |> element(~s(button[phx-value-provider="telegram"]))
+      |> render_click()
+
+      html =
+        view
+        |> element(~s(form[phx-submit="save_new"]))
+        |> render_submit(%{"_intent" => "test", "bot_token" => typed_token})
+
+      assert html =~ typed_token
+    end
+  end
+end

--- a/test/integration/phoenix_kit_web/live/settings/integration_form_secret_masking_test.exs
+++ b/test/integration/phoenix_kit_web/live/settings/integration_form_secret_masking_test.exs
@@ -1,0 +1,125 @@
+defmodule PhoenixKitWeb.Live.Settings.IntegrationFormSecretMaskingTest do
+  @moduledoc """
+  D011: a saved credential must never round-trip into the rendered HTML of
+  the system integration setup form (`/admin/settings/integrations/website/:uuid`).
+
+  Uses `aws_ses` as the exercising provider — it mixes a non-sensitive
+  required field (`access_key`, `aws_region`) with a sensitive one
+  (`secret_key`), so one provider proves both "secret is masked" and
+  "non-secret fields keep working" at once.
+  """
+
+  use PhoenixKitWeb.ConnCase, async: true
+
+  alias PhoenixKit.Integrations
+  alias PhoenixKit.Users.Permissions
+  alias PhoenixKit.Users.Roles
+  alias PhoenixKit.Utils.Routes
+
+  @new_path Routes.path("/admin/settings/integrations/website/new")
+
+  defp setup_admin(%{conn: conn}) do
+    {user, _token} = create_admin_user()
+
+    # Website integrations are gated by "integrations_system"; the test DB's
+    # Admin role carries no permission rows (the auto-grant sweep runs at app
+    # boot, not here) — see `integrations_test.exs` for the same fixture.
+    admin_role = Roles.get_role_by_name("Admin")
+    {:ok, _} = Permissions.grant_permission(admin_role.uuid, "integrations_system")
+
+    conn = log_in_user(conn, user)
+    %{conn: conn, user: user}
+  end
+
+  defp seed_aws_ses(secret) do
+    {:ok, %{uuid: uuid}} = Integrations.add_connection("aws_ses", "prod ses")
+
+    {:ok, _} =
+      Integrations.save_setup(uuid, %{
+        "access_key" => "AKIAEXAMPLE123",
+        "secret_key" => secret,
+        "aws_region" => "eu-central-1"
+      })
+
+    uuid
+  end
+
+  describe "new connection (nothing saved yet)" do
+    setup :setup_admin
+
+    test "the secret field is empty and shows the provider's own placeholder, not a saved indicator",
+         %{conn: conn} do
+      {:ok, view, _html} = live(conn, @new_path)
+
+      html =
+        view
+        |> element(~s(button[phx-value-provider="aws_ses"]))
+        |> render_click()
+
+      refute html =~ "already configured"
+      assert html =~ ~s(placeholder="...")
+      assert html =~ ~s(name="secret_key" id="field-secret_key" value="")
+    end
+  end
+
+  describe "editing a connection with a saved secret" do
+    setup :setup_admin
+
+    test "the saved secret never appears in the rendered HTML", %{conn: conn} do
+      secret = "AwsSecretKey-#{System.unique_integer([:positive])}"
+      uuid = seed_aws_ses(secret)
+
+      {:ok, _view, html} = live(conn, Routes.path("/admin/settings/integrations/website/#{uuid}"))
+
+      refute html =~ secret
+    end
+
+    test "the operator sees the S009 'already configured' placeholder instead of the secret",
+         %{conn: conn} do
+      secret = "AwsSecretKey-#{System.unique_integer([:positive])}"
+      uuid = seed_aws_ses(secret)
+
+      {:ok, _view, html} = live(conn, Routes.path("/admin/settings/integrations/website/#{uuid}"))
+
+      assert html =~ "A secret is already configured — leave blank to keep the current value"
+      assert html =~ ~s(name="secret_key" id="field-secret_key" value="")
+    end
+
+    test "non-secret fields keep showing their saved value", %{conn: conn} do
+      uuid = seed_aws_ses("AwsSecretKey-irrelevant")
+
+      {:ok, _view, html} = live(conn, Routes.path("/admin/settings/integrations/website/#{uuid}"))
+
+      assert html =~ "AKIAEXAMPLE123"
+      assert html =~ "eu-central-1"
+    end
+  end
+
+  describe "a failed dry-run test on /new preserves what the operator typed" do
+    setup :setup_admin
+
+    test "the just-typed secret is NOT swallowed by masking when the test fails", %{conn: conn} do
+      typed_secret = "just-typed-secret-#{System.unique_integer([:positive])}"
+
+      {:ok, view, _html} = live(conn, @new_path)
+
+      view
+      |> element(~s(button[phx-value-provider="aws_ses"]))
+      |> render_click()
+
+      html =
+        view
+        |> element(~s(form[phx-submit="save_form"]))
+        |> render_submit(%{
+          "_intent" => "test",
+          "access_key" => "AKIAEXAMPLE123",
+          "secret_key" => typed_secret,
+          # Blank region -> Validators.aws_ses/1 fails locally, no network call.
+          "aws_region" => ""
+        })
+
+      assert html =~ "Test failed"
+      assert html =~ typed_secret
+    end
+  end
+end


### PR DESCRIPTION
## Summary

A saved integration credential — Shopify Admin API token and every other
`:password`-typed setup field (SMTP, AWS SES, Telegram, OpenAI, OAuth
client secrets, etc.) — round-tripped into the rendered HTML on the
integration setup forms. Not on `/new`: only when a saved connection's
Edit page was opened, or re-rendered after any action on that page.

### Continues #742 (S009)

Same class of bug as #742 ("Fix Authorization page leaking OAuth secrets
via DOM and event logs", tagged `S009` in the code) — a secret
round-tripping into `value=` — reaching the integration setup forms that
#742 didn't touch. Same pattern, applied here: render `value=""`
unconditionally for a `:password` field plus a placeholder that signals a
secret is already configured, on top of save-side semantics ("an empty
submitted value means keep the existing credential") that were already
correct on this page too, independently of #742. The placeholder string
is taken verbatim from #742's `oauth_secret_placeholder/2` rather than
inventing a second wording for the same situation (see "The fix" below).

### Where it leaked

Both forms — `Live.Settings.IntegrationForm` (system,
`/admin/settings/integrations/website/:uuid`) and
`Live.Integrations.MyIntegrationForm` (personal,
`/admin/settings/integrations/:uuid`) — render every provider's setup
fields through one shared component, `IntegrationsUI.setup_field/1`. It
put the value straight into the input's `value=` attribute regardless of
the field's declared `:type`:

```
integrations.ex:162-167    get_integration_by_uuid -> data: decrypted (plaintext)
integration_form.ex:91     assign(:data, data)
integration_form.html.heex:233
                            value={... || @data[field.key] || ""}
integrations_ui.ex         <input type="text" ... value={@value}>
                            (credential fields are intentionally NOT type="password")
```

`type="text"` is a deliberate, pre-existing choice for these fields — API
keys and tokens, not site logins; `type="password"` would trigger
browsers' password-save heuristics. That choice is correct and unrelated
to this bug: the field's *value* leaked, not its *type*. Nothing masked
the plaintext once it reached the DOM.

### Scope

Every provider that declares a `:password` setup field is affected — on
both forms:

- **16 providers, 16 fields** — 15 declared in
  `PhoenixKit.Integrations.Providers` (`google`, `openai`, `openrouter`,
  `mistral`, `deepseek`, `xai`, `elevenlabs`, `amazon_bedrock`, `github`,
  `aws_ses`, `object_storage`, `smtp`, `brevo_api`, `telegram`,
  `microsoft`) plus `shopify`'s `access_token`, declared separately in
  `phoenix_kit_ecommerce`.
- `shopify` inherits the fix automatically without any change in
  `phoenix_kit_ecommerce` — masking keys off the field's declared
  `:password` type (`setup_field_value/1` in `integrations_ui.ex`), not
  off the provider. Its `access_token` field already declared
  `type: :password`.

### The fix — render-only, three states

The save side was already correct: an empty submitted `:password` field
has always meant "keep the existing credential" —
`extract_setup_attrs/2` (system form) and its independent duplicate
`MyIntegrationForm.setup_attrs/2` (personal form) both already stripped
blank password submissions before this change. The fix brings the
*render* side in line with that already-established save-side contract,
in the one shared component, so both forms and every provider get it in
one place:

1. **Typed** — the operator just typed something (a dry-run Test
   re-render on `/new`, or a failed Test on an existing connection) —
   render it verbatim, unmasked. Losing this would silently eat the
   operator's input, which is exactly the regression the second test
   file guards against.
2. **Saved, `:password`, nothing typed** — render an empty field with
   `"A secret is already configured — leave blank to keep the current
   value"` instead of the decrypted secret — the same placeholder string
   #742/S009 uses on the Authorization page, taken verbatim (not a call
   to its `oauth_secret_placeholder/2`, since a shared core component
   shouldn't depend on a LiveView module — just the shared string, so an
   operator sees one wording for "a secret is saved," not two, and
   translators get one msgid instead of two).
3. **Everything else** — non-`:password` fields, or a `:password` field
   with nothing saved yet — render the saved value as before (unchanged
   from before this fix).

No server-side / encryption / storage change of any kind.

## Breaking change

`setup_field/1`'s `attr :value` is removed, replaced by `typed_value` +
`saved_value` (both default `""`):

```elixir
# before
<.setup_field field={field} value={form_values[field.key] || data[field.key] || ""} />
# after
<.setup_field field={field} typed_value={form_values[field.key] || ""} saved_value={data[field.key] || ""} />
```

A caller outside this repo that invokes `setup_field/1` directly (rather
than through `IntegrationForm` / `MyIntegrationForm`) will stop getting a
value rendered until it migrates.

**Why no deprecated `value` alias:** the old `value` was already a merged
string with no marker for *where* it came from — typed vs. saved. A
compatibility shim has no safe default to guess with: treating a
passed-in `value` as "saved" would silently mask a caller's live,
freshly-typed input (a new, different bug); treating it as "never
mask" would silently leave this exact vulnerability open for any
external caller still on the old attr — quietly, with no signal that
anything is wrong. For a security fix, a loud build break that forces a
one-line migration is better than a quiet gap. This was raised and
decided explicitly rather than assumed.

## Proof

Two new LiveView test files, 8 tests total (5 system form, 3 personal
form). 4 prove the leak is gone — one pair per form, asserting the saved
secret no longer appears in the HTML and the S009 "already configured"
placeholder appears instead. The other 4 are regression guards that were
green both before and after this change, confirming the fix didn't break
what already worked: the system form additionally covers the `/new`
empty state (no placeholder before anything is saved) and that
non-secret fields keep showing their saved value; both forms cover a
freshly typed value surviving a failed dry-run test:

- `test/integration/phoenix_kit_web/live/settings/integration_form_secret_masking_test.exs`
  (system form, `aws_ses` — mixes a non-secret required field with a
  `:password` one)
- `test/integration/phoenix_kit_web/live/integrations/my_integration_form_secret_masking_test.exs`
  (personal form, `telegram`)

RED → GREEN, reproduced fresh immediately before this commit. Checked out
against the parent commit's versions of the three touched `lib/` files
rather than `git stash` — on a clean checkout of this branch there is
nothing uncommitted to stash, so `stash` is a no-op that would silently
pass without ever exercising the pre-fix code:

```
git checkout HEAD~1 -- lib/phoenix_kit_web/components/core/integrations_ui.ex \
  lib/phoenix_kit_web/live/settings/integration_form.html.heex \
  lib/phoenix_kit_web/live/integrations/my_integration_form.ex

MIX_ENV=test mix compile --force
MIX_ENV=test mix test --no-compile <the two files above> --seed 0
# -> 8 tests, 4 failures (the saved secret appears in the HTML; no S009 placeholder)

git checkout HEAD -- lib/phoenix_kit_web/components/core/integrations_ui.ex \
  lib/phoenix_kit_web/live/settings/integration_form.html.heex \
  lib/phoenix_kit_web/live/integrations/my_integration_form.ex

MIX_ENV=test mix compile --force
MIX_ENV=test mix test --no-compile <the two files above> --seed 0
# -> 8 tests, 0 failures
```

No `Excluding tags: [:integration]` and no `Could not connect to test
database` in the output of either run — the integration tests actually
executed against a live Postgres, not skipped-and-passed. The Postgres
server log for that window shows real queries from the run (unrelated
suite noise included), independently confirming the DB was live, not a
silent no-op.

Full suite, same tree, after the fix: **43 doctests, 3986 tests, 0
failures.** `mix compile --warnings-as-errors`, `mix format
--check-formatted`, and `mix credo --strict` are clean on the changed
files.

**Not verified:** the actual `shopify` provider end-to-end — it lives in
`phoenix_kit_ecommerce`, which is not a dependency of this bare
`phoenix_kit` checkout, so it could only be checked by reading its field
declaration (confirmed `type: :password`), not by rendering it. The
production install this bug was found on was not touched or re-tested
(out of scope / off-limits for this change).

## A tooling note for whoever reviews/runs this

This repo's CI pins **Elixir 1.18** (`.github/workflows/ci.yml`). Run
against **Elixir 1.19.5**, a bare `mix test <file>` fails every
integration test with `CompileError: module PhoenixKitWeb.ConnCase is
not loaded and could not be found` — even with a fully migrated test
database reachable. Root cause: on 1.19.5, `mix test`'s own compile step
only compiles `elixirc_paths(:test) == ["lib", "test/support"]`'s `lib`
half (524 files, matching the `:dev` env count) — it silently drops
`test/support` (the extra ~5 files, `ConnCase`/`DataCase`/`Test.Repo`/
etc.) from what it compiles, and if a prior separate compile had already
produced those `.beam` files, a bare `mix test` run prunes them as
"no longer part of the source list" before `test_helper.exs` runs. `mix
compile` / `mix run` under the same `MIX_ENV=test` do **not** have this
problem — they honor `elixirc_paths(:test)` fully.

Workaround, reliable on 1.19.5: run the two steps back-to-back, no plain
`mix test` in between (which would re-trigger the prune):

```
MIX_ENV=test mix compile --force
MIX_ENV=test mix test --no-compile <files> --seed 0
```

Worth knowing if 1.19 is ever the CI target, or if a contributor on a
newer local toolchain reports the same false "ConnCase not loaded"
failure.
