### PR TITLE
Second i18n wave: Estonian gaps and wrong Russian fuzzy-matched translations

### DIFF
--- a/priv/gettext/et/LC_MESSAGES/default.po
+++ b/priv/gettext/et/LC_MESSAGES/default.po
@@ -12275,7 +12275,7 @@ msgstr "Nõuandev tase: igaüks võib saata suvalise User-Agenti, seega valetav 
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:124
 #, elixir-autogen, elixir-format
 msgid "Allowed"
-msgstr ""
+msgstr "Lubatud"
 
 #: lib/phoenix_kit/integrations/providers.ex:697
 #, elixir-autogen, elixir-format
@@ -12300,7 +12300,7 @@ msgstr "Bedrocki API võti"
 #: lib/phoenix_kit/integrations/validators.ex:222
 #, elixir-autogen, elixir-format
 msgid "Bedrock error %{status}"
-msgstr ""
+msgstr "Bedrock viga %{status}"
 
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:306
 #, elixir-autogen, elixir-format
@@ -12310,7 +12310,7 @@ msgstr "Blokeeri rakenduse tasemel"
 #: lib/phoenix_kit_web/live/modules.html.heex:451
 #, elixir-autogen, elixir-format
 msgid "Blocked groups"
-msgstr ""
+msgstr "Blokeeritud rühmad"
 
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:103
 #, elixir-autogen, elixir-format
@@ -12330,12 +12330,12 @@ msgstr "Halda, kuidas otsingumootorid ja AI-botid seda saiti roomavad ja indekse
 #: lib/phoenix_kit/integrations/providers.ex:740
 #, elixir-autogen, elixir-format
 msgid "Copy the key (shown once, `ABSK…`) and paste it into the form above"
-msgstr ""
+msgstr "Kopeeri võti (kuvatakse ainult üks kord, `ABSK…`) ja kleebi see ülalolevasse vormi"
 
 #: lib/phoenix_kit/integrations/providers.ex:816
 #, elixir-autogen, elixir-format
 msgid "Copy the token and paste it into the form above"
-msgstr ""
+msgstr "Kopeeri token ja kleebi see ülalolevasse vormi"
 
 #: lib/phoenix_kit/integrations/validators.ex:226
 #, elixir-autogen, elixir-format
@@ -12350,18 +12350,18 @@ msgstr "Päringut ei õnnestunud saata."
 #: lib/phoenix_kit_web/live/settings/email_sending.ex:136
 #, elixir-autogen, elixir-format
 msgid "Could not update the mailbox setting"
-msgstr ""
+msgstr "Postkasti seadet ei saanud uuendada"
 
 #: lib/phoenix_kit_web/live/settings/crawlers.ex:35
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Crawler Settings"
-msgstr ""
+msgstr "Roomajate seaded"
 
 #: lib/modules/sitemap/web/settings.html.heex:679
 #, elixir-autogen, elixir-format
 msgid "Crawler settings"
-msgstr ""
+msgstr "Roomajate seaded"
 
 #: lib/phoenix_kit_web/live/modules.html.heex:406
 #, elixir-autogen, elixir-format
@@ -12371,17 +12371,17 @@ msgstr "Roomajad"
 #: lib/phoenix_kit_web/live/settings/crawlers.ex:55
 #, elixir-autogen, elixir-format
 msgid "Crawlers module is disabled. Enable it from the Modules page to configure settings."
-msgstr ""
+msgstr "Roomajate moodul on keelatud. Luba see moodulite lehel, et seadeid seadistada."
 
 #: lib/phoenix_kit/integrations/providers.ex:732
 #, elixir-autogen, elixir-format
 msgid "Create a Bedrock API key"
-msgstr ""
+msgstr "Loo Bedrocki API võti"
 
 #: lib/phoenix_kit/integrations/providers.ex:808
 #, elixir-autogen, elixir-format
 msgid "Create a token"
-msgstr ""
+msgstr "Loo token"
 
 #: lib/phoenix_kit/integrations/providers.ex:872
 #, elixir-autogen, elixir-format
@@ -12406,7 +12406,7 @@ msgstr "Toimeta arenduskirjad kausta /dev/mailbox"
 #: lib/phoenix_kit/integrations/providers.ex:748
 #, elixir-autogen, elixir-format
 msgid "Enable model access"
-msgstr ""
+msgstr "Luba juurdepääs mudelitele"
 
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:304
 #, elixir-autogen, elixir-format
@@ -12421,12 +12421,12 @@ msgstr "Jõustamine"
 #: lib/phoenix_kit_web/live/settings/crawlers.ex:161
 #, elixir-autogen, elixir-format
 msgid "Failed to update crawler settings"
-msgstr ""
+msgstr "Roomajate seadete uuendamine ebaõnnestus"
 
 #: lib/phoenix_kit/integrations/providers.ex:781
 #, elixir-autogen, elixir-format
 msgid "GitHub"
-msgstr ""
+msgstr "GitHub"
 
 #: lib/phoenix_kit/integrations/providers.ex:783
 #, elixir-autogen, elixir-format
@@ -12526,7 +12526,7 @@ msgstr "Pole enam saadaval"
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:191
 #, elixir-autogen, elixir-format
 msgid "No priv/static/robots.txt found. Without one, crawlers assume everything is allowed — and any groups you blocked above are not being told."
-msgstr ""
+msgstr "Faili priv/static/robots.txt ei leitud. Ilma selleta eeldavad otsingurobotid, et kõik on lubatud — ja ülalpool blokeeritud rühmadest neile ei anta teada."
 
 #: lib/phoenix_kit_web/components/core/mention_text.ex:152
 #, elixir-autogen, elixir-format
@@ -12586,7 +12586,7 @@ msgstr "Repositooriumide ligipääs: **Public repositories (read-only)** — ava
 #: lib/phoenix_kit/mentions/live.ex:227
 #, elixir-autogen, elixir-format
 msgid "Request access"
-msgstr ""
+msgstr "Taotle ligipääsu"
 
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:259
 #, elixir-autogen, elixir-format
@@ -12601,12 +12601,12 @@ msgstr "Saada päring"
 #: lib/phoenix_kit/mentions/live.ex:254
 #, elixir-autogen, elixir-format
 msgid "Sending…"
-msgstr ""
+msgstr "Saatmine…"
 
 #: lib/phoenix_kit/mentions/live.ex:76
 #, elixir-autogen, elixir-format
 msgid "Sign in to request access."
-msgstr ""
+msgstr "Logi sisse, et ligipääsu taotleda."
 
 #: lib/phoenix_kit/integrations/providers.ex:761
 #, elixir-autogen, elixir-format
@@ -12658,7 +12658,7 @@ msgstr "Kasuta seda AI moodulist"
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:257
 #, elixir-autogen, elixir-format
 msgid "Verification"
-msgstr ""
+msgstr "Kinnitamine"
 
 #: lib/phoenix_kit_web/live/settings/crawlers.ex:145
 #, elixir-autogen, elixir-format
@@ -12899,7 +12899,7 @@ msgstr "Praegust krüpteerimise olekut ei õnnestunud sellel haldusleheküljel k
 #: lib/phoenix_kit_web/live/settings/authorization.ex:247
 #, elixir-autogen, elixir-format
 msgid "A secret is already configured — leave blank to keep the current value"
-msgstr ""
+msgstr "Saladus on juba seadistatud — jäta tühjaks, et praegust väärtust säilitada."
 
 #: lib/phoenix_kit_web/users/oauth.ex:365
 #: lib/phoenix_kit_web/users/session.ex:245
@@ -12965,7 +12965,7 @@ msgstr "Konteksti vahetamine ei ole lubatud"
 #: lib/phoenix_kit/integrations/validators.ex:740
 #, elixir-autogen, elixir-format
 msgid "Could not reach the storage endpoint"
-msgstr ""
+msgstr "Salvestuse lõpp-punktiga ei saanud ühendust"
 
 #: lib/phoenix_kit_web/users/session.ex:365
 #, elixir-autogen, elixir-format
@@ -12980,17 +12980,17 @@ msgstr "Konto vahetamine ebaõnnestus."
 #: lib/phoenix_kit/integrations/validators.ex:721
 #, elixir-autogen, elixir-format
 msgid "Credentials are valid, but not authorized to list buckets"
-msgstr ""
+msgstr "Mandaadid on kehtivad, kuid puudub õigus bucketite loetlemiseks"
 
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Exempt"
-msgstr ""
+msgstr "Erand"
 
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:86
 #, elixir-autogen, elixir-format
 msgid "Follows noindex"
-msgstr ""
+msgstr "Järgib noindexit"
 
 #: lib/phoenix_kit_web/users/magic_link.ex:120
 #, elixir-autogen, elixir-format
@@ -13040,7 +13040,7 @@ msgstr "Vigane registreerimislink. Palun taotlege uus link."
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:77
 #, elixir-autogen, elixir-format
 msgid "Keep publishing the sitemap's real URLs even while noindex is on, so the feed can be verified without exposing the site to indexing. The noindex meta tag above is unaffected either way."
-msgstr ""
+msgstr "Jätka saidikaardi tegelike URL-ide avaldamist ka siis, kui noindex on sees, nii et voogu saab kontrollida ilma saiti indekseerimisele avamata. Ülalolev noindex-metasilt jääb mõlemal juhul mõjutamata."
 
 #: lib/phoenix_kit_web/users/session.ex:104
 #, elixir-autogen, elixir-format
@@ -13088,7 +13088,7 @@ msgstr "Mitme konto vahel lülitumine ei ole saadaval."
 #: lib/phoenix_kit/integrations/providers.ex:950
 #, elixir-autogen, elixir-format
 msgid "Not every S3-compatible provider needs one — leave blank if the endpoint doesn't require it."
-msgstr ""
+msgstr "Mitte iga S3-ühilduv teenusepakkuja ei vaja seda — jäta tühjaks, kui lõpp-punkt seda ei nõua."
 
 #: lib/phoenix_kit_web/users/oauth.ex:119
 #, elixir-autogen, elixir-format
@@ -13108,7 +13108,7 @@ msgstr "OAuth teenusepakkuja '%{provider}' ei ole seadistatud. Palun võtke ühe
 #: lib/phoenix_kit/integrations/providers.ex:913
 #, elixir-autogen, elixir-format
 msgid "Object Storage (S3-compatible)"
-msgstr ""
+msgstr "Objektisalvestus (S3-ühilduv)"
 
 #: lib/phoenix_kit_web/users/reset_password.ex:41
 #, elixir-autogen, elixir-format
@@ -13146,7 +13146,7 @@ msgstr "Registreerimislink saadetud! Vaata oma e-posti."
 #: lib/phoenix_kit/integrations/providers.ex:962
 #, elixir-autogen, elixir-format
 msgid "Required for Cloudflare R2, Backblaze B2, Tigris, and self-hosted S3-compatible storage. Leave blank for AWS S3."
-msgstr ""
+msgstr "Vajalik Cloudflare R2, Backblaze B2, Tigrise ja oma S3-ühilduva salvestuse jaoks. Jäta AWS S3 puhul tühjaks."
 
 #: lib/phoenix_kit_web/users/reset_password.ex:59
 #, elixir-autogen, elixir-format
@@ -13156,12 +13156,12 @@ msgstr "Parooli lähtestamise link on kehtetu või aegunud."
 #: lib/phoenix_kit/integrations/providers.ex:915
 #, elixir-autogen, elixir-format
 msgid "S3-compatible object storage — AWS S3, Cloudflare R2, Backblaze B2, Tigris, or a self-hosted endpoint"
-msgstr ""
+msgstr "S3-ühilduv objektisalvestus — AWS S3, Cloudflare R2, Backblaze B2, Tigris või oma lõpp-punkt"
 
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:75
 #, elixir-autogen, elixir-format
 msgid "Sitemap Exemption"
-msgstr ""
+msgstr "Saidikaardi erand"
 
 #: lib/phoenix_kit_web/users/magic_link_registration_request.ex:144
 #, elixir-autogen, elixir-format
@@ -13171,12 +13171,12 @@ msgstr "Midagi läks valesti"
 #: lib/phoenix_kit/integrations/validators.ex:735
 #, elixir-autogen, elixir-format
 msgid "Storage error: %{code}"
-msgstr ""
+msgstr "Salvestuse viga: %{code}"
 
 #: lib/phoenix_kit/integrations/validators.ex:729
 #, elixir-autogen, elixir-format
 msgid "Storage service is busy — try again in a moment"
-msgstr ""
+msgstr "Salvestusteenus on hõivatud — proovige hetke pärast uuesti"
 
 #: lib/phoenix_kit_web/users/magic_link_verify.ex:56
 #, elixir-autogen, elixir-format

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -12295,7 +12295,7 @@ msgid "Access requested."
 msgstr "Запрос на доступ отправлен."
 
 #: lib/phoenix_kit/integrations/validators.ex:99
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Account %{id}"
 msgstr "Аккаунт %{id}"
 
@@ -12305,9 +12305,9 @@ msgid "Advisory-grade: anything can send any User-Agent, so a scraper that lies 
 msgstr "Рекомендательный уровень: любой может отправить произвольный User-Agent, поэтому лгущий парсер пройдёт. Реальное принуждение — на вашем CDN или обратном прокси; здесь ловятся честные, но неосведомлённые. Боты, определяемые только по токенам robots.txt (Google-Extended, Applebot-Extended), обходят сайт под своим основным user agent и здесь никогда не совпадают, поэтому блокировка обучения ИИ не может вернуть 403 для Googlebot."
 
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:124
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Allowed"
-msgstr "Все"
+msgstr "Разрешён"
 
 #: lib/phoenix_kit/integrations/providers.ex:697
 #, elixir-autogen, elixir-format
@@ -12330,9 +12330,9 @@ msgid "Bedrock API key"
 msgstr "API-ключ Bedrock"
 
 #: lib/phoenix_kit/integrations/validators.ex:222
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Bedrock error %{status}"
-msgstr "Ошибка Brevo %{status}"
+msgstr "Ошибка Bedrock %{status}"
 
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:306
 #, elixir-autogen, elixir-format
@@ -12340,9 +12340,9 @@ msgid "Block at the application"
 msgstr "Блокировать на уровне приложения"
 
 #: lib/phoenix_kit_web/live/modules.html.heex:451
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Blocked groups"
-msgstr "Заблокирован"
+msgstr "Заблокированные группы"
 
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:103
 #, elixir-autogen, elixir-format
@@ -12360,17 +12360,17 @@ msgid "Control how search engines and AI bots crawl and index this site"
 msgstr "Управление тем, как поисковые системы и ИИ-боты сканируют и индексируют этот сайт"
 
 #: lib/phoenix_kit/integrations/providers.ex:740
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Copy the key (shown once, `ABSK…`) and paste it into the form above"
 msgstr "Скопируйте ключ (показывается один раз) и вставьте его в форму выше"
 
 #: lib/phoenix_kit/integrations/providers.ex:816
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Copy the token and paste it into the form above"
-msgstr "Скопируйте ключ и вставьте его в форму выше"
+msgstr "Скопируйте токен и вставьте его в форму выше"
 
 #: lib/phoenix_kit/integrations/validators.ex:226
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Could not reach Bedrock in %{region}"
 msgstr "Не удалось связаться с Bedrock в регионе %{region}"
 
@@ -12380,20 +12380,20 @@ msgid "Could not send that request."
 msgstr "Не удалось отправить запрос."
 
 #: lib/phoenix_kit_web/live/settings/email_sending.ex:136
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Could not update the mailbox setting"
-msgstr "Не удалось обновить интеграцию отправки по умолчанию"
+msgstr "Не удалось обновить настройку почтового ящика"
 
 #: lib/phoenix_kit_web/live/settings/crawlers.ex:35
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:5
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Crawler Settings"
-msgstr "Настройки юридической информации"
+msgstr "Настройки сканеров"
 
 #: lib/modules/sitemap/web/settings.html.heex:679
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Crawler settings"
-msgstr "Инструкции для поисковых роботов"
+msgstr "Настройки сканеров"
 
 #: lib/phoenix_kit_web/live/modules.html.heex:406
 #, elixir-autogen, elixir-format
@@ -12401,19 +12401,19 @@ msgid "Crawlers"
 msgstr "Сканеры"
 
 #: lib/phoenix_kit_web/live/settings/crawlers.ex:55
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Crawlers module is disabled. Enable it from the Modules page to configure settings."
-msgstr "Модуль SEO отключён. Включите его на странице Модулей для настройки."
+msgstr "Модуль Сканеры отключён. Включите его на странице Модулей для настройки."
 
 #: lib/phoenix_kit/integrations/providers.ex:732
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Create a Bedrock API key"
-msgstr "Создайте API-ключ"
+msgstr "Создайте API-ключ Bedrock"
 
 #: lib/phoenix_kit/integrations/providers.ex:808
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Create a token"
-msgstr "Создать роль"
+msgstr "Создайте токен"
 
 #: lib/phoenix_kit/integrations/providers.ex:872
 #, elixir-autogen, elixir-format
@@ -12436,9 +12436,9 @@ msgid "Deliver development mail to /dev/mailbox"
 msgstr "Доставлять письма разработки в /dev/mailbox"
 
 #: lib/phoenix_kit/integrations/providers.ex:748
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Enable model access"
-msgstr "Включите модуль для доступа к настройкам"
+msgstr "Включите доступ к моделям"
 
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:304
 #, elixir-autogen, elixir-format
@@ -12451,14 +12451,14 @@ msgstr "Принуждение"
 #: lib/phoenix_kit_web/live/settings/crawlers.ex:132
 #: lib/phoenix_kit_web/live/settings/crawlers.ex:148
 #: lib/phoenix_kit_web/live/settings/crawlers.ex:161
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Failed to update crawler settings"
 msgstr "Не удалось обновить настройку"
 
 #: lib/phoenix_kit/integrations/providers.ex:781
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "GitHub"
-msgstr "Вход через GitHub"
+msgstr "GitHub"
 
 #: lib/phoenix_kit/integrations/providers.ex:783
 #, elixir-autogen, elixir-format
@@ -12556,9 +12556,9 @@ msgid "No longer available"
 msgstr "Больше недоступно"
 
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:191
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "No priv/static/robots.txt found. Without one, crawlers assume everything is allowed — and any groups you blocked above are not being told."
-msgstr "Файл priv/static/robots.txt не найден. Без него поисковые роботы считают, что разрешено всё — обычно это не проблема, но они не узнают, где находится карта сайта."
+msgstr "Файл priv/static/robots.txt не найден. Без него поисковые роботы считают, что разрешено всё — и о заблокированных вами выше группах они не узнают."
 
 #: lib/phoenix_kit_web/components/core/mention_text.ex:152
 #, elixir-autogen, elixir-format
@@ -12616,9 +12616,9 @@ msgid "Repository access: **Public repositories (read-only)** — no extra permi
 msgstr "Доступ к репозиториям: **Public repositories (read-only)** — для статистики публичной организации дополнительные права не нужны"
 
 #: lib/phoenix_kit/mentions/live.ex:227
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Request access"
-msgstr "Запрошено"
+msgstr "Запросить доступ"
 
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:259
 #, elixir-autogen, elixir-format
@@ -12631,14 +12631,14 @@ msgid "Send request"
 msgstr "Отправить запрос"
 
 #: lib/phoenix_kit/mentions/live.ex:254
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Sending…"
-msgstr "Ожидает"
+msgstr "Отправка…"
 
 #: lib/phoenix_kit/mentions/live.ex:76
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Sign in to request access."
-msgstr "Войти под пользователем"
+msgstr "Войдите, чтобы запросить доступ."
 
 #: lib/phoenix_kit/integrations/providers.ex:761
 #, elixir-autogen, elixir-format
@@ -12656,7 +12656,7 @@ msgid "The mailbox is off: outgoing mail is written to the server log instead."
 msgstr "Почтовый ящик выключен: исходящие письма вместо этого пишутся в лог сервера."
 
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:205
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "The noindex toggle and robots.txt are separate mechanisms: noindex is a per-page meta tag that tells crawlers not to index what they fetched, while robots.txt tells them what not to fetch at all. A staging site usually wants both."
 msgstr "Переключатель noindex выше и robots.txt — разные механизмы: noindex это метатег на странице, который говорит роботам не индексировать загруженное, а robots.txt говорит им, что вообще не нужно загружать. Тестовому сайту обычно нужны оба."
 
@@ -12688,9 +12688,9 @@ msgid "Use it from the AI module"
 msgstr "Используйте его из модуля AI"
 
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:257
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Verification"
-msgstr "Уведомления"
+msgstr "Подтверждение"
 
 #: lib/phoenix_kit_web/live/settings/crawlers.ex:145
 #, elixir-autogen, elixir-format
@@ -12748,7 +12748,7 @@ msgid "management API: %{services}"
 msgstr "API управления: %{services}"
 
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:195
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "priv/static/robots.txt exists but has no Sitemap: line. Paste the file above so crawlers are told where to look."
 msgstr "Файл priv/static/robots.txt существует, но в нём нет строки Sitemap:. Добавьте строку выше, чтобы роботы знали, где искать."
 

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -8521,7 +8521,7 @@ msgstr "Доступные поля"
 #: lib/phoenix_kit_web/live/users/users.ex:722
 #, elixir-autogen, elixir-format
 msgid "Cannot deactivate the last system owner"
-msgstr "Невозможно удалить последнего системного владельца"
+msgstr "Невозможно деактивировать последнего системного владельца"
 
 #: lib/phoenix_kit_web/live/users/users.ex:424
 #, elixir-autogen, elixir-format
@@ -8550,7 +8550,7 @@ msgstr "Невозможно изменить свой статус"
 #: lib/phoenix_kit_web/live/users/users.ex:955
 #, elixir-autogen, elixir-format
 msgid "Cannot remove the last system owner"
-msgstr "Невозможно удалить последнего системного владельца"
+msgstr "Невозможно снять роль владельца с последнего системного владельца"
 
 #: lib/phoenix_kit_web/live/users/users.html.heex:359
 #, elixir-autogen, elixir-format
@@ -13350,12 +13350,12 @@ msgstr ""
 #: lib/phoenix_kit_web/users/magic_link.ex:130
 #, elixir-autogen, elixir-format
 msgid "Failed to send magic link. Please try again."
-msgstr "Не удалось отключить провайдер. Попробуйте ещё раз."
+msgstr "Не удалось отправить Magic Link. Попробуйте ещё раз."
 
 #: lib/phoenix_kit_web/users/magic_link_registration_request.ex:143
 #, elixir-autogen, elixir-format
 msgid "Failed to send registration link. Please try again."
-msgstr "Не удалось отклонить приглашение. Попробуйте ещё раз."
+msgstr "Не удалось отправить ссылку для регистрации. Попробуйте ещё раз."
 
 #: lib/phoenix_kit_web/users/magic_link.ex:98
 #, elixir-autogen, elixir-format

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -13360,12 +13360,12 @@ msgstr "Не удалось отклонить приглашение. Попр�
 #: lib/phoenix_kit_web/users/magic_link.ex:98
 #, elixir-autogen, elixir-format
 msgid "Please enter a valid email address"
-msgstr "Введите название"
+msgstr "Введите корректный адрес электронной почты"
 
 #: lib/phoenix_kit_web/users/magic_link_registration_request.ex:109
 #, elixir-autogen, elixir-format
 msgid "Please enter a valid email address."
-msgstr "Введите название"
+msgstr "Введите корректный адрес электронной почты."
 
 #: lib/phoenix_kit_web/users/magic_link_registration_request.ex:117
 #, elixir-autogen, elixir-format


### PR DESCRIPTION
## Что вошло

Вторая волна переводов ядра, две локали.

**Эстонский** — переведены все остававшиеся пустыми записи `default.po`.
Контекст употребления поднимался из кода по `#:`-комментариям, а не
переводился по одной строке.

**Русский** — исправлены переводы, подставленные `gettext.extract` по
совпадению формы строки. Две группы:

- помеченные флагом `fuzzy`: разобраны все, неверные переведены заново, флаг
  снят и с подтверждённо верных;
- **без флага** — подмены, неотличимые от проверенного перевода. Среди них
  кластер на путях входа: `Failed to send magic link` показывал перевод
  `Failed to disconnect provider`, `Please enter a valid email address` —
  перевод `Please enter a name`.

## Чем проверено

Все затронутые записи прогнаны через `Gettext.dgettext` **рантаймом**, а не
проверены чтением файла: 61 запись, совпало 61.

Наборы плейсхолдеров `%{...}` сверены множествами msgid против msgstr по всему
диффу. Записи с интерполяцией проверены различимыми тестовыми значениями:
`%{status}` → `Bedrock viga TEST_STATUS_42` (et), `Ошибка Bedrock
TEST_STATUS_42` (ru).

Отдельно проверено, что снятие флага `fuzzy` с верных записей не изменило и не
стёрло перевод.

## ⚠️ Граница нашей проверки

**Эстонский проверен словарно, не носителем языка.** То же ограничение мы
указывали в #747.

## Что НЕ вошло и почему

`de`, `es`, `fr`, `it`, `pl` несут подмены того же класса. Они намеренно
оставлены за пределами этого PR: другая тема — отдельный заход, по принципу
«каждый PR по своей теме».

## Что в русском осталось непереведённым

В `ru/default.po` остаются **82 пустые записи**. Этот PR их не трогает: число
то же и на базовом коммите. Они не относятся к его теме — здесь исправляются
только уже существующие **неверные** переводы, а не заполняются пробелы.

Пустая запись отдаёт исходную английскую строку, то есть ведёт себя честно.
Неверный перевод — нет, и потому взят первым.
