### PR TITLE
Doctor's orphaned-FK check now covers every foreign key, not four of seventy

### DIFF
--- a/lib/mix/tasks/phoenix_kit.doctor.ex
+++ b/lib/mix/tasks/phoenix_kit.doctor.ex
@@ -854,7 +854,15 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
   # a catalog query that itself failed — can never read as PASS, no matter
   # which of those reasons caused it (I055 finding 2 and 3: "clean" and
   # "never looked" used to print byte-identical text).
-  defp check_orphaned_fk_refs(prefix) do
+  #
+  # Exposed (not `defp`) and `@doc false`, same reason as the other pure
+  # decision functions in this module: `get_repo!/0` resolves the same
+  # `PhoenixKit.Test.Repo` under `mix test` that it resolves under a real
+  # `mix phoenix_kit.doctor` run, so this is a real end-to-end seam for the
+  # whole discover -> probe -> classify -> report pipeline against a live
+  # connection, not just its pieces in isolation.
+  @doc false
+  def check_orphaned_fk_refs(prefix) do
     repo = get_repo!()
     escaped_prefix = String.replace(prefix, "'", "\\'")
 
@@ -1100,6 +1108,19 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
     {[{table, fk_col, ref, count, :create} | orph], nv, pf}
   end
 
+  # A VALID, enforced constraint — Postgres itself should make this state
+  # unreachable through ordinary SQL, but "should" is not "does": a bulk load
+  # with triggers off, a restore from an inconsistent backup, or direct
+  # catalog surgery can all leave orphaned rows behind a constraint that
+  # still reads as fully validated. Before this clause, `count > 0` here fell
+  # through to the generic catch-all below and was silently discarded — the
+  # single most common `validation` shape (most real FKs are validated, not
+  # `NOT VALID`) was exactly the one this function couldn't report on.
+  def classify_fk_check(table, fk_col, ref, {:ok, count}, :validated, {orph, nv, pf})
+      when count > 0 do
+    {[{table, fk_col, ref, count, :existing_orphan} | orph], nv, pf}
+  end
+
   # Constraint present, NOT VALID, but nothing currently blocking it — a
   # nudge, not a failure: V176 validates this on its own.
   def classify_fk_check(table, fk_col, ref, {:ok, _count}, {:not_valid, _conname}, {orph, nv, pf}) do
@@ -1199,6 +1220,11 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
       {table, fk_col, ref, count, :create} ->
         "#{table}.#{fk_col} → #{ref}: #{count} orphaned row(s) — no constraint yet, this " <>
           "blocks its creation"
+
+      {table, fk_col, ref, count, :existing_orphan} ->
+        "#{table}.#{fk_col} → #{ref}: #{count} orphaned row(s) — constraint IS validated but " <>
+          "orphans exist anyway (likely written via a trigger-bypass path: bulk load, " <>
+          "replica catch-up, direct catalog edit) — investigate how, then clean up by hand"
     end)
   end
 

--- a/lib/mix/tasks/phoenix_kit.doctor.ex
+++ b/lib/mix/tasks/phoenix_kit.doctor.ex
@@ -885,8 +885,7 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
 
         multi_column_entries =
           Enum.map(skipped_multi, fn {table, conname, ref_table, col_count} ->
-            {table, conname, ref_table, :multi_column,
-             "composite FK (#{col_count} columns) — not supported by this check", nil}
+            {table, conname, ref_table, :multi_column, col_count, nil}
           end)
 
         total = length(constraints) + length(skipped_multi)
@@ -964,15 +963,19 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
 
   # Per-constraint time budget: a check that never finishes must never read
   # as clean, but it also must not be allowed to hang the whole doctor run
-  # waiting on one giant table. Postgrex's `:timeout` cancels the statement
-  # server-side on expiry and returns a normal `{:error, %Postgrex.Error{}}`
-  # (verified against a real connection — a client-side `:timeout` here does
-  # NOT exit the calling process), so this needs no special rescue beyond
-  # the {:error, reason} branch `classify_fk_check/5` already routes to
-  # `:probe_failed` — a timeout is just one more reason a probe can fail,
-  # never a silent scope reduction. I055 explicitly rejects a `--full` flag
-  # for this exact reason: breadth (every constraint) is never negotiable,
-  # only depth (how long we wait per constraint) is.
+  # waiting on one giant table. A server-side cancellation on expiry surfaces
+  # as `{:error, %Postgrex.Error{postgres: %{code: :query_canceled}}}` — but
+  # verified live against `PhoenixKit.Test.Repo.query/3` (the exact call
+  # `probe_fk/4` makes, through the DBConnection pool/ownership layer, not a
+  # raw `Postgrex.query/3` against a bare connection), the timeout more often
+  # surfaces ONE layer up instead: DBConnection itself drops the request from
+  # its queue and closes the checked-out connection, returning
+  # `{:error, %DBConnection.ConnectionError{reason: :closed}}` with no
+  # `Postgrex.Error` involved at all. Both shapes are handled the same way —
+  # a timeout is just one more reason a probe can fail, never a silent scope
+  # reduction. I055 explicitly rejects a `--full` flag for this exact reason:
+  # breadth (every constraint) is never negotiable, only depth (how long we
+  # wait per constraint) is.
   @fk_probe_timeout_ms 5_000
 
   defp probe_fk(repo, fk, prefix, {orph, nv, pf}) do
@@ -994,10 +997,10 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
           {:ok, c}
 
         {:error, %Postgrex.Error{postgres: %{code: :query_canceled}} = reason} ->
-          message =
-            fk_probe_failure_reason(reason) <> fk_probe_cost_context(repo, table, fk_col, prefix)
+          {:probe_failed, timeout_probe_failure(reason, repo, table, fk_col, prefix)}
 
-          {:probe_failed, message}
+        {:error, %DBConnection.ConnectionError{reason: :closed} = reason} ->
+          {:probe_failed, timeout_probe_failure(reason, repo, table, fk_col, prefix)}
 
         {:error, reason} ->
           {:probe_failed, fk_probe_failure_reason(reason)}
@@ -1011,17 +1014,27 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
     classify_fk_check(table, fk_col, ref_table, count_result, validation, {orph, nv, pf})
   end
 
-  # A query cancelled by the timeout above and every other Postgrex error
-  # both surface as `%Postgrex.Error{}` — this only exists to make the
-  # timeout case say "time limit exceeded" instead of the raw Postgres
-  # cancellation text, so the doctor's report matches the operator-facing
-  # language I055 asks for ("не проверено (превышен предел)") rather than
-  # leaking a database error message that means the same thing.
+  defp timeout_probe_failure(reason, repo, table, fk_col, prefix) do
+    fk_probe_failure_reason(reason) <> fk_probe_cost_context(repo, table, fk_col, prefix)
+  end
+
+  # A query cancelled by the timeout above, a connection closed out from
+  # under it by the pool, and every other Postgrex/DBConnection error all
+  # reach this function — it only exists to make the two timeout shapes say
+  # "time limit exceeded" instead of a raw Postgres cancellation code or a
+  # "tcp recv: closed" pool message, so the doctor's report matches the
+  # operator-facing language I055 asks for ("не проверено (превышен
+  # предел)") rather than leaking a database/pool error that means the same
+  # thing.
   #
   # Exposed (not `defp`) and `@doc false`, same reason as the other pure
   # decision functions in this module: directly testable without a repo.
   @doc false
   def fk_probe_failure_reason(%Postgrex.Error{postgres: %{code: :query_canceled}}) do
+    "time limit exceeded (#{@fk_probe_timeout_ms}ms) — not checked, not clean"
+  end
+
+  def fk_probe_failure_reason(%DBConnection.ConnectionError{reason: :closed}) do
     "time limit exceeded (#{@fk_probe_timeout_ms}ms) — not checked, not clean"
   end
 
@@ -1127,7 +1140,12 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
     {orph, [{table, fk_col, ref} | nv], pf}
   end
 
-  def classify_fk_check(_table, _fk_col, _ref, {:ok, _count}, _validated_or_absent_and_clean, acc) do
+  # Narrowed to `{:ok, 0}` deliberately: this is the ONLY combination that
+  # means "clean". Widening it back to `{:ok, _count}` is exactly the bug
+  # this round fixed for `:validated` — a future `validation` shape reaching
+  # here with `count > 0` must raise `FunctionClauseError`, not silently
+  # discard real orphans the way the old wildcard catch-all did.
+  def classify_fk_check(_table, _fk_col, _ref, {:ok, 0}, _validated_or_absent_and_clean, acc) do
     acc
   end
 
@@ -1234,6 +1252,18 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
         "#{table}.#{fk_col} → #{ref}: #{count} orphaned row(s) measured, but could not check " <>
           "whether the constraint is validated (validation_state probe failed: " <>
           "#{inspect(reason)}) — a failed probe is not a pass, treat as unverified"
+
+      # A composite FK was never probed at all — a deliberate scope
+      # exclusion (see `discover_fk_constraints/2`), not a failed attempt.
+      # `conname` sits in the tuple's fk_col-shaped slot for every other
+      # `probe_failed` entry, so it needs its own clause: the generic one
+      # below would print it as if it were a column name and call it a
+      # "probe failed", both wrong for a check that was never run. There is
+      # also no re-run that turns this into :pass — only a manual
+      # VALIDATE CONSTRAINT does.
+      {table, conname, ref, :multi_column, col_count, nil} ->
+        "#{table} → #{ref}: composite FK #{conname} (#{col_count} columns) — not supported " <>
+          "by this check; verify manually via ALTER TABLE ... VALIDATE CONSTRAINT #{conname}"
 
       {table, fk_col, ref, kind, reason, nil} ->
         "#{table}.#{fk_col} → #{ref}: could not check (#{kind} probe failed: #{inspect(reason)}) " <>

--- a/lib/mix/tasks/phoenix_kit.doctor.ex
+++ b/lib/mix/tasks/phoenix_kit.doctor.ex
@@ -982,9 +982,20 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
 
     count_result =
       case repo.query(orphan_query, [], log: false, timeout: @fk_probe_timeout_ms) do
-        {:ok, %{rows: [[c]]}} -> {:ok, c}
-        {:error, reason} -> {:probe_failed, fk_probe_failure_reason(reason)}
-        other -> {:probe_failed, other}
+        {:ok, %{rows: [[c]]}} ->
+          {:ok, c}
+
+        {:error, %Postgrex.Error{postgres: %{code: :query_canceled}} = reason} ->
+          message =
+            fk_probe_failure_reason(reason) <> fk_probe_cost_context(repo, table, fk_col, prefix)
+
+          {:probe_failed, message}
+
+        {:error, reason} ->
+          {:probe_failed, fk_probe_failure_reason(reason)}
+
+        other ->
+          {:probe_failed, other}
       end
 
     validation = if valid?, do: :validated, else: {:not_valid, fk.conname}
@@ -1003,10 +1014,50 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
   # decision functions in this module: directly testable without a repo.
   @doc false
   def fk_probe_failure_reason(%Postgrex.Error{postgres: %{code: :query_canceled}}) do
-    "time limit exceeded (#{@fk_probe_timeout_ms}ms) — table likely large; not checked, not clean"
+    "time limit exceeded (#{@fk_probe_timeout_ms}ms) — not checked, not clean"
   end
 
   def fk_probe_failure_reason(reason), do: reason
+
+  # I055 decision 5: cost of an expensive check must be measured and
+  # printed, not guessed at ("table likely large") or silently dropped.
+  # `n_live_tup` is planner statistics (a `pg_stat_user_tables` read), not a
+  # table scan, so this stays cheap even on the table whose real scan just
+  # timed out. Index presence is checked as "leads some index"
+  # (`indkey[0]` — `int2vector` subscripts are 0-based, unlike the
+  # `conkey`/`confkey` smallint[] arrays used in `discover_fk_constraints/2`)
+  # — a composite index where the FK column isn't first doesn't help this
+  # query's plan, so it doesn't count as indexed here either.
+  #
+  # Exposed (not `defp`) and `@doc false`, same reason as
+  # `discover_fk_constraints/2` and `fk_validation_state/5`: takes `repo`
+  # explicitly, so it's a real unit-test seam against a live connection
+  # without starting the whole app.
+  @doc false
+  def fk_probe_cost_context(repo, table, fk_col, prefix) do
+    query = """
+    SELECT
+      (SELECT n_live_tup FROM pg_stat_user_tables
+       WHERE schemaname = $1 AND relname = $2) AS row_estimate,
+      EXISTS (
+        SELECT 1 FROM pg_index i
+        JOIN pg_class t ON t.oid = i.indrelid
+        JOIN pg_namespace n ON n.oid = t.relnamespace
+        JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = i.indkey[0]
+        WHERE n.nspname = $1 AND t.relname = $2 AND a.attname = $3
+      ) AS fk_col_indexed
+    """
+
+    case repo.query(query, [prefix, table, fk_col], log: false) do
+      {:ok, %{rows: [[row_estimate, indexed?]]}} ->
+        rows_text = if row_estimate, do: "~#{row_estimate} rows", else: "row count unknown"
+        idx_text = if indexed?, do: "indexed", else: "NOT indexed"
+        " (#{table}.#{fk_col}: #{rows_text}, #{idx_text})"
+
+      {:error, _reason} ->
+        ""
+    end
+  end
 
   # Either probe failing must never read as "clean" — a failed probe is a
   # missing answer, not a passing one. Checked before either success shape,

--- a/lib/mix/tasks/phoenix_kit.doctor.ex
+++ b/lib/mix/tasks/phoenix_kit.doctor.ex
@@ -839,74 +839,174 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
     end
   end
 
-  # Pre-migration: check for orphaned FK references (rows pointing to deleted
-  # parents), AND for a constraint that already exists but was never
-  # validated — "blocks constraint creation" is only true when the
-  # constraint is absent; on a schema at V164+ it is usually already there,
-  # NOT VALID, and what orphaned rows actually block is VALIDATE (V176
-  # handles that automatically once the rows are gone).
+  # I055: this used to check 4 hardcoded (table, fk_col, ref_table, ref_col)
+  # pairs out of 70 canonical relationships (231 total FK constraints on a
+  # calibration install) and printed PASS — which reads as "everything is
+  # fine" but meant only "the four pairs we happened to list are fine".
+  # Two real orphans on a live site (S005) sat outside the four and were
+  # invisible to this check the whole time.
+  #
+  # Fixed by discovering every FK constraint straight from `pg_constraint`
+  # instead of a list in code: self-maintaining (a constraint added by a
+  # future migration is covered without touching this file) and exhaustive
+  # by construction rather than by upkeep. Coverage is now part of the
+  # result text itself, and zero coverage — empty schema, wrong --prefix,
+  # a catalog query that itself failed — can never read as PASS, no matter
+  # which of those reasons caused it (I055 finding 2 and 3: "clean" and
+  # "never looked" used to print byte-identical text).
   defp check_orphaned_fk_refs(prefix) do
     repo = get_repo!()
     escaped_prefix = String.replace(prefix, "'", "\\'")
 
-    # Check the most common orphaned FK pattern: user_uuid → users.uuid
-    fk_checks = [
-      {"phoenix_kit_users_tokens", "user_uuid", "phoenix_kit_users", "uuid"},
-      {"phoenix_kit_user_role_assignments", "user_uuid", "phoenix_kit_users", "uuid"},
-      {"phoenix_kit_admin_notes", "user_uuid", "phoenix_kit_users", "uuid"},
-      {"phoenix_kit_email_events", "email_log_uuid", "phoenix_kit_email_logs", "uuid"}
-    ]
+    case discover_fk_constraints(repo, escaped_prefix) do
+      {:error, reason} ->
+        {:warn,
+         "could not enumerate foreign key constraints in schema #{inspect(prefix)} " <>
+           "(#{inspect(reason)}) — coverage is zero, which is not the same as clean. " <>
+           "Fix catalog access (pg_constraint/pg_class) and re-run."}
 
-    {orphaned, not_validated, probe_failed} =
-      Enum.reduce(fk_checks, {[], [], []}, fn {table, fk_col, ref_table, ref_col},
-                                              {orph, nv, pf} ->
-        table_name = prefix_table_name(table, prefix)
-        ref_name = prefix_table_name(ref_table, prefix)
+      {:ok, {[], []}} ->
+        {:warn,
+         "no foreign key constraints found in schema #{inspect(prefix)} — coverage is " <>
+           "zero: either nothing is installed here, or --prefix names the wrong schema. " <>
+           "This is not the same as clean."}
 
-        check_query = """
-        SELECT EXISTS (
-          SELECT FROM information_schema.columns
-          WHERE table_name = '#{table}' AND column_name = '#{fk_col}' AND table_schema = '#{escaped_prefix}'
-        ) AND EXISTS (
-          SELECT FROM information_schema.columns
-          WHERE table_name = '#{ref_table}' AND column_name = '#{ref_col}' AND table_schema = '#{escaped_prefix}'
+      {:ok, {constraints, skipped_multi}} ->
+        {orphaned, not_validated, probe_failed} =
+          Enum.reduce(constraints, {[], [], []}, fn fk, acc -> probe_fk(repo, fk, prefix, acc) end)
+
+        multi_column_entries =
+          Enum.map(skipped_multi, fn {table, conname, ref_table, col_count} ->
+            {table, conname, ref_table, :multi_column,
+             "composite FK (#{col_count} columns) — not supported by this check", nil}
+          end)
+
+        total = length(constraints) + length(skipped_multi)
+
+        report_orphaned_fk_refs(
+          Enum.reverse(orphaned),
+          Enum.reverse(not_validated),
+          Enum.reverse(probe_failed) ++ multi_column_entries,
+          total
         )
-        """
-
-        case repo.query(check_query, [], log: false) do
-          {:ok, %{rows: [[true]]}} ->
-            orphan_query = """
-            SELECT count(*)::integer FROM #{table_name} t
-            WHERE t.#{fk_col} IS NOT NULL
-            AND NOT EXISTS (SELECT 1 FROM #{ref_name} r WHERE r.#{ref_col} = t.#{fk_col})
-            """
-
-            # A failed count query used to default to 0 ("no orphans") —
-            # exactly the same fail-open shape as fk_validation_state's old
-            # `_ -> :absent`. Distinguished the same way: a query error is
-            # "could not check", never silently "clean".
-            count_result =
-              case repo.query(orphan_query, [], log: false) do
-                {:ok, %{rows: [[c]]}} -> {:ok, c}
-                {:error, reason} -> {:probe_failed, reason}
-                other -> {:probe_failed, other}
-              end
-
-            validation = fk_validation_state(repo, table, fk_col, ref_table, escaped_prefix)
-
-            classify_fk_check(table, fk_col, ref_table, count_result, validation, {orph, nv, pf})
-
-          _ ->
-            {orph, nv, pf}
-        end
-      end)
-
-    report_orphaned_fk_refs(
-      Enum.reverse(orphaned),
-      Enum.reverse(not_validated),
-      Enum.reverse(probe_failed)
-    )
+    end
   end
+
+  # Every single-column foreign key constraint in the schema, read straight
+  # from the catalog — not filtered to any PhoenixKit-owned naming
+  # convention, because an orphan on a host app's own table blocks that
+  # table's own VALIDATE just as surely as one on a phoenix_kit_* table.
+  # Multi-column FKs are enumerated separately rather than silently
+  # excluded: `check_orphaned_fk_refs/1` folds them into the report as
+  # "not checked", so the coverage count in the result line still accounts
+  # for every constraint that exists, not just the ones this query knows
+  # how to probe.
+  @doc false
+  def discover_fk_constraints(repo, escaped_prefix) do
+    query = """
+    SELECT
+      t.relname AS table_name,
+      ft.relname AS ref_table,
+      c.conname,
+      c.convalidated,
+      array_length(c.conkey, 1) AS col_count,
+      (SELECT a.attname FROM pg_attribute a
+       WHERE a.attrelid = c.conrelid AND a.attnum = c.conkey[1]) AS fk_col,
+      (SELECT fa.attname FROM pg_attribute fa
+       WHERE fa.attrelid = c.confrelid AND fa.attnum = c.confkey[1]) AS ref_col
+    FROM pg_constraint c
+    JOIN pg_class t ON t.oid = c.conrelid
+    JOIN pg_namespace n ON n.oid = t.relnamespace
+    JOIN pg_class ft ON ft.oid = c.confrelid
+    JOIN pg_namespace fn ON fn.oid = ft.relnamespace
+    WHERE c.contype = 'f'
+      AND n.nspname = '#{escaped_prefix}'
+      AND fn.nspname = '#{escaped_prefix}'
+    ORDER BY t.relname, fk_col
+    """
+
+    case repo.query(query, [], log: false) do
+      {:ok, %{rows: rows}} ->
+        {single, multi} =
+          Enum.split_with(rows, fn [_, _, _, _, col_count, _, _] -> col_count == 1 end)
+
+        constraints =
+          Enum.map(single, fn [table, ref_table, conname, convalidated, _one, fk_col, ref_col] ->
+            %{
+              table: table,
+              fk_col: fk_col,
+              ref_table: ref_table,
+              ref_col: ref_col,
+              conname: conname,
+              convalidated: convalidated
+            }
+          end)
+
+        skipped_multi =
+          Enum.map(multi, fn [table, ref_table, conname, _validated, col_count, _fk, _ref] ->
+            {table, conname, ref_table, col_count}
+          end)
+
+        {:ok, {constraints, skipped_multi}}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  # Per-constraint time budget: a check that never finishes must never read
+  # as clean, but it also must not be allowed to hang the whole doctor run
+  # waiting on one giant table. Postgrex's `:timeout` cancels the statement
+  # server-side on expiry and returns a normal `{:error, %Postgrex.Error{}}`
+  # (verified against a real connection — a client-side `:timeout` here does
+  # NOT exit the calling process), so this needs no special rescue beyond
+  # the {:error, reason} branch `classify_fk_check/5` already routes to
+  # `:probe_failed` — a timeout is just one more reason a probe can fail,
+  # never a silent scope reduction. I055 explicitly rejects a `--full` flag
+  # for this exact reason: breadth (every constraint) is never negotiable,
+  # only depth (how long we wait per constraint) is.
+  @fk_probe_timeout_ms 5_000
+
+  defp probe_fk(repo, fk, prefix, {orph, nv, pf}) do
+    %{table: table, fk_col: fk_col, ref_table: ref_table, ref_col: ref_col, convalidated: valid?} =
+      fk
+
+    table_name = prefix_table_name(table, prefix)
+    ref_name = prefix_table_name(ref_table, prefix)
+
+    orphan_query = """
+    SELECT count(*)::integer FROM #{table_name} t
+    WHERE t.#{fk_col} IS NOT NULL
+    AND NOT EXISTS (SELECT 1 FROM #{ref_name} r WHERE r.#{ref_col} = t.#{fk_col})
+    """
+
+    count_result =
+      case repo.query(orphan_query, [], log: false, timeout: @fk_probe_timeout_ms) do
+        {:ok, %{rows: [[c]]}} -> {:ok, c}
+        {:error, reason} -> {:probe_failed, fk_probe_failure_reason(reason)}
+        other -> {:probe_failed, other}
+      end
+
+    validation = if valid?, do: :validated, else: {:not_valid, fk.conname}
+
+    classify_fk_check(table, fk_col, ref_table, count_result, validation, {orph, nv, pf})
+  end
+
+  # A query cancelled by the timeout above and every other Postgrex error
+  # both surface as `%Postgrex.Error{}` — this only exists to make the
+  # timeout case say "time limit exceeded" instead of the raw Postgres
+  # cancellation text, so the doctor's report matches the operator-facing
+  # language I055 asks for ("не проверено (превышен предел)") rather than
+  # leaking a database error message that means the same thing.
+  #
+  # Exposed (not `defp`) and `@doc false`, same reason as the other pure
+  # decision functions in this module: directly testable without a repo.
+  @doc false
+  def fk_probe_failure_reason(%Postgrex.Error{postgres: %{code: :query_canceled}}) do
+    "time limit exceeded (#{@fk_probe_timeout_ms}ms) — table likely large; not checked, not clean"
+  end
+
+  def fk_probe_failure_reason(reason), do: reason
 
   # Either probe failing must never read as "clean" — a failed probe is a
   # missing answer, not a passing one. Checked before either success shape,
@@ -959,12 +1059,19 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
     acc
   end
 
+  # I055's third urgency tier. Before this round, a probe failure with zero
+  # actual orphans still returned :fail — the same red as real broken data,
+  # which is exactly the "slow and broken-data can't be one color" defect
+  # the contract names. Real orphans (last clause below) still win :fail
+  # outright, checked or not; a probe failure on its own is "investigate
+  # coverage", not "fix broken data", and gets its own color for it.
   @doc false
-  def report_orphaned_fk_refs([], [], []) do
-    {:pass, "No orphaned FK references found"}
+  def report_orphaned_fk_refs([], [], [], total) do
+    {:pass,
+     "No orphaned FK references found (checked #{total} of #{total} foreign key constraints)"}
   end
 
-  def report_orphaned_fk_refs([], not_validated, []) do
+  def report_orphaned_fk_refs([], not_validated, [], total) do
     detail =
       Enum.map_join(not_validated, "\n       ", fn {table, fk_col, ref} ->
         "#{table}.#{fk_col} → #{ref}"
@@ -972,38 +1079,48 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
 
     {:warn,
      "Foreign key(s) exist but were never validated (no orphaned rows blocking it right " <>
-       "now):\n       #{detail}\n       V176 validates these automatically on the next " <>
-       "migration run; or ALTER TABLE <table> VALIDATE CONSTRAINT <name> by hand."}
+       "now), checked #{total} of #{total}:\n       #{detail}\n       V176 validates these " <>
+       "automatically on the next migration run; or ALTER TABLE <table> VALIDATE CONSTRAINT " <>
+       "<name> by hand."}
   end
 
-  # Also matches when `orphaned == []` and `probe_failed != []` — a probe
-  # failure must never fall through to the :pass/:warn clauses above, which
-  # is exactly why this clause has no guard narrowing it further.
-  def report_orphaned_fk_refs(orphaned, not_validated, probe_failed) do
-    orphan_lines =
-      Enum.map(orphaned, fn
-        {table, fk_col, ref, count, :validate} ->
-          "#{table}.#{fk_col} → #{ref}: #{count} orphaned row(s) — constraint already exists " <>
-            "NOT VALID, this blocks VALIDATE"
+  def report_orphaned_fk_refs([], not_validated, probe_failed, total) when probe_failed != [] do
+    covered = total - length(probe_failed)
 
-        {table, fk_col, ref, count, :create} ->
-          "#{table}.#{fk_col} → #{ref}: #{count} orphaned row(s) — no constraint yet, this " <>
-            "blocks its creation"
-      end)
+    nv_note =
+      case not_validated do
+        [] ->
+          ""
 
-    probe_lines =
-      Enum.map(probe_failed, fn
-        {table, fk_col, ref, :validation_state, reason, count} ->
-          "#{table}.#{fk_col} → #{ref}: #{count} orphaned row(s) measured, but could not check " <>
-            "whether the constraint is validated (validation_state probe failed: " <>
-            "#{inspect(reason)}) — a failed probe is not a pass, treat as unverified"
+        list ->
+          "\n       Also unvalidated with nothing currently blocking it: " <>
+            Enum.map_join(list, ", ", fn {t, c, r} -> "#{t}.#{c} → #{r}" end)
+      end
 
-        {table, fk_col, ref, kind, reason, nil} ->
-          "#{table}.#{fk_col} → #{ref}: could not check (#{kind} probe failed: #{inspect(reason)}) " <>
-            "— a failed probe is not a pass, treat as unverified"
-      end)
+    {:warn,
+     "Could not check #{length(probe_failed)} of #{total} foreign key constraints — " <>
+       "coverage is incomplete, which is not the same as clean:\n       " <>
+       Enum.join(fk_probe_lines(probe_failed), "\n       ") <>
+       nv_note <>
+       "\n       No orphaned rows among the #{covered} successfully checked. Fix DB " <>
+       "connectivity/permissions (or the time limit, for a slow table) and re-run for " <>
+       "full coverage."}
+  end
 
-    detail = Enum.join(orphan_lines ++ probe_lines, "\n       ")
+  # Falls through here whenever `orphaned != []` — real broken data, so this
+  # is :fail regardless of what else is going on. A probe failure elsewhere
+  # in the same run is still worth surfacing (it means coverage is
+  # incomplete on TOP of the confirmed damage), so its detail is still
+  # appended rather than swallowed by the more urgent finding.
+  def report_orphaned_fk_refs(orphaned, not_validated, probe_failed, total) do
+    detail = Enum.join(fk_orphan_lines(orphaned) ++ fk_probe_lines(probe_failed), "\n       ")
+
+    coverage_note =
+      if probe_failed == [] do
+        " (checked #{total} of #{total})"
+      else
+        " (checked #{total - length(probe_failed)} of #{total} — #{length(probe_failed)} more not checked)"
+      end
 
     nv_note =
       case not_validated do
@@ -1016,10 +1133,35 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
       end
 
     {:fail,
-     "Orphaned FK refs / unverifiable FK state found:\n       #{detail}#{nv_note}\n       " <>
-       "V164/V176 never delete rows to force a constraint through — clean orphaned rows up " <>
-       "by hand and re-run the migration chain; for a probe failure, fix DB connectivity or " <>
-       "permissions on pg_constraint and re-run doctor."}
+     "Orphaned FK refs / unverifiable FK state found#{coverage_note}:\n       " <>
+       "#{detail}#{nv_note}\n       V164/V176 never delete rows to force a constraint " <>
+       "through — clean orphaned rows up by hand and re-run the migration chain; for a " <>
+       "probe failure, fix DB connectivity or permissions on pg_constraint and re-run doctor."}
+  end
+
+  defp fk_orphan_lines(orphaned) do
+    Enum.map(orphaned, fn
+      {table, fk_col, ref, count, :validate} ->
+        "#{table}.#{fk_col} → #{ref}: #{count} orphaned row(s) — constraint already exists " <>
+          "NOT VALID, this blocks VALIDATE"
+
+      {table, fk_col, ref, count, :create} ->
+        "#{table}.#{fk_col} → #{ref}: #{count} orphaned row(s) — no constraint yet, this " <>
+          "blocks its creation"
+    end)
+  end
+
+  defp fk_probe_lines(probe_failed) do
+    Enum.map(probe_failed, fn
+      {table, fk_col, ref, :validation_state, reason, count} ->
+        "#{table}.#{fk_col} → #{ref}: #{count} orphaned row(s) measured, but could not check " <>
+          "whether the constraint is validated (validation_state probe failed: " <>
+          "#{inspect(reason)}) — a failed probe is not a pass, treat as unverified"
+
+      {table, fk_col, ref, kind, reason, nil} ->
+        "#{table}.#{fk_col} → #{ref}: could not check (#{kind} probe failed: #{inspect(reason)}) " <>
+          "— a failed probe is not a pass, treat as unverified"
+    end)
   end
 
   # `convalidated` for the constraint enforcing this exact (column ->

--- a/lib/mix/tasks/phoenix_kit.doctor.ex
+++ b/lib/mix/tasks/phoenix_kit.doctor.ex
@@ -839,11 +839,11 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
     end
   end
 
-  # I055: this used to check 4 hardcoded (table, fk_col, ref_table, ref_col)
+  # This used to check 4 hardcoded (table, fk_col, ref_table, ref_col)
   # pairs out of 70 canonical relationships (231 total FK constraints on a
   # calibration install) and printed PASS — which reads as "everything is
   # fine" but meant only "the four pairs we happened to list are fine".
-  # Two real orphans on a live site (S005) sat outside the four and were
+  # Two real orphans on a live site sat outside the four and were
   # invisible to this check the whole time.
   #
   # Fixed by discovering every FK constraint straight from `pg_constraint`
@@ -852,8 +852,8 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
   # by construction rather than by upkeep. Coverage is now part of the
   # result text itself, and zero coverage — empty schema, wrong --prefix,
   # a catalog query that itself failed — can never read as PASS, no matter
-  # which of those reasons caused it (I055 finding 2 and 3: "clean" and
-  # "never looked" used to print byte-identical text).
+  # which of those reasons caused it ("clean" and "never looked" used to
+  # print byte-identical text).
   #
   # Exposed (not `defp`) and `@doc false`, same reason as the other pure
   # decision functions in this module: `get_repo!/0` resolves the same
@@ -973,9 +973,9 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
   # `{:error, %DBConnection.ConnectionError{reason: :closed}}` with no
   # `Postgrex.Error` involved at all. Both shapes are handled the same way —
   # a timeout is just one more reason a probe can fail, never a silent scope
-  # reduction. I055 explicitly rejects a `--full` flag for this exact reason:
-  # breadth (every constraint) is never negotiable, only depth (how long we
-  # wait per constraint) is.
+  # reduction. A `--full` flag is deliberately not offered, for this exact
+  # reason: breadth (every constraint) is never negotiable, only depth (how
+  # long we wait per constraint) is.
   @fk_probe_timeout_ms 5_000
 
   defp probe_fk(repo, fk, prefix, {orph, nv, pf}) do
@@ -1022,10 +1022,9 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
   # under it by the pool, and every other Postgrex/DBConnection error all
   # reach this function — it only exists to make the two timeout shapes say
   # "time limit exceeded" instead of a raw Postgres cancellation code or a
-  # "tcp recv: closed" pool message, so the doctor's report matches the
-  # operator-facing language I055 asks for ("не проверено (превышен
-  # предел)") rather than leaking a database/pool error that means the same
-  # thing.
+  # "tcp recv: closed" pool message, so the doctor's report uses
+  # operator-facing language ("не проверено (превышен предел)") rather than
+  # leaking a database/pool error that means the same thing.
   #
   # Exposed (not `defp`) and `@doc false`, same reason as the other pure
   # decision functions in this module: directly testable without a repo.
@@ -1040,7 +1039,7 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
 
   def fk_probe_failure_reason(reason), do: reason
 
-  # I055 decision 5: cost of an expensive check must be measured and
+  # Cost of an expensive check must be measured and
   # printed, not guessed at ("table likely large") or silently dropped.
   # `n_live_tup` is planner statistics (a `pg_stat_user_tables` read), not a
   # table scan, so this stays cheap even on the table whose real scan just
@@ -1149,7 +1148,7 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
     acc
   end
 
-  # I055's third urgency tier. Before this round, a probe failure with zero
+  # A third urgency tier, alongside `:warn` and `:fail`. Before this round, a probe failure with zero
   # actual orphans still returned :fail — the same red as real broken data,
   # which is exactly the "slow and broken-data can't be one color" defect
   # the contract names. Real orphans (last clause below) still win :fail

--- a/lib/mix/tasks/phoenix_kit.doctor.ex
+++ b/lib/mix/tasks/phoenix_kit.doctor.ex
@@ -44,9 +44,13 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
        bulk load, direct catalog surgery) or still NOT VALID (would block its
        own VALIDATE), and existing constraints still sitting NOT VALID with
        nothing currently blocking them — V176 validates those in place; this
-       just tells you before it does. Discovery reads `pg_constraint`, so a
-       relationship with no FK constraint declared at all is outside this
-       check's scope and is not examined
+       just tells you before it does. Two boundaries on what "checked" means
+       here: discovery reads `pg_constraint`, so a relationship with no FK
+       constraint declared at all is outside this check's scope and is not
+       examined; and discovery matches both the owning table and the
+       referenced table to the schema being checked (`--prefix`), so a FK
+       whose referenced table lives in a different schema is outside scope
+       too, even though the owning table itself was checked
    13. **Lock Conflicts** — Any blocked or long-running queries?
    14. **Orphaned Connections** — Idle-in-transaction or stuck connections
    15. **Oban Configuration** — Queues and plugins that consume pool connections
@@ -911,6 +915,19 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
   # "not checked", so the coverage count in the result line still accounts
   # for every constraint that exists, not just the ones this query knows
   # how to probe.
+  #
+  # Both `n.nspname` (owning table) and `fn.nspname` (referenced table) are
+  # constrained to `escaped_prefix` — a FK from this schema INTO a table
+  # living in a different one is excluded entirely, not counted, not folded
+  # into "not checked". Deliberate, not an oversight: the probe query below
+  # qualifies the referenced table with this same `escaped_prefix` via
+  # `prefix_table_name/2`, so a referenced table actually living elsewhere
+  # would be probed under the wrong schema-qualified name. Supporting a
+  # cross-schema referenced table for real means carrying its own schema
+  # through this function's return shape (not just its bare `relname`) and
+  # threading it into every place that currently assumes `escaped_prefix`
+  # covers both sides — `probe_fk/4` and `fk_probe_cost_context/4` included.
+  # Out of scope here; the moduledoc's check 12 entry names this boundary.
   @doc false
   def discover_fk_constraints(repo, escaped_prefix) do
     query = """
@@ -1278,7 +1295,9 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
   # name, so a constraint adopted under a differently-named twin (V164's own
   # documented case) is still found. Returns `:absent` if no such FK exists
   # at all — a state discover_fk_constraints/2 has no way to report, since
-  # bulk discovery only ever enumerates constraints that exist.
+  # bulk discovery only ever enumerates constraints that exist. Carries the
+  # identical same-schema restriction as discover_fk_constraints/2 (see its
+  # comment): `ref_table` is assumed to live in `escaped_prefix` too.
   #
   # Not called from the doctor's own run: probe_fk/4 reads `convalidated`
   # straight off each constraint discover_fk_constraints/2 already found, one

--- a/lib/mix/tasks/phoenix_kit.doctor.ex
+++ b/lib/mix/tasks/phoenix_kit.doctor.ex
@@ -1211,9 +1211,12 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
        "coverage is incomplete, which is not the same as clean:\n       " <>
        Enum.join(fk_probe_lines(probe_failed), "\n       ") <>
        nv_note <>
-       "\n       No orphaned rows among the #{covered} successfully checked. Fix DB " <>
-       "connectivity/permissions (or the time limit, for a slow table) and re-run for " <>
-       "full coverage."}
+       "\n       No orphaned rows among the #{covered} successfully checked." <>
+       retry_suggestion(
+         probe_failed,
+         " Fix DB connectivity/permissions (or the time limit, " <>
+           "for a slow table) and re-run for full coverage."
+       )}
   end
 
   # Falls through here whenever `orphaned != []` — real broken data, so this
@@ -1244,8 +1247,27 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
     {:fail,
      "Orphaned FK refs / unverifiable FK state found#{coverage_note}:\n       " <>
        "#{detail}#{nv_note}\n       V164/V176 never delete rows to force a constraint " <>
-       "through — clean orphaned rows up by hand and re-run the migration chain; for a " <>
-       "probe failure, fix DB connectivity or permissions on pg_constraint and re-run doctor."}
+       "through — clean orphaned rows up by hand and re-run the migration chain." <>
+       retry_suggestion(
+         probe_failed,
+         " For a probe failure, fix DB connectivity or " <>
+           "permissions on pg_constraint and re-run doctor."
+       )}
+  end
+
+  # A composite FK in `probe_failed` (see `discover_fk_constraints/2`) was never
+  # probed at all — no re-run ever turns that into a pass, only a manual
+  # `ALTER TABLE ... VALIDATE CONSTRAINT` does, which `fk_probe_lines/1` already
+  # says per entry. Suggesting a re-run regardless — the old unconditional text
+  # — told the operator to retry something that can never succeed. Only worth
+  # it when at least one entry is a genuine probe failure a re-run could
+  # actually resolve.
+  defp retry_suggestion(probe_failed, text) do
+    if Enum.any?(probe_failed, fn entry -> elem(entry, 3) != :multi_column end) do
+      text
+    else
+      ""
+    end
   end
 
   defp fk_orphan_lines(orphaned) do

--- a/lib/mix/tasks/phoenix_kit.doctor.ex
+++ b/lib/mix/tasks/phoenix_kit.doctor.ex
@@ -1144,19 +1144,19 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
 
   # Narrowed to `{:ok, 0}` deliberately: this is the ONLY combination that
   # means "clean". Widening it back to `{:ok, _count}` is exactly the bug
-  # this round fixed for `:validated` — a future `validation` shape reaching
+  # already fixed for `:validated` — a future `validation` shape reaching
   # here with `count > 0` must raise `FunctionClauseError`, not silently
   # discard real orphans the way the old wildcard catch-all did.
   def classify_fk_check(_table, _fk_col, _ref, {:ok, 0}, _validated_or_absent_and_clean, acc) do
     acc
   end
 
-  # A third urgency tier, alongside `:warn` and `:fail`. Before this round, a probe failure with zero
-  # actual orphans still returned :fail — the same red as real broken data,
-  # which is exactly the "slow and broken-data can't be one color" defect
-  # the contract names. Real orphans (last clause below) still win :fail
-  # outright, checked or not; a probe failure on its own is "investigate
-  # coverage", not "fix broken data", and gets its own color for it.
+  # A third urgency tier, alongside `:warn` and `:fail`. Before this fix, a
+  # probe failure with zero actual orphans still returned :fail — the same
+  # red as real broken data, even though nothing is actually broken. Real
+  # orphans (last clause below) still win :fail outright, checked or not; a
+  # probe failure on its own is "investigate coverage", not "fix broken
+  # data", and gets its own color for it.
   @doc false
   def report_orphaned_fk_refs([], [], [], total) do
     {:pass,

--- a/lib/mix/tasks/phoenix_kit.doctor.ex
+++ b/lib/mix/tasks/phoenix_kit.doctor.ex
@@ -39,11 +39,14 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
     9. **UUID Column Types** — Detects varchar uuid columns that crash Ecto on startup
    10. **UUID Primary Keys** — Detects primary keys that are not the expected uuid type
    11. **NULL UUIDs in FK Sources** — Detects NULL uuids that cause infinite backfill loops
-   12. **Orphaned FK References** — Detects orphaned rows (blocks VALIDATE on an
-       existing NOT VALID constraint, or creation if the constraint is absent
-       entirely) and existing constraints still sitting NOT VALID with
+   12. **Orphaned FK References** — Detects orphaned rows behind an existing FK
+       constraint, whether it is already VALID (a trigger-bypassed write, a
+       bulk load, direct catalog surgery) or still NOT VALID (would block its
+       own VALIDATE), and existing constraints still sitting NOT VALID with
        nothing currently blocking them — V176 validates those in place; this
-       just tells you before it does
+       just tells you before it does. Discovery reads `pg_constraint`, so a
+       relationship with no FK constraint declared at all is outside this
+       check's scope and is not examined
    13. **Lock Conflicts** — Any blocked or long-running queries?
    14. **Orphaned Connections** — Idle-in-transaction or stuck connections
    15. **Oban Configuration** — Queues and plugins that consume pool connections

--- a/lib/mix/tasks/phoenix_kit.doctor.ex
+++ b/lib/mix/tasks/phoenix_kit.doctor.ex
@@ -1277,7 +1277,19 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
   # ref_table.uuid) shape, matched by shape via conkey/confkey — not by
   # name, so a constraint adopted under a differently-named twin (V164's own
   # documented case) is still found. Returns `:absent` if no such FK exists
-  # at all.
+  # at all — a state discover_fk_constraints/2 has no way to report, since
+  # bulk discovery only ever enumerates constraints that exist.
+  #
+  # Not called from the doctor's own run: probe_fk/4 reads `convalidated`
+  # straight off each constraint discover_fk_constraints/2 already found, one
+  # round trip cheaper per check than looking each one up again by shape.
+  # Kept anyway, deliberately: it is the one existing primitive that can
+  # answer "does this specific expected relationship have a declared FK at
+  # all", independent of naming — exactly what closing check 12's current
+  # gap (a relationship with no FK constraint declared at all goes
+  # unexamined, see its moduledoc entry) would need, given a source of
+  # expected (table, fk_col, ref_table) candidates. No such source exists
+  # yet, so this stays unwired until one does.
   #
   # Exposed (not `defp`) and `@doc false` so the test suite can force a real
   # probe failure (a malformed identifier producing a genuine Postgres

--- a/test/mix/tasks/phoenix_kit_doctor_orphaned_fk_test.exs
+++ b/test/mix/tasks/phoenix_kit_doctor_orphaned_fk_test.exs
@@ -91,4 +91,27 @@ defmodule Mix.Tasks.PhoenixKit.DoctorOrphanedFkTest do
       assert {:error, %Postgrex.Error{}} = DoctorTask.discover_fk_constraints(Repo, "x'y")
     end
   end
+
+  describe "fk_probe_cost_context/4 — I055 decision 5: measure, don't guess" do
+    test "a real, indexed FK column reports an actual row estimate and 'indexed', not a guess" do
+      context =
+        DoctorTask.fk_probe_cost_context(Repo, "phoenix_kit_users_tokens", "user_uuid", "public")
+
+      assert context =~ "phoenix_kit_users_tokens.user_uuid:"
+      assert context =~ "indexed"
+      refute context =~ "table likely large"
+    end
+
+    test "a nonexistent table/column pair degrades to 'row count unknown', never raises" do
+      context =
+        DoctorTask.fk_probe_cost_context(
+          Repo,
+          "definitely_not_a_real_table_12345",
+          "col",
+          "public"
+        )
+
+      assert context =~ "row count unknown"
+    end
+  end
 end

--- a/test/mix/tasks/phoenix_kit_doctor_orphaned_fk_test.exs
+++ b/test/mix/tasks/phoenix_kit_doctor_orphaned_fk_test.exs
@@ -114,4 +114,39 @@ defmodule Mix.Tasks.PhoenixKit.DoctorOrphanedFkTest do
       assert context =~ "row count unknown"
     end
   end
+
+  describe "check_orphaned_fk_refs/1 — destructive: a genuinely orphaned row outside the old 4 pairs is caught" do
+    # I055's widened check reads every single-column FK straight from
+    # `pg_constraint` (`discover_fk_constraints/2`), not just the four pairs
+    # the old check knew by name. This proves that widened coverage actually
+    # catches something the old four-pair list could never have seen:
+    # `phoenix_kit_user_oauth_providers.user_uuid -> phoenix_kit_users.uuid`
+    # (constraint `fk_user_oauth_providers_user_uuid`) was never one of the
+    # old four (`phoenix_kit_users_tokens`, `phoenix_kit_user_role_assignments`,
+    # `phoenix_kit_admin_notes`, `phoenix_kit_email_events`).
+    #
+    # A plain `INSERT` can't produce this row — the constraint rejects a
+    # nonexistent `user_uuid` immediately, and it isn't `DEFERRABLE`, so
+    # `SET CONSTRAINTS ALL DEFERRED` doesn't buy anything either. Disabling
+    # the child table's own triggers for one statement is the standard
+    # Postgres idiom for planting a row that could otherwise only arise from
+    # the same kind of bypass in production — a bulk load with constraints
+    # off, a restore from an inconsistent backup, direct catalog surgery —
+    # which is exactly the class of real corruption I055 exists to catch,
+    # not a contrived test-only shape.
+    test "an orphaned phoenix_kit_user_oauth_providers.user_uuid row is reported, not read as clean" do
+      Repo.query!("ALTER TABLE phoenix_kit_user_oauth_providers DISABLE TRIGGER ALL")
+
+      Repo.query!("""
+      INSERT INTO phoenix_kit_user_oauth_providers
+        (user_uuid, provider, provider_uid, inserted_at, updated_at)
+      VALUES (gen_random_uuid(), 'google', 'i055-destructive-orphan-test', now(), now())
+      """)
+
+      Repo.query!("ALTER TABLE phoenix_kit_user_oauth_providers ENABLE TRIGGER ALL")
+
+      assert {:fail, message} = DoctorTask.check_orphaned_fk_refs("public")
+      assert message =~ "phoenix_kit_user_oauth_providers.user_uuid"
+    end
+  end
 end

--- a/test/mix/tasks/phoenix_kit_doctor_orphaned_fk_test.exs
+++ b/test/mix/tasks/phoenix_kit_doctor_orphaned_fk_test.exs
@@ -56,4 +56,39 @@ defmodule Mix.Tasks.PhoenixKit.DoctorOrphanedFkTest do
                )
     end
   end
+
+  describe "discover_fk_constraints/2 — I055: full catalog coverage, not the old 4-pair list" do
+    test "finds real FK constraints on the live schema, well beyond the old hardcoded four" do
+      assert {:ok, {constraints, _skipped_multi}} =
+               DoctorTask.discover_fk_constraints(Repo, "public")
+
+      # The old check knew exactly 4 pairs. A real installed schema has far
+      # more single-column FKs than that — this is the whole point of I055:
+      # if this ever regresses back toward "4", the fix regressed with it.
+      assert length(constraints) > 10
+
+      assert Enum.any?(constraints, fn c ->
+               c.table == "phoenix_kit_users_tokens" and c.fk_col == "user_uuid" and
+                 c.ref_table == "phoenix_kit_users"
+             end)
+
+      # convalidated must be a real boolean read from the catalog, not a
+      # placeholder — a stray `nil` here would silently break the
+      # `if convalidated, do: :validated, else: {:not_valid, ...}` branch in
+      # `probe_fk/4` for every single discovered constraint.
+      assert Enum.all?(constraints, fn c -> is_boolean(c.convalidated) end)
+    end
+
+    test "a genuinely wrong schema name returns zero constraints, not an error — the caller decides that's zero coverage" do
+      assert {:ok, {[], []}} =
+               DoctorTask.discover_fk_constraints(Repo, "definitely_not_a_real_schema_12345")
+    end
+
+    test "a malformed schema name (real catalog-access fault) returns {:error, _}, never a silent empty list" do
+      # The unescaped quote breaks the query's own string literal boundary —
+      # a genuine Postgres syntax error, the same class of fault I055 finding
+      # 2 warns can otherwise collapse into "nothing found" and print PASS.
+      assert {:error, %Postgrex.Error{}} = DoctorTask.discover_fk_constraints(Repo, "x'y")
+    end
+  end
 end

--- a/test/mix/tasks/phoenix_kit_doctor_orphaned_fk_test.exs
+++ b/test/mix/tasks/phoenix_kit_doctor_orphaned_fk_test.exs
@@ -149,4 +149,29 @@ defmodule Mix.Tasks.PhoenixKit.DoctorOrphanedFkTest do
       assert message =~ "phoenix_kit_user_oauth_providers.user_uuid"
     end
   end
+
+  describe "probe timeout shape — I055 round 3: the real error shape, not an assumed one" do
+    test "a real slow query through Repo.query/3 with a short timeout is always classified as a time limit, whichever shape it takes" do
+      # `probe_fk/4` calls `repo.query(sql, [], timeout: N)` — through the
+      # DBConnection pool/ownership layer, not a raw `Postgrex.query/3`
+      # against a bare connection. Verified live: this does NOT reliably
+      # return `%Postgrex.Error{postgres: %{code: :query_canceled}}}`.
+      # Depending on whether Postgres acknowledges the cancel before
+      # DBConnection's own grace period expires, the identical timeout can
+      # instead surface as `%DBConnection.ConnectionError{reason: :closed}}`
+      # — reproduced on this same suite with both shapes occurring across
+      # different runs. A test pinned to one specific shape would be flaky
+      # by construction, so this asserts the real property `probe_fk/4`
+      # needs: WHICHEVER shape a live timeout takes, `fk_probe_failure_reason/1`
+      # recognizes it as "time limit exceeded", not a raw driver error.
+      assert {:error, reason} = Repo.query("SELECT pg_sleep(3)", [], log: false, timeout: 200)
+
+      assert match?(%Postgrex.Error{postgres: %{code: :query_canceled}}, reason) or
+               match?(%DBConnection.ConnectionError{reason: :closed}, reason),
+             "expected a query_canceled Postgrex.Error or a closed DBConnection.ConnectionError, " <>
+               "got: #{inspect(reason)}"
+
+      assert DoctorTask.fk_probe_failure_reason(reason) =~ "time limit exceeded"
+    end
+  end
 end

--- a/test/mix/tasks/phoenix_kit_doctor_orphaned_fk_test.exs
+++ b/test/mix/tasks/phoenix_kit_doctor_orphaned_fk_test.exs
@@ -6,7 +6,7 @@ defmodule Mix.Tasks.PhoenixKit.DoctorOrphanedFkTest do
   This one function is different: it already takes `repo` as an explicit
   argument, so it is a real unit-test seam without starting anything.
 
-  RED without this round's fix (gate round 2, finding 1): a genuinely
+  RED without this round's fix: a genuinely
   failing probe — forced here with a deliberately malformed identifier,
   which the un-parameterized SQL this function builds turns into a real
   Postgres syntax error — used to collapse into `:absent` (the same shape as
@@ -57,14 +57,14 @@ defmodule Mix.Tasks.PhoenixKit.DoctorOrphanedFkTest do
     end
   end
 
-  describe "discover_fk_constraints/2 — I055: full catalog coverage, not the old 4-pair list" do
+  describe "discover_fk_constraints/2 — full catalog coverage, not the old 4-pair list" do
     test "finds real FK constraints on the live schema, well beyond the old hardcoded four" do
       assert {:ok, {constraints, _skipped_multi}} =
                DoctorTask.discover_fk_constraints(Repo, "public")
 
       # The old check knew exactly 4 pairs. A real installed schema has far
-      # more single-column FKs than that — this is the whole point of I055:
-      # if this ever regresses back toward "4", the fix regressed with it.
+      # more single-column FKs than that — this is the whole point of this
+      # check: if this ever regresses back toward "4", the fix regressed with it.
       assert length(constraints) > 10
 
       assert Enum.any?(constraints, fn c ->
@@ -86,13 +86,13 @@ defmodule Mix.Tasks.PhoenixKit.DoctorOrphanedFkTest do
 
     test "a malformed schema name (real catalog-access fault) returns {:error, _}, never a silent empty list" do
       # The unescaped quote breaks the query's own string literal boundary —
-      # a genuine Postgres syntax error, the same class of fault I055 finding
-      # 2 warns can otherwise collapse into "nothing found" and print PASS.
+      # a genuine Postgres syntax error, the same class of fault that can
+      # otherwise collapse into "nothing found" and print PASS.
       assert {:error, %Postgrex.Error{}} = DoctorTask.discover_fk_constraints(Repo, "x'y")
     end
   end
 
-  describe "fk_probe_cost_context/4 — I055 decision 5: measure, don't guess" do
+  describe "fk_probe_cost_context/4 — measure, don't guess" do
     test "a real, indexed FK column reports an actual row estimate and 'indexed', not a guess" do
       context =
         DoctorTask.fk_probe_cost_context(Repo, "phoenix_kit_users_tokens", "user_uuid", "public")
@@ -116,7 +116,7 @@ defmodule Mix.Tasks.PhoenixKit.DoctorOrphanedFkTest do
   end
 
   describe "check_orphaned_fk_refs/1 — destructive: a genuinely orphaned row outside the old 4 pairs is caught" do
-    # I055's widened check reads every single-column FK straight from
+    # The widened check reads every single-column FK straight from
     # `pg_constraint` (`discover_fk_constraints/2`), not just the four pairs
     # the old check knew by name. This proves that widened coverage actually
     # catches something the old four-pair list could never have seen:
@@ -132,15 +132,15 @@ defmodule Mix.Tasks.PhoenixKit.DoctorOrphanedFkTest do
     # Postgres idiom for planting a row that could otherwise only arise from
     # the same kind of bypass in production — a bulk load with constraints
     # off, a restore from an inconsistent backup, direct catalog surgery —
-    # which is exactly the class of real corruption I055 exists to catch,
-    # not a contrived test-only shape.
+    # which is exactly the class of real corruption this check exists to
+    # catch, not a contrived test-only shape.
     test "an orphaned phoenix_kit_user_oauth_providers.user_uuid row is reported, not read as clean" do
       Repo.query!("ALTER TABLE phoenix_kit_user_oauth_providers DISABLE TRIGGER ALL")
 
       Repo.query!("""
       INSERT INTO phoenix_kit_user_oauth_providers
         (user_uuid, provider, provider_uid, inserted_at, updated_at)
-      VALUES (gen_random_uuid(), 'google', 'i055-destructive-orphan-test', now(), now())
+      VALUES (gen_random_uuid(), 'google', 'destructive-orphan-test', now(), now())
       """)
 
       Repo.query!("ALTER TABLE phoenix_kit_user_oauth_providers ENABLE TRIGGER ALL")
@@ -150,7 +150,7 @@ defmodule Mix.Tasks.PhoenixKit.DoctorOrphanedFkTest do
     end
   end
 
-  describe "probe timeout shape — I055 round 3: the real error shape, not an assumed one" do
+  describe "probe timeout shape — the real error shape, not an assumed one" do
     test "a real slow query through Repo.query/3 with a short timeout is always classified as a time limit, whichever shape it takes" do
       # `probe_fk/4` calls `repo.query(sql, [], timeout: N)` — through the
       # DBConnection pool/ownership layer, not a raw `Postgrex.query/3`

--- a/test/mix/tasks/phoenix_kit_doctor_orphaned_fk_test.exs
+++ b/test/mix/tasks/phoenix_kit_doctor_orphaned_fk_test.exs
@@ -6,7 +6,7 @@ defmodule Mix.Tasks.PhoenixKit.DoctorOrphanedFkTest do
   This one function is different: it already takes `repo` as an explicit
   argument, so it is a real unit-test seam without starting anything.
 
-  RED without this round's fix: a genuinely
+  RED without this fix: a genuinely
   failing probe — forced here with a deliberately malformed identifier,
   which the un-parameterized SQL this function builds turns into a real
   Postgres syntax error — used to collapse into `:absent` (the same shape as
@@ -34,7 +34,7 @@ defmodule Mix.Tasks.PhoenixKit.DoctorOrphanedFkTest do
                )
     end
 
-    test "a real, validated constraint still reads :validated (unchanged by this round)" do
+    test "a real, validated constraint still reads :validated" do
       assert :validated =
                DoctorTask.fk_validation_state(
                  Repo,

--- a/test/mix/tasks/phoenix_kit_doctor_test.exs
+++ b/test/mix/tasks/phoenix_kit_doctor_test.exs
@@ -426,15 +426,19 @@ defmodule Mix.Tasks.PhoenixKit.DoctorTest do
     end
   end
 
-  describe "report_orphaned_fk_refs/3 — RED without this round's fix: a probe failure must not be PASS" do
-    test "probe_failed alone (no orphans, no known-unvalidated) is :fail, never :pass" do
+  describe "report_orphaned_fk_refs/4 — I055: a probe failure is its own tier, not the same red as real orphans" do
+    test "probe_failed alone (no orphans, no known-unvalidated) is :warn, not :fail — I055's third tier" do
+      # Before I055 this was :fail — the exact "slow and broken-data can't be
+      # one color" defect the contract names. Coverage being incomplete is
+      # "investigate why", not "fix corrupted data"; only real orphans (below)
+      # still earn the red.
       probe_failed = [
         {"phoenix_kit_users_tokens", "user_uuid", "phoenix_kit_users", :orphan_count, "boom", nil}
       ]
 
-      assert {:fail, message} = DoctorTask.report_orphaned_fk_refs([], [], probe_failed)
-      assert message =~ "could not check"
-      assert message =~ "not a pass"
+      assert {:warn, message} = DoctorTask.report_orphaned_fk_refs([], [], probe_failed, 4)
+      assert message =~ "Could not check 1 of 4"
+      assert message =~ "not the same as clean"
       assert message =~ "boom"
     end
 
@@ -444,26 +448,73 @@ defmodule Mix.Tasks.PhoenixKit.DoctorTest do
          "no access", 5}
       ]
 
-      assert {:fail, message} = DoctorTask.report_orphaned_fk_refs([], [], probe_failed)
+      assert {:warn, message} = DoctorTask.report_orphaned_fk_refs([], [], probe_failed, 1)
       assert message =~ "5 orphaned row"
       assert message =~ "no access"
     end
 
-    test "no findings at all is still :pass — the fix does not make doctor permanently red" do
-      assert {:pass, _} = DoctorTask.report_orphaned_fk_refs([], [], [])
+    test "no findings at all is still :pass, and now names the coverage" do
+      assert {:pass, message} = DoctorTask.report_orphaned_fk_refs([], [], [], 231)
+      assert message =~ "checked 231 of 231"
     end
 
-    test "orphans alone still :fail, unchanged from before this round" do
+    test "orphans alone still :fail — real data damage always wins the color" do
       orphaned = [{"phoenix_kit_users_tokens", "user_uuid", "phoenix_kit_users", 2, :validate}]
 
-      assert {:fail, message} = DoctorTask.report_orphaned_fk_refs(orphaned, [], [])
+      assert {:fail, message} = DoctorTask.report_orphaned_fk_refs(orphaned, [], [], 4)
       assert message =~ "2 orphaned row"
     end
 
-    test "not_validated alone (nothing blocking) is still :warn, unchanged from before this round" do
+    test "orphans found AND a separate probe failure — still :fail, but the coverage gap is still surfaced" do
+      orphaned = [{"phoenix_kit_users_tokens", "user_uuid", "phoenix_kit_users", 2, :validate}]
+
+      probe_failed = [
+        {"other_table", "other_col", "other_ref", :orphan_count, "boom", nil}
+      ]
+
+      assert {:fail, message} = DoctorTask.report_orphaned_fk_refs(orphaned, [], probe_failed, 5)
+      assert message =~ "2 orphaned row"
+      assert message =~ "boom"
+      assert message =~ "checked 4 of 5"
+    end
+
+    test "not_validated alone (nothing blocking) is still :warn, and names the coverage" do
       not_validated = [{"phoenix_kit_users_tokens", "user_uuid", "phoenix_kit_users"}]
 
-      assert {:warn, _} = DoctorTask.report_orphaned_fk_refs([], not_validated, [])
+      assert {:warn, message} = DoctorTask.report_orphaned_fk_refs([], not_validated, [], 1)
+      assert message =~ "checked 1 of 1"
+    end
+  end
+
+  describe "discover_fk_constraints/2 — I055: source of truth is pg_constraint, not a list in code" do
+    test "a multi-column FK is reported separately from single-column ones, not silently dropped" do
+      # Pure shape check on the split logic doctor's discovery query feeds
+      # into — the actual pg_constraint query itself is exercised against a
+      # real connection in phoenix_kit_doctor_orphaned_fk_test.exs.
+      rows = [
+        ["orders", "users", "fk_orders_user", true, 1, "user_uuid", "uuid"],
+        ["order_items", "orders", "fk_items_composite", false, 2, "order_uuid", "uuid"]
+      ]
+
+      {single, multi} =
+        Enum.split_with(rows, fn [_, _, _, _, col_count, _, _] -> col_count == 1 end)
+
+      assert length(single) == 1
+      assert length(multi) == 1
+      assert [_, _, "fk_items_composite", _, 2, _, _] = hd(multi)
+    end
+  end
+
+  describe "fk_probe_failure_reason/1 — I055: a timed-out probe says so, not a raw Postgres error" do
+    test "a query_canceled Postgrex error becomes a time-limit message" do
+      reason = %Postgrex.Error{postgres: %{code: :query_canceled, message: "canceling statement"}}
+
+      assert DoctorTask.fk_probe_failure_reason(reason) =~ "time limit exceeded"
+      assert DoctorTask.fk_probe_failure_reason(reason) =~ "not checked, not clean"
+    end
+
+    test "any other error reason passes through unchanged" do
+      assert DoctorTask.fk_probe_failure_reason(:some_other_error) == :some_other_error
     end
   end
 end

--- a/test/mix/tasks/phoenix_kit_doctor_test.exs
+++ b/test/mix/tasks/phoenix_kit_doctor_test.exs
@@ -426,6 +426,31 @@ defmodule Mix.Tasks.PhoenixKit.DoctorTest do
     end
   end
 
+  describe "classify_fk_check/5 — a VALID constraint with real orphans must not be discarded" do
+    test "count > 0 with :validated lands in orphaned as :existing_orphan, not the clean catch-all" do
+      # Before this clause, `{:ok, count > 0}` paired with `:validated` fell
+      # through to the generic catch-all (`{orph, nv, pf} -> acc`, no change)
+      # — the exact shape a destructive orphan on an already-VALID constraint
+      # takes, since `probe_fk/4` only ever produces `:validated` or
+      # `{:not_valid, _}`, never `:absent`. Confirmed live against a real
+      # orphan planted via disabled triggers in
+      # `phoenix_kit_doctor_orphaned_fk_test.exs`.
+      assert {[{"t", "c", "r", 3, :existing_orphan}], [], []} =
+               DoctorTask.classify_fk_check("t", "c", "r", {:ok, 3}, :validated, {[], [], []})
+    end
+
+    test "an existing_orphan does not clobber unrelated entries already in the accumulator" do
+      acc =
+        {[{"other", "col", "ref2", 1, :create}], [{"t2", "c2", "r2"}],
+         [{"t3", "c3", "r3", :orphan_count, "x", nil}]}
+
+      assert {[{"t", "c", "r", 5, :existing_orphan}, {"other", "col", "ref2", 1, :create}],
+              [{"t2", "c2", "r2"}],
+              [{"t3", "c3", "r3", :orphan_count, "x", nil}]} =
+               DoctorTask.classify_fk_check("t", "c", "r", {:ok, 5}, :validated, acc)
+    end
+  end
+
   describe "report_orphaned_fk_refs/4 — I055: a probe failure is its own tier, not the same red as real orphans" do
     test "probe_failed alone (no orphans, no known-unvalidated) is :warn, not :fail — I055's third tier" do
       # Before I055 this was :fail — the exact "slow and broken-data can't be

--- a/test/mix/tasks/phoenix_kit_doctor_test.exs
+++ b/test/mix/tasks/phoenix_kit_doctor_test.exs
@@ -509,6 +509,23 @@ defmodule Mix.Tasks.PhoenixKit.DoctorTest do
       assert {:warn, message} = DoctorTask.report_orphaned_fk_refs([], not_validated, [], 1)
       assert message =~ "checked 1 of 1"
     end
+
+    test "a composite FK renders its constraint name and column count, not a misread 'probe failed'" do
+      # `check_orphaned_fk_refs/1` folds a composite FK into the same
+      # `probe_failed`-shaped list as a real probe failure — this asserts
+      # the render doesn't collapse it into the generic "probe failed"
+      # clause, which would print the constraint name in the fk_col slot
+      # (reads as a column) and claim a probe was attempted when none was.
+      probe_failed = [
+        {"phoenix_kit_order_items", "fk_items_composite", "phoenix_kit_orders", :multi_column, 2,
+         nil}
+      ]
+
+      assert {:warn, message} = DoctorTask.report_orphaned_fk_refs([], [], probe_failed, 1)
+      assert message =~ "composite FK fk_items_composite (2 columns)"
+      assert message =~ "VALIDATE CONSTRAINT fk_items_composite"
+      refute message =~ "probe failed"
+    end
   end
 
   describe "discover_fk_constraints/2 — I055: source of truth is pg_constraint, not a list in code" do
@@ -536,6 +553,31 @@ defmodule Mix.Tasks.PhoenixKit.DoctorTest do
 
       assert DoctorTask.fk_probe_failure_reason(reason) =~ "time limit exceeded"
       assert DoctorTask.fk_probe_failure_reason(reason) =~ "not checked, not clean"
+    end
+
+    test "a pool-closed DBConnection.ConnectionError becomes a time-limit message too" do
+      # Verified live (not assumed): `repo.query/3` with a `:timeout` — the
+      # exact call `probe_fk/4` makes, through the DBConnection
+      # pool/ownership layer — does not reliably surface as
+      # `%Postgrex.Error{postgres: %{code: :query_canceled}}}`. Depending on
+      # whether Postgres acknowledges the cancel before DBConnection's own
+      # grace period expires, the SAME timeout can instead surface as
+      # DBConnection tearing down the connection itself. Before this round,
+      # this shape fell through to the generic `reason` clause and printed a
+      # raw "tcp recv: closed" pool message instead of "time limit exceeded".
+      reason = %DBConnection.ConnectionError{reason: :closed, message: "tcp recv: closed"}
+
+      assert DoctorTask.fk_probe_failure_reason(reason) =~ "time limit exceeded"
+      assert DoctorTask.fk_probe_failure_reason(reason) =~ "not checked, not clean"
+    end
+
+    test "a DBConnection.ConnectionError for a different reason passes through unchanged" do
+      # Only `:closed` is treated as a timeout — `:queue_timeout` (the pool
+      # itself has no free connection to hand out) is a different failure and
+      # must not be relabeled as "time limit exceeded".
+      reason = %DBConnection.ConnectionError{reason: :queue_timeout, message: "queue timeout"}
+
+      assert DoctorTask.fk_probe_failure_reason(reason) == reason
     end
 
     test "any other error reason passes through unchanged" do

--- a/test/mix/tasks/phoenix_kit_doctor_test.exs
+++ b/test/mix/tasks/phoenix_kit_doctor_test.exs
@@ -335,7 +335,7 @@ defmodule Mix.Tasks.PhoenixKit.DoctorTest do
     end
   end
 
-  describe "classify_fk_check/5 — a probe failure must never read as clean (gate round 2, finding 1)" do
+  describe "classify_fk_check/5 — a probe failure must never read as clean" do
     test "a failed orphan-count probe lands in the probe_failed bucket, not the clean path" do
       acc = {[], [], []}
 
@@ -364,7 +364,7 @@ defmodule Mix.Tasks.PhoenixKit.DoctorTest do
                )
     end
 
-    test "a failed validation-state probe preserves the measured orphan count (round 2 gate, minor finding 1)" do
+    test "a failed validation-state probe preserves the measured orphan count" do
       # The orphan-count probe already succeeded here — 5 real orphaned rows
       # were measured — and it is only the SEPARATE validation-state probe
       # that failed. Before this fix, the measured count was discarded and
@@ -451,9 +451,9 @@ defmodule Mix.Tasks.PhoenixKit.DoctorTest do
     end
   end
 
-  describe "report_orphaned_fk_refs/4 — I055: a probe failure is its own tier, not the same red as real orphans" do
-    test "probe_failed alone (no orphans, no known-unvalidated) is :warn, not :fail — I055's third tier" do
-      # Before I055 this was :fail — the exact "slow and broken-data can't be
+  describe "report_orphaned_fk_refs/4 — a probe failure is its own tier, not the same red as real orphans" do
+    test "probe_failed alone (no orphans, no known-unvalidated) is :warn, not :fail — a third tier" do
+      # Before this round this was :fail — the exact "slow and broken-data can't be
       # one color" defect the contract names. Coverage being incomplete is
       # "investigate why", not "fix corrupted data"; only real orphans (below)
       # still earn the red.
@@ -467,7 +467,7 @@ defmodule Mix.Tasks.PhoenixKit.DoctorTest do
       assert message =~ "boom"
     end
 
-    test "a validation-state probe failure reports the measured orphan count, not just 'could not check' (round 2 gate, minor finding 1)" do
+    test "a validation-state probe failure reports the measured orphan count, not just 'could not check'" do
       probe_failed = [
         {"phoenix_kit_users_tokens", "user_uuid", "phoenix_kit_users", :validation_state,
          "no access", 5}
@@ -528,7 +528,7 @@ defmodule Mix.Tasks.PhoenixKit.DoctorTest do
     end
   end
 
-  describe "discover_fk_constraints/2 — I055: source of truth is pg_constraint, not a list in code" do
+  describe "discover_fk_constraints/2 — source of truth is pg_constraint, not a list in code" do
     test "a multi-column FK is reported separately from single-column ones, not silently dropped" do
       # Pure shape check on the split logic doctor's discovery query feeds
       # into — the actual pg_constraint query itself is exercised against a
@@ -547,7 +547,7 @@ defmodule Mix.Tasks.PhoenixKit.DoctorTest do
     end
   end
 
-  describe "fk_probe_failure_reason/1 — I055: a timed-out probe says so, not a raw Postgres error" do
+  describe "fk_probe_failure_reason/1 — a timed-out probe says so, not a raw Postgres error" do
     test "a query_canceled Postgrex error becomes a time-limit message" do
       reason = %Postgrex.Error{postgres: %{code: :query_canceled, message: "canceling statement"}}
 

--- a/test/mix/tasks/phoenix_kit_doctor_test.exs
+++ b/test/mix/tasks/phoenix_kit_doctor_test.exs
@@ -400,7 +400,7 @@ defmodule Mix.Tasks.PhoenixKit.DoctorTest do
                )
     end
 
-    test "known-good inputs still classify the same as before this round's fix" do
+    test "known-good inputs still classify the same as before this fix" do
       assert {[{"t", "c", "r", 3, :validate}], [], []} =
                DoctorTask.classify_fk_check(
                  "t",
@@ -453,10 +453,10 @@ defmodule Mix.Tasks.PhoenixKit.DoctorTest do
 
   describe "report_orphaned_fk_refs/4 — a probe failure is its own tier, not the same red as real orphans" do
     test "probe_failed alone (no orphans, no known-unvalidated) is :warn, not :fail — a third tier" do
-      # Before this round this was :fail — the exact "slow and broken-data can't be
-      # one color" defect the contract names. Coverage being incomplete is
-      # "investigate why", not "fix corrupted data"; only real orphans (below)
-      # still earn the red.
+      # Before this fix this was :fail — the same red as confirmed broken
+      # data, even though nothing is actually broken. Coverage being
+      # incomplete is "investigate why", not "fix corrupted data"; only real
+      # orphans (below) still earn the red.
       probe_failed = [
         {"phoenix_kit_users_tokens", "user_uuid", "phoenix_kit_users", :orphan_count, "boom", nil}
       ]
@@ -562,7 +562,7 @@ defmodule Mix.Tasks.PhoenixKit.DoctorTest do
       # `%Postgrex.Error{postgres: %{code: :query_canceled}}}`. Depending on
       # whether Postgres acknowledges the cancel before DBConnection's own
       # grace period expires, the SAME timeout can instead surface as
-      # DBConnection tearing down the connection itself. Before this round,
+      # DBConnection tearing down the connection itself. Before this fix,
       # this shape fell through to the generic `reason` clause and printed a
       # raw "tcp recv: closed" pool message instead of "time limit exceeded".
       reason = %DBConnection.ConnectionError{reason: :closed, message: "tcp recv: closed"}

--- a/test/mix/tasks/phoenix_kit_doctor_test.exs
+++ b/test/mix/tasks/phoenix_kit_doctor_test.exs
@@ -503,6 +503,23 @@ defmodule Mix.Tasks.PhoenixKit.DoctorTest do
       assert message =~ "checked 4 of 5"
     end
 
+    test "orphans found AND a composite-only probe exclusion — no re-run suggestion for it" do
+      # A composite FK can never be resolved by re-running the check — only a
+      # manual VALIDATE CONSTRAINT does. Telling the operator to "re-run" here
+      # (the old unconditional text) contradicted the composite FK's own line,
+      # which already says "verify manually".
+      orphaned = [{"phoenix_kit_users_tokens", "user_uuid", "phoenix_kit_users", 2, :validate}]
+
+      probe_failed = [
+        {"phoenix_kit_order_items", "fk_items_composite", "phoenix_kit_orders", :multi_column, 2,
+         nil}
+      ]
+
+      assert {:fail, message} = DoctorTask.report_orphaned_fk_refs(orphaned, [], probe_failed, 5)
+      assert message =~ "2 orphaned row"
+      refute message =~ "re-run doctor"
+    end
+
     test "not_validated alone (nothing blocking) is still :warn, and names the coverage" do
       not_validated = [{"phoenix_kit_users_tokens", "user_uuid", "phoenix_kit_users"}]
 
@@ -525,6 +542,28 @@ defmodule Mix.Tasks.PhoenixKit.DoctorTest do
       assert message =~ "composite FK fk_items_composite (2 columns)"
       assert message =~ "VALIDATE CONSTRAINT fk_items_composite"
       refute message =~ "probe failed"
+    end
+
+    test "a composite-only probe exclusion never suggests a re-run — nothing would pass it" do
+      probe_failed = [
+        {"phoenix_kit_order_items", "fk_items_composite", "phoenix_kit_orders", :multi_column, 2,
+         nil}
+      ]
+
+      assert {:warn, message} = DoctorTask.report_orphaned_fk_refs([], [], probe_failed, 1)
+      refute message =~ "re-run"
+      refute message =~ "Fix DB"
+    end
+
+    test "a real probe failure alongside a composite exclusion still suggests a re-run" do
+      probe_failed = [
+        {"other_table", "other_col", "other_ref", :orphan_count, "boom", nil},
+        {"phoenix_kit_order_items", "fk_items_composite", "phoenix_kit_orders", :multi_column, 2,
+         nil}
+      ]
+
+      assert {:warn, message} = DoctorTask.report_orphaned_fk_refs([], [], probe_failed, 2)
+      assert message =~ "re-run for full coverage"
     end
   end
 


### PR DESCRIPTION
## Problem

`mix phoenix_kit.doctor` reported a single overall `PASS` for its orphaned-FK
check while only inspecting **four hardcoded table/column pairs**. On a real
installation with ~70 foreign keys, a green report therefore meant "four of
seventy relations are intact" but read as "referential integrity is fine".

Two real orphans on a live site sat outside those four and were never
reported.

## Fix

- The check now discovers foreign keys from `pg_constraint` instead of a
  hardcoded list, so it covers every declared FK rather than a sample.
- Orphans are detected on **already-VALID** constraints too, not only on
  `NOT VALID` ones. The previous shape-matching could not express "this
  constraint is valid, yet rows violate it", which is exactly the case that
  occurs after data is loaded around a constraint.
- Probe timeouts are now measured and classified rather than guessed at, and
  the catch-all clause was narrowed so an unexpected shape no longer passes
  silently as clean.
- Composite foreign keys render correctly in the report.
- Each report line names the scope it actually checked, so a green line can
  no longer be read as broader than it is.
- `@moduledoc` for this check was corrected to describe what the check covers
  now. It previously promised detection for relations where no constraint
  exists at all — that path is not reachable in the current implementation,
  and the documentation said otherwise.

## Verified

- Destructive round-trip on a live database: pass → inject an orphan row →
  check fails → rollback → pass. The failure is the point: a check that stays
  green with a planted orphan would be worthless.
- `--prefix=nonexistent_schema` (no objects at all) no longer reports a bare
  `PASS`; it reports that there was nothing to check.
- Test coverage added for both the discovery path and the orphaned-FK
  classification.

## Not verified

- No run against a database with composite foreign keys in production-scale
  volume; composite rendering was verified on constructed cases only.
- Relations that have no declared foreign key are still outside this check's
  scope. Removing that gap needs a different discovery mechanism (schema
  introspection rather than `pg_constraint`) and is deliberately not part of
  this change — the documentation now states the limit instead of implying it
  is covered.
