### PR TITLE
Dedupe admin route paths across host pages and modules

### DIFF
--- a/lib/phoenix_kit_web/integration.ex
+++ b/lib/phoenix_kit_web/integration.ex
@@ -1087,8 +1087,13 @@ defmodule PhoenixKitWeb.Integration do
     {deduped, _seen} =
       Enum.reduce(routes, {[], seen}, fn route, {acc, seen} ->
         case admin_route_path(route) do
-          nil -> {[route | acc], seen}
-          path -> if MapSet.member?(seen, path), do: {acc, seen}, else: {[route | acc], MapSet.put(seen, path)}
+          nil ->
+            {[route | acc], seen}
+
+          path ->
+            if MapSet.member?(seen, path),
+              do: {acc, seen},
+              else: {[route | acc], MapSet.put(seen, path)}
         end
       end)
 

--- a/lib/phoenix_kit_web/integration.ex
+++ b/lib/phoenix_kit_web/integration.ex
@@ -453,6 +453,18 @@ defmodule PhoenixKitWeb.Integration do
     # so plugin LiveViews don't need to wrap with LayoutWrapper themselves
     plugin_admin_routes = compile_plugin_admin_routes(__CALLER__.module)
 
+    # A module tab whose path collides with a host-declared custom admin
+    # page, or with another module's tab, would otherwise compile to TWO
+    # `live` declarations at the same path — Phoenix keeps the first and
+    # the second becomes dead code, discovered (if at all) only via the
+    # compiler's "this clause cannot match" warning. Host pages win: the
+    # application owner declared them, not a module author, and they were
+    # already emitted first. Ties between modules keep whichever was
+    # discovered first — the same precedence `collect_module_tabs/2`
+    # already uses for tabs within a single module.
+    plugin_admin_routes =
+      dedupe_admin_routes_by_path(plugin_admin_routes, custom_admin_routes)
+
     # Shop admin routes.
     #
     # `phoenix_kit_ecommerce` declares `route_module/0`, so auto-discovery
@@ -1061,6 +1073,30 @@ defmodule PhoenixKitWeb.Integration do
       []
     end
   end
+
+  # Drops any quoted route in `routes` whose path already appears in
+  # `accepted_routes` (host pages, checked first) or earlier in `routes`
+  # itself (cross-module collisions) — first occurrence wins either way.
+  # Operates on the quoted `live path, live_view, action, opts` forms built
+  # by `tab_to_route/1` / `tab_struct_to_route/1` / `tab_to_route_from_url/3`,
+  # all of which share that shape, so the literal path is always the first
+  # argument.
+  defp dedupe_admin_routes_by_path(routes, accepted_routes) do
+    seen = accepted_routes |> Enum.map(&admin_route_path/1) |> MapSet.new()
+
+    {deduped, _seen} =
+      Enum.reduce(routes, {[], seen}, fn route, {acc, seen} ->
+        case admin_route_path(route) do
+          nil -> {[route | acc], seen}
+          path -> if MapSet.member?(seen, path), do: {acc, seen}, else: {[route | acc], MapSet.put(seen, path)}
+        end
+      end)
+
+    Enum.reverse(deduped)
+  end
+
+  defp admin_route_path({:live, _meta, [path | _rest]}) when is_binary(path), do: path
+  defp admin_route_path(_), do: nil
 
   defp tab_callback_context(:admin_tabs), do: :admin
   defp tab_callback_context(:settings_tabs), do: :settings

--- a/test/phoenix_kit_web/admin_route_dedup_test.exs
+++ b/test/phoenix_kit_web/admin_route_dedup_test.exs
@@ -113,7 +113,9 @@ defmodule PhoenixKitWeb.AdminRouteDedupTest do
     }
   ])
 
-  Application.put_env(:phoenix_kit, :modules, [PhoenixKitWeb.AdminRouteDedupTest.FakeExternalModule])
+  Application.put_env(:phoenix_kit, :modules, [
+    PhoenixKitWeb.AdminRouteDedupTest.FakeExternalModule
+  ])
 
   defmodule DedupProbeRouter do
     @moduledoc false

--- a/test/phoenix_kit_web/admin_route_dedup_test.exs
+++ b/test/phoenix_kit_web/admin_route_dedup_test.exs
@@ -1,0 +1,192 @@
+defmodule PhoenixKitWeb.AdminRouteDedupTest do
+  @moduledoc """
+  Pins the fix for the admin-tab route duplication defect.
+
+  Two places generate `live` route declarations for the admin surface and
+  neither dedupes against the other:
+
+    * `PhoenixKitWeb.Integration.collect_module_tabs/2` calls
+      `Enum.uniq_by(&(&1.path))`, but only across ONE module's own tab list.
+    * `PhoenixKitWeb.Integration.compile_module_admin_routes/0` `flat_map`s
+      that per-module list across ALL discovered modules with no dedup
+      between them, and the host's own `:admin_dashboard_tabs` pages
+      (`compile_custom_admin_routes/1`) are never checked against either.
+
+  A host-declared admin page and a module tab that resolve to the SAME path
+  therefore compile into TWO `live` declarations at an identical path. The
+  router keeps the first and the second becomes dead code — reachable only
+  by luck of declaration order, discovered by accident via the compiler's
+  "this clause cannot match" warning (absent under `--warnings-as-errors`
+  it isn't discovered at all).
+
+  Compiled in a THROWAWAY router (`DedupProbeRouter` below), not
+  `PhoenixKitWeb.Router`: the real dev/test router special-cases itself in
+  `compile_custom_admin_routes/1` and `compile_plugin_admin_routes/1`
+  (`caller_module == PhoenixKitWeb.Router` short-circuits to `[]` — "parent
+  app modules aren't available when it compiles") so it can never exhibit
+  this defect. A router under a different module name goes through the
+  real code paths and lets the resulting `__routes__()` speak for itself.
+
+  Config (`:admin_dashboard_tabs`, `:modules`) is set as PLAIN CODE at the
+  top of this file, before `DedupProbeRouter` is defined — not inside
+  `setup/1`. `phoenix_kit_routes()` expands at COMPILE time, which for a
+  module nested in a test file happens the moment `Kernel.ParallelCompiler`
+  reaches this file, well before any `setup` block would run.
+  """
+  use ExUnit.Case, async: false
+
+  alias PhoenixKit.Dashboard.Tab
+
+  # Two probe LiveViews per side so a real collision (same path) and a
+  # non-collision (different paths) can be checked in the same router.
+  defmodule HostCollisionLive do
+    @moduledoc false
+    use Phoenix.LiveView
+    @impl true
+    def render(assigns), do: ~H"<div>host-collision</div>"
+  end
+
+  defmodule ModuleCollisionLive do
+    @moduledoc false
+    use Phoenix.LiveView
+    @impl true
+    def render(assigns), do: ~H"<div>module-collision</div>"
+  end
+
+  defmodule HostOnlyLive do
+    @moduledoc false
+    use Phoenix.LiveView
+    @impl true
+    def render(assigns), do: ~H"<div>host-only</div>"
+  end
+
+  defmodule ModuleOnlyLive do
+    @moduledoc false
+    use Phoenix.LiveView
+    @impl true
+    def render(assigns), do: ~H"<div>module-only</div>"
+  end
+
+  # Stand-in for an external PhoenixKit module discovered via the
+  # `Application.get_env(:phoenix_kit, :modules, [])` fallback in
+  # `PhoenixKit.ModuleDiscovery.discover_external_modules/0` — no beam
+  # scanning or `@phoenix_kit_module` attribute required.
+  defmodule FakeExternalModule do
+    @moduledoc false
+
+    def admin_tabs do
+      [
+        Tab.new!(
+          id: :dedup_probe_module_collision_tab,
+          label: "Module (collision)",
+          path: "/admin/dedup-collision-probe",
+          live_view: {PhoenixKitWeb.AdminRouteDedupTest.ModuleCollisionLive, :index}
+        ),
+        Tab.new!(
+          id: :dedup_probe_module_only_tab,
+          label: "Module-only",
+          path: "module-only-probe",
+          live_view: {PhoenixKitWeb.AdminRouteDedupTest.ModuleOnlyLive, :index}
+        )
+      ]
+    end
+  end
+
+  # --- compile-time fixture config, restored immediately after the router
+  # below finishes compiling (routes are baked in; nothing after this point
+  # reads these keys at compile time again) ---
+  @previous_admin_dashboard_tabs Application.compile_env(:phoenix_kit, :admin_dashboard_tabs)
+  @previous_modules Application.compile_env(:phoenix_kit, :modules)
+
+  Application.put_env(:phoenix_kit, :admin_dashboard_tabs, [
+    %{
+      id: :dedup_probe_host_collision_tab,
+      label: "Host (collision)",
+      path: "/admin/dedup-collision-probe",
+      live_view: {PhoenixKitWeb.AdminRouteDedupTest.HostCollisionLive, :index}
+    },
+    %{
+      id: :dedup_probe_host_only_tab,
+      label: "Host-only",
+      path: "/admin/host-only-probe",
+      live_view: {PhoenixKitWeb.AdminRouteDedupTest.HostOnlyLive, :index}
+    }
+  ])
+
+  Application.put_env(:phoenix_kit, :modules, [PhoenixKitWeb.AdminRouteDedupTest.FakeExternalModule])
+
+  defmodule DedupProbeRouter do
+    @moduledoc false
+    use PhoenixKitWeb, :router
+
+    import PhoenixKitWeb.Integration
+    import PhoenixKitWeb.Users.Auth
+
+    pipeline :browser do
+      plug :accepts, ["html"]
+      plug :fetch_session
+      plug :fetch_live_flash
+      plug :put_root_layout, html: PhoenixKit.LayoutConfig.get_root_layout()
+      plug :protect_from_forgery
+      plug :put_secure_browser_headers
+      plug :ensure_session_uuid
+      plug :fetch_phoenix_kit_current_user
+    end
+
+    phoenix_kit_routes()
+
+    defp ensure_session_uuid(conn, _opts) do
+      case Plug.Conn.get_session(conn, :phoenix_kit_session_uuid) do
+        nil -> Plug.Conn.put_session(conn, :phoenix_kit_session_uuid, UUIDv7.generate())
+        _ -> conn
+      end
+    end
+  end
+
+  if @previous_admin_dashboard_tabs do
+    Application.put_env(:phoenix_kit, :admin_dashboard_tabs, @previous_admin_dashboard_tabs)
+  else
+    Application.delete_env(:phoenix_kit, :admin_dashboard_tabs)
+  end
+
+  if @previous_modules do
+    Application.put_env(:phoenix_kit, :modules, @previous_modules)
+  else
+    Application.delete_env(:phoenix_kit, :modules)
+  end
+
+  defp routes_ending_in(suffix) do
+    DedupProbeRouter.__routes__()
+    |> Enum.filter(&(&1.verb == :get and String.ends_with?(&1.path, suffix)))
+  end
+
+  # Every admin page compiles to TWO routes by design — one for the plain
+  # `/admin/...` shape, one for the locale-prefixed `/:locale/admin/...`
+  # shape (see `build_live_surface/5`). That doubling is intentional and
+  # orthogonal to this defect: a colliding path must collapse ONE pair
+  # (host source vs. module source) into one surviving declaration PER
+  # shape, i.e. 2 routes total, not 1 — and a non-colliding path must keep
+  # its normal 2, unaffected.
+  test "a host page and a module tab resolving to the same path compile to one declaration per URL shape, not two" do
+    matches = routes_ending_in("/admin/dedup-collision-probe")
+
+    assert length(matches) == 2,
+           "expected 2 routes (one per URL shape) at the colliding path, found " <>
+             "#{length(matches)}: #{inspect(Enum.map(matches, & &1.path))}"
+
+    # The host declares the collision point, so it wins — the application
+    # owner gets precedence over an installed module's opinion about the
+    # same URL.
+    live_views =
+      matches
+      |> Enum.map(fn route -> elem(route.metadata[:phoenix_live_view], 0) end)
+      |> Enum.uniq()
+
+    assert live_views == [PhoenixKitWeb.AdminRouteDedupTest.HostCollisionLive]
+  end
+
+  test "distinct paths are left alone — dedup does not swallow real pages" do
+    assert length(routes_ending_in("/admin/host-only-probe")) == 2
+    assert length(routes_ending_in("/admin/module-only-probe")) == 2
+  end
+end


### PR DESCRIPTION
## What breaks

A host application can declare its own admin page via the `:admin_dashboard_tabs`
config (`compile_custom_admin_routes/1`), and a discovered external module can
declare an admin tab via its `admin_tabs/0` callback
(`compile_module_admin_routes/0`). If the two happen to resolve to the same
URL path, the router ends up with **two `live` declarations at an identical
path**. Phoenix keeps the first and the second becomes dead code — reachable
only by luck of declaration order.

In practice this is discovered by accident, via the compiler's
`this clause cannot match` warning — and on an install that doesn't build with
`--warnings-as-errors`, it isn't discovered at all.

This is not a hypothesis: we hit it ourselves — a module's admin page was
silently unreachable until we moved it to a different path.

## Two defect locations — a fix in only one does not close it

- `collect_module_tabs/2` (`lib/phoenix_kit_web/integration.ex`) already calls
  `Enum.uniq_by(&(&1.path))`, but only across **one module's own** tab list.
- `compile_module_admin_routes/0` `flat_map`s that per-module list across
  **all** discovered modules with no dedup between them, and never checks
  against the host's own `:admin_dashboard_tabs` pages either.

A test that only exercises the first location goes green while the second
defect is still live.

## The fix

`phoenix_kit_admin_routes/1` now dedupes `plugin_admin_routes` (module tabs)
against `custom_admin_routes` (host pages) by resolved path, via a small
`dedupe_admin_routes_by_path/2` helper that operates on the quoted `live`
route forms both sides already produce.

**Who wins:** the host-declared page. It was declared by the application
owner, not a module author, and it was already emitted first in the route
table. Ties between two modules keep whichever is discovered first — but
unlike the ordering *within* one module's own tab list (which is
deterministic, set by whoever wrote that list), the ordering *between*
modules comes from `discover_external_modules/0`, i.e. `:code.get_path()` —
codepath order, which is not a guaranteed-stable ordering. There is no
dedicated test in this PR for the two-module collision case.

## Proof: red → green → red → green

A new test, `test/phoenix_kit_web/admin_route_dedup_test.exs`, compiles a
throwaway router (not `PhoenixKitWeb.Router` — that router special-cases
itself out of both route-generation paths, since parent app modules aren't
available while it compiles, so it can never exhibit this defect) with a host
page and a module tab pointed at the same path, plus a second pair at
distinct paths as a control.

```
before the fix:  assert length(matches) == 2   -> found 4
                 (2 sources × 2 URL shapes: plain + locale-prefixed)
                 compiler also warns twice: "this clause cannot match"
after the fix:   2 tests, 0 failures — warning gone
fix reverted:    found 4 again, warning back
fix restored:    2 tests, 0 failures again
```

The control pair (distinct paths) stays at 2 routes throughout, before and
after the fix — the dedup does not swallow a real page it shouldn't touch. A
separate assertion confirms the surviving route at the colliding path is the
host's LiveView, not the module's.

Full core suite after the fix: `43 doctests, 4068 tests, 0 failures`.

## What this does NOT close, on purpose

- **`user_dashboard_tabs`** goes through a separate code path
  (`phoenix_kit_authenticated_routes`) and is not touched by this fix. Kept
  out of scope deliberately — the underlying mechanism is the same, but
  extending the fix there would go beyond what's proven with a live test
  case in this PR.
- **`external_admin_routes`** (multi-page module routes, e.g. the shop admin
  routes) are also left alone — they aren't single-path tabs, so a
  path-based dedup doesn't apply to them the same way.
- **A module tab colliding with one of PhoenixKit's own core `/admin/...`
  routes** (`/admin/users`, `/admin/jobs`, `/admin/modules`, and the rest of
  the ~50 routes declared literally inside `phoenix_kit_admin_routes/1`,
  `lib/phoenix_kit_web/integration.ex:521-596`) is **not** closed by this fix
  either. The dedup added here only checks module tabs against
  `custom_admin_routes` (host pages) — it never sees the core routes, which
  aren't a list at all, just `live` calls written directly in the macro body.
  Verified by hand: a module tab pointed at `/admin/users` still produces 4
  routes (2 sources × 2 URL shapes) with this fix applied, same as before.
  Not fixed here because closing it needs either a manually maintained list
  of every core admin path (which will drift the next time one is added or
  renamed) or restructuring the macro to build its route table as data
  instead of literal `live` calls — and, more importantly, it needs a
  maintainer call on who should win a module-vs-core collision, and whether
  the right answer is silent dedup at all rather than a loud build-time
  warning. Flagging it here rather than leaving it to be found the same way
  the module-vs-module gap was.

Each of these would need its own dedicated fix and test if it turns out to
matter.
