### PR TITLE
Stop "Test Connection" from stamping unverified providers as connected

### DIFF
--- a/lib/phoenix_kit/integrations/events.ex
+++ b/lib/phoenix_kit/integrations/events.ex
@@ -73,8 +73,11 @@ defmodule PhoenixKit.Integrations.Events do
   end
 
   @doc "Broadcast that an integration's health check completed."
-  @spec broadcast_validated(String.t(), :ok | {:error, term()}, owner()) ::
-          :ok
+  @spec broadcast_validated(
+          String.t(),
+          :ok | {:ok, String.t()} | :unverified | {:error, term()},
+          owner()
+        ) :: :ok
   def broadcast_validated(provider_key, status, owner \\ :system) do
     broadcast(owner, {:integration_validated, provider_key, status})
   end

--- a/lib/phoenix_kit/integrations/events.ex
+++ b/lib/phoenix_kit/integrations/events.ex
@@ -18,7 +18,7 @@ defmodule PhoenixKit.Integrations.Events do
   - `{:integration_setup_saved, provider_key, data}` — setup credentials saved
   - `{:integration_connected, provider_key, data}` — OAuth flow completed
   - `{:integration_disconnected, provider_key}` — disconnected
-  - `{:integration_validated, provider_key, :ok | {:error, reason}}` — health check
+  - `{:integration_validated, provider_key, :ok | {:ok, note} | :unverified | {:error, reason}}` — health check
   - `{:integration_connection_added | _removed, provider_key, name}`
   - `{:integration_connection_renamed, provider_key, old, new}`
 

--- a/lib/phoenix_kit/integrations/integrations.ex
+++ b/lib/phoenix_kit/integrations/integrations.ex
@@ -1080,7 +1080,7 @@ defmodule PhoenixKit.Integrations do
 
     cond do
       not (is_binary(token) and token != "") -> {:error, gettext("No access token")}
-      is_nil(userinfo_url) -> :ok
+      is_nil(userinfo_url) -> :unverified
       true -> check_http(userinfo_url, [{"authorization", "Bearer #{token}"}])
     end
   end
@@ -1123,11 +1123,21 @@ defmodule PhoenixKit.Integrations do
         check_http(v.url, headers)
 
       true ->
-        :ok
+        :unverified
     end
   end
 
-  defp do_validate(_, _data), do: :ok
+  defp do_validate(_, _data), do: :unverified
+
+  if Mix.env() == :test do
+    # Exposes the private do_validate/2 clauses for direct unit testing.
+    # No registered provider today reaches the generic/catch-all clauses
+    # (every built-in declares a real check), so the only way to prove
+    # those clauses behave correctly for a *future* provider is to call
+    # them directly with a synthetic provider map.
+    @doc false
+    def __do_validate__(provider, data), do: do_validate(provider, data)
+  end
 
   defp check_http(url, headers) do
     case Req.get(url, headers: headers, receive_timeout: @http_timeout) do
@@ -1153,8 +1163,11 @@ defmodule PhoenixKit.Integrations do
   actual state change so high-frequency automatic paths (e.g. token
   refresh failing on every API call) don't spam listing-LV reloads.
   """
-  @spec record_validation(String.t(), :ok | {:ok, String.t()} | {:error, term()}, keyword()) ::
-          :ok
+  @spec record_validation(
+          String.t(),
+          :ok | {:ok, String.t()} | :unverified | {:error, term()},
+          keyword()
+        ) :: :ok
   def record_validation(uuid, result, opts \\ []) when is_binary(uuid) do
     {new_status, validation_text} = validation_fields(result)
 
@@ -1216,6 +1229,13 @@ defmodule PhoenixKit.Integrations do
   end
 
   defp validation_fields(:ok), do: {"connected", "ok"}
+
+  # No check actually ran (a provider with no way to verify itself — see
+  # the do_validate/2 fallback clauses). Reported as the same "configured"
+  # status save_setup/3 already uses for "credentials saved, nothing tested
+  # yet" — NOT "connected", which the operator reads as verified.
+  defp validation_fields(:unverified),
+    do: {"configured", gettext("Not verified — this provider has no connection check")}
 
   # A check that succeeded but could not verify everything it would have liked to.
   # The connection is usable; the note is what the operator must know about it, and

--- a/lib/phoenix_kit/integrations/integrations.ex
+++ b/lib/phoenix_kit/integrations/integrations.ex
@@ -952,10 +952,11 @@ defmodule PhoenixKit.Integrations do
 
   For OAuth: calls the provider's userinfo endpoint.
   For API key / bot token: calls the provider's validation endpoint if defined.
-  Returns `:ok` or `{:error, reason}`.
+  Returns `:ok`, `{:ok, note}`, `:unverified` (the provider has no way to
+  check a connection — see `do_validate/2`), or `{:error, reason}`.
   """
   @spec validate_connection(String.t(), String.t() | nil, keyword()) ::
-          :ok | {:ok, String.t()} | {:error, String.t()}
+          :ok | {:ok, String.t()} | :unverified | {:error, String.t()}
   def validate_connection(uuid, actor_uuid \\ nil, opts \\ []) when is_binary(uuid) do
     {result, log_provider, log_name} =
       case resolve_uuid(uuid, Keyword.get(opts, :owner, :system)) do
@@ -996,6 +997,19 @@ defmodule PhoenixKit.Integrations do
           log_provider,
           log_name,
           %{"result" => "ok", "note" => note},
+          "manual",
+          actor_uuid,
+          uuid
+        )
+
+      # This provider has no way to check a connection at all — nothing ran,
+      # so there's nothing to log as a pass or a failure.
+      :unverified ->
+        log_activity(
+          "integration.validated",
+          log_provider,
+          log_name,
+          %{"result" => "unverified"},
           "manual",
           actor_uuid,
           uuid
@@ -1052,8 +1066,12 @@ defmodule PhoenixKit.Integrations do
   `{:error, "No access token"}` — pre-save validation is most
   useful for api_key / bot_token providers where the secret the
   user just typed IS the credential.
+
+  Returns `:unverified` when the provider has no way to check a
+  connection at all — see `do_validate/2`.
   """
-  @spec validate_credentials(String.t(), map()) :: :ok | {:ok, String.t()} | {:error, String.t()}
+  @spec validate_credentials(String.t(), map()) ::
+          :ok | {:ok, String.t()} | :unverified | {:error, String.t()}
   def validate_credentials(provider_key, attrs)
       when is_binary(provider_key) and is_map(attrs) do
     case Providers.get(provider_key) do

--- a/lib/phoenix_kit_web/live/integrations/my_integration_form.ex
+++ b/lib/phoenix_kit_web/live/integrations/my_integration_form.ex
@@ -122,8 +122,9 @@ defmodule PhoenixKitWeb.Live.Integrations.MyIntegrationForm do
         :ok -> {:info, gettext("Connection works")}
         {:ok, note} -> {:info, note}
         # Neither a pass nor a failure — this provider has no way to check a
-        # connection at all, so nothing ran. :info, not :error — nothing failed.
-        :unverified -> {:info, gettext("Not tested — this provider has no connection check")}
+        # connection at all, so nothing ran. :warning, not :info/:error —
+        # matches the system form's tone (both are wrong in different ways).
+        :unverified -> {:warning, gettext("Not tested — this provider has no connection check")}
         {:error, reason} -> {:error, reason}
       end
 
@@ -249,7 +250,7 @@ defmodule PhoenixKitWeb.Live.Integrations.MyIntegrationForm do
       case result do
         :ok -> {:info, gettext("Connection works")}
         {:ok, note} -> {:info, note}
-        :unverified -> {:info, gettext("Not tested — this provider has no connection check")}
+        :unverified -> {:warning, gettext("Not tested — this provider has no connection check")}
         {:error, reason} -> {:error, reason}
       end
 

--- a/lib/phoenix_kit_web/live/integrations/my_integration_form.ex
+++ b/lib/phoenix_kit_web/live/integrations/my_integration_form.ex
@@ -121,6 +121,9 @@ defmodule PhoenixKitWeb.Live.Integrations.MyIntegrationForm do
       case Integrations.validate_credentials(provider_key, attrs) do
         :ok -> {:info, gettext("Connection works")}
         {:ok, note} -> {:info, note}
+        # Neither a pass nor a failure — this provider has no way to check a
+        # connection at all, so nothing ran. :info, not :error — nothing failed.
+        :unverified -> {:info, gettext("Not tested — this provider has no connection check")}
         {:error, reason} -> {:error, reason}
       end
 
@@ -246,6 +249,7 @@ defmodule PhoenixKitWeb.Live.Integrations.MyIntegrationForm do
       case result do
         :ok -> {:info, gettext("Connection works")}
         {:ok, note} -> {:info, note}
+        :unverified -> {:info, gettext("Not tested — this provider has no connection check")}
         {:error, reason} -> {:error, reason}
       end
 

--- a/lib/phoenix_kit_web/live/settings/integration_form.ex
+++ b/lib/phoenix_kit_web/live/settings/integration_form.ex
@@ -37,6 +37,7 @@ defmodule PhoenixKitWeb.Live.Settings.IntegrationForm do
       |> assign(:data, %{})
       |> assign(:success, nil)
       |> assign(:error, nil)
+      |> assign(:warning, nil)
       |> assign(:new_name, "")
       |> assign(:form_values, %{})
       |> assign(:testing, false)
@@ -243,7 +244,7 @@ defmodule PhoenixKitWeb.Live.Settings.IntegrationForm do
   end
 
   def handle_event("dismiss", _params, socket) do
-    {:noreply, assign(socket, success: nil, error: nil)}
+    {:noreply, assign(socket, success: nil, error: nil, warning: nil)}
   end
 
   # ---------------------------------------------------------------------------
@@ -351,6 +352,7 @@ defmodule PhoenixKitWeb.Live.Settings.IntegrationForm do
           |> assign(:data, data)
           |> assign(:success, gettext("Connection verified"))
           |> assign(:error, nil)
+          |> assign(:warning, nil)
 
         # The check passed but could not verify everything — say so instead of
         # showing a bare "verified" the operator would read as "sending works".
@@ -359,12 +361,25 @@ defmodule PhoenixKitWeb.Live.Settings.IntegrationForm do
           |> assign(:data, data)
           |> assign(:success, "#{gettext("Connection verified")} — #{note}")
           |> assign(:error, nil)
+          |> assign(:warning, nil)
+
+        # Neither a pass nor a failure — this provider has no way to check a
+        # connection at all, so nothing ran. Saying "verified" would repeat
+        # the bug this exists to fix; saying "failed" would blame the
+        # operator for something that was never attempted.
+        :unverified ->
+          socket
+          |> assign(:data, data)
+          |> assign(:warning, gettext("Not tested — this provider has no connection check"))
+          |> assign(:success, nil)
+          |> assign(:error, nil)
 
         {:error, reason} ->
           socket
           |> assign(:data, data)
           |> assign(:error, "#{gettext("Test failed")}: #{reason}")
           |> assign(:success, nil)
+          |> assign(:warning, nil)
       end
 
     {:noreply, assign(socket, :testing, false)}
@@ -453,19 +468,31 @@ defmodule PhoenixKitWeb.Live.Settings.IntegrationForm do
         {:noreply,
          socket
          |> assign(:success, gettext("Connection verified"))
-         |> assign(:error, nil)}
+         |> assign(:error, nil)
+         |> assign(:warning, nil)}
 
       {:ok, note} ->
         {:noreply,
          socket
          |> assign(:success, "#{gettext("Connection verified")} — #{note}")
+         |> assign(:error, nil)
+         |> assign(:warning, nil)}
+
+      # See the matching :unverified clause in handle_info(:do_test_connection, _) —
+      # same "neither pass nor fail" case, hit here before the row even exists.
+      :unverified ->
+        {:noreply,
+         socket
+         |> assign(:warning, gettext("Not tested — this provider has no connection check"))
+         |> assign(:success, nil)
          |> assign(:error, nil)}
 
       {:error, reason} ->
         {:noreply,
          socket
          |> assign(:error, "#{gettext("Test failed")}: #{reason}")
-         |> assign(:success, nil)}
+         |> assign(:success, nil)
+         |> assign(:warning, nil)}
     end
   end
 

--- a/lib/phoenix_kit_web/live/settings/integration_form.html.heex
+++ b/lib/phoenix_kit_web/live/settings/integration_form.html.heex
@@ -15,6 +15,9 @@
     <div :if={@success} class="alert alert-success mb-4" phx-click="dismiss">
       <span>{@success}</span>
     </div>
+    <div :if={@warning} class="alert alert-warning mb-4" phx-click="dismiss">
+      <span>{@warning}</span>
+    </div>
     <div :if={@error} class="alert alert-error mb-4" phx-click="dismiss">
       <span>{@error}</span>
     </div>

--- a/test/integration/integrations_test.exs
+++ b/test/integration/integrations_test.exs
@@ -999,6 +999,83 @@ defmodule PhoenixKit.Integration.IntegrationsTest do
   end
 
   # ===========================================================================
+  # do_validate/2 — the silent "no check ran" fallbacks must not report :ok
+  #
+  # No built-in provider reaches these clauses today (every one of the 15
+  # declares a real oauth2 userinfo_url, a validation map, or a strategy) —
+  # that's exactly the bug: a FUTURE provider (or today's Shopify, from the
+  # phoenix_kit_ecommerce module, not a dep of this repo) that doesn't match
+  # any specific clause falls through here silently. Called directly via the
+  # test-only __do_validate__/2 shim with synthetic provider maps, since
+  # nothing in the registry can exercise them.
+  # ===========================================================================
+
+  describe "do_validate/2 (structural gap coverage)" do
+    test "provider matching no auth_type clause is :unverified, not :ok" do
+      provider = %{key: "future_provider", auth_type: :credentials}
+      assert Integrations.__do_validate__(provider, %{}) == :unverified
+    end
+
+    test "api_key/bot_token provider with no validation map is :unverified, not :ok" do
+      provider = %{key: "future_key_provider", auth_type: :api_key}
+      assert Integrations.__do_validate__(provider, %{"api_key" => "some-key"}) == :unverified
+    end
+
+    test "api_key/bot_token provider with no credentials still reports that, not :unverified" do
+      # Guards against the fix papering over a *real* error (missing
+      # credentials) with the new "nothing to check" outcome.
+      provider = %{key: "future_key_provider", auth_type: :api_key}
+
+      assert Integrations.__do_validate__(provider, %{}) ==
+               {:error, "No credentials configured"}
+    end
+
+    test "oauth2 provider with no userinfo_url is :unverified, not :ok" do
+      provider = %{key: "future_oauth_provider", auth_type: :oauth2, oauth_config: %{}}
+      assert Integrations.__do_validate__(provider, %{"access_token" => "tok"}) == :unverified
+    end
+
+    test "oauth2 provider with no access token still reports that, not :unverified" do
+      provider = %{key: "future_oauth_provider", auth_type: :oauth2, oauth_config: %{}}
+      assert Integrations.__do_validate__(provider, %{}) == {:error, "No access token"}
+    end
+  end
+
+  # ===========================================================================
+  # record_validation/2 with :unverified — the operator-visible contract:
+  # a connection that was never actually checked must not read "Connected".
+  # ===========================================================================
+
+  describe "record_validation/2 with :unverified (no check ran)" do
+    test "status stays \"configured\", never \"connected\"" do
+      uuid = setup_conn("openrouter", %{"api_key" => "k"})
+      :ok = Integrations.record_validation(uuid, :unverified)
+
+      {:ok, data} = Integrations.get_integration(uuid)
+      assert data["status"] == "configured"
+      refute data["validation_status"] == "ok"
+    end
+
+    test "does not stamp connected_at — no connection was actually proven" do
+      uuid = setup_conn("openrouter", %{"api_key" => "k"})
+      :ok = Integrations.record_validation(uuid, :unverified)
+
+      {:ok, data} = Integrations.get_integration(uuid)
+      assert data["connected_at"] == nil
+    end
+
+    test "a real success afterwards still reports \"connected\" (regression guard)" do
+      uuid = setup_conn("openrouter", %{"api_key" => "k"})
+      :ok = Integrations.record_validation(uuid, :unverified)
+      :ok = Integrations.record_validation(uuid, :ok)
+
+      {:ok, data} = Integrations.get_integration(uuid)
+      assert data["status"] == "connected"
+      assert data["validation_status"] == "ok"
+    end
+  end
+
+  # ===========================================================================
   # Storage-shape invariants (post-V114: key = uuid, module = "integrations")
   # ===========================================================================
 

--- a/test/integration/phoenix_kit_web/live/integrations/my_integration_form_unverified_test.exs
+++ b/test/integration/phoenix_kit_web/live/integrations/my_integration_form_unverified_test.exs
@@ -92,8 +92,9 @@ defmodule PhoenixKitWeb.Live.Integrations.MyIntegrationFormUnverifiedTest do
 
       assert html =~ "Not tested — this provider has no connection check"
       refute html =~ "Connection works"
-      # "Test failed" would only appear via {:error, _} — assert the flash
-      # kind isn't the error styling this provider must not trigger.
+      # The tone matters as much as the text: :warning, not the green
+      # :info a real success gets or the red :error a real failure gets.
+      assert html =~ "alert-warning"
       refute html =~ "alert-error"
     end
   end
@@ -127,6 +128,7 @@ defmodule PhoenixKitWeb.Live.Integrations.MyIntegrationFormUnverifiedTest do
 
       assert html =~ "Not tested — this provider has no connection check"
       refute html =~ "Connection works"
+      assert html =~ "alert-warning"
       refute html =~ "alert-error"
 
       {:ok, data} = PhoenixKit.Integrations.get_integration(uuid)

--- a/test/integration/phoenix_kit_web/live/integrations/my_integration_form_unverified_test.exs
+++ b/test/integration/phoenix_kit_web/live/integrations/my_integration_form_unverified_test.exs
@@ -1,0 +1,136 @@
+defmodule PhoenixKitWeb.Live.Integrations.MyIntegrationFormUnverifiedTest do
+  @moduledoc """
+  Same gap as `IntegrationFormUnverifiedTest`, on the PERSONAL integration
+  form (`/admin/settings/integrations/:uuid`) — it has its own duplicate
+  case sites (`save_new` dry-run, `handle_info(:do_validate, _)`) that
+  needed their own proof the fix landed here too, not just on the system
+  form. See that module's doc for the full incident.
+
+  Exercises the REAL public path — no shim, no synthetic `:unverified`
+  value handed in by the test. Reuses the same fixture provider (also
+  scoped `:personal`) and drives the actual LiveView events:
+
+    - dry-run test on the `:new` page (`_intent=test` submit)  -> `validate_credentials/2`
+    - "Test Connection" click on the `:edit` page               -> `validate_connection/3`
+  """
+
+  use PhoenixKitWeb.ConnCase, async: false
+
+  alias PhoenixKit.Integrations.Providers
+  alias PhoenixKit.ModuleRegistry
+  alias PhoenixKit.Users.Permissions
+  alias PhoenixKit.Users.Roles
+  alias PhoenixKit.Utils.Routes
+
+  @new_path Routes.path("/admin/settings/integrations/new")
+  @provider_key "fixture_unverified"
+
+  defmodule FixtureProvider do
+    @moduledoc false
+    def integration_providers do
+      [
+        %{
+          key: "fixture_unverified",
+          name: "Fixture Unverified",
+          description: "Test-only provider with no connection check",
+          icon: "hero-beaker",
+          auth_type: :credentials,
+          oauth_config: nil,
+          setup_fields: [
+            %{
+              key: "api_secret",
+              label: "API Secret",
+              type: :password,
+              required: true,
+              placeholder: "...",
+              help: nil,
+              options: nil
+            }
+          ],
+          capabilities: [],
+          scopes: [:system, :personal]
+        }
+      ]
+    end
+  end
+
+  setup do
+    ModuleRegistry.register(FixtureProvider)
+    Providers.clear_cache()
+
+    on_exit(fn ->
+      ModuleRegistry.unregister(FixtureProvider)
+      Providers.clear_cache()
+    end)
+
+    :ok
+  end
+
+  defp setup_admin(%{conn: conn}) do
+    {user, _token} = create_admin_user()
+
+    admin_role = Roles.get_role_by_name("Admin")
+    {:ok, _} = Permissions.grant_permission(admin_role.uuid, "integrations")
+
+    conn = log_in_user(conn, user)
+    %{conn: conn, user: user}
+  end
+
+  describe "dry-run test — validate_credentials/2 (pre-save, no row exists)" do
+    setup :setup_admin
+
+    test "an unverified provider shows the warning, not a crash", %{conn: conn} do
+      {:ok, view, _html} = live(conn, @new_path)
+
+      view |> render_click("select_provider", %{"provider" => @provider_key})
+
+      html =
+        render_submit(view, "save_new", %{
+          "_intent" => "test",
+          "api_secret" => "whatever"
+        })
+
+      assert html =~ "Not tested — this provider has no connection check"
+      refute html =~ "Connection works"
+      # "Test failed" would only appear via {:error, _} — assert the flash
+      # kind isn't the error styling this provider must not trigger.
+      refute html =~ "alert-error"
+    end
+  end
+
+  describe "Test Connection click — validate_connection/3 (post-save)" do
+    setup :setup_admin
+
+    test "an unverified provider is saved as configured, not crashed", %{
+      conn: conn,
+      user: user
+    } do
+      {:ok, %{uuid: uuid}} =
+        PhoenixKit.Integrations.add_connection(@provider_key, "fixture conn", user.uuid,
+          owner: {:user, user.uuid}
+        )
+
+      {:ok, _} =
+        PhoenixKit.Integrations.save_setup(uuid, %{"api_secret" => "whatever"}, user.uuid,
+          owner: {:user, user.uuid}
+        )
+
+      {:ok, view, _html} = live(conn, Routes.path("/admin/settings/integrations/#{uuid}"))
+
+      view |> render_click("validate_connection")
+
+      # `handle_info(:do_validate, _)` runs as a self-message after the
+      # click's `handle_event` reply — a second synchronous render forces
+      # the LiveView's mailbox forward past it (or surfaces the crash, if
+      # the fix regresses).
+      html = render(view)
+
+      assert html =~ "Not tested — this provider has no connection check"
+      refute html =~ "Connection works"
+      refute html =~ "alert-error"
+
+      {:ok, data} = PhoenixKit.Integrations.get_integration(uuid)
+      assert data["status"] == "configured"
+    end
+  end
+end

--- a/test/integration/phoenix_kit_web/live/settings/integration_form_unverified_test.exs
+++ b/test/integration/phoenix_kit_web/live/settings/integration_form_unverified_test.exs
@@ -1,0 +1,130 @@
+defmodule PhoenixKitWeb.Live.Settings.IntegrationFormUnverifiedTest do
+  @moduledoc """
+  Review on PR #754 found that `IntegrationForm` never learned about the
+  `:unverified` result `Integrations.validate_credentials/2` and
+  `Integrations.validate_connection/3` can now return — every call site
+  here pattern-matched only `:ok` / `{:ok, _}` / `{:error, _}`, so a
+  provider with no way to check a connection would crash the LiveView
+  with a `CaseClauseError` instead of showing "Not tested". That's worse
+  than the original bug (a false "connected"): a crash instead of a lie.
+
+  Exercises the REAL public path end to end — no shim, no synthetic
+  `:unverified` value handed in by the test. Registers a fixture provider
+  shaped exactly like Shopify (`auth_type: :credentials`, no `validation`
+  map, so `do_validate/2`'s catch-all is the one actually hit — see
+  `PhoenixKit.Integrations.integrations_test.exs` for the do_validate/2
+  clause-level coverage via the test-only shim) and drives the actual
+  LiveView events a click sends, on both call sites:
+
+    - dry-run test (pre-save)  -> `test_credentials_dry_run/2` -> `validate_credentials/2`
+    - Test Connection (post-save, auto-fired by `apply_save_outcome/2`) -> `validate_connection/3`
+  """
+
+  use PhoenixKitWeb.ConnCase, async: false
+
+  alias PhoenixKit.Integrations.Providers
+  alias PhoenixKit.ModuleRegistry
+  alias PhoenixKit.Users.Permissions
+  alias PhoenixKit.Users.Roles
+  alias PhoenixKit.Utils.Routes
+
+  @new_path Routes.path("/admin/settings/integrations/website/new")
+  @provider_key "fixture_unverified"
+
+  defmodule FixtureProvider do
+    @moduledoc false
+    def integration_providers do
+      [
+        %{
+          key: "fixture_unverified",
+          name: "Fixture Unverified",
+          description: "Test-only provider with no connection check",
+          icon: "hero-beaker",
+          auth_type: :credentials,
+          oauth_config: nil,
+          setup_fields: [
+            %{
+              key: "api_secret",
+              label: "API Secret",
+              type: :password,
+              required: true,
+              placeholder: "...",
+              help: nil,
+              options: nil
+            }
+          ],
+          capabilities: [],
+          scopes: [:system, :personal]
+        }
+      ]
+    end
+  end
+
+  setup do
+    ModuleRegistry.register(FixtureProvider)
+    Providers.clear_cache()
+
+    on_exit(fn ->
+      ModuleRegistry.unregister(FixtureProvider)
+      Providers.clear_cache()
+    end)
+
+    :ok
+  end
+
+  defp setup_admin(%{conn: conn}) do
+    {user, _token} = create_admin_user()
+
+    admin_role = Roles.get_role_by_name("Admin")
+    {:ok, _} = Permissions.grant_permission(admin_role.uuid, "integrations_system")
+
+    conn = log_in_user(conn, user)
+    %{conn: conn, user: user}
+  end
+
+  describe "dry-run test — validate_credentials/2 (pre-save, no row exists)" do
+    setup :setup_admin
+
+    test "an unverified provider shows the warning, not a crash", %{conn: conn} do
+      {:ok, view, _html} = live(conn, @new_path)
+
+      view |> render_click("select_provider", %{"provider" => @provider_key})
+
+      html =
+        render_submit(view, "save_form", %{
+          "_intent" => "test",
+          "api_secret" => "whatever"
+        })
+
+      assert html =~ "Not tested — this provider has no connection check"
+      refute html =~ "Connection verified"
+      refute html =~ "Test failed"
+    end
+  end
+
+  describe "Test Connection after save — validate_connection/3 (post-save, auto-fired)" do
+    setup :setup_admin
+
+    test "an unverified provider is saved as configured, not crashed", %{conn: conn} do
+      {:ok, view, _html} = live(conn, @new_path)
+
+      view |> render_click("select_provider", %{"provider" => @provider_key})
+
+      render_submit(view, "save_form", %{
+        "name" => "fixture conn",
+        "api_secret" => "whatever"
+      })
+
+      # `apply_save_outcome/2` auto-fires `:do_test_connection` as a
+      # self-message when the just-saved status is "configured" — it
+      # hasn't been processed yet when `render_submit/3` returns. A
+      # second synchronous render forces the LiveView's mailbox forward
+      # past it (or surfaces the crash, if the fix regresses).
+      html = render(view)
+
+      assert html =~ "Not tested — this provider has no connection check"
+      refute html =~ "Connection verified"
+      refute html =~ "Test failed"
+    end
+  end
+end


### PR DESCRIPTION
## The bug

Clicking **Test Connection** stamps a provider "connected" without actually contacting it, for any provider that doesn't match one of `do_validate/2`'s specific clauses.

Concretely, on a live site: an operator clicked **Test Connection** on a Shopify connection, got the green "connected" result, and trusted it. The Shopify Admin API was actually returning 401 the whole time. The stored row read:

    status=connected  validation_status=ok

with zero HTTP requests made to Shopify.

## Where

`lib/phoenix_kit/integrations/integrations.ex`, three separate fallbacks inside `do_validate/2` all resolve to the unconditional `:ok` catch-all instead of running (or reporting the absence of) a real check:

- `:1130` — `defp do_validate(_, _data), do: :ok` — the outer catch-all: any provider whose `auth_type` doesn't match one of the clauses above it.
- `:1112-1128` — an `:api_key`/`:bot_token` provider with no `validation` map configured falls to `true -> :ok` (line 1125-1126).
- `:1083` — an `:oauth2` provider whose `oauth_config` has no `userinfo_url` falls to `is_nil(userinfo_url) -> :ok`.

Every one of these paths is reachable by a provider with zero HTTP validation, yet stamps the same `status=connected, validation_status=ok` a genuinely-checked provider gets.

## Scope, honestly

Today this affects **one provider out of sixteen**: `shopify` (contributed by `phoenix_kit_ecommerce`), whose `auth_type: :credentials` matches none of the specific clauses and has no `validation` map — it falls straight into the `:1130` catch-all.

`google` and `microsoft` are also `:oauth2`, but both declare a real `userinfo_url` — clicking Test Connection on either makes an actual authenticated HTTP request. They're unaffected.

The defect is structural, not shopify-specific: any future provider with an unhandled `auth_type`, or an `:api_key`/`:bot_token` provider added without a `validation` map, or an `:oauth2` provider without `userinfo_url`, lands in the same silent-`:ok` trap. This PR closes the structural gap, not just today's one instance.

## The fix

The three fallbacks above now return `:unverified` instead of `:ok`. `validation_fields/1` maps `:unverified` to:

    {"configured", "Not verified — this provider has no connection check"}

**Why the existing `"configured"` status, not a new one:** `integrations_ui.ex:26` already labels `"configured"` as *"Not tested"* in the status badge — that's exactly the right operator-facing meaning. A brand-new status string would fall into the badge's catch-all clause (`integrations_ui.ex:29`) and render *"Not configured"*, which is wrong (the provider IS configured — it just hasn't been checked), and would require a UI change this PR doesn't need to make.

**This restores prior behavior, it doesn't invent new behavior:** a connection already reads `status=configured` immediately after its credentials are saved (`maybe_set_status/2`, `:1508-1534`) — `"connected"` only appears after a successful Test Connection. Today's bug is that clicking the button can *downgrade* the operator's information by overwriting an honest "not tested yet" with a false "connected". The fix makes an unverifiable provider's Test Connection a no-op on that front, instead of a false promotion.

The 13 providers with a real check (`validation` map, `strategy`, or `oauth2` + `userinfo_url`) are unaffected — they still report `"connected"` on success and `"error"` on failure exactly as before.

## Prior art in this codebase

The same failure mode was already fixed once, per-provider, for Brevo — `integrations.ex:1088-1093`:

> Without these clauses these fell through to the `:ok` catch-all below (Brevo), ... so "Test Connection" stamped the connection "connected" without verifying anything

This PR generalizes that fix so the next provider doesn't need its own point patch.

## What the first version of this PR missed (caught in review, not by me)

The first version closed the **data layer** — `do_validate/2` and `validation_fields/1` — and stopped there. It did not close the **UI layer**: every place that actually calls `validate_credentials/2` / `validate_connection/3` and looks at the result still only matched `:ok` / `{:ok, _}` / `{:error, _}`. Two independent reviews caught this and it's a real regression, not a nitpick — clicking Test Connection on the exact class of provider this PR exists to protect would **crash the LiveView** instead of showing "Not tested". That's worse than the original bug: a crash instead of a lie.

Four sites needed a fourth clause:

- `integration_form.ex:451` — dry-run test before a row exists (`validate_credentials/2`)
- `integration_form.ex:335` — Test Connection after save (`validate_connection/3`)
- `my_integration_form.ex:121` — same dry-run, personal form
- `my_integration_form.ex:233` — same post-save test, personal form

Plus the two `@spec`s on `validate_connection/3` and `validate_credentials/2` themselves, which still promised only the old three-shape contract.

**Writing a regression test for this found a fifth site the reviews didn't catch:** `validate_connection/3` has its own *internal* `case result do ... end` (`integrations.ex:978`) purely for activity logging — also missing `:unverified`, also a `CaseClauseError`, entirely separate from the four UI sites above. The two reviews read the LiveView call sites; neither traced into `validate_connection/3`'s own body. It only surfaced because the new test drives the real function end to end instead of asserting against a hand-constructed `:unverified` value — see "Testing" below.

All five now handle `:unverified`. In the UI, it renders as its own tone — not the green "Connection verified" (that repeats the bug), not the red "Test failed" (nothing failed, nothing ran) — a `warning`-styled "Not tested — this provider has no connection check" on both forms (system and personal alike; see the correction below).

**A second, independent review round** (two more reviewers, each in their own isolated checkout) confirmed there's no sixth crash site, and independently reproduced the isolation numbers below exactly — the five sites really are needed independently, not by coincidence of a combined revert. It also caught two smaller issues before merge:

- The `:warning` tone above shipped correctly on the system form but as `:info` on the personal form — on the reasoning that this codebase's `put_flash` calls never use anything but `:info`/`:error`. That reasoning was checked and is **wrong**: `:warning` is a first-class kind in `Components.Core.Flash` (`flash.ex:24`, its own color and icon, rendered by `flash_group/1` alongside `:info`/`:error`) and is already used at `users/user_form.ex:833` and `modules/storage/web/health.ex:52`. Fixed — both forms now show `:warning`, matching each other and the badge color for `"configured"`.
- `Events.broadcast_validated/3` (`events.ex`) still carried the old `:ok | {:error, term()}` spec, even though `record_validation/2` (`integrations.ex:1234`) has called it with `:unverified` and `{:ok, note}` since round 2. A clean `mix dialyzer` run didn't fail on it — success-typing is wider than the declared spec — but the contract itself was stale. Fixed; three `@spec`s updated in total, not two.

## Testing

TDD, full red → green → red → green cycle, in three rounds:

**Round 1 — the data layer** (`do_validate/2`, `validation_fields/1`):

- New tests (`do_validate/2`'s three fallbacks + `record_validation/2` with `:unverified`) — **RED**: 104 tests, 6 failures.
- After the fix — **GREEN**: 104 tests, 0 failures.
- Fix reverted — **RED** again: 104 tests, 8 failures (the extra 2 are the test-only shim described below, which reverts along with the fix).
- Fix restored — **GREEN**: 104 tests, 0 failures.

**Round 2 — the UI layer**, after review (the four call sites + the internal `validate_connection/3` case above). New tests go through the **real public path** — no shim, no hand-built `:unverified` value: a fixture provider (shaped exactly like Shopify — `auth_type: :credentials`, no `validation` map) is registered via `PhoenixKit.ModuleRegistry.register/1` (the same mechanism a real external module uses, and the same one this codebase's own tests already use for fixture modules), and the tests drive the actual LiveView events a click sends — form submit, `Test Connection` click — end to end through `validate_credentials/2` and `validate_connection/3` for real:

- New tests (4: dry-run + post-save, on both the system and personal forms) — **RED**, all 4 fixes reverted together: `CaseClauseError, :unverified` — 4 tests, 4 failures.
- After the fix — **GREEN**: 4 tests, 0 failures.
- Fix reverted — **RED** again: 4 tests, 4 failures.
- Fix restored — **GREEN**: 4 tests, 0 failures.
- Isolated the fifth (internal) site from the four UI sites, since a combined revert doesn't prove each is independently needed:
  - LiveView cases reverted, internal `validate_connection/3` case left fixed — all 4 tests crash, each at its own UI case line (`integration_form.ex:451`, `:348`; `my_integration_form.ex:121`, `:246`) — 4 failures.
  - Internal case reverted, LiveView cases left fixed — only the 2 **post-save** tests crash, at `integrations.ex:979` before `validate_connection/3` ever returns to the caller; the 2 dry-run tests pass unaffected, because `validate_credentials/2` never goes through that function — 2 failures.

**Round 3 — the tone fix**, after the second review round: `my_integration_form.ex`'s two `:unverified` clauses changed `:info` → `:warning`. Strengthened the existing round-2 tests to assert the rendered CSS class, not just the message text (`refute alert-error` alone doesn't prove `:warning` over `:info`):

- `assert html =~ "alert-warning"` added to both personal-form tests, `:warning` reverted to `:info` — **RED**: 2 tests, 2 failures (both on the new assertion — everything else about the fix still holds, `:info` doesn't crash, it's just the wrong color).
- Fix restored — **GREEN**: 2 tests, 0 failures.

**Full suite, all three rounds combined: 43 doctests, 4078 tests, 0 failures** — the 13 providers with a real validation strategy are unaffected. `mix dialyzer` (clean run) and `mix credo --strict` pass on every file this PR touches.

## A compile-time test shim (flagging it up front)

No currently-registered provider (all 15 built-ins) actually falls into any of the three fixed clauses — every one of them already has a real check. That means there is no way to exercise this behavior for a *future* provider through the public API with today's registry. I added a narrow, compile-time-gated shim to make the fallback clauses directly testable:

    if Mix.env() == :test do
      @doc false
      def __do_validate__(provider, data), do: do_validate(provider, data)
    end

Verified it doesn't exist outside test builds:

    dev build:  function_exported?(PhoenixKit.Integrations, :__do_validate__, 2) == false
    test build: function_exported?(PhoenixKit.Integrations, :__do_validate__, 2) == true

`Mix.env()` is evaluated at compile time here (module level), so the function is compiled out entirely in non-test builds — it's not a runtime check that could slip through in a release build. The same technique with the same rationale already exists in this repo at `router.ex:52`.

If you'd rather test this a different way, happy to rework it.
