### PR TITLE
Add doctor check for belongs_to relations with no database FK

### DIFF
--- a/lib/mix/tasks/phoenix_kit.doctor.ex
+++ b/lib/mix/tasks/phoenix_kit.doctor.ex
@@ -1390,12 +1390,15 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
   # Check 12 above only ever examines a relationship that already HAS a
   # declared FK constraint — its own moduledoc entry names this boundary
   # ("a relationship with no FK constraint declared at all is outside this
-  # check's scope"), and `fk_validation_state/5`'s own comment names the
-  # missing piece: "given a source of expected (table, fk_col, ref_table)
-  # candidates. No such source exists yet". `belongs_to` IS that source —
-  # every one PhoenixKit's own Ecto schemas declare names its (table,
-  # owner_key, ref_table) unambiguously via `owner_key`/`related_key`,
-  # without guessing from a column name.
+  # check's scope"). `belongs_to` is a source of exactly the (table,
+  # owner_key, ref_table) triple a check like that would need — every one
+  # PhoenixKit's own Ecto schemas declare names its target unambiguously
+  # via `owner_key`/`related`, without guessing from a column name. This
+  # check resolves that triple itself and cross-references it against
+  # `pg_constraint` directly (a bulk, two-query scan — see
+  # `discover_schema_declared_relations_without_fk/2` — not a per-candidate
+  # call to `fk_validation_state/5`, which answers a related but different
+  # question, a constraint's VALIDATE state, that this check does not use).
   #
   # It found two real gaps on a live install: phoenix_kit_activities's
   # actor_uuid and target_uuid, both declared in PhoenixKit.Activity.Entry
@@ -1415,76 +1418,118 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
   def check_schema_declared_relations_without_fk(prefix) do
     repo = get_repo!()
 
-    missing = discover_schema_declared_relations_without_fk(repo, prefix)
+    case discover_schema_declared_relations_without_fk(repo, prefix) do
+      {:error, reason} ->
+        {:warn,
+         "could not enumerate belongs_to relations or foreign keys in schema " <>
+           "#{inspect(prefix)} (#{inspect(reason)}) — coverage is zero, which is not the " <>
+           "same as clean. Fix catalog access (pg_constraint/information_schema) and re-run."}
 
-    case missing do
-      [] ->
-        {:pass, "Every belongs_to PhoenixKit's schemas declare has a matching DB foreign key"}
+      {:ok, {0, _missing}} ->
+        {:warn,
+         "no belongs_to-declared relation found to check in schema #{inspect(prefix)} — " <>
+           "coverage is zero: either PhoenixKit's own schemas' tables aren't installed here " <>
+           "yet, or --prefix names the wrong schema. This is not the same as clean."}
 
-      list ->
+      {:ok, {total, []}} ->
+        {:pass,
+         "Every belongs_to PhoenixKit's schemas declare has a matching DB foreign key " <>
+           "(checked #{total} of #{total})"}
+
+      {:ok, {total, missing}} ->
         detail =
-          Enum.map_join(list, "\n       ", fn {table, column} -> "#{table}.#{column}" end)
+          Enum.map_join(missing, "\n       ", fn {table, column} -> "#{table}.#{column}" end)
 
         {:warn,
-         "#{length(list)} relation(s) declared via `belongs_to` in PhoenixKit's own Ecto " <>
-           "schemas have no matching database foreign key:\n       #{detail}\n       This is " <>
-           "advisory, not a failure — some are intentional (a federated/soft reference cannot " <>
-           "carry a FK across an optional module boundary, see V179/V180). Derived from " <>
-           "declared `belongs_to` associations only, cross-referenced against pg_constraint — " <>
-           "not exhaustive: a soft reference held as a plain field (no `belongs_to` at all, " <>
-           "e.g. a polymorphic pair) is invisible to this scan too."}
+         "#{length(missing)} of #{total} relation(s) declared via `belongs_to` in " <>
+           "PhoenixKit's own Ecto schemas have no matching database foreign key:\n       " <>
+           "#{detail}\n       This is advisory, not a failure — some are intentional (a " <>
+           "federated/soft reference cannot carry a FK across an optional module boundary, " <>
+           "see V179/V180). Derived from declared `belongs_to` associations only, cross-" <>
+           "referenced against pg_constraint — not exhaustive: a soft reference held as a " <>
+           "plain field (no `belongs_to` at all, e.g. a polymorphic pair) is invisible to " <>
+           "this scan too."}
     end
   end
 
-  # Returns [{table, column}] for every `belongs_to` owner_key that exists as
-  # a real column in this schema but has no `pg_constraint` FK on it.
-  # Existence is checked against `information_schema.columns`, not just
-  # `pg_constraint` membership, so a schema module for a not-yet-installed
-  # module (table absent entirely) is correctly excluded rather than
-  # miscounted as "declared, no FK".
+  # Returns `{:ok, {total_candidates, missing}}`, `missing` a `[{table,
+  # column}]` for every `belongs_to` owner_key that exists as a real column
+  # in this schema but has no `pg_constraint` FK matching its declared
+  # target table — or `{:error, reason}` if either catalog query itself
+  # fails. `total_candidates` is every belongs_to owner_key that DOES exist
+  # as a real column here (checked against `information_schema.columns`,
+  # not just `pg_constraint` membership, so a schema module for a
+  # not-yet-installed module — table absent entirely — is correctly
+  # excluded rather than miscounted as "declared, no FK"), surfaced so a
+  # caller can tell "checked N, all clean" apart from "checked nothing" —
+  # an empty `existing_columns` (wrong --prefix, nothing installed yet)
+  # would otherwise filter every candidate out and report the same `[]`
+  # `missing` as a genuinely clean install, printing PASS for a schema
+  # this check never actually looked at.
+  #
+  # The FK side is matched on the full (table, column, ref_table) triple,
+  # not just (table, column): a column carrying a single-column FK to the
+  # WRONG table (or a table caught up in a multi-column constraint via
+  # `array_length(c.conkey, 1) = 1` below) must still show up as missing
+  # its DECLARED relation, not be waved through because some other FK
+  # happens to touch the same column.
   @doc false
   def discover_schema_declared_relations_without_fk(repo, prefix) do
     escaped_prefix = String.replace(prefix, "'", "\\'")
 
-    {:ok, %{rows: fk_rows}} =
-      repo.query(
-        """
-        SELECT t.relname, a.attname
-        FROM pg_constraint c
-        JOIN pg_class t ON t.oid = c.conrelid
-        JOIN pg_namespace n ON n.oid = t.relnamespace
-        JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = ANY(c.conkey)
-        WHERE c.contype = 'f' AND n.nspname = '#{escaped_prefix}'
-        """,
-        [],
-        log: false
-      )
+    with {:ok, %{rows: fk_rows}} <-
+           repo.query(
+             """
+             SELECT t.relname, a.attname, ft.relname
+             FROM pg_constraint c
+             JOIN pg_class t ON t.oid = c.conrelid
+             JOIN pg_namespace n ON n.oid = t.relnamespace
+             JOIN pg_class ft ON ft.oid = c.confrelid
+             JOIN pg_namespace fn ON fn.oid = ft.relnamespace
+             JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = c.conkey[1]
+             WHERE c.contype = 'f'
+               AND n.nspname = '#{escaped_prefix}'
+               AND fn.nspname = '#{escaped_prefix}'
+               AND array_length(c.conkey, 1) = 1
+             """,
+             [],
+             log: false
+           ),
+         {:ok, %{rows: col_rows}} <-
+           repo.query(
+             "SELECT table_name, column_name FROM information_schema.columns WHERE table_schema = '#{escaped_prefix}'",
+             [],
+             log: false
+           ) do
+      declared_fk_relations =
+        MapSet.new(fk_rows, fn [table, col, ref_table] -> {table, col, ref_table} end)
 
-    declared_fk_columns = MapSet.new(fk_rows, fn [table, col] -> {table, col} end)
+      existing_columns = MapSet.new(col_rows, fn [table, col] -> {table, col} end)
 
-    {:ok, %{rows: col_rows}} =
-      repo.query(
-        "SELECT table_name, column_name FROM information_schema.columns WHERE table_schema = '#{escaped_prefix}'",
-        [],
-        log: false
-      )
+      {:ok, modules} = :application.get_key(:phoenix_kit, :modules)
 
-    existing_columns = MapSet.new(col_rows, fn [table, col] -> {table, col} end)
+      candidates =
+        modules
+        # `function_exported?/3` checks only what's already loaded in THIS
+        # process — for a schema module nothing has called yet, it reads
+        # false even though `Code.ensure_loaded?/1` would trigger the load
+        # and it would work fine one line later. Without the ensure_loaded?
+        # first, this filtered out nearly every schema.
+        |> Enum.filter(&(Code.ensure_loaded?(&1) and function_exported?(&1, :__schema__, 1)))
+        |> Enum.flat_map(&belongs_to_owner_columns/1)
+        |> Enum.uniq()
+        |> Enum.filter(fn {table, col, _ref_table} ->
+          MapSet.member?(existing_columns, {table, col})
+        end)
+        |> Enum.sort()
 
-    {:ok, modules} = :application.get_key(:phoenix_kit, :modules)
+      missing =
+        candidates
+        |> Enum.reject(&MapSet.member?(declared_fk_relations, &1))
+        |> Enum.map(fn {table, col, _ref_table} -> {table, col} end)
 
-    modules
-    # `function_exported?/3` checks only what's already loaded in THIS
-    # process — for a schema module nothing has called yet, it reads
-    # false even though `Code.ensure_loaded?/1` would trigger the load
-    # and it would work fine one line later. Without the ensure_loaded?
-    # first, this filtered out nearly every schema.
-    |> Enum.filter(&(Code.ensure_loaded?(&1) and function_exported?(&1, :__schema__, 1)))
-    |> Enum.flat_map(&belongs_to_owner_columns/1)
-    |> Enum.uniq()
-    |> Enum.filter(&MapSet.member?(existing_columns, &1))
-    |> Enum.reject(&MapSet.member?(declared_fk_columns, &1))
-    |> Enum.sort()
+      {:ok, {length(candidates), missing}}
+    end
   end
 
   defp belongs_to_owner_columns(schema) do
@@ -1493,7 +1538,9 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
     schema.__schema__(:associations)
     |> Enum.map(&schema.__schema__(:association, &1))
     |> Enum.filter(&match?(%Ecto.Association.BelongsTo{}, &1))
-    |> Enum.map(fn assoc -> {table, Atom.to_string(assoc.owner_key)} end)
+    |> Enum.map(fn assoc ->
+      {table, Atom.to_string(assoc.owner_key), assoc.related.__schema__(:source)}
+    end)
   end
 
   defp check_lock_conflicts do

--- a/lib/mix/tasks/phoenix_kit.doctor.ex
+++ b/lib/mix/tasks/phoenix_kit.doctor.ex
@@ -51,25 +51,38 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
        referenced table to the schema being checked (`--prefix`), so a FK
        whose referenced table lives in a different schema is outside scope
        too, even though the owning table itself was checked
-   13. **Lock Conflicts** — Any blocked or long-running queries?
-   14. **Orphaned Connections** — Idle-in-transaction or stuck connections
-   15. **Oban Configuration** — Queues and plugins that consume pool connections
-   16. **Oban Cron Queues** — Does every crontab worker have its queue configured?
-   17. **PhoenixKit Supervisor** — What's running (update_mode vs full)?
-   18. **Child Start Order** — Does the Repo start before PhoenixKit/Oban in application.ex?
-   19. **Update Mode** — Is update_mode active?
-   20. **daisyUI Version** — Is the host's vendored daisyUI recent enough?
-   21. **User Dashboard (deprecated)** — Is the host still on the retired dashboard?
-   22. **Sitemap Discoverability** — Is the sitemap actually reachable?
-   23. **Crawler Visibility** — noindex on a production-looking host, or a
+   13. **Schema-Declared Relations Without a DB FK** — Every `belongs_to`
+       PhoenixKit's own Ecto schemas declare, cross-referenced against
+       `pg_constraint` for a matching foreign key. Reports the COUNT found
+       with no DB-level FK — informational, not a failure: some are
+       intentional (a federated/soft reference cannot carry a FK across an
+       optional module boundary, see V179/V180). This is the complement to
+       check 12's own stated gap above: check 12 only ever sees a
+       relationship that already HAS a declared FK constraint; this one
+       finds relationships Ecto declares that never got one. Derived
+       entirely from what the schema itself declares (`owner_key` on the
+       `belongs_to`), never guessed from a column name — so it also cannot
+       see a soft reference that isn't declared as a `belongs_to` at all
+       (e.g. a plain field, or a polymorphic `*_uuid`/`*_type` pair).
+   14. **Lock Conflicts** — Any blocked or long-running queries?
+   15. **Orphaned Connections** — Idle-in-transaction or stuck connections
+   16. **Oban Configuration** — Queues and plugins that consume pool connections
+   17. **Oban Cron Queues** — Does every crontab worker have its queue configured?
+   18. **PhoenixKit Supervisor** — What's running (update_mode vs full)?
+   19. **Child Start Order** — Does the Repo start before PhoenixKit/Oban in application.ex?
+   20. **Update Mode** — Is update_mode active?
+   21. **daisyUI Version** — Is the host's vendored daisyUI recent enough?
+   22. **User Dashboard (deprecated)** — Is the host still on the retired dashboard?
+   23. **Sitemap Discoverability** — Is the sitemap actually reachable?
+   24. **Crawler Visibility** — noindex on a production-looking host, or a
        staging-looking host left indexable
-   24. **Demo Auth Pages** — Are the demo auth routes still exposed?
-   25. **Manifest Repair (dry-run)** — `PhoenixKit.Migrations.Repair.verify/1`
+   25. **Demo Auth Pages** — Are the demo auth routes still exposed?
+   26. **Manifest Repair (dry-run)** — `PhoenixKit.Migrations.Repair.verify/1`
        runs read-only against the generated
        `PhoenixKit.Migrations.ExpectedSchema` manifest as an additional,
        non-fatal check (never `:fail`). Passes and says so if the manifest
        has been removed or overridden away in this checkout.
-   26. **Git Hooks** — is `.githooks/pre-commit` enabled via
+   27. **Git Hooks** — is `.githooks/pre-commit` enabled via
        `core.hooksPath`? Only runs inside a checkout of phoenix_kit itself
        (`.githooks/pre-commit` is a phoenix_kit-repo convention, not
        something installed into a consuming host app) — silently skipped
@@ -139,6 +152,9 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
         run_check("UUID Primary Keys", fn -> check_uuid_primary_keys(prefix) end),
         run_check("NULL UUIDs in FK Sources", fn -> check_null_uuids(prefix) end),
         run_check("Orphaned FK References", fn -> check_orphaned_fk_refs(prefix) end),
+        run_check("Schema-Declared Relations Without a DB FK", fn ->
+          check_schema_declared_relations_without_fk(prefix)
+        end),
         run_check("Lock Conflicts", fn -> check_lock_conflicts() end),
         run_check("Orphaned Connections", fn -> check_orphaned_connections() end),
         run_check("Oban Configuration", fn -> check_oban_config(oban_config) end),
@@ -1369,6 +1385,115 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
       {:error, reason} -> {:probe_failed, reason}
       other -> {:probe_failed, other}
     end
+  end
+
+  # Check 12 above only ever examines a relationship that already HAS a
+  # declared FK constraint — its own moduledoc entry names this boundary
+  # ("a relationship with no FK constraint declared at all is outside this
+  # check's scope"), and `fk_validation_state/5`'s own comment names the
+  # missing piece: "given a source of expected (table, fk_col, ref_table)
+  # candidates. No such source exists yet". `belongs_to` IS that source —
+  # every one PhoenixKit's own Ecto schemas declare names its (table,
+  # owner_key, ref_table) unambiguously via `owner_key`/`related_key`,
+  # without guessing from a column name.
+  #
+  # It found two real gaps on a live install: phoenix_kit_activities's
+  # actor_uuid and target_uuid, both declared in PhoenixKit.Activity.Entry
+  # with no matching foreign key in the database. Reported as advisory
+  # (warn, not fail) — this can be intentional, a federated reference
+  # (V179/V180) cannot carry a FK across an optional module boundary.
+  #
+  # A polymorphic pair (a *_uuid column with a sibling *_type
+  # discriminator) structurally cannot appear in this check's findings:
+  # Ecto has no way to declare belongs_to against a type that varies per
+  # row, so there is nothing to filter for, unlike a name-based scan.
+  #
+  # Exposed (not `defp`) and `@doc false`, same reason as the other pure
+  # decision functions in this module: a real end-to-end seam against a
+  # live repo, directly testable without going through `run/1`.
+  @doc false
+  def check_schema_declared_relations_without_fk(prefix) do
+    repo = get_repo!()
+
+    missing = discover_schema_declared_relations_without_fk(repo, prefix)
+
+    case missing do
+      [] ->
+        {:pass, "Every belongs_to PhoenixKit's schemas declare has a matching DB foreign key"}
+
+      list ->
+        detail =
+          Enum.map_join(list, "\n       ", fn {table, column} -> "#{table}.#{column}" end)
+
+        {:warn,
+         "#{length(list)} relation(s) declared via `belongs_to` in PhoenixKit's own Ecto " <>
+           "schemas have no matching database foreign key:\n       #{detail}\n       This is " <>
+           "advisory, not a failure — some are intentional (a federated/soft reference cannot " <>
+           "carry a FK across an optional module boundary, see V179/V180). Derived from " <>
+           "declared `belongs_to` associations only, cross-referenced against pg_constraint — " <>
+           "not exhaustive: a soft reference held as a plain field (no `belongs_to` at all, " <>
+           "e.g. a polymorphic pair) is invisible to this scan too."}
+    end
+  end
+
+  # Returns [{table, column}] for every `belongs_to` owner_key that exists as
+  # a real column in this schema but has no `pg_constraint` FK on it.
+  # Existence is checked against `information_schema.columns`, not just
+  # `pg_constraint` membership, so a schema module for a not-yet-installed
+  # module (table absent entirely) is correctly excluded rather than
+  # miscounted as "declared, no FK".
+  @doc false
+  def discover_schema_declared_relations_without_fk(repo, prefix) do
+    escaped_prefix = String.replace(prefix, "'", "\\'")
+
+    {:ok, %{rows: fk_rows}} =
+      repo.query(
+        """
+        SELECT t.relname, a.attname
+        FROM pg_constraint c
+        JOIN pg_class t ON t.oid = c.conrelid
+        JOIN pg_namespace n ON n.oid = t.relnamespace
+        JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = ANY(c.conkey)
+        WHERE c.contype = 'f' AND n.nspname = '#{escaped_prefix}'
+        """,
+        [],
+        log: false
+      )
+
+    declared_fk_columns = MapSet.new(fk_rows, fn [table, col] -> {table, col} end)
+
+    {:ok, %{rows: col_rows}} =
+      repo.query(
+        "SELECT table_name, column_name FROM information_schema.columns WHERE table_schema = '#{escaped_prefix}'",
+        [],
+        log: false
+      )
+
+    existing_columns = MapSet.new(col_rows, fn [table, col] -> {table, col} end)
+
+    {:ok, modules} = :application.get_key(:phoenix_kit, :modules)
+
+    modules
+    # `function_exported?/3` checks only what's already loaded in THIS
+    # process — for a schema module nothing has called yet, it reads
+    # false even though `Code.ensure_loaded?/1` would trigger the load
+    # and it would work fine one line later. Without the ensure_loaded?
+    # first, this filtered out nearly every schema.
+    |> Enum.filter(&(Code.ensure_loaded?(&1) and function_exported?(&1, :__schema__, 1)))
+    |> Enum.flat_map(&belongs_to_owner_columns/1)
+    |> Enum.uniq()
+    |> Enum.filter(&MapSet.member?(existing_columns, &1))
+    |> Enum.reject(&MapSet.member?(declared_fk_columns, &1))
+    |> Enum.sort()
+  end
+
+  defp belongs_to_owner_columns(schema) do
+    table = schema.__schema__(:source)
+
+    schema.__schema__(:associations)
+    |> Enum.map(&schema.__schema__(:association, &1))
+    |> Enum.filter(&match?(%Ecto.Association.BelongsTo{}, &1))
+    |> Enum.map(fn assoc -> {table, Atom.to_string(assoc.owner_key)} end)
   end
 
   defp check_lock_conflicts do

--- a/test/mix/tasks/phoenix_kit_doctor_orphaned_fk_destructive_test.exs
+++ b/test/mix/tasks/phoenix_kit_doctor_orphaned_fk_destructive_test.exs
@@ -73,7 +73,9 @@ defmodule Mix.Tasks.PhoenixKit.DoctorOrphanedFkDestructiveTest do
     # transaction itself is real, though, and still takes a real
     # `ShareRowExclusiveLock` for its duration — hence `async: false` here.
     test "adding the matching FK constraint drops that relation out of the count" do
-      before_fix = DoctorTask.discover_schema_declared_relations_without_fk(Repo, "public")
+      assert {:ok, {total_before, before_fix}} =
+               DoctorTask.discover_schema_declared_relations_without_fk(Repo, "public")
+
       assert {"phoenix_kit_activities", "actor_uuid"} in before_fix
 
       Repo.query!("""
@@ -82,11 +84,54 @@ defmodule Mix.Tasks.PhoenixKit.DoctorOrphanedFkDestructiveTest do
       FOREIGN KEY (actor_uuid) REFERENCES phoenix_kit_users(uuid)
       """)
 
-      after_fix = DoctorTask.discover_schema_declared_relations_without_fk(Repo, "public")
+      assert {:ok, {total_after, after_fix}} =
+               DoctorTask.discover_schema_declared_relations_without_fk(Repo, "public")
 
       refute {"phoenix_kit_activities", "actor_uuid"} in after_fix
       assert {"phoenix_kit_activities", "target_uuid"} in after_fix
       assert length(after_fix) == length(before_fix) - 1
+      # Adding a constraint changes which relations are MISSING, never how
+      # many candidates exist to check in the first place.
+      assert total_after == total_before
+    end
+
+    # Review finding (PR #755, HIGH-adjacent MEDIUM): the original SQL
+    # matched a column against pg_constraint by (table, column) alone, with
+    # no join back to the referenced table at all — a FK from
+    # actor_uuid to ANY table, not specifically phoenix_kit_users, was
+    # enough to silence the finding. Proven live before this fix: adding
+    # exactly this (a real, single-column FK, just pointed at the wrong
+    # target) left actor_uuid missing from the report. RED without the
+    # (table, column, ref_table) triple match in the query.
+    test "a FK on the right column pointing at the WRONG table does not silence the missing relation" do
+      assert {:ok, {total_before, before_fix}} =
+               DoctorTask.discover_schema_declared_relations_without_fk(Repo, "public")
+
+      assert {"phoenix_kit_activities", "actor_uuid"} in before_fix
+
+      # phoenix_kit_user_roles is a real table with a real `uuid` PK — a
+      # perfectly valid single-column FK target, just not the one
+      # PhoenixKit.Activity.Entry's `belongs_to :actor` declares
+      # (`phoenix_kit_users`).
+      Repo.query!("""
+      ALTER TABLE phoenix_kit_activities
+      ADD CONSTRAINT phoenix_kit_activities_actor_uuid_wrong_target_fkey
+      FOREIGN KEY (actor_uuid) REFERENCES phoenix_kit_user_roles(uuid)
+      """)
+
+      assert {:ok, {total_after, after_wrong_target}} =
+               DoctorTask.discover_schema_declared_relations_without_fk(Repo, "public")
+
+      assert {"phoenix_kit_activities", "actor_uuid"} in after_wrong_target,
+             "a FK to the wrong table must not count as satisfying the declared relation"
+
+      assert after_wrong_target == before_fix
+      assert total_after == total_before
+
+      Repo.query!("""
+      ALTER TABLE phoenix_kit_activities
+      DROP CONSTRAINT phoenix_kit_activities_actor_uuid_wrong_target_fkey
+      """)
     end
   end
 

--- a/test/mix/tasks/phoenix_kit_doctor_orphaned_fk_destructive_test.exs
+++ b/test/mix/tasks/phoenix_kit_doctor_orphaned_fk_destructive_test.exs
@@ -1,0 +1,113 @@
+defmodule Mix.Tasks.PhoenixKit.DoctorOrphanedFkDestructiveTest do
+  @moduledoc """
+  Every test here runs real DDL (`ALTER TABLE ... ADD CONSTRAINT`,
+  `ALTER TABLE ... DISABLE/ENABLE TRIGGER`) against `phoenix_kit_activities`,
+  `phoenix_kit_user_oauth_providers`, and `phoenix_kit_users` — split out of
+  `DoctorOrphanedFkTest` for exactly that reason.
+
+  `ALTER TABLE ... ADD CONSTRAINT ... FOREIGN KEY ... REFERENCES` takes a
+  `ShareRowExclusiveLock` on BOTH the altered table and the referenced one.
+  These tests used to live in `DoctorOrphanedFkTest`, declared
+  `async: true` — fine in isolation, but a live full-suite run deadlocked
+  (Postgres `40P01`) between two of these DDL statements and one of the
+  dozen-plus other async test files that write to `phoenix_kit_users`
+  concurrently: this session's ALTER waits on a `ShareRowExclusiveLock`
+  held by another async test's row lock, while that test's own next
+  write waits on a lock this ALTER already holds — a real deadlock, not
+  bad luck, and one the full suite could hit on any run, at random,
+  depending on which async tests happened to interleave.
+
+  ExUnit's own scheduling guarantee is the fix: every `async: true` test
+  module runs first and concurrently, and every `async: false` module
+  runs only after ALL of them have finished, one at a time. Moving the
+  actual DDL out of the async module into this one, `async: false`,
+  makes the deadlock structurally impossible rather than merely less
+  likely — by the time any test here runs, nothing else in the suite is
+  still touching `phoenix_kit_users` at all.
+  """
+  use PhoenixKit.DataCase, async: false
+
+  alias Mix.Tasks.PhoenixKit.Doctor, as: DoctorTask
+  alias PhoenixKit.Test.Repo
+
+  describe "check_orphaned_fk_refs/1 — destructive: a genuinely orphaned row outside the old 4 pairs is caught" do
+    # The widened check reads every single-column FK straight from
+    # `pg_constraint` (`discover_fk_constraints/2`), not just the four pairs
+    # the old check knew by name. This proves that widened coverage actually
+    # catches something the old four-pair list could never have seen:
+    # `phoenix_kit_user_oauth_providers.user_uuid -> phoenix_kit_users.uuid`
+    # (constraint `fk_user_oauth_providers_user_uuid`) was never one of the
+    # old four (`phoenix_kit_users_tokens`, `phoenix_kit_user_role_assignments`,
+    # `phoenix_kit_admin_notes`, `phoenix_kit_email_events`).
+    #
+    # A plain `INSERT` can't produce this row — the constraint rejects a
+    # nonexistent `user_uuid` immediately, and it isn't `DEFERRABLE`, so
+    # `SET CONSTRAINTS ALL DEFERRED` doesn't buy anything either. Disabling
+    # the child table's own triggers for one statement is the standard
+    # Postgres idiom for planting a row that could otherwise only arise from
+    # the same kind of bypass in production — a bulk load with constraints
+    # off, a restore from an inconsistent backup, direct catalog surgery —
+    # which is exactly the class of real corruption this check exists to
+    # catch, not a contrived test-only shape.
+    test "an orphaned phoenix_kit_user_oauth_providers.user_uuid row is reported, not read as clean" do
+      Repo.query!("ALTER TABLE phoenix_kit_user_oauth_providers DISABLE TRIGGER ALL")
+
+      Repo.query!("""
+      INSERT INTO phoenix_kit_user_oauth_providers
+        (user_uuid, provider, provider_uid, inserted_at, updated_at)
+      VALUES (gen_random_uuid(), 'google', 'destructive-orphan-test', now(), now())
+      """)
+
+      Repo.query!("ALTER TABLE phoenix_kit_user_oauth_providers ENABLE TRIGGER ALL")
+
+      assert {:fail, message} = DoctorTask.check_orphaned_fk_refs("public")
+      assert message =~ "phoenix_kit_user_oauth_providers.user_uuid"
+    end
+  end
+
+  describe "discover_schema_declared_relations_without_fk/2 — I082, second step (destructive)" do
+    # Proof by destruction: adding the FK a `belongs_to` already declares
+    # must remove it from this list. Runs inside the test's own sandbox
+    # transaction — Postgres DDL is transactional, so nothing outside this
+    # test ever sees the added constraint; no manual cleanup needed. The
+    # transaction itself is real, though, and still takes a real
+    # `ShareRowExclusiveLock` for its duration — hence `async: false` here.
+    test "adding the matching FK constraint drops that relation out of the count" do
+      before_fix = DoctorTask.discover_schema_declared_relations_without_fk(Repo, "public")
+      assert {"phoenix_kit_activities", "actor_uuid"} in before_fix
+
+      Repo.query!("""
+      ALTER TABLE phoenix_kit_activities
+      ADD CONSTRAINT phoenix_kit_activities_actor_uuid_fkey
+      FOREIGN KEY (actor_uuid) REFERENCES phoenix_kit_users(uuid)
+      """)
+
+      after_fix = DoctorTask.discover_schema_declared_relations_without_fk(Repo, "public")
+
+      refute {"phoenix_kit_activities", "actor_uuid"} in after_fix
+      assert {"phoenix_kit_activities", "target_uuid"} in after_fix
+      assert length(after_fix) == length(before_fix) - 1
+    end
+  end
+
+  describe "check_schema_declared_relations_without_fk/1 — I082, second step: PASS is not vacuous (destructive)" do
+    # Symmetric to the destruction check above: close BOTH real gaps and
+    # confirm the check actually reads clean, not just "never fails".
+    test "closing every real gap makes it :pass, not just non-:fail" do
+      Repo.query!("""
+      ALTER TABLE phoenix_kit_activities
+      ADD CONSTRAINT phoenix_kit_activities_actor_uuid_fkey
+      FOREIGN KEY (actor_uuid) REFERENCES phoenix_kit_users(uuid)
+      """)
+
+      Repo.query!("""
+      ALTER TABLE phoenix_kit_activities
+      ADD CONSTRAINT phoenix_kit_activities_target_uuid_fkey
+      FOREIGN KEY (target_uuid) REFERENCES phoenix_kit_users(uuid)
+      """)
+
+      assert {:pass, message} = DoctorTask.check_schema_declared_relations_without_fk("public")
+      assert message =~ "Every belongs_to"
+    end
+  end
+end

--- a/test/mix/tasks/phoenix_kit_doctor_orphaned_fk_test.exs
+++ b/test/mix/tasks/phoenix_kit_doctor_orphaned_fk_test.exs
@@ -141,25 +141,53 @@ defmodule Mix.Tasks.PhoenixKit.DoctorOrphanedFkTest do
   end
 
   describe "discover_schema_declared_relations_without_fk/2 — I082, second step" do
-    test "finds the real, known gap: activities.actor_uuid and .target_uuid declare belongs_to with no DB FK" do
-      found = DoctorTask.discover_schema_declared_relations_without_fk(Repo, "public")
+    test "finds EXACTLY the real, known gap: activities.actor_uuid and .target_uuid, nothing else" do
+      # Exact-list, not membership: `in` alone would still pass if a future
+      # belongs_to-without-FK went unnoticed alongside these two — silently
+      # absorbed into "found more than expected" instead of failing loud.
+      # `_total` (every belongs_to-declared column PhoenixKit's schemas have
+      # that also exists in this DB) is deliberately not asserted exactly —
+      # it grows with every module that adds an association, unrelated to
+      # what this test is pinning down.
+      assert {:ok, {_total, missing}} =
+               DoctorTask.discover_schema_declared_relations_without_fk(Repo, "public")
 
-      assert {"phoenix_kit_activities", "actor_uuid"} in found
-      assert {"phoenix_kit_activities", "target_uuid"} in found
+      assert missing == [
+               {"phoenix_kit_activities", "actor_uuid"},
+               {"phoenix_kit_activities", "target_uuid"}
+             ]
     end
 
     test "never includes a polymorphic pair — Ecto cannot declare belongs_to against a varying type" do
-      found = DoctorTask.discover_schema_declared_relations_without_fk(Repo, "public")
+      assert {:ok, {_total, missing}} =
+               DoctorTask.discover_schema_declared_relations_without_fk(Repo, "public")
 
       # phoenix_kit_activities.resource_uuid is paired with resource_type
       # (polymorphic) — no belongs_to is declared for it in Entry's schema,
       # so it structurally cannot appear here, unlike a name-based scan
       # that would need an explicit filter to exclude it.
-      refute {"phoenix_kit_activities", "resource_uuid"} in found
+      refute {"phoenix_kit_activities", "resource_uuid"} in missing
     end
 
-    # The destructive proof-by-mutation direction (adding the FK a
-    # `belongs_to` already declares must remove it from this list) lives in
+    test "a genuinely wrong schema name reports zero candidates, not an error" do
+      assert {:ok, {0, []}} =
+               DoctorTask.discover_schema_declared_relations_without_fk(
+                 Repo,
+                 "definitely_not_a_real_schema_12345"
+               )
+    end
+
+    test "a malformed schema name (real catalog-access fault) returns {:error, _}, never a silent empty result" do
+      # The unescaped quote breaks both catalog queries' own string literal
+      # boundary — a genuine Postgres syntax error, the same class of fault
+      # that can otherwise collapse into "nothing found" and print PASS.
+      assert {:error, %Postgrex.Error{}} =
+               DoctorTask.discover_schema_declared_relations_without_fk(Repo, "x'y")
+    end
+
+    # The destructive proof-by-mutation directions — adding the FK a
+    # `belongs_to` already declares must remove it from this list, and a FK
+    # that exists but points at the WRONG table must NOT — live in
     # `DoctorOrphanedFkDestructiveTest`, `async: false` — see that module's
     # moduledoc for why: the real `ALTER TABLE ... ADD CONSTRAINT` it runs
     # takes a `ShareRowExclusiveLock` on `phoenix_kit_users`, which deadlocked
@@ -171,7 +199,23 @@ defmodule Mix.Tasks.PhoenixKit.DoctorOrphanedFkTest do
     test "reports the real count as :warn, never :fail — this is advisory, not a defect" do
       assert {:warn, message} = DoctorTask.check_schema_declared_relations_without_fk("public")
       assert message =~ "phoenix_kit_activities.actor_uuid"
+      assert message =~ "phoenix_kit_activities.target_uuid"
       assert message =~ "advisory, not a failure"
+    end
+
+    test "a genuinely wrong schema name is :warn naming zero coverage, never :pass" do
+      assert {:warn, message} =
+               DoctorTask.check_schema_declared_relations_without_fk(
+                 "definitely_not_a_real_schema_12345"
+               )
+
+      assert message =~ "coverage is zero"
+      assert message =~ "not the same as clean"
+    end
+
+    test "a malformed schema name (catalog-access fault) is :warn, never :fail" do
+      assert {:warn, message} = DoctorTask.check_schema_declared_relations_without_fk("x'y")
+      assert message =~ "coverage is zero"
     end
 
     # The "closes every real gap -> :pass" destructive proof lives in

--- a/test/mix/tasks/phoenix_kit_doctor_orphaned_fk_test.exs
+++ b/test/mix/tasks/phoenix_kit_doctor_orphaned_fk_test.exs
@@ -115,41 +115,6 @@ defmodule Mix.Tasks.PhoenixKit.DoctorOrphanedFkTest do
     end
   end
 
-  describe "check_orphaned_fk_refs/1 — destructive: a genuinely orphaned row outside the old 4 pairs is caught" do
-    # The widened check reads every single-column FK straight from
-    # `pg_constraint` (`discover_fk_constraints/2`), not just the four pairs
-    # the old check knew by name. This proves that widened coverage actually
-    # catches something the old four-pair list could never have seen:
-    # `phoenix_kit_user_oauth_providers.user_uuid -> phoenix_kit_users.uuid`
-    # (constraint `fk_user_oauth_providers_user_uuid`) was never one of the
-    # old four (`phoenix_kit_users_tokens`, `phoenix_kit_user_role_assignments`,
-    # `phoenix_kit_admin_notes`, `phoenix_kit_email_events`).
-    #
-    # A plain `INSERT` can't produce this row — the constraint rejects a
-    # nonexistent `user_uuid` immediately, and it isn't `DEFERRABLE`, so
-    # `SET CONSTRAINTS ALL DEFERRED` doesn't buy anything either. Disabling
-    # the child table's own triggers for one statement is the standard
-    # Postgres idiom for planting a row that could otherwise only arise from
-    # the same kind of bypass in production — a bulk load with constraints
-    # off, a restore from an inconsistent backup, direct catalog surgery —
-    # which is exactly the class of real corruption this check exists to
-    # catch, not a contrived test-only shape.
-    test "an orphaned phoenix_kit_user_oauth_providers.user_uuid row is reported, not read as clean" do
-      Repo.query!("ALTER TABLE phoenix_kit_user_oauth_providers DISABLE TRIGGER ALL")
-
-      Repo.query!("""
-      INSERT INTO phoenix_kit_user_oauth_providers
-        (user_uuid, provider, provider_uid, inserted_at, updated_at)
-      VALUES (gen_random_uuid(), 'google', 'destructive-orphan-test', now(), now())
-      """)
-
-      Repo.query!("ALTER TABLE phoenix_kit_user_oauth_providers ENABLE TRIGGER ALL")
-
-      assert {:fail, message} = DoctorTask.check_orphaned_fk_refs("public")
-      assert message =~ "phoenix_kit_user_oauth_providers.user_uuid"
-    end
-  end
-
   describe "probe timeout shape — the real error shape, not an assumed one" do
     test "a real slow query through Repo.query/3 with a short timeout is always classified as a time limit, whichever shape it takes" do
       # `probe_fk/4` calls `repo.query(sql, [], timeout: N)` — through the
@@ -173,5 +138,43 @@ defmodule Mix.Tasks.PhoenixKit.DoctorOrphanedFkTest do
 
       assert DoctorTask.fk_probe_failure_reason(reason) =~ "time limit exceeded"
     end
+  end
+
+  describe "discover_schema_declared_relations_without_fk/2 — I082, second step" do
+    test "finds the real, known gap: activities.actor_uuid and .target_uuid declare belongs_to with no DB FK" do
+      found = DoctorTask.discover_schema_declared_relations_without_fk(Repo, "public")
+
+      assert {"phoenix_kit_activities", "actor_uuid"} in found
+      assert {"phoenix_kit_activities", "target_uuid"} in found
+    end
+
+    test "never includes a polymorphic pair — Ecto cannot declare belongs_to against a varying type" do
+      found = DoctorTask.discover_schema_declared_relations_without_fk(Repo, "public")
+
+      # phoenix_kit_activities.resource_uuid is paired with resource_type
+      # (polymorphic) — no belongs_to is declared for it in Entry's schema,
+      # so it structurally cannot appear here, unlike a name-based scan
+      # that would need an explicit filter to exclude it.
+      refute {"phoenix_kit_activities", "resource_uuid"} in found
+    end
+
+    # The destructive proof-by-mutation direction (adding the FK a
+    # `belongs_to` already declares must remove it from this list) lives in
+    # `DoctorOrphanedFkDestructiveTest`, `async: false` — see that module's
+    # moduledoc for why: the real `ALTER TABLE ... ADD CONSTRAINT` it runs
+    # takes a `ShareRowExclusiveLock` on `phoenix_kit_users`, which deadlocked
+    # against another async test file's write to that same table on a real
+    # full-suite run.
+  end
+
+  describe "check_schema_declared_relations_without_fk/1 — I082, second step: PASS is not vacuous" do
+    test "reports the real count as :warn, never :fail — this is advisory, not a defect" do
+      assert {:warn, message} = DoctorTask.check_schema_declared_relations_without_fk("public")
+      assert message =~ "phoenix_kit_activities.actor_uuid"
+      assert message =~ "advisory, not a failure"
+    end
+
+    # The "closes every real gap -> :pass" destructive proof lives in
+    # `DoctorOrphanedFkDestructiveTest`, `async: false` — same reason as above.
   end
 end


### PR DESCRIPTION
## What

A thirteenth doctor check: **Schema-Declared Relations Without a DB FK** —
every `belongs_to` the Ecto schemas declare, whose `(table, owner_key,
ref_table)` triple has no matching constraint in `pg_constraint`.

## Why here, and why now

`fk_validation_state/5` already answers "does this specific expected
relationship have a declared FK at all", and the comment above it names
exactly what was missing:

> Kept anyway, deliberately: it is the one existing primitive that can answer
> "does this specific expected relationship have a declared FK at all",
> independent of naming — exactly what closing check 12's current gap … would
> need, given a source of expected `(table, fk_col, ref_table)` candidates.
> **No such source exists yet, so this stays unwired until one does.**

The schemas are that source. Every `belongs_to` names its triple
unambiguously via `owner_key`/`related_key`, so the candidate list can be
derived rather than hardcoded.

`fk_validation_state/5` itself is **not** called: it answers one relationship
per round trip, and check 12 already shows what that costs (one query per
constraint — 231 on a calibration install). This check instead asks the same
question in bulk, two catalog queries regardless of how many associations
exist, comparing the same full shape the primitive compares: owning table,
column, referenced table, and single-column key. The primitive's comment stays
accurate for its own call site; this is a second reader of the same catalogs,
not a replacement.

Check 12 covers relations that *have* a constraint; this one covers the
relations that never had one — the case check 12's own moduledoc puts outside
its scope.

## Advisory by design

A declared relation without a database FK is a real gap but not automatically
a defect: some are deliberate. So the check reports `:warn` with the count and
the offending relations, and never `:fail` — including when a catalog query
itself fails, which is reported as `:warn` with the reason rather than being
allowed to crash into `:fail`. On the installations available to us it names
`phoenix_kit_activities.actor_uuid` and `.target_uuid`.

Zero coverage is never reported as clean. If no declared relation could be
checked at all — wrong `--prefix`, a host before its first migration, an
interrupted update — the result is `:warn` naming that explicitly, in the
same spirit as check 12's own `coverage is zero, which is not the same as
clean`. A `:pass` from this check states how many relations it actually
examined.

## The destructive test move

`ADD CONSTRAINT … FOREIGN KEY` takes a `ShareRowExclusiveLock` on **both**
tables. In an `async: true` module that deadlocks (`40P01`) against any other
async test file writing to `phoenix_kit_users` — observed on a real full-suite
run, and reproducible only there: the file passes 34/34 in isolation, which is
what makes it easy to miss.

So the destructive tests move into their own `async: false` module
(`DoctorOrphanedFkDestructiveTest`); ExUnit runs sync modules after the async
ones, so the collision cannot happen. The existing destructive orphan test
carries the same hazard, so it moves with them rather than being left behind
in the async file. A comment at the old site records why, so the tests cannot
quietly migrate back.

This part is separable if you would rather take it on its own — it is one
commit's worth of change and touches no production code.

## Verification

- Full suite on a tree carrying this change: **43 doctests, 4102 tests, 0
  failures**, with integration tests actually running (no
  `Excluding tags: [:integration]` line).
- Before the async split, that same full run reproduced the deadlock; after
  it, two consecutive full runs were clean.
- `mix format --check-formatted`, `mix credo --strict` and `mix dialyzer` all
  clean via the repository's own pre-commit gate.

## Not covered

- Not run against a real named-schema (`prefix:`) installation. The
  zero-coverage path that a wrong prefix produces *is* covered by a test.
- The check reads schemas reachable from the loaded application; a module not
  loaded at doctor time contributes no candidates. The zero-coverage branch
  catches the total case; a partially-loaded application is still counted as
  examined.
