### PR TITLE
Verify config.exs splices parse and land before adopting them

### DIFF
--- a/lib/mix/tasks/phoenix_kit.update.ex
+++ b/lib/mix/tasks/phoenix_kit.update.ex
@@ -1563,7 +1563,7 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
           # Case 1: Incorrect configuration with providers: []
           String.contains?(content, "config :ueberauth, Ueberauth") &&
               Regex.match?(~r/providers:\s*\[\s*\]/, content) ->
-            fix_ueberauth_providers_config(igniter, content)
+            fix_ueberauth_providers_config(igniter)
 
           # Case 2: Configuration exists and is correct (providers: %{} or with values)
           String.contains?(content, "config :ueberauth, Ueberauth") ->
@@ -1584,36 +1584,55 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
     # I103: wrapped with the same parse-then-verify safety net as the Oban
     # config splices — a single-line `Regex.replace/3` is lower risk than a
     # multi-line block splice, but it is still blind to comments/strings.
-    # The verify+rollback decision happens BEFORE `Igniter.update_file/3` on
-    # purpose, against the `content` already read by the caller
-    # (`validate_and_fix_ueberauth_config/1`) — Igniter buffers writes and
-    # does not flush them to disk mid-pipeline, so re-reading the file
-    # inside (or after) the `update_file` callback would still see the
-    # PRE-change content and could never detect success at all.
-    defp fix_ueberauth_providers_config(igniter, content) do
-      candidate =
-        Regex.replace(
-          ~r/(config\s+:ueberauth,\s+Ueberauth,\s+providers:\s*)\[\s*\]/,
-          content,
-          "\\1%{}"
-        )
+    # The verify+rollback decision happens INSIDE the `Igniter.update_file/3`
+    # callback, against the BUFFERED content (`Rewrite.Source.get(source,
+    # :content)`) — NOT a fresh disk read taken before this runs. Igniter
+    # buffers writes and never flushes them to disk mid-pipeline: building
+    # the candidate from a stale disk read and then unconditionally
+    # overwriting the buffer with it discarded whatever earlier steps in the
+    # SAME run had already staged for config/config.exs — concretely,
+    # `BasicConfiguration.add_basic_config/1` and
+    # `PrefixConfig.add_prefix_configuration/2`, both of which write to this
+    # exact file earlier in `mix phoenix_kit.update`'s pipeline. A lost
+    # `prefix:` backfill sends the next `update`/`status` looking for the
+    # installation in `public` (see `PhoenixKit.Install.PrefixConfig`'s
+    # moduledoc).
+    #
+    # Public (not `defp`), `@doc false`: a real unit-test seam, the same
+    # reasoning as `PhoenixKit.Install.ObanConfig`'s exposed splice helpers —
+    # the defect this guards against lives in what actually lands in the
+    # buffer, which only an Igniter-level test (`Igniter.Test.test_project/1`)
+    # can reach.
+    @doc false
+    @spec fix_ueberauth_providers_config(Igniter.t()) :: Igniter.t()
+    def fix_ueberauth_providers_config(igniter) do
+      Igniter.update_file(igniter, "config/config.exs", fn source ->
+        content = Rewrite.Source.get(source, :content)
 
-      case ConfigVerify.verify_or_rollback(content, candidate, &ueberauth_providers_map?/1) do
-        {:ok, updated_content} ->
-          igniter
-          |> Igniter.update_file("config/config.exs", fn source ->
-            Rewrite.Source.update(source, :content, updated_content)
-          end)
-          |> add_ueberauth_fix_notice()
-
-        {:rolled_back, _original, _reason} ->
-          Igniter.add_warning(
-            igniter,
-            "Could not safely fix Ueberauth's providers: [] -> %{} (the replacement would " <>
-              "have produced invalid or misplaced config) - please change it manually in " <>
-              "config/config.exs."
+        candidate =
+          Regex.replace(
+            ~r/(config\s+:ueberauth,\s+Ueberauth,\s+providers:\s*)\[\s*\]/,
+            content,
+            "\\1%{}"
           )
-      end
+
+        case ConfigVerify.verify_or_rollback(content, candidate, &ueberauth_providers_map?/1) do
+          {:ok, updated_content} ->
+            Mix.shell().info("""
+
+            ✅ Fixed Ueberauth configuration: providers: [] → providers: %{}
+               OAuth authentication will now work correctly.
+            """)
+
+            Rewrite.Source.update(source, :content, updated_content)
+
+          {:rolled_back, _original, _reason} ->
+            {:warning,
+             "Could not safely fix Ueberauth's providers: [] -> %{} (the replacement would " <>
+               "have produced invalid or misplaced config) - please change it manually in " <>
+               "config/config.exs."}
+        end
+      end)
     end
 
     # True if `ast` has `config :ueberauth, Ueberauth, providers: %{}` (or
@@ -1628,16 +1647,6 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
         _ ->
           false
       end)
-    end
-
-    # Add notice about Ueberauth configuration fix
-    defp add_ueberauth_fix_notice(igniter) do
-      notice = """
-      ✅ Fixed Ueberauth configuration: providers: [] → providers: %{}
-         OAuth authentication will now work correctly.
-      """
-
-      Igniter.add_notice(igniter, String.trim(notice))
     end
 
     # Add missing Ueberauth configuration

--- a/lib/mix/tasks/phoenix_kit.update.ex
+++ b/lib/mix/tasks/phoenix_kit.update.ex
@@ -89,6 +89,7 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
       BasicConfiguration,
       BootHook,
       Common,
+      ConfigVerify,
       CssIntegration,
       DaisyUI,
       DbConnectionCheck,
@@ -1579,22 +1580,54 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
     end
 
     # Fix Ueberauth providers configuration from [] to %{}
-    defp fix_ueberauth_providers_config(igniter, _content) do
-      igniter
-      |> Igniter.update_file("config/config.exs", fn source ->
-        content = Rewrite.Source.get(source, :content)
+    #
+    # I103: wrapped with the same parse-then-verify safety net as the Oban
+    # config splices — a single-line `Regex.replace/3` is lower risk than a
+    # multi-line block splice, but it is still blind to comments/strings.
+    # The verify+rollback decision happens BEFORE `Igniter.update_file/3` on
+    # purpose, against the `content` already read by the caller
+    # (`validate_and_fix_ueberauth_config/1`) — Igniter buffers writes and
+    # does not flush them to disk mid-pipeline, so re-reading the file
+    # inside (or after) the `update_file` callback would still see the
+    # PRE-change content and could never detect success at all.
+    defp fix_ueberauth_providers_config(igniter, content) do
+      candidate =
+        Regex.replace(
+          ~r/(config\s+:ueberauth,\s+Ueberauth,\s+providers:\s*)\[\s*\]/,
+          content,
+          "\\1%{}"
+        )
 
-        # Replace providers: [] with providers: %{}
-        updated_content =
-          Regex.replace(
-            ~r/(config\s+:ueberauth,\s+Ueberauth,\s+providers:\s*)\[\s*\]/,
-            content,
-            "\\1%{}"
+      case ConfigVerify.verify_or_rollback(content, candidate, &ueberauth_providers_map?/1) do
+        {:ok, updated_content} ->
+          igniter
+          |> Igniter.update_file("config/config.exs", fn source ->
+            Rewrite.Source.update(source, :content, updated_content)
+          end)
+          |> add_ueberauth_fix_notice()
+
+        {:rolled_back, _original, _reason} ->
+          Igniter.add_warning(
+            igniter,
+            "Could not safely fix Ueberauth's providers: [] -> %{} (the replacement would " <>
+              "have produced invalid or misplaced config) - please change it manually in " <>
+              "config/config.exs."
           )
+      end
+    end
 
-        Rewrite.Source.update(source, :content, updated_content)
+    # True if `ast` has `config :ueberauth, Ueberauth, providers: %{}` (or
+    # any non-empty `providers:` map/keyword) — used to confirm the
+    # `[] -> %{}` replacement actually landed on the real Ueberauth config
+    # call, not on a comment or string that happened to match the same text.
+    defp ueberauth_providers_map?(ast) do
+      ConfigVerify.ast_contains?(ast, fn
+        {:config, _, [:ueberauth, {:__aliases__, _, [:Ueberauth]}, opts]} when is_list(opts) ->
+          match?({:ok, {:%{}, _, _}}, ConfigVerify.keyword_get(opts, :providers))
+
+        _ ->
+          false
       end)
-      |> add_ueberauth_fix_notice()
     end
 
     # Add notice about Ueberauth configuration fix

--- a/lib/phoenix_kit/install/boot_hook.ex
+++ b/lib/phoenix_kit/install/boot_hook.ex
@@ -32,6 +32,7 @@ if Code.ensure_loaded?(Igniter) do
     """
     use PhoenixKit.Install.IgniterCompat
 
+    alias PhoenixKit.Install.ConfigVerify
     alias PhoenixKit.Install.IgniterHelpers
 
     @standard_call ~r/Supervisor\.start_link\(children,\s*opts\)/
@@ -65,25 +66,46 @@ if Code.ensure_loaded?(Igniter) do
       |> String.contains?("PhoenixKit.boot")
     end
 
+    # I103: the verify+rollback decision happens BEFORE `Igniter.update_file/3`,
+    # against `content` already read from disk — same reasoning as
+    # `PhoenixKit.Install.ConfigVerify`'s moduledoc and
+    # `fix_ueberauth_providers_config/2`: Igniter buffers writes, so nothing
+    # read from disk mid-pipeline reflects a change made earlier in the same
+    # pipeline run.
     defp wire_in(igniter, app_file) do
       content = File.read!(app_file)
 
       if Regex.match?(@standard_call, content) do
-        igniter
-        |> Igniter.update_file(app_file, fn source ->
-          rewritten =
-            Regex.replace(
-              @standard_call,
-              Rewrite.Source.get(source, :content),
-              "Supervisor.start_link(children, opts) |> PhoenixKit.boot()",
-              global: false
-            )
+        candidate =
+          Regex.replace(
+            @standard_call,
+            content,
+            "Supervisor.start_link(children, opts) |> PhoenixKit.boot()",
+            global: false
+          )
 
-          Rewrite.Source.update(source, :content, rewritten)
-        end)
+        case ConfigVerify.verify_or_rollback(content, candidate, &boot_hook_wired?/1) do
+          {:ok, updated_content} ->
+            Igniter.update_file(igniter, app_file, fn source ->
+              Rewrite.Source.update(source, :content, updated_content)
+            end)
+
+          {:rolled_back, _original, _reason} ->
+            Igniter.add_warning(igniter, manual_instructions(app_file))
+        end
       else
         Igniter.add_warning(igniter, manual_instructions(app_file))
       end
+    end
+
+    # True if `ast` contains `... |> PhoenixKit.boot()` anywhere — confirms
+    # the rewrite actually landed as a real pipe into `PhoenixKit.boot/1`,
+    # not inside a comment or a string that happened to match the same text.
+    defp boot_hook_wired?(ast) do
+      ConfigVerify.ast_contains?(ast, fn
+        {:|>, _, [_lhs, {{:., _, [{:__aliases__, _, [:PhoenixKit]}, :boot]}, _, []}]} -> true
+        _ -> false
+      end)
     end
 
     defp manual_instructions(app_file) do

--- a/lib/phoenix_kit/install/boot_hook.ex
+++ b/lib/phoenix_kit/install/boot_hook.ex
@@ -48,54 +48,60 @@ if Code.ensure_loaded?(Igniter) do
       app_name = IgniterHelpers.get_parent_app_name(igniter)
       app_file = "lib/#{app_name}/application.ex"
 
-      cond do
-        not File.exists?(app_file) ->
-          igniter
-
-        already_wired?(app_file) ->
-          igniter
-
-        true ->
-          wire_in(igniter, app_file)
-      end
-    end
-
-    defp already_wired?(app_file) do
-      app_file
-      |> File.read!()
-      |> String.contains?("PhoenixKit.boot")
-    end
-
-    # I103: the verify+rollback decision happens BEFORE `Igniter.update_file/3`,
-    # against `content` already read from disk — same reasoning as
-    # `PhoenixKit.Install.ConfigVerify`'s moduledoc and
-    # `fix_ueberauth_providers_config/2`: Igniter buffers writes, so nothing
-    # read from disk mid-pipeline reflects a change made earlier in the same
-    # pipeline run.
-    defp wire_in(igniter, app_file) do
-      content = File.read!(app_file)
-
-      if Regex.match?(@standard_call, content) do
-        candidate =
-          Regex.replace(
-            @standard_call,
-            content,
-            "Supervisor.start_link(children, opts) |> PhoenixKit.boot()",
-            global: false
-          )
-
-        case ConfigVerify.verify_or_rollback(content, candidate, &boot_hook_wired?/1) do
-          {:ok, updated_content} ->
-            Igniter.update_file(igniter, app_file, fn source ->
-              Rewrite.Source.update(source, :content, updated_content)
-            end)
-
-          {:rolled_back, _original, _reason} ->
-            Igniter.add_warning(igniter, manual_instructions(app_file))
-        end
+      # `Igniter.exists?/2`, not bare `File.exists?/1`: the latter only ever
+      # sees the real filesystem, missing a file that exists only in
+      # Igniter's own buffer (an earlier step in this run created it, or —
+      # the case that matters for testing this function at all — a test
+      # project built with `Igniter.Test.test_project/1`, which never
+      # touches real disk).
+      if Igniter.exists?(igniter, app_file) do
+        wire_in(igniter, app_file)
       else
-        Igniter.add_warning(igniter, manual_instructions(app_file))
+        igniter
       end
+    end
+
+    # I103: the verify+rollback decision happens INSIDE the
+    # `Igniter.update_file/3` callback, against the BUFFERED content
+    # (`Rewrite.Source.get(source, :content)`) rather than a fresh
+    # `File.read!/1` — Igniter never flushes a step's writes to disk before
+    # the next step runs, so reading the file mid-pipeline sees whatever was
+    # on disk BEFORE this run started. The regression this fixes: this used
+    # to read `content` from disk and then unconditionally overwrite the
+    # buffer with a candidate built from it, discarding whatever an EARLIER
+    # step in the same run had already staged for the same file — most
+    # concretely `ApplicationSupervisor.add_supervisor/2` adding
+    # `PhoenixKit.Supervisor` to `children` on a fresh install, silently
+    # producing a boot pipe with no supervisor in it. Same reasoning as
+    # `PhoenixKit.Install.ObanConfig.update_existing_oban_config/3` and
+    # `PhoenixKit.Install.MailerConfig.repair_runtime_import_order/1`, both
+    # of which already decide from the buffer.
+    defp wire_in(igniter, app_file) do
+      Igniter.update_file(igniter, app_file, fn source ->
+        content = Rewrite.Source.get(source, :content)
+
+        cond do
+          String.contains?(content, "PhoenixKit.boot") ->
+            source
+
+          not Regex.match?(@standard_call, content) ->
+            {:warning, manual_instructions(app_file)}
+
+          true ->
+            candidate =
+              Regex.replace(
+                @standard_call,
+                content,
+                "Supervisor.start_link(children, opts) |> PhoenixKit.boot()",
+                global: false
+              )
+
+            case ConfigVerify.verify_or_rollback(content, candidate, &boot_hook_wired?/1) do
+              {:ok, updated_content} -> Rewrite.Source.update(source, :content, updated_content)
+              {:rolled_back, _original, _reason} -> {:warning, manual_instructions(app_file)}
+            end
+        end
+      end)
     end
 
     # True if `ast` contains `... |> PhoenixKit.boot()` anywhere — confirms

--- a/lib/phoenix_kit/install/config_verify.ex
+++ b/lib/phoenix_kit/install/config_verify.ex
@@ -24,6 +24,17 @@ defmodule PhoenixKit.Install.ConfigVerify do
   message the safe call sites in this codebase already print. A rollback is
   never worse than what the file had before; a wrong bracket must never win
   silently over "tell the operator to do it by hand".
+
+  ## What this deliberately does NOT cover
+
+  `PhoenixKit.Install.JsIntegration` and `PhoenixKit.Install.CssIntegration`
+  splice regex-built text into a host's `assets/js/app.js`,
+  `root.html.heex`, and `app.css` the same way — but `Code.string_to_quoted/1`
+  only understands Elixir, so there is no equivalent parse-then-verify step
+  for JavaScript, HEEX, or CSS available here. That is a real, permanent gap
+  in coverage, not an oversight: those splices stay regex-only, checked (where
+  they are checked at all) by a plain `if updated != content` before writing.
+  Each site says so in its own comment.
   """
 
   @typedoc "Whether the candidate came back invalid, or valid but the intended change wasn't found."
@@ -144,4 +155,47 @@ defmodule PhoenixKit.Install.ConfigVerify do
       _ -> false
     end)
   end
+
+  @doc """
+  Scopes a `keyword_list_satisfies?/3`-style check to ONE application's
+  config block.
+
+  True if `ast` contains a `config(app_name, module, opts)` call — the
+  `Config.config/3` macro invoked as `config :app_name, Module, key: value` —
+  whose `opts` contain a `{root_key, list}` pair (at any depth, e.g. a
+  `crontab:` nested inside an `Oban.Plugins.Cron` tuple inside `plugins:`)
+  satisfying `list_check`.
+
+  `keyword_list_satisfies?/3` alone answers "does a `root_key: [...]` list
+  like this appear ANYWHERE in the file" — true even when it belongs to a
+  DIFFERENT application's block. Paired with a splice that isn't anchored to
+  the right app either, that isn't a safety net: it is a check that can
+  confirm the WRONG outcome, reporting success while the intended
+  application's config was never touched. See
+  `PhoenixKit.Install.ObanConfig`'s `plugins:`/`crontab:` splices, which
+  anchor both the insertion and this check to `app_name`.
+  """
+  @spec app_config_satisfies?(
+          Macro.t(),
+          atom() | String.t(),
+          module(),
+          atom(),
+          ([Macro.t()] -> boolean())
+        ) :: boolean()
+  def app_config_satisfies?(ast, app_name, module, root_key, list_check)
+      when is_function(list_check, 1) do
+    target = to_app_atom(app_name)
+
+    ast_contains?(ast, fn
+      {:config, _meta, [app, alias_node, opts]} when is_atom(app) and is_list(opts) ->
+        app == target and alias_matches?(alias_node, module) and
+          keyword_list_satisfies?(opts, root_key, list_check)
+
+      _ ->
+        false
+    end)
+  end
+
+  defp to_app_atom(app) when is_atom(app), do: app
+  defp to_app_atom(app) when is_binary(app), do: String.to_atom(app)
 end

--- a/lib/phoenix_kit/install/config_verify.ex
+++ b/lib/phoenix_kit/install/config_verify.ex
@@ -1,0 +1,147 @@
+defmodule PhoenixKit.Install.ConfigVerify do
+  @moduledoc """
+  I103: the config-editing helpers across `oban_config.ex`, `phoenix_kit.update.ex`,
+  `boot_hook.ex`, and `runtime_detector.ex` all splice text into a host's own
+  `.ex`/`.exs` file via regex, then hand the result back without ever checking
+  what they produced. Two independent ways that goes wrong, found the same day:
+
+    * The splice lands on the wrong delimiter (a `]` inside a comment, inside a
+      string) and produces text that is not valid Elixir at all — reproduced
+      live as `MismatchedDelimiterError` from `add_scheduled_posts_job_to_crontab/1`
+      given nothing more unusual than an ordinary explanatory comment.
+    * The splice lands on the wrong delimiter and STILL produces valid Elixir —
+      the new entry ends up nested inside an unrelated value (an existing
+      entry's own `args: %{tags: [...]}` list) instead of as a sibling of the
+      list it was meant to join. A parse check alone accepts this silently;
+      it is the exact shape of a green that doesn't back its own claim, same
+      as I082's doctor check before it named its own scope.
+
+  This module is the shared fix for both: parse the candidate text, then hand
+  the parsed AST to a caller-supplied predicate that confirms the SPECIFIC
+  change is actually present where it was meant to land — not just that some
+  valid Elixir came out. Either failure returns the ORIGINAL, untouched
+  content plus a reason a caller turns into the same kind of manual-fallback
+  message the safe call sites in this codebase already print. A rollback is
+  never worse than what the file had before; a wrong bracket must never win
+  silently over "tell the operator to do it by hand".
+  """
+
+  @typedoc "Whether the candidate came back invalid, or valid but the intended change wasn't found."
+  @type failure :: :syntax | :semantic
+
+  @doc """
+  Parses `candidate`, then runs `semantic_check` against the resulting AST.
+
+  Returns `{:ok, candidate}` only when both the parse succeeds AND
+  `semantic_check` returns `true`. Otherwise returns `{:error, reason}` —
+  the caller is expected to fall back to whatever content it started from
+  (this module never sees or returns `original`; it isn't needed to make
+  that decision, and threading it through here would only invite a caller
+  to skip the fallback by mistake).
+  """
+  @spec verify(String.t(), (Macro.t() -> boolean())) :: {:ok, String.t()} | {:error, failure()}
+  def verify(candidate, semantic_check)
+      when is_binary(candidate) and is_function(semantic_check, 1) do
+    case Code.string_to_quoted(candidate) do
+      {:ok, ast} ->
+        if semantic_check.(ast) do
+          {:ok, candidate}
+        else
+          {:error, :semantic}
+        end
+
+      {:error, _reason} ->
+        {:error, :syntax}
+    end
+  end
+
+  @doc """
+  Runs a regex-built `candidate` through `verify/2` and returns either the
+  candidate (accepted) or `original` (rolled back) — the one-line shape
+  every call site in this codebase wants: try the insertion, keep it only
+  if it's provably correct, otherwise behave exactly as if the insertion
+  had never been attempted.
+  """
+  @spec verify_or_rollback(String.t(), String.t(), (Macro.t() -> boolean())) ::
+          {:ok, String.t()} | {:rolled_back, String.t(), failure()}
+  def verify_or_rollback(original, candidate, semantic_check) do
+    case verify(candidate, semantic_check) do
+      {:ok, result} -> {:ok, result}
+      {:error, reason} -> {:rolled_back, original, reason}
+    end
+  end
+
+  @doc """
+  True if any node in `ast` satisfies `matcher`. Stops at the first match —
+  every caller here asks "is this one thing present", not "collect every
+  occurrence".
+  """
+  @spec ast_contains?(Macro.t(), (Macro.t() -> boolean())) :: boolean()
+  def ast_contains?(ast, matcher) when is_function(matcher, 1) do
+    {_, found} =
+      Macro.prewalk(ast, false, fn node, acc ->
+        if acc, do: {node, acc}, else: {node, matcher.(node)}
+      end)
+
+    found
+  end
+
+  @doc """
+  The elements of a quoted tuple of any size.
+
+  A literal 2-tuple is its own AST node (`{a, b}`) — but Elixir represents
+  every OTHER tuple size as `{:{}, meta, elements}`, the one case a bare
+  `is_tuple/1` check on quoted code would miss. Returns `nil` for anything
+  that isn't a quoted tuple at all.
+  """
+  @spec tuple_elements(Macro.t()) :: [Macro.t()] | nil
+  def tuple_elements({:{}, _meta, elements}), do: elements
+
+  def tuple_elements(tuple) when is_tuple(tuple) and tuple_size(tuple) == 2,
+    do: Tuple.to_list(tuple)
+
+  def tuple_elements(_), do: nil
+
+  @doc "True if the quoted node is a `__aliases__` resolving to exactly `module`."
+  @spec alias_matches?(Macro.t(), module()) :: boolean()
+  def alias_matches?({:__aliases__, _meta, parts}, module), do: Module.concat(parts) == module
+  def alias_matches?(_, _), do: false
+
+  @doc """
+  True if `module` appears as one of the elements of the quoted tuple `node` —
+  used to confirm a newly-spliced plugin/worker tuple actually landed as its
+  own list entry, not nested deeper inside an unrelated value.
+  """
+  @spec tuple_names_module?(Macro.t(), module()) :: boolean()
+  def tuple_names_module?(node, module) do
+    case tuple_elements(node) do
+      nil -> false
+      elements -> Enum.any?(elements, &alias_matches?(&1, module))
+    end
+  end
+
+  @doc "Looks up `key` in a quoted keyword list; `{:ok, value}` or `nil`."
+  @spec keyword_get(Macro.t(), atom()) :: {:ok, Macro.t()} | nil
+  def keyword_get(kw, key) when is_list(kw) do
+    Enum.find_value(kw, fn
+      {^key, value} -> {:ok, value}
+      _ -> nil
+    end)
+  end
+
+  def keyword_get(_, _), do: nil
+
+  @doc """
+  True if `ast` contains a `{root_key, list}` pair (e.g. a `crontab:`,
+  `plugins:`, or `queues:` entry inside some enclosing keyword list) where
+  `list` satisfies `list_check` — the shared shape behind "did my new entry
+  land inside the RIGHT list", regardless of how deep that list sits.
+  """
+  @spec keyword_list_satisfies?(Macro.t(), atom(), ([Macro.t()] -> boolean())) :: boolean()
+  def keyword_list_satisfies?(ast, root_key, list_check) when is_function(list_check, 1) do
+    ast_contains?(ast, fn
+      {^root_key, list} when is_list(list) -> list_check.(list)
+      _ -> false
+    end)
+  end
+end

--- a/lib/phoenix_kit/install/css_integration.ex
+++ b/lib/phoenix_kit/install/css_integration.ex
@@ -99,6 +99,11 @@ defmodule PhoenixKit.Install.CssIntegration do
   end
 
   # Update daisyUI plugin configuration to enable all themes
+  #
+  # I103: regex-only, on purpose — this splices into `app.css`, and
+  # `PhoenixKit.Install.ConfigVerify`'s parse-then-verify safety net only
+  # understands Elixir via `Code.string_to_quoted/1`. See `ConfigVerify`'s
+  # moduledoc, "What this deliberately does NOT cover".
   defp update_daisyui_themes_config(source) do
     content = source.content
 

--- a/lib/phoenix_kit/install/js_integration.ex
+++ b/lib/phoenix_kit/install/js_integration.ex
@@ -334,6 +334,13 @@ defmodule PhoenixKit.Install.JsIntegration do
     end
   end
 
+  # I103: regex-only, on purpose — `app.js` is JavaScript, and
+  # `PhoenixKit.Install.ConfigVerify` (the parse-then-verify safety net the
+  # Oban/config.exs splices use) only understands Elixir via
+  # `Code.string_to_quoted/1`. There is no equivalent check available here;
+  # correctness rests entirely on the regex and the `if updated != content`
+  # guard below. See `ConfigVerify`'s moduledoc, "What this deliberately does
+  # NOT cover".
   defp add_hooks_to_app_js(igniter) do
     app_js_path = Path.join([File.cwd!(), "assets", "js", "app.js"])
 
@@ -472,6 +479,11 @@ defmodule PhoenixKit.Install.JsIntegration do
     end
   end
 
+  # I103: regex-only, on purpose — this splices into HEEX, and
+  # `PhoenixKit.Install.ConfigVerify`'s parse-then-verify only understands
+  # Elixir. See `ConfigVerify`'s moduledoc, "What this deliberately does NOT
+  # cover", and `add_hooks_to_app_js/1` above for the same boundary on the JS
+  # side.
   defp inject_modules_script_tag(igniter, layout_path, content) do
     tag = """
         #{@modules_script_marker}

--- a/lib/phoenix_kit/install/oban_config.ex
+++ b/lib/phoenix_kit/install/oban_config.ex
@@ -661,8 +661,17 @@ if Code.ensure_loaded?(Igniter) do
         # inserting there corrupts the file (review finding on this very
         # function). Nested lists are always indented deeper, so anchoring
         # the close to the keyword's indentation skips them.
+        #
+        # I103: the whole pattern is anchored to THIS app's own
+        # `config :app_name, Oban` block first (same prefix `insert_queue/4`
+        # already uses for `queues:`), bounded at the next top-level
+        # `config`/`import_config`. Without it, a host with any OTHER
+        # `plugins: [...]` list earlier in config.exs — a completely
+        # unrelated `config :some_lib, plugins: [...]` — matched first: this
+        # inserted Lifeline into the WRONG application's list and reported
+        # success, while `:app_name`'s own Oban config stayed untouched.
         case Regex.run(
-               ~r/(^([ \t]+)plugins:\s*\[\n)(.*?)(\n\2\])/ms,
+               ~r/(^config\s+:#{app_name},\s+Oban\b(?:(?!\n(?:config\s|import_config\s)).)*?\n([ \t]+)plugins:\s*\[\n)(.*?)(\n\2\])/ms,
                content,
                capture: :all
              ) do
@@ -689,7 +698,7 @@ if Code.ensure_loaded?(Igniter) do
             case ConfigVerify.verify_or_rollback(
                    content,
                    candidate,
-                   &plugins_contains_module?(&1, Oban.Plugins.Lifeline)
+                   &plugins_contains_module?(&1, app_name, Oban.Plugins.Lifeline)
                  ) do
               {:ok, result} ->
                 result
@@ -715,11 +724,16 @@ if Code.ensure_loaded?(Igniter) do
       Mix.shell().error("     Please manually add: #{lifeline_entry()}")
     end
 
-    # True if `ast` has a `plugins: [...]` list somewhere containing a tuple
-    # naming `module` — shared by every splice below that adds a plugin
-    # tuple to an Oban `plugins:` list.
-    defp plugins_contains_module?(ast, module) do
-      ConfigVerify.keyword_list_satisfies?(ast, :plugins, fn list ->
+    # True if `ast` has a `plugins: [...]` list containing a tuple naming
+    # `module`, INSIDE `app_name`'s own `config :app_name, Oban` block —
+    # shared by every splice below that adds a plugin tuple to an Oban
+    # `plugins:` list. Scoped to `app_name` for the same reason the splices
+    # themselves are: an unscoped `keyword_list_satisfies?/3` is satisfied by
+    # ANY `plugins:` list in the file, including a different application's,
+    # and would report success on an insertion that landed in the wrong
+    # place — or never landed at all.
+    defp plugins_contains_module?(ast, app_name, module) do
+      ConfigVerify.app_config_satisfies?(ast, app_name, Oban, :plugins, fn list ->
         Enum.any?(list, &ConfigVerify.tuple_names_module?(&1, module))
       end)
     end
@@ -838,6 +852,15 @@ if Code.ensure_loaded?(Igniter) do
         # Case 1: the old worker is scheduled and the core worker is not.
         # Rename it in place — the core worker's catch-up already calls
         # PhoenixKitPosts.process_scheduled_posts/0, so it subsumes the entry.
+        #
+        # I103: deliberately NOT wrapped in `ConfigVerify.verify_or_rollback/3`,
+        # unlike every other splice in this module — a plain identifier-to-
+        # identifier text substitution cannot land on the wrong bracket or
+        # misplace anything structurally, so there is no failure mode for a
+        # parse-then-verify step to catch. `global: false` is left off (the
+        # default, global replace) on purpose too: if the old module path
+        # somehow appears more than once, renaming every occurrence
+        # consistently is correct, not a hazard to guard against.
         Regex.match?(@old_posts_worker, content) and
             not String.contains?(content, "ProcessScheduledJobsWorker") ->
           Mix.shell().info(
@@ -879,7 +902,7 @@ if Code.ensure_loaded?(Igniter) do
             "  ➕ Adding ProcessScheduledJobsWorker to existing cron configuration..."
           )
 
-          add_scheduled_posts_job_to_crontab(content)
+          add_scheduled_posts_job_to_crontab(content, app_name)
 
         # Case 4: No cron plugin at all - add entire plugin with new worker
         true ->
@@ -907,9 +930,20 @@ if Code.ensure_loaded?(Igniter) do
     # semantic check below only accepts a result where the new tuple shows
     # up as a direct member of the `crontab:` list itself, not buried deeper
     # in some other value that also happened to close with a `]`.
-    defp add_scheduled_posts_job_to_crontab(content) do
-      # Pattern: crontab: [...] within Cron plugin
-      case Regex.run(~r/(crontab:\s*\[)(.*?)(\])/s, content, capture: :all) do
+    #
+    # I103: the pattern is additionally anchored to THIS app's own
+    # `config :app_name, Oban` block, bounded at the next top-level
+    # `config`/`import_config` — same prefix `insert_queue/4` uses for
+    # `queues:`. Without it, the (still lazy) `crontab:` search could match a
+    # different application's `crontab:` list first if one appeared earlier
+    # in config.exs.
+    defp add_scheduled_posts_job_to_crontab(content, app_name) do
+      # Pattern: crontab: [...] within Cron plugin, inside app_name's own block
+      case Regex.run(
+             ~r/(^config\s+:#{app_name},\s+Oban\b(?:(?!\n(?:config\s|import_config\s)).)*?crontab:\s*\[)(.*?)(\])/ms,
+             content,
+             capture: :all
+           ) do
         [full_match, before_crontab, crontab_content, after_crontab] ->
           # `crontab_content` keeps its OWN trailing whitespace/newline up to
           # (not including) the closing `]` — appending straight onto that
@@ -944,6 +978,7 @@ if Code.ensure_loaded?(Igniter) do
                  candidate,
                  &crontab_contains_module?(
                    &1,
+                   app_name,
                    PhoenixKit.ScheduledJobs.Workers.ProcessScheduledJobsWorker
                  )
                ) do
@@ -961,13 +996,15 @@ if Code.ensure_loaded?(Igniter) do
       end
     end
 
-    # True if `ast` has a `crontab: [...]` list somewhere containing a tuple
-    # naming `module` — used both to confirm a splice landed where it was
-    # meant to (a direct list member, not nested inside some other entry's
-    # own value) and, unchanged, to check the SAME thing for the sibling
-    # crontab-splice functions below.
-    defp crontab_contains_module?(ast, module) do
-      ConfigVerify.keyword_list_satisfies?(ast, :crontab, fn list ->
+    # True if `ast` has a `crontab: [...]` list containing a tuple naming
+    # `module`, INSIDE `app_name`'s own `config :app_name, Oban` block — used
+    # both to confirm a splice landed where it was meant to (a direct list
+    # member, not nested inside some other entry's own value) and, unchanged,
+    # to check the SAME thing for the sibling crontab-splice functions below.
+    # Scoped to `app_name` for the same reason `plugins_contains_module?/3`
+    # is: an unscoped check is satisfied by ANY `crontab:` list in the file.
+    defp crontab_contains_module?(ast, app_name, module) do
+      ConfigVerify.app_config_satisfies?(ast, app_name, Oban, :crontab, fn list ->
         Enum.any?(list, &ConfigVerify.tuple_names_module?(&1, module))
       end)
     end
@@ -1055,25 +1092,41 @@ if Code.ensure_loaded?(Igniter) do
       end
     end
 
+    # I103: anchored to THIS app's own `config :app_name, Oban` block (same
+    # prefix `insert_queue/4` uses for `queues:`), and the leading separator
+    # before the new entries now checks `has_trailing_comma` instead of
+    # always prepending `,\n` — the same hardening `add_scheduled_posts_job_to_crontab/2`
+    # already has. A crontab whose last entry legitimately already ends in a
+    # comma (a perfectly ordinary shape, e.g. `mix format`'s own output for a
+    # multi-entry list) got a DOUBLE comma before this fix: `Code.string_to_quoted/1`
+    # then fails, `verify_or_rollback/3` rolls back, and the operator is told
+    # their own config is the problem when the insertion logic was.
     defp add_worker_entries_to_crontab(content, missing, app_name) do
-      case Regex.run(~r/(^([ \t]+)crontab:\s*\[\n)(.*?)(\n\2\])/ms, content, capture: :all) do
+      case Regex.run(
+             ~r/(^config\s+:#{app_name},\s+Oban\b(?:(?!\n(?:config\s|import_config\s)).)*?\n([ \t]+)crontab:\s*\[\n)(.*?)(\n\2\])/ms,
+             content,
+             capture: :all
+           ) do
         [full_match, crontab_open, indent, crontab_content, crontab_close] ->
           entry_indent = indent <> "  "
+          trimmed_content = String.trim_trailing(crontab_content)
+          has_trailing_comma = String.ends_with?(trimmed_content, ",")
 
-          new_entries =
-            Enum.map_join(missing, "", fn {cron, mod} ->
-              ",\n#{entry_indent}{\"#{cron}\", #{mod}}"
+          entries =
+            Enum.map_join(missing, ",\n", fn {cron, mod} ->
+              "#{entry_indent}{\"#{cron}\", #{mod}}"
             end)
 
-          updated =
-            crontab_open <> String.trim_trailing(crontab_content) <> new_entries <> crontab_close
+          new_entries = if has_trailing_comma, do: "\n" <> entries, else: ",\n" <> entries
+
+          updated = crontab_open <> trimmed_content <> new_entries <> crontab_close
 
           candidate = String.replace(content, full_match, updated, global: false)
 
           case ConfigVerify.verify_or_rollback(
                  content,
                  candidate,
-                 &crontab_has_all_modules?(&1, missing)
+                 &crontab_has_all_modules?(&1, app_name, missing)
                ) do
             {:ok, result} ->
               result
@@ -1101,9 +1154,11 @@ if Code.ensure_loaded?(Igniter) do
     end
 
     # True if `ast` has a `crontab: [...]` list containing, for EVERY
-    # `{_cron, mod_string}` pair in `missing`, a tuple naming that module.
-    defp crontab_has_all_modules?(ast, missing) do
-      ConfigVerify.keyword_list_satisfies?(ast, :crontab, fn list ->
+    # `{_cron, mod_string}` pair in `missing`, a tuple naming that module —
+    # scoped to `app_name`'s own Oban block for the same reason
+    # `crontab_contains_module?/3` is.
+    defp crontab_has_all_modules?(ast, app_name, missing) do
+      ConfigVerify.app_config_satisfies?(ast, app_name, Oban, :crontab, fn list ->
         Enum.all?(missing, fn {_cron, mod} ->
           module = Module.concat(String.split(mod, "."))
           Enum.any?(list, &ConfigVerify.tuple_names_module?(&1, module))
@@ -1115,26 +1170,40 @@ if Code.ensure_loaded?(Igniter) do
     # anchored to the `crontab:` keyword's own indentation (backreference `\\2`)
     # for the same reason as `add_cron_plugin_to_plugins/2`: a lazy `.*?` to the
     # first `]` can stop inside an entry's own nested list.
+    #
+    # I103: anchored to THIS app's own `config :app_name, Oban` block (same
+    # prefix as `add_worker_entries_to_crontab/3`), and the leading separator
+    # before the new entries checks `has_trailing_comma` instead of always
+    # prepending `,\n` — see `add_worker_entries_to_crontab/3` for why an
+    # unconditional leading comma corrupts a crontab that legitimately
+    # already ends in one.
     defp add_digest_entries_to_crontab(content, missing, app_name) do
-      case Regex.run(~r/(^([ \t]+)crontab:\s*\[\n)(.*?)(\n\2\])/ms, content, capture: :all) do
+      case Regex.run(
+             ~r/(^config\s+:#{app_name},\s+Oban\b(?:(?!\n(?:config\s|import_config\s)).)*?\n([ \t]+)crontab:\s*\[\n)(.*?)(\n\2\])/ms,
+             content,
+             capture: :all
+           ) do
         [full_match, crontab_open, indent, crontab_content, crontab_close] ->
           entry_indent = indent <> "  "
+          trimmed_content = String.trim_trailing(crontab_content)
+          has_trailing_comma = String.ends_with?(trimmed_content, ",")
 
-          new_entries =
-            Enum.map_join(missing, "", fn {cron, cadence} ->
-              ",\n#{entry_indent}{\"#{cron}\", PhoenixKit.Notifications.DigestWorker, " <>
+          entries =
+            Enum.map_join(missing, ",\n", fn {cron, cadence} ->
+              "#{entry_indent}{\"#{cron}\", PhoenixKit.Notifications.DigestWorker, " <>
                 "args: %{cadence: \"#{cadence}\"}}"
             end)
 
-          updated =
-            crontab_open <> String.trim_trailing(crontab_content) <> new_entries <> crontab_close
+          new_entries = if has_trailing_comma, do: "\n" <> entries, else: ",\n" <> entries
+
+          updated = crontab_open <> trimmed_content <> new_entries <> crontab_close
 
           candidate = String.replace(content, full_match, updated, global: false)
 
           case ConfigVerify.verify_or_rollback(
                  content,
                  candidate,
-                 &crontab_has_all_digest_cadences?(&1, missing)
+                 &crontab_has_all_digest_cadences?(&1, app_name, missing)
                ) do
             {:ok, result} ->
               result
@@ -1169,8 +1238,8 @@ if Code.ensure_loaded?(Igniter) do
     # map carries that exact cadence — not just "a DigestWorker tuple
     # exists somewhere", which would pass even if only one of several
     # missing cadences actually landed.
-    defp crontab_has_all_digest_cadences?(ast, missing) do
-      ConfigVerify.keyword_list_satisfies?(ast, :crontab, fn list ->
+    defp crontab_has_all_digest_cadences?(ast, app_name, missing) do
+      ConfigVerify.app_config_satisfies?(ast, app_name, Oban, :crontab, fn list ->
         Enum.all?(missing, fn {_cron, cadence} ->
           Enum.any?(list, &digest_tuple_has_cadence?(&1, cadence))
         end)
@@ -1215,8 +1284,12 @@ if Code.ensure_loaded?(Igniter) do
       # stats plugin — puts one right there), and inserting there corrupts
       # the file. Nested lists are always indented deeper, so anchoring to
       # the keyword's indentation skips them.
+      #
+      # I103: also anchored to THIS app's own `config :app_name, Oban` block
+      # — see `ensure_lifeline_plugin/2` for why an unanchored `plugins:`
+      # search can match a different application's list first.
       case Regex.run(
-             ~r/(^([ \t]+)plugins:\s*\[\n)(.*?)(\n\2\])/ms,
+             ~r/(^config\s+:#{app_name},\s+Oban\b(?:(?!\n(?:config\s|import_config\s)).)*?\n([ \t]+)plugins:\s*\[\n)(.*?)(\n\2\])/ms,
              content,
              capture: :all
            ) do
@@ -1256,6 +1329,7 @@ if Code.ensure_loaded?(Igniter) do
                  candidate,
                  &crontab_contains_module?(
                    &1,
+                   app_name,
                    PhoenixKit.ScheduledJobs.Workers.ProcessScheduledJobsWorker
                  )
                ) do

--- a/lib/phoenix_kit/install/oban_config.ex
+++ b/lib/phoenix_kit/install/oban_config.ex
@@ -31,9 +31,18 @@ if Code.ensure_loaded?(Igniter) do
     @dialyzer {:nowarn_function, ensure_lifeline_plugin: 2}
     @dialyzer {:nowarn_function, maybe_raise_lifeline_rescue_after: 1}
     @dialyzer {:nowarn_function, add_cron_plugin_to_plugins: 2}
+    @dialyzer {:nowarn_function, queue_manual_notice: 3}
+    @dialyzer {:nowarn_function, lifeline_manual_notice: 1}
+    @dialyzer {:nowarn_function, scheduled_posts_job_manual_notice: 0}
+    @dialyzer {:nowarn_function, worker_entries_manual_notice: 2}
+    @dialyzer {:nowarn_function, digest_entries_manual_notice: 2}
+    @dialyzer {:nowarn_function, cron_plugin_manual_notice: 1}
+    @dialyzer {:nowarn_function, pruner_manual_notice: 0}
+    @dialyzer {:nowarn_function, apply_pruner_max_age: 2}
 
     alias Igniter.Libs.Phoenix
     alias Igniter.Project.Application
+    alias PhoenixKit.Install.ConfigVerify
     alias PhoenixKit.Install.IgniterHelpers
 
     # Lifeline rescues purely by elapsed time, with no check that the node
@@ -439,16 +448,54 @@ if Code.ensure_loaded?(Igniter) do
           updated_queues =
             queues_open <> add_queue_entry(queues_content, indent <> "  ", entry) <> queues_close
 
-          String.replace(content, full_match, updated_queues, global: false)
+          candidate = String.replace(content, full_match, updated_queues, global: false)
+          queue_atom = String.to_atom(queue)
+
+          case ConfigVerify.verify_or_rollback(
+                 content,
+                 candidate,
+                 &keyword_list_has_key?(&1, :queues, queue_atom, limit)
+               ) do
+            {:ok, result} ->
+              result
+
+            {:rolled_back, original, _reason} ->
+              queue_manual_notice(app_name, queue, limit)
+              original
+          end
 
         nil ->
-          Mix.shell().error(
-            "  ⚠️  Could not parse queues block for :#{app_name} - skipping #{queue} queue update"
-          )
-
-          Mix.shell().error("     Please manually add: #{queue}: #{limit}")
+          queue_manual_notice(app_name, queue, limit)
           content
       end
+    end
+
+    defp queue_manual_notice(app_name, queue, limit) do
+      Mix.shell().error(
+        "  ⚠️  Could not safely add #{queue} to the queues block for :#{app_name} " <>
+          "(not found, or the insertion would have produced invalid or misplaced config)"
+      )
+
+      Mix.shell().error("     Please manually add: #{queue}: #{limit}")
+    end
+
+    # True if `ast` has a `root_key: [...]` list containing `{key, value}` or
+    # `{key, [limit: value]}` — the two shapes Oban accepts for a queue entry,
+    # and the shared check behind confirming a splice into any flat
+    # `key: value`-style keyword list (queues here) actually landed.
+    defp keyword_list_has_key?(ast, root_key, key, value) do
+      ConfigVerify.keyword_list_satisfies?(ast, root_key, fn list ->
+        Enum.any?(list, fn
+          {^key, ^value} ->
+            true
+
+          {^key, kw} when is_list(kw) ->
+            ConfigVerify.keyword_get(kw, :limit) == {:ok, value}
+
+          _ ->
+            false
+        end)
+      end)
     end
 
     # The entry goes after the last line carrying code, not at the end of the
@@ -489,7 +536,13 @@ if Code.ensure_loaded?(Igniter) do
     end
 
     # Ensure Pruner has max_age configured for 30-day retention
-    defp ensure_pruner_max_age(content, _app_name) do
+    # I103: exposed (not `defp`) and `@doc false`, same reason as
+    # `ensure_lifeline_plugin/2` above — a real unit-test seam for the
+    # verify-and-rollback behavior against plain content strings, without an
+    # Igniter/Rewrite context (this is only otherwise reachable through the
+    # full `update_existing_oban_config/3` pipeline).
+    @doc false
+    def ensure_pruner_max_age(content, _app_name) do
       # Check if max_age is already configured
       if Regex.match?(~r/Oban\.Plugins\.Pruner.*max_age:/s, content) do
         Mix.shell().info("  ℹ️  Pruner max_age already configured")
@@ -500,27 +553,69 @@ if Code.ensure_loaded?(Igniter) do
           Mix.shell().info("  ➕ Adding max_age to Oban.Plugins.Pruner...")
 
           # Replace bare Pruner with tuple form including max_age
-          Regex.replace(
-            ~r/Oban\.Plugins\.Pruner(\s*)(,|\])/,
-            content,
-            "{Oban.Plugins.Pruner, max_age: 60 * 60 * 24 * 30}\\1\\2  # Keep jobs for 30 days"
-          )
+          candidate =
+            Regex.replace(
+              ~r/Oban\.Plugins\.Pruner(\s*)(,|\])/,
+              content,
+              "{Oban.Plugins.Pruner, max_age: 60 * 60 * 24 * 30}\\1\\2  # Keep jobs for 30 days"
+            )
+
+          apply_pruner_max_age(content, candidate)
         else
           # Check for tuple form without max_age: {Oban.Plugins.Pruner}
           if Regex.match?(~r/\{Oban\.Plugins\.Pruner\}/, content) do
             Mix.shell().info("  ➕ Adding max_age to {Oban.Plugins.Pruner}...")
 
-            String.replace(
-              content,
-              "{Oban.Plugins.Pruner}",
-              "{Oban.Plugins.Pruner, max_age: 60 * 60 * 24 * 30}  # Keep jobs for 30 days"
-            )
+            candidate =
+              String.replace(
+                content,
+                "{Oban.Plugins.Pruner}",
+                "{Oban.Plugins.Pruner, max_age: 60 * 60 * 24 * 30}  # Keep jobs for 30 days"
+              )
+
+            apply_pruner_max_age(content, candidate)
           else
             Mix.shell().info("  ℹ️  Pruner configuration not found or already has options")
             content
           end
         end
       end
+    end
+
+    defp apply_pruner_max_age(content, candidate) do
+      case ConfigVerify.verify_or_rollback(content, candidate, &pruner_has_max_age?/1) do
+        {:ok, result} ->
+          result
+
+        {:rolled_back, original, _reason} ->
+          pruner_manual_notice()
+          original
+      end
+    end
+
+    defp pruner_manual_notice do
+      Mix.shell().error(
+        "  ⚠️  Could not safely add max_age to Oban.Plugins.Pruner " <>
+          "(the insertion would have produced invalid or misplaced config) - please add it manually:"
+      )
+
+      Mix.shell().error("     {Oban.Plugins.Pruner, max_age: 60 * 60 * 24 * 30}")
+    end
+
+    defp pruner_has_max_age?(ast) do
+      ConfigVerify.ast_contains?(ast, fn node ->
+        case ConfigVerify.tuple_elements(node) do
+          nil ->
+            false
+
+          elements ->
+            Enum.any?(elements, &ConfigVerify.alias_matches?(&1, Oban.Plugins.Pruner)) and
+              Enum.any?(elements, fn
+                kw when is_list(kw) -> match?({:ok, _}, ConfigVerify.keyword_get(kw, :max_age))
+                _ -> false
+              end)
+        end
+      end)
     end
 
     @doc """
@@ -589,19 +684,44 @@ if Code.ensure_loaded?(Igniter) do
               end
 
             updated_plugins = plugins_open <> plugins_content <> lifeline_plugin <> plugins_close
+            candidate = String.replace(content, full_match, updated_plugins, global: false)
 
-            String.replace(content, full_match, updated_plugins, global: false)
+            case ConfigVerify.verify_or_rollback(
+                   content,
+                   candidate,
+                   &plugins_contains_module?(&1, Oban.Plugins.Lifeline)
+                 ) do
+              {:ok, result} ->
+                result
+
+              {:rolled_back, original, _reason} ->
+                lifeline_manual_notice(app_name)
+                original
+            end
 
           nil ->
-            Mix.shell().error(
-              "  ⚠️  Could not parse plugins block for :#{app_name} - skipping Lifeline plugin update"
-            )
-
-            Mix.shell().error("     Please manually add: #{lifeline_entry()}")
-
+            lifeline_manual_notice(app_name)
             content
         end
       end
+    end
+
+    defp lifeline_manual_notice(app_name) do
+      Mix.shell().error(
+        "  ⚠️  Could not safely add Lifeline to the plugins block for :#{app_name} " <>
+          "(not found, or the insertion would have produced invalid or misplaced config)"
+      )
+
+      Mix.shell().error("     Please manually add: #{lifeline_entry()}")
+    end
+
+    # True if `ast` has a `plugins: [...]` list somewhere containing a tuple
+    # naming `module` — shared by every splice below that adds a plugin
+    # tuple to an Oban `plugins:` list.
+    defp plugins_contains_module?(ast, module) do
+      ConfigVerify.keyword_list_satisfies?(ast, :plugins, fn list ->
+        Enum.any?(list, &ConfigVerify.tuple_names_module?(&1, module))
+      end)
     end
 
     # Single source for the entry every emit site writes, so the value and the
@@ -633,7 +753,25 @@ if Code.ensure_loaded?(Igniter) do
                 "(at or below PhoenixKit's longest worker timeout, jobs would be rescued mid-flight)"
             )
 
-            String.replace(content, full_match, lifeline_entry(), global: false)
+            candidate = String.replace(content, full_match, lifeline_entry(), global: false)
+
+            case ConfigVerify.verify_or_rollback(
+                   content,
+                   candidate,
+                   &lifeline_rescue_after_raised?/1
+                 ) do
+              {:ok, result} ->
+                result
+
+              {:rolled_back, original, _reason} ->
+                Mix.shell().error(
+                  "  ⚠️  Could not safely raise Lifeline rescue_after " <>
+                    "(the replacement would have produced invalid or misplaced config) - please set it manually:"
+                )
+
+                Mix.shell().error("     #{lifeline_entry()}")
+                original
+            end
           else
             Mix.shell().info("  ℹ️  Lifeline plugin already configured")
             content
@@ -644,6 +782,36 @@ if Code.ensure_loaded?(Igniter) do
           content
       end
     end
+
+    defp lifeline_rescue_after_raised?(ast) do
+      ConfigVerify.ast_contains?(ast, fn node ->
+        case ConfigVerify.tuple_elements(node) do
+          nil -> false
+          elements -> lifeline_tuple_raised?(elements)
+        end
+      end)
+    end
+
+    defp lifeline_tuple_raised?(elements) do
+      Enum.any?(elements, &ConfigVerify.alias_matches?(&1, Oban.Plugins.Lifeline)) and
+        Enum.any?(elements, &rescue_after_raised?/1)
+    end
+
+    # `:timer.minutes(N)` calls the ERLANG `:timer` module — a lowercase
+    # atom, not an Elixir alias — so its AST head is a bare `:timer` atom,
+    # never `{:__aliases__, _, [:timer]}` (that shape is for a capitalized
+    # Elixir module reference).
+    defp rescue_after_raised?(kw) when is_list(kw) do
+      case ConfigVerify.keyword_get(kw, :rescue_after) do
+        {:ok, {{:., _, [:timer, :minutes]}, _, [minutes]}} ->
+          minutes == @lifeline_rescue_after_minutes
+
+        _ ->
+          false
+      end
+    end
+
+    defp rescue_after_raised?(_), do: false
 
     # Any module path ending in the old worker's name. The replacement used to
     # be the literal "PhoenixKit.Posts.Workers.PublishScheduledPostsJob", a
@@ -721,27 +889,98 @@ if Code.ensure_loaded?(Igniter) do
     end
 
     # Add ProcessScheduledJobsWorker to existing crontab
+    #
+    # I103: this is the one crontab-splice function that used a lazy `.*?`
+    # instead of the anchored, same-indentation-close pattern the sibling
+    # functions below use (`add_worker_entries_to_crontab/3`,
+    # `add_digest_entries_to_crontab/3`) — the only one of the six
+    # block-splice helpers in this file with no anchor at all. Reproduced
+    # live: an entirely ordinary comment inside the crontab block containing
+    # a `]` (e.g. "# historically took a priority list, e.g. [1, 2] - removed")
+    # makes the lazy match stop at the comment's own bracket and corrupts the
+    # file into invalid Elixir. A DIFFERENT shape — an existing entry whose
+    # own `args:` value is itself a list (`args: %{tags: ["a", "b"]}`) —
+    # corrupts just as badly but produces something that still PARSES: the
+    # new entry lands nested inside that list instead of as a crontab
+    # sibling. `ConfigVerify.verify_or_rollback/3` catches both: the first
+    # via `Code.string_to_quoted/1` failing outright, the second because the
+    # semantic check below only accepts a result where the new tuple shows
+    # up as a direct member of the `crontab:` list itself, not buried deeper
+    # in some other value that also happened to close with a `]`.
     defp add_scheduled_posts_job_to_crontab(content) do
       # Pattern: crontab: [...] within Cron plugin
       case Regex.run(~r/(crontab:\s*\[)(.*?)(\])/s, content, capture: :all) do
         [full_match, before_crontab, crontab_content, after_crontab] ->
-          # Check if crontab is empty or has entries
+          # `crontab_content` keeps its OWN trailing whitespace/newline up to
+          # (not including) the closing `]` — appending straight onto that
+          # puts a bare `,` alone on its own line, detached by a newline from
+          # the element before it, which Elixir's parser rejects outright
+          # ("syntax error before: ','"). `String.trim_trailing/1` here
+          # matches what the anchored sibling splices below already do
+          # correctly (`add_worker_entries_to_crontab/3`,
+          # `add_digest_entries_to_crontab/3`): drop the trailing whitespace
+          # first, so the new comma lands directly after the last real token.
+          trimmed_entries = String.trim_trailing(crontab_content)
           has_entries = String.trim(crontab_content) != ""
+          has_trailing_comma = String.ends_with?(trimmed_entries, ",")
 
           new_job_entry =
-            if has_entries do
-              ",\n           {\"* * * * *\", PhoenixKit.ScheduledJobs.Workers.ProcessScheduledJobsWorker}"
-            else
-              "\n           {\"* * * * *\", PhoenixKit.ScheduledJobs.Workers.ProcessScheduledJobsWorker}\n         "
+            cond do
+              not has_entries ->
+                "\n           {\"* * * * *\", PhoenixKit.ScheduledJobs.Workers.ProcessScheduledJobsWorker}\n         "
+
+              has_trailing_comma ->
+                "\n           {\"* * * * *\", PhoenixKit.ScheduledJobs.Workers.ProcessScheduledJobsWorker}\n"
+
+              true ->
+                ",\n           {\"* * * * *\", PhoenixKit.ScheduledJobs.Workers.ProcessScheduledJobsWorker}\n"
             end
 
-          updated_crontab = before_crontab <> crontab_content <> new_job_entry <> after_crontab
+          updated_crontab = before_crontab <> trimmed_entries <> new_job_entry <> after_crontab
+          candidate = String.replace(content, full_match, updated_crontab, global: false)
 
-          String.replace(content, full_match, updated_crontab, global: false)
+          case ConfigVerify.verify_or_rollback(
+                 content,
+                 candidate,
+                 &crontab_contains_module?(
+                   &1,
+                   PhoenixKit.ScheduledJobs.Workers.ProcessScheduledJobsWorker
+                 )
+               ) do
+            {:ok, result} ->
+              result
+
+            {:rolled_back, original, _reason} ->
+              scheduled_posts_job_manual_notice()
+              original
+          end
 
         _ ->
+          scheduled_posts_job_manual_notice()
           content
       end
+    end
+
+    # True if `ast` has a `crontab: [...]` list somewhere containing a tuple
+    # naming `module` — used both to confirm a splice landed where it was
+    # meant to (a direct list member, not nested inside some other entry's
+    # own value) and, unchanged, to check the SAME thing for the sibling
+    # crontab-splice functions below.
+    defp crontab_contains_module?(ast, module) do
+      ConfigVerify.keyword_list_satisfies?(ast, :crontab, fn list ->
+        Enum.any?(list, &ConfigVerify.tuple_names_module?(&1, module))
+      end)
+    end
+
+    defp scheduled_posts_job_manual_notice do
+      Mix.shell().error(
+        "  ⚠️  Could not safely add ProcessScheduledJobsWorker to the existing crontab " <>
+          "(the insertion would have produced invalid or misplaced config) - please add it manually:"
+      )
+
+      Mix.shell().error(
+        "     {\"* * * * *\", PhoenixKit.ScheduledJobs.Workers.ProcessScheduledJobsWorker}"
+      )
     end
 
     # The notification digest sweeps — one cron entry per cadence, matching the
@@ -829,15 +1068,47 @@ if Code.ensure_loaded?(Igniter) do
           updated =
             crontab_open <> String.trim_trailing(crontab_content) <> new_entries <> crontab_close
 
-          String.replace(content, full_match, updated, global: false)
+          candidate = String.replace(content, full_match, updated, global: false)
+
+          case ConfigVerify.verify_or_rollback(
+                 content,
+                 candidate,
+                 &crontab_has_all_modules?(&1, missing)
+               ) do
+            {:ok, result} ->
+              result
+
+            {:rolled_back, original, _reason} ->
+              worker_entries_manual_notice(app_name, missing)
+              original
+          end
 
         nil ->
-          Mix.shell().error(
-            "  ⚠️  Could not parse crontab block for :#{app_name} - skipping worker cron entries"
-          )
-
+          worker_entries_manual_notice(app_name, missing)
           content
       end
+    end
+
+    defp worker_entries_manual_notice(app_name, missing) do
+      Mix.shell().error(
+        "  ⚠️  Could not safely add worker cron entries for :#{app_name} " <>
+          "(crontab block not found, or the insertion would have produced invalid or misplaced config)"
+      )
+
+      Enum.each(missing, fn {cron, mod} ->
+        Mix.shell().error("     Please manually add: {\"#{cron}\", #{mod}}")
+      end)
+    end
+
+    # True if `ast` has a `crontab: [...]` list containing, for EVERY
+    # `{_cron, mod_string}` pair in `missing`, a tuple naming that module.
+    defp crontab_has_all_modules?(ast, missing) do
+      ConfigVerify.keyword_list_satisfies?(ast, :crontab, fn list ->
+        Enum.all?(missing, fn {_cron, mod} ->
+          module = Module.concat(String.split(mod, "."))
+          Enum.any?(list, &ConfigVerify.tuple_names_module?(&1, module))
+        end)
+      end)
     end
 
     # Append the missing entries to the existing crontab list. The closing `]` is
@@ -858,18 +1129,76 @@ if Code.ensure_loaded?(Igniter) do
           updated =
             crontab_open <> String.trim_trailing(crontab_content) <> new_entries <> crontab_close
 
-          String.replace(content, full_match, updated, global: false)
+          candidate = String.replace(content, full_match, updated, global: false)
+
+          case ConfigVerify.verify_or_rollback(
+                 content,
+                 candidate,
+                 &crontab_has_all_digest_cadences?(&1, missing)
+               ) do
+            {:ok, result} ->
+              result
+
+            {:rolled_back, original, _reason} ->
+              digest_entries_manual_notice(app_name, missing)
+              original
+          end
 
         nil ->
-          Mix.shell().error(
-            "  ⚠️  Could not parse crontab block for :#{app_name} - skipping digest cron entries"
-          )
-
-          Mix.shell().error(
-            "     Please manually add the PhoenixKit.Notifications.DigestWorker cron entries"
-          )
-
+          digest_entries_manual_notice(app_name, missing)
           content
+      end
+    end
+
+    defp digest_entries_manual_notice(app_name, missing) do
+      Mix.shell().error(
+        "  ⚠️  Could not safely add digest cron entries for :#{app_name} " <>
+          "(crontab block not found, or the insertion would have produced invalid or misplaced config)"
+      )
+
+      Enum.each(missing, fn {cron, cadence} ->
+        Mix.shell().error(
+          "     Please manually add: {\"#{cron}\", PhoenixKit.Notifications.DigestWorker, " <>
+            "args: %{cadence: \"#{cadence}\"}}"
+        )
+      end)
+    end
+
+    # True if `ast` has a `crontab: [...]` list containing, for EVERY
+    # `{_cron, cadence}` in `missing`, a DigestWorker tuple whose `args:`
+    # map carries that exact cadence — not just "a DigestWorker tuple
+    # exists somewhere", which would pass even if only one of several
+    # missing cadences actually landed.
+    defp crontab_has_all_digest_cadences?(ast, missing) do
+      ConfigVerify.keyword_list_satisfies?(ast, :crontab, fn list ->
+        Enum.all?(missing, fn {_cron, cadence} ->
+          Enum.any?(list, &digest_tuple_has_cadence?(&1, cadence))
+        end)
+      end)
+    end
+
+    defp digest_tuple_has_cadence?(node, cadence) do
+      case ConfigVerify.tuple_elements(node) do
+        nil ->
+          false
+
+        elements ->
+          Enum.any?(
+            elements,
+            &ConfigVerify.alias_matches?(&1, PhoenixKit.Notifications.DigestWorker)
+          ) and
+            Enum.any?(elements, fn
+              kw when is_list(kw) ->
+                with {:ok, {:%{}, _meta, map_kv}} <- ConfigVerify.keyword_get(kw, :args),
+                     {:ok, ^cadence} <- ConfigVerify.keyword_get(map_kv, :cadence) do
+                  true
+                else
+                  _ -> false
+                end
+
+              _ ->
+                false
+            end)
       end
     end
 
@@ -920,17 +1249,37 @@ if Code.ensure_loaded?(Igniter) do
             end
 
           updated_plugins = plugins_open <> plugins_content <> cron_plugin <> plugins_close
+          candidate = String.replace(content, full_match, updated_plugins, global: false)
 
-          String.replace(content, full_match, updated_plugins, global: false)
+          case ConfigVerify.verify_or_rollback(
+                 content,
+                 candidate,
+                 &crontab_contains_module?(
+                   &1,
+                   PhoenixKit.ScheduledJobs.Workers.ProcessScheduledJobsWorker
+                 )
+               ) do
+            {:ok, result} ->
+              result
+
+            {:rolled_back, original, _reason} ->
+              cron_plugin_manual_notice(app_name)
+              original
+          end
 
         nil ->
-          Mix.shell().error(
-            "  ⚠️  Could not parse plugins block for :#{app_name} - skipping cron plugin update"
-          )
-
-          Mix.shell().error("     Please manually add Oban.Plugins.Cron configuration")
+          cron_plugin_manual_notice(app_name)
           content
       end
+    end
+
+    defp cron_plugin_manual_notice(app_name) do
+      Mix.shell().error(
+        "  ⚠️  Could not safely add Oban.Plugins.Cron to the plugins block for :#{app_name} " <>
+          "(not found, or the insertion would have produced invalid or misplaced config)"
+      )
+
+      Mix.shell().error("     Please manually add Oban.Plugins.Cron configuration")
     end
 
     # Get repo module from PhoenixKit config or detect from app

--- a/lib/phoenix_kit/install/runtime_detector.ex
+++ b/lib/phoenix_kit/install/runtime_detector.ex
@@ -15,6 +15,8 @@ defmodule PhoenixKit.Install.RuntimeDetector do
   `undefined function config/3`.
   """
 
+  alias PhoenixKit.Install.ConfigVerify
+
   @doc """
   Detects if the project uses runtime configuration patterns.
 
@@ -279,11 +281,46 @@ defmodule PhoenixKit.Install.RuntimeDetector do
     if already_wrapped? do
       content
     else
-      Regex.replace(@unguarded_216_mailer, content, String.trim(@wrapped_dev_mailer))
+      candidate = Regex.replace(@unguarded_216_mailer, content, String.trim(@wrapped_dev_mailer))
+
+      # I103: this function is a pure String -> String transform with no
+      # Igniter/Mix.shell context to print a notice through, so a rollback
+      # here is silent by necessity — same "no-op" contract this function
+      # already documents for the already-wrapped/absent cases, just
+      # extended to a would-be-corrupting match too. `@unguarded_216_mailer`
+      # anchors on an exact, specific multi-line snippet rather than a
+      # variable-length block, so this is lower risk than the Oban splices;
+      # verified anyway, for the same reason as every other site in I103 —
+      # a regex match on raw text is still blind to what it lands inside.
+      case ConfigVerify.verify_or_rollback(content, candidate, &mailer_wrapped_in_dev_guard?/1) do
+        {:ok, result} -> result
+        {:rolled_back, original, _reason} -> original
+      end
     end
   end
 
   # Private functions
+
+  # True if `ast` has `if config_env() == :dev do ... end` wrapping a real
+  # `config :phoenix_kit, PhoenixKit.Mailer, ...` call — confirms the wrap
+  # landed on the actual mailer config, not on a comment or string that
+  # happened to match the same anchored text.
+  defp mailer_wrapped_in_dev_guard?(ast) do
+    ConfigVerify.ast_contains?(ast, fn
+      {:if, _, [{:==, _, [{:config_env, _, []}, :dev]}, [do: body]]} ->
+        mailer_config_call?(body)
+
+      _ ->
+        false
+    end)
+  end
+
+  defp mailer_config_call?(
+         {:config, _, [:phoenix_kit, {:__aliases__, _, [:PhoenixKit, :Mailer]}, _opts]}
+       ),
+       do: true
+
+  defp mailer_config_call?(_), do: false
 
   defp optional_file(path) do
     case File.read(path) do

--- a/test/mix/tasks/phoenix_kit_update_ueberauth_test.exs
+++ b/test/mix/tasks/phoenix_kit_update_ueberauth_test.exs
@@ -1,0 +1,83 @@
+defmodule Mix.Tasks.PhoenixKit.Update.UeberauthConfigTest do
+  @moduledoc """
+  I103, finding 2 (MEDIUM): `fix_ueberauth_providers_config/2` used to build
+  its regex candidate from `content` the CALLER
+  (`validate_and_fix_ueberauth_config/1`) had already read off disk, then
+  unconditionally overwrite the Igniter buffer with it. On a real `mix
+  phoenix_kit.update` run, `BasicConfiguration.add_basic_config/1` and
+  `PrefixConfig.add_prefix_configuration/2` both write to
+  `config/config.exs` earlier in the SAME pipeline — Igniter never flushes
+  those writes to disk before this step runs, so the stale-content-based
+  overwrite silently discarded them.
+
+  Reproduced here the same way as `PhoenixKit.Install.BootHookTest`: an
+  Igniter "probe" — stage an edit to config/config.exs, then run the fixed
+  function, and confirm the earlier edit survives.
+  """
+  use ExUnit.Case, async: true
+
+  import Igniter.Test
+
+  alias Mix.Tasks.PhoenixKit.Update
+
+  @config_file "config/config.exs"
+
+  @initial_content """
+  import Config
+
+  config :ueberauth, Ueberauth,
+    providers: []
+  """
+
+  defp config_content(igniter) do
+    igniter.rewrite |> Rewrite.source!(@config_file) |> Rewrite.Source.get(:content)
+  end
+
+  # Stands in for `PrefixConfig.add_prefix_configuration/2` (or
+  # `BasicConfiguration.add_basic_config/1`): an earlier step in the SAME
+  # pipeline run staging an edit to the SAME file.
+  defp stage_prefix_backfill(igniter) do
+    Igniter.update_file(igniter, @config_file, fn source ->
+      content = Rewrite.Source.get(source, :content)
+      updated = content <> "\nconfig :phoenix_kit, prefix: \"acme\"\n"
+      Rewrite.Source.update(source, :content, updated)
+    end)
+  end
+
+  test "does not discard an earlier step's edit to config/config.exs" do
+    igniter =
+      test_project(files: %{@config_file => @initial_content})
+      |> stage_prefix_backfill()
+      |> Update.fix_ueberauth_providers_config()
+      |> apply_igniter!()
+
+    content = config_content(igniter)
+
+    assert content =~ ~r/config :phoenix_kit, prefix: "acme"/,
+           "the earlier step's prefix backfill was discarded:\n#{content}"
+
+    assert content =~ "providers: %{}",
+           "the ueberauth fix itself did not land:\n#{content}"
+
+    refute content =~ "providers: []"
+  end
+
+  test "rolls back instead of reporting success when the match isn't a real config call" do
+    # The regex has no notion of strings — it matches the same text whether
+    # it names a real `config :ueberauth, Ueberauth, providers: []` call or
+    # just happens to appear inside a string literal. The replacement still
+    # produces syntactically valid Elixir either way (a string's contents
+    # don't affect parse validity), so only the semantic check —
+    # confirming a REAL `config(:ueberauth, Ueberauth, providers: %{})` call
+    # exists in the AST — catches this and rolls back instead of reporting
+    # success over nothing.
+    weird = ~s(some_string = "config :ueberauth, Ueberauth, providers: []"\n)
+
+    igniter =
+      test_project(files: %{@config_file => weird})
+      |> Update.fix_ueberauth_providers_config()
+      |> apply_igniter!()
+
+    assert config_content(igniter) == weird
+  end
+end

--- a/test/phoenix_kit/install/boot_hook_test.exs
+++ b/test/phoenix_kit/install/boot_hook_test.exs
@@ -1,0 +1,121 @@
+defmodule PhoenixKit.Install.BootHookTest do
+  @moduledoc """
+  I103, finding 1 (CRITICAL): `add_boot_hook/1` used to read
+  `lib/<app>/application.ex` straight off disk and unconditionally overwrite
+  the Igniter buffer with a candidate built from that stale read. Igniter
+  never flushes a step's writes to disk before the next step runs, so on a
+  fresh install — where an EARLIER step in the same run
+  (`ApplicationSupervisor.add_supervisor/2`) stages `PhoenixKit.Supervisor`
+  into the same file's `children` list — that earlier edit was silently
+  discarded: the host got a boot pipe with no supervisor in it, and the
+  installer reported success.
+
+  Reproduced here with an Igniter "probe": two `Igniter.update_file/3` calls
+  against the SAME file in the SAME pipeline run, the second one being
+  `add_boot_hook/1` itself. No real Mix task or disk I/O involved — this is
+  exactly what `PhoenixKit.Install.Common.ensure_compilers_registered/2`'s
+  own tests already do via `Igniter.Test`.
+  """
+  use ExUnit.Case, async: true
+
+  import Igniter.Test
+
+  alias PhoenixKit.Install.BootHook
+
+  @app_file "lib/my_app/application.ex"
+
+  @initial_content """
+  defmodule MyApp.Application do
+    use Application
+
+    @impl true
+    def start(_type, _args) do
+      children = [
+        MyApp.Repo,
+        MyAppWeb.Endpoint
+      ]
+
+      opts = [strategy: :one_for_one, name: MyApp.Supervisor]
+      Supervisor.start_link(children, opts)
+    end
+  end
+  """
+
+  defp app_content(igniter) do
+    igniter.rewrite |> Rewrite.source!(@app_file) |> Rewrite.Source.get(:content)
+  end
+
+  # Stands in for `ApplicationSupervisor.add_supervisor/2`: an earlier step
+  # in the SAME pipeline run staging an edit to the SAME file, via the same
+  # `Igniter.update_file/3` + `Rewrite.Source` mechanism the real helper
+  # uses. Nothing about this reproduction depends on that helper's own
+  # (separately tested) logic for FINDING the right insertion point — only
+  # on the fact that Igniter buffers the result rather than writing it to
+  # disk immediately.
+  defp stage_supervisor_addition(igniter) do
+    Igniter.update_file(igniter, @app_file, fn source ->
+      content = Rewrite.Source.get(source, :content)
+
+      updated =
+        String.replace(content, "MyApp.Repo,", "MyApp.Repo,\n        PhoenixKit.Supervisor,")
+
+      Rewrite.Source.update(source, :content, updated)
+    end)
+  end
+
+  test "the boot hook does not discard an earlier step's edit to the same file" do
+    igniter =
+      test_project(app_name: :my_app, files: %{@app_file => @initial_content})
+      |> stage_supervisor_addition()
+      |> BootHook.add_boot_hook()
+      |> apply_igniter!()
+
+    content = app_content(igniter)
+
+    assert content =~ "PhoenixKit.Supervisor",
+           "the earlier step's supervisor edit was discarded:\n#{content}"
+
+    assert content =~ "|> PhoenixKit.boot()",
+           "the boot hook itself did not land:\n#{content}"
+  end
+
+  test "is idempotent — already-wired content is left alone" do
+    already_wired =
+      String.replace(
+        @initial_content,
+        "Supervisor.start_link(children, opts)",
+        "Supervisor.start_link(children, opts) |> PhoenixKit.boot()"
+      )
+
+    igniter =
+      test_project(app_name: :my_app, files: %{@app_file => already_wired})
+      |> BootHook.add_boot_hook()
+      |> apply_igniter!()
+
+    assert app_content(igniter) == already_wired
+  end
+
+  test "a non-standard Supervisor.start_link call is left untouched, with a warning" do
+    # `@standard_call`'s pattern has no leading anchor, so a DIFFERENTLY
+    # NAMED supervisor module (e.g. "MySupervisor.start_link(...)") still
+    # matches it — it merely needs "Supervisor.start_link(children, opts)" as
+    # a substring, which "MySupervisor..." still contains. The genuinely
+    # non-standard shape changes the `opts` VARIABLE name, which the pattern
+    # requires verbatim.
+    non_standard =
+      String.replace(
+        @initial_content,
+        "Supervisor.start_link(children, opts)",
+        "Supervisor.start_link(children, supervisor_opts)"
+      )
+
+    igniter =
+      test_project(app_name: :my_app, files: %{@app_file => non_standard})
+      |> BootHook.add_boot_hook()
+
+    assert igniter.warnings != [], "expected a warning about the non-standard form"
+
+    applied = apply_igniter!(igniter)
+    assert app_content(applied) == non_standard
+  end
+end

--- a/test/phoenix_kit/install/config_verify_test.exs
+++ b/test/phoenix_kit/install/config_verify_test.exs
@@ -152,4 +152,86 @@ defmodule PhoenixKit.Install.ConfigVerifyTest do
       refute CV.keyword_list_satisfies?(ast, :crontab, fn _ -> true end)
     end
   end
+
+  describe "app_config_satisfies?/5" do
+    @content """
+    config :some_lib, plugins: [SomeLib.Plugin]
+
+    config :my_app, Oban,
+      repo: MyApp.Repo,
+      plugins: [
+        {Oban.Plugins.Lifeline, rescue_after: :timer.minutes(60)}
+      ]
+    """
+
+    test "true when the target app's own block has the matching list" do
+      ast = Code.string_to_quoted!(@content)
+
+      assert CV.app_config_satisfies?(ast, "my_app", Oban, :plugins, fn list ->
+               Enum.any?(list, &CV.tuple_names_module?(&1, Oban.Plugins.Lifeline))
+             end)
+    end
+
+    # I103, finding 3: this is the exact defect an unscoped
+    # `keyword_list_satisfies?/3` had — it is satisfied by ANY `plugins:`
+    # list in the file, including a DIFFERENT application's, so a check
+    # built on it would report success even though `:my_app`'s own config
+    # was never touched.
+    test "false when only a DIFFERENT application's config satisfies the check" do
+      content = """
+      config :other_app, Oban,
+        plugins: [
+          {Oban.Plugins.Lifeline, rescue_after: :timer.minutes(60)}
+        ]
+
+      config :my_app, Oban,
+        repo: MyApp.Repo,
+        plugins: [
+          {Oban.Plugins.Pruner, max_age: 60}
+        ]
+      """
+
+      ast = Code.string_to_quoted!(content)
+
+      refute CV.app_config_satisfies?(ast, "my_app", Oban, :plugins, fn list ->
+               Enum.any?(list, &CV.tuple_names_module?(&1, Oban.Plugins.Lifeline))
+             end)
+    end
+
+    test "false when the app matches but the configured module doesn't" do
+      content = """
+      config :my_app, SomeOtherLib,
+        plugins: [
+          {Oban.Plugins.Lifeline, rescue_after: :timer.minutes(60)}
+        ]
+      """
+
+      ast = Code.string_to_quoted!(content)
+
+      refute CV.app_config_satisfies?(ast, "my_app", Oban, :plugins, fn list ->
+               Enum.any?(list, &CV.tuple_names_module?(&1, Oban.Plugins.Lifeline))
+             end)
+    end
+
+    test "accepts app_name as either an atom or a string" do
+      ast = Code.string_to_quoted!(@content)
+
+      for app_name <- [:my_app, "my_app"] do
+        assert CV.app_config_satisfies?(ast, app_name, Oban, :plugins, fn list ->
+                 Enum.any?(list, &CV.tuple_names_module?(&1, Oban.Plugins.Lifeline))
+               end)
+      end
+    end
+
+    test "does not crash on a dynamically-computed (non-atom) app argument" do
+      content = """
+      config Application.get_env(:parent, :app), Oban,
+        plugins: [Oban.Plugins.Lifeline]
+      """
+
+      ast = Code.string_to_quoted!(content)
+
+      refute CV.app_config_satisfies?(ast, "my_app", Oban, :plugins, fn _ -> true end)
+    end
+  end
 end

--- a/test/phoenix_kit/install/config_verify_test.exs
+++ b/test/phoenix_kit/install/config_verify_test.exs
@@ -1,0 +1,155 @@
+defmodule PhoenixKit.Install.ConfigVerifyTest do
+  @moduledoc """
+  I103: `ConfigVerify` is the shared parse-then-verify-then-rollback
+  primitive behind every regex-based config splice fixed this round. These
+  tests exercise it directly, against plain strings and quoted ASTs, with
+  no Igniter/Mix context needed.
+  """
+  use ExUnit.Case, async: true
+
+  alias PhoenixKit.Install.ConfigVerify, as: CV
+
+  describe "verify/2" do
+    test "accepts a candidate that parses and satisfies the semantic check" do
+      assert {:ok, _} =
+               CV.verify("[crontab: [{\"* * * * *\", MyApp.Worker}]]", fn ast ->
+                 CV.keyword_list_satisfies?(ast, :crontab, fn list ->
+                   Enum.any?(list, &CV.tuple_names_module?(&1, MyApp.Worker))
+                 end)
+               end)
+    end
+
+    test "rejects a candidate that does not parse — :syntax" do
+      assert {:error, :syntax} = CV.verify("crontab: [", fn _ -> true end)
+    end
+
+    test "rejects a candidate that parses but fails the semantic check — :semantic" do
+      assert {:error, :semantic} =
+               CV.verify("[crontab: [{\"0 3 * * *\", Other.Worker}]]", fn ast ->
+                 CV.keyword_list_satisfies?(ast, :crontab, fn list ->
+                   Enum.any?(list, &CV.tuple_names_module?(&1, MyApp.Worker))
+                 end)
+               end)
+    end
+  end
+
+  describe "verify_or_rollback/3" do
+    test "returns {:ok, candidate} on success" do
+      assert {:ok, "[a: 1]"} = CV.verify_or_rollback("[]", "[a: 1]", fn _ -> true end)
+    end
+
+    test "returns {:rolled_back, original, :syntax} on a syntax failure" do
+      assert {:rolled_back, "[]", :syntax} =
+               CV.verify_or_rollback("[]", "[a: 1", fn _ -> true end)
+    end
+
+    test "returns {:rolled_back, original, :semantic} on a semantic failure" do
+      assert {:rolled_back, "[]", :semantic} =
+               CV.verify_or_rollback("[]", "[a: 1]", fn _ -> false end)
+    end
+  end
+
+  describe "ast_contains?/2" do
+    test "finds a matching node anywhere in the tree" do
+      ast = quote do: [a: [b: [c: 1]]]
+      assert CV.ast_contains?(ast, &match?({:c, 1}, &1))
+    end
+
+    test "false when nothing matches" do
+      ast = quote do: [a: 1]
+      refute CV.ast_contains?(ast, &match?({:z, _}, &1))
+    end
+  end
+
+  describe "tuple_elements/1" do
+    test "a literal 2-tuple returns its two elements" do
+      assert CV.tuple_elements({:a, :b}) == [:a, :b]
+    end
+
+    test "a 3+ tuple (quoted as {:{}, meta, elements}) returns its elements" do
+      assert CV.tuple_elements({:{}, [], [:a, :b, :c]}) == [:a, :b, :c]
+    end
+
+    test "not a tuple at all returns nil" do
+      assert CV.tuple_elements([:a, :b]) == nil
+      assert CV.tuple_elements(:atom) == nil
+    end
+  end
+
+  describe "alias_matches?/2" do
+    test "a quoted __aliases__ node matching the module" do
+      {:ok, ast} = Code.string_to_quoted("Oban.Plugins.Cron")
+      assert CV.alias_matches?(ast, Oban.Plugins.Cron)
+    end
+
+    test "a quoted __aliases__ node NOT matching the module" do
+      {:ok, ast} = Code.string_to_quoted("Oban.Plugins.Cron")
+      refute CV.alias_matches?(ast, Oban.Plugins.Pruner)
+    end
+
+    test "anything that isn't an alias node" do
+      refute CV.alias_matches?("Oban.Plugins.Cron", Oban.Plugins.Cron)
+      refute CV.alias_matches?(42, Oban.Plugins.Cron)
+    end
+  end
+
+  describe "tuple_names_module?/2" do
+    test "true when the module appears anywhere among the tuple's elements" do
+      {:ok, ast} = Code.string_to_quoted(~s({"* * * * *", MyApp.Workers.Nightly}))
+      assert CV.tuple_names_module?(ast, MyApp.Workers.Nightly)
+    end
+
+    test "false when a different module is named" do
+      {:ok, ast} = Code.string_to_quoted(~s({"* * * * *", MyApp.Workers.Nightly}))
+      refute CV.tuple_names_module?(ast, MyApp.Workers.Other)
+    end
+
+    test "false when the module is nested inside a value, not a direct element" do
+      # The exact shape I103's mutation B reproduced: the target module
+      # buried inside an existing entry's own nested list value.
+      {:ok, ast} =
+        Code.string_to_quoted(
+          ~s({"*/5 * * * *", MyApp.Workers.TagSweeper, args: %{tags: ["a", MyApp.Workers.Nightly]}})
+        )
+
+      refute CV.tuple_names_module?(ast, MyApp.Workers.Nightly)
+    end
+  end
+
+  describe "keyword_get/2" do
+    test "finds the value for an existing key" do
+      assert CV.keyword_get([a: 1, b: 2], :b) == {:ok, 2}
+    end
+
+    test "nil when the key is absent" do
+      assert CV.keyword_get([a: 1], :z) == nil
+    end
+
+    test "nil when not even a keyword list" do
+      assert CV.keyword_get(:not_a_list, :a) == nil
+    end
+  end
+
+  describe "keyword_list_satisfies?/3" do
+    test "true when a matching root_key list exists anywhere and satisfies the check" do
+      ast = quote do: [plugins: [{Oban.Plugins.Cron, crontab: [{"* * * * *", MyApp.Worker}]}]]
+
+      assert CV.keyword_list_satisfies?(ast, :crontab, fn list ->
+               Enum.any?(list, &CV.tuple_names_module?(&1, MyApp.Worker))
+             end)
+    end
+
+    test "false when the root_key list exists but the check fails" do
+      ast = quote do: [plugins: [{Oban.Plugins.Cron, crontab: [{"* * * * *", MyApp.Worker}]}]]
+
+      refute CV.keyword_list_satisfies?(ast, :crontab, fn list ->
+               Enum.any?(list, &CV.tuple_names_module?(&1, MyApp.Other))
+             end)
+    end
+
+    test "false when there is no root_key list at all" do
+      ast = quote do: [plugins: [Oban.Plugins.Pruner]]
+      refute CV.keyword_list_satisfies?(ast, :crontab, fn _ -> true end)
+    end
+  end
+end

--- a/test/phoenix_kit/install/oban_config_test.exs
+++ b/test/phoenix_kit/install/oban_config_test.exs
@@ -311,6 +311,168 @@ defmodule PhoenixKit.Install.ObanConfigTest do
     end
   end
 
+  describe "plugins:/crontab: splices never land in a neighbouring application's config" do
+    # I103: `insert_queue/4` already anchors its splice — and the semantic
+    # check it verifies against — to `config :app_name, Oban` specifically.
+    # The plugins:/crontab: splices below did neither: an unanchored
+    # `^([ \t]+)plugins:\s*\[\n...\]` (or `crontab:`) matches the FIRST such
+    # list in the whole file, and the semantic check that "confirms" the
+    # result (`plugins_contains_module?/3`, `crontab_contains_module?/3`, …)
+    # asked the same unscoped question — so an insertion that landed in a
+    # NEIGHBOURING application's block was reported as success while
+    # `:my_app`'s own Oban config went untouched. Reproduced live: exactly
+    # this shape, before the fix, put Lifeline in `:some_lib`'s plugins list
+    # and returned `:ok`.
+    @neighbour_plugins """
+    config :some_lib,
+      plugins: [
+        SomeLib.Plugin
+      ]
+
+    """
+
+    @neighbour_crontab """
+    config :some_lib,
+      crontab: [
+        {"* * * * *", SomeLib.Worker}
+      ]
+
+    """
+
+    test "ensure_lifeline_plugin/2 lands Lifeline in :my_app's own block" do
+      content =
+        @neighbour_plugins <>
+          """
+          config :my_app, Oban,
+            repo: MyApp.Repo,
+            plugins: [
+              {Oban.Plugins.Pruner, max_age: 60}
+            ]
+          """
+
+      updated = ObanConfig.ensure_lifeline_plugin(content, "my_app")
+
+      # The neighbour's own block is untouched, byte for byte.
+      assert String.starts_with?(updated, @neighbour_plugins)
+      refute updated =~ ~r/SomeLib\.Plugin[^\]]*Lifeline/s
+
+      assert {:ok, ast} = Code.string_to_quoted(updated)
+
+      assert ConfigVerify.app_config_satisfies?(ast, "my_app", Oban, :plugins, fn list ->
+               Enum.any?(list, &ConfigVerify.tuple_names_module?(&1, Oban.Plugins.Lifeline))
+             end)
+    end
+
+    test "ensure_cron_plugin/2 Case 4 (no Cron plugin yet) lands it in :my_app's own block" do
+      content =
+        @neighbour_plugins <>
+          """
+          config :my_app, Oban,
+            repo: MyApp.Repo,
+            plugins: [
+              {Oban.Plugins.Pruner, max_age: 60}
+            ]
+          """
+
+      updated = ObanConfig.ensure_cron_plugin(content, "my_app")
+
+      assert String.starts_with?(updated, @neighbour_plugins)
+      assert {:ok, ast} = Code.string_to_quoted(updated)
+
+      assert ConfigVerify.app_config_satisfies?(ast, "my_app", Oban, :crontab, fn list ->
+               Enum.any?(
+                 list,
+                 &ConfigVerify.tuple_names_module?(
+                   &1,
+                   PhoenixKit.ScheduledJobs.Workers.ProcessScheduledJobsWorker
+                 )
+               )
+             end)
+    end
+
+    test "ensure_cron_plugin/2 Case 3 (posts worker missing) lands it in :my_app's own crontab" do
+      content =
+        @neighbour_crontab <>
+          """
+          config :my_app, Oban,
+            repo: MyApp.Repo,
+            plugins: [
+              {Oban.Plugins.Cron,
+               crontab: [
+                 {"0 3 * * *", MyApp.Workers.Nightly}
+               ]}
+            ]
+          """
+
+      updated = ObanConfig.ensure_cron_plugin(content, "my_app")
+
+      assert String.starts_with?(updated, @neighbour_crontab)
+      assert {:ok, ast} = Code.string_to_quoted(updated)
+
+      assert ConfigVerify.app_config_satisfies?(ast, "my_app", Oban, :crontab, fn list ->
+               Enum.any?(
+                 list,
+                 &ConfigVerify.tuple_names_module?(
+                   &1,
+                   PhoenixKit.ScheduledJobs.Workers.ProcessScheduledJobsWorker
+                 )
+               )
+             end)
+    end
+
+    test "ensure_worker_cron_entries/2 lands entries in :my_app's own crontab" do
+      content =
+        @neighbour_crontab <>
+          """
+          config :my_app, Oban,
+            repo: MyApp.Repo,
+            plugins: [
+              {Oban.Plugins.Cron,
+               crontab: [
+                 {"* * * * *", PhoenixKit.ScheduledJobs.Workers.ProcessScheduledJobsWorker}
+               ]}
+            ]
+          """
+
+      updated = ObanConfig.ensure_worker_cron_entries(content, "my_app")
+
+      assert String.starts_with?(updated, @neighbour_crontab)
+      assert {:ok, ast} = Code.string_to_quoted(updated)
+
+      assert ConfigVerify.app_config_satisfies?(ast, "my_app", Oban, :crontab, fn list ->
+               Enum.any?(
+                 list,
+                 &ConfigVerify.tuple_names_module?(&1, PhoenixKit.Users.Referrals.PruneWorker)
+               )
+             end)
+    end
+
+    test "ensure_digest_cron_entries/2 lands entries in :my_app's own crontab" do
+      content =
+        @neighbour_crontab <>
+          """
+          config :my_app, Oban,
+            repo: MyApp.Repo,
+            plugins: [
+              {Oban.Plugins.Cron,
+               crontab: [
+                 {"* * * * *", PhoenixKit.ScheduledJobs.Workers.ProcessScheduledJobsWorker}
+               ]}
+            ]
+          """
+
+      updated = ObanConfig.ensure_digest_cron_entries(content, "my_app")
+
+      assert String.starts_with?(updated, @neighbour_crontab)
+
+      for cadence <- ~w(hourly 12h daily weekly) do
+        assert updated =~ ~r/DigestWorker[^\n]*cadence: "#{cadence}"/
+      end
+
+      assert {:ok, _} = Code.string_to_quoted(updated)
+    end
+  end
+
   describe "ensure_digest_cron_entries/2" do
     @existing_crontab """
     config :my_app, Oban,
@@ -401,6 +563,139 @@ defmodule PhoenixKit.Install.ObanConfigTest do
       digestable = MapSet.delete(MapSet.new(ChannelConfig.cadences()), "immediate")
 
       assert scheduled == digestable
+    end
+
+    # I103 / finding 4: same bug, same fix as
+    # `add_worker_entries_to_crontab/3` — see
+    # "ensure_worker_cron_entries/2 — I103: previously untested" for the
+    # full explanation.
+    test "a crontab with a legitimate trailing comma gets entries added, not rolled back" do
+      content = """
+      config :my_app, Oban,
+        repo: MyApp.Repo,
+        plugins: [
+          {Oban.Plugins.Cron,
+           crontab: [
+             {"* * * * *", PhoenixKit.ScheduledJobs.Workers.ProcessScheduledJobsWorker},
+           ]}
+        ]
+      """
+
+      updated = ObanConfig.ensure_digest_cron_entries(content, "my_app")
+
+      refute updated == content, "the entries were rolled back instead of added"
+      refute updated =~ ",,"
+
+      for cadence <- ~w(hourly 12h daily weekly) do
+        assert updated =~ ~r/DigestWorker[^\n]*cadence: "#{cadence}"/
+      end
+
+      assert {:ok, _} = Code.string_to_quoted(updated)
+    end
+  end
+
+  describe "ensure_worker_cron_entries/2 — I103: previously untested" do
+    test "adds the PruneWorker entry to an existing crontab" do
+      content = """
+      config :my_app, Oban,
+        repo: MyApp.Repo,
+        plugins: [
+          {Oban.Plugins.Cron,
+           crontab: [
+             {"* * * * *", PhoenixKit.ScheduledJobs.Workers.ProcessScheduledJobsWorker}
+           ]}
+        ]
+      """
+
+      updated = ObanConfig.ensure_worker_cron_entries(content, "my_app")
+
+      assert updated =~ "PhoenixKit.Users.Referrals.PruneWorker"
+      assert {:ok, _} = Code.string_to_quoted(updated)
+    end
+
+    test "is idempotent — an entry already present is not duplicated" do
+      content = """
+      config :my_app, Oban,
+        plugins: [
+          {Oban.Plugins.Cron,
+           crontab: [
+             {"30 4 * * *", PhoenixKit.Users.Referrals.PruneWorker}
+           ]}
+        ]
+      """
+
+      assert ObanConfig.ensure_worker_cron_entries(content, "my_app") == content
+    end
+
+    test "leaves content unchanged when no crontab block can be found" do
+      content = """
+      config :my_app, Oban,
+        repo: MyApp.Repo,
+        queues: [default: 10]
+      """
+
+      assert ObanConfig.ensure_worker_cron_entries(content, "my_app") == content
+    end
+
+    # I103 / finding 4: `add_worker_entries_to_crontab/3` used to prepend a
+    # leading `,\n` to the new entries UNCONDITIONALLY. A crontab whose last
+    # entry already ends in a comma (an entirely ordinary shape — `mix
+    # format`'s own output for a multi-entry list) then got a DOUBLE comma,
+    # which fails to parse; `verify_or_rollback/3` correctly rolled back, but
+    # rolling back a well-formed host config over the installer's own bug
+    # blames the wrong side. The fix mirrors
+    # `add_scheduled_posts_job_to_crontab/2`'s existing `has_trailing_comma`
+    # check.
+    test "a crontab with a legitimate trailing comma gets the entry added, not rolled back" do
+      content = """
+      config :my_app, Oban,
+        repo: MyApp.Repo,
+        plugins: [
+          {Oban.Plugins.Cron,
+           crontab: [
+             {"* * * * *", PhoenixKit.ScheduledJobs.Workers.ProcessScheduledJobsWorker},
+           ]}
+        ]
+      """
+
+      updated = ObanConfig.ensure_worker_cron_entries(content, "my_app")
+
+      refute updated == content, "the entry was rolled back instead of added"
+      refute updated =~ ",,"
+      assert updated =~ "PhoenixKit.Users.Referrals.PruneWorker"
+      assert {:ok, _} = Code.string_to_quoted(updated)
+    end
+
+    test "never lands in a neighbouring application's crontab" do
+      content = """
+      config :some_lib,
+        crontab: [
+          {"* * * * *", SomeLib.Worker}
+        ]
+
+      config :my_app, Oban,
+        repo: MyApp.Repo,
+        plugins: [
+          {Oban.Plugins.Cron,
+           crontab: [
+             {"* * * * *", PhoenixKit.ScheduledJobs.Workers.ProcessScheduledJobsWorker}
+           ]}
+        ]
+      """
+
+      updated = ObanConfig.ensure_worker_cron_entries(content, "my_app")
+
+      assert updated =~
+               ~r/config :some_lib,\s+crontab: \[\s+\{"\* \* \* \* \*", SomeLib\.Worker\}\s+\]\s*\n/
+
+      assert {:ok, ast} = Code.string_to_quoted(updated)
+
+      assert ConfigVerify.app_config_satisfies?(ast, "my_app", Oban, :crontab, fn list ->
+               Enum.any?(
+                 list,
+                 &ConfigVerify.tuple_names_module?(&1, PhoenixKit.Users.Referrals.PruneWorker)
+               )
+             end)
     end
   end
 

--- a/test/phoenix_kit/install/oban_config_test.exs
+++ b/test/phoenix_kit/install/oban_config_test.exs
@@ -1,6 +1,7 @@
 defmodule PhoenixKit.Install.ObanConfigTest do
   use ExUnit.Case, async: true
 
+  alias PhoenixKit.Install.ConfigVerify
   alias PhoenixKit.Install.ObanConfig
   alias PhoenixKit.Notifications.ChannelConfig
 
@@ -403,6 +404,74 @@ defmodule PhoenixKit.Install.ObanConfigTest do
     end
   end
 
+  describe "ensure_pruner_max_age/2 — I103: exposed for testing, previously untested" do
+    test "adds max_age to a bare Oban.Plugins.Pruner atom" do
+      content = """
+      config :my_app, Oban,
+        plugins: [
+          Oban.Plugins.Pruner
+        ]
+      """
+
+      updated = ObanConfig.ensure_pruner_max_age(content, "my_app")
+
+      assert {:ok, ast} = Code.string_to_quoted(updated)
+      assert pruner_has_max_age?(ast)
+    end
+
+    test "adds max_age to a bare {Oban.Plugins.Pruner} tuple" do
+      content = """
+      config :my_app, Oban,
+        plugins: [
+          {Oban.Plugins.Pruner}
+        ]
+      """
+
+      updated = ObanConfig.ensure_pruner_max_age(content, "my_app")
+
+      assert {:ok, ast} = Code.string_to_quoted(updated)
+      assert pruner_has_max_age?(ast)
+    end
+
+    test "leaves a Pruner that already has max_age alone" do
+      content = """
+      config :my_app, Oban,
+        plugins: [
+          {Oban.Plugins.Pruner, max_age: 60}
+        ]
+      """
+
+      assert ObanConfig.ensure_pruner_max_age(content, "my_app") == content
+    end
+
+    test "leaves content untouched when Pruner is not configured at all" do
+      content = "config :my_app, Oban,\n  plugins: []\n"
+      assert ObanConfig.ensure_pruner_max_age(content, "my_app") == content
+    end
+
+    defp pruner_has_max_age?(ast) do
+      ConfigVerify.ast_contains?(ast, fn node ->
+        case ConfigVerify.tuple_elements(node) do
+          nil ->
+            false
+
+          elements ->
+            Enum.any?(
+              elements,
+              &ConfigVerify.alias_matches?(&1, Oban.Plugins.Pruner)
+            ) and
+              Enum.any?(elements, fn
+                kw when is_list(kw) ->
+                  match?({:ok, _}, ConfigVerify.keyword_get(kw, :max_age))
+
+                _ ->
+                  false
+              end)
+        end
+      end)
+    end
+  end
+
   describe "ensure_cron_plugin/2 — migrating off the old posts worker" do
     defp crontab_with(worker) do
       """
@@ -454,6 +523,117 @@ defmodule PhoenixKit.Install.ObanConfigTest do
       content = crontab_with("PhoenixKit.ScheduledJobs.Workers.ProcessScheduledJobsWorker")
 
       assert ObanConfig.ensure_cron_plugin(content, "my_app") == content
+    end
+  end
+
+  describe "ensure_cron_plugin/2 Case 3 — I103: add_scheduled_posts_job_to_crontab must never corrupt config.exs" do
+    # `add_scheduled_posts_job_to_crontab/1` was the one crontab-splice
+    # function in this module with NO anchor on its regex (a lazy `.*?`
+    # instead of the `\n<indent>]` backreference the sibling functions use)
+    # — the only one of the six block-splice helpers this file has. Reached
+    # via Case 3 of `ensure_cron_plugin/2`: a Cron plugin already exists but
+    # `ProcessScheduledJobsWorker` is not in it yet — the exact state of
+    # every host installed before that worker existed.
+    test "happy path: single existing entry with no trailing comma still gets the worker added" do
+      # I103, found while adding the safety net: the ORIGINAL insertion
+      # logic appended `,\n<entry>` straight onto the captured interior
+      # text, which itself ends in trailing whitespace before the `]` (not
+      # the last real token) — the comma landed alone on its own line,
+      # which Elixir's parser rejects outright ("syntax error before: ','").
+      # This is the single most common real shape (`mix format`'s own
+      # output for a one-entry list carries no trailing comma), so before
+      # the fix this path corrupted config.exs on the ORDINARY case, not
+      # just an adversarial one.
+      content = crontab_with("MyApp.Workers.Nightly")
+
+      updated = ObanConfig.ensure_cron_plugin(content, "my_app")
+
+      assert {:ok, ast} = Code.string_to_quoted(updated)
+      assert updated =~ "PhoenixKit.ScheduledJobs.Workers.ProcessScheduledJobsWorker"
+      assert updated =~ "MyApp.Workers.Nightly"
+
+      assert crontab_has_module?(ast, PhoenixKit.ScheduledJobs.Workers.ProcessScheduledJobsWorker)
+      assert crontab_has_module?(ast, MyApp.Workers.Nightly)
+    end
+
+    test "happy path: an existing entry that already ends with a trailing comma" do
+      content = """
+      config :my_app, Oban,
+        repo: MyApp.Repo,
+        queues: [default: 10],
+        plugins: [
+          {Oban.Plugins.Cron,
+           crontab: [
+             {"0 3 * * *", MyApp.Workers.Nightly},
+           ]}
+        ]
+      """
+
+      updated = ObanConfig.ensure_cron_plugin(content, "my_app")
+
+      assert {:ok, ast} = Code.string_to_quoted(updated)
+      assert crontab_has_module?(ast, PhoenixKit.ScheduledJobs.Workers.ProcessScheduledJobsWorker)
+      assert crontab_has_module?(ast, MyApp.Workers.Nightly)
+    end
+
+    test "MUTATION A — a comment containing ']' before the real entries rolls back instead of corrupting" do
+      # Reproduced live before this fix: an entirely ordinary explanatory
+      # comment ("...took a priority list, e.g. [1, 2] - removed") makes the
+      # unanchored `.*?` stop at the comment's own bracket, producing a real
+      # `MismatchedDelimiterError` when the host next compiles config.exs.
+      content = """
+      config :my_app, Oban,
+        repo: MyApp.Repo,
+        queues: [default: 10],
+        plugins: [
+          {Oban.Plugins.Cron,
+           crontab: [
+             # historically this queue took a priority list, e.g. [1, 2] - removed
+             {"0 3 * * *", MyApp.Workers.Nightly}
+           ]}
+        ]
+      """
+
+      updated = ObanConfig.ensure_cron_plugin(content, "my_app")
+
+      assert updated == content, "a rollback must return the ORIGINAL content unchanged"
+      assert {:ok, _} = Code.string_to_quoted(updated)
+      refute updated =~ "ProcessScheduledJobsWorker"
+    end
+
+    test "MUTATION B — a nested-list value that still parses rolls back instead of silently misplacing the entry" do
+      # The other way this can fail: no comment at all, just an ordinary
+      # Oban shape (a tag list in an existing entry's own args). The lazy
+      # regex stops at THAT list's closing ']' — the result still parses
+      # (a green a parse-only check would have accepted), but the new
+      # tuple lands nested inside `tags:` instead of as a crontab sibling.
+      content = """
+      config :my_app, Oban,
+        repo: MyApp.Repo,
+        queues: [default: 10],
+        plugins: [
+          {Oban.Plugins.Cron,
+           crontab: [
+             {"*/5 * * * *", MyApp.Workers.TagSweeper, args: %{tags: ["a", "b"]}}
+           ]}
+        ]
+      """
+
+      updated = ObanConfig.ensure_cron_plugin(content, "my_app")
+
+      assert updated == content, "a rollback must return the ORIGINAL content unchanged"
+      assert {:ok, ast} = Code.string_to_quoted(updated)
+
+      refute crontab_has_module?(
+               ast,
+               PhoenixKit.ScheduledJobs.Workers.ProcessScheduledJobsWorker
+             )
+    end
+
+    defp crontab_has_module?(ast, module) do
+      ConfigVerify.keyword_list_satisfies?(ast, :crontab, fn list ->
+        Enum.any?(list, &ConfigVerify.tuple_names_module?(&1, module))
+      end)
     end
   end
 


### PR DESCRIPTION
## What

The installer edits a host's `config.exs` by regular expression. A regex cannot
tell Elixir code from a `#` comment or a string literal, so a `]` written inside
a crontab comment ends the list as far as the pattern is concerned, and the
splice lands inside the comment. The host's next compile then fails with

    ** (MismatchedDelimiterError) ... unexpected token: ]

on a file the installer reported as successfully updated.

This adds a check after every such splice: parse the candidate before adopting
it, and if it does not parse, roll back to the original and print the block for
the operator to paste manually.

## Why the parse alone is not enough

An insertion into a comment that happens to contain no `]` produces a file that
parses perfectly and silently lacks the entry. So the check is not "does it
parse" but "does it parse **and** is the entry actually there": `ConfigVerify`
walks the resulting AST for the key that was supposed to be added, and a
mismatch rolls back exactly like a syntax error does.

## Scope

Fourteen call sites across `oban_config.ex`, `phoenix_kit.update.ex`,
`boot_hook.ex` and `runtime_detector.ex` — every place that splices into an
existing config structure by pattern.

`js_integration.ex` is deliberately **not** touched. Its splices are into
JS/HEEX, where the Elixir parser does not apply and no equivalent checker is
available here. Guarding them with something unverifiable would trade a real
check for the appearance of one, so they keep their current behaviour and stay
a known gap rather than a covered-looking one.

## Verification

Against `main` (2.13.12), driving the real entry point rather than the internals:

    crontab carrying "# daily digest [see runbook]"
      -> file untouched, entry not inserted, manual-instruction notice printed
         (previously: MismatchedDelimiterError)

    crontab entry with a nested list, args: %{tags: ["a", "b"]}
      -> file untouched, entry did not land inside the nested list
         (this is the case a parse-only check would pass)

    the same config with neither trap
      -> entry inserted, result parses

Full suite: `43 doctests, 4123 tests, 0 failures`, with integration tests
actually running. `mix compile --warnings-as-errors` clean.

## Also in here

One independent bug in `add_scheduled_posts_job_to_crontab/1`, found while
reproducing the above: the appended comma was glued to trailing whitespace
rather than to the last real token, which produced `syntax error before: ','`
on inputs that had nothing to do with comments. Fixed to match the pattern the
anchored siblings in the same module already used.
