### PR TITLE
Encrypt restricted setting values at rest

### DIFF
--- a/lib/phoenix_kit/settings/setting.ex
+++ b/lib/phoenix_kit/settings/setting.ex
@@ -174,12 +174,19 @@ defmodule PhoenixKit.Settings.Setting do
   # `PhoenixKit.Settings.restricted_setting_keys/0` (`oauth_*_secret`,
   # `aws_access_key_id`/`aws_secret_access_key` — live credential material,
   # not just data an admin would rather keep quiet) is stored encrypted.
-  # `get_change/2`, not `get_field/2`: only a genuinely NEW value gets
-  # encrypted here — a changeset that leaves `:value` untouched (e.g.
-  # `update_setting_with_module/3` re-saving `module` alone) must not
-  # re-touch whatever is already stored, encrypted or not. Existing plaintext
-  # rows are deliberately left alone by this change — migrating them is a
-  # separate, live-database step, not implied by this changeset.
+  # `get_change/2`, not `get_field/2`: `get_change/2` is `nil` both when
+  # `attrs` never carried `:value` at all AND when it did but the submitted
+  # value equals what `changeset.data` already holds (Ecto's own cast
+  # diffing, not something this function decides) — either way, nothing
+  # here re-touches whatever is already stored, encrypted or not. (Every
+  # current caller happens to always pass `:value` — e.g.
+  # `update_setting_with_module/3` always includes it alongside `module` —
+  # so it is this second case, an unchanged resubmission, not an absent
+  # key, that `get_change/2` actually needs to catch today; a future caller
+  # that omits `:value` entirely is covered by the same check for free.)
+  # Existing plaintext rows are deliberately left alone by this change —
+  # migrating them is a separate, live-database step, not implied by this
+  # changeset.
   #
   # `Encryption.encrypt_value/1` already does the right thing for every edge
   # case this needs: nil/empty pass through unchanged (no ciphertext for

--- a/lib/phoenix_kit/settings/setting.ex
+++ b/lib/phoenix_kit/settings/setting.ex
@@ -50,6 +50,7 @@ defmodule PhoenixKit.Settings.Setting do
   use PhoenixKit.SchemaPrefix
   import Ecto.Changeset
 
+  alias PhoenixKit.Integrations.Encryption
   alias PhoenixKit.Users.Role
   alias PhoenixKit.Users.Roles
   alias PhoenixKit.Utils.Date, as: UtilsDate
@@ -149,6 +150,7 @@ defmodule PhoenixKit.Settings.Setting do
     |> validate_value_exclusivity()
     |> validate_length(:module, max: 255)
     |> unique_constraint(:key, name: :phoenix_kit_settings_key_uidx)
+    |> maybe_encrypt_restricted_value()
     |> maybe_set_timestamps()
   end
 
@@ -164,7 +166,41 @@ defmodule PhoenixKit.Settings.Setting do
     |> validate_setting_value()
     |> validate_value_exclusivity()
     |> validate_length(:module, max: 255)
+    |> maybe_encrypt_restricted_value()
     |> put_change(:date_updated, UtilsDate.utc_now())
+  end
+
+  # S015 pt.3 (write side): a NEW value for a key in
+  # `PhoenixKit.Settings.restricted_setting_keys/0` (`oauth_*_secret`,
+  # `aws_access_key_id`/`aws_secret_access_key` — live credential material,
+  # not just data an admin would rather keep quiet) is stored encrypted.
+  # `get_change/2`, not `get_field/2`: only a genuinely NEW value gets
+  # encrypted here — a changeset that leaves `:value` untouched (e.g.
+  # `update_setting_with_module/3` re-saving `module` alone) must not
+  # re-touch whatever is already stored, encrypted or not. Existing plaintext
+  # rows are deliberately left alone by this change — migrating them is a
+  # separate, live-database step, not implied by this changeset.
+  #
+  # `Encryption.encrypt_value/1` already does the right thing for every edge
+  # case this needs: nil/empty pass through unchanged (no ciphertext for
+  # nothing to protect — matches `@optional_settings` allowing these keys to
+  # be blank), and an already-`enc:v1:`-prefixed value passes through
+  # unchanged too (idempotent, so re-saving an already-encrypted value never
+  # double-wraps it).
+  defp maybe_encrypt_restricted_value(changeset) do
+    key = get_field(changeset, :key)
+
+    case get_change(changeset, :value) do
+      nil ->
+        changeset
+
+      value when is_binary(value) ->
+        if key in PhoenixKit.Settings.restricted_setting_keys() do
+          put_change(changeset, :value, Encryption.encrypt_value(value))
+        else
+          changeset
+        end
+    end
   end
 
   # Private helper to set timestamps on new records

--- a/lib/phoenix_kit/settings/settings.ex
+++ b/lib/phoenix_kit/settings/settings.ex
@@ -67,6 +67,7 @@ defmodule PhoenixKit.Settings do
   import Ecto.Changeset, only: [add_error: 3]
 
   alias PhoenixKit.Config.AWS
+  alias PhoenixKit.Integrations.Encryption
   alias PhoenixKit.Modules.Languages
   alias PhoenixKit.Settings.Queries
   alias PhoenixKit.Settings.Setting
@@ -327,7 +328,7 @@ defmodule PhoenixKit.Settings do
       setting_record = Queries.get_setting_by_key(key)
 
       case setting_record do
-        %Setting{value: value} -> value
+        %Setting{value: value} -> decrypt_if_restricted(key, value)
         nil -> nil
       end
     end
@@ -588,7 +589,7 @@ defmodule PhoenixKit.Settings do
     if Application.get_env(:phoenix_kit, :update_mode, false) or not repo_available?() do
       :error
     else
-      {:ok, keys |> Queries.list_settings_key_values_by_keys() |> Map.new()}
+      {:ok, keys |> Queries.list_settings_key_values_by_keys() |> decrypt_and_map_settings()}
     end
   rescue
     error ->
@@ -1015,7 +1016,7 @@ defmodule PhoenixKit.Settings do
     else
       if repo_available?() do
         Queries.list_settings_key_values_by_keys(keys)
-        |> Map.new()
+        |> decrypt_and_map_settings()
       else
         %{}
       end
@@ -1161,7 +1162,7 @@ defmodule PhoenixKit.Settings do
   """
   def list_all_settings do
     Queries.list_settings_key_values()
-    |> Map.new()
+    |> decrypt_and_map_settings()
   end
 
   @doc """
@@ -1206,6 +1207,98 @@ defmodule PhoenixKit.Settings do
 
   @doc false
   def restricted_setting_keys, do: @restricted_setting_keys
+
+  # Classifies one raw stored value against `PhoenixKit.Integrations.Encryption`'s
+  # `enc:v1:` scheme (S015 pt.2). Exactly three outcomes, deliberately never
+  # collapsed into two:
+  #
+  #   * `{:decrypted, plaintext}` — carried the prefix and decrypted under the
+  #     currently active key. The value that would previously have been
+  #     returned unencrypted.
+  #   * `{:legacy, value}` — no prefix at all. A value written before this
+  #     encryption existed, or a key that was never restricted. Returned
+  #     as-is (`Encryption.decrypt_value/1`'s own backwards-compatibility
+  #     rule) but tagged distinctly from `:decrypted` — this is the
+  #     difference `decrypt_if_restricted/2` and any future migration/audit
+  #     tooling can tell apart; an ordinary caller of `get_setting/1` cannot
+  #     (both are equally usable plaintext to it), and is not meant to.
+  #   * `{:error, reason}` — carried the prefix but did NOT decrypt (wrong or
+  #     rotated key, corrupted ciphertext). Never resolves to a value here —
+  #     see `decrypt_if_restricted/2` for what a caller-facing function does
+  #     with this instead of ever returning the raw `enc:v1:...` string.
+  #
+  # Public (but undocumented) so it has its own direct unit test seam for
+  # each of the three states — the same reason
+  # `Mix.Tasks.PhoenixKit.Repair.exit_code/1` is public: the decision is pure
+  # and worth testing in isolation from the DB-touching callers that use it.
+  @doc false
+  @spec decrypt_restricted_value(String.t() | nil) ::
+          {:decrypted, String.t()} | {:legacy, String.t() | nil} | {:error, term()}
+  def decrypt_restricted_value(nil), do: {:legacy, nil}
+
+  def decrypt_restricted_value(value) when is_binary(value) do
+    if Encryption.encrypted?(value) do
+      case Encryption.decrypt_value(value) do
+        {:ok, plaintext} -> {:decrypted, plaintext}
+        {:error, reason} -> {:error, reason}
+      end
+    else
+      {:legacy, value}
+    end
+  end
+
+  # Read side of S015 pt.2: applies `decrypt_restricted_value/1` to a value
+  # ALREADY KNOWN to have come from `key`, and collapses its three states to
+  # the `String.t() | nil` every existing `get_setting*` caller already
+  # expects — `:decrypted`/`:legacy` both resolve to the plaintext (equally
+  # usable to a caller that just wants "the setting's value"; the
+  # distinction is for `decrypt_restricted_value/1`'s own callers, not for
+  # this one), `:error` NEVER resolves to the raw value. Matches
+  # `PhoenixKit.Integrations.Encryption.decrypt_fields/1`'s own precedent
+  # for the identical dilemma: "a caller must never mistake stale
+  # ciphertext for a real value" — log loudly (this must never fail
+  # silently) and report the value as absent, exactly like a row that
+  # never existed. A caller reading `nil` back for a restricted key already
+  # has a documented fallback path (config, `||` defaults) for "not
+  # configured"; falling into that path is the safe outcome here, not a
+  # regression — the alternative is handing a broken key to whatever reads
+  # it next (an OAuth strategy, `AWS.access_key_id/0`).
+  #
+  # A key NOT in `restricted_setting_keys/0` never reaches
+  # `decrypt_restricted_value/1` at all — every ordinary setting's value
+  # passes through unchanged, at the cost of one list membership check.
+  defp decrypt_if_restricted(key, value) do
+    if key in @restricted_setting_keys do
+      case decrypt_restricted_value(value) do
+        {:decrypted, plaintext} ->
+          plaintext
+
+        {:legacy, legacy_value} ->
+          legacy_value
+
+        {:error, reason} ->
+          Logger.error(
+            "PhoenixKit.Settings: #{inspect(key)} carries enc:v1: but failed to decrypt " <>
+              "(#{inspect(reason)}) — treating as missing rather than returning ciphertext"
+          )
+
+          nil
+      end
+    else
+      value
+    end
+  end
+
+  # Same as `decrypt_if_restricted/2`, applied across a whole `{key, value}`
+  # list — the shape `Queries.list_settings_key_values_by_keys/1` and
+  # `Queries.list_settings_key_values/0` both return. Shared by every
+  # multi-key read path (`get_settings_direct/1`, the cache miss-fill behind
+  # `get_settings_cached/2`, `list_all_settings/0`) so there is exactly one
+  # place that decides how a batch of raw rows becomes the map a caller
+  # reads — not one call site each, silently drifting apart.
+  defp decrypt_and_map_settings(pairs) do
+    Map.new(pairs, fn {key, value} -> {key, decrypt_if_restricted(key, value)} end)
+  end
 
   @doc """
   Gets the available role options for the new user default role setting.
@@ -1911,7 +2004,7 @@ defmodule PhoenixKit.Settings do
   # Batch query multiple string settings from database in a single operation
   defp query_settings_batch(keys) do
     Queries.list_settings_key_values_by_keys(keys)
-    |> Map.new()
+    |> decrypt_and_map_settings()
   rescue
     _error ->
       # If query fails, return empty map
@@ -1945,8 +2038,9 @@ defmodule PhoenixKit.Settings do
       if repo_available?() do
         case Queries.get_setting_by_key(key) do
           %Setting{value: value} ->
-            PhoenixKit.Cache.put(@cache_name, key, value)
-            value
+            decrypted = decrypt_if_restricted(key, value)
+            PhoenixKit.Cache.put(@cache_name, key, decrypted)
+            decrypted
 
           nil ->
             # Cache a sentinel value to indicate this setting doesn't exist

--- a/lib/phoenix_kit/settings/settings.ex
+++ b/lib/phoenix_kit/settings/settings.ex
@@ -1291,11 +1291,17 @@ defmodule PhoenixKit.Settings do
 
   # Same as `decrypt_if_restricted/2`, applied across a whole `{key, value}`
   # list — the shape `Queries.list_settings_key_values_by_keys/1` and
-  # `Queries.list_settings_key_values/0` both return. Shared by every
-  # multi-key read path (`get_settings_direct/1`, the cache miss-fill behind
-  # `get_settings_cached/2`, `list_all_settings/0`) so there is exactly one
-  # place that decides how a batch of raw rows becomes the map a caller
-  # reads — not one call site each, silently drifting apart.
+  # `Queries.list_settings_key_values/0` both return, and the shape
+  # `warm_cache_data/0` builds by hand from `Queries.list_settings/0`
+  # (S015 review finding 1 — that hand-built list originally bypassed this
+  # entirely and fed the boot-time cache warmer raw ciphertext for every
+  # restricted key, on every app start, forever until the next write; a
+  # cache HIT never even reaches the decrypting miss-fill path below it).
+  # Shared by every multi-key read path (`get_settings_direct/1`, the cache
+  # miss-fill behind `get_settings_cached/2`, `list_all_settings/0`,
+  # `warm_cache_data/0`) so there is exactly one place that decides how a
+  # batch of raw rows becomes the map a caller — or the cache itself —
+  # reads, not one call site each, silently drifting apart.
   defp decrypt_and_map_settings(pairs) do
     Map.new(pairs, fn {key, value} -> {key, decrypt_if_restricted(key, value)} end)
   end
@@ -1919,8 +1925,18 @@ defmodule PhoenixKit.Settings do
   @doc """
   Warms the cache by loading all settings from database.
 
-  Called by PhoenixKit.Cache to pre-populate cache with all existing settings.
-  Prioritizes JSON values over string values for cache storage.
+  Called by `PhoenixKit.Cache` (`supervisor.ex`'s `:settings` child,
+  `sync_init: true`) to pre-populate cache with all existing settings —
+  synchronously, on every app boot, before the rest of the supervision tree
+  starts. Prioritizes JSON values over string values for cache storage.
+
+  Runs every restricted key's value (S015) through `decrypt_and_map_settings/1`
+  before returning — the cache itself is a bare ETS passthrough with no
+  notion of encryption (`PhoenixKit.Cache`'s warmer just `:ets.insert`s
+  whatever this returns, verbatim), so this is the only place that stands
+  between a boot-time warm and `get_setting_cached/2`/`get_settings_cached/2`
+  serving `enc:v1:...` as if it were the real secret on every cache HIT
+  until the next write invalidates it.
   """
   def warm_cache_data do
     # In update_mode, skip DB warming — the update task only needs the Repo for migrations.
@@ -1944,7 +1960,7 @@ defmodule PhoenixKit.Settings do
 
           {setting.key, value}
         end)
-        |> Map.new()
+        |> decrypt_and_map_settings()
       else
         # Repo not available (likely during Mix task execution)
         # Return empty map - cache will be warmed later when repo becomes available

--- a/test/phoenix_kit/settings_test.exs
+++ b/test/phoenix_kit/settings_test.exs
@@ -133,4 +133,135 @@ defmodule PhoenixKit.SettingsTest do
                "GOCSPX-test-secret-value"
     end
   end
+
+  # S015 pt.1-3: oauth_*/aws_* live in this context, not
+  # PhoenixKit.Integrations — `PhoenixKit.Integrations.Encryption`'s
+  # single-value API (`encrypt_value/1`/`decrypt_value/1`) is reused here
+  # poштучно (encrypt_fields/1 assumes an integration-shaped map, which a
+  # flat setting is not). New writes only — an existing plaintext row on a
+  # live install is a separate, live-database migration step, not implied
+  # by this changeset (see `Setting.maybe_encrypt_restricted_value/1`).
+  describe "restricted-key encryption at rest (S015)" do
+    alias PhoenixKit.Integrations.Encryption
+    alias PhoenixKit.Settings.Queries
+
+    setup do
+      assert Encryption.enabled?(),
+             "test config's secret_key_base must resolve a key — see config/test.exs"
+
+      :ok
+    end
+
+    # State 1 of 3: enc:v1:-prefixed, decrypts under the active key.
+    test "decrypt_restricted_value/1: an encrypted value decrypts to the original plaintext" do
+      encrypted = Encryption.encrypt_value("synthetic-oauth-secret")
+      assert String.starts_with?(encrypted, "enc:v1:")
+
+      assert Settings.decrypt_restricted_value(encrypted) ==
+               {:decrypted, "synthetic-oauth-secret"}
+    end
+
+    # State 2 of 3: no prefix at all — legacy, returned as-is, but tagged
+    # distinctly from state 1 (that is what "отличимо" in the card means:
+    # `decrypt_restricted_value/1` itself, not `get_setting/1`, can tell
+    # "already encrypted" apart from "predates encryption").
+    test "decrypt_restricted_value/1: an unprefixed value is legacy, not decrypted" do
+      assert Settings.decrypt_restricted_value("plain-legacy-value") ==
+               {:legacy, "plain-legacy-value"}
+
+      assert Settings.decrypt_restricted_value(nil) == {:legacy, nil}
+    end
+
+    # State 3 of 3: prefixed, but decryption itself fails (corrupted
+    # ciphertext here; a rotated/mismatched key on a live install is the
+    # same code path). Must be an explicit error, never a value.
+    test "decrypt_restricted_value/1: a corrupted enc:v1: value is an explicit error, not a value" do
+      corrupted =
+        "synthetic-value-to-corrupt"
+        |> Encryption.encrypt_value()
+        |> String.slice(0..-6//1)
+
+      assert {:error, _reason} = Settings.decrypt_restricted_value(corrupted)
+    end
+
+    test "write then read: a new restricted-key value is stored encrypted and reads back as plaintext" do
+      {:ok, _} =
+        Settings.update_setting("oauth_google_client_secret", "synthetic-round-trip-secret")
+
+      # The write path (point 3): assert against the RAW row, not another
+      # Settings.* reader — proves encryption happened at rest, not merely
+      # that the read side hides it.
+      raw = Queries.get_setting_by_key("oauth_google_client_secret")
+      assert String.starts_with?(raw.value, "enc:v1:")
+      refute raw.value == "synthetic-round-trip-secret"
+
+      # The read path (point 2, state 1): the same plaintext comes back.
+      assert Settings.get_setting("oauth_google_client_secret") == "synthetic-round-trip-secret"
+
+      assert Settings.list_all_settings()["oauth_google_client_secret"] ==
+               "synthetic-round-trip-secret"
+    end
+
+    test "an existing plaintext value is read back unchanged (legacy, not touched by this change)" do
+      # Ecto.Changeset.change/2, not Setting.changeset/2, on purpose — this
+      # is what an already-plaintext row from before this change looks
+      # like, written directly rather than through the (encrypting) write
+      # path this test is not exercising.
+      {:ok, _} =
+        %PhoenixKit.Settings.Setting{}
+        |> Ecto.Changeset.change(%{
+          key: "oauth_github_client_secret",
+          value: "already-plaintext-legacy-value"
+        })
+        |> Queries.insert_setting()
+
+      raw = Queries.get_setting_by_key("oauth_github_client_secret")
+      refute String.starts_with?(raw.value, "enc:v1:")
+
+      assert Settings.get_setting("oauth_github_client_secret") ==
+               "already-plaintext-legacy-value"
+    end
+
+    # 🔴 The guard the card exists for: a secret that stops decrypting on
+    # the read path must read as a broken login, never as a value — and
+    # never as the raw enc:v1: ciphertext handed to whatever reads it next
+    # (an OAuth strategy, AWS.access_key_id/0). This is the test that must
+    # go red if a future change makes the read path fall back to the raw
+    # stored value on a decrypt failure.
+    test "the read path never returns raw ciphertext when decryption fails" do
+      {:ok, _} =
+        Settings.update_setting("oauth_google_client_secret", "synthetic-will-be-corrupted")
+
+      raw = Queries.get_setting_by_key("oauth_google_client_secret")
+      assert String.starts_with?(raw.value, "enc:v1:")
+
+      # Simulate "the read path stopped decrypting" (mismatched/rotated key,
+      # corrupted ciphertext) by corrupting the stored ciphertext directly —
+      # via a bare Ecto.Changeset.change/2, bypassing Setting.changeset/2 on
+      # purpose, so this writes the corrupted bytes as-is instead of the
+      # write path re-encrypting them as if they were fresh plaintext.
+      corrupted_ciphertext = String.slice(raw.value, 0..-6//1)
+
+      {:ok, _} =
+        raw
+        |> Ecto.Changeset.change(value: corrupted_ciphertext)
+        |> Queries.update_setting()
+
+      PhoenixKit.Cache.invalidate(:settings, "oauth_google_client_secret")
+
+      result = Settings.get_setting("oauth_google_client_secret")
+
+      refute result == corrupted_ciphertext
+      refute is_binary(result) and String.starts_with?(result, "enc:v1:")
+      assert result == nil
+
+      # Same guard through the plural read path OAuth login actually uses.
+      PhoenixKit.Cache.invalidate(:settings, "oauth_google_client_secret")
+      direct = Settings.get_settings_direct(["oauth_google_client_secret"])
+      direct_value = Map.get(direct, "oauth_google_client_secret")
+
+      refute direct_value == corrupted_ciphertext
+      refute is_binary(direct_value) and String.starts_with?(direct_value, "enc:v1:")
+    end
+  end
 end

--- a/test/phoenix_kit/settings_test.exs
+++ b/test/phoenix_kit/settings_test.exs
@@ -202,6 +202,45 @@ defmodule PhoenixKit.SettingsTest do
                "synthetic-round-trip-secret"
     end
 
+    # S015 review finding 1: warm_cache_data/0 originally read `setting.value`
+    # directly, bypassing `decrypt_and_map_settings/1` — the one place every
+    # OTHER multi-key read path funnels through.
+    # `PhoenixKit.Cache` is a bare ETS passthrough with no notion of
+    # encryption — its warmer just `:ets.insert`s whatever this function
+    # returns, verbatim — so every app boot (`supervisor.ex`'s `:settings`
+    # child, `sync_init: true`) filled the cache with raw `enc:v1:...` for
+    # every restricted key, and `get_setting_cached/2`/`get_settings_cached/2`
+    # (their own docstrings: "preferred") served it as if it were the real
+    # secret on every cache HIT — no error, no log — until the next write
+    # invalidated that one key.
+    test "the boot-time cache warmer does not populate the cache with raw ciphertext" do
+      {:ok, _} =
+        Settings.update_setting("oauth_google_client_secret", "synthetic-cache-warm-secret")
+
+      # The exact function supervisor.ex wires as the :settings cache's
+      # warmer. `PhoenixKit.Cache`'s own warm_critical_data/2 is a bare
+      # :ets.insert per {key, value} pair returned here — no transformation
+      # of its own — so asserting on THIS return value is asserting on
+      # exactly what a fresh boot would serve.
+      warmed = Settings.warm_cache_data()
+      assert warmed["oauth_google_client_secret"] == "synthetic-cache-warm-secret"
+
+      # Prove it through the real cache and the public, docstring-preferred
+      # get_setting_cached/2 too. Seeded directly rather than by triggering
+      # the real sync_init warmer: that warmer runs its query inside a
+      # spawned Task (`PhoenixKit.Cache.do_sync_warm/2`), which does not
+      # inherit this test's :manual-mode Sandbox connection — triggering it
+      # for real here would just fail to reach the database and prove
+      # nothing. `test/phoenix_kit/utils/safe_destination_settings_test.exs`
+      # seeds this same cache the same way, for the same reason.
+      start_supervised!({PhoenixKit.Cache.Registry, []})
+      start_supervised!({PhoenixKit.Cache, name: :settings})
+      :ok = PhoenixKit.Cache.put_multiple(:settings, warmed)
+
+      assert Settings.get_setting_cached("oauth_google_client_secret") ==
+               "synthetic-cache-warm-secret"
+    end
+
     test "an existing plaintext value is read back unchanged (legacy, not touched by this change)" do
       # Ecto.Changeset.change/2, not Setting.changeset/2, on purpose — this
       # is what an already-plaintext row from before this change looks


### PR DESCRIPTION
## What

`PhoenixKit.Settings` stores values as plain text. Among them are login OAuth
secrets and AWS keys:

    oauth_google_client_secret     oauth_github_client_secret
    oauth_facebook_app_secret      aws_access_key_id
                                   aws_secret_access_key

Measured on two installations on 28 Aug (lengths and prefix flags only, values
never read): not one of them carries an encryption marker.

`PhoenixKit.Integrations.Encryption` already exists, but it covers the
integrations subsystem only — `grep -r "Encryption\|encrypt\|enc:v1"` over
`lib/phoenix_kit/settings/` returns nothing. This wires the existing primitive
into settings rather than adding a second mechanism: `encrypt_value/1` and
`decrypt_value/1` take a string, which is exactly the shape a flat setting has.

## The read path distinguishes three states, not two

This is the part that matters, and it is why the change is not a one-liner.
`decrypt_value/1` returns `{:ok, value}` for a value that carries no prefix —
deliberate backward compatibility. A caller that treats "decrypted" and "was
never encrypted" as the same thing will one day hand out ciphertext believing it
is plaintext. So the read path resolves to one of:

    prefixed and decrypted        -> the plaintext
    no prefix                     -> legacy value, returned as-is, but distinguishable
    prefixed and decryption FAILED -> an explicit error; the raw value is never returned

The third state is the one worth guarding: a secret that stopped decrypting is a
broken login, not a protected one, and silently returning the ciphertext would
turn a key problem into an authentication problem somewhere far away.

## Write path, and what is deliberately not done

New values for restricted keys are stored encrypted. **Existing values are left
untouched.** Migrating what is already in a database is a separate, deliberate
step against a live installation, and it belongs with the operator, not with
this change.

## Verification

- Four tests, one per read state plus one that fails if the read path ever
  returns ciphertext on a failed decrypt. The guard was checked in both
  directions — broken deliberately to confirm the test goes red, then restored.
- Round-trip: plaintext in, `enc:v1:…` in the database, plaintext back out.
- A test pinning that pre-existing plaintext values keep working.
- Full suite in the primary checkout: `43 doctests, 4141 tests, 0 failures`,
  integration tests actually running. `mix precommit` (compile, docs, credo
  --strict, dialyzer) clean.

One honest caveat about test runs in a **git worktree**: full-suite runs there
are unstable, with a moving target — one run failed `CommonUnreachableTest`, the
next failed five different tests around module discovery and route dedup. The
same files pass in isolation on this branch and on clean `main` in the same
worktree (67 tests, 0 failures), and a full-suite run on clean `main` in a
worktree shows the same sandbox-ownership errors. So the instability tracks the
environment, not this change — but it is named here rather than smoothed over.

## Not covered

- Existing stored values are not migrated; nothing on any installation is
  encrypted by this change.
- Login through a provider has not been exercised end to end — that needs real
  credentials, and the sensible order is migrate, then verify a login, then call
  it done.
- The subject is wider than the title: `aws_access_key_id` and
  `aws_secret_access_key` sit in the same unencrypted list and are covered by the
  same restricted-key list here.
