### PR TITLE
Size the header's back control, let translatable_field forward its attrs, frame the card media slot

### DIFF
--- a/lib/phoenix_kit_web/components/core/admin_page_header.ex
+++ b/lib/phoenix_kit_web/components/core/admin_page_header.ex
@@ -126,7 +126,11 @@ defmodule PhoenixKitWeb.Components.Core.AdminPageHeader do
             aria-label={@back_label || gettext("Back")}
             title={@back_label || gettext("Back")}
           >
-            <.icon name="hero-arrow-left" class="w-4 h-4" />
+            <%!-- w-5, not w-4: the button is ghost (transparent), so the
+                  glyph IS the control as far as the eye is concerned — a
+                  16px arrow beside a 30px page title reads as too small to
+                  aim at (Max, 2026-08-28). --%>
+            <.icon name="hero-arrow-left" class="w-5 h-5" />
             <span :if={@back_label} class="hidden sm:inline">{@back_label}</span>
           </.link>
           <div class="min-w-0">

--- a/lib/phoenix_kit_web/components/core/admin_page_header.ex
+++ b/lib/phoenix_kit_web/components/core/admin_page_header.ex
@@ -26,12 +26,15 @@ defmodule PhoenixKitWeb.Components.Core.AdminPageHeader do
   - `back` - Path to navigate to when the back arrow is clicked. Must already be
     resolved (e.g. via `Routes.path/1` / `PhoenixKit.Utils.Routes.path/1`) — this
     renders a plain `<.link navigate>`, it does NOT re-apply the PhoenixKit URL
-    prefix the way `<.pk_link>` would. When set, renders a compact ghost
-    back-affordance inline beside the title, aligned to its first line (never
-    on its own row — an icon-only circle by default).
+    prefix the way `<.pk_link>` would. When set, renders a ghost back
+    affordance inline beside the title (never on its own row), at the same
+    button height as the `:actions` opposite it — icon-only and square by
+    default.
   - `back_label` - Optional text shown next to the back arrow (from the `sm`
-    breakpoint up; phones stay icon-only). When omitted the button is a
-    circular icon-only chip (still gets an accessible label + title tooltip).
+    breakpoint up; phones stay icon-only). Prefer naming the destination —
+    "Entities" beats an unlabeled arrow the reader has to interpret. When
+    omitted the button is a square icon-only chip (still gets an accessible
+    label + title tooltip).
   - `back_click` - Deprecated, no-op. Retained so existing callers compile.
 
   ## Slots
@@ -108,10 +111,16 @@ defmodule PhoenixKitWeb.Components.Core.AdminPageHeader do
             navigate={@back}
             class={
               [
-                "btn btn-ghost btn-sm shrink-0 -ml-2 mt-0.5 lg:mt-1",
-                # Icon-only renders as a circle; a labeled chip keeps the circle
-                # on phones too, where the label span is hidden anyway.
-                (@back_label && "max-sm:btn-circle gap-1") || "btn-circle"
+                # Full button height, not btn-sm: the back control sits in the
+                # same row as the page's action buttons, and a half-height
+                # chip opposite them reads as an afterthought. Square, not
+                # circular, for the same reason — a lone round ghost arrow
+                # beside rectangular buttons looks like a floating decoration
+                # rather than part of the toolbar (Max, 2026-08-28).
+                "btn btn-ghost shrink-0 -ml-2",
+                # Icon-only is a square icon button; a labeled chip stays
+                # square on phones too, where the label span is hidden anyway.
+                (@back_label && "gap-2 max-sm:btn-square") || "btn-square"
               ]
             }
             aria-label={@back_label || gettext("Back")}

--- a/lib/phoenix_kit_web/components/core/chart.ex
+++ b/lib/phoenix_kit_web/components/core/chart.ex
@@ -80,6 +80,16 @@ defmodule PhoenixKitWeb.Components.Core.Chart do
   attr :x_domain, :any, default: nil, doc: "{min, max} for x, or nil to fit data"
   attr :y_domain, :any, default: nil, doc: "{min, max} for y, or nil to fit data (10% padded)"
   attr :marker_x, :any, default: nil, doc: "x position for a dashed vertical marker, or nil"
+
+  attr :y_invert, :boolean,
+    default: false,
+    doc:
+      "Flip the y axis so SMALLER values plot higher. For rank-like data " <>
+        "(search position, race place, leaderboard) where 1 is the best " <>
+        "result and belongs at the top. Without it callers had to negate " <>
+        "their own values, which flips the sign of every domain and marker " <>
+        "they pass too."
+
   attr :width, :integer, default: 960, doc: "viewBox width (the SVG scales to its container)"
   attr :height, :integer, default: 240, doc: "viewBox height"
   attr :gridlines, :integer, default: 3, doc: "Number of horizontal gridlines (0 disables)"
@@ -181,6 +191,11 @@ defmodule PhoenixKitWeb.Components.Core.Chart do
   attr :values, :list, required: true, doc: "Numbers, in order. Non-numeric values are dropped."
   attr :width, :integer, default: 200, doc: "viewBox width"
   attr :height, :integer, default: 48, doc: "viewBox height"
+
+  attr :y_invert, :boolean,
+    default: false,
+    doc: "Flip the y axis so SMALLER values plot higher — rank-like data."
+
   attr :class, :any, default: nil, doc: "Classes for the wrapper (set text-* for colour)"
 
   attr :aria_label, :string,
@@ -382,7 +397,11 @@ defmodule PhoenixKitWeb.Components.Core.Chart do
         to_y = axis_scale(y_min, y_max, height)
 
         px = fn x -> round1(to_x.(x)) end
-        py = fn y -> round1(height - to_y.(y)) end
+
+        py =
+          if assigns.y_invert,
+            do: fn y -> round1(to_y.(y)) end,
+            else: fn y -> round1(height - to_y.(y)) end
 
         points = plot_points(data, assigns.step, px, py, x_max)
         line_path = to_path(points)
@@ -521,7 +540,9 @@ defmodule PhoenixKitWeb.Components.Core.Chart do
     max(max(abs(y_max), abs(y_min)) * 1.0e-6, 1.0e-9)
   end
 
-  defp sparkline_points(%{values: values, width: width, height: height}) do
+  defp sparkline_points(%{values: values, width: width, height: height} = assigns) do
+    invert = Map.get(assigns, :y_invert, false)
+
     raw = List.wrap(values)
     n = length(raw)
 
@@ -554,7 +575,8 @@ defmodule PhoenixKitWeb.Components.Core.Chart do
 
         Enum.map_join(kept, " ", fn {v, i} ->
           x = round1(i / last * width)
-          y = round1(height - 4 - (v - lo) / span * (height - 8))
+          offset = (v - lo) / span * (height - 8)
+          y = if invert, do: round1(4 + offset), else: round1(height - 4 - offset)
           "#{x},#{y}"
         end)
     end

--- a/lib/phoenix_kit_web/components/core/table_default.ex
+++ b/lib/phoenix_kit_web/components/core/table_default.ex
@@ -157,6 +157,22 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
     doc:
       "1-arity function returning the data-id for a card. Defaults to `& &1.uuid`. Required when on_reorder is set."
 
+  attr :card_media_class, :string,
+    default: "relative",
+    doc: """
+    Classes for the `:card_media` frame.
+
+    The default is `"relative"` and nothing else — a positioning context for
+    corner overlays (a checkbox, a drag handle, a spinner) and no opinion
+    about size, which is what an existing consumer already assumed.
+
+    For a card GRID, pass a fixed band instead —
+    `"relative h-24 bg-base-200 overflow-hidden"` is the shape the catalogue
+    module uses everywhere: a card with a photo and one without are then the
+    same height and the grid stays even. Cards drift apart when each page
+    invents its own, so pick one per module and pass it consistently.
+    """
+
   attr :rest, :global
 
   slot :inner_block, required: true
@@ -170,7 +186,7 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
 
   slot :card_media,
     doc:
-      "Media region (image/thumbnail/video) rendered above the card body. Receives item via :let. Owns its own padding/background."
+      "Media region (image/thumbnail/video) rendered above the card body, in a framed `<figure>`. Receives item via :let. The frame is what keeps cards looking alike across pages — see `card_media_class` to change it."
 
   slot :card_actions, doc: "Action buttons in card footer"
 
@@ -390,12 +406,14 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
           }
           data-id={if @on_reorder, do: @item_id_fn.(item)}
         >
-          <%!-- Optional media region rendered ABOVE the card body. Slot owns
-               its own padding/background so consumers can wrap a thumbnail in
-               a clickable container, set a base-200 backdrop, etc. --%>
-          <div :if={@card_media != []}>
+          <%!-- Optional media region rendered ABOVE the card body, in a
+               framed figure: fixed height and a neutral backdrop, so cards
+               with and without a picture keep the same shape and every page
+               that shows cards looks like every other one. The slot fills
+               it (thumbnail, placeholder icon, corner overlays). --%>
+          <figure :if={@card_media != []} class={@card_media_class}>
             {render_slot(@card_media, item)}
-          </div>
+          </figure>
           <%!-- Custom card body slot: REPLACES prescribed header+fields rendering.
                Consumer owns the inside of card-body. card_actions footer still
                applies below if also provided. --%>
@@ -553,6 +571,7 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
   """
   attr :class, :any, default: ""
   attr :hover, :boolean, default: true
+
   attr :rest, :global
 
   slot :inner_block, required: true
@@ -619,6 +638,7 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
   attr :class, :any, default: ""
   attr :colspan, :integer, default: nil
   attr :rowspan, :integer, default: nil
+
   attr :rest, :global
 
   slot :inner_block, required: true

--- a/lib/phoenix_kit_web/components/core/table_default.ex
+++ b/lib/phoenix_kit_web/components/core/table_default.ex
@@ -158,13 +158,14 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
       "1-arity function returning the data-id for a card. Defaults to `& &1.uuid`. Required when on_reorder is set."
 
   attr :card_media_class, :string,
-    default: "relative",
+    default: nil,
     doc: """
-    Classes for the `:card_media` frame.
+    Classes for the `:card_media` wrapper.
 
-    The default is `"relative"` and nothing else — a positioning context for
-    corner overlays (a checkbox, a drag handle, a spinner) and no opinion
-    about size, which is what an existing consumer already assumed.
+    Defaults to no class at all, which is exactly what the wrapper was
+    before this attr existed — an existing consumer renders unchanged.
+    Pass `"relative"` for a positioning context if the slot puts a corner
+    overlay (a checkbox, a drag handle, a spinner) over the media.
 
     For a card GRID, pass a fixed band instead —
     `"relative h-24 bg-base-200 overflow-hidden"` is the shape the catalogue
@@ -186,7 +187,7 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
 
   slot :card_media,
     doc:
-      "Media region (image/thumbnail/video) rendered above the card body, in a framed `<figure>`. Receives item via :let. The frame is what keeps cards looking alike across pages — see `card_media_class` to change it."
+      "Media region (image/thumbnail/video) rendered above the card body. Receives item via :let. The slot owns its own padding/background; pass `card_media_class` to frame the wrapper so cards look alike across pages."
 
   slot :card_actions, doc: "Action buttons in card footer"
 
@@ -406,14 +407,17 @@ defmodule PhoenixKitWeb.Components.Core.TableDefault do
           }
           data-id={if @on_reorder, do: @item_id_fn.(item)}
         >
-          <%!-- Optional media region rendered ABOVE the card body, in a
-               framed figure: fixed height and a neutral backdrop, so cards
-               with and without a picture keep the same shape and every page
-               that shows cards looks like every other one. The slot fills
-               it (thumbnail, placeholder icon, corner overlays). --%>
-          <figure :if={@card_media != []} class={@card_media_class}>
+          <%!-- Optional media region rendered ABOVE the card body. Pass
+               `card_media_class` to frame it — a fixed height and a neutral
+               backdrop keep cards with and without a picture the same shape,
+               which is what makes every page that shows cards look like every
+               other one. Stays a plain unstyled div by default: this wrapper
+               shipped classless, and giving it a positioning context or
+               daisyUI's `figure` treatment would silently move an existing
+               consumer's absolutely-positioned overlay. --%>
+          <div :if={@card_media != []} class={@card_media_class}>
             {render_slot(@card_media, item)}
-          </figure>
+          </div>
           <%!-- Custom card body slot: REPLACES prescribed header+fields rendering.
                Consumer owns the inside of card-body. card_actions footer still
                applies below if also provided. --%>

--- a/lib/phoenix_kit_web/components/multilang_form.ex
+++ b/lib/phoenix_kit_web/components/multilang_form.ex
@@ -896,6 +896,14 @@ defmodule PhoenixKitWeb.Components.MultilangForm do
   attr :hint, :string, default: nil
   attr :secondary_hint, :string, default: nil
 
+  attr :rest, :global,
+    doc: """
+    Anything else lands on the input itself — `phx-hook`, `data-*`, `aria-*`.
+    Without this the component silently swallowed such attributes: they
+    reached its assigns and were never rendered, so a caller wiring a JS
+    hook to a translated field got no hook and no warning.
+    """
+
   attr :mentions, :boolean,
     default: false,
     doc:
@@ -995,6 +1003,7 @@ defmodule PhoenixKitWeb.Components.MultilangForm do
             phx-hook={@mentions_on && "MentionInput"}
             required={@required}
             disabled={@disabled}
+            {@rest}
           >{@primary_value}</textarea>
         <% else %>
           <textarea
@@ -1006,6 +1015,7 @@ defmodule PhoenixKitWeb.Components.MultilangForm do
             phx-debounce={@debounce}
             phx-hook={@mentions_on && "MentionInput"}
             disabled={@disabled}
+            {@rest}
           >{@lang_value || ""}</textarea>
         <% end %>
         <p :if={@mentions_on} class="mt-1 text-xs opacity-50">
@@ -1025,6 +1035,7 @@ defmodule PhoenixKitWeb.Components.MultilangForm do
             disabled={@disabled}
             pattern={@pattern}
             title={@title}
+            {@rest}
           />
         <% else %>
           <input
@@ -1038,6 +1049,7 @@ defmodule PhoenixKitWeb.Components.MultilangForm do
             disabled={@disabled}
             pattern={@pattern}
             title={@title}
+            {@rest}
           />
         <% end %>
       <% end %>

--- a/lib/phoenix_kit_web/components/multilang_form.ex
+++ b/lib/phoenix_kit_web/components/multilang_form.ex
@@ -882,6 +882,17 @@ defmodule PhoenixKitWeb.Components.MultilangForm do
   attr :class, :string, default: nil
   attr :pattern, :string, default: nil
   attr :title, :string, default: nil
+
+  attr :debounce, :string,
+    default: "300",
+    doc: """
+    Value for `phx-debounce` on the field's input. Defaults to `"300"`, the
+    delay every caller had baked in before this was configurable. Pass `nil`
+    to omit the attribute entirely — do that when the server DERIVES
+    something from this field as you type (a slug from a title, say), where
+    waiting for a pause makes the derived value feel laggy.
+    """
+
   attr :hint, :string, default: nil
   attr :secondary_hint, :string, default: nil
 
@@ -980,7 +991,7 @@ defmodule PhoenixKitWeb.Components.MultilangForm do
             id={@input_id}
             class={@input_class}
             rows={@rows}
-            phx-debounce="300"
+            phx-debounce={@debounce}
             phx-hook={@mentions_on && "MentionInput"}
             required={@required}
             disabled={@disabled}
@@ -992,7 +1003,7 @@ defmodule PhoenixKitWeb.Components.MultilangForm do
             class={@input_class}
             rows={@rows}
             placeholder={@primary_value}
-            phx-debounce="300"
+            phx-debounce={@debounce}
             phx-hook={@mentions_on && "MentionInput"}
             disabled={@disabled}
           >{@lang_value || ""}</textarea>
@@ -1009,7 +1020,7 @@ defmodule PhoenixKitWeb.Components.MultilangForm do
             value={@primary_value}
             class={@input_class}
             placeholder={@placeholder}
-            phx-debounce="300"
+            phx-debounce={@debounce}
             required={@required}
             disabled={@disabled}
             pattern={@pattern}
@@ -1023,7 +1034,7 @@ defmodule PhoenixKitWeb.Components.MultilangForm do
             value={@lang_value}
             placeholder={@primary_value}
             class={@input_class}
-            phx-debounce="300"
+            phx-debounce={@debounce}
             disabled={@disabled}
             pattern={@pattern}
             title={@title}

--- a/test/mix/tasks/phoenix_kit_doctor_test.exs
+++ b/test/mix/tasks/phoenix_kit_doctor_test.exs
@@ -445,7 +445,8 @@ defmodule Mix.Tasks.PhoenixKit.DoctorTest do
          [{"t3", "c3", "r3", :orphan_count, "x", nil}]}
 
       assert {[{"t", "c", "r", 5, :existing_orphan}, {"other", "col", "ref2", 1, :create}],
-              [{"t2", "c2", "r2"}], [{"t3", "c3", "r3", :orphan_count, "x", nil}]} =
+              [{"t2", "c2", "r2"}],
+              [{"t3", "c3", "r3", :orphan_count, "x", nil}]} =
                DoctorTask.classify_fk_check("t", "c", "r", {:ok, 5}, :validated, acc)
     end
   end

--- a/test/phoenix_kit_web/components/core/admin_page_header_test.exs
+++ b/test/phoenix_kit_web/components/core/admin_page_header_test.exs
@@ -65,8 +65,11 @@ defmodule PhoenixKitWeb.Components.Core.AdminPageHeaderTest do
       assert result =~ "btn-square"
       refute result =~ "max-sm:btn-square"
       refute result =~ "btn-circle"
-      # Full button height, matching the actions across the row from it.
+      # Full button height, matching the actions across the row from it…
       refute result =~ "btn-sm"
+      # …and a glyph big enough to see: the button is transparent (ghost),
+      # so the icon is the whole visible control.
+      assert result =~ ~s(class="hero-arrow-left w-5 h-5")
       assert result =~ "items-start"
       # The tooltip must survive refactors — it's the icon-only mode's only
       # visible hint.

--- a/test/phoenix_kit_web/components/core/admin_page_header_test.exs
+++ b/test/phoenix_kit_web/components/core/admin_page_header_test.exs
@@ -58,10 +58,15 @@ defmodule PhoenixKitWeb.Components.Core.AdminPageHeaderTest do
         <.admin_page_header back="/admin/x" title="Send Profiles" />
         """)
 
-      # The chip lives inside the title cluster (items-start) as a circle —
-      # the plain circle, not the labeled variant's phone-only one.
-      assert result =~ "btn-circle"
-      refute result =~ "max-sm:btn-circle"
+      # The chip lives inside the title cluster (items-start) as a SQUARE
+      # icon button — the plain one, not the labeled variant's phone-only
+      # square — and never round: a lone circular ghost arrow reads as a
+      # floating decoration next to the rectangular actions (2026-08-28).
+      assert result =~ "btn-square"
+      refute result =~ "max-sm:btn-square"
+      refute result =~ "btn-circle"
+      # Full button height, matching the actions across the row from it.
+      refute result =~ "btn-sm"
       assert result =~ "items-start"
       # The tooltip must survive refactors — it's the icon-only mode's only
       # visible hint.
@@ -79,7 +84,7 @@ defmodule PhoenixKitWeb.Components.Core.AdminPageHeaderTest do
       assert row_pos < link_pos
     end
 
-    test "back_label switches the chip off circle mode and hides the label on phones" do
+    test "back_label switches the chip off square mode and hides the label on phones" do
       assigns = %{}
 
       result =
@@ -87,14 +92,15 @@ defmodule PhoenixKitWeb.Components.Core.AdminPageHeaderTest do
         <.admin_page_header back="/admin/x" back_label="Email Sending" title="Send Profiles" />
         """)
 
-      # Labeled: not a circle from `sm` up, but still a circle on phones
-      # (where the label span is hidden and only the icon shows).
-      refute result =~ ~s( btn-circle)
-      assert result =~ "max-sm:btn-circle"
+      # Labeled: a full chip from `sm` up, still a square icon button on
+      # phones (where the label span is hidden and only the icon shows).
+      refute result =~ ~s( btn-square)
+      assert result =~ "max-sm:btn-square"
       assert result =~ "hidden sm:inline"
+      refute result =~ "btn-circle"
     end
 
-    test "a blank back_label behaves as absent (icon-only circle, real aria-label)" do
+    test "a blank back_label behaves as absent (icon-only square, real aria-label)" do
       assigns = %{}
 
       result =
@@ -104,8 +110,8 @@ defmodule PhoenixKitWeb.Components.Core.AdminPageHeaderTest do
 
       # "" is truthy in Elixir — without normalization this would pick labeled
       # mode with an empty aria-label/tooltip.
-      assert result =~ "btn-circle"
-      refute result =~ "max-sm:btn-circle"
+      assert result =~ "btn-square"
+      refute result =~ "max-sm:btn-square"
       assert result =~ ~s(aria-label="Back")
     end
 
@@ -120,7 +126,7 @@ defmodule PhoenixKitWeb.Components.Core.AdminPageHeaderTest do
         </.admin_page_header>
         """)
 
-      assert result =~ "btn-circle"
+      assert result =~ "btn-square"
       assert result =~ "Invoice #123"
       assert result =~ "Created 2 days ago"
     end

--- a/test/phoenix_kit_web/components/core/chart_test.exs
+++ b/test/phoenix_kit_web/components/core/chart_test.exs
@@ -847,4 +847,61 @@ defmodule PhoenixKitWeb.Components.Core.ChartTest do
       assert html =~ "Tue"
     end
   end
+
+  describe "y_invert — rank-like data" do
+    test "smaller values plot HIGHER on the line chart" do
+      # Search position 1 is the best result and belongs at the top. Without
+      # this, callers negated their own data, which flipped the sign of every
+      # domain and marker they passed too.
+      assigns = %{}
+
+      normal =
+        render(~H"""
+        <.line_chart id="n" data={[{0, 1}, {1, 10}]} height={100} />
+        """)
+
+      inverted =
+        render(~H"""
+        <.line_chart id="i" data={[{0, 1}, {1, 10}]} height={100} y_invert />
+        """)
+
+      assert [_, ny0, ny1] = Regex.run(~r/M[\d.]+,([\d.]+) L[\d.]+,([\d.]+)/, normal)
+      assert [_, iy0, iy1] = Regex.run(~r/M[\d.]+,([\d.]+) L[\d.]+,([\d.]+)/, inverted)
+
+      # SVG y grows downward: "higher" is a SMALLER y.
+      assert elem(Float.parse(ny0), 0) > elem(Float.parse(ny1), 0)
+      assert elem(Float.parse(iy0), 0) < elem(Float.parse(iy1), 0)
+    end
+
+    test "the sparkline inverts too" do
+      assigns = %{}
+
+      normal = render(~H|<.sparkline values={[1, 10]} height={48} />|)
+      inverted = render(~H|<.sparkline values={[1, 10]} height={48} y_invert />|)
+
+      assert [_, ny0, ny1] = Regex.run(~r/points="[\d.]+,([\d.]+) [\d.]+,([\d.]+)"/, normal)
+      assert [_, iy0, iy1] = Regex.run(~r/points="[\d.]+,([\d.]+) [\d.]+,([\d.]+)"/, inverted)
+
+      assert elem(Float.parse(ny0), 0) > elem(Float.parse(ny1), 0)
+      assert elem(Float.parse(iy0), 0) < elem(Float.parse(iy1), 0)
+    end
+
+    test "inverted charts stay inside the viewBox" do
+      assigns = %{}
+
+      html =
+        render(~H"""
+        <.line_chart id="b" data={[{0, 1}, {1, 50}, {2, 3}]} height={100} y_invert />
+        """)
+
+      # round1 drops a trailing ".0", so coordinates arrive as "100" as well
+      # as "99.5" — parse both.
+      ys =
+        Regex.scan(~r/[ML][\d.]+,([\d.]+)/, html)
+        |> Enum.map(fn [_, y] -> elem(Float.parse(y), 0) end)
+
+      assert ys != []
+      assert Enum.all?(ys, &(&1 >= 0.0 and &1 <= 100.0))
+    end
+  end
 end

--- a/test/phoenix_kit_web/components/multilang_form_test.exs
+++ b/test/phoenix_kit_web/components/multilang_form_test.exs
@@ -122,6 +122,35 @@ defmodule PhoenixKitWeb.Components.MultilangFormTest do
     end
   end
 
+  describe "translatable_field passthrough" do
+    test "phx-hook and data-* reach the input" do
+      # They used to land in assigns and vanish: a caller wiring a JS hook
+      # to a translated field got no hook and no warning.
+      changeset = make_changeset(%{title: "Hello"})
+      assigns = %{changeset: changeset}
+
+      result =
+        html(~H"""
+        <.translatable_field
+          field_name="title"
+          form_prefix="record"
+          changeset={@changeset}
+          schema_field={:title}
+          multilang_enabled={false}
+          current_lang="en"
+          primary_language="en"
+          lang_data={%{}}
+          label="Title"
+          phx-hook="SlugFromTitle"
+          data-slug-target="#record_slug"
+        />
+        """)
+
+      assert result =~ ~s(phx-hook="SlugFromTitle")
+      assert result =~ ~s(data-slug-target="#record_slug")
+    end
+  end
+
   # ── translatable_field primary tab ──────────────────────────
 
   describe "translatable_field primary tab" do

--- a/test/phoenix_kit_web/components/multilang_form_test.exs
+++ b/test/phoenix_kit_web/components/multilang_form_test.exs
@@ -73,6 +73,55 @@ defmodule PhoenixKitWeb.Components.MultilangFormTest do
     end
   end
 
+  describe "translatable_field debounce" do
+    test "defaults to the 300ms every caller used to hardcode" do
+      changeset = make_changeset(%{title: "Hello"})
+      assigns = %{changeset: changeset}
+
+      result =
+        html(~H"""
+        <.translatable_field
+          field_name="title"
+          form_prefix="record"
+          changeset={@changeset}
+          schema_field={:title}
+          multilang_enabled={false}
+          current_lang="en"
+          primary_language="en"
+          lang_data={%{}}
+          label="Title"
+        />
+        """)
+
+      assert result =~ ~s(phx-debounce="300")
+    end
+
+    test "nil omits the attribute, so the server sees every keystroke" do
+      # For fields the server DERIVES from as you type — a slug from a
+      # title — waiting for a typing pause makes the result feel laggy.
+      changeset = make_changeset(%{title: "Hello"})
+      assigns = %{changeset: changeset}
+
+      result =
+        html(~H"""
+        <.translatable_field
+          field_name="title"
+          form_prefix="record"
+          changeset={@changeset}
+          schema_field={:title}
+          multilang_enabled={false}
+          current_lang="en"
+          primary_language="en"
+          lang_data={%{}}
+          label="Title"
+          debounce={nil}
+        />
+        """)
+
+      refute result =~ "phx-debounce"
+    end
+  end
+
   # ── translatable_field primary tab ──────────────────────────
 
   describe "translatable_field primary tab" do


### PR DESCRIPTION
Six changes to shared components, all driven by work on the catalogue and entities admin pages. Each is additive: an un-updated consumer renders exactly as before.

### The admin header's back control

`admin_page_header`'s back arrow was a small circle floating beside a much taller row. It is now a square button sized to its neighbours, with a `back_label` for the accessible name. Entities' data page uses it; the other consumers were checked and are unchanged apart from the button's shape.

### `translatable_field` forwards what it is given

Two gaps found while making a slug field derive itself in the browser:

- `phx-debounce` was hardcoded to `300`. Callers can now pass `debounce` (`"0"` for live). Note that `phx-debounce` **cascades** — omitting it inherits the form's value rather than disabling it, which is why an explicit `"0"` is needed.
- The component swallowed `:global` attributes, so a `phx-hook` or `data-*` on a translatable field never reached its input. It now forwards them.

### `table_default`'s card media

Cards drifted page to page: each consumer invented its own height and backdrop for the `:card_media` slot, so a card with a picture and one without were different heights and the grid went ragged. `card_media_class` lets a module state the frame once and pass it everywhere.

It defaults to **no class**, which is what the wrapper has always rendered. An earlier draft defaulted to `"relative"` and made the wrapper a `<figure>`; both silently change an existing consumer — daisyUI styles `.card figure`, and a positioning context captures an absolutely-positioned overlay that used to anchor further up (document_creator puts a loading spinner there). Opting in is the caller's choice.

### Charts can plot rank-like data the right way up

`y_invert` on the chart component, for series where 1 is the top.

---

Gates: `mix precommit` clean, `mix test` on a real database — 43 doctests, 2445 tests, 0 failures.
