### PR TITLE
Fix repair reporting two composite-key PRIMARY KEYs as missing

### DIFF
--- a/lib/phoenix_kit/migrations/expected_schema.ex
+++ b/lib/phoenix_kit/migrations/expected_schema.ex
@@ -27743,30 +27743,29 @@ defmodule PhoenixKit.Migrations.ExpectedSchema do
         backfill: nil
       },
       %{
-        id: "index:phoenix_kit_shop_product_slugs_pkey",
+        id: "constraint:phoenix_kit_shop_product_slugs.phoenix_kit_shop_product_slugs_pkey",
         owner: :core,
         check:
           {:catalog,
            %{
              name: "phoenix_kit_shop_product_slugs_pkey",
              table: "phoenix_kit_shop_product_slugs",
-             kind: :index
+             kind: :constraint
            }},
         create: nil,
         since: 171,
-        class: :index,
+        class: :constraint,
         revisions: [
           {171,
            %{
-             table: "phoenix_kit_shop_product_slugs",
-             keys: ["lang", "value"],
-             unique: true,
-             method: "btree",
-             definition:
-               "CREATE UNIQUE INDEX phoenix_kit_shop_product_slugs_pkey ON __SCHEMA__.phoenix_kit_shop_product_slugs USING btree (lang, value)",
-             predicate: nil,
-             opclasses: ["text_ops", "text_ops"],
-             name_template: nil
+             type: "p",
+             columns: ["lang", "value"],
+             definition: "PRIMARY KEY (lang, value)",
+             name_template: nil,
+             foreign_table: nil,
+             foreign_columns: nil,
+             on_delete: nil,
+             on_update: nil
            }}
         ],
         presence: :required,
@@ -27785,30 +27784,29 @@ defmodule PhoenixKit.Migrations.ExpectedSchema do
         backfill: nil
       },
       %{
-        id: "index:phoenix_kit_shop_category_slugs_pkey",
+        id: "constraint:phoenix_kit_shop_category_slugs.phoenix_kit_shop_category_slugs_pkey",
         owner: :core,
         check:
           {:catalog,
            %{
              name: "phoenix_kit_shop_category_slugs_pkey",
              table: "phoenix_kit_shop_category_slugs",
-             kind: :index
+             kind: :constraint
            }},
         create: nil,
         since: 171,
-        class: :index,
+        class: :constraint,
         revisions: [
           {171,
            %{
-             table: "phoenix_kit_shop_category_slugs",
-             keys: ["lang", "value"],
-             unique: true,
-             method: "btree",
-             definition:
-               "CREATE UNIQUE INDEX phoenix_kit_shop_category_slugs_pkey ON __SCHEMA__.phoenix_kit_shop_category_slugs USING btree (lang, value)",
-             predicate: nil,
-             opclasses: ["text_ops", "text_ops"],
-             name_template: nil
+             type: "p",
+             columns: ["lang", "value"],
+             definition: "PRIMARY KEY (lang, value)",
+             name_template: nil,
+             foreign_table: nil,
+             foreign_columns: nil,
+             on_delete: nil,
+             on_update: nil
            }}
         ],
         presence: :required,

--- a/lib/phoenix_kit/migrations/repair/probe.ex
+++ b/lib/phoenix_kit/migrations/repair/probe.ex
@@ -36,11 +36,12 @@ defmodule PhoenixKit.Migrations.Repair.Probe do
   @typedoc "`:absent` (table missing), `nil` (table exists, no comment), or the numeric comment."
   @type raw_comment :: :absent | nil | :unparseable | non_neg_integer()
 
-  @typedoc "One schema's structural snapshot — mirrors `PhoenixKit.Squash.Generate.Catalog.snapshot/2`'s shape, minus seeds (see moduledoc \"Seeds\" note on `PhoenixKit.Migrations.Repair.Differ`)."
+  @typedoc "One schema's structural snapshot — mirrors `PhoenixKit.Squash.Generate.Catalog.snapshot/2`'s shape, minus seeds (see moduledoc \"Seeds\" note on `PhoenixKit.Migrations.Repair.Differ`), plus `constraint_backed_indexes` (I095 pt.3 — see `lookup/2`)."
   @type snapshot :: %{
           tables: %{String.t() => map()},
           columns: %{{String.t(), String.t()} => map()},
           indexes: %{String.t() => map()},
+          constraint_backed_indexes: %{String.t() => map()},
           constraints: %{{String.t(), String.t()} => map()},
           sequences: %{String.t() => map()},
           functions: %{{String.t(), String.t()} => map()},
@@ -156,6 +157,31 @@ defmodule PhoenixKit.Migrations.Repair.Probe do
   # 'u')` — the only two constraint kinds where "this index backs a constraint
   # ON ITS OWN TABLE, so don't ALSO list it as a bare index" is the intended
   # rule.
+  #
+  # ## Why a matched row is no longer dropped by the `WHERE`, and what happens
+  # ## to it instead (I095 pt.3)
+  #
+  # A `p`/`u`-backed row used to be excluded outright (`AND con.oid IS NULL`
+  # in the `WHERE`) on the reasoning that such an index is already represented
+  # via `:constraint` — correct for the OBJECT the manifest is SUPPOSED to
+  # declare, but silent about the case where a manifest entry gets the `kind`
+  # wrong (`kind: :index` for an object that is, on the catalog, a `p`/`u`
+  # constraint's own backing index — confirmed live twice: `idx_shop_
+  # category_slugs_pkey`/`idx_shop_product_slugs_pkey`, PRIMARY KEY on a
+  # composite natural key). `lookup/2`'s `kind: :index` clause only ever
+  # consulted `indexes`, so that row read as permanently absent — a healthy
+  # object reported `:missing` forever, no matter how many times repair ran.
+  #
+  # The row is now kept (the `con.oid IS NULL` filter moved from `WHERE` to
+  # the query below deciding which of TWO maps it lands in) rather than
+  # dropped: `indexes/2` partitions on the same `contype` this join already
+  # computes, so `snapshot.indexes` holds exactly the rows it always did (a
+  # `p`/`u`-backed index is still never double-listed there) and the
+  # partitioned-out rows land in the new `constraint_backed_indexes` map
+  # instead of nowhere. `lookup/2` only reaches into that second map as a
+  # fallback for a `kind: :index` check the first map couldn't answer — never
+  # a substitute for declaring `kind: :constraint` on a NEW object (see that
+  # function's doc for what this fallback does and does not cover).
   @indexes_sql """
   SELECT t.relname,
          ic.relname,
@@ -168,7 +194,8 @@ defmodule PhoenixKit.Migrations.Repair.Probe do
          (SELECT array_agg(op.opcname ORDER BY u.ord)
           FROM unnest(string_to_array(i.indclass::text, ' ')::oid[])
                WITH ORDINALITY AS u(opcoid, ord)
-          JOIN pg_opclass op ON op.oid = u.opcoid)
+          JOIN pg_opclass op ON op.oid = u.opcoid),
+         con.contype::text
   FROM pg_index i
   JOIN pg_class ic ON ic.oid = i.indexrelid
   JOIN pg_class t ON t.oid = i.indrelid
@@ -176,7 +203,7 @@ defmodule PhoenixKit.Migrations.Repair.Probe do
   JOIN pg_am am ON am.oid = ic.relam
   LEFT JOIN pg_constraint con
     ON con.conindid = i.indexrelid AND con.contype IN ('p', 'u')
-  WHERE n.nspname = $1 AND con.oid IS NULL
+  WHERE n.nspname = $1
   """
 
   @constraints_sql """
@@ -233,12 +260,15 @@ defmodule PhoenixKit.Migrations.Repair.Probe do
 
   @doc """
   A full structural snapshot of `prefix` on the target server — one round
-  trip per class (7 queries total), mirroring
+  trip per class (7 queries total, `indexes`/`constraint_backed_indexes`
+  sharing the single `@indexes_sql` round trip), mirroring
   `PhoenixKit.Squash.Generate.Catalog.snapshot/2`'s shape exactly (minus
   seeds — see `PhoenixKit.Migrations.Repair.Differ`'s moduledoc for why seed
   rows are checked for presence only, never snapshotted for value
-  comparison). `oban_*` tables/sequences/functions and `schema_migrations`
-  are excluded — Oban is delegated, never manifested (spec §6.1).
+  comparison; plus `constraint_backed_indexes`, which the generator's
+  `Catalog` module has no equivalent of — see `lookup/2`). `oban_*` tables/
+  sequences/functions and `schema_migrations` are excluded — Oban is
+  delegated, never manifested (spec §6.1).
 
   ## Why this forces `search_path = ''` for the duration of the snapshot
 
@@ -293,10 +323,13 @@ defmodule PhoenixKit.Migrations.Repair.Probe do
       repo.query!("SET search_path TO ''", [], log: false)
 
       try do
+        {plain_indexes, constraint_backed_indexes} = indexes(repo, prefix)
+
         %{
           tables: tables(repo, prefix),
           columns: columns(repo, prefix),
-          indexes: indexes(repo, prefix),
+          indexes: plain_indexes,
+          constraint_backed_indexes: constraint_backed_indexes,
           constraints: constraints(repo, prefix),
           sequences: sequences(repo, prefix),
           functions: functions(repo, prefix),
@@ -323,21 +356,36 @@ defmodule PhoenixKit.Migrations.Repair.Probe do
     end
   end
 
+  # Splits on the same `contype` the `@indexes_sql` join already computes —
+  # `nil` (no p/u constraint owns this index) into the first map exactly as
+  # before this split existed; a `p`/`u`-backed row into the second, keyed
+  # the same way (bare index names are unique within a schema regardless of
+  # what — if anything — owns them) rather than dropped. See `@indexes_sql`'s
+  # comment and `lookup/2` for why the second map exists and what reaches it.
   defp indexes(repo, prefix) do
-    for [table, name, unique, method, definition, predicate, keys, opclasses] <-
-          rows!(repo, @indexes_sql, [prefix]),
-        keep_table?(table),
-        into: %{} do
-      {name,
-       %{
-         table: table,
-         unique: unique,
-         method: method,
-         definition: definition,
-         predicate: predicate,
-         keys: keys || [],
-         opclasses: opclasses || []
-       }}
+    rows!(repo, @indexes_sql, [prefix])
+    |> Enum.filter(fn [table | _] -> keep_table?(table) end)
+    |> Enum.reduce({%{}, %{}}, &partition_index_row/2)
+  end
+
+  defp partition_index_row(
+         [table, name, unique, method, definition, predicate, keys, opclasses, backing_contype],
+         {plain, constraint_backed}
+       ) do
+    shape = %{
+      table: table,
+      unique: unique,
+      method: method,
+      definition: definition,
+      predicate: predicate,
+      keys: keys || [],
+      opclasses: opclasses || []
+    }
+
+    if is_nil(backing_contype) do
+      {Map.put(plain, name, shape), constraint_backed}
+    else
+      {plain, Map.put(constraint_backed, name, shape)}
     end
   end
 
@@ -413,11 +461,50 @@ defmodule PhoenixKit.Migrations.Repair.Probe do
   test (`probe_test.exs` builds a snapshot by hand).
 
       iex> snapshot = %{tables: %{"widgets" => %{}}, columns: %{}, indexes: %{},
-      ...>   constraints: %{}, sequences: %{}, functions: %{}, extensions: %{}}
+      ...>   constraint_backed_indexes: %{}, constraints: %{}, sequences: %{},
+      ...>   functions: %{}, extensions: %{}}
       iex> Probe.lookup(snapshot, {:catalog, %{kind: :table, name: "widgets"}})
       %{}
       iex> Probe.lookup(snapshot, {:catalog, %{kind: :table, name: "missing"}})
       nil
+
+  ## The `kind: :index` fallback into `constraint_backed_indexes` (I095 pt.3)
+
+  A `kind: :index` check misses `snapshot.indexes` by construction for an
+  object that is, on the catalog, a `p`/`u` constraint's own backing index —
+  `@indexes_sql`'s comment explains why that index is never listed there.
+  Before this fallback existed, that meant a manifest entry with the wrong
+  `kind` (should have been `:constraint`) read as permanently `:missing` —
+  confirmed live twice (`idx_shop_category_slugs_pkey`/
+  `idx_shop_product_slugs_pkey`, both PRIMARY KEY on a composite natural
+  key). The fallback below checks `constraint_backed_indexes` next — same
+  index-shaped map (`table`/`unique`/`method`/`definition`/`predicate`/
+  `keys`/`opclasses`, read from the SAME `pg_get_indexdef`/`pg_opclass` data
+  a genuinely bare index would have), so `Differ.compare(:index, ...)`
+  keeps comparing every field with full fidelity — nothing here is
+  synthesized or exempted from comparison.
+
+  What this fallback does NOT do:
+
+    * It does not make `kind: :index` an acceptable way to declare a NEW
+      constraint-backed object. `Executor.create_action/2` still dispatches
+      on `object.class`, and `class: :index` still rebuilds a bare
+      `CREATE INDEX IF NOT EXISTS` — wrong DDL for a genuinely MISSING
+      composite-key PRIMARY KEY (no `PRIMARY KEY` semantics, doesn't
+      participate as an FK target). This only rescues PRESENCE detection
+      for an object that already exists; a real gap on some install would
+      still get repaired into the wrong kind of object. New objects must
+      still be declared `kind: :constraint`/`class: :constraint`.
+    * It is restricted to `contype IN ('p', 'u')`, matching `@indexes_sql`'s
+      own restriction — a `CHECK`/exclusion constraint (`c`/`x`) has no
+      guaranteed backing index at all, so there is nothing here for a
+      `kind: :index` check to fall back onto for those.
+    * It does not touch anything outside this runtime read path — the
+      standalone generator (`dev_docs/squash/generate_baseline.exs`'s
+      `Catalog` module) that produces `expected_schema.ex` in the first
+      place is unaffected; regenerating the manifest from scratch can still
+      assign the wrong `kind` to a future composite-key PRIMARY KEY the same
+      way it did for these two.
   """
   @spec lookup(snapshot(), Object.check()) :: map() | nil
   def lookup(snapshot, {:catalog, %{kind: :table, name: name}}),
@@ -429,7 +516,12 @@ defmodule PhoenixKit.Migrations.Repair.Probe do
   def lookup(snapshot, {:catalog, %{kind: :column, table: t, column: c}}),
     do: Map.get(snapshot.columns, {t, c})
 
-  def lookup(snapshot, {:catalog, %{kind: :index, name: n}}), do: Map.get(snapshot.indexes, n)
+  def lookup(snapshot, {:catalog, %{kind: :index, name: n}}) do
+    case Map.get(snapshot.indexes, n) do
+      nil -> Map.get(snapshot, :constraint_backed_indexes, %{}) |> Map.get(n)
+      shape -> shape
+    end
+  end
 
   def lookup(snapshot, {:catalog, %{kind: :constraint, table: t, name: n}}),
     do: Map.get(snapshot.constraints, {t, n})

--- a/lib/phoenix_kit/migrations/repair/probe.ex
+++ b/lib/phoenix_kit/migrations/repair/probe.ex
@@ -501,10 +501,27 @@ defmodule PhoenixKit.Migrations.Repair.Probe do
       `kind: :index` check to fall back onto for those.
     * It does not touch anything outside this runtime read path — the
       standalone generator (`dev_docs/squash/generate_baseline.exs`'s
-      `Catalog` module) that produces `expected_schema.ex` in the first
-      place is unaffected; regenerating the manifest from scratch can still
-      assign the wrong `kind` to a future composite-key PRIMARY KEY the same
-      way it did for these two.
+      `Catalog` module) that produces `expected_schema.ex` is a SEPARATE
+      artifact this fallback has no bearing on either way.
+
+  I127 pt.4/checked claim, corrected: an earlier version of this moduledoc
+  asserted regenerating the manifest "can still assign the wrong `kind` to
+  a future composite-key PRIMARY KEY the same way it did for these two" —
+  checked against a real regeneration run (`--keep-schemas`, `phoenix_kit_test`,
+  full V135..V181 chain) and found FALSE. `Catalog`'s own indexes query
+  already carries the identical `contype IN ('p', 'u')` exclusion this
+  module's `@indexes_sql` does (both fixed in the same commit, `992b09b336`,
+  2026-08-07) — a week before `958da2d2ab` (2026-08-14) added V171 and, with
+  it, these two objects' manifest entries as `kind: :index`. The regenerated
+  manifest emits `id: "constraint:...pkey"`, `kind: :constraint`,
+  `class: :constraint` for both — byte-identical to the class-A fix except
+  one inert field (`create:`, never read for `class: :constraint` —
+  `Executor.create_action/2` always rebuilds from `shape`). The two bad
+  entries were hand-authored alongside V171, after the generator was
+  already correct — not something the generator produced and would
+  reproduce. This fallback's own future-proofing (the bullet above) still
+  stands on its own merits for a hand-authored mistake; it was just never
+  the generator's fault to begin with.
   """
   @spec lookup(snapshot(), Object.check()) :: map() | nil
   def lookup(snapshot, {:catalog, %{kind: :table, name: name}}),

--- a/test/integration/hand_declared_manifest_test.exs
+++ b/test/integration/hand_declared_manifest_test.exs
@@ -16,7 +16,7 @@ defmodule PhoenixKit.Migrations.HandDeclaredManifestTest do
 
   ## Why it is scoped rather than asserting a clean report
 
-  A full clean assertion fails today on four PRE-EXISTING findings that have
+  A full clean assertion fails today on two PRE-EXISTING findings that have
   nothing to do with the hand-declared block, recorded here so the next person
   does not rediscover them:
 
@@ -24,10 +24,18 @@ defmodule PhoenixKit.Migrations.HandDeclaredManifestTest do
       `..._recipient_unseen_first_idx` (both `since: 170`) declare expression
       keys with doubled parentheses — `"((metadata ->> 'dedupe_key'::text))"` —
       where the catalog reports single. A manifest-text bug, not a schema one.
-    * `index:phoenix_kit_shop_category_slugs_pkey` and
-      `..._shop_product_slugs_pkey` (both `since: 171`) report missing.
 
-  Widen `@hand_declared_from` down to 170 once those are fixed.
+  Widen `@hand_declared_from` down to 170 once those are fixed too.
+
+  (Previously this list also carried `index:phoenix_kit_shop_category_slugs_pkey`
+  and `..._shop_product_slugs_pkey`, since: 171: both are PRIMARY KEY on a
+  composite natural key, so their backing index is excluded from
+  `PhoenixKit.Migrations.Repair.Probe`'s index snapshot — the same join that
+  guards against double-listing an FK-referenced unique index (see that
+  module's `@indexes_sql` comment) also hides a PK/UNIQUE-backing index from
+  `kind: :index` lookups. Declaring the check as `kind: :constraint` instead
+  — what they actually are on the catalog — fixed both; `@hand_declared_from`
+  moved from 178 to 171 to keep this test exercising V171+.)
   """
   use PhoenixKit.DataCase, async: false
 
@@ -37,8 +45,10 @@ defmodule PhoenixKit.Migrations.HandDeclaredManifestTest do
 
   @moduletag :integration
 
-  # V178 is where hand-declaration started (the CRM party bridge).
-  @hand_declared_from 178
+  # V178 is where hand-declaration started (the CRM party bridge); pinned to
+  # 171 rather than 178 so this test also exercises the two composite-key
+  # PRIMARY KEY objects fixed there (see moduledoc).
+  @hand_declared_from 171
 
   test "hand-declared manifest objects match what the chain actually builds" do
     {:ok, report} = Repair.verify(prefix: "public", repo: Repo)

--- a/test/integration/v171_shop_slug_projection_test.exs
+++ b/test/integration/v171_shop_slug_projection_test.exs
@@ -221,7 +221,23 @@ defmodule PhoenixKit.Integration.V171ShopSlugProjectionTest do
       assert by_id["index:idx_shop_products_slug_primary"].presence == :legacy_optional
       assert by_id["index:idx_shop_categories_slug_primary"].presence == :legacy_optional
       assert by_id["table:phoenix_kit_shop_product_slugs"].since == 171
-      assert by_id["index:phoenix_kit_shop_category_slugs_pkey"].since == 171
+
+      # Both PK objects are declared `kind: :constraint`, not `kind: :index`:
+      # `Probe`'s index snapshot deliberately excludes an index backing a
+      # `p`/`u` constraint on its own table (`probe.ex`'s `@indexes_sql`
+      # comment), so a `kind: :index` check here can never find its own
+      # PRIMARY KEY's backing index and permanently reports it missing — the
+      # exact failure this test would catch on a revert.
+      category_pkey =
+        by_id["constraint:phoenix_kit_shop_category_slugs.phoenix_kit_shop_category_slugs_pkey"]
+
+      product_pkey =
+        by_id["constraint:phoenix_kit_shop_product_slugs.phoenix_kit_shop_product_slugs_pkey"]
+
+      assert category_pkey.since == 171
+      assert product_pkey.since == 171
+      assert {:catalog, %{kind: :constraint}} = category_pkey.check
+      assert {:catalog, %{kind: :constraint}} = product_pkey.check
     end
   end
 end

--- a/test/phoenix_kit/migrations/repair/probe_test.exs
+++ b/test/phoenix_kit/migrations/repair/probe_test.exs
@@ -8,6 +8,7 @@ defmodule PhoenixKit.Migrations.Repair.ProbeTest do
     tables: %{},
     columns: %{},
     indexes: %{},
+    constraint_backed_indexes: %{},
     constraints: %{},
     sequences: %{},
     functions: %{},
@@ -56,6 +57,48 @@ defmodule PhoenixKit.Migrations.Repair.ProbeTest do
 
       assert Probe.lookup(snapshot, {:catalog, %{kind: :index, name: "widgets_owner_idx"}}) ==
                shape
+    end
+
+    test "index: absent from indexes but present in constraint_backed_indexes — found via fallback (I095 pt.3)" do
+      # A kind: :index check whose object is actually a p/u constraint's own
+      # backing index (`widgets_pkey` on a composite natural key) — the row
+      # `@indexes_sql` never puts in `indexes` (see that module attribute's
+      # comment), only in `constraint_backed_indexes`. Same shape a bare
+      # index would have — `Differ.compare(:index, ...)` needs no awareness
+      # of where it came from.
+      shape = %{
+        table: "widgets",
+        unique: true,
+        method: "btree",
+        definition: "CREATE UNIQUE INDEX widgets_pkey ON public.widgets USING btree (a, b)",
+        predicate: nil,
+        keys: ["a", "b"],
+        opclasses: ["text_ops", "text_ops"]
+      }
+
+      snapshot = %{@empty_snapshot | constraint_backed_indexes: %{"widgets_pkey" => shape}}
+
+      assert Probe.lookup(snapshot, {:catalog, %{kind: :index, name: "widgets_pkey"}}) == shape
+    end
+
+    test "index: present in indexes always wins over constraint_backed_indexes for the same name" do
+      # Not a real-world case (a name is unique per schema, so both maps can
+      # never legitimately hold the same key at once) — pins that the direct
+      # bucket is still tried FIRST, so the fallback is strictly additive.
+      direct = %{table: "widgets", unique: false}
+      fallback = %{table: "widgets", unique: true}
+
+      snapshot = %{
+        @empty_snapshot
+        | indexes: %{"ambiguous" => direct},
+          constraint_backed_indexes: %{"ambiguous" => fallback}
+      }
+
+      assert Probe.lookup(snapshot, {:catalog, %{kind: :index, name: "ambiguous"}}) == direct
+    end
+
+    test "index: absent from both — nil, same as before this fallback existed" do
+      assert Probe.lookup(@empty_snapshot, {:catalog, %{kind: :index, name: "ghost"}}) == nil
     end
 
     test "constraint: keyed by {table, name}" do
@@ -132,6 +175,7 @@ defmodule PhoenixKit.Migrations.Repair.ProbeTest do
       tables: %{},
       columns: %{},
       indexes: %{},
+      constraint_backed_indexes: %{},
       constraints: %{},
       sequences: %{},
       functions: %{},


### PR DESCRIPTION
`mix phoenix_kit.repair` and `mix phoenix_kit.doctor` have been reporting two
objects as `missing` on every healthy install:

    phoenix_kit_shop_category_slugs_pkey
    phoenix_kit_shop_product_slugs_pkey

Both are the composite PRIMARY KEY on the natural key `(lang, value)` added in
V171. Both exist. The report was wrong, and a real `repair` run would have
reported `:missing -> :repaired/"created"` while creating nothing.

## Root cause, two layers

1. **The manifest declared them as `kind: :index`.** On the catalog they are
   PRIMARY KEY constraints, not standalone indexes.

2. **Even a correct `kind: :index` entry could never have matched.**
   `@indexes_sql` deliberately excludes any index backing a p/u constraint on
   its own table — that exclusion is there to stop an FK-referenced unique index
   from being listed twice. So the `kind: :index` lookup was structurally unable
   to find these objects, for any entry of this shape, ever.

Fixing only the first layer would leave the second one armed for the next
composite-key PRIMARY KEY somebody declares.

## What changes

- Both manifest entries move to `kind: :constraint` / `class: :constraint` with
  a proper constraint-shape body.
- `Probe.indexes/2` now partitions the *same* SQL join into two buckets instead
  of discarding the second one — `constraint_backed_indexes` — and `lookup/2`
  falls back to that bucket when a `kind: :index` entry finds nothing in the
  primary one.

The fallback deliberately does **not** make `kind: :index` a legitimate way to
declare a new constraint-backed object: `Executor.create_action/2` still
dispatches on `class`, and `class: :index` would emit the wrong DDL. That
boundary is documented in the code rather than left implied.

## Acceptance

The double acceptance this needed is both halves, not just the first:

- `:missing` is gone for both objects.
- **The FK-referenced unique index is not listed twice again.** Index snapshot
  before the change: 627 entries. After: 627. Byte-identical diff.

Destructive check, both directions: reverting one manifest entry's `id`/`kind`
back to `index:`/`:index` turns `test/integration/v171_shop_slug_projection_test.exs`
and `test/integration/hand_declared_manifest_test.exs` red with messages that
name what broke. Restoring returns them to green.

One note for anyone reproducing that: the failure surfaces as
`KeyError: key :unique not found`, not `:columns`. `Differ.compare/3` dispatches
to the index clause as soon as `id`/`kind`/`class` are reverted, while the
revision body is still constraint-shaped; `reason_field(:unique, ...)` is the
first field in that pipe, so it raises before reaching `:columns`. Deterministic,
and independent of which of the two objects is reverted.

## Third commit

Docstring only. An earlier version of the `Probe.lookup/2` moduledoc claimed that
regenerating the manifest could reintroduce the wrong `kind` for a future
composite-key PRIMARY KEY. That claim is false and is removed.

Established by running the generator, not by reading it: the constraint-backed
exclusion entered `dev_docs/squash/generate_baseline.exs` in 992b09b336
(7 August), and V171 arrived in 958da2d2ab (14 August) — after. `git log -S`
places both bad entries in the V171 commit itself. They were hand-declared
against the pattern of older `kind: :index` neighbours while the generator was
already correct. The generator never produced them and will not bring them back.

## Verification

- Targeted runs green on the branch; destructive check run in both directions.
- `mix compile --warnings-as-errors`, `mix format --check-formatted`,
  `mix credo --strict` clean on the touched files.
- Full suite was run on the primary checkout, not in the worktree: a full
  `mix test` inside a secondary worktree is unstable here for reasons unrelated
  to this change (module-discovery tests see a different build), so it is not
  offered as evidence.
- Not verified by us: behaviour against a live install of this exact branch. The
  underlying fixes were verified against a live install when originally written;
  this branch is their rebased delivery.

## Not included, deliberately

- The remaining 26 stale manifest names (renamed objects) and the 21 objects on a
  lagging install: those are a different problem — the manifest and the tool are
  both right, the *install* is behind. Separate work, and it touches live schemas.
