### PR TITLE
Fix stale disk read in fix_supervisor_ordering during update

### DIFF
--- a/lib/mix/tasks/phoenix_kit.update.ex
+++ b/lib/mix/tasks/phoenix_kit.update.ex
@@ -1698,12 +1698,41 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
     # Validate and add Oban configuration if missing
     # Fix supervisor ordering in application.ex to prevent startup crashes
     # Ensures correct order: Repo → PhoenixKit.Supervisor → Oban → Endpoint
-    defp fix_supervisor_ordering(igniter) do
+    #
+    # P013: this used to decide `:correct` / `:needs_fix` from a fresh
+    # `File.read!/1` of application.ex — the same class of bug fixed under
+    # I103 for `BootHook.add_boot_hook/1` and
+    # `fix_ueberauth_providers_config/1`. Igniter never flushes a step's
+    # writes to disk before the next step runs; on a real `mix
+    # phoenix_kit.update`, TWO earlier steps in the SAME pipeline stage
+    # `application.ex` edits before this one runs —
+    # `ApplicationSupervisor.add_supervisor/1` (unconditionally, at the top
+    # of `igniter/1`) and `ObanConfig.add_oban_supervisor/1` (right before
+    # this call, inside `perform_igniter_update/2`) — both via
+    # `Igniter.Project.Application.add_new_child/3`, which only ever
+    # touches the Igniter buffer. A disk read here is blind to both: it can
+    # see no `PhoenixKit.Supervisor`/`Oban` line at all, match
+    # `validate_supervisor_positions/4`'s trivial "nothing to check yet"
+    # clauses, and report `:correct` while the buffer — the content that
+    # actually reaches disk when this run finishes — sits misordered.
+    # `Igniter.exists?/2` + loading the file into the Igniter buffer before
+    # reading its content (`Rewrite.Source.get/2`) makes this check see the
+    # SAME up-to-date state the subsequent fix in
+    # `fix_application_supervisor_order/3` already reads from.
+    #
+    # Test seam: made public (`@doc false`) the same way I103 exposed
+    # `fix_ueberauth_providers_config/1` — this defect can only be
+    # exercised end-to-end (a real, non-test-mode Igniter + real temp
+    # disk), not via a pure-content unit test.
+    @doc false
+    @spec fix_supervisor_ordering(Igniter.t()) :: Igniter.t()
+    def fix_supervisor_ordering(igniter) do
       app_name = IgniterHelpers.get_parent_app_name(igniter)
       app_file = "lib/#{app_name}/application.ex"
 
-      if File.exists?(app_file) do
-        content = File.read!(app_file)
+      if Igniter.exists?(igniter, app_file) do
+        igniter = Igniter.include_existing_file(igniter, app_file)
+        content = igniter.rewrite |> Rewrite.source!(app_file) |> Rewrite.Source.get(:content)
 
         # Check current supervisor ordering
         case check_supervisor_order(content, app_name) do

--- a/test/mix/tasks/phoenix_kit_update_supervisor_ordering_test.exs
+++ b/test/mix/tasks/phoenix_kit_update_supervisor_ordering_test.exs
@@ -1,0 +1,188 @@
+defmodule Mix.Tasks.PhoenixKit.Update.SupervisorOrderingTest do
+  @moduledoc """
+  P013: `fix_supervisor_ordering/1` used to decide whether `application.ex`
+  needed reordering by reading the file straight off REAL disk
+  (`content = File.read!(app_file)`), then making its correct/needs-fix
+  decision from that snapshot. Igniter never flushes a step's writes to
+  disk before the next step runs — on a real `mix phoenix_kit.update` run,
+  TWO earlier steps in the SAME pipeline stage edits to this exact file
+  before `fix_supervisor_ordering/1` runs: `ApplicationSupervisor.add_supervisor/1`
+  (unconditionally, at the very top of `igniter/1`) and, when missing,
+  `ObanConfig.add_oban_supervisor/1` (inside `perform_igniter_update/2`,
+  immediately before `fix_supervisor_ordering/1` itself). Both write via
+  `Igniter.Project.Application.add_new_child/3`, which only ever touches
+  the Igniter buffer.
+
+  Same defect class as I103 (`PhoenixKit.Install.BootHook.add_boot_hook/1`,
+  `Mix.Tasks.PhoenixKit.Update.fix_ueberauth_providers_config/1`) — except
+  here the consequence isn't a discarded edit, it's a SKIPPED fix: the
+  disk-based check saw no `PhoenixKit.Supervisor` line at all (it wasn't on
+  disk yet), matched the `(repo, nil, nil, _) -> :correct` clause in
+  `validate_supervisor_positions/4`, and returned the igniter untouched —
+  leaving whatever position the earlier step landed the supervisor in,
+  correct or not, uncorrected.
+
+  Reproduced/verified with a REAL (non-test-mode) `Igniter.new/0` rooted at
+  a throwaway temp directory — `Igniter.Test.test_project/1` cannot be
+  used here because it never touches real disk (see
+  `PhoenixKit.Install.BootHookTest`'s moduledoc), so `File.exists?/1` /
+  `File.read!/1` would simply see nothing and the whole function would
+  short-circuit before reaching the code under test.
+  """
+  use ExUnit.Case, async: false
+
+  alias Mix.Tasks.PhoenixKit.Update
+
+  @app_file "lib/probe_app/application.ex"
+
+  @mix_exs """
+  defmodule ProbeApp.MixProject do
+    use Mix.Project
+
+    def project do
+      [app: :probe_app, version: "0.1.0"]
+    end
+  end
+  """
+
+  @initial_content """
+  defmodule ProbeApp.Application do
+    use Application
+
+    @impl true
+    def start(_type, _args) do
+      children = [
+        ProbeApp.Repo,
+        ProbeAppWeb.Endpoint
+      ]
+
+      opts = [strategy: :one_for_one, name: ProbeApp.Supervisor]
+      Supervisor.start_link(children, opts)
+    end
+  end
+  """
+
+  setup do
+    tmp_dir =
+      Path.join(System.tmp_dir!(), "pk_p013_probe_#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(Path.join(tmp_dir, "lib/probe_app"))
+    File.write!(Path.join(tmp_dir, "mix.exs"), @mix_exs)
+
+    on_exit(fn -> File.rm_rf!(tmp_dir) end)
+
+    {:ok, tmp_dir: tmp_dir}
+  end
+
+  # Stands in for `ApplicationSupervisor.add_supervisor/1` landing
+  # `PhoenixKit.Supervisor` in the WRONG spot — the shape it takes when
+  # `Igniter.Libs.Ecto.list_repos/1` finds no repo to anchor `after:` on,
+  # so only `before: [endpoint]` applies and the child lands at the very
+  # top of the list, ahead of the Repo.
+  defp stage_misordered_phoenix_kit_supervisor(igniter) do
+    Igniter.update_file(igniter, @app_file, fn source ->
+      content = Rewrite.Source.get(source, :content)
+
+      updated =
+        String.replace(content, "children = [", "children = [\n        PhoenixKit.Supervisor,")
+
+      Rewrite.Source.update(source, :content, updated)
+    end)
+  end
+
+  defp final_content(igniter) do
+    assert Rewrite.has_source?(igniter.rewrite, @app_file),
+           "#{@app_file} was never loaded into the Igniter buffer — " <>
+             "fix_supervisor_ordering/1 decided from a bare File.read!/1 " <>
+             "instead of the Igniter-tracked source"
+
+    igniter.rewrite |> Rewrite.source!(@app_file) |> Rewrite.Source.get(:content)
+  end
+
+  defp index_of!(content, needle) do
+    {index, _} = :binary.match(content, needle)
+    index
+  end
+
+  test "detects and corrects a misordering staged by an earlier step in the same run",
+       %{tmp_dir: tmp_dir} do
+    File.write!(Path.join(tmp_dir, @app_file), @initial_content)
+
+    File.cd!(tmp_dir, fn ->
+      igniter =
+        Igniter.new()
+        |> stage_misordered_phoenix_kit_supervisor()
+        |> Update.fix_supervisor_ordering()
+
+      content = final_content(igniter)
+
+      repo_index = index_of!(content, "ProbeApp.Repo")
+      pk_index = index_of!(content, "PhoenixKit.Supervisor")
+      endpoint_index = index_of!(content, "ProbeAppWeb.Endpoint")
+
+      assert repo_index < pk_index and pk_index < endpoint_index, """
+      expected Repo -> PhoenixKit.Supervisor -> Endpoint, got:
+      #{content}
+      """
+    end)
+  end
+
+  test "still fixes a misordering that is already on disk (no earlier staged step)",
+       %{tmp_dir: tmp_dir} do
+    already_broken =
+      String.replace(
+        @initial_content,
+        "children = [",
+        "children = [\n        PhoenixKit.Supervisor,"
+      )
+
+    File.write!(Path.join(tmp_dir, @app_file), already_broken)
+
+    File.cd!(tmp_dir, fn ->
+      igniter = Igniter.new() |> Update.fix_supervisor_ordering()
+      content = final_content(igniter)
+
+      repo_index = index_of!(content, "ProbeApp.Repo")
+      pk_index = index_of!(content, "PhoenixKit.Supervisor")
+      endpoint_index = index_of!(content, "ProbeAppWeb.Endpoint")
+
+      assert repo_index < pk_index and pk_index < endpoint_index, """
+      expected Repo -> PhoenixKit.Supervisor -> Endpoint, got:
+      #{content}
+      """
+    end)
+  end
+
+  test "is idempotent and leaves a foreign/unrelated child untouched when order is already correct",
+       %{tmp_dir: tmp_dir} do
+    already_correct = """
+    defmodule ProbeApp.Application do
+      use Application
+
+      @impl true
+      def start(_type, _args) do
+        children = [
+          ProbeApp.Repo,
+          SomeOtherLib.Supervisor,
+          PhoenixKit.Supervisor,
+          ProbeAppWeb.Endpoint,
+          {Oban, Application.get_env(:probe_app, Oban)}
+        ]
+
+        opts = [strategy: :one_for_one, name: ProbeApp.Supervisor]
+        Supervisor.start_link(children, opts)
+      end
+    end
+    """
+
+    File.write!(Path.join(tmp_dir, @app_file), already_correct)
+
+    File.cd!(tmp_dir, fn ->
+      igniter = Igniter.new() |> Update.fix_supervisor_ordering()
+      content = final_content(igniter)
+
+      assert content == already_correct,
+             "an already-correct order with a foreign child must be left untouched:\n#{content}"
+    end)
+  end
+end


### PR DESCRIPTION
Follow-up to #758, which fixed one instance of "the auto-patcher reads the disk
while the edit lives in the Igniter buffer". A comment on that PR named
`reorder_supervisors` as carrying the same class of defect but left it untouched
so the fix would not be mixed with refactoring pre-existing code. This is that
suspicion, reproduced and fixed.

It is **not** withdrawn: the defect is real.

## What it does

`fix_supervisor_ordering/1` decides whether `PhoenixKit.Supervisor` needs to be
moved in the host's `application.ex`. It made that decision from
`File.exists?`/`File.read!` — the state on disk — while two earlier steps of the
same pipeline had already staged edits to that file in the Igniter buffer:

- `ApplicationSupervisor.add_supervisor/1`, unconditionally, at the start of
  `igniter/1`
- `ObanConfig.add_oban_supervisor/1`, immediately before this call

So the check ran against a stale snapshot. With `PhoenixKit.Supervisor` present
only in the buffer, the disk read found nothing, matched the trivial
`validate_supervisor_positions(repo, nil, nil, _) -> :correct` clause, and
skipped the reordering entirely. The buffer that then went to disk had
`PhoenixKit.Supervisor` **before** `Repo` — which crashes on boot, since the
supervisor reads `Settings` from the database before the repo is up.

Same class as #758, opposite consequence: there the disk read *overwrote*
somebody else's staged edit; here it *skips a needed fix* it cannot see.

## How it was established — probe, not code reading

Reading the code was not enough, and neither was the test harness used in #758:
`Igniter.Test.test_project/1` never touches a real disk, so under it
`File.exists?`/`File.read!` simply find nothing and the function becomes a silent
no-op *before* reaching the code under suspicion. A green test there would have
proved nothing.

The probe (`test/mix/tasks/phoenix_kit_update_supervisor_ordering_test.exs`) uses
a real `Igniter.new/0` bound to a real temporary directory:

1. a real `application.ex` on disk (Repo, Endpoint; no `PhoenixKit.Supervisor`,
   no Oban) — the pre-update state
2. an edit staged into the Igniter buffer, mimicking the real earlier step, that
   inserts `PhoenixKit.Supervisor` in the wrong position
3. `fix_supervisor_ordering/1` invoked directly (made public with `@doc false`,
   the same approach #758 used for `fix_ueberauth_providers_config/1`)

Before the fix, the probe fails exactly as predicted, and the resulting file has
the wrong order.

## The fix

`File.exists?`/`File.read!` replaced with `Igniter.exists?/2` plus loading the
file into the Igniter buffer and reading its content through
`Rewrite.Source.get/2` — so the check sees the same state the subsequent edit in
`fix_application_supervisor_order/3` acts on. That function was already correct;
only the decision feeding it was reading the wrong source.

## Acceptance, both directions

Order is asserted against the resulting file, not declared:

- **Before the fix** the probe is red and names the problem: expected
  `Repo -> PhoenixKit.Supervisor -> Endpoint`, and it prints the real (wrong)
  output file. A second test reports `application.ex was never loaded into the
  Igniter buffer — fix_supervisor_ordering/1 decided from a bare File.read!/1
  instead of the Igniter-tracked source.`
- **After the fix** all three new tests pass, together with the existing #758
  suite (`phoenix_kit_update_ueberauth_test.exs`, `boot_hook_test.exs`,
  `oban_config_test.exs`): 74/74.
- The third new test **also goes red before the fix**, and this description
  originally claimed the opposite — corrected after an independent review
  reproduced the mutation on the real pre-fix body. It fails on the guard at
  `supervisor_ordering_test.exs:94` (`application.ex was never loaded into the
  Igniter buffer`), because the old body never loaded the file at all on the
  `:correct` branch. The "stays green" claim holds only for a narrower mutation
  that reverts the read but keeps `include_existing_file`. The test is therefore
  a more sensitive detector than this description first gave it credit for, not
  a redundant one.

`mix precommit` in full (compile, docs, `credo --strict`, dialyzer with the PLT
built from scratch) passed on the commit.

## Scope

One commit, two files. Deliberately separate from #758: different object,
different branch, so each can be reviewed and reverted on its own.


## Same mechanism, elsewhere in this task — named, not fixed here

The defect is not one function's slip. The mechanism is general: Igniter does not
flush staged edits to disk between steps, so any `File.exists?`/`File.read!` in a
later step sees the pre-pipeline snapshot. An independent review of this branch
traced the other places it already applies. Listing them here rather than folding
them in, so the mechanism is on record even though this PR fixes one instance:

- `phoenix_kit.update.ex:1558-1559` — `validate_and_fix_ueberauth_config/1`: the
  outer **gate** still reads `config/config.exs` from disk to choose its branch.
  #758 made only the inner `fix_ueberauth_providers_config/1` (:1610) buffer-aware.
  Called at :382, after `add_basic_config` (:145) and `add_prefix_configuration`
  (:379) have both staged that file. Closest to live: on a first install
  `config/config.exs` may exist only in the buffer, so `File.exists?` returns
  false and the gate is skipped entirely.
- `rate_limiter_config.ex:43-45` — `hammer_config_exists?/1` takes the igniter and
  ignores it (`_igniter`), reading `config/config.exs` from disk; gate reached at
  :385, after the same two stagings.
- `oban_config.ex:1543-1547` — `oban_supervisor_exists?/1` reads
  `lib/<app>/application.ex` from disk; gate at :386-387 → :2050, after
  `add_supervisor` (:146) stages it. Latent today, same structure.
- `oban_config.ex:166-171` — `oban_config_exists?/1`, same shape for the Oban
  config stanza. Latent today.

Explicitly **not** instances, checked so the list is honest:
`update.ex:292 check_required_configuration` runs before the igniter pipeline
starts, where disk is the correct source. The host-file reads in
`js_integration.ex`, `daisyui.ex`, `mailer_config.ex` and `runtime_detector.ex`
were not traced for staging order and are offered as triage candidates, not as
confirmed instances.

One known nit left alone: the new test's moduledoc points at `BootHookTest`'s
moduledoc as explaining why a virtual project is unsuitable here; that moduledoc
argues for virtual projects rather than against them. Happy to correct on request.
