### PR TITLE
Add a repository-level guard against tests pointed at a live database

### DIFF
--- a/test/live_database_guard_test.exs
+++ b/test/live_database_guard_test.exs
@@ -1,0 +1,101 @@
+defmodule PhoenixKit.Test.LiveDatabaseGuardTest do
+  @moduledoc """
+  Pure unit coverage for `check!/1`'s own decision — separate from
+  `LiveDatabaseGuardWiringTest`, which proves the module is actually
+  reachable from `test_helper.exs`'s real boot sequence, not just that its
+  logic is correct in isolation.
+  """
+  use ExUnit.Case, async: true
+
+  alias PhoenixKit.Test.LiveDatabaseGuard
+
+  describe "check!/1 — built-in suffix pattern (zero configuration)" do
+    test "raises for example database names ending in a dangerous suffix" do
+      for db <- ~w(phoenix_kit_dev decor_3d_print_dev phoenixkit_hello_world_dev) do
+        assert_raise LiveDatabaseGuard.LiveDatabaseError, ~r/#{db}/, fn ->
+          LiveDatabaseGuard.check!(db)
+        end
+      end
+    end
+
+    test "raises for further suffix examples with nothing hardcoded behind them" do
+      # These names illustrate the refusal is genuinely suffix-based —
+      # none of them is special-cased anywhere in the module.
+      for db <- ~w(acme_production shop_staging widgets_development other_app_prod) do
+        assert_raise LiveDatabaseGuard.LiveDatabaseError, fn ->
+          LiveDatabaseGuard.check!(db)
+        end
+      end
+    end
+
+    test "suffix match is case-insensitive" do
+      assert_raise LiveDatabaseGuard.LiveDatabaseError, fn ->
+        LiveDatabaseGuard.check!("Acme_PRODUCTION")
+      end
+    end
+
+    test "the raised message says WHY, not just which database" do
+      assert_raise LiveDatabaseGuard.LiveDatabaseError,
+                   ~r/non-test environment/,
+                   fn -> LiveDatabaseGuard.check!("phoenix_kit_dev") end
+    end
+  end
+
+  describe "check!/1 — a foreign host's legitimately different test database name" do
+    test "an arbitrary pre-provisioned scratch name (no CREATEDB workflow) passes through" do
+      # This is exactly the case config/test.exs's own PGDATABASE-honoring
+      # comment describes: "a database you already have instead of one
+      # this role is allowed to CREATE". Nothing about these names
+      # resembles a non-test environment, so none of them are refused.
+      for db <- ~w(ci_runner_42 pk_scratch_7 shared_ci_db build_42_scratch) do
+        assert :ok = LiveDatabaseGuard.check!(db)
+      end
+    end
+
+    test "passes an isolated test database name straight through" do
+      assert :ok = LiveDatabaseGuard.check!("phoenix_kit_test")
+    end
+
+    test "an empty or unusual name is never mistaken for a live database" do
+      assert :ok = LiveDatabaseGuard.check!("")
+      assert :ok = LiveDatabaseGuard.check!("phoenix_kit_test1")
+    end
+
+    test "a name that merely CONTAINS a dangerous suffix, not ENDS with it, is not a match" do
+      # Substring-anywhere matching would be its own bug: a scratch DB
+      # deliberately named to mention "dev" mid-string must not be refused
+      # — only a database name actually ENDING in a dangerous suffix is.
+      assert :ok = LiveDatabaseGuard.check!("dev_tools_scratch")
+      assert :ok = LiveDatabaseGuard.check!("phoenix_kit_dev_backup")
+    end
+  end
+
+  describe "check!/1 — PHOENIX_KIT_TEST_DB_DENYLIST (opt-in extra names)" do
+    setup do
+      on_exit(fn -> System.delete_env("PHOENIX_KIT_TEST_DB_DENYLIST") end)
+    end
+
+    test "refuses an exact name a host declares, even without a dangerous suffix" do
+      System.put_env("PHOENIX_KIT_TEST_DB_DENYLIST", "acme_main,other_live_db")
+
+      assert_raise LiveDatabaseGuard.LiveDatabaseError, ~r/acme_main/, fn ->
+        LiveDatabaseGuard.check!("acme_main")
+      end
+
+      assert :ok = LiveDatabaseGuard.check!("acme_scratch")
+    end
+
+    test "denylist comparison is case-insensitive and trims whitespace" do
+      System.put_env("PHOENIX_KIT_TEST_DB_DENYLIST", " Acme_Main , other_db ")
+
+      assert_raise LiveDatabaseGuard.LiveDatabaseError, fn ->
+        LiveDatabaseGuard.check!("acme_main")
+      end
+    end
+
+    test "unset (the upstream default) refuses nothing beyond the suffix pattern" do
+      System.delete_env("PHOENIX_KIT_TEST_DB_DENYLIST")
+      assert :ok = LiveDatabaseGuard.check!("acme_main")
+    end
+  end
+end

--- a/test/live_database_guard_test.exs
+++ b/test/live_database_guard_test.exs
@@ -11,7 +11,7 @@ defmodule PhoenixKit.Test.LiveDatabaseGuardTest do
 
   describe "check!/1 — built-in suffix pattern (zero configuration)" do
     test "raises for example database names ending in a dangerous suffix" do
-      for db <- ~w(phoenix_kit_dev decor_3d_print_dev phoenixkit_hello_world_dev) do
+      for db <- ~w(phoenix_kit_dev shop_dev blog_dev) do
         assert_raise LiveDatabaseGuard.LiveDatabaseError, ~r/#{db}/, fn ->
           LiveDatabaseGuard.check!(db)
         end

--- a/test/live_database_guard_wiring_test.exs
+++ b/test/live_database_guard_wiring_test.exs
@@ -40,7 +40,7 @@ defmodule PhoenixKit.LiveDatabaseGuardWiringTest do
   @unreachable_host "127.0.0.1"
   @unreachable_port "1"
 
-  for live_db <- ~w(phoenix_kit_dev decor_3d_print_dev phoenixkit_hello_world_dev acme_production) do
+  for live_db <- ~w(phoenix_kit_dev shop_dev blog_dev acme_production) do
     test "refuses before any connection attempt when PGDATABASE=#{live_db}" do
       env = [
         {"PGDATABASE", unquote(live_db)},

--- a/test/live_database_guard_wiring_test.exs
+++ b/test/live_database_guard_wiring_test.exs
@@ -1,0 +1,155 @@
+defmodule PhoenixKit.LiveDatabaseGuardWiringTest do
+  @moduledoc """
+  `LiveDatabaseGuardTest` calls `check!/1` directly — it proves the logic
+  is correct, not that `test_helper.exs` actually calls it. Deleting the
+  call from `test_helper.exs` leaves that test green; it would prove the
+  module still works, not that anything still protects a real `mix test`
+  run.
+
+  This test runs `test_helper.exs` for real, as a genuine `mix test`
+  subprocess, with `PGDATABASE` set to a name the guard exists to refuse —
+  several example dev-suffixed names, plus one generalized pattern-only
+  example (`acme_production`) and one denylist-only example (`acme_main`,
+  via `PHOENIX_KIT_TEST_DB_DENYLIST`) to prove the wiring survives both
+  refusal paths, not just the suffix pattern. It never lets that
+  subprocess reach a real Postgres server, though — `PGHOST` points at an
+  address nothing is listening on. That is what makes it safe to name a
+  live-looking database literally here: whatever the guard does or
+  doesn't do, no real Postgres exists at the address this subprocess is
+  given, so it can never actually touch a real database.
+
+  Verified live (mutation, not assumption) that this still tells a correct
+  refusal apart from a cut wiring call: with the `check!/1` call commented
+  out, the subprocess does NOT fail — `test_helper.exs`'s own existing
+  "can't reach the database" fallback (already there for a genuinely
+  missing DB) catches the bogus host, prints its own warning, excludes
+  `:integration`, and exits 0 normally, since this test file needs no
+  database at all. A correct refusal looks categorically different: a
+  nonzero exit and the guard's own `LiveDatabaseError` in the output,
+  before that fallback ever gets a chance to paper over anything. This
+  test asserts exactly that pair (exit code, exception name) rather than
+  looking for a connection-failure message that a cut wiring call turns
+  out not to produce.
+  """
+
+  use ExUnit.Case, async: true
+
+  # A loopback port nothing binds during a normal test run —
+  # `ECONNREFUSED` is near-instant, unlike a routed-but-silent address
+  # (which would hang for a connect timeout instead of failing fast).
+  @unreachable_host "127.0.0.1"
+  @unreachable_port "1"
+
+  for live_db <- ~w(phoenix_kit_dev decor_3d_print_dev phoenixkit_hello_world_dev acme_production) do
+    test "refuses before any connection attempt when PGDATABASE=#{live_db}" do
+      env = [
+        {"PGDATABASE", unquote(live_db)},
+        {"PGHOST", @unreachable_host},
+        {"PGPORT", @unreachable_port},
+        {"PGUSER", "postgres"},
+        {"PGPASSWORD", "postgres"},
+        {"MIX_ENV", "test"}
+      ]
+
+      # One fast, unrelated test file — test_helper.exs's boot code runs
+      # unconditionally as part of loading the suite, regardless of which
+      # test is targeted.
+      {output, exit_code} =
+        System.cmd("mix", ["test", "test/live_database_guard_test.exs"],
+          env: env,
+          stderr_to_stdout: true,
+          cd: File.cwd!()
+        )
+
+      refute exit_code == 0,
+             "a boot with PGDATABASE=#{unquote(live_db)} must refuse, not succeed:\n#{output}"
+
+      assert output =~ "LiveDatabaseError",
+             "process failed, but not with the guard's own exception — some other crash " <>
+               "reached this nonzero exit instead:\n#{output}"
+
+      assert output =~ unquote(live_db),
+             "refusal happened but didn't name the actual database, not the legible " <>
+               "message the guard promises:\n#{output}"
+    end
+  end
+
+  test "refuses via PHOENIX_KIT_TEST_DB_DENYLIST for a name with no dangerous suffix" do
+    env = [
+      {"PGDATABASE", "acme_main"},
+      {"PHOENIX_KIT_TEST_DB_DENYLIST", "acme_main"},
+      {"PGHOST", @unreachable_host},
+      {"PGPORT", @unreachable_port},
+      {"PGUSER", "postgres"},
+      {"PGPASSWORD", "postgres"},
+      {"MIX_ENV", "test"}
+    ]
+
+    {output, exit_code} =
+      System.cmd("mix", ["test", "test/live_database_guard_test.exs"],
+        env: env,
+        stderr_to_stdout: true,
+        cd: File.cwd!()
+      )
+
+    refute exit_code == 0,
+           "a denylisted PGDATABASE=acme_main must refuse, not succeed:\n#{output}"
+
+    assert output =~ "LiveDatabaseError",
+           "process failed, but not with the guard's own exception:\n#{output}"
+  end
+
+  test "a foreign host's arbitrary scratch database name is NOT refused" do
+    env = [
+      {"PGDATABASE", "ci_runner_42"},
+      {"PGHOST", @unreachable_host},
+      {"PGPORT", @unreachable_port},
+      {"PGUSER", "postgres"},
+      {"PGPASSWORD", "postgres"},
+      {"MIX_ENV", "test"}
+    ]
+
+    {output, exit_code} =
+      System.cmd("mix", ["test", "test/live_database_guard_test.exs"],
+        env: env,
+        stderr_to_stdout: true,
+        cd: File.cwd!()
+      )
+
+    refute output =~ "LiveDatabaseError",
+           "an arbitrary scratch name with no dangerous suffix must not be refused:\n#{output}"
+
+    # Same fallback the module doc describes: an unreachable PGHOST is
+    # caught by test_helper.exs's own existing "can't reach the database"
+    # branch (not the guard), which excludes :integration and still exits
+    # 0, since this targeted file needs no database at all.
+    assert exit_code == 0,
+           "guard correctly did not fire, but the boot itself failed for an unrelated " <>
+             "reason — not the case this test means to prove:\n#{output}"
+  end
+
+  test "an isolated test database name is not refused — the guard does not block a real run" do
+    # No PGHOST/PGUSER/PGPASSWORD overrides here on purpose: this process is
+    # itself already running as a `mix test` inside this exact repo, which
+    # only happens with a working, resolved connection to the real isolated
+    # test database — inheriting that ambient environment gives the
+    # subprocess a genuine, already-proven-safe connection without this
+    # tracked file ever needing to know a password or a machine-specific
+    # path (the same reason a machine-specific wrapper script would live
+    # outside the repo too).
+    env = [{"PGDATABASE", System.get_env("PGDATABASE", "phoenix_kit_test")}]
+
+    {output, exit_code} =
+      System.cmd("mix", ["test", "test/live_database_guard_test.exs"],
+        env: env,
+        stderr_to_stdout: true,
+        cd: File.cwd!()
+      )
+
+    assert exit_code == 0,
+           "a boot against the real isolated test database must succeed, not be blocked " <>
+             "by the live-database guard:\n#{output}"
+
+    refute output =~ "LiveDatabaseError", "the guard fired on a database it must not refuse"
+  end
+end

--- a/test/support/live_database_guard.ex
+++ b/test/support/live_database_guard.ex
@@ -1,0 +1,124 @@
+defmodule PhoenixKit.Test.LiveDatabaseGuard do
+  @moduledoc """
+  `config/test.exs` honors `PGDATABASE` — precisely so the suite CAN target
+  an already-provisioned database on a role without `CREATEDB` (a shared or
+  managed Postgres instance, most often). That is legitimate and must keep
+  working: this guard does NOT require any particular test database name.
+  What it refuses is a database name that *looks like* a non-test
+  environment — because a shell that leaks an environment-tagged
+  `PGDATABASE` (say, `myapp_dev`) into every process turns a bare `mix
+  test` run, in any working directory, into a silent migrate-and-seed of
+  the real, live database. Some hosts already guard against this with an
+  external wrapper script that checks the resolved database name before
+  invoking `mix test` — but a wrapper living outside the repo only
+  protects a caller who remembers to use it, and can only ever check for
+  the one name (or few names) it was written against. This guard is the
+  same idea, generalized to travel with the repo itself, to any host,
+  checking a whole class of dangerous-looking names rather than a fixed
+  list.
+
+  Two layers, checked in order:
+
+  1. **Built-in suffix pattern** (`@dangerous_suffixes`) — refuses a
+     database name ending in `_dev`, `_development`, `_prod`,
+     `_production`, or `_staging` (case-insensitive). These are the
+     near-universal Rails/Phoenix/Django convention for naming an
+     environment's database (e.g. `phoenix_kit_dev`, `myapp_production`,
+     `shop_staging`), so this fires with zero configuration on any host
+     that follows it.
+
+  2. **Optional extra denylist**, read from the `PHOENIX_KIT_TEST_DB_DENYLIST`
+     environment variable (comma-separated exact names, case-insensitive) —
+     for a live database whose name doesn't happen to match the pattern
+     above. Empty by default: nothing is refused beyond the pattern unless
+     a host opts in. This is an env var rather than app config on purpose —
+     it lets a host declare its own known-live names (e.g. in its shell
+     profile or process supervisor) without editing a tracked file, the
+     same way `PGDATABASE` itself already reaches this repo.
+
+  **What this does NOT do:** refuse a name for merely NOT ending in
+  `_test`. An arbitrary pre-provisioned scratch database name (the exact
+  case `PGDATABASE`-honoring exists for) — `ci_runner_42`, `pk_scratch_7`,
+  a UUID-suffixed throwaway — passes through untouched, because nothing
+  about that name resembles a non-test environment. A rule that instead
+  *required* a `_test` suffix would refuse that legitimate case outright,
+  which is why this guard does not use one. The residual risk this leaves
+  is real and is not hidden: a host whose live database is named with no
+  recognizable environment suffix (e.g. bare `acme`, or `acme_main`) is
+  NOT caught by the built-in pattern and must add it to
+  `PHOENIX_KIT_TEST_DB_DENYLIST` itself — nothing here can guess a name
+  that carries no signal of what it is.
+
+  Deliberately NOT the `phoenix_kit_crm`/`phoenix_kit_entities`
+  `SchemaOwnerGuard` pattern (a `schema_migrations` ownership-marker
+  comment, stamped by a package after its own migrations succeed): that
+  mechanism only catches a database another *tracked, guard-wearing*
+  package has already stamped — confirmed against a scratch database
+  built to look exactly like an untouched live one, that it reads a
+  database it has never seen, comment-less `schema_migrations` included,
+  as `:ok`. A live dev database populated by ordinary `mix ecto.migrate` is
+  exactly that shape: nothing has ever stamped it, so a marker check alone
+  would wave it through. This guard instead judges the NAME itself.
+  """
+
+  @dangerous_suffixes ~w(_dev _development _prod _production _staging)
+
+  defmodule LiveDatabaseError do
+    defexception [:message]
+  end
+
+  @doc """
+  Raises `LiveDatabaseError` if `database` looks like a non-test
+  environment's database (see moduledoc). Takes the already-resolved name
+  (what `config/test.exs` put in `Application.get_env/2`), not
+  `PGDATABASE` itself — the config file's own fallback-when-unset logic is
+  the single source of truth for what the suite will actually connect to,
+  and duplicating it here would drift the moment either copy changed.
+  """
+  @spec check!(String.t()) :: :ok
+  def check!(database) when is_binary(database) do
+    downcased = String.downcase(database)
+
+    cond do
+      database == "" ->
+        :ok
+
+      Enum.any?(@dangerous_suffixes, &String.ends_with?(downcased, &1)) ->
+        raise LiveDatabaseError, message: refusal_message(database, :suffix)
+
+      downcased in extra_denylist() ->
+        raise LiveDatabaseError, message: refusal_message(database, :denylist)
+
+      true ->
+        :ok
+    end
+  end
+
+  defp extra_denylist do
+    "PHOENIX_KIT_TEST_DB_DENYLIST"
+    |> System.get_env("")
+    |> String.split(",", trim: true)
+    |> Enum.map(&(&1 |> String.trim() |> String.downcase()))
+    |> Enum.reject(&(&1 == ""))
+    |> MapSet.new()
+  end
+
+  defp refusal_message(database, :suffix) do
+    """
+    Test database resolved to #{inspect(database)}, whose name ends in a \
+    suffix (#{Enum.join(@dangerous_suffixes, ", ")}) this guard treats as a \
+    non-test environment, not a database a test suite may migrate and seed. \
+    Point PGDATABASE at an isolated test database instead \
+    (see PhoenixKit.Test.LiveDatabaseGuard's moduledoc).\
+    """
+  end
+
+  defp refusal_message(database, :denylist) do
+    """
+    Test database resolved to #{inspect(database)}, which PHOENIX_KIT_TEST_DB_DENYLIST \
+    names as a live database this host must never let a test suite touch. \
+    Point PGDATABASE at an isolated test database instead \
+    (see PhoenixKit.Test.LiveDatabaseGuard's moduledoc).\
+    """
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,10 +1,17 @@
 # Test helper for PhoenixKit test suite
 
+# Refuse before anything else touches the database — see
+# PhoenixKit.Test.LiveDatabaseGuard's moduledoc for why this exists
+# alongside (not instead of) an external wrapper script some hosts
+# already use for the same purpose.
+db_name =
+  Application.get_env(:phoenix_kit, PhoenixKit.Test.Repo)[:database] || "phoenix_kit_test"
+
+PhoenixKit.Test.LiveDatabaseGuard.check!(db_name)
+
 # Check if the test database exists before trying to connect.
 # Uses `psql -lqt` for a fast check that avoids Postgrex connection hangs.
 # Falls back to attempting connection directly if psql is unavailable (e.g., CI).
-db_name =
-  Application.get_env(:phoenix_kit, PhoenixKit.Test.Repo)[:database] || "phoenix_kit_test"
 
 db_check =
   try do


### PR DESCRIPTION
`config/test.exs` reads `PGDATABASE` verbatim when it is set — deliberately, and
the file documents why: it lets you point the suite at a database you already
have instead of one the test role is allowed to `CREATE`. That is the right
design for a managed or shared Postgres.

It also means the suite runs against whatever `PGDATABASE` happens to say. If a
shell exports it for development, `mix test` connects to the development
database and the Ecto sandbox proceeds to migrate and truncate it. `MIX_ENV=test`
does not help: the two variables are independent, and forcing one does not clear
the other.

This adds a guard that refuses that case **by name and before any connection is
attempted**, at `test/test_helper.exs:10` — after the `db_name` binding it needs
and before everything that touches a database: the `psql` reachability probe, the
repo, and ExUnit.

## What it refuses

Two layers:

1. A built-in suffix pattern — `_dev`, `_development`, `_prod`, `_production`,
   `_staging`, case-insensitive. This needs no configuration and covers any host
   following the ordinary convention.
2. An optional `PHOENIX_KIT_TEST_DB_DENYLIST` (comma-separated), empty by
   default, for a live database whose name the pattern cannot recognise.

## What it deliberately does not do

**It never requires a particular name.** A `_test` suffix requirement was
considered and rejected: it would refuse exactly the legitimate case
`config/test.exs` documents — an already-provisioned database on a role without
`CREATEDB`, which has no reason to carry a `_test` suffix. The guard only refuses
a name that looks like a non-test environment; anything else passes through
untouched, verified both as a unit assertion and as a live subprocess run with
`PGDATABASE=ci_runner_42` (exit 0, no error raised).

It also changes nothing about how `config/test.exs` resolves `PGDATABASE`.

## Residual risks, stated rather than hidden

Two, in opposite directions, both named in the module's moduledoc so a reader does
not mistake the pattern for exhaustive coverage:

- A host whose live database has no recognisable environment suffix — bare `acme`,
  `acme_main` — is not caught by the pattern and has to add that name to
  `PHOENIX_KIT_TEST_DB_DENYLIST` itself.
- The mirror case: a host whose *legitimate test* database happens to end in a
  live-looking suffix is refused, and the denylist only adds refusals — there is
  no override. The refusal is loud, before any connection, and names the reason,
  so this is a deliberate trade-off rather than an oversight; an allowlist
  counterpart is the obvious extension if anyone hits it.

## Why it lives in the repository

An external wrapper script can do the same check, and protects only the person
who remembers to use it. Inside the repository, a plain `mix test` is guarded for
everyone, including CI and a contributor running the suite for the first time.

## Acceptance

Mutation in both directions, run as real `mix test` subprocesses with
`PGHOST=127.0.0.1:1` so that even a broken guard could not physically reach a
real database while the guard itself is under test:

```
PGDATABASE=acme_production   exit 1, LiveDatabaseError raised at test_helper.exs:9,
                             refused before ExUnit started, no test executed
PGDATABASE=phoenix_kit_test  exit 0, 11 tests, 0 failures
guard suite                  18 tests, 0 failures
PGDATABASE=ci_runner_42      passes through, exit 0, no error
```

Reverse check — the `check!/1` call removed from `test_helper.exs`, tests left in
place:

```
naive repeat of the refusal case   exit 0, 11 tests, 0 failures — silently green
                                   with no protection in place
the wiring suite catches it        exit 2, 7 tests, 5 failures
call restored                      18 tests, 0 failures
```

The wiring test matters more than the unit tests here: an earlier version of this
guard was mutation-tested and showed that simply deleting the call is **not**
caught by the module's own unit tests — the pre-existing fallback in
`test_helper.exs` ("cannot reach the database") quietly excludes `:integration`
and exits 0. The wiring test runs `mix test` as a subprocess specifically so that
a removed call fails loudly instead of passing as a skipped integration suite.

## Not verified

`mix dialyzer` was not run against this branch.
