### PR TITLE
Fix add_connection accepting unregistered provider keys

### DIFF
--- a/lib/phoenix_kit/integrations/integrations.ex
+++ b/lib/phoenix_kit/integrations/integrations.ex
@@ -776,11 +776,12 @@ defmodule PhoenixKit.Integrations do
   """
   @spec add_connection(String.t(), String.t(), String.t() | nil, keyword()) ::
           {:ok, %{uuid: String.t(), data: map()}}
-          | {:error, :empty_name | :scope_not_allowed | term()}
+          | {:error, :empty_name | :unknown_provider | :scope_not_allowed | term()}
   def add_connection(provider_key, name, actor_uuid \\ nil, opts \\ [])
       when is_binary(provider_key) and is_binary(name) do
     owner = Keyword.get(opts, :owner, :system)
     trimmed = String.trim(name)
+    provider = Providers.get(provider_key)
     # A typed owner (user, dashboard, team, …) births an owned connection, so it
     # requires the provider to allow the `:personal` scope; `:system` requires
     # `:system`. (A provider offered "personally" is fine for any entity owner.)
@@ -790,10 +791,20 @@ defmodule PhoenixKit.Integrations do
       trimmed == "" ->
         {:error, :empty_name}
 
+      # Enforce provider existence at row-birth, NOT just in the picker —
+      # same tamperable "select_provider" event as the scope check below.
+      # Without this, an unregistered key makes `Providers.get/1` return
+      # `nil`, which makes `scopes_of/1` default to `[:system]` and
+      # trivially pass that check — a crafted key would birth a row that
+      # `list_connections/1` then reports as a real connection for a
+      # provider that was never installed.
+      is_nil(provider) ->
+        {:error, :unknown_provider}
+
       # Enforce the provider's declared scope at row-birth, NOT just in the
       # picker — the provider comes from a tamperable event, so a crafted
       # create_connection can't birth (e.g.) a personal Google connection.
-      scope_atom not in Providers.scopes_of(provider_key) ->
+      scope_atom not in Providers.scopes_of(provider) ->
         {:error, :scope_not_allowed}
 
       true ->

--- a/test/integration/integrations_scope_test.exs
+++ b/test/integration/integrations_scope_test.exs
@@ -50,6 +50,23 @@ defmodule PhoenixKit.Integration.IntegrationsScopeTest do
       # system add of the same provider is fine
       assert {:ok, _} = Integrations.add_connection("google", "sysgoogle")
     end
+
+    test "add of an unregistered provider key is rejected, not silently birthed" do
+      # `Providers.get/1` returns nil for an unknown key, and
+      # `Providers.scopes_of/1` then defaults an unknown provider to
+      # `[:system]` (see "provider scopes" below) — without a dedicated
+      # guard, a crafted `provider_key` from the tamperable
+      # "select_provider" event trivially clears the :system scope check
+      # and births a row `list_connections/1` reports as real.
+      bogus = "definitely-not-a-real-provider-#{System.unique_integer([:positive])}"
+
+      assert {:error, :unknown_provider} = Integrations.add_connection(bogus, "bogus-conn")
+
+      assert {:error, :unknown_provider} =
+               Integrations.add_connection(bogus, "bogus-conn", nil, owner: {:user, uid()})
+
+      assert Integrations.list_connections(bogus) == []
+    end
   end
 
   describe "list reads are owner-scoped (default :system)" do

--- a/test/integration/integrations_test.exs
+++ b/test/integration/integrations_test.exs
@@ -201,7 +201,7 @@ defmodule PhoenixKit.Integration.IntegrationsTest do
   describe "disconnect/2 for key_secret provider" do
     test "removes credentials like other non-OAuth types" do
       uuid =
-        seed_raw("aws", %{
+        seed_raw("aws_ses", %{
           "auth_type" => "key_secret",
           "access_key" => "AKIATEST",
           "secret_key" => "secret123",
@@ -211,8 +211,8 @@ defmodule PhoenixKit.Integration.IntegrationsTest do
 
       :ok = Integrations.disconnect(uuid)
 
-      {:ok, data} = Integrations.get_integration("aws")
-      assert data["provider"] == "aws"
+      {:ok, data} = Integrations.get_integration("aws_ses")
+      assert data["provider"] == "aws_ses"
       assert data["auth_type"] == "key_secret"
       assert data["status"] == "disconnected"
       refute Map.has_key?(data, "access_key")
@@ -296,14 +296,14 @@ defmodule PhoenixKit.Integration.IntegrationsTest do
     end
 
     test "returns credentials for key_secret provider" do
-      seed_raw("aws", %{
+      seed_raw("aws_ses", %{
         "auth_type" => "key_secret",
         "access_key" => "AKIATEST",
         "secret_key" => "secret",
         "status" => "connected"
       })
 
-      assert {:ok, creds} = Integrations.get_credentials("aws")
+      assert {:ok, creds} = Integrations.get_credentials("aws_ses")
       assert creds["access_key"] == "AKIATEST"
     end
 


### PR DESCRIPTION
`Integrations.add_connection/4` accepts any `provider_key`, including one that is
not in the registry at all. The chain: `Providers.get/1` returns `nil` for an
unknown key, `normalize_scopes(nil)` falls back to `[:system]`, the `:system`
scope check then passes trivially, and the row is inserted.

## Reproduced, not inferred

Two measurements against the unpatched code, on a real test database:

```
control  provider_key "openrouter" (registered)
         -> {:ok, ...}, data["provider"] == "openrouter",
            auth_type "api_key", visible in list_connections

claim    provider_key "definitely-not-a-real-provider-xyz-49666"
         -> {:ok, ...}, row INSERTED:
            %{"auth_type" => nil, "name" => "bogus-conn",
              "provider" => "definitely-not-a-real-provider-xyz-49666",
              "status" => "disconnected"}
         -> the same row comes back through get_json_setting_by_uuid
         -> list_connections(bogus_key) -> true, 1 row listed
```

## What this is and is not

No credential leaks — the row is empty. But it is fully visible through
`list_connections`, so it misrepresents the connection list: a crafted key can
create a row named after a provider on a host where that provider's package is
not installed at all. This is bookkeeping corruption, not a secrets issue, and
the fix is sized accordingly.

## The fix

One clause in `add_connection/4`, `is_nil(provider) -> {:error, :unknown_provider}`,
placed directly above the existing `scope_not_allowed` clause. That neighbouring
clause already carries a comment saying the check belongs here rather than only
in the UI picker, because the event is tamperable — the same reasoning applies,
so the guard goes in the same place rather than a new one.

`Providers.scopes_of/1`'s own default-to-`[:system]` for unknown keys is left
alone: that default is correct for its other callers. Only the row-birth path
needed an explicit existence check.

## The contributed-provider question, answered by fact

An obvious objection: `provider_key` not being in the registry might mean "an
external module has not been discovered yet", not "forged". If so, the guard
would refuse a legitimate call during startup.

Checked rather than assumed: `PhoenixKit.boot/1` closes the `ModuleRegistry`
discovery race before any request traffic is served, and the UI picker is built
from the same `Providers.all()`. So the guard narrows nothing that was reachable
in the first place.

## Two existing tests were passing only because of this bug

While fixing it, two pre-existing tests turned out to be using a provider key
`"aws"` that does not exist in the registry — they passed only because
`add_connection/4` accepted anything. They now use the real `aws_ses` provider.

Those two tests were strengthened in place rather than left alongside a new file:
a new test file next to a stale one creates the appearance of coverage while the
old one quietly stops testing its subject.

## Acceptance

Reverting only the library fix and leaving the tests produces exactly one
failure, and it names the leaked `{:ok, ...}` row rather than failing vaguely.

Targeted suite: 272 tests, 0 failures. `mix format`, `mix compile
--warnings-as-errors` and `mix credo --strict` clean on the changed files.

## Not verified

`mix dialyzer` was not run — out of proportion for a single guard clause.
`integrations_key_rotation_test.exs` was excluded from the run: 5 of its 14 tests
fail identically on completely untouched code, for reasons unrelated to this
change, and that is tracked separately.
