### PR TITLE
Add coverage for rotating a still-plaintext restricted setting

### DIFF
--- a/test/integration/integrations_key_rotation_test.exs
+++ b/test/integration/integrations_key_rotation_test.exs
@@ -81,6 +81,24 @@ defmodule PhoenixKit.Integration.KeyRotationTest do
     updated
   end
 
+  # Same idea as `write_plaintext_field!/3`, for a restricted
+  # `PhoenixKit.Settings` row's bare `value` string instead of an
+  # integration's `value_json` map. `Ecto.Changeset.change/2` — NOT
+  # `Setting.update_changeset/2` — is the point: the latter runs
+  # `maybe_encrypt_restricted_value/1` on every `:value` change, which would
+  # immediately re-encrypt whatever this writes and defeat the whole point
+  # of simulating a row saved before the encryption feature existed.
+  defp write_plaintext_setting_value!(key, value) do
+    {:ok, _} = Settings.update_setting(key, "placeholder-overwritten-below")
+
+    key
+    |> Queries.get_setting_by_key()
+    |> Ecto.Changeset.change(value: value)
+    |> Queries.update_setting()
+
+    :ok
+  end
+
   describe "rotate/2 — real run" do
     test "re-encrypts every connection under the new secret; the old key can no longer read it" do
       uuid1 = seed_connection("openrouter", "one", %{"api_key" => "sk-one"})
@@ -253,6 +271,54 @@ defmodule PhoenixKit.Integration.KeyRotationTest do
       matched = Enum.find(rows, &(&1.key == restricted_key))
       assert matched
       assert matched.module == nil
+    end
+
+    # Every other test in this describe block seeds via
+    # `Settings.update_setting/2`, which is ITSELF the encrypting write path
+    # (`Setting.maybe_encrypt_restricted_value/1`) — so none of them can
+    # distinguish "rotation handles a restricted setting" from "rotation
+    # handles a restricted setting that happens to already be encrypted".
+    # The real-world row this exists to protect (`oauth_google_client_secret`
+    # written before the encryption feature shipped, e.g. on hosts running a
+    # pre-#759 core) is genuinely plaintext in `value` — never `enc:v1:` at
+    # all. `has_sensitive_field?/1` and `decrypt_row/1` key off the
+    # DECRYPTED view (`Encryption.decrypt_value/1` passes plaintext through
+    # unchanged, tagged `:legacy` by `Settings.decrypt_restricted_value/1`),
+    # not off "does the raw value already look encrypted" — this test is
+    # what actually exercises that, instead of it being a claim in a
+    # comment.
+    test "a restricted setting still PLAINTEXT (predates the feature) gets encrypted, " <>
+           "and the real OAuth-credential read path hands back the original secret" do
+      key = "oauth_google_client_secret"
+      write_plaintext_setting_value!(key, "sk-legacy-plaintext-secret")
+
+      before_row = Queries.get_setting_by_key(key)
+      refute String.starts_with?(before_row.value, "enc:v1:")
+
+      assert {:ok, %{rotated: 1, dry_run: false}} =
+               KeyRotation.rotate("brand-new-secret-well-over-min-length")
+
+      after_row = Queries.get_setting_by_key(key)
+      assert String.starts_with?(after_row.value, "enc:v1:")
+      refute after_row.value == before_row.value
+
+      Application.put_env(
+        :phoenix_kit,
+        :integrations_encryption_key,
+        "brand-new-secret-well-over-min-length"
+      )
+
+      # Not just "decrypt_value returns the right string" — the actual
+      # function `PhoenixKit.Users.OAuthConfig.configure_providers/0` calls
+      # to build the live Ueberauth `client_secret:` for Google. If this
+      # returned the ciphertext, an empty string, or nil, OAuth login would
+      # be broken by the fix, not protected by it.
+      assert Settings.get_oauth_credentials_direct(:google).client_secret ==
+               "sk-legacy-plaintext-secret"
+
+      # Same guarantee through the plain single-key read path every other
+      # caller of a restricted setting uses.
+      assert Settings.get_setting(key) == "sk-legacy-plaintext-secret"
     end
   end
 


### PR DESCRIPTION
`mix phoenix_kit.integrations.rotate_key` is the path that takes an existing
install's restricted settings and brings them under encryption. Every existing
rotation test seeds its fixtures **through the encrypting write path** — so the
suite covers rotating a value that was already encrypted, and never covers the
state a real install is actually in before it updates: a genuine plaintext value
written by an older version.

That is the road the data on a live install travelled. It had no test.

## What the test asserts

A restricted setting is written as raw plaintext, bypassing the encrypting write,
to reproduce the pre-#759 state. Then `KeyRotation.rotate/1` runs, and the test
checks two things:

1. the row is swept — `rotated: 1`, and the stored value now carries the
   `enc:v1:` marker;
2. **the value still works** — `Settings.get_oauth_credentials_direct(:google).client_secret`
   returns the original secret. That is the same function
   `OAuthConfig.configure_providers/0` feeds into the live Ueberauth
   configuration, so this is the read path a real login uses, not a
   marker-shaped proxy for it.

The second assertion is the point. Checking for the `enc:v1:` prefix would pass
just as happily on a value that had been encrypted into something unreadable.

## Mutation, both directions

```
with a simulated fault in decrypt_row/1   rotated: 0
                                          the plaintext row is silently skipped
                                          and stays plaintext for good

with the code as it stands                rotated: 1, marker present,
                                          and the credential reads back intact
```

No library change was needed: the current implementation is already correct. The
first direction was produced by temporarily faulting `decrypt_row/1` to confirm
the test actually detects the failure it claims to; that mutation was reverted
immediately and `git diff` on `key_rotation.ex` is empty.

The failure mode this guards against is quiet and permanent: a rotation that
reports success while leaving a plaintext credential untouched forever, because
it only considered rows it recognised as already encrypted.

## Out of scope, named

- Migrating rows already sitting in a production database as plaintext is a
  live-database operation for whoever operates that host, not something a core PR
  does. `rotate_key` handles it correctly — including with `--new-key` set to the
  currently active secret when only a first-time encryption sweep is wanted, with
  no real key change. Running it is the host operator's decision.
- A genuine end-to-end OAuth round trip (browser → provider → callback) is not
  exercised: that needs a live provider and real credentials. The test goes
  through the real function the login path calls instead, which is the closest
  verification available without one.
