### PR TITLE
Update Select/Textarea and translatable-field labels to match Input's

### DIFF
--- a/lib/phoenix_kit_web/components/core/form_field_label.ex
+++ b/lib/phoenix_kit_web/components/core/form_field_label.ex
@@ -13,8 +13,13 @@ defmodule PhoenixKitWeb.Components.Core.FormFieldLabel do
 
   def label(assigns) do
     ~H"""
+    <%!-- Plain font-semibold, matching <.input>'s inline label
+    (2026-08-31): `fieldset-legend` is daisyUI 5's hook for legends
+    inside a real `.fieldset`, and borrowed inside `.label` it shrank
+    and muted Select/Textarea labels next to full-size Input ones —
+    the "Unit looks different from the fields around it" bug. --%>
     <label for={@for} class={["label", @class]}>
-      <span class="fieldset-legend font-semibold">
+      <span class="font-semibold">
         {render_slot(@inner_block)}
       </span>
     </label>

--- a/lib/phoenix_kit_web/components/multilang_form.ex
+++ b/lib/phoenix_kit_web/components/multilang_form.ex
@@ -988,8 +988,14 @@ defmodule PhoenixKitWeb.Components.MultilangForm do
       class="fieldset flex flex-col gap-1"
       phx-feedback-for={if @is_primary, do: "#{@form_prefix}[#{@field_name}]"}
     >
+      <%!-- Plain font-semibold like <.input>'s label (2026-08-31, same
+           sweep as FormFieldLabel) — but with an explicit text-sm: this
+           label sits inside a real `.fieldset` wrapper, whose 0.75rem
+           inheritance `fieldset-legend` used to override. Dropping the
+           class without restoring the size made these labels SMALLER,
+           not matching (caught verifying on the box). --%>
       <label for={@input_id} class="label">
-        <span class="fieldset-legend font-semibold">
+        <span class="font-semibold text-sm">
           {@label}
           <%= if @required && @is_primary do %>
             *

--- a/test/phoenix_kit_web/components/core/form_field_label_test.exs
+++ b/test/phoenix_kit_web/components/core/form_field_label_test.exs
@@ -1,0 +1,26 @@
+defmodule PhoenixKitWeb.Components.Core.FormFieldLabelTest do
+  use ExUnit.Case, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias PhoenixKitWeb.Components.Core.FormFieldLabel
+
+  # 2026-08-31: Select/Textarea labels (through this component) must
+  # match <.input>'s inline label — a plain font-semibold span, NOT
+  # daisyUI's fieldset-legend, whose smaller/muted styling made a select
+  # label visibly differ from the input labels beside it in one grid
+  # (the "Unit looks different from the fields around it" report).
+  test "renders the plain font-semibold span Input uses, not fieldset-legend" do
+    html =
+      render_component(&FormFieldLabel.label/1,
+        for: "some-input",
+        class: "block mb-2",
+        inner_block: [%{inner_block: fn _, _ -> "Unit" end}]
+      )
+
+    assert html =~ ~s(for="some-input")
+    assert html =~ "font-semibold"
+    assert html =~ "Unit"
+    refute html =~ "fieldset-legend"
+  end
+end

--- a/test/phoenix_kit_web/components/multilang_form_test.exs
+++ b/test/phoenix_kit_web/components/multilang_form_test.exs
@@ -96,6 +96,34 @@ defmodule PhoenixKitWeb.Components.MultilangFormTest do
       assert result =~ ~s(phx-debounce="300")
     end
 
+    # 2026-08-31 label harmonisation: same plain font-semibold span
+    # Input uses — but with an explicit text-sm, because this label sits
+    # inside a real `.fieldset` wrapper whose 0.75rem inheritance
+    # `fieldset-legend` used to override. Dropping the class WITHOUT
+    # text-sm made these labels smaller than their Input neighbours.
+    test "the label span matches Input's typography inside the fieldset wrapper" do
+      changeset = make_changeset(%{title: "Hello"})
+      assigns = %{changeset: changeset}
+
+      result =
+        html(~H"""
+        <.translatable_field
+          field_name="title"
+          form_prefix="record"
+          changeset={@changeset}
+          schema_field={:title}
+          multilang_enabled={false}
+          current_lang="en"
+          primary_language="en"
+          lang_data={%{}}
+          label="Title"
+        />
+        """)
+
+      assert result =~ ~s(<span class="font-semibold text-sm">)
+      refute result =~ "fieldset-legend"
+    end
+
     test "nil omits the attribute, so the server sees every keystroke" do
       # For fields the server DERIVES from as you type — a slug from a
       # title — waiting for a typing pause makes the result feel laggy.


### PR DESCRIPTION
## Summary

One commit fixing a form-primitive inconsistency the owner reported ("the Unit select looks different from the fields around it"): `FormFieldLabel` (labelling Select and Textarea) and `translatable_field` rendered their label spans with `fieldset-legend` — daisyUI 5's hook for legends inside a real `.fieldset` — which, borrowed inside `.label`, shrank and muted those labels next to full-size Input ones. Both now render the plain `font-semibold` span Input uses; `translatable_field` keeps an explicit `text-sm` because its real `.fieldset` wrapper inherits 0.75rem (verified live — dropping the class without restoring the size made those labels smaller, not matching).

Checked with a 3-seat external panel before writing: unanimous on the direction (Input is the dominant primitive; `fieldset-legend` here was load-bearing for nothing but the bug, and losing its muted colour improves contrast). Verified on max-dev: Name/SKU/Unit/Category labels now render at the same size and colour on the catalogue item form.

**Deliberately out of scope** (per-case judgment, flagged for a follow-up sweep): the hand-rolled `fieldset-legend font-semibold` sites in `user_form.html.heex`, `mentions/live.ex` and `searchable_select.ex` (the last is a real `<legend>` in a real fieldset — the sanctioned idiom); and the `div.fieldset` helper-text wrapper pattern, which shrinks Input and Select labels *equally* to 12px (Base Price/Markup/Status on the item form) — a pre-existing design question, not part of this bug.

## Verification

- New pins: `form_field_label_test.exs` (plain font-semibold span, no fieldset-legend) and a `multilang_form_test.exs` case for the text-sm-inside-fieldset subtlety.
- `mix compile --warnings-as-errors` + `credo --strict` clean; component/web test dirs green (858 tests). Dialyzer skipped for a template-only class swap. Note: `mix format --check-formatted` fails on this tree for a pre-existing wrap difference in `test/mix/tasks/phoenix_kit_doctor_test.exs` untouched by this PR (local formatter version variance) — left alone rather than churning an unrelated file.

## Test plan

- [x] `mix test test/phoenix_kit_web/components/` (621 tests) + `test/phoenix_kit_web/` (858)
- [x] compile --warnings-as-errors, credo --strict
- [x] Browser check on max-dev: catalogue item form labels aligned in size and colour

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bbQqpwP4bRCYWNtsJAksH