### PR TITLE
Doctor: check that hooksPath has an executable pre-commit, not that it equals .githooks

### DIFF
--- a/lib/mix/tasks/phoenix_kit.doctor.ex
+++ b/lib/mix/tasks/phoenix_kit.doctor.ex
@@ -82,11 +82,12 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
        `PhoenixKit.Migrations.ExpectedSchema` manifest as an additional,
        non-fatal check (never `:fail`). Passes and says so if the manifest
        has been removed or overridden away in this checkout.
-   27. **Git Hooks** — is `.githooks/pre-commit` enabled via
-       `core.hooksPath`? Only runs inside a checkout of phoenix_kit itself
-       (`.githooks/pre-commit` is a phoenix_kit-repo convention, not
-       something installed into a consuming host app) — silently skipped
-       otherwise.
+   27. **Git Hooks** — does `core.hooksPath` point at a directory that has an
+       executable `pre-commit` in it? Any directory qualifies — `.githooks`
+       is only the convention this checkout happens to track. Only runs
+       inside a checkout of phoenix_kit itself (that convention is a
+       phoenix_kit-repo thing, not something installed into a consuming host
+       app) — silently skipped otherwise.
   """
 
   use Mix.Task
@@ -214,9 +215,23 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
   assumed). So repository-ness is probed separately, and only inside a
   repository is exit 1 read as the fact "not configured".
 
+  A second trap, independent of the first: `:hooks_path` holding anything
+  other than the literal string `.githooks` does not mean the hook is broken.
+  `core.hooksPath` names a directory, and a user is free to point it anywhere
+  — any directory with an executable `pre-commit` in it works exactly the way
+  `.githooks` does; `.githooks` is only the name this checkout's own
+  convention happens to use. Treating one specific value as the only correct
+  answer reports a perfectly working setup as broken, and its "fix" tells the
+  reader to point at a location that has nothing to do with why. So this
+  checks the property that actually matters — an executable `pre-commit` at
+  wherever `core.hooksPath` points — never string equality with `.githooks`.
+
     * `:repo` — `{:ok, common_dir}` when git answered, `:unknown` otherwise
       (not a repository, git missing, anything else).
     * `:hooks_path` — `{:ok, value}` | `:unset` (a fact) | `:unknown` (a gap).
+    * `:pre_commit_executable` — whether the directory `:hooks_path` names has
+      an executable `pre-commit` in it: `:yes` | `:no` | `:unknown` (only
+      meaningful when `:hooks_path` is `{:ok, _}`; see `pre_commit_executable?/1`).
     * `:tracked?` — whether `.githooks/pre-commit` exists in this checkout.
     * `:shadow` — `{:ok, path}` for a leftover hook in the **common** hooks dir
       (worktrees do not have their own), `:none`, or `:unknown`.
@@ -246,10 +261,18 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
        "       Fix: git config core.hooksPath .githooks"}
   end
 
-  def git_hooks_verdict(%{hooks_path: {:ok, path}}) when path != ".githooks" do
+  def git_hooks_verdict(%{hooks_path: {:ok, path}, pre_commit_executable: :no}) do
     {:warn,
-     "The tracked hook is NOT running: core.hooksPath points at #{inspect(path)}.\n" <>
-       "       Fix: git config core.hooksPath .githooks"}
+     "The tracked hook is NOT running: core.hooksPath points at #{inspect(path)}, " <>
+       "which has no executable pre-commit in it.\n" <>
+       "       Fix: point core.hooksPath at a directory that has one " <>
+       "(for example .githooks, if this checkout tracks it)."}
+  end
+
+  def git_hooks_verdict(%{hooks_path: {:ok, path}, pre_commit_executable: :unknown}) do
+    {:warn,
+     "Could not check whether #{inspect(path)} has an executable pre-commit.\n" <>
+       "       This is NOT the same as \"the hook is not installed\": nothing was verified."}
   end
 
   def git_hooks_verdict(%{shadow: {:ok, path}}) do
@@ -263,6 +286,45 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
   end
 
   def git_hooks_verdict(%{}), do: {:pass, "tracked hook enabled via core.hooksPath"}
+
+  @doc """
+  Whether `dir` has an executable `pre-commit` in it.
+
+  The property `git_hooks_verdict/1` actually cares about, regardless of what
+  the configured directory is named or where it lives — `core.hooksPath`
+  works identically for any directory that has this file, `.githooks` is not
+  special to git itself.
+
+  Public for the same reason `exit_code/1` is: a test seam over a filesystem
+  fact, so `git_hooks_verdict/1` above can stay a pure function of an
+  already-decided map instead of doing its own I/O.
+
+  A relative `dir` is resolved the same way git resolves a relative
+  `core.hooksPath`: against the top of the working tree (see githooks(5)),
+  which is also where this task itself runs.
+  """
+  @spec pre_commit_executable?(String.t()) :: :yes | :no | :unknown
+  def pre_commit_executable?(dir) do
+    file = dir |> Path.expand(File.cwd!()) |> Path.join("pre-commit")
+
+    case File.stat(file) do
+      {:ok, %File.Stat{type: :regular, mode: mode}} ->
+        if Bitwise.band(mode, 0o111) != 0, do: :yes, else: :no
+
+      # A directory (or anything else) named "pre-commit" is not a hook git
+      # can run, whatever its permission bits say.
+      {:ok, _not_a_regular_file} ->
+        :no
+
+      {:error, :enoent} ->
+        :no
+
+      # Anything else (denied, a broken mount, ...) is a gap in what we know,
+      # never evidence that the hook is missing.
+      {:error, _reason} ->
+        :unknown
+    end
+  end
 
   # Printing "N failures" and exiting 0 makes this task unusable as a deploy
   # gate — and it now owns a check (Module Schema Versions) whose whole point is
@@ -380,17 +442,29 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
 
     case git_cmd(["rev-parse", "--git-common-dir"]) do
       {:ok, common} ->
+        hooks_path = hooks_path_config()
+
         %{
           repo: {:ok, common},
-          hooks_path: hooks_path_config(),
+          hooks_path: hooks_path,
+          pre_commit_executable: hooks_path_executable(hooks_path),
           tracked?: tracked?,
           shadow: shadow_hook(common)
         }
 
       :error ->
-        %{repo: :unknown, hooks_path: :unknown, tracked?: tracked?, shadow: :unknown}
+        %{
+          repo: :unknown,
+          hooks_path: :unknown,
+          pre_commit_executable: :unknown,
+          tracked?: tracked?,
+          shadow: :unknown
+        }
     end
   end
+
+  defp hooks_path_executable({:ok, path}), do: pre_commit_executable?(path)
+  defp hooks_path_executable(_not_ok), do: :unknown
 
   defp hooks_path_config do
     case System.cmd("git", ["config", "--get", "core.hooksPath"], stderr_to_stdout: true) do

--- a/test/mix/tasks/phoenix_kit_doctor_test.exs
+++ b/test/mix/tasks/phoenix_kit_doctor_test.exs
@@ -353,6 +353,7 @@ defmodule Mix.Tasks.PhoenixKit.DoctorTest do
     @ok %{
       repo: {:ok, "/repo/.git"},
       hooks_path: {:ok, ".githooks"},
+      pre_commit_executable: :yes,
       tracked?: true,
       shadow: :none
     }
@@ -368,11 +369,44 @@ defmodule Mix.Tasks.PhoenixKit.DoctorTest do
       assert detail =~ "git config core.hooksPath .githooks"
     end
 
-    test "pointing somewhere else → warns and names where" do
-      {status, detail} = DoctorTask.git_hooks_verdict(%{@ok | hooks_path: {:ok, "hooks"}})
+    # `.githooks` is not privileged: any directory with an executable
+    # `pre-commit` in it passes, exactly like `.githooks` does above.
+    test "pointing somewhere else, with an executable pre-commit there → pass" do
+      verdict =
+        DoctorTask.git_hooks_verdict(%{
+          @ok
+          | hooks_path: {:ok, "/root/.laisk-hooks"},
+            pre_commit_executable: :yes
+        })
+
+      assert {:pass, _} = verdict
+    end
+
+    test "pointing somewhere else, with NO executable pre-commit there → warns and names where" do
+      {status, detail} =
+        DoctorTask.git_hooks_verdict(%{
+          @ok
+          | hooks_path: {:ok, "hooks"},
+            pre_commit_executable: :no
+        })
+
       assert status == :warn
       assert detail =~ ~s("hooks")
-      assert detail =~ "git config core.hooksPath .githooks"
+      assert detail =~ "no executable pre-commit"
+    end
+
+    test "pointing somewhere else, but could not tell if pre-commit is there → warns, refuses to guess" do
+      {status, detail} =
+        DoctorTask.git_hooks_verdict(%{
+          @ok
+          | hooks_path: {:ok, "/some/dir"},
+            pre_commit_executable: :unknown
+        })
+
+      assert status == :warn
+      assert detail =~ ~s("/some/dir")
+      assert detail =~ "NOT the same"
+      refute detail =~ "Fix:"
     end
 
     test "tracked hook missing from the checkout → warns about that, not about config" do
@@ -419,6 +453,53 @@ defmodule Mix.Tasks.PhoenixKit.DoctorTest do
       {status, detail} = DoctorTask.git_hooks_verdict(%{@ok | shadow: :unknown})
       assert status == :warn
       assert detail =~ "could not check for a stale copy"
+    end
+  end
+
+  # The filesystem-facing half of the Git Hooks check: does the directory
+  # `core.hooksPath` names actually have an executable `pre-commit` in it?
+  # Absolute paths only — a relative one is resolved against `File.cwd!()`,
+  # and changing cwd to prove that would not be safe under `async: true`
+  # (cwd is a process-wide OS attribute, not scoped to the test process).
+  describe "pre_commit_executable?/1 — the property git_hooks_verdict/1 relies on" do
+    test "an executable file named pre-commit → :yes" do
+      dir = tmp_dir!()
+      write_executable!(dir, "pre-commit", "#!/bin/sh\nexit 0\n")
+
+      assert DoctorTask.pre_commit_executable?(dir) == :yes
+    end
+
+    test "a pre-commit file that exists but is NOT executable → :no" do
+      dir = tmp_dir!()
+      path = Path.join(dir, "pre-commit")
+      File.write!(path, "#!/bin/sh\nexit 0\n")
+      File.chmod!(path, 0o644)
+
+      assert DoctorTask.pre_commit_executable?(dir) == :no
+    end
+
+    test "no pre-commit file at all → :no, not :unknown" do
+      dir = tmp_dir!()
+      assert DoctorTask.pre_commit_executable?(dir) == :no
+    end
+
+    test "the whole directory does not exist → :no" do
+      dir =
+        Path.join(
+          System.tmp_dir!(),
+          "pk_doctor_hooks_missing_#{System.unique_integer([:positive])}"
+        )
+
+      refute File.exists?(dir)
+
+      assert DoctorTask.pre_commit_executable?(dir) == :no
+    end
+
+    test "pre-commit exists but is a directory, not a file → :no" do
+      dir = tmp_dir!()
+      File.mkdir_p!(Path.join(dir, "pre-commit"))
+
+      assert DoctorTask.pre_commit_executable?(dir) == :no
     end
   end
 
@@ -721,5 +802,25 @@ defmodule Mix.Tasks.PhoenixKit.DoctorTest do
     test "any other error reason passes through unchanged" do
       assert DoctorTask.fk_probe_failure_reason(:some_other_error) == :some_other_error
     end
+  end
+
+  # -------------------------------------------------------------------
+  # helpers
+  # -------------------------------------------------------------------
+
+  defp tmp_dir! do
+    dir =
+      Path.join(System.tmp_dir!(), "pk_doctor_hooks_test_#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(dir)
+    on_exit(fn -> File.rm_rf(dir) end)
+    dir
+  end
+
+  defp write_executable!(dir, name, content) do
+    path = Path.join(dir, name)
+    File.write!(path, content)
+    File.chmod!(path, 0o755)
+    path
   end
 end


### PR DESCRIPTION
The Git Hooks doctor check currently passes only when `core.hooksPath` equals the literal string `.githooks`. That tests for one particular configuration rather than for the property the check exists to verify — that a tracked, executable `pre-commit` hook is actually reachable.

**What changes.** The check now asks whether the directory `core.hooksPath` points at contains an executable `pre-commit`, instead of comparing the path to a fixed string. A setup that keeps hooks somewhere else — a shared directory outside the worktree, for instance — stops being reported as broken when it is not.

**What deliberately does not change.** `core.hooksPath` being unset still warns, with the same text and the same suggested fix (`git config core.hooksPath .githooks`). A checkout where the hook is missing or not executable still warns rather than passing. The goal is to stop rejecting valid configurations, not to loosen the check.

Verified against fixtures covering four states:

| state | verdict |
|---|---|
| hooksPath → other dir, executable `pre-commit` present | pass |
| hooksPath → other dir, `pre-commit` missing | warn |
| hooksPath → other dir, `pre-commit` present but not executable | warn |
| hooksPath unset | warn (text unchanged) |
| `.githooks` with executable `pre-commit` | pass (unchanged behaviour) |

Two files touched: the doctor task and its test. `mix compile --warnings-as-errors`, `mix format --check-formatted` and `mix credo --strict` are clean on both.

One note in the interest of full disclosure: the `tracked?: false` clause matches before the `hooks_path` clauses, so in a checkout without `.githooks/pre-commit` the doctor still suggests fixing `.githooks` even when `core.hooksPath` points somewhere workable. That is a warning rather than a false pass, and reordering the older clause is a wider behavioural change than this PR intends — happy to follow up separately if you would like it addressed.
