### PR TITLE
Center described checkboxes against their first text line

### DIFF
--- a/lib/modules/storage/web/settings.html.heex
+++ b/lib/modules/storage/web/settings.html.heex
@@ -377,7 +377,6 @@
               name="form_auto_generate_variants"
               checked={@form_auto_generate_variants}
               phx-click="toggle_form_variants"
-              class="mt-0.5 flex-shrink-0"
               label={gettext("Auto-Generate Variants")}
             >
               <:description>
@@ -392,7 +391,6 @@
               name="form_tile_generation_enabled"
               checked={@form_tile_generation_enabled}
               phx-click="toggle_form_tile_generation"
-              class="mt-0.5 flex-shrink-0"
               label={gettext("Deep Zoom Tile Generation")}
             >
               <:description>
@@ -409,7 +407,6 @@
               name="form_annotated_thumbnails_enabled"
               checked={@form_annotated_thumbnails_enabled}
               phx-click="toggle_form_annotated_thumbnails"
-              class="mt-0.5 flex-shrink-0"
               label={gettext("Annotated Thumbnails")}
             >
               <:description>

--- a/lib/phoenix_kit_web/components/core/checkbox.ex
+++ b/lib/phoenix_kit_web/components/core/checkbox.ex
@@ -104,16 +104,24 @@ defmodule PhoenixKitWeb.Components.Core.Checkbox do
       >
         <input type="hidden" name={@name} value="false" />
 
-        <input
-          type="checkbox"
-          id={@id}
-          name={@name}
-          value="true"
-          checked={@checked}
-          disabled={@disabled}
-          class={["checkbox checkbox-primary", has_description? && "mt-0.5", @class]}
-          {@rest}
-        />
+        <%!-- With a description the label is items-start, so the box must
+             center itself against the FIRST text line. The line box is 24px
+             (text-sm leading-6) — an h-6 flex wrapper centers any checkbox
+             size in it. The old `mt-0.5` nudge was tuned for checkbox-sm and
+             sat the default 24px box 2px low ("the checkbox and the text are
+             kind of not centered"). --%>
+        <span class={["flex items-center shrink-0", has_description? && "h-6"]}>
+          <input
+            type="checkbox"
+            id={@id}
+            name={@name}
+            value="true"
+            checked={@checked}
+            disabled={@disabled}
+            class={["checkbox checkbox-primary", @class]}
+            {@rest}
+          />
+        </span>
 
         <span class="select-none">
           <span class={has_description? && "font-medium"}>

--- a/test/phoenix_kit_web/components/core/checkbox_test.exs
+++ b/test/phoenix_kit_web/components/core/checkbox_test.exs
@@ -76,6 +76,32 @@ defmodule PhoenixKitWeb.Components.Core.CheckboxTest do
     assert html =~ "Disabled profiles are never used."
   end
 
+  test "with a description the box centers against the first text line, not a fixed nudge" do
+    # The label goes items-start when a description is present, so the input
+    # needs its own first-line-height (h-6, matching leading-6) centering
+    # wrapper. The old `mt-0.5` nudge was tuned for checkbox-sm and sat the
+    # default 24px box 2px below the text's centerline.
+    assigns = %{}
+
+    with_description =
+      render(~H"""
+      <.checkbox name="opt" checked={false} label="Enabled">
+        <:description>Secondary line.</:description>
+      </.checkbox>
+      """)
+
+    assert with_description =~ "h-6"
+    refute with_description =~ "mt-0.5"
+
+    # Without a description the whole label is items-center — no wrapper height.
+    without_description =
+      render(~H"""
+      <.checkbox name="opt" checked={false} label="Enabled" />
+      """)
+
+    refute without_description =~ "h-6"
+  end
+
   test "rich default-slot content renders alongside (not instead of) the label" do
     assigns = %{}
 


### PR DESCRIPTION
Two small commits fixing checkbox/label vertical alignment, found while working the CRM todo's "the text and the checkbox are kind of not centered vertically" item.

## What changed

- **`<.checkbox>` with a description centers the box against the first text line** (`c3620f11`). The label goes `items-start` when a description is present, and the input carried a hard `mt-0.5` — a nudge tuned for `checkbox-sm` that sat the default 24px box 2px below the 24px first line box (`text-sm leading-6`). The input now sits in an `h-6` flex `items-center` wrapper, which centers any checkbox size against the first line; the no-description path keeps its `items-center` label unchanged. The hidden-false fallback input stays outside the wrapper, so submission semantics are untouched, and `{@rest}` still lands on the real `<input>`. Pinned by a component test.
- **Storage settings drop their caller-side nudges** (`dee0995e`). Its three described checkboxes passed their own `mt-0.5 flex-shrink-0` through `class=`, re-introducing the sag on exactly those rows once the component centered itself (the wrapper centers the input's margin box). The component owns alignment and shrink now.

## Verification

- `mix precommit` green (compile -Werror, format, credo --strict, dialyzer, test.js); checkbox component tests 7/7.
- An external review round over the pair confirmed: no consumer passes layout-coupled classes; `checkbox-sm`/`checkbox-xs` callers benefit from the centering rather than breaking.
- Deployed to max-dev alongside the CRM branch; verified in the browser on the CRM settings and Storage settings pages.

## Notes

- Independent of the phoenix_kit_crm PR — neither gates the other.
- Per workspace policy: no version bump, no CHANGELOG entry.
