### PR TITLE
Fix two duplicate/hreflang defects in multi-domain sitemaps

### DIFF
--- a/dev_docs/pull_requests/2026/782-sitemap-domain-mode-hreflang-and-duplicate-home/CLAUDE_REVIEW.md
+++ b/dev_docs/pull_requests/2026/782-sitemap-domain-mode-hreflang-and-duplicate-home/CLAUDE_REVIEW.md
@@ -1,0 +1,107 @@
+# Claude Review — PR #782
+
+**Title:** Fix two duplicate/hreflang defects in multi-domain sitemaps
+**Author:** timujinne
+**Head commit:** 3ef2174a
+**Verdict:** Approve — two IMPROVEMENT-HIGH findings raised in review, both applied in the branch
+
+## Summary
+
+Two defects in `DomainMode`, both found on a live three-domain install
+(en primary + de + fr) by comparing the generated per-host sitemaps against
+what the rendered pages actually emit:
+
+1. A canonical-path group containing a single language still received a
+   self + `x-default` hreflang pair whenever that language was the primary
+   domain's. The page-level builders already drop an under-2-entry set as
+   noise and emit nothing, so the sitemap advertised an alternate set the
+   page's own `<head>` never backed up.
+2. One host's file could list the same `<loc>` twice. A locale-prefixed clone
+   route (`live "/de"` on the home LiveView, so `/de` does not 404 on a prefix
+   install) is discovered by `RouterDiscovery` with no `canonical_path`, so it
+   forms its own group; re-hosting strips the prefix and lands it on
+   `https://<de-host>/`, where the static source has already placed that
+   domain's home. The two groups cannot merge, so the home appeared twice —
+   once with the full cross-domain alternates, once bare.
+
+## Review scope
+
+Read in full: the diff against `a9a66190` across `domain_mode.ex`,
+`generator.ex`, `url_entry.ex` and `domain_mode_test.exs`; plus the
+surrounding `rebuild_for_domains/2` → `domain_entries/5` →
+`group_alternates/4` path, `extra_for_primary/5`, `domainless_entries/4`,
+`home_url/5`, and the pre-existing dedup in `generator.ex`.
+
+Specifically checked and found correct:
+
+- **The guard does not drop URLs.** `loc` and `alternates` are computed
+  independently in `domain_entries/5`; an emptied alternate list still emits
+  the entry.
+- **Single-language non-primary groups.** These previously produced a lone
+  self-reference. A one-entry hreflang set is not a set, so returning `[]`
+  for them is a correction, not a regression.
+- **Domainless languages survive.** `extra_for_primary/5` filters against
+  `taken` before dedup runs, so an own-language entry and a domainless entry
+  cannot collide into a loss.
+- **Sort order.** Non-primary hosts were sorted inside `domain_entries/5`,
+  the primary after concatenation; both now sort by `loc` on the same key
+  after dedup, which makes the order strictly total rather than changing it.
+- **Priority parsing.** `priority` arrives as float, string, or nil depending
+  on the source; the shared ranking reuses `UrlEntry.parse_priority/1` and
+  falls back to `0.0` rather than raising on an unparseable value.
+
+## Findings
+
+### IMPROVEMENT - HIGH — the guard silently voided an existing assertion (applied)
+
+`test/integration/sitemap/domain_mode_test.exs` — the test "untranslated group
+appears only on its language's domain" pinned rule m2 (never mislabel another
+language as `x-default`, stated in the `DomainMode` moduledoc) with
+`refute Enum.any?(fr_entry.alternates, &(&1.hreflang == "x-default"))`.
+
+That group is single-language, so after the new guard `alternates == []` and
+the `refute` passes against an empty list — vacuously, for a reason unrelated
+to what it claims to test. Proven by mutation: making `group_alternates/4`
+append an `x-default` on the `nil -> links` branch (i.e. violating m2 outright)
+left the suite fully green.
+
+Applied: that test now asserts the empty list it actually exercises, and a new
+test pins m2 with a genuine two-language group carrying no primary-language
+entry, so the `refute` is meaningful again.
+
+### IMPROVEMENT - HIGH — a second dedup policy beside the one already shipped (applied)
+
+The branch introduced a local `dedup_by_loc/1` in `DomainMode` ranking
+candidates by alternate count, then priority, then arrival order. `Generator`
+already carried `dedupe_by_loc/1` + `entry_richness/1` solving the same
+problem, with a comment describing this very scenario, and with one rule the
+new implementation did not reproduce: a `RouterDiscovery` entry scores `0` and
+therefore **always** loses a same-`loc` collision, regardless of its own
+priority. A ranking that compares only alternates and priority would let a
+route-discovery entry win as soon as it happened to carry either.
+
+Applied: the policy moved to `UrlEntry.dedupe_by_loc/1` +
+`UrlEntry.richness/1`, and both `Generator` and `DomainMode` now call it. The
+duplicate implementation and its private priority parser were removed rather
+than kept in parallel.
+
+## Verification
+
+- `mix test test/integration/sitemap/` — 77 tests, 0 failures.
+- Full suite: 43 doctests, 4388 tests, 0 failures.
+- `mix format --check-formatted` clean on all touched files.
+- **Mutation-proven, one failure each, green after restore:** violating m2 in
+  `group_alternates/4` fails the new m2 test; removing the dedup call from
+  `rebuild_for_domains/2` fails the duplicate-home test.
+- Confirmed against the live three-domain install by regenerating: the
+  duplicate home is gone from both non-primary domains (639 → 638 URLs each,
+  primary unchanged at 643); untranslated URLs carry no hreflang block,
+  matching their rendered pages; fully translated URLs keep their complete
+  de/en/fr/x-default sets pointing at the correct per-domain translated slugs;
+  and the surviving home entry is the rich one (priority 0.9 with the full
+  alternate set), not the bare clone.
+
+## Not done here
+
+`@version` and `CHANGELOG.md` are deliberately left untouched for the
+maintainer.

--- a/lib/modules/sitemap/domain_mode.ex
+++ b/lib/modules/sitemap/domain_mode.ex
@@ -122,19 +122,22 @@ defmodule PhoenixKit.Modules.Sitemap.DomainMode do
           |> Map.values()
           |> Enum.map(&group_by_language(&1, base_url, default_lang, enabled_bases))
 
+        # One host's file must list a URL once, and two producers can reach the
+        # same <loc> here: a locale-prefixed clone route (/de, /fr on the home
+        # LiveView) is discovered with no canonical_path, so it forms its own
+        # group, and re-hosting strips the prefix onto exactly the home URL the
+        # static source already placed on that language's domain. The two groups
+        # cannot merge, so the file listed the home twice. Resolved by the same
+        # richness policy the flat generator uses (UrlEntry.dedupe_by_loc/1).
         Map.new(domains, fn %{host: host, language: lang, primary: primary?} ->
           own = domain_entries(groups, lang, host_by_lang, primary, base_url)
 
           entries =
             if primary?,
-              do:
-                Enum.sort_by(
-                  own ++ extra_for_primary(own, groups, host_by_lang, primary, base_url),
-                  & &1.loc
-                ),
+              do: own ++ extra_for_primary(own, groups, host_by_lang, primary, base_url),
               else: own
 
-          {host, entries}
+          {host, entries |> UrlEntry.dedupe_by_loc() |> Enum.sort_by(& &1.loc)}
         end)
     end
   end
@@ -212,6 +215,18 @@ defmodule PhoenixKit.Modules.Sitemap.DomainMode do
 
   # Computed once per group and reused verbatim for every domain that carries
   # the group — the spec's "identical hreflang set on every duplicate".
+  #
+  # A group with only one language present is not a hreflang set: the app's
+  # own page-level builders (`Decor3dprintWeb.SEO.with_x_default/1`,
+  # `PhoenixKitEcommerce.Web.SEOHelpers.dedup_or_empty/1`) already drop
+  # under-2-entry sets as noise rather than emit a lone self+x-default pair.
+  # Without this guard here, an untranslated product/page's <head> carried
+  # NO hreflang tags (per that same rule) while its sitemap entry advertised
+  # one — the live page silently failed to back up a promise its own sitemap
+  # made for the identical URL.
+  defp group_alternates(by_lang, _host_by_lang, _primary, _base_url) when map_size(by_lang) < 2,
+    do: []
+
   defp group_alternates(by_lang, host_by_lang, primary, base_url) do
     links =
       by_lang

--- a/lib/modules/sitemap/generator.ex
+++ b/lib/modules/sitemap/generator.ex
@@ -677,7 +677,7 @@ defmodule PhoenixKit.Modules.Sitemap.Generator do
       Logger.debug("Sitemap: Collected #{length(entries)} entries from #{inspect(source_module)}")
       entries
     end)
-    |> dedupe_by_loc()
+    |> UrlEntry.dedupe_by_loc()
     |> Enum.sort_by(& &1.loc)
   end
 
@@ -772,7 +772,7 @@ defmodule PhoenixKit.Modules.Sitemap.Generator do
         entry
       end
     end)
-    |> dedupe_by_loc()
+    |> UrlEntry.dedupe_by_loc()
     |> Enum.sort_by(& &1.loc)
   end
 
@@ -788,36 +788,6 @@ defmodule PhoenixKit.Modules.Sitemap.Generator do
       [_, lang] -> lang
       _ -> Routes.get_default_admin_locale()
     end
-  end
-
-  # Deduplicates entries by `loc`, preferring the entry with the richer
-  # sitemap metadata when a URL is emitted by more than one source. This
-  # matters because RouterDiscovery blindly enumerates every GET route and
-  # can emit the same `loc` as a content source (Publishing, Entities, ...)
-  # that also generates a richer entry (canonical_path/alternates for
-  # hreflang, higher priority) for that same URL. A RouterDiscovery entry
-  # always loses to a same-loc entry from any other source: it only carries
-  # generic route metadata (priority 0.5, no hreflang) and must never mask
-  # an authoritative content-source entry. `Enum.uniq_by/2` alone is not
-  # enough here since it keeps whichever entry happens to come first, which
-  # depends on source ordering rather than which entry is actually richer.
-  defp dedupe_by_loc(entries) do
-    entries
-    |> Enum.group_by(& &1.loc)
-    |> Enum.map(fn {_loc, group} -> Enum.max_by(group, &entry_richness/1) end)
-  end
-
-  # RouterDiscovery entries always score lowest (0), so any other source
-  # wins a same-loc collision regardless of its own priority/canonical_path.
-  # Among non-RouterDiscovery entries, richer entries win ties.
-  defp entry_richness(%UrlEntry{source: :router_discovery}), do: 0
-
-  defp entry_richness(%UrlEntry{} = entry) do
-    canonical_bonus = if entry.canonical_path in [nil, ""], do: 0, else: 2
-    alternates_bonus = if entry.alternates in [nil, []], do: 0, else: 2
-    priority = UrlEntry.parse_priority(entry.priority) || 0.0
-
-    1 + canonical_bonus + alternates_bonus + priority
   end
 
   # ── Internal: XML building ─────────────────────────────────────────

--- a/lib/modules/sitemap/url_entry.ex
+++ b/lib/modules/sitemap/url_entry.ex
@@ -236,4 +236,43 @@ defmodule PhoenixKit.Modules.Sitemap.UrlEntry do
   end
 
   def parse_priority(_), do: nil
+
+  @doc """
+  Deduplicates entries by `loc`, keeping the richest description of each URL.
+
+  A sitemap file must list a URL once, but more than one producer can arrive at
+  the same `loc`. `RouterDiscovery` blindly enumerates every GET route and can
+  emit the `loc` a content source (Publishing, Entities, ...) also emits with
+  far better metadata; and under `DomainMode` a locale-prefixed clone route is
+  re-hosted prefix-free onto that language's domain, landing on the home URL the
+  static source already placed there.
+
+  `Enum.uniq_by/2` alone is not enough: it keeps whichever entry happens to come
+  first, which depends on source ordering rather than on which entry is actually
+  richer.
+  """
+  @spec dedupe_by_loc([t()]) :: [t()]
+  def dedupe_by_loc(entries) do
+    entries
+    |> Enum.group_by(& &1.loc)
+    |> Enum.map(fn {_loc, group} -> Enum.max_by(group, &richness/1) end)
+  end
+
+  @doc """
+  Ranks an entry for a same-`loc` collision; higher wins.
+
+  A `RouterDiscovery` entry always scores lowest, so any other source wins
+  regardless of its own priority: route discovery carries only generic metadata
+  (priority 0.5, no hreflang) and must never mask an authoritative content-source
+  entry. Among the rest, the entry describing the URL more fully wins.
+  """
+  @spec richness(t()) :: number()
+  def richness(%__MODULE__{source: :router_discovery}), do: 0
+
+  def richness(%__MODULE__{} = entry) do
+    canonical_bonus = if entry.canonical_path in [nil, ""], do: 0, else: 2
+    alternates_bonus = if entry.alternates in [nil, []], do: 0, else: 2
+
+    1 + canonical_bonus + alternates_bonus + (parse_priority(entry.priority) || 0.0)
+  end
 end

--- a/test/integration/sitemap/domain_mode_test.exs
+++ b/test/integration/sitemap/domain_mode_test.exs
@@ -183,7 +183,30 @@ defmodule PhoenixKit.Integration.Sitemap.DomainModeTest do
       assert result["site.example.com"] == []
       [fr_entry] = result["site.example.fr"]
       assert fr_entry.loc == "https://site.example.fr/only-french"
-      # no x-default: the primary language has no entry in this group (m2)
+      # One language is not a hreflang set, so this URL carries none at all.
+      # m2 (no x-default when the primary's language is absent) is NOT what
+      # this asserts — against an empty list any `refute Enum.any?` passes
+      # vacuously. m2 is covered by the two-language test below.
+      assert fr_entry.alternates == []
+    end
+
+    test "no x-default when the group has no entry for the primary's language (m2)" do
+      # Two non-primary languages, so the group is a real hreflang set and the
+      # single-language guard does not fire — only then does the absence of
+      # x-default mean the rule holds rather than the list simply being empty.
+      put_provider(:all_mapped)
+
+      entries = [
+        entry("/fr/only-french", "/only-french"),
+        entry("/de/nur-deutsch", "/only-french")
+      ]
+
+      result = DomainMode.rebuild_for_domains(entries, @base)
+
+      assert result["site.example.com"] == []
+      [fr_entry] = result["site.example.fr"]
+
+      assert Enum.map(fr_entry.alternates, & &1.hreflang) == ["de", "fr"]
       refute Enum.any?(fr_entry.alternates, &(&1.hreflang == "x-default"))
     end
 
@@ -198,6 +221,51 @@ defmodule PhoenixKit.Integration.Sitemap.DomainModeTest do
       [en_entry] = result["site.example.com"]
       assert en_entry.loc == "https://site.example.com/some/tool"
       assert result["site.example.fr"] == []
+    end
+
+    test "a single-language group on the PRIMARY's own language carries no alternates at all" do
+      # Regression: an untranslated product/page whose only language happens
+      # to be the primary domain's would previously get a self+x-default
+      # pair here — a lone entry, i.e. exactly the "hreflang for a single
+      # language is noise" case the app's own page-level builders already
+      # special-case. Left unguarded, the sitemap advertised an alternate
+      # set for this URL that the live page's <head> never repeated (it
+      # correctly emits none), so a crawler following the sitemap saw a
+      # promise the page itself did not keep.
+      entries = [entry("/only-english", "/only-english")]
+      result = DomainMode.rebuild_for_domains(entries, @base)
+
+      [en_entry] = result["site.example.com"]
+      assert en_entry.loc == "https://site.example.com/only-english"
+      assert en_entry.alternates == []
+      assert result["site.example.fr"] == []
+    end
+
+    test "one host lists a <loc> once when two sources produce it, keeping the richer entry" do
+      # Regression: a locale-prefixed clone route (`live "/fr"` pointing at the
+      # home LiveView) is discovered from the router with no canonical_path, so
+      # it forms its own single-language group. Re-hosting strips the prefix and
+      # lands it on `https://<fr-host>/` — exactly where the static home, grouped
+      # with the default language's `/` under canonical_path "/", already sits.
+      # The two groups cannot merge, so the French file listed its home twice:
+      # once with the full cross-domain alternates, once bare.
+      entries = [
+        entry("/", "/"),
+        entry("/fr/", "/"),
+        entry("/fr", nil)
+      ]
+
+      result = DomainMode.rebuild_for_domains(entries, @base)
+
+      assert [fr_home] = result["site.example.fr"]
+      assert fr_home.loc == "https://site.example.fr/"
+
+      # The survivor is the entry carrying the hreflang set, not the bare clone.
+      assert Enum.map(fr_home.alternates, & &1.hreflang) == ["en", "fr", "x-default"]
+
+      # The primary is unaffected — its own home is still listed exactly once.
+      assert [en_home] = result["site.example.com"]
+      assert en_home.loc == "https://site.example.com/"
     end
 
     test "a non-locale first segment is not treated as a language" do


### PR DESCRIPTION
Two defects in multi-domain sitemap generation, both found on a live three-domain site (en primary + de + fr) where the generated per-host sitemaps disagreed with what the rendered pages actually emit.

### 1. Lone self+x-default hreflang on a single-language URL

`DomainMode.group_alternates/4` emitted a self + `x-default` pair for a canonical-path group containing only one language, whenever that language was the primary domain's. That is a two-entry hreflang "set" for a page with no translations.

The page-level builders already treat an under-2-entry set as noise and emit nothing, so the sitemap advertised an alternate set that the page's own `<head>` never backed up — a crawler following the sitemap saw a promise the page did not keep. `group_alternates/4` now returns `[]` for such a group.

Because the function is shared by every source via `rebuild_for_domains/2`, this affected shop products and publishing posts alike, not one source.

### 2. The same `<loc>` listed twice in one host's file

A locale-prefixed clone route (e.g. `live "/de"` pointing at the home LiveView, so `/de` does not 404 on a prefix install) is picked up by `RouterDiscovery` with no `canonical_path`, so it forms its own group. Re-hosting strips the prefix and lands it on `https://<de-host>/` — exactly where the static source has already placed that domain's home. The two groups cannot merge, so the file listed the home twice: once with the full cross-domain alternates, once bare.

Per-host entries are now deduplicated by `<loc>`, keeping the richest description of the URL: alternates first, then priority, then arrival order so the result is deterministic run to run.

`extra_for_primary/5` already enforced this same "the same `<loc>` in one file twice" rule across sources for the domainless case — it simply never applied within a host's own set, which is where the clone-route duplicate lands.

### Verification

Regression tests added for both cases in `test/integration/sitemap/domain_mode_test.exs`. Full sitemap integration suite: 76 tests, 0 failures. `mix format` clean.

Confirmed against a live three-domain install by regenerating the sitemaps:

* duplicate home gone from both non-primary domains (639 -> 638 URLs each; primary unchanged at 643),
* untranslated URLs now carry no hreflang block, matching their rendered pages,
* fully translated URLs keep their complete de/en/fr/x-default sets pointing at the correct per-domain translated slugs,
* the surviving home entry is the rich one (priority 0.9 with the full alternate set), not the bare clone.

### Note

Version and CHANGELOG are intentionally left untouched for the maintainer.