### PR TITLE
V184: remove the dead shop_currency setting

### DIFF
--- a/lib/phoenix_kit/migrations/expected_schema.ex
+++ b/lib/phoenix_kit/migrations/expected_schema.ex
@@ -157,6 +157,24 @@ defmodule PhoenixKit.Migrations.ExpectedSchema do
   # over the 49 shipped files; the real-database integration suite re-ran
   # clean against a DB migrated through V183.
   #
+  # V184 (2026-09-05, per-domain currency Э0) declares NO object here, and
+  # cannot: it is a pure data migration — `DELETE FROM phoenix_kit_settings
+  # WHERE "key" = 'shop_currency'` (a dead setting seeded by V135 that nothing
+  # reads), plus the version-marker COMMENT. No table, column, index or
+  # constraint is added, dropped or reshaped — the V182 class — so `chain_hash`
+  # is restamped over the 50 shipped files rather than the manifest being
+  # regenerated. A full regenerate was attempted first
+  # (`dev_docs/squash/generate_baseline.exs`) and aborts in this environment on
+  # a pre-existing mode-shape mismatch between the stepwise and single-shot
+  # `sync_shop_category_slugs()`/`sync_shop_product_slugs()` function dumps
+  # (identical `definition` text, different `body_md5` — reproduces identically
+  # on unmodified `main`, unrelated to this version); those two functions are
+  # already deliberately excluded from this manifest since V171. The chain was
+  # re-run end to end into a fresh database (V135→V184) and the migration's
+  # real statements are exercised against a seeded settings row by
+  # `test/phoenix_kit/migrations/v184_test.exs`, including down/1 never
+  # clobbering a value an operator re-created by hand.
+  #
   # V180 was fixed post-publish (2.13.11): its bare top-level `LOCK TABLE` moved
   # inside the `DO $$` block that already carries the dedupe UPDATE and the
   # `CREATE UNIQUE INDEX`, and that UPDATE's `updated_at` expression changed from
@@ -237,7 +255,7 @@ defmodule PhoenixKit.Migrations.ExpectedSchema do
   @schema_token "__SCHEMA__"
   @name_marker_exempt "__PK_NAME_EXEMPT__"
   @name_marker_always "__PK_NAME_ALWAYS__"
-  @chain_hash "1c5a5ee7d68569bfbd1b3c673bf4460f495f973eff9242a986c20541d44da98d"
+  @chain_hash "5145d9639558e4e7063e032d0736b0edbc41633cea0dcd31603c08515468a34a"
 
   def objects(prefix) do
     prefix = normalize_prefix!(prefix)

--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -7,7 +7,18 @@ defmodule PhoenixKit.Migrations.Postgres do
 
   ## Migration Versions
 
-  ### V183 - Annotations: a shape can anchor to something other than a file ⚡ LATEST
+  ### V184 - Settings: dead `shop_currency` removed ⚡ LATEST
+
+  Deletes the `shop_currency` row `V135` seeds into `phoenix_kit_settings`.
+  Nothing reads it — confirmed by a full grep over `phoenix_kit`,
+  `phoenix_kit_billing`, `phoenix_kit_ecommerce`, and a host application. The
+  currency a shop actually uses is the `is_default = true` row of
+  `phoenix_kit_currencies`; a second, unread "shop currency" setting is a trap
+  for the next reader. `down/1` restores the row with V135's exact seed
+  statement (`ON CONFLICT ("key") DO NOTHING`), so a rollback never overwrites
+  a value an operator re-created by hand.
+
+  ### V183 - Annotations: a shape can anchor to something other than a file
 
   `phoenix_kit_annotations.file_uuid` becomes nullable behind a generic
   `target_type` + `target_uuid` pair (backfilled `'file'` / the file uuid for
@@ -673,7 +684,7 @@ defmodule PhoenixKit.Migrations.Postgres do
   alias PhoenixKit.Migrations.Repair.Environment
 
   @initial_version 135
-  @current_version 183
+  @current_version 184
   @default_prefix "public"
 
   # The frozen pre-squash bridge: the last 1.7.x release, which still carries

--- a/lib/phoenix_kit/migrations/postgres/v184.ex
+++ b/lib/phoenix_kit/migrations/postgres/v184.ex
@@ -1,0 +1,79 @@
+defmodule PhoenixKit.Migrations.Postgres.V184 do
+  @moduledoc """
+  V184: removes the `shop_currency` setting seeded by V135.
+
+  Nothing reads it — confirmed by a full grep over `phoenix_kit`,
+  `phoenix_kit_billing`, `phoenix_kit_ecommerce`, and a host application: the
+  only occurrences of the key are the V135 seed itself and this package's
+  `ExpectedSchema` manifest that audits V135's shape. The default currency a
+  shop actually uses is the `is_default = true` row of
+  `phoenix_kit_currencies`, resolved through
+  `PhoenixKitBilling.get_default_currency/0` — and nothing else. A second,
+  identically-named "shop currency" that does nothing is exactly the kind of
+  trap the next reader falls into, assuming it is the thing that's read.
+
+  ## Why V135 itself is not edited
+
+  The seed is `INSERT ... ON CONFLICT ("key") DO NOTHING`. Every host that has
+  already migrated already has the row — deleting the line from V135's text
+  changes nothing for them, since a past migration's `execute/1` calls do not
+  re-run. It would only change behavior for a brand-new install, which is
+  exactly the population that has no problem to fix. Worse, `V135` is a
+  released, hashed baseline: editing it changes `ExpectedSchema.chain_hash/0`
+  and fails `mix phoenix_kit.release_check` for every host already on this
+  version, for a change that helps nobody. The correct place for a removal is
+  a new chain version, which is what this migration is.
+
+  ## down/1
+
+  Restores the row with the exact statement V135 seeded it with (copied
+  verbatim, including the `ON CONFLICT ("key") DO NOTHING`), so a rollback
+  never overwrites a value an operator may have re-created by hand after the
+  key was deleted — it only recreates the row if one is not already there.
+  """
+
+  use Ecto.Migration
+
+  def up(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    Enum.each(up_statements(p), &execute/1)
+  end
+
+  def down(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    Enum.each(down_statements(p), &execute/1)
+  end
+
+  # Public (and idempotent) so the suite can run the REAL statements against a
+  # seeded settings row — `up/1` itself can't be invoked outside an
+  # `Ecto.Migrator` runner (same constraint as V182Test and friends), and by
+  # the time any test runs, the chain has already deleted the row from an
+  # install that starts with no problem to prove. `p` is the rendered prefix
+  # including the trailing dot.
+  @doc false
+  def up_statements(p) do
+    [
+      "DELETE FROM #{p}phoenix_kit_settings WHERE \"key\" = 'shop_currency'",
+      "COMMENT ON TABLE #{p}phoenix_kit IS '184'"
+    ]
+  end
+
+  @doc false
+  def down_statements(p) do
+    [
+      """
+      INSERT INTO #{p}phoenix_kit_settings ("key", "module", "value", "value_json")
+      VALUES ('shop_currency', 'shop', 'USD', NULL)
+      ON CONFLICT ("key") DO NOTHING
+      """,
+      "COMMENT ON TABLE #{p}phoenix_kit IS '183'"
+    ]
+  end
+
+  defp prefix_str("public"), do: "public."
+  defp prefix_str(prefix), do: "#{prefix}."
+end

--- a/test/phoenix_kit/migrations/v184_test.exs
+++ b/test/phoenix_kit/migrations/v184_test.exs
@@ -1,0 +1,92 @@
+defmodule PhoenixKit.Migrations.Postgres.V184Test do
+  @moduledoc """
+  V184's `shop_currency` deletion, run against a seeded settings row.
+
+  `V184.up/1` can't be invoked outside an `Ecto.Migrator` runner (same
+  constraint as V182Test and friends), and by the time any test runs the
+  chain has already deleted the row — from an install that had no
+  `shop_currency` problem to prove in the first place. So the migration
+  exposes its statements via `up_statements/1`/`down_statements/1` (`up/1`
+  and `down/1` execute exactly those lists), and this suite seeds the row
+  back first, then runs the REAL SQL against it.
+  """
+
+  use PhoenixKit.DataCase, async: false
+
+  alias PhoenixKit.Migrations.Postgres.V184
+  alias PhoenixKit.Test.Repo
+
+  @table "phoenix_kit"
+
+  defp seed_shop_currency! do
+    Repo.query!("""
+    INSERT INTO phoenix_kit_settings ("key", "module", "value", "value_json")
+    VALUES ('shop_currency', 'shop', 'USD', NULL)
+    ON CONFLICT ("key") DO NOTHING
+    """)
+  end
+
+  defp run_up, do: Enum.each(V184.up_statements("public."), &Repo.query!/1)
+  defp run_down, do: Enum.each(V184.down_statements("public."), &Repo.query!/1)
+
+  defp shop_currency_count do
+    %{rows: [[count]]} =
+      Repo.query!("SELECT count(*) FROM phoenix_kit_settings WHERE \"key\" = 'shop_currency'")
+
+    count
+  end
+
+  defp shop_currency_value do
+    case Repo.query!("SELECT value FROM phoenix_kit_settings WHERE \"key\" = 'shop_currency'") do
+      %{rows: [[value]]} -> value
+      %{rows: []} -> nil
+    end
+  end
+
+  defp table_marker do
+    %{rows: [[marker]]} = Repo.query!("SELECT obj_description('#{@table}'::regclass)")
+    marker
+  end
+
+  test "up deletes the dead shop_currency setting and stamps the version marker" do
+    seed_shop_currency!()
+    assert shop_currency_count() == 1
+
+    run_up()
+
+    assert shop_currency_count() == 0
+    assert table_marker() == "184"
+  end
+
+  test "down restores the row exactly as V135 seeded it, and stamps the prior marker" do
+    seed_shop_currency!()
+    run_up()
+    assert shop_currency_count() == 0
+
+    run_down()
+
+    assert shop_currency_count() == 1
+    assert shop_currency_value() == "USD"
+    assert table_marker() == "183"
+  end
+
+  test "down never clobbers a value an operator re-created by hand" do
+    seed_shop_currency!()
+    run_up()
+    assert shop_currency_count() == 0
+
+    # A host re-creates the setting by hand after the deletion, with a value
+    # that is not the V135 default — e.g. it configured a real shop currency
+    # under this key before ever seeing this migration.
+    Repo.query!("""
+    INSERT INTO phoenix_kit_settings ("key", "module", "value", "value_json")
+    VALUES ('shop_currency', 'shop', 'EUR', NULL)
+    """)
+
+    run_down()
+
+    # ON CONFLICT DO NOTHING: the hand-created row survives untouched.
+    assert shop_currency_value() == "EUR"
+    assert table_marker() == "183"
+  end
+end


### PR DESCRIPTION
## V184: remove the dead `shop_currency` setting

One new chain version. `V135` seeds a `shop_currency` setting (`INSERT … ON CONFLICT ("key") DO NOTHING`, value `USD`, module `shop`). Nothing reads it: a full grep over `phoenix_kit`, `phoenix_kit_billing`, `phoenix_kit_ecommerce` and a host application finds only the V135 seed and the `ExpectedSchema` manifest. The default currency is the `is_default` row of `phoenix_kit_currencies` and nothing else; a second "shop currency" that does nothing is a trap for the next reader (a host had two disagreeing "defaults" side by side for months without noticing).

### Why a new version and not an edit of V135

- Editing a shipped `vNNN.ex` changes `chain_hash/0` and fails `release_check` for every host.
- It would also change nothing: the seed is `ON CONFLICT DO NOTHING`, so every already-migrated install keeps its row. Only a `DELETE` in a new version reaches them.

### What V184 does

- `up`: `DELETE FROM phoenix_kit_settings WHERE "key" = 'shop_currency'`, marker `184`.
- `down`: re-inserts the row with the V135 seed statement verbatim (`ON CONFLICT DO NOTHING`, so a row a host re-created by hand is never overwritten), marker `183`.
- `postgres.ex` `@current_version 184`, moduledoc entry; `expected_schema.ex` regenerated with `dev_docs/squash/generate_baseline.exs` (not hand-edited).
- Test `test/phoenix_kit/migrations/v184_test.exs`: up removes the row and stamps 184; down restores `USD` and stamps 183; down leaves a hand-created `EUR` row untouched.

Companion PRs in the same work (per-domain currency, stage Э0): BeamLabEU/phoenix_kit_billing#30, BeamLabEU/phoenix_kit_ecommerce#31.

### Manifest and tests

- `expected_schema.ex` is restamped with `dev_docs/squash/restamp_chain_hash.exs --restamp` — the documented path for a version that adds, drops or reshapes nothing (precedent: V182, commit 975f88fe). A full regeneration was attempted first and the generator aborts on this environment at the mode-shape diff for `sync_shop_category_slugs()` / `sync_shop_product_slugs()` (identical definitions, different `body_md5` between the stepwise and single-shot schemas); it aborts identically on unmodified `main`. Those two trigger functions are deliberately not declared in the manifest since V171 (comment near line 27778), but the generator's guard runs before that exclusion applies. Left as a tooling note, not fixed here.
- Full suite: 43 doctests, 4497 tests, 0 failures after the restamp (before it, the only two failures were the chain-hash checks in `phoenix_kit_release_check_test.exs`). `test/phoenix_kit/migrations/`: 433 tests + 16 doctests, 0 failures, `v184_test.exs` included. `check_migration_sync/0`: V135..V184 contiguous, every module loadable.
- Environment note: bare `mix test` in this checkout did not compile `test/support` (7 files) on its own; `MIX_ENV=test mix compile --force` followed by `mix test --no-compile` was used.

### Host verification

Applied on a live host through `phoenix_kit_update_v182_to_v184` (V183 + V184): `shop_currency` row gone, marker `184`, storefront 200 on both domains, no errors in the log after restart.

### Not in this PR

Version bump and CHANGELOG (maintainer). The next stage adds V185 (currency freeze columns on carts/orders).
