### PR TITLE
V185: currency-freeze columns on carts, cart items and orders (stacked on #785)

### DIFF
--- a/lib/phoenix_kit/migrations/expected_schema.ex
+++ b/lib/phoenix_kit/migrations/expected_schema.ex
@@ -267,7 +267,7 @@ defmodule PhoenixKit.Migrations.ExpectedSchema do
   @schema_token "__SCHEMA__"
   @name_marker_exempt "__PK_NAME_EXEMPT__"
   @name_marker_always "__PK_NAME_ALWAYS__"
-  @chain_hash "392311c98d0a098057892ecb002e4664181a9e5511bcc3c91cc774ee596feac2"
+  @chain_hash "46e4d896a31c6881e4d3ceae73231957a72c6509740b555a994c02c77e318560"
 
   def objects(prefix) do
     prefix = normalize_prefix!(prefix)
@@ -27804,6 +27804,98 @@ defmodule PhoenixKit.Migrations.ExpectedSchema do
            }}
         ],
         presence: :legacy_optional,
+        backfill: nil
+      },
+      # DECLARED POST-GENERATION (2026-09-06): V185 freezes the base
+      # currency and exchange rate on carts/orders. Hand-declared the way
+      # V171's/V183's objects are — the environment's full regenerate
+      # aborts on a pre-existing mode-shape mismatch in
+      # sync_shop_category_slugs()/sync_shop_product_slugs() (see V184's
+      # moduledoc; reproduces identically on unmodified main), so these six
+      # columns cannot go through `generate_baseline.exs`. All six are
+      # nullable with no default (`ALTER TABLE ... ADD COLUMN`), backfilled
+      # by explicit `UPDATE` statements rather than a column `DEFAULT`,
+      # which is why `backfill: nil` here mirrors V183's `target_uuid`
+      # entry rather than V183's `target_type` (which does carry a real
+      # `DEFAULT` and is declared `backfill: :default`).
+      %{
+        id: "column:phoenix_kit_shop_carts.base_currency",
+        owner: :core,
+        check:
+          {:catalog, %{table: "phoenix_kit_shop_carts", column: "base_currency", kind: :column}},
+        create:
+          "ALTER TABLE __SCHEMA__.phoenix_kit_shop_carts ADD COLUMN IF NOT EXISTS \"base_currency\" character varying(3)",
+        since: 185,
+        class: :column,
+        revisions: [
+          {185, %{default: nil, type: "character varying(3)", pos: 23, not_null: false}}
+        ],
+        presence: :required,
+        backfill: nil
+      },
+      %{
+        id: "column:phoenix_kit_shop_carts.exchange_rate",
+        owner: :core,
+        check:
+          {:catalog, %{table: "phoenix_kit_shop_carts", column: "exchange_rate", kind: :column}},
+        create:
+          "ALTER TABLE __SCHEMA__.phoenix_kit_shop_carts ADD COLUMN IF NOT EXISTS \"exchange_rate\" numeric(15,6)",
+        since: 185,
+        class: :column,
+        revisions: [{185, %{default: nil, type: "numeric(15,6)", pos: 24, not_null: false}}],
+        presence: :required,
+        backfill: nil
+      },
+      %{
+        id: "column:phoenix_kit_shop_cart_items.base_unit_price",
+        owner: :core,
+        check:
+          {:catalog,
+           %{table: "phoenix_kit_shop_cart_items", column: "base_unit_price", kind: :column}},
+        create:
+          "ALTER TABLE __SCHEMA__.phoenix_kit_shop_cart_items ADD COLUMN IF NOT EXISTS \"base_unit_price\" numeric(15,2)",
+        since: 185,
+        class: :column,
+        revisions: [{185, %{default: nil, type: "numeric(15,2)", pos: 21, not_null: false}}],
+        presence: :required,
+        backfill: nil
+      },
+      %{
+        id: "column:phoenix_kit_orders.base_currency",
+        owner: :core,
+        check: {:catalog, %{table: "phoenix_kit_orders", column: "base_currency", kind: :column}},
+        create:
+          "ALTER TABLE __SCHEMA__.phoenix_kit_orders ADD COLUMN IF NOT EXISTS \"base_currency\" character varying(3)",
+        since: 185,
+        class: :column,
+        revisions: [
+          {185, %{default: nil, type: "character varying(3)", pos: 28, not_null: false}}
+        ],
+        presence: :required,
+        backfill: nil
+      },
+      %{
+        id: "column:phoenix_kit_orders.exchange_rate",
+        owner: :core,
+        check: {:catalog, %{table: "phoenix_kit_orders", column: "exchange_rate", kind: :column}},
+        create:
+          "ALTER TABLE __SCHEMA__.phoenix_kit_orders ADD COLUMN IF NOT EXISTS \"exchange_rate\" numeric(15,6)",
+        since: 185,
+        class: :column,
+        revisions: [{185, %{default: nil, type: "numeric(15,6)", pos: 29, not_null: false}}],
+        presence: :required,
+        backfill: nil
+      },
+      %{
+        id: "column:phoenix_kit_orders.base_total",
+        owner: :core,
+        check: {:catalog, %{table: "phoenix_kit_orders", column: "base_total", kind: :column}},
+        create:
+          "ALTER TABLE __SCHEMA__.phoenix_kit_orders ADD COLUMN IF NOT EXISTS \"base_total\" numeric(15,2)",
+        since: 185,
+        class: :column,
+        revisions: [{185, %{default: nil, type: "numeric(15,2)", pos: 30, not_null: false}}],
+        presence: :required,
         backfill: nil
       },
       # DECLARED POST-GENERATION (V171): the shop slug projection tables and

--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -7,7 +7,24 @@ defmodule PhoenixKit.Migrations.Postgres do
 
   ## Migration Versions
 
-  ### V185 - Activities can be permanent and are ordered to the microsecond; posts remember their zone ⚡ LATEST
+  ### V186 - Carts/orders: frozen base currency and exchange rate ⚡ LATEST
+
+  Adds `base_currency`/`exchange_rate` to `phoenix_kit_shop_carts` and
+  `phoenix_kit_orders`, and `base_unit_price` to
+  `phoenix_kit_shop_cart_items` — all nullable, no default. A `DO` block
+  raises before touching a column if `phoenix_kit_currencies` does not have
+  exactly one `is_default` row, since the backfill's subqueries would
+  otherwise pick an arbitrary one and silently mis-price. The backfill
+  itself derives every value from the currency table's *current* state
+  rather than from a literal: a row already in the base currency gets
+  `exchange_rate = 1.0` and its own totals copied into `base_*`; a row in
+  another currency gets that currency's rate (or `NULL` if the currency is
+  gone from the table) and `NULL` `base_*` amounts, since computing them
+  now would fabricate a conversion nobody performed. On a host whose base
+  currency is USD with all-USD carts and orders (ours), the backfill is the
+  identity — no price changes, no order is repriced.
+
+  ### V185 - Activities can be permanent and are ordered to the microsecond; posts remember their zone
 
   `phoenix_kit_activities.permanent` (`boolean`, default false): an entry
   the pruner never deletes, for records rather than news — the settings
@@ -699,7 +716,7 @@ defmodule PhoenixKit.Migrations.Postgres do
   alias PhoenixKit.Migrations.Repair.Environment
 
   @initial_version 135
-  @current_version 185
+  @current_version 186
   @default_prefix "public"
 
   # The frozen pre-squash bridge: the last 1.7.x release, which still carries

--- a/lib/phoenix_kit/migrations/postgres/v186.ex
+++ b/lib/phoenix_kit/migrations/postgres/v186.ex
@@ -1,0 +1,209 @@
+defmodule PhoenixKit.Migrations.Postgres.V186 do
+  @moduledoc """
+  V186: freezes the base currency and exchange rate on carts, cart items,
+  and orders.
+
+  ## What it adds
+
+    * `phoenix_kit_shop_carts.base_currency varchar(3)` and
+      `.exchange_rate numeric(15,6)` — the base currency and the
+      `base -> cart.currency` rate at the moment the cart was created,
+      frozen there so a later change to the currency table (or to the
+      shop's base currency) cannot silently reprice a cart the shopper
+      is still looking at.
+    * `phoenix_kit_shop_cart_items.base_unit_price numeric(15,2)` — the
+      line's unit price expressed in the base currency, kept purely for
+      *auditing new rows going forward*: without it a support agent
+      looking at a mispriced line cannot tell whether the rate, an
+      option modifier, or rounding is at fault.
+    * `phoenix_kit_orders.base_currency varchar(3)`,
+      `.exchange_rate numeric(15,6)`, `.base_total numeric(15,2)` — the
+      same freeze at the moment an order is placed, so a rate change
+      tomorrow can never retroactively change what an order is recorded
+      as having cost, and so a multi-domain deployment can total orders
+      placed in different currencies against one reporting currency.
+
+  All six columns are added nullable, with no default — `ALTER TABLE ...
+  ADD COLUMN` without a rewrite, safe at any table size. They stay
+  nullable permanently, not just during the migration: a currency that
+  is absent from `phoenix_kit_currencies` has no rate to report, and
+  "unknown" has to be representable rather than replaced with a
+  plausible-looking number.
+
+  ## The `is_default` guard
+
+  The backfill below derives every value from the *current* state of
+  `phoenix_kit_currencies` rather than from a literal (see "Why the
+  backfill is derived, not literal" below). That means the two
+  `(SELECT code FROM phoenix_kit_currencies WHERE is_default)`-shaped
+  subqueries silently pick an arbitrary row and produce a wrong-but-not
+  crashing backfill if more than one currency claims `is_default = true`
+  — the worst kind of bug, because it looks like it worked. A `DO`
+  block runs first and raises before a single column is touched if the
+  count is not exactly 1. Today the uniqueness of `is_default` is
+  enforced only inside a transaction in
+  `PhoenixKitBilling.set_default_currency/1`; the database has no
+  constraint of its own (a partial unique index lands separately, owned
+  by the billing package, since it owns that table's write path — see
+  the plan's §9.1). This migration cannot assume that index exists on
+  every host that reaches V186, so it re-checks the invariant itself
+  rather than trusting a constraint it does not own.
+
+  ## Why the backfill is derived, not literal
+
+  An earlier draft backfilled with `base_currency = 'USD'`,
+  `exchange_rate = 1.0` as constants. That is correct for a shop whose
+  base currency happens to be USD, but this migration ships to every
+  host running this package, including ones whose base is something
+  else, or whose carts were created in a currency other than their own
+  base. A literal would write a plausible-looking lie into a column
+  that exists specifically to record the truth about the past.
+
+  Instead every value is derived from the data in front of it: the base
+  currency is read from the (now-verified-unique) `is_default` row, and
+  the rate applied to a non-base row is the rate that row's currency
+  actually carries in `phoenix_kit_currencies` today — `NULL` if that
+  currency is not there at all. "This cart's rate is unknown" is a more
+  honest answer than any number we could invent, and the fail-safe
+  display path (spec §6.3) is required to survive exactly that `NULL`.
+
+  ## Why `base_unit_price`/`base_total` are `NULL` for non-base rows
+
+  For a cart or order already in the base currency, `base_unit_price`/
+  `base_total` are filled in — they equal the row's own `unit_price`/
+  `total`, no conversion needed. For a cart or order in a *different*
+  currency, they are left `NULL` even when a rate was found, rather than
+  computed as `unit_price / rate` or similar. Backfilling that
+  multiplication would silently create the one thing this migration is
+  built to avoid: a computed number nobody asked for and nobody can
+  trace back to a real conversion event. These columns are meant to
+  describe *new* rows created going forward under the real conversion
+  path (`Currency.present/3`, cart snapshot, order freeze); a backfilled
+  guess wearing the same column would be indistinguishable from the real
+  thing to every later reader. `base_currency`/`exchange_rate` do not
+  have this problem — they describe the row's own currency situation,
+  not a converted amount, so deriving them from the currency table is
+  reporting a fact, not fabricating one.
+
+  On our stand this entire distinction is moot: the base currency is
+  USD (an assumption, spec §3.1) and every existing cart, cart item, and
+  order is already in USD, so the backfill is the identity — every
+  `exchange_rate` becomes `1.000000` and every `base_*` equals its own
+  source column. No price changes and no order is repriced. That
+  identity is what makes USD-as-base a real argument rather than
+  "that's how it's always been" (spec §9.3).
+
+  ## Why the columns landed here and not with the tables' owning packages
+
+  `phoenix_kit_shop_carts`, `phoenix_kit_shop_cart_items`, and
+  `phoenix_kit_orders` are core tables consumed by the `ecommerce` and
+  `billing` packages' own `Ecto.Schema`s. Ecto selects every field a
+  schema declares, so a package that adds a field to its own schema
+  without the column existing on the host fails every `Repo.all/1` with
+  a `Postgrex.Error`. Core must create the column before either
+  dependent package's schema can declare the field, which is why this
+  migration exists in core and runs before the billing/ecommerce
+  currency work pins onto a host (plan §0.3).
+
+  ## `down/1`
+
+  Drops all six columns. This is irreversible **in meaning**, not just
+  mechanically: an order's frozen `exchange_rate` is the only record of
+  what it was actually priced at, and dropping the column throws that
+  fact away for good — a later `up/1` backfills a *fresh* guess from
+  whatever the currency table says at that later moment, which is not
+  the same information. `down/1` is provided because every migration in
+  this chain needs one, not because rolling back is free.
+  """
+
+  use Ecto.Migration
+
+  def up(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    Enum.each(up_statements(p), &execute/1)
+  end
+
+  def down(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    Enum.each(down_statements(p), &execute/1)
+  end
+
+  # Public (and idempotent) so the suite can run the REAL statements against
+  # seeded cart/order rows — `up/1` itself can't be invoked outside an
+  # `Ecto.Migrator` runner (same constraint as V182Test/V184Test and
+  # friends), and by the time any test runs, the chain has already added
+  # these columns to an install with no rows to backfill in the first
+  # place. `p` is the rendered prefix including the trailing dot.
+  @doc false
+  def up_statements(p) do
+    [
+      """
+      DO $$
+      DECLARE
+        n integer;
+      BEGIN
+        SELECT count(*) INTO n FROM #{p}phoenix_kit_currencies WHERE is_default;
+        IF n <> 1 THEN
+          RAISE EXCEPTION 'V186 needs exactly one default currency in #{p}phoenix_kit_currencies, found %', n;
+        END IF;
+      END $$
+      """,
+      "ALTER TABLE #{p}phoenix_kit_shop_carts ADD COLUMN IF NOT EXISTS base_currency character varying(3)",
+      "ALTER TABLE #{p}phoenix_kit_shop_carts ADD COLUMN IF NOT EXISTS exchange_rate numeric(15,6)",
+      "ALTER TABLE #{p}phoenix_kit_shop_cart_items ADD COLUMN IF NOT EXISTS base_unit_price numeric(15,2)",
+      "ALTER TABLE #{p}phoenix_kit_orders ADD COLUMN IF NOT EXISTS base_currency character varying(3)",
+      "ALTER TABLE #{p}phoenix_kit_orders ADD COLUMN IF NOT EXISTS exchange_rate numeric(15,6)",
+      "ALTER TABLE #{p}phoenix_kit_orders ADD COLUMN IF NOT EXISTS base_total numeric(15,2)",
+      """
+      UPDATE #{p}phoenix_kit_shop_carts c
+         SET base_currency = b.code,
+             exchange_rate = CASE
+               WHEN c.currency = b.code THEN 1.0
+               ELSE (SELECT x.exchange_rate FROM #{p}phoenix_kit_currencies x WHERE x.code = c.currency)
+             END
+        FROM (SELECT code FROM #{p}phoenix_kit_currencies WHERE is_default) b
+       WHERE c.base_currency IS NULL
+      """,
+      """
+      UPDATE #{p}phoenix_kit_shop_cart_items ci
+         SET base_unit_price = ci.unit_price
+        FROM #{p}phoenix_kit_shop_carts c
+       WHERE c.uuid = ci.cart_uuid
+         AND ci.base_unit_price IS NULL
+         AND c.currency = c.base_currency
+      """,
+      """
+      UPDATE #{p}phoenix_kit_orders o
+         SET base_currency = b.code,
+             exchange_rate = CASE
+               WHEN o.currency = b.code THEN 1.0
+               ELSE (SELECT x.exchange_rate FROM #{p}phoenix_kit_currencies x WHERE x.code = o.currency)
+             END,
+             base_total = CASE WHEN o.currency = b.code THEN o.total ELSE NULL END
+        FROM (SELECT code FROM #{p}phoenix_kit_currencies WHERE is_default) b
+       WHERE o.base_currency IS NULL
+      """,
+      "COMMENT ON TABLE #{p}phoenix_kit IS '186'"
+    ]
+  end
+
+  @doc false
+  def down_statements(p) do
+    [
+      "ALTER TABLE #{p}phoenix_kit_shop_carts DROP COLUMN IF EXISTS base_currency",
+      "ALTER TABLE #{p}phoenix_kit_shop_carts DROP COLUMN IF EXISTS exchange_rate",
+      "ALTER TABLE #{p}phoenix_kit_shop_cart_items DROP COLUMN IF EXISTS base_unit_price",
+      "ALTER TABLE #{p}phoenix_kit_orders DROP COLUMN IF EXISTS base_currency",
+      "ALTER TABLE #{p}phoenix_kit_orders DROP COLUMN IF EXISTS exchange_rate",
+      "ALTER TABLE #{p}phoenix_kit_orders DROP COLUMN IF EXISTS base_total",
+      "COMMENT ON TABLE #{p}phoenix_kit IS '185'"
+    ]
+  end
+
+  defp prefix_str("public"), do: "public."
+  defp prefix_str(prefix), do: "#{prefix}."
+end

--- a/test/phoenix_kit/migrations/v186_test.exs
+++ b/test/phoenix_kit/migrations/v186_test.exs
@@ -1,0 +1,93 @@
+defmodule PhoenixKit.Migrations.Postgres.V186Test do
+  @moduledoc """
+  V186's freeze columns and backfill, run against real cart/cart-item rows.
+
+  `V186.up/1` can't be invoked outside an `Ecto.Migrator` runner (same
+  constraint as V182Test/V184Test and friends), and by the time any test
+  runs, the chain has already added these columns to an install with no
+  rows to backfill in the first place. So the migration exposes its
+  statements via `up_statements/1`/`down_statements/1` (`up/1`/`down/1`
+  execute exactly those lists), and this suite runs the REAL SQL against
+  currency and cart rows seeded to reproduce the three cases the backfill
+  has to tell apart: a cart in the base currency, a cart in a currency the
+  currency table still knows a rate for, and a cart in a currency the
+  currency table has never heard of.
+  """
+
+  use PhoenixKit.DataCase, async: false
+
+  alias PhoenixKit.Migrations.Postgres.V186
+  alias PhoenixKit.Test.Repo
+
+  @table "phoenix_kit"
+
+  defp run_up, do: Enum.each(V186.up_statements("public."), &Repo.query!/1)
+
+  defp table_marker do
+    %{rows: [[marker]]} = Repo.query!("SELECT obj_description('#{@table}'::regclass)")
+    marker
+  end
+
+  test "V186 backfills from the default-currency row, never from literals" do
+    Repo.query!("DELETE FROM phoenix_kit_currencies")
+
+    Repo.query!("""
+    INSERT INTO phoenix_kit_currencies (uuid, code, name, symbol, is_default, enabled, exchange_rate, inserted_at, updated_at) VALUES
+      (gen_random_uuid(),'USD','d','$',true,true,1.0,now(),now()),
+      (gen_random_uuid(),'EUR','e','€',false,true,0.909091,now(),now())
+    """)
+
+    Repo.query!("""
+    INSERT INTO phoenix_kit_shop_carts (uuid, session_id, status, currency, total, inserted_at, updated_at) VALUES
+      ('018f0000-0000-7000-8000-000000000001','s1','active','USD',10.00,now(),now()),
+      ('018f0000-0000-7000-8000-000000000002','s2','active','EUR',9.09,now(),now()),
+      ('018f0000-0000-7000-8000-000000000003','s3','active','XXX',1.00,now(),now())
+    """)
+
+    Repo.query!("""
+    INSERT INTO phoenix_kit_shop_cart_items (uuid, cart_uuid, product_title, unit_price, currency, quantity, line_total, inserted_at, updated_at) VALUES
+      (gen_random_uuid(),'018f0000-0000-7000-8000-000000000001','t',10.00,'USD',1,10.00,now(),now()),
+      (gen_random_uuid(),'018f0000-0000-7000-8000-000000000002','t',9.09,'EUR',1,9.09,now(),now())
+    """)
+
+    run_up()
+
+    assert %{rows: [["USD", "1.000000"], ["USD", "0.909091"], ["USD", nil]]} =
+             Repo.query!("""
+             SELECT base_currency, exchange_rate::text FROM phoenix_kit_shop_carts
+             ORDER BY session_id
+             """)
+
+    assert %{rows: [["10.00"], [nil]]} =
+             Repo.query!("""
+             SELECT ci.base_unit_price::text FROM phoenix_kit_shop_cart_items ci
+             JOIN phoenix_kit_shop_carts c ON c.uuid = ci.cart_uuid
+             ORDER BY c.session_id
+             """)
+
+    assert table_marker() == "186"
+  end
+
+  test "V186 refuses to run while two currencies claim is_default" do
+    # The scratch database this suite runs against also carries billing's
+    # own `phoenix_kit_currencies_default_uidx` (a partial unique index on
+    # `is_default`, owned by phoenix_kit_billing, not core — plan §9.1). V186
+    # cannot assume every host it reaches has that index, so it re-checks the
+    # invariant itself (see the DO block in `up_statements/1`); this test
+    # proves that guard fires on its own, without relying on the index. The
+    # DROP happens inside this test's sandboxed transaction and is rolled
+    # back with everything else at the end of the test.
+    Repo.query!("DROP INDEX IF EXISTS phoenix_kit_currencies_default_uidx")
+    Repo.query!("DELETE FROM phoenix_kit_currencies")
+
+    Repo.query!("""
+    INSERT INTO phoenix_kit_currencies (uuid, code, name, symbol, is_default, inserted_at, updated_at) VALUES
+      (gen_random_uuid(),'USD','d','$',true,now(),now()),
+      (gen_random_uuid(),'EUR','e','€',true,now(),now())
+    """)
+
+    assert_raise Postgrex.Error, ~r/exactly one default currency/, fn ->
+      run_up()
+    end
+  end
+end


### PR DESCRIPTION
## V185: currency-freeze columns on carts, cart items and orders

Stacked on #785 (V184). Companions: BeamLabEU/phoenix_kit_billing#32 and the ecommerce stage-Э1 PR, which read these columns through their schemas (`Order`, `Cart`, `CartItem`).

### What V185 does

- `phoenix_kit_shop_carts`: `base_currency varchar(3)`, `exchange_rate numeric(15,6)`; `phoenix_kit_shop_cart_items`: `base_unit_price numeric(15,2)`; `phoenix_kit_orders`: `base_currency varchar(3)`, `exchange_rate numeric(15,6)`, `base_total numeric(15,2)`. All nullable, no default — `ADD COLUMN IF NOT EXISTS`, no table rewrite.
- A `DO` block raises unless `phoenix_kit_currencies` has exactly one `is_default` row (the billing chain's V2 partial unique index guarantees it; the guard makes the failure visible before any backfill).
- Backfill without literals: `base_currency` from the `is_default` row; `exchange_rate` = 1.0 when the record's currency is the base, else that currency's table rate (NULL when unknown — honest "unknown rate"); `base_unit_price`/`base_total` only for records already in the base currency, NULL otherwise (a conversion nobody performed is not fabricated).
- `down/1` drops the six columns and stamps 184 — irreversible in meaning (orders forget the rate they were priced at), said in the comment.
- `expected_schema.ex`: the six columns are declared by hand (V171 "DECLARED POST-GENERATION" precedent; positions/types from the live `ordinal_position`), then `chain_hash` restamped — the full generator aborts on this environment (see #785 for the `sync_shop_*_slugs` mode-shape mismatch).

### Tests

`test/phoenix_kit/migrations/v185_test.exs` (backfill from the default row; refusal with two defaults). Migrations dir + release_check tests: 16 doctests, 450 tests, 0 failures; `expected_schema/` tests 67/0; `mix phoenix_kit.release_check` Migration Version Sync passes (V135..V185 contiguous, chain hash over 51 files). Applied on a live host: 94/94 carts backfilled `USD`/1.000000, 11/11 items `base_unit_price = unit_price`, the one order `base_total = total`, marker 185. Version bump and CHANGELOG left to the maintainer.
