### PR TITLE
Core: recognize catalogue-owned tables in storage/doctor, document module table ownership

### DIFF
--- a/dev_docs/guides/2026-09-05-module-table-extraction-guide.md
+++ b/dev_docs/guides/2026-09-05-module-table-extraction-guide.md
@@ -39,3 +39,64 @@ example `phoenix_kit_shop_products` once the shop reads products from
 `phoenix_kit_catalogue`) are marked with a `COMMENT ON TABLE … 'deprecated
 <date>: …'` by the host app, never dropped by anyone in this cycle; the
 squash of Phase 2 decides their fate.
+
+## Inventory: which core-baseline tables are already module-owned
+
+Each module below is at Phase 0 (adopted, `down/1` only unstamps) or
+already past it. Core's baseline still creates every table listed — this
+inventory is what a future baseline squash removes from core once all
+hosts have adopted the owning module's V1, not something this PR drops or
+migrates. Only the module's designated version table carries the
+`COMMENT ON TABLE … '<ns>_schema:<N>'` marker; the rest of a module's
+tables are recognized by ownership (this list), not by a per-table
+comment.
+
+**`phoenix_kit_ecommerce`** — marker `pke_schema:<N>` on
+`phoenix_kit_shop_config` (`PhoenixKitEcommerce.Migrations.version_table/0`).
+Ten tables, all `phoenix_kit_shop_*`:
+
+* `phoenix_kit_shop_config`
+* `phoenix_kit_shop_shipping_methods`
+* `phoenix_kit_shop_categories`
+* `phoenix_kit_shop_products`
+* `phoenix_kit_shop_product_slugs`
+* `phoenix_kit_shop_category_slugs`
+* `phoenix_kit_shop_carts`
+* `phoenix_kit_shop_cart_items`
+* `phoenix_kit_shop_import_configs`
+* `phoenix_kit_shop_import_logs`
+
+**`phoenix_kit_catalogue`** — marker `pkc_schema:<N>` on
+`phoenix_kit_cat_catalogues` (`PhoenixKitCatalogue.Migrations.version_table/0`).
+Eighteen tables, all `phoenix_kit_cat_*`:
+
+* `phoenix_kit_cat_catalogues`
+* `phoenix_kit_cat_folders`
+* `phoenix_kit_cat_categories`
+* `phoenix_kit_cat_manufacturers`
+* `phoenix_kit_cat_suppliers`
+* `phoenix_kit_cat_manufacturer_suppliers`
+* `phoenix_kit_cat_items`
+* `phoenix_kit_cat_item_catalogue_rules`
+* `phoenix_kit_cat_item_supplier_info`
+* `phoenix_kit_cat_pdfs`
+* `phoenix_kit_cat_pdf_pages`
+* `phoenix_kit_cat_pdf_page_contents`
+* `phoenix_kit_cat_pdf_extractions`
+* `phoenix_kit_cat_attribute_groups`
+* `phoenix_kit_cat_attributes`
+* `phoenix_kit_cat_attribute_values`
+* `phoenix_kit_cat_item_attribute_groups`
+* `phoenix_kit_cat_item_attribute_sets`
+
+**`phoenix_kit_entities`** — marker `pkn_schema:<N>` on
+`phoenix_kit_entities` itself (`PhoenixKitEntities.Migrations.version_table/0`).
+Two tables:
+
+* `phoenix_kit_entities`
+* `phoenix_kit_entity_data`
+
+Storage's orphaned-file check and doctor's NULL-uuid check are the two
+places that have historically hardcoded a table list next to this kind of
+inventory; see their own comments for why each one currently does or does
+not need the catalogue tables added — the answer is not the same for both.

--- a/lib/mix/tasks/phoenix_kit.doctor.ex
+++ b/lib/mix/tasks/phoenix_kit.doctor.ex
@@ -944,7 +944,13 @@ defmodule Mix.Tasks.PhoenixKit.Doctor do
     repo = get_repo!()
     escaped_prefix = String.replace(prefix, "'", "\\'")
 
-    # Key FK source tables whose uuid column must not be NULL
+    # Key FK source tables whose uuid column must not be NULL.
+    #
+    # `phoenix_kit_cat_items`/`phoenix_kit_cat_categories` (catalogue module)
+    # are deliberately absent: their uuid column has carried `DEFAULT
+    # uuid_generate_v7() NOT NULL` since their V135 baseline creation, so
+    # they never went through the V56 backfill this check exists to catch
+    # and cannot hold a NULL uuid.
     source_tables = [
       "phoenix_kit_users",
       "phoenix_kit_user_roles",

--- a/lib/modules/storage/storage.ex
+++ b/lib/modules/storage/storage.ex
@@ -2158,6 +2158,29 @@ defmodule PhoenixKit.Modules.Storage do
            f.uuid
          )
        )},
+      # The catalogue module (phoenix_kit_catalogue) stores its image
+      # references inside the JSONB `data` column rather than dedicated
+      # columns — a plain join would miss them entirely, and a live
+      # catalogue item/category image would look orphaned and get queued
+      # for deletion by DeleteOrphanedFileJob.
+      {"phoenix_kit_cat_items",
+       dynamic(
+         [f],
+         fragment(
+           "NOT EXISTS (SELECT 1 FROM phoenix_kit_cat_items ci WHERE ci.data->>'featured_image_uuid' = ?::text) AND NOT EXISTS (SELECT 1 FROM phoenix_kit_cat_items ci WHERE ci.data->'media_order' @> to_jsonb(ARRAY[?::text])) AND NOT EXISTS (SELECT 1 FROM phoenix_kit_cat_items ci WHERE ci.data->'ecommerce'->>'file_uuid' = ?::text)",
+           f.uuid,
+           f.uuid,
+           f.uuid
+         )
+       )},
+      {"phoenix_kit_cat_categories",
+       dynamic(
+         [f],
+         fragment(
+           "NOT EXISTS (SELECT 1 FROM phoenix_kit_cat_categories cc WHERE cc.data->'ecommerce'->>'image_uuid' = ?::text)",
+           f.uuid
+         )
+       )},
       {"phoenix_kit_publishing_contents",
        dynamic(
          [f],

--- a/lib/modules/storage/storage.ex
+++ b/lib/modules/storage/storage.ex
@@ -2160,9 +2160,9 @@ defmodule PhoenixKit.Modules.Storage do
        )},
       # The catalogue module (phoenix_kit_catalogue) stores its image
       # references inside the JSONB `data` column rather than dedicated
-      # columns — a plain join would miss them entirely, and a live
-      # catalogue item/category image would look orphaned and get queued
-      # for deletion by DeleteOrphanedFileJob.
+      # columns — a plain join would miss them entirely, and a
+      # live catalogue item, category, or catalogue-record image would
+      # look orphaned and get queued for deletion by DeleteOrphanedFileJob.
       {"phoenix_kit_cat_items",
        dynamic(
          [f],
@@ -2177,7 +2177,18 @@ defmodule PhoenixKit.Modules.Storage do
        dynamic(
          [f],
          fragment(
-           "NOT EXISTS (SELECT 1 FROM phoenix_kit_cat_categories cc WHERE cc.data->'ecommerce'->>'image_uuid' = ?::text)",
+           "NOT EXISTS (SELECT 1 FROM phoenix_kit_cat_categories cc WHERE cc.data->>'featured_image_uuid' = ?::text) AND NOT EXISTS (SELECT 1 FROM phoenix_kit_cat_categories cc WHERE cc.data->'media_order' @> to_jsonb(ARRAY[?::text])) AND NOT EXISTS (SELECT 1 FROM phoenix_kit_cat_categories cc WHERE cc.data->'ecommerce'->>'image_uuid' = ?::text)",
+           f.uuid,
+           f.uuid,
+           f.uuid
+         )
+       )},
+      {"phoenix_kit_cat_catalogues",
+       dynamic(
+         [f],
+         fragment(
+           "NOT EXISTS (SELECT 1 FROM phoenix_kit_cat_catalogues ct WHERE ct.data->>'featured_image_uuid' = ?::text) AND NOT EXISTS (SELECT 1 FROM phoenix_kit_cat_catalogues ct WHERE ct.data->'media_order' @> to_jsonb(ARRAY[?::text]))",
+           f.uuid,
            f.uuid
          )
        )},

--- a/test/integration/storage_catalogue_orphan_test.exs
+++ b/test/integration/storage_catalogue_orphan_test.exs
@@ -3,11 +3,12 @@ defmodule PhoenixKit.Integration.StorageCatalogueOrphanTest do
   The orphan-file check must see catalogue references.
 
   The catalogue module (`phoenix_kit_catalogue`) stores its image references
-  inside the JSONB `data` column of `phoenix_kit_cat_items` /
-  `phoenix_kit_cat_categories` rather than dedicated FK columns, so a plain
-  join misses them — without the JSONB-aware checks added alongside this
-  test, a live catalogue item/category image would be classified as an
-  orphan and queued for deletion by `DeleteOrphanedFileJob`.
+  inside the JSONB `data` column of `phoenix_kit_cat_items`,
+  `phoenix_kit_cat_categories`, and `phoenix_kit_cat_catalogues` rather than
+  dedicated FK columns, so a plain join misses them — without the
+  JSONB-aware checks added alongside this test, a live catalogue item,
+  category, or catalogue-record image would be classified as an orphan and
+  queued for deletion by `DeleteOrphanedFileJob`.
   """
   use PhoenixKit.DataCase, async: false
 
@@ -35,13 +36,16 @@ defmodule PhoenixKit.Integration.StorageCatalogueOrphanTest do
     file
   end
 
-  defp insert_catalogue! do
+  defp insert_catalogue!(data \\ %{}) do
     %{rows: [[uuid]]} =
-      Repo.query!("""
-      INSERT INTO phoenix_kit_cat_catalogues (uuid, name, inserted_at, updated_at)
-      VALUES (gen_random_uuid(), 'Test catalogue', now(), now())
-      RETURNING uuid
-      """)
+      Repo.query!(
+        """
+        INSERT INTO phoenix_kit_cat_catalogues (uuid, name, data, inserted_at, updated_at)
+        VALUES (gen_random_uuid(), 'Test catalogue', $1, now(), now())
+        RETURNING uuid
+        """,
+        [data]
+      )
 
     uuid
   end
@@ -110,6 +114,22 @@ defmodule PhoenixKit.Integration.StorageCatalogueOrphanTest do
   end
 
   describe "phoenix_kit_cat_categories" do
+    test "featured_image_uuid keeps a file from being orphaned", %{user: user} do
+      file = make_file(user.uuid)
+      catalogue_uuid = insert_catalogue!()
+      insert_category!(catalogue_uuid, %{"featured_image_uuid" => file.uuid})
+
+      refute Storage.file_orphaned?(file.uuid)
+    end
+
+    test "media_order keeps a file from being orphaned", %{user: user} do
+      file = make_file(user.uuid)
+      catalogue_uuid = insert_catalogue!()
+      insert_category!(catalogue_uuid, %{"media_order" => [file.uuid, Ecto.UUID.generate()]})
+
+      refute Storage.file_orphaned?(file.uuid)
+    end
+
     test "ecommerce.image_uuid keeps a file from being orphaned", %{user: user} do
       file = make_file(user.uuid)
       catalogue_uuid = insert_catalogue!()
@@ -122,6 +142,29 @@ defmodule PhoenixKit.Integration.StorageCatalogueOrphanTest do
       file = make_file(user.uuid)
       catalogue_uuid = insert_catalogue!()
       insert_category!(catalogue_uuid, %{"ecommerce" => %{"image_uuid" => Ecto.UUID.generate()}})
+
+      assert Storage.file_orphaned?(file.uuid)
+    end
+  end
+
+  describe "phoenix_kit_cat_catalogues" do
+    test "featured_image_uuid keeps a file from being orphaned", %{user: user} do
+      file = make_file(user.uuid)
+      insert_catalogue!(%{"featured_image_uuid" => file.uuid})
+
+      refute Storage.file_orphaned?(file.uuid)
+    end
+
+    test "media_order keeps a file from being orphaned", %{user: user} do
+      file = make_file(user.uuid)
+      insert_catalogue!(%{"media_order" => [file.uuid, Ecto.UUID.generate()]})
+
+      refute Storage.file_orphaned?(file.uuid)
+    end
+
+    test "a catalogue referencing a different file does not protect this one", %{user: user} do
+      file = make_file(user.uuid)
+      insert_catalogue!(%{"featured_image_uuid" => Ecto.UUID.generate()})
 
       assert Storage.file_orphaned?(file.uuid)
     end

--- a/test/integration/storage_catalogue_orphan_test.exs
+++ b/test/integration/storage_catalogue_orphan_test.exs
@@ -1,0 +1,129 @@
+defmodule PhoenixKit.Integration.StorageCatalogueOrphanTest do
+  @moduledoc """
+  The orphan-file check must see catalogue references.
+
+  The catalogue module (`phoenix_kit_catalogue`) stores its image references
+  inside the JSONB `data` column of `phoenix_kit_cat_items` /
+  `phoenix_kit_cat_categories` rather than dedicated FK columns, so a plain
+  join misses them — without the JSONB-aware checks added alongside this
+  test, a live catalogue item/category image would be classified as an
+  orphan and queued for deletion by `DeleteOrphanedFileJob`.
+  """
+  use PhoenixKit.DataCase, async: false
+
+  import PhoenixKit.Test.Fixtures
+
+  alias PhoenixKit.Modules.Storage
+
+  defp make_file(owner_uuid) do
+    checksum = "cs_#{System.unique_integer([:positive])}"
+
+    {:ok, file} =
+      Storage.create_file(%{
+        original_file_name: "photo.jpg",
+        file_name: "photo.jpg",
+        mime_type: "image/jpeg",
+        file_type: "image",
+        ext: "jpg",
+        file_checksum: checksum,
+        user_file_checksum: "u_#{checksum}",
+        size: 1234,
+        status: "active",
+        user_uuid: owner_uuid
+      })
+
+    file
+  end
+
+  defp insert_catalogue! do
+    %{rows: [[uuid]]} =
+      Repo.query!("""
+      INSERT INTO phoenix_kit_cat_catalogues (uuid, name, inserted_at, updated_at)
+      VALUES (gen_random_uuid(), 'Test catalogue', now(), now())
+      RETURNING uuid
+      """)
+
+    uuid
+  end
+
+  defp insert_category!(catalogue_uuid, data) do
+    %{rows: [[uuid]]} =
+      Repo.query!(
+        """
+        INSERT INTO phoenix_kit_cat_categories (uuid, name, catalogue_uuid, data, inserted_at, updated_at)
+        VALUES (gen_random_uuid(), 'Test category', $1, $2, now(), now())
+        RETURNING uuid
+        """,
+        [catalogue_uuid, data]
+      )
+
+    uuid
+  end
+
+  defp insert_item!(data) do
+    %{rows: [[uuid]]} =
+      Repo.query!(
+        """
+        INSERT INTO phoenix_kit_cat_items (uuid, name, data, inserted_at, updated_at)
+        VALUES (gen_random_uuid(), 'Test item', $1, now(), now())
+        RETURNING uuid
+        """,
+        [data]
+      )
+
+    uuid
+  end
+
+  setup do
+    user = confirmed_user_fixture()
+    %{user: user}
+  end
+
+  describe "phoenix_kit_cat_items" do
+    test "featured_image_uuid keeps a file from being orphaned", %{user: user} do
+      file = make_file(user.uuid)
+      insert_item!(%{"featured_image_uuid" => file.uuid})
+
+      refute Storage.file_orphaned?(file.uuid)
+    end
+
+    test "media_order keeps a file from being orphaned", %{user: user} do
+      file = make_file(user.uuid)
+      insert_item!(%{"media_order" => [file.uuid, Ecto.UUID.generate()]})
+
+      refute Storage.file_orphaned?(file.uuid)
+    end
+
+    test "ecommerce.file_uuid keeps a file from being orphaned", %{user: user} do
+      file = make_file(user.uuid)
+      insert_item!(%{"ecommerce" => %{"file_uuid" => file.uuid}})
+
+      refute Storage.file_orphaned?(file.uuid)
+    end
+
+    test "an item referencing a different file does not protect this one", %{user: user} do
+      file = make_file(user.uuid)
+      insert_item!(%{"featured_image_uuid" => Ecto.UUID.generate()})
+
+      assert Storage.file_orphaned?(file.uuid)
+    end
+  end
+
+  describe "phoenix_kit_cat_categories" do
+    test "ecommerce.image_uuid keeps a file from being orphaned", %{user: user} do
+      file = make_file(user.uuid)
+      catalogue_uuid = insert_catalogue!()
+      insert_category!(catalogue_uuid, %{"ecommerce" => %{"image_uuid" => file.uuid}})
+
+      refute Storage.file_orphaned?(file.uuid)
+    end
+
+    test "a category referencing a different file does not protect this one", %{user: user} do
+      file = make_file(user.uuid)
+      catalogue_uuid = insert_catalogue!()
+      insert_category!(catalogue_uuid, %{"ecommerce" => %{"image_uuid" => Ecto.UUID.generate()}})
+
+      assert Storage.file_orphaned?(file.uuid)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Storage's orphaned-file check now recognizes the catalogue module's JSONB-embedded image references on all three catalogue tables that go through `PhoenixKitCatalogue.Attachments`: `phoenix_kit_cat_items.data->>'featured_image_uuid'` / `data->'media_order'` / `data->'ecommerce'->>'file_uuid'`, `phoenix_kit_cat_categories.data->>'featured_image_uuid'` / `data->'media_order'` / `data->'ecommerce'->>'image_uuid'`, and `phoenix_kit_cat_catalogues.data->>'featured_image_uuid'` / `data->'media_order'` — gated on the tables actually existing. Without this, a live catalogue item, category, or catalogue-record image would be classified as an orphan and queued for deletion.
- Documented (comment only, no behavior change) why doctor's V56 NULL-uuid check deliberately does not include the catalogue tables: their uuid column has carried `DEFAULT uuid_generate_v7() NOT NULL` since creation, so they never went through the backfill that check exists to catch.
- Added an inventory section to `dev_docs/guides/2026-09-05-module-table-extraction-guide.md` listing which core-baseline tables are already owned by `phoenix_kit_ecommerce` (10 tables), `phoenix_kit_catalogue` (18 tables), and `phoenix_kit_entities` (2 tables) — informational only, ahead of a future baseline squash. No drop, no migration change.
- Checked `lib/modules/sitemap/generator.ex`'s source registry — it already picks up module-registered sources generically, no change needed there.

## Test plan

- [x] `test/integration/storage_catalogue_orphan_test.exs` (11 tests) — each JSONB reference shape (featured image, media order, and the ecommerce-extension namespace on items/categories) protects a real file from `Storage.file_orphaned?/1`; negative cases confirm an unrelated file still reads as orphaned.
- [x] `mix format` — clean
- [x] `mix compile --warnings-as-errors` — clean
- [x] `mix credo --strict` on changed files — no issues
- [x] `mix test` — 42 doctests, 4754 tests, 0 failures (fresh scratch DB; the previously reported "3 pre-existing failures" in `phoenix_kit_doctor_orphaned_fk_destructive_test.exs` did not reproduce — that file alone also runs clean, 4 tests, 0 failures)
