### PR TITLE
Add non-destructive avatar cropping

### DIFF
--- a/lib/phoenix_kit/users/auth.ex
+++ b/lib/phoenix_kit/users/auth.ex
@@ -2103,7 +2103,30 @@ defmodule PhoenixKit.Users.Auth do
     existing_custom_fields = user.custom_fields || %{}
     merged_custom_fields = Map.merge(existing_custom_fields, attrs)
 
-    update_user_custom_fields(user, merged_custom_fields)
+    update_user_custom_fields(
+      user,
+      drop_stale_avatar_crop(merged_custom_fields, existing_custom_fields, attrs)
+    )
+  end
+
+  # A stored crop describes the file it was made against — its aspect ratio
+  # is baked into the map — so a crop must never outlive its file: applied
+  # to a different image it renders stretched and mis-framed everywhere.
+  # Enforced HERE, at the one merge every custom-fields write goes through,
+  # because every other enforcement point proved forgettable: the settings
+  # page cleared the crop on a new pick, while the admin form and
+  # update_user_avatar/4 did not. A caller that sets the crop alongside the
+  # file (the settings crop editor) is explicit and wins.
+  defp drop_stale_avatar_crop(merged, existing, attrs) do
+    changed_file? =
+      Map.has_key?(attrs, "avatar_file_uuid") and
+        Map.get(attrs, "avatar_file_uuid") != Map.get(existing, "avatar_file_uuid")
+
+    if changed_file? and not Map.has_key?(attrs, "avatar_crop") do
+      Map.put(merged, "avatar_crop", nil)
+    else
+      merged
+    end
   end
 
   @doc """

--- a/lib/phoenix_kit/users/avatar_crop.ex
+++ b/lib/phoenix_kit/users/avatar_crop.ex
@@ -1,0 +1,166 @@
+defmodule PhoenixKit.Users.AvatarCrop do
+  @moduledoc """
+  Non-destructive avatar cropping, Apple Photos style.
+
+  A crop is data, never pixels: `custom_fields["avatar_crop"]` holds a focal
+  point, a zoom, and the image's aspect ratio, while the original file — and
+  every generated variant of it — stays exactly as uploaded. Adjusting the
+  crop rewrites four numbers; resetting it drops the key; nothing is ever
+  re-encoded, so there is no quality loss and no way to crop yourself into a
+  corner.
+
+  Rendering applies the stored geometry as an inline style on the `<img>`
+  inside the avatar's (square, overflow-hidden) frame. Because the storage
+  module's image variants are aspect-preserving scales of the original, the
+  same normalized numbers are valid against any of them — a page full of
+  avatars keeps loading the small variants it always loaded, and the crop
+  costs a few floats that were already in the user record. No extra request,
+  no imaging job, no per-crop file.
+
+  ## The stored map
+
+      %{"x" => 0.5, "y" => 0.35, "zoom" => 2.0, "ar" => 1.5}
+
+  - `x`, `y` — the focal point (what the person centered), as fractions of
+    the image's width and height. `0.5/0.5` is the image center.
+  - `zoom` — magnification relative to the cover fit. `1.0` shows exactly
+    what `object-fit: cover` would show; the ceiling is #{inspect(8.0)}.
+  - `ar` — the image's width/height ratio, captured when the crop was made
+    so rendering never needs to look dimensions up (avatars appear dozens to
+    a page; a per-avatar dimension query would be the N+1 this design
+    exists to avoid).
+
+  ## Geometry
+
+  Inside a square frame taken as 100%: the cover fit makes the image's short
+  side match the frame, so a landscape image is `100·zoom` tall and
+  `100·zoom·ar` wide (portrait mirrored). The image is then offset so the
+  focal point sits at the frame's center, clamped so the frame never shows
+  past an edge — the same clamp the editor applies, so what was saved is
+  what renders.
+  """
+
+  @min_zoom 1.0
+  @max_zoom 8.0
+  @min_ar 0.05
+  @max_ar 20.0
+
+  # The storage module's seeded image dimensions, widest edge each, in
+  # ascending order. A missing variant is served as the original while it
+  # generates, so an entry here never 404s.
+  @variant_ladder [{"small", 300}, {"medium", 800}, {"large", 1920}]
+
+  @doc """
+  The user's stored crop, or nil when there is none (or it is invalid).
+  """
+  def from_user(%{custom_fields: %{"avatar_crop" => crop}}), do: normalize(crop)
+  def from_user(_user), do: nil
+
+  @doc """
+  Clamp raw crop params into a storable map, or nil if they do not describe
+  a crop at all.
+
+  Accepts string or atom keys and numbers or numeric strings — the values
+  arrive from a JS hook. Out-of-range values are clamped rather than
+  refused: a drag that overshoots an edge is intent to reach the edge.
+  """
+  def normalize(%{} = params) do
+    with {:ok, x} <- number(params, [:x, "x"]),
+         {:ok, y} <- number(params, [:y, "y"]),
+         {:ok, zoom} <- number(params, [:zoom, "zoom"]),
+         {:ok, ar} <- number(params, [:ar, "ar"]) do
+      %{
+        "x" => clamp(x, 0.0, 1.0),
+        "y" => clamp(y, 0.0, 1.0),
+        "zoom" => clamp(zoom, @min_zoom, @max_zoom),
+        "ar" => clamp(ar, @min_ar, @max_ar)
+      }
+    else
+      _ -> nil
+    end
+  end
+
+  def normalize(_), do: nil
+
+  @doc """
+  The image's placement inside its square frame, as percentages of the
+  frame: `%{width:, height:, left:, top:}`.
+
+  Mirrored by `avatarCropLayout` in `priv/static/assets/phoenix_kit.js` —
+  the editor previews with the same math that later renders, so the saved
+  crop cannot drift from the preview. Change one, change both.
+  """
+  def layout(%{"zoom" => zoom, "ar" => ar, "x" => x, "y" => y}) do
+    {width, height} =
+      if ar >= 1.0 do
+        {100.0 * zoom * ar, 100.0 * zoom}
+      else
+        {100.0 * zoom, 100.0 * zoom / ar}
+      end
+
+    %{
+      width: width,
+      height: height,
+      left: clamp(50.0 - x * width, 100.0 - width, 0.0),
+      top: clamp(50.0 - y * height, 100.0 - height, 0.0)
+    }
+  end
+
+  @doc """
+  The inline style that seats a cropped image in its frame.
+
+  The frame supplies `position: relative; overflow: hidden` (the avatar
+  component already has both); `max-width: none` undoes Tailwind's global
+  `img { max-width: 100% }`, without which every percentage below is
+  re-clamped and the crop silently collapses to a stretch.
+  """
+  def img_style(crop) do
+    l = layout(crop)
+
+    "position:absolute;max-width:none;" <>
+      "width:#{fmt(l.width)}%;height:#{fmt(l.height)}%;" <>
+      "left:#{fmt(l.left)}%;top:#{fmt(l.top)}%;"
+  end
+
+  @doc """
+  The cheapest stored variant that still renders sharply: a zoomed crop
+  shows `1/zoom` of the source, so a box of `box_px` CSS pixels needs
+  `box_px · 2 (retina) · zoom` source pixels along the frame edge.
+
+  Without a crop, zoom is 1.0 and this degrades to plain size-based
+  selection. Falls through to `"original"` when even the large variant
+  would be soft.
+  """
+  def variant_for(box_px, zoom \\ 1.0) do
+    needed = box_px * 2 * max(zoom, 1.0)
+
+    Enum.find_value(@variant_ladder, "original", fn {name, edge} ->
+      if edge >= needed, do: name
+    end)
+  end
+
+  @doc "The zoom ceiling, shared with the editor UI."
+  def max_zoom, do: @max_zoom
+
+  defp number(params, keys) do
+    case Enum.find_value(keys, fn k -> Map.get(params, k) end) do
+      value when is_number(value) ->
+        {:ok, value / 1}
+
+      value when is_binary(value) ->
+        case Float.parse(value) do
+          {parsed, ""} -> {:ok, parsed}
+          _ -> :error
+        end
+
+      _ ->
+        :error
+    end
+  end
+
+  defp clamp(value, low, high), do: value |> max(low) |> min(high)
+
+  # Two decimals is sub-pixel at any avatar size and keeps the style strings
+  # (one per avatar on a busy page) short.
+  defp fmt(value), do: :erlang.float_to_binary(value / 1, decimals: 2)
+end

--- a/lib/phoenix_kit/users/avatar_crop.ex
+++ b/lib/phoenix_kit/users/avatar_crop.ex
@@ -45,9 +45,14 @@ defmodule PhoenixKit.Users.AvatarCrop do
   @min_ar 0.05
   @max_ar 20.0
 
-  # The storage module's seeded image dimensions, widest edge each, in
+  # The storage module's seeded image dimensions — the WIDTH each variant
+  # is scaled to (`ImageProcessor.resize(input, output, width, nil)`), in
   # ascending order. A missing variant is served as the original while it
-  # generates, so an entry here never 404s.
+  # generates, so an entry here never 404s. These mirror the seeds in
+  # `Storage.reset_dimensions_to_defaults/0`; an operator who edits the
+  # dimension rows changes what the names deliver, and this ladder then
+  # over- or under-promises — deriving it from the dimension config is the
+  # upgrade path if that ever bites.
   @variant_ladder [{"small", 300}, {"medium", 800}, {"large", 1920}]
 
   @doc """
@@ -127,16 +132,41 @@ defmodule PhoenixKit.Users.AvatarCrop do
   shows `1/zoom` of the source, so a box of `box_px` CSS pixels needs
   `box_px · 2 (retina) · zoom` source pixels along the frame edge.
 
-  Without a crop, zoom is 1.0 and this degrades to plain size-based
-  selection. Falls through to `"original"` when even the large variant
-  would be soft.
-  """
-  def variant_for(box_px, zoom \\ 1.0) do
-    needed = box_px * 2 * max(zoom, 1.0)
+  The frame edge is covered by the image's SHORT side, while variants are
+  scaled by width — so a landscape image needs its width to be `ar` times
+  the frame requirement before the short side suffices. Portrait images'
+  width is their short side, so their factor is 1.
 
-    Enum.find_value(@variant_ladder, "original", fn {name, edge} ->
+  Without a crop, zoom is 1.0 and this degrades to plain size-based
+  selection. Capped at `"large"`: past it only the original upload could
+  help, and serving an unbounded file into an avatar circle buys marginal
+  sharpness at arbitrary transfer cost.
+  """
+  def variant_for(box_px, zoom \\ 1.0, ar \\ 1.0) do
+    needed = box_px * 2 * max(zoom, 1.0) * max(ar, 1.0)
+
+    Enum.find_value(@variant_ladder, "large", fn {name, edge} ->
       if edge >= needed, do: name
     end)
+  end
+
+  @doc """
+  Nil for a crop that shows exactly what no crop would show.
+
+  Centered at cover fit is the identity: storing it as numbers would make
+  every future render do geometry for nothing, and (worse) pin the avatar
+  to the aspect ratio recorded at save time. Tolerances absorb the float
+  noise a drag leaves behind.
+  """
+  def drop_identity(nil), do: nil
+
+  def drop_identity(crop) do
+    identity? =
+      crop["zoom"] <= 1.001 and
+        abs(crop["x"] - 0.5) < 0.005 and
+        abs(crop["y"] - 0.5) < 0.005
+
+    if identity?, do: nil, else: crop
   end
 
   @doc "The zoom ceiling, shared with the editor UI."

--- a/lib/phoenix_kit/users/custom_fields.ex
+++ b/lib/phoenix_kit/users/custom_fields.ex
@@ -76,6 +76,7 @@ defmodule PhoenixKit.Users.CustomFields do
   # definitions for the five stay; only new registrations stop.
   @internal_keys ~w(
     activity_view_mode
+    avatar_crop
     avatar_file_uuid
     etcher_colors
     etcher_line_params

--- a/lib/phoenix_kit_web/components/core/user_info.ex
+++ b/lib/phoenix_kit_web/components/core/user_info.ex
@@ -10,6 +10,7 @@ defmodule PhoenixKitWeb.Components.Core.UserInfo do
   use Phoenix.Component
 
   alias PhoenixKit.Modules.Storage.URLSigner
+  alias PhoenixKit.Users.AvatarCrop
   alias PhoenixKit.Users.Role
 
   # Gradient colors for avatar fallback (15 variants)
@@ -42,7 +43,7 @@ defmodule PhoenixKitWeb.Components.Core.UserInfo do
 
   ## Attributes
   - `user` - User struct with email and optional custom_fields
-  - `size` - Avatar size: "xs" (w-6), "sm" (w-8), "md" (w-10), "lg" (w-12). Defaults to "sm"
+  - `size` - Avatar size: "xs" (w-6), "sm" (w-8), "md" (w-10), "lg" (w-12), "xl" (w-40). Defaults to "sm"
   - `class` - Additional CSS classes
 
   ## Examples
@@ -59,10 +60,26 @@ defmodule PhoenixKitWeb.Components.Core.UserInfo do
     email = get_email(assigns.user)
     avatar_result = get_avatar_source(assigns.user, assigns.size)
 
+    # A stored crop only applies to the uploaded file it was made against —
+    # OAuth and Gravatar avatars have no variants and no crop.
+    crop =
+      case avatar_result do
+        {:storage, _file_id, _variant} -> AvatarCrop.from_user(assigns.user)
+        _ -> nil
+      end
+
     avatar_url =
       case avatar_result do
-        {:storage, file_id, storage_size} ->
-          URLSigner.signed_url(file_id, storage_size)
+        {:storage, file_id, variant} ->
+          # A zoomed crop shows only part of the source, so it may need a
+          # bigger variant than the box alone would: the geometry is free,
+          # the sharpness has to come from somewhere.
+          variant =
+            if crop,
+              do: AvatarCrop.variant_for(box_px(assigns.size), crop["zoom"]),
+              else: variant
+
+          URLSigner.signed_url(file_id, variant)
 
         {:url, url} ->
           url
@@ -81,6 +98,7 @@ defmodule PhoenixKitWeb.Components.Core.UserInfo do
     assigns =
       assigns
       |> assign(:avatar_url, avatar_url)
+      |> assign(:crop_style, crop && AvatarCrop.img_style(crop))
       |> assign(:size_classes, size_classes)
       |> assign(:gradient, gradient)
       |> assign(:initial, initial)
@@ -107,12 +125,22 @@ defmodule PhoenixKitWeb.Components.Core.UserInfo do
             {@initial}
           </span>
           <%!-- Image overlay (hides fallback when loaded successfully) --%>
-          <img
-            src={@avatar_url}
-            alt="Avatar"
-            class="absolute inset-0 w-full h-full object-cover"
-            onerror="this.style.display='none';"
-          />
+          <%= if @crop_style do %>
+            <%!-- Non-destructive crop: the stored geometry, as a style. --%>
+            <img
+              src={@avatar_url}
+              alt="Avatar"
+              style={@crop_style}
+              onerror="this.style.display='none';"
+            />
+          <% else %>
+            <img
+              src={@avatar_url}
+              alt="Avatar"
+              class="absolute inset-0 w-full h-full object-cover"
+              onerror="this.style.display='none';"
+            />
+          <% end %>
         <% else %>
           <span>{@initial}</span>
         <% end %>
@@ -179,7 +207,21 @@ defmodule PhoenixKitWeb.Components.Core.UserInfo do
       "sm" -> 64
       "md" -> 80
       "lg" -> 96
+      "xl" -> 320
       _ -> 64
+    end
+  end
+
+  # The CSS box each size renders into, for picking a variant that stays
+  # sharp under the crop's zoom (2x displays assumed).
+  defp box_px(size) do
+    case size do
+      "xs" -> 24
+      "sm" -> 32
+      "md" -> 40
+      "lg" -> 48
+      "xl" -> 160
+      _ -> 32
     end
   end
 
@@ -190,17 +232,22 @@ defmodule PhoenixKitWeb.Components.Core.UserInfo do
       "sm" -> "w-8 h-8 text-xs"
       "md" -> "w-10 h-10 text-sm"
       "lg" -> "w-12 h-12 text-base"
+      "xl" -> "w-40 h-40 text-5xl"
       _ -> "w-8 h-8 text-xs"
     end
   end
 
-  # Storage size for PhoenixKit Storage
+  # Storage size for PhoenixKit Storage. The settings page's "xl" preview
+  # was the reported blur: it used to load the 150px thumbnail into a 160px
+  # (320px on 2x displays) circle. It gets "medium" (800px) like the admin
+  # form always did.
   defp storage_size(size) do
     case size do
       "xs" -> "small"
       "sm" -> "small"
       "md" -> "medium"
       "lg" -> "medium"
+      "xl" -> "medium"
       _ -> "small"
     end
   end

--- a/lib/phoenix_kit_web/components/core/user_info.ex
+++ b/lib/phoenix_kit_web/components/core/user_info.ex
@@ -76,7 +76,7 @@ defmodule PhoenixKitWeb.Components.Core.UserInfo do
           # the sharpness has to come from somewhere.
           variant =
             if crop,
-              do: AvatarCrop.variant_for(box_px(assigns.size), crop["zoom"]),
+              do: AvatarCrop.variant_for(box_px(assigns.size), crop["zoom"], crop["ar"]),
               else: variant
 
           URLSigner.signed_url(file_id, variant)
@@ -124,23 +124,17 @@ defmodule PhoenixKitWeb.Components.Core.UserInfo do
           >
             {@initial}
           </span>
-          <%!-- Image overlay (hides fallback when loaded successfully) --%>
-          <%= if @crop_style do %>
-            <%!-- Non-destructive crop: the stored geometry, as a style. --%>
-            <img
-              src={@avatar_url}
-              alt="Avatar"
-              style={@crop_style}
-              onerror="this.style.display='none';"
-            />
-          <% else %>
-            <img
-              src={@avatar_url}
-              alt="Avatar"
-              class="absolute inset-0 w-full h-full object-cover"
-              onerror="this.style.display='none';"
-            />
-          <% end %>
+          <%!-- Image overlay (hides fallback when loaded successfully).
+               With a stored crop the geometry arrives as an inline style;
+               without one, classic object-cover. One tag either way, so
+               future img attributes cannot drift between branches. --%>
+          <img
+            src={@avatar_url}
+            alt="Avatar"
+            style={@crop_style}
+            class={unless @crop_style, do: "absolute inset-0 w-full h-full object-cover"}
+            onerror="this.style.display='none';"
+          />
         <% else %>
           <span>{@initial}</span>
         <% end %>

--- a/lib/phoenix_kit_web/live/components/user_settings.ex
+++ b/lib/phoenix_kit_web/live/components/user_settings.ex
@@ -45,10 +45,12 @@ defmodule PhoenixKitWeb.Live.Components.UserSettings do
 
   alias PhoenixKit.Integrations
   alias PhoenixKit.Integrations.Providers
+  alias PhoenixKit.Modules.Storage.URLSigner
   alias PhoenixKit.Notifications.Prefs, as: NotificationPrefs
   alias PhoenixKit.Notifications.Types, as: NotificationTypes
   alias PhoenixKit.Settings
   alias PhoenixKit.Users.Auth
+  alias PhoenixKit.Users.AvatarCrop
   alias PhoenixKit.Users.CustomFields
   alias PhoenixKit.Users.OAuth
   alias PhoenixKit.Users.OAuthAvailability
@@ -85,7 +87,7 @@ defmodule PhoenixKitWeb.Live.Components.UserSettings do
   def update(%{action: :set_avatar, file_uuid: file_uuid}, socket) do
     user = socket.assigns.user
 
-    case Auth.update_user_fields(user, %{"avatar_file_uuid" => file_uuid}) do
+    case Auth.update_user_fields(user, %{"avatar_file_uuid" => file_uuid, "avatar_crop" => nil}) do
       {:ok, updated_user} ->
         send(self(), {:phoenix_kit_user_updated, updated_user})
 
@@ -186,6 +188,8 @@ defmodule PhoenixKitWeb.Live.Components.UserSettings do
       end)
       |> assign_new(:last_uploaded_avatar_uuid, fn -> nil end)
       |> assign_new(:show_avatar_selector, fn -> false end)
+      |> assign_new(:show_avatar_crop, fn -> false end)
+      |> assign_new(:pending_avatar_crop, fn -> nil end)
       |> assign_new(:show_email_form, fn -> false end)
       |> assign_new(:show_password_form, fn -> false end)
       |> assign_new(:show_notification_prefs, fn -> false end)
@@ -450,6 +454,49 @@ defmodule PhoenixKitWeb.Live.Components.UserSettings do
 
   def handle_event("open_avatar_selector", _params, socket) do
     {:noreply, assign(socket, :show_avatar_selector, true)}
+  end
+
+  # ---- non-destructive avatar crop -----------------------------------------
+  #
+  # The crop is data in custom_fields["avatar_crop"], never a new image file:
+  # the editor below adjusts four numbers, and rendering applies them as CSS.
+  # See PhoenixKit.Users.AvatarCrop.
+
+  def handle_event("open_avatar_crop", _params, socket) do
+    {:noreply,
+     socket
+     |> assign(:show_avatar_crop, true)
+     |> assign(:pending_avatar_crop, AvatarCrop.from_user(socket.assigns.user))}
+  end
+
+  def handle_event("close_avatar_crop", _params, socket) do
+    {:noreply,
+     socket
+     |> assign(:show_avatar_crop, false)
+     |> assign(:pending_avatar_crop, nil)}
+  end
+
+  # Pushed by the AvatarCrop hook at the end of every gesture (drag release,
+  # zoom change), so "Save" always persists what the person is looking at.
+  def handle_event("avatar_crop_changed", params, socket) do
+    {:noreply, assign(socket, :pending_avatar_crop, AvatarCrop.normalize(params))}
+  end
+
+  def handle_event("save_avatar_crop", _params, socket) do
+    case socket.assigns.pending_avatar_crop do
+      nil ->
+        {:noreply, assign(socket, :show_avatar_crop, false)}
+
+      crop ->
+        persist_avatar_crop(socket, crop, gettext("Avatar crop updated!"))
+    end
+  end
+
+  # Back to the uncropped avatar. Storing nil rather than deleting the key:
+  # update_user_fields merges custom fields, and a merged nil reads as
+  # "no crop" everywhere while needing no delete plumbing.
+  def handle_event("reset_avatar_crop", _params, socket) do
+    persist_avatar_crop(socket, nil, gettext("Avatar crop reset."))
   end
 
   def handle_event("toggle_email_form", _params, socket) do
@@ -746,6 +793,43 @@ defmodule PhoenixKitWeb.Live.Components.UserSettings do
     end
   end
 
+  defp persist_avatar_crop(socket, crop, success_message) do
+    user = socket.assigns.user
+
+    case Auth.update_user_fields(user, %{"avatar_crop" => crop}) do
+      {:ok, updated_user} ->
+        send(self(), {:phoenix_kit_user_updated, updated_user})
+
+        PhoenixKit.Activity.log(%{
+          action: "user.avatar_crop_changed",
+          module: "users",
+          mode: "manual",
+          actor_uuid: updated_user.uuid,
+          resource_type: "user",
+          resource_uuid: updated_user.uuid,
+          metadata: %{
+            "cropped" => crop != nil,
+            "actor_role" => "user"
+          }
+        })
+
+        {:noreply,
+         socket
+         |> assign(:user, updated_user)
+         |> assign(:show_avatar_crop, false)
+         |> assign(:pending_avatar_crop, nil)
+         |> assign(:avatar_success_message, success_message)
+         |> assign(:avatar_error_message, nil)}
+
+      {:error, _changeset} ->
+        {:noreply,
+         socket
+         |> assign(:show_avatar_crop, false)
+         |> assign(:avatar_error_message, gettext("Failed to update avatar crop"))
+         |> assign(:avatar_success_message, nil)}
+    end
+  end
+
   defp format_provider_name("google"), do: "Google"
   defp format_provider_name("apple"), do: "Apple"
   defp format_provider_name("github"), do: "GitHub"
@@ -792,24 +876,11 @@ defmodule PhoenixKitWeb.Live.Components.UserSettings do
               <div class="flex flex-col gap-6 lg:flex-row lg:gap-4 lg:items-start">
                 <%!-- Avatar Section --%>
                 <div class="flex flex-col items-center gap-2 mx-auto lg:mx-0">
-                  <%= if get_in(@user.custom_fields, ["avatar_file_uuid"]) do %>
-                    <% avatar_url =
-                      PhoenixKit.Modules.Storage.URLSigner.signed_url(
-                        get_in(@user.custom_fields, ["avatar_file_uuid"]),
-                        "thumbnail"
-                      ) %>
-                    <img
-                      src={avatar_url}
-                      alt="Avatar"
-                      class="w-40 h-40 rounded-full object-cover border-2 border-primary"
-                    />
-                  <% else %>
-                    <div class="w-40 h-40 rounded-full bg-primary/10 border-2 border-primary flex items-center justify-center">
-                      <span class="text-5xl font-bold text-primary">
-                        {String.upcase(String.at(@user.email, 0))}
-                      </span>
-                    </div>
-                  <% end %>
+                  <%!-- The shared component: same cascade as everywhere else,
+                       and the "xl" size loads the medium (800px) variant — the
+                       old inline <img> here loaded the 150px thumbnail into
+                       this 160px circle, which is what made it blurry. --%>
+                  <.user_avatar user={@user} size="xl" class="border-2 border-primary" />
                   <button
                     type="button"
                     phx-click="open_avatar_selector"
@@ -817,6 +888,15 @@ defmodule PhoenixKitWeb.Live.Components.UserSettings do
                     class="btn btn-primary w-40"
                   >
                     <.icon name="hero-photo" class="w-5 h-5" /> Browse Media
+                  </button>
+                  <button
+                    :if={get_in(@user.custom_fields, ["avatar_file_uuid"])}
+                    type="button"
+                    phx-click="open_avatar_crop"
+                    phx-target={@myself}
+                    class="btn btn-ghost btn-sm w-40"
+                  >
+                    <.icon name="hero-viewfinder-circle" class="w-4 h-4" /> {gettext("Adjust Crop")}
                   </button>
                 </div>
 
@@ -912,6 +992,93 @@ defmodule PhoenixKitWeb.Live.Components.UserSettings do
               phoenix_kit_current_user={@user}
               on_select={{PhoenixKitWeb.Live.Components.UserSettings, @id, :set_avatar}}
             />
+
+            <%!-- Non-destructive crop editor. Drag to position, slider or
+                 wheel to zoom — the AvatarCrop hook previews with the same
+                 math the avatar component renders with, and the original
+                 image is never touched. --%>
+            <.modal
+              :if={@show_avatar_crop}
+              show={@show_avatar_crop}
+              on_close="close_avatar_crop"
+              id={"#{@id}-avatar-crop-modal"}
+              max_width="md"
+            >
+              <:title>{gettext("Adjust Avatar Crop")}</:title>
+              <div
+                id={"#{@id}-avatar-crop-editor"}
+                phx-hook="AvatarCrop"
+                phx-target={@myself}
+                phx-update="ignore"
+                data-image-url={
+                  URLSigner.signed_url(
+                    get_in(@user.custom_fields, ["avatar_file_uuid"]),
+                    "large"
+                  )
+                }
+                data-crop={Phoenix.json_library().encode!(@pending_avatar_crop || %{})}
+                data-max-zoom={AvatarCrop.max_zoom()}
+                class="flex flex-col items-center gap-4 py-2"
+              >
+                <div
+                  data-crop-frame
+                  class="relative w-64 h-64 rounded-full overflow-hidden bg-neutral cursor-grab touch-none select-none ring-2 ring-primary ring-offset-2"
+                >
+                  <img
+                    data-crop-img
+                    src={
+                      URLSigner.signed_url(
+                        get_in(@user.custom_fields, ["avatar_file_uuid"]),
+                        "large"
+                      )
+                    }
+                    alt=""
+                    draggable="false"
+                    class="absolute max-w-none pointer-events-none"
+                  />
+                </div>
+                <div class="flex items-center gap-3 w-64">
+                  <.icon name="hero-magnifying-glass-minus" class="w-4 h-4 opacity-60" />
+                  <input
+                    data-crop-zoom
+                    type="range"
+                    min="1"
+                    max={AvatarCrop.max_zoom()}
+                    step="0.01"
+                    value="1"
+                    class="range range-primary range-xs flex-1"
+                    aria-label={gettext("Zoom")}
+                  />
+                  <.icon name="hero-magnifying-glass-plus" class="w-4 h-4 opacity-60" />
+                </div>
+              </div>
+              <:actions>
+                <button
+                  type="button"
+                  phx-click="reset_avatar_crop"
+                  phx-target={@myself}
+                  class="btn btn-ghost btn-sm mr-auto"
+                >
+                  {gettext("Reset")}
+                </button>
+                <button
+                  type="button"
+                  phx-click="close_avatar_crop"
+                  phx-target={@myself}
+                  class="btn btn-sm"
+                >
+                  {gettext("Cancel")}
+                </button>
+                <button
+                  type="button"
+                  phx-click="save_avatar_crop"
+                  phx-target={@myself}
+                  class="btn btn-primary btn-sm"
+                >
+                  {gettext("Save Crop")}
+                </button>
+              </:actions>
+            </.modal>
 
             <%= if Enum.any?([:custom_fields, :email, :password, :oauth], & &1 in @sections) do %>
               <div class="divider"></div>

--- a/lib/phoenix_kit_web/live/components/user_settings.ex
+++ b/lib/phoenix_kit_web/live/components/user_settings.ex
@@ -440,11 +440,18 @@ defmodule PhoenixKitWeb.Live.Components.UserSettings do
   # See PhoenixKit.Users.AvatarCrop.
 
   def handle_event("open_avatar_crop", _params, socket) do
-    {:noreply,
-     socket
-     |> assign(:show_avatar_crop, true)
-     |> assign(:pending_avatar_uuid, nil)
-     |> assign(:pending_avatar_crop, AvatarCrop.from_user(socket.assigns.user))}
+    # A stale DOM click can arrive after the avatar was removed; with no
+    # file there is nothing to crop, and rendering the modal would call
+    # URLSigner.signed_url(nil, ...) and take the LiveView down.
+    if get_in(socket.assigns.user.custom_fields, ["avatar_file_uuid"]) do
+      {:noreply,
+       socket
+       |> assign(:show_avatar_crop, true)
+       |> assign(:pending_avatar_uuid, nil)
+       |> assign(:pending_avatar_crop, AvatarCrop.from_user(socket.assigns.user))}
+    else
+      {:noreply, socket}
+    end
   end
 
   def handle_event("close_avatar_crop", _params, socket) do
@@ -467,13 +474,18 @@ defmodule PhoenixKitWeb.Live.Components.UserSettings do
     cond do
       # A freshly picked file: the file and its framing land together. An
       # untouched editor saves no crop at all — the default fit IS the
-      # uncropped avatar, and storing it as numbers would only make every
-      # future render do geometry for nothing.
+      # uncropped avatar (see AvatarCrop.drop_identity/1).
       uuid = socket.assigns.pending_avatar_uuid ->
-        persist_new_avatar(socket, uuid, unless_identity(crop))
+        persist_new_avatar(socket, uuid, AvatarCrop.drop_identity(crop))
 
       crop ->
-        persist_avatar_crop(socket, crop, gettext("Avatar crop updated!"))
+        # Same identity rule on the adjust path: zooming back out to the
+        # default fit and saving IS a reset.
+        persist_avatar_crop(
+          socket,
+          AvatarCrop.drop_identity(crop),
+          gettext("Avatar crop updated!")
+        )
 
       true ->
         {:noreply, assign(socket, :show_avatar_crop, false)}
@@ -781,20 +793,6 @@ defmodule PhoenixKitWeb.Live.Components.UserSettings do
     end
   end
 
-  # A crop that shows exactly what no crop would show. Panning freedom only
-  # exists once the image overflows the frame, so centered-at-cover-fit is
-  # the identity; the tolerances absorb float noise from the drag math.
-  defp unless_identity(nil), do: nil
-
-  defp unless_identity(crop) do
-    identity? =
-      crop["zoom"] <= 1.001 and
-        abs(crop["x"] - 0.5) < 0.005 and
-        abs(crop["y"] - 0.5) < 0.005
-
-    if identity?, do: nil, else: crop
-  end
-
   defp persist_new_avatar(socket, file_uuid, crop) do
     user = socket.assigns.user
 
@@ -937,6 +935,7 @@ defmodule PhoenixKitWeb.Live.Components.UserSettings do
                   <button
                     :if={get_in(@user.custom_fields, ["avatar_file_uuid"])}
                     type="button"
+                    id={"#{@id}-avatar-crop-open"}
                     phx-click="open_avatar_crop"
                     phx-target={@myself}
                     class="btn btn-ghost btn-sm w-40"
@@ -1055,12 +1054,6 @@ defmodule PhoenixKitWeb.Live.Components.UserSettings do
                 phx-hook="AvatarCrop"
                 phx-target={@myself}
                 phx-update="ignore"
-                data-image-url={
-                  URLSigner.signed_url(
-                    @pending_avatar_uuid || get_in(@user.custom_fields, ["avatar_file_uuid"]),
-                    "large"
-                  )
-                }
                 data-crop={Phoenix.json_library().encode!(@pending_avatar_crop || %{})}
                 data-max-zoom={AvatarCrop.max_zoom()}
                 class="flex flex-col items-center gap-4 py-2"
@@ -1103,6 +1096,7 @@ defmodule PhoenixKitWeb.Live.Components.UserSettings do
                 <button
                   :if={is_nil(@pending_avatar_uuid)}
                   type="button"
+                  id={"#{@id}-avatar-crop-reset"}
                   phx-click="reset_avatar_crop"
                   phx-target={@myself}
                   class="btn btn-ghost btn-sm mr-auto"
@@ -1111,14 +1105,21 @@ defmodule PhoenixKitWeb.Live.Components.UserSettings do
                 </button>
                 <button
                   type="button"
+                  id={"#{@id}-avatar-crop-cancel"}
                   phx-click="close_avatar_crop"
                   phx-target={@myself}
                   class="btn btn-sm"
                 >
                   {gettext("Cancel")}
                 </button>
+                <%!-- data-crop-save-btn: the AvatarCrop hook flushes its
+                     pending state on this click (capture phase, so the
+                     flush is pushed before the phx-click), closing the
+                     window where a debounced wheel-zoom would be lost. --%>
                 <button
                   type="button"
+                  id={"#{@id}-avatar-crop-save"}
+                  data-crop-save-btn
                   phx-click="save_avatar_crop"
                   phx-target={@myself}
                   class="btn btn-primary btn-sm"

--- a/lib/phoenix_kit_web/live/components/user_settings.ex
+++ b/lib/phoenix_kit_web/live/components/user_settings.ex
@@ -83,43 +83,19 @@ defmodule PhoenixKitWeb.Live.Components.UserSettings do
   @spec default_sections() :: [atom()]
   def default_sections, do: @default_sections
 
+  # Picking a file no longer sets it on the spot: the crop editor opens on
+  # the picked image first, so the person frames it once instead of
+  # set-then-crop-then-set-again. Pressing Save without touching anything
+  # accepts the default fit; Cancel discards the pick and the old avatar
+  # never changed. Nothing persists until the Save in the editor.
   @impl true
   def update(%{action: :set_avatar, file_uuid: file_uuid}, socket) do
-    user = socket.assigns.user
-
-    case Auth.update_user_fields(user, %{"avatar_file_uuid" => file_uuid, "avatar_crop" => nil}) do
-      {:ok, updated_user} ->
-        send(self(), {:phoenix_kit_user_updated, updated_user})
-
-        PhoenixKit.Activity.log(%{
-          action: "user.avatar_changed",
-          module: "users",
-          mode: "manual",
-          actor_uuid: updated_user.uuid,
-          resource_type: "user",
-          resource_uuid: updated_user.uuid,
-          metadata: %{
-            "avatar_from" => get_in(user.custom_fields, ["avatar_file_uuid"]) || "",
-            "avatar_to" => file_uuid,
-            "actor_role" => "user"
-          }
-        })
-
-        {:ok,
-         socket
-         |> assign(:user, updated_user)
-         |> assign(:show_avatar_selector, false)
-         |> assign(:last_uploaded_avatar_uuid, file_uuid)
-         |> assign(:avatar_success_message, gettext("Avatar updated successfully!"))
-         |> assign(:avatar_error_message, nil)}
-
-      {:error, _changeset} ->
-        {:ok,
-         socket
-         |> assign(:show_avatar_selector, false)
-         |> assign(:avatar_error_message, gettext("Failed to update avatar"))
-         |> assign(:avatar_success_message, nil)}
-    end
+    {:ok,
+     socket
+     |> assign(:show_avatar_selector, false)
+     |> assign(:pending_avatar_uuid, file_uuid)
+     |> assign(:pending_avatar_crop, nil)
+     |> assign(:show_avatar_crop, true)}
   end
 
   def update(%{action: :avatar_selector_closed}, socket) do
@@ -190,6 +166,7 @@ defmodule PhoenixKitWeb.Live.Components.UserSettings do
       |> assign_new(:show_avatar_selector, fn -> false end)
       |> assign_new(:show_avatar_crop, fn -> false end)
       |> assign_new(:pending_avatar_crop, fn -> nil end)
+      |> assign_new(:pending_avatar_uuid, fn -> nil end)
       |> assign_new(:show_email_form, fn -> false end)
       |> assign_new(:show_password_form, fn -> false end)
       |> assign_new(:show_notification_prefs, fn -> false end)
@@ -466,6 +443,7 @@ defmodule PhoenixKitWeb.Live.Components.UserSettings do
     {:noreply,
      socket
      |> assign(:show_avatar_crop, true)
+     |> assign(:pending_avatar_uuid, nil)
      |> assign(:pending_avatar_crop, AvatarCrop.from_user(socket.assigns.user))}
   end
 
@@ -473,7 +451,8 @@ defmodule PhoenixKitWeb.Live.Components.UserSettings do
     {:noreply,
      socket
      |> assign(:show_avatar_crop, false)
-     |> assign(:pending_avatar_crop, nil)}
+     |> assign(:pending_avatar_crop, nil)
+     |> assign(:pending_avatar_uuid, nil)}
   end
 
   # Pushed by the AvatarCrop hook at the end of every gesture (drag release,
@@ -483,12 +462,21 @@ defmodule PhoenixKitWeb.Live.Components.UserSettings do
   end
 
   def handle_event("save_avatar_crop", _params, socket) do
-    case socket.assigns.pending_avatar_crop do
-      nil ->
-        {:noreply, assign(socket, :show_avatar_crop, false)}
+    crop = socket.assigns.pending_avatar_crop
+
+    cond do
+      # A freshly picked file: the file and its framing land together. An
+      # untouched editor saves no crop at all — the default fit IS the
+      # uncropped avatar, and storing it as numbers would only make every
+      # future render do geometry for nothing.
+      uuid = socket.assigns.pending_avatar_uuid ->
+        persist_new_avatar(socket, uuid, unless_identity(crop))
 
       crop ->
         persist_avatar_crop(socket, crop, gettext("Avatar crop updated!"))
+
+      true ->
+        {:noreply, assign(socket, :show_avatar_crop, false)}
     end
   end
 
@@ -793,6 +781,62 @@ defmodule PhoenixKitWeb.Live.Components.UserSettings do
     end
   end
 
+  # A crop that shows exactly what no crop would show. Panning freedom only
+  # exists once the image overflows the frame, so centered-at-cover-fit is
+  # the identity; the tolerances absorb float noise from the drag math.
+  defp unless_identity(nil), do: nil
+
+  defp unless_identity(crop) do
+    identity? =
+      crop["zoom"] <= 1.001 and
+        abs(crop["x"] - 0.5) < 0.005 and
+        abs(crop["y"] - 0.5) < 0.005
+
+    if identity?, do: nil, else: crop
+  end
+
+  defp persist_new_avatar(socket, file_uuid, crop) do
+    user = socket.assigns.user
+
+    case Auth.update_user_fields(user, %{"avatar_file_uuid" => file_uuid, "avatar_crop" => crop}) do
+      {:ok, updated_user} ->
+        send(self(), {:phoenix_kit_user_updated, updated_user})
+
+        PhoenixKit.Activity.log(%{
+          action: "user.avatar_changed",
+          module: "users",
+          mode: "manual",
+          actor_uuid: updated_user.uuid,
+          resource_type: "user",
+          resource_uuid: updated_user.uuid,
+          metadata: %{
+            "avatar_from" => get_in(user.custom_fields, ["avatar_file_uuid"]) || "",
+            "avatar_to" => file_uuid,
+            "cropped" => crop != nil,
+            "actor_role" => "user"
+          }
+        })
+
+        {:noreply,
+         socket
+         |> assign(:user, updated_user)
+         |> assign(:show_avatar_crop, false)
+         |> assign(:pending_avatar_crop, nil)
+         |> assign(:pending_avatar_uuid, nil)
+         |> assign(:last_uploaded_avatar_uuid, file_uuid)
+         |> assign(:avatar_success_message, gettext("Avatar updated successfully!"))
+         |> assign(:avatar_error_message, nil)}
+
+      {:error, _changeset} ->
+        {:noreply,
+         socket
+         |> assign(:show_avatar_crop, false)
+         |> assign(:pending_avatar_uuid, nil)
+         |> assign(:avatar_error_message, gettext("Failed to update avatar"))
+         |> assign(:avatar_success_message, nil)}
+    end
+  end
+
   defp persist_avatar_crop(socket, crop, success_message) do
     user = socket.assigns.user
 
@@ -818,6 +862,7 @@ defmodule PhoenixKitWeb.Live.Components.UserSettings do
          |> assign(:user, updated_user)
          |> assign(:show_avatar_crop, false)
          |> assign(:pending_avatar_crop, nil)
+         |> assign(:pending_avatar_uuid, nil)
          |> assign(:avatar_success_message, success_message)
          |> assign(:avatar_error_message, nil)}
 
@@ -1012,7 +1057,7 @@ defmodule PhoenixKitWeb.Live.Components.UserSettings do
                 phx-update="ignore"
                 data-image-url={
                   URLSigner.signed_url(
-                    get_in(@user.custom_fields, ["avatar_file_uuid"]),
+                    @pending_avatar_uuid || get_in(@user.custom_fields, ["avatar_file_uuid"]),
                     "large"
                   )
                 }
@@ -1028,7 +1073,7 @@ defmodule PhoenixKitWeb.Live.Components.UserSettings do
                     data-crop-img
                     src={
                       URLSigner.signed_url(
-                        get_in(@user.custom_fields, ["avatar_file_uuid"]),
+                        @pending_avatar_uuid || get_in(@user.custom_fields, ["avatar_file_uuid"]),
                         "large"
                       )
                     }
@@ -1053,7 +1098,10 @@ defmodule PhoenixKitWeb.Live.Components.UserSettings do
                 </div>
               </div>
               <:actions>
+                <%!-- Nothing to reset on a fresh pick — the default fit
+                     already is the uncropped image. --%>
                 <button
+                  :if={is_nil(@pending_avatar_uuid)}
                   type="button"
                   phx-click="reset_avatar_crop"
                   phx-target={@myself}

--- a/lib/phoenix_kit_web/users/user_form.html.heex
+++ b/lib/phoenix_kit_web/users/user_form.html.heex
@@ -31,10 +31,18 @@
                   <%= if avatar_file_uuid do %>
                     <% avatar_url =
                       PhoenixKit.Modules.Storage.URLSigner.signed_url(avatar_file_uuid, variant) %>
+                    <%!-- The stored crop belongs to the CURRENT avatar; a
+                         pending selection is a different file, previewed
+                         uncropped until saved. --%>
+                    <% crop =
+                      if @pending_avatar_file_uuid,
+                        do: nil,
+                        else: PhoenixKit.Users.AvatarCrop.from_user(@user) %>
                     <img
                       src={avatar_url}
                       alt="Avatar"
-                      class="w-full h-full object-cover"
+                      style={crop && PhoenixKit.Users.AvatarCrop.img_style(crop)}
+                      class={if crop, do: nil, else: "w-full h-full object-cover"}
                       onerror="this.style.display='none'; this.nextElementSibling.style.display='flex';"
                     />
                     <div class="hidden w-full h-full bg-primary flex items-center justify-center text-center">

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -127,8 +127,8 @@ msgstr "Neues Konto erstellen"
 #: lib/phoenix_kit_web/users/forgot_password.html.heex:15
 #: lib/phoenix_kit_web/users/magic_link.html.heex:30
 #: lib/phoenix_kit_web/users/registration.html.heex:56
-#: lib/phoenix_kit_web/users/user_form.html.heex:761
-#: lib/phoenix_kit_web/users/user_form.html.heex:840
+#: lib/phoenix_kit_web/users/user_form.html.heex:769
+#: lib/phoenix_kit_web/users/user_form.html.heex:848
 #, elixir-autogen
 msgid "Email"
 msgstr "E-Mail"
@@ -188,7 +188,7 @@ msgstr "Registrierte Konten"
 
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:259
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:264
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1399
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1615
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:18
 #, elixir-autogen
 msgid "Active Sessions"
@@ -379,7 +379,7 @@ msgstr "Authentifizierung"
 #: lib/phoenix_kit_web/live/users/users.ex:1200
 #: lib/phoenix_kit_web/live/users/users.html.heex:248
 #: lib/phoenix_kit_web/live/users/users.html.heex:573
-#: lib/phoenix_kit_web/users/user_form.html.heex:786
+#: lib/phoenix_kit_web/users/user_form.html.heex:794
 #, elixir-autogen
 msgid "Active"
 msgstr "Aktiv"
@@ -399,7 +399,7 @@ msgstr "Aktiv"
 #: lib/phoenix_kit_web/live/modules.html.heex:284
 #: lib/phoenix_kit_web/live/modules.html.heex:349
 #: lib/phoenix_kit_web/live/modules.html.heex:405
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:59
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:61
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:49
 #: lib/phoenix_kit_web/live/settings/send_profile_form.html.heex:90
 #: lib/phoenix_kit_web/live/settings/users.html.heex:465
@@ -439,7 +439,7 @@ msgstr "%{language} (Entwurf)"
 msgid "%{language} (Published)"
 msgstr "%{language} (veröffentlicht)"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:403
+#: lib/phoenix_kit_web/live/components/user_settings.ex:384
 #, elixir-autogen, elixir-format
 msgid "%{provider} account disconnected successfully"
 msgstr "%{provider}-Konto erfolgreich getrennt"
@@ -459,7 +459,7 @@ msgstr "(optional)"
 msgid "123 Business Street"
 msgstr "Musterstraße 123"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:250
+#: lib/phoenix_kit_web/live/components/user_settings.ex:231
 #, elixir-autogen, elixir-format
 msgid "A link to confirm your email change has been sent to the new address."
 msgstr "Ein Link zur Bestätigung Ihrer E-Mail-Änderung wurde an die neue Adresse gesendet."
@@ -506,8 +506,8 @@ msgstr "Kontoinformationen"
 #: lib/phoenix_kit_web/live/users/roles.html.heex:163
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:269
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:651
-#: lib/phoenix_kit_web/users/user_form.html.heex:763
-#: lib/phoenix_kit_web/users/user_form.html.heex:843
+#: lib/phoenix_kit_web/users/user_form.html.heex:771
+#: lib/phoenix_kit_web/users/user_form.html.heex:851
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr "Aktionen"
@@ -516,7 +516,7 @@ msgstr "Aktionen"
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:610
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:314
 #: lib/phoenix_kit_web/live/settings/users.html.heex:795
-#: lib/phoenix_kit_web/users/user_form.html.heex:742
+#: lib/phoenix_kit_web/users/user_form.html.heex:750
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr "Hinzufügen"
@@ -646,7 +646,8 @@ msgstr "Aufzählungsliste"
 #: lib/phoenix_kit_web/components/media_browser.html.heex:2440
 #: lib/phoenix_kit_web/components/user_dashboard_nav.ex:317
 #: lib/phoenix_kit_web/live/components/media_selector_modal.html.heex:65
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1327
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1113
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1543
 #: lib/phoenix_kit_web/live/notifications/settings.ex:434
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:493
 #: lib/phoenix_kit_web/live/settings/send_profile_form.html.heex:152
@@ -686,12 +687,12 @@ msgstr "Der letzte Systeminhaber kann nicht gelöscht werden"
 msgid "Cannot delete your own account"
 msgstr "Sie können Ihr eigenes Konto nicht löschen"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:437
+#: lib/phoenix_kit_web/live/components/user_settings.ex:418
 #, elixir-autogen, elixir-format
 msgid "Cannot disconnect %{provider}. Please ensure you have at least one sign-in method available."
 msgstr "%{provider} kann nicht getrennt werden. Stellen Sie sicher, dass mindestens eine Anmeldemethode verfügbar bleibt."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:432
+#: lib/phoenix_kit_web/live/components/user_settings.ex:413
 #, elixir-autogen, elixir-format
 msgid "Cannot disconnect %{provider}. This is your only sign-in method. Please set a password or connect another provider first."
 msgstr "%{provider} kann nicht getrennt werden. Dies ist Ihre einzige Anmeldemethode. Legen Sie zuerst ein Passwort fest oder verbinden Sie einen anderen Anbieter."
@@ -1098,7 +1099,7 @@ msgstr "Rolle konnte nicht gelöscht werden"
 msgid "Failed to delete user"
 msgstr "Benutzer konnte nicht gelöscht werden"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:423
+#: lib/phoenix_kit_web/live/components/user_settings.ex:404
 #, elixir-autogen, elixir-format
 msgid "Failed to disconnect provider. Please try again."
 msgstr "Anbieter konnte nicht getrennt werden. Bitte versuchen Sie es erneut."
@@ -1237,7 +1238,7 @@ msgstr "Bild"
 #: lib/phoenix_kit_web/live/users/users.ex:1200
 #: lib/phoenix_kit_web/live/users/users.html.heex:249
 #: lib/phoenix_kit_web/live/users/users.html.heex:577
-#: lib/phoenix_kit_web/users/user_form.html.heex:790
+#: lib/phoenix_kit_web/users/user_form.html.heex:798
 #, elixir-autogen, elixir-format
 msgid "Inactive"
 msgstr "Inaktiv"
@@ -1480,7 +1481,7 @@ msgstr "OK"
 msgid "Only the Owner can edit Admin permissions"
 msgstr "Nur der Inhaber kann Administratorberechtigungen bearbeiten"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:236
+#: lib/phoenix_kit_web/users/user_form.html.heex:244
 #, elixir-autogen, elixir-format
 msgid "Optional"
 msgstr "Optional"
@@ -1542,7 +1543,7 @@ msgstr "Seite erfolgreich veröffentlicht"
 msgid "Password"
 msgstr "Passwort"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:301
+#: lib/phoenix_kit_web/live/components/user_settings.ex:282
 #, elixir-autogen, elixir-format
 msgid "Password changed successfully."
 msgstr "Passwort erfolgreich geändert."
@@ -1625,7 +1626,7 @@ msgstr "Datenschutzeinstellungen"
 msgid "Profile"
 msgstr "Profil"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:362
+#: lib/phoenix_kit_web/live/components/user_settings.ex:343
 #, elixir-autogen, elixir-format
 msgid "Profile updated successfully"
 msgstr "Profil erfolgreich aktualisiert"
@@ -1641,7 +1642,7 @@ msgstr "Geschützt"
 msgid "Protected core roles"
 msgstr "Geschützte Kernrollen"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:413
+#: lib/phoenix_kit_web/live/components/user_settings.ex:394
 #, elixir-autogen, elixir-format
 msgid "Provider not found"
 msgstr "Anbieter nicht gefunden"
@@ -1945,7 +1946,7 @@ msgstr "Bundesland/Provinz"
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:294
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:650
 #: lib/phoenix_kit_web/live/users/users.html.heex:263
-#: lib/phoenix_kit_web/users/user_form.html.heex:762
+#: lib/phoenix_kit_web/users/user_form.html.heex:770
 #, elixir-autogen, elixir-format
 msgid "Status"
 msgstr "Status"
@@ -2140,7 +2141,7 @@ msgstr "Video"
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:695
 #: lib/phoenix_kit_web/live/users/users.html.heex:667
 #: lib/phoenix_kit_web/live/users/users.html.heex:794
-#: lib/phoenix_kit_web/users/user_form.html.heex:801
+#: lib/phoenix_kit_web/users/user_form.html.heex:809
 #, elixir-autogen, elixir-format
 msgid "View"
 msgstr "Ansehen"
@@ -2272,7 +2273,7 @@ msgstr "Bucket löschen"
 #: lib/modules/storage/web/dimensions.html.heex:466
 #: lib/modules/storage/web/settings.html.heex:221
 #: lib/modules/storage/web/settings.html.heex:257
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:126
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:128
 #: lib/phoenix_kit_web/live/settings/users.html.heex:563
 #: lib/phoenix_kit_web/live/settings/users.html.heex:609
 #, elixir-autogen, elixir-format
@@ -2298,7 +2299,7 @@ msgstr "Aktivieren"
 
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:166
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:268
-#: lib/phoenix_kit_web/users/user_form.html.heex:842
+#: lib/phoenix_kit_web/users/user_form.html.heex:850
 #, elixir-autogen, elixir-format
 msgid "Expires"
 msgstr "Läuft ab"
@@ -2314,7 +2315,7 @@ msgstr "Modul „Rechtliches“ konnte nicht %{action} werden"
 msgid "Hide"
 msgstr "Ausblenden"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:400
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:402
 #, elixir-autogen, elixir-format
 msgid "Live Preview"
 msgstr "Live-Vorschau"
@@ -2359,9 +2360,9 @@ msgstr "Entziehen"
 msgid "Revoke all"
 msgstr "Alle entziehen"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:117
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:230
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:234
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:119
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:232
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:236
 #, elixir-autogen, elixir-format
 msgid "Set Default"
 msgstr "Als Standard festlegen"
@@ -3250,6 +3251,7 @@ msgid "Required field"
 msgstr "Pflichtfeld"
 
 #: lib/phoenix_kit_web/components/core/column_settings.ex:136
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1104
 #: lib/phoenix_kit_web/live/settings.html.heex:640
 #, elixir-autogen, elixir-format
 msgid "Reset"
@@ -3474,7 +3476,7 @@ msgid "Type an option and press Enter or click Add"
 msgstr "Geben Sie eine Option ein und drücken Sie die Eingabetaste oder klicken Sie auf „Hinzufügen“"
 
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:262
-#: lib/phoenix_kit_web/users/user_form.html.heex:760
+#: lib/phoenix_kit_web/users/user_form.html.heex:768
 #, elixir-autogen, elixir-format
 msgid "User"
 msgstr "Benutzer"
@@ -3860,7 +3862,7 @@ msgstr "Konto"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:210
 #: lib/phoenix_kit_web/users/registration.html.heex:119
-#: lib/phoenix_kit_web/users/user_form.html.heex:166
+#: lib/phoenix_kit_web/users/user_form.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "Account Type"
 msgstr "Kontotyp"
@@ -3946,7 +3948,7 @@ msgstr "Autorisierung fehlgeschlagen: %{reason}"
 msgid "Authorize access to your %{provider} account. This will open a sign-in page where you choose which account to connect."
 msgstr "Autorisieren Sie den Zugriff auf Ihr %{provider}-Konto. Dabei wird eine Anmeldeseite geöffnet, auf der Sie das zu verbindende Konto auswählen."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:111
+#: lib/phoenix_kit_web/live/components/user_settings.ex:825
 #, elixir-autogen, elixir-format
 msgid "Avatar updated successfully!"
 msgstr "Avatar erfolgreich aktualisiert!"
@@ -3986,12 +3988,12 @@ msgstr "Bucket-Aktionen"
 msgid "CRF 0-51, lower = higher quality. 18-28 recommended."
 msgstr "CRF 0–51, niedriger = bessere Qualität. 18–28 empfohlen."
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:862
+#: lib/phoenix_kit_web/users/user_form.html.heex:870
 #, elixir-autogen, elixir-format
 msgid "Cancel invitation"
 msgstr "Einladung zurückziehen"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:863
+#: lib/phoenix_kit_web/users/user_form.html.heex:871
 #, elixir-autogen, elixir-format
 msgid "Cancel this invitation?"
 msgstr "Diese Einladung zurückziehen?"
@@ -4049,7 +4051,7 @@ msgstr "Cloudflare-Endpunkt"
 msgid "Company info, tax settings, and bank details are shared across Legal, Billing, and Shop modules."
 msgstr "Firmeninformationen, Steuereinstellungen und Bankverbindung werden von den Modulen „Rechtliches“, „Abrechnung“ und „Shop“ gemeinsam genutzt."
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:199
+#: lib/phoenix_kit_web/users/user_form.html.heex:207
 #, elixir-autogen, elixir-format
 msgid "Company or organization name"
 msgstr "Firmen- oder Organisationsname"
@@ -4334,7 +4336,7 @@ msgstr "Mitglied konnte nicht entfernt werden"
 msgid "Failed to save"
 msgstr "Speichern fehlgeschlagen"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:542
+#: lib/phoenix_kit_web/live/components/user_settings.ex:589
 #, elixir-autogen, elixir-format
 msgid "Failed to save notification preferences."
 msgstr "Benachrichtigungseinstellungen konnten nicht gespeichert werden."
@@ -4344,7 +4346,7 @@ msgstr "Benachrichtigungseinstellungen konnten nicht gespeichert werden."
 msgid "Failed to send invitation"
 msgstr "Einladung konnte nicht gesendet werden"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:118
+#: lib/phoenix_kit_web/live/components/user_settings.ex:833
 #, elixir-autogen, elixir-format
 msgid "Failed to update avatar"
 msgstr "Avatar konnte nicht aktualisiert werden"
@@ -4467,7 +4469,7 @@ msgid "Integration deleted"
 msgstr "Integration gelöscht"
 
 #: lib/phoenix_kit/dashboard/admin_tabs.ex:308
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1476
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1692
 #: lib/phoenix_kit_web/live/settings/integration_form.html.heex:10
 #: lib/phoenix_kit_web/live/settings/integrations.ex:31
 #: lib/phoenix_kit_web/live/users/permissions_matrix.html.heex:75
@@ -4505,17 +4507,17 @@ msgstr "Einladung abgelehnt."
 msgid "Invitation sent to %{email}"
 msgstr "Einladung an %{email} gesendet"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:885
+#: lib/phoenix_kit_web/users/user_form.html.heex:893
 #, elixir-autogen, elixir-format
 msgid "Invite"
 msgstr "Einladen"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:881
+#: lib/phoenix_kit_web/users/user_form.html.heex:889
 #, elixir-autogen, elixir-format
 msgid "Invite by email..."
 msgstr "Per E-Mail einladen …"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:841
+#: lib/phoenix_kit_web/users/user_form.html.heex:849
 #, elixir-autogen, elixir-format
 msgid "Invited"
 msgstr "Eingeladen"
@@ -4662,12 +4664,12 @@ msgid "No integrations match your search."
 msgstr "Keine Integrationen entsprechen Ihrer Suche."
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:641
-#: lib/phoenix_kit_web/users/user_form.html.heex:752
+#: lib/phoenix_kit_web/users/user_form.html.heex:760
 #, elixir-autogen, elixir-format
 msgid "No members yet"
 msgstr "Noch keine Mitglieder"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:834
+#: lib/phoenix_kit_web/users/user_form.html.heex:842
 #, elixir-autogen, elixir-format
 msgid "No pending invitations"
 msgstr "Keine offenen Einladungen"
@@ -4693,13 +4695,13 @@ msgstr "Nicht verbunden"
 msgid "Not tested"
 msgstr "Nicht getestet"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:535
+#: lib/phoenix_kit_web/live/components/user_settings.ex:582
 #: lib/phoenix_kit_web/live/notifications/settings.ex:66
 #, elixir-autogen, elixir-format
 msgid "Notification preferences saved."
 msgstr "Benachrichtigungseinstellungen gespeichert."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1314
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1530
 #: lib/phoenix_kit_web/live/integrations/my_integration_form.ex:483
 #: lib/phoenix_kit_web/live/modules.html.heex:337
 #: lib/phoenix_kit_web/live/settings.html.heex:382
@@ -4735,14 +4737,14 @@ msgstr "Org."
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:228
 #: lib/phoenix_kit_web/live/users/users.html.heex:203
 #: lib/phoenix_kit_web/users/registration.html.heex:136
-#: lib/phoenix_kit_web/users/user_form.html.heex:187
-#: lib/phoenix_kit_web/users/user_form.html.heex:235
+#: lib/phoenix_kit_web/users/user_form.html.heex:195
+#: lib/phoenix_kit_web/users/user_form.html.heex:243
 #, elixir-autogen, elixir-format
 msgid "Organization"
 msgstr "Organisation"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:637
-#: lib/phoenix_kit_web/users/user_form.html.heex:716
+#: lib/phoenix_kit_web/users/user_form.html.heex:724
 #, elixir-autogen, elixir-format
 msgid "Organization Members"
 msgstr "Organisationsmitglieder"
@@ -4750,7 +4752,7 @@ msgstr "Organisationsmitglieder"
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:220
 #: lib/phoenix_kit_web/users/magic_link_registration.html.heex:58
 #: lib/phoenix_kit_web/users/registration.html.heex:148
-#: lib/phoenix_kit_web/users/user_form.html.heex:198
+#: lib/phoenix_kit_web/users/user_form.html.heex:206
 #, elixir-autogen, elixir-format
 msgid "Organization Name"
 msgstr "Organisationsname"
@@ -4760,7 +4762,7 @@ msgstr "Organisationsname"
 msgid "Pause"
 msgstr "Pause"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:827
+#: lib/phoenix_kit_web/users/user_form.html.heex:835
 #, elixir-autogen, elixir-format
 msgid "Pending Invitations"
 msgstr "Offene Einladungen"
@@ -4773,12 +4775,12 @@ msgstr "Benutzerspezifischer Posteingang, gesteuert vom Aktivitätsfeed"
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:161
 #: lib/phoenix_kit_web/live/users/users.html.heex:202
 #: lib/phoenix_kit_web/users/registration.html.heex:130
-#: lib/phoenix_kit_web/users/user_form.html.heex:177
+#: lib/phoenix_kit_web/users/user_form.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "Personal"
 msgstr "Privatperson"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1353
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1569
 #, elixir-autogen, elixir-format
 msgid "Pick which notification types you want to receive. Unchecked types are muted — activities still record in the audit log but no bell notification is created for you."
 msgstr "Wählen Sie, welche Benachrichtigungstypen Sie erhalten möchten. Nicht markierte Typen sind stummgeschaltet – Aktivitäten werden weiterhin im Prüfprotokoll erfasst, es wird jedoch keine Glockenbenachrichtigung für Sie erstellt."
@@ -4829,12 +4831,12 @@ msgid "Redundancy target: %{n} copies"
 msgstr "Redundanzziel: %{n} Kopien"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:704
-#: lib/phoenix_kit_web/users/user_form.html.heex:810
+#: lib/phoenix_kit_web/users/user_form.html.heex:818
 #, elixir-autogen, elixir-format
 msgid "Remove from organization"
 msgstr "Aus der Organisation entfernen"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:811
+#: lib/phoenix_kit_web/users/user_form.html.heex:819
 #, elixir-autogen, elixir-format
 msgid "Remove this member from the organization?"
 msgstr "Dieses Mitglied aus der Organisation entfernen?"
@@ -4859,7 +4861,7 @@ msgstr "Bucket speichern"
 msgid "Save Tax Settings"
 msgstr "Steuereinstellungen speichern"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1383
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1599
 #: lib/phoenix_kit_web/live/notifications/settings.ex:348
 #, elixir-autogen, elixir-format
 msgid "Save preferences"
@@ -4880,7 +4882,7 @@ msgstr "Integrationen suchen …"
 msgid "Security check failed. Please try connecting again."
 msgstr "Sicherheitsprüfung fehlgeschlagen. Bitte versuchen Sie die Verbindung erneut."
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:731
+#: lib/phoenix_kit_web/users/user_form.html.heex:739
 #, elixir-autogen, elixir-format
 msgid "Select a user to add..."
 msgstr "Benutzer zum Hinzufügen auswählen …"
@@ -5074,7 +5076,7 @@ msgstr "Unterrepliziert"
 msgid "Unknown provider"
 msgstr "Unbekannter Anbieter"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:753
+#: lib/phoenix_kit_web/users/user_form.html.heex:761
 #, elixir-autogen, elixir-format
 msgid "Use the dropdown above to add members"
 msgstr "Verwenden Sie das Auswahlfeld oben, um Mitglieder hinzuzufügen"
@@ -5627,7 +5629,6 @@ msgstr "Aufgaben"
 
 #: lib/phoenix_kit_web/live/modules.html.heex:77
 #: lib/phoenix_kit_web/live/modules/languages.ex:46
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr "Sprachen"
@@ -5808,112 +5809,112 @@ msgid_plural "%{count}d ago"
 msgstr[0] "vor %{count} T."
 msgstr[1] "vor %{count} T."
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:19
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:21
 #, elixir-autogen
 msgid "Summary"
 msgstr "Zusammenfassung"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:24
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:26
 #, elixir-autogen
 msgid "Languages Enabled"
 msgstr "Aktivierte Sprachen"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:28
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:147
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:30
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:149
 #, elixir-autogen
 msgid "Countries Covered"
 msgstr "Abgedeckte Länder"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:37
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:39
 #, elixir-autogen
 msgid "Enabled Languages"
 msgstr "Aktivierte Sprachen"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:134
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:136
 #, elixir-autogen
 msgid "Default language"
 msgstr "Standardsprache"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:164
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:166
 #, elixir-autogen
 msgid "Available Languages"
 msgstr "Verfügbare Sprachen"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:266
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:268
 #, elixir-autogen
 msgid "Language Configuration"
 msgstr "Sprachkonfiguration"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:312
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:314
 #, elixir-autogen
 msgid "Frontend Language Switcher"
 msgstr "Sprachumschalter im Frontend"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:322
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:324
 #, elixir-autogen
 msgid "Switcher Settings"
 msgstr "Einstellungen des Umschalters"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:327
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:329
 #, elixir-autogen
 msgid "Show Flags"
 msgstr "Flaggen anzeigen"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:341
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:343
 #, elixir-autogen
 msgid "Show Names"
 msgstr "Namen anzeigen"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:355
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:357
 #, elixir-autogen
 msgid "Native Names"
 msgstr "Eigenbezeichnungen"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:369
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:371
 #, elixir-autogen
 msgid "Go to Home"
 msgstr "Zur Startseite"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:383
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:385
 #, elixir-autogen
 msgid "Hide Current"
 msgstr "Aktuelle ausblenden"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:414
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:416
 #, elixir-autogen
 msgid "Generated Code"
 msgstr "Erzeugter Code"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:429
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:431
 #, elixir-autogen
 msgid "Implementation Notes"
 msgstr "Hinweise zur Implementierung"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:447
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:449
 #, elixir-autogen
 msgid "Enable and Configure Languages"
 msgstr "Sprachen aktivieren und konfigurieren"
 
 #: lib/phoenix_kit_web/components/media_browser.html.heex:623
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:47
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:49
 #, elixir-autogen
 msgid "Done"
 msgstr "Fertig"
 
 #: lib/phoenix_kit_web/components/core/reorder_modal.ex:65
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:49
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:51
 #, elixir-autogen
 msgid "Reorder"
 msgstr "Neu anordnen"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:54
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:219
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:56
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:221
 #: lib/phoenix_kit_web/live/users/users.html.heex:1206
 #, elixir-autogen
 msgid "Default"
 msgstr "Standard"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:155
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:157
 #, elixir-autogen
 msgid "No languages enabled yet."
 msgstr "Noch keine Sprachen aktiviert."
@@ -7271,12 +7272,12 @@ msgstr "Sortieren nach"
 msgid "Status:"
 msgstr "Status:"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:280
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:282
 #, elixir-autogen, elixir-format
 msgid "Controls how the primary language appears in URLs across the site — admin pages, public pages, sitemap, and redirects."
 msgstr "Legt fest, wie die Primärsprache in URLs auf der gesamten Website erscheint – Administrationsseiten, öffentliche Seiten, Sitemap und Weiterleitungen."
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:290
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:292
 #, elixir-autogen, elixir-format
 msgid "Default Language Without Prefix"
 msgstr "Standardsprache ohne Präfix"
@@ -7286,12 +7287,12 @@ msgstr "Standardsprache ohne Präfix"
 msgid "Failed to update URL behavior setting"
 msgstr "Einstellung konnte nicht aktualisiert werden"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:278
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:280
 #, elixir-autogen, elixir-format
 msgid "URL Behavior"
 msgstr "URL-Verhalten"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:293
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:295
 #, elixir-autogen, elixir-format
 msgid "When on, the primary language drops its locale segment in every URL (e.g. /admin/users instead of /en/admin/users, /blog/post instead of /en/blog/post). Other languages always keep their prefix."
 msgstr "Wenn aktiviert, entfällt bei der Primärsprache das Sprachsegment in jeder URL (z. B. /admin/users statt /en/admin/users, /blog/post statt /en/blog/post). Andere Sprachen behalten ihr Präfix immer."
@@ -10179,12 +10180,12 @@ msgstr "xAI"
 msgid "xAI requires a funded account before the API will return completions"
 msgstr "xAI erfordert ein aufgeladenes Konto, bevor die API Completions zurückgibt"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:618
+#: lib/phoenix_kit_web/live/components/user_settings.ex:665
 #, elixir-autogen, elixir-format
 msgid "Active now"
 msgstr "Jetzt aktiv"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1410
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1626
 #, elixir-autogen, elixir-format
 msgid "Devices currently signed in to your account. If you don't recognize one, sign it out."
 msgstr "Geräte, die derzeit bei Ihrem Konto angemeldet sind. Wenn Sie ein Gerät nicht erkennen, melden Sie es ab."
@@ -10199,58 +10200,58 @@ msgstr "Neue Anmeldung bei Ihrem Konto von %{details}."
 msgid "New sign-in to your account."
 msgstr "Neue Anmeldung bei Ihrem Konto."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1443
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1659
 #, elixir-autogen, elixir-format
 msgid "Sign out"
 msgstr "Abmelden"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1454
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1670
 #, elixir-autogen, elixir-format
 msgid "Sign out of all other sessions?"
 msgstr "Von allen anderen Sitzungen abmelden?"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1457
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1673
 #, elixir-autogen, elixir-format
 msgid "Sign out other sessions"
 msgstr "Andere Sitzungen abmelden"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:569
+#: lib/phoenix_kit_web/live/components/user_settings.ex:616
 #, elixir-autogen, elixir-format
 msgid "Signed out of all other sessions."
 msgstr "Von allen anderen Sitzungen abgemeldet."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:552
+#: lib/phoenix_kit_web/live/components/user_settings.ex:599
 #, elixir-autogen, elixir-format
 msgid "Signed out of that session."
 msgstr "Von dieser Sitzung abgemeldet."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:553
+#: lib/phoenix_kit_web/live/components/user_settings.ex:600
 #, elixir-autogen, elixir-format
 msgid "That session is no longer active."
 msgstr "Diese Sitzung ist nicht mehr aktiv."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1427
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1643
 #, elixir-autogen, elixir-format
 msgid "This device"
 msgstr "Dieses Gerät"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:610
+#: lib/phoenix_kit_web/live/components/user_settings.ex:657
 #: lib/phoenix_kit_web/live/users/sessions.ex:342
 #, elixir-autogen, elixir-format
 msgid "Unknown device"
 msgstr "Unbekanntes Gerät"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:632
+#: lib/phoenix_kit_web/live/components/user_settings.ex:679
 #, elixir-autogen, elixir-format
 msgid "Active %{date} at %{time}"
 msgstr "Aktiv am %{date} um %{time}"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:626
+#: lib/phoenix_kit_web/live/components/user_settings.ex:673
 #, elixir-autogen, elixir-format
 msgid "Active today at %{time}"
 msgstr "Heute um %{time} aktiv"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:629
+#: lib/phoenix_kit_web/live/components/user_settings.ex:676
 #, elixir-autogen, elixir-format
 msgid "Active yesterday at %{time}"
 msgstr "Gestern um %{time} aktiv"
@@ -12346,8 +12347,8 @@ msgstr "Verarbeitung auf dem Server…"
 msgid "Select Audio"
 msgstr "Audio auswählen"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:997
-#: lib/phoenix_kit_web/users/user_form.html.heex:1009
+#: lib/phoenix_kit_web/users/user_form.html.heex:1005
+#: lib/phoenix_kit_web/users/user_form.html.heex:1017
 #, elixir-autogen, elixir-format
 msgid "Select Avatar"
 msgstr "Avatar auswählen"
@@ -12911,7 +12912,7 @@ msgstr "Bitte geben Sie einen Namen ein"
 msgid "Too many registration attempts. Please try again later."
 msgstr "Zu viele Registrierungsversuche. Bitte versuchen Sie es später erneut."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1335
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1551
 #, elixir-autogen, elixir-format
 msgid "%{enabled} of %{total} notification types enabled"
 msgstr "%{enabled} von %{total} Benachrichtigungstypen aktiviert"
@@ -12951,12 +12952,12 @@ msgstr "Ein Schlüsselspeicher ist konfiguriert, sein Secret konnte jedoch nicht
 msgid "Back at it"
 msgstr "Weiter geht's"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:892
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1016
 #, elixir-autogen, elixir-format
 msgid "Browser detected: %{zone}"
 msgstr "Vom Browser erkannt: %{zone}"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:871
+#: lib/phoenix_kit_web/live/components/user_settings.ex:995
 #, elixir-autogen, elixir-format
 msgid "Check your timezone"
 msgstr "Prüfen Sie Ihre Zeitzone"
@@ -13036,7 +13037,7 @@ msgstr "Hallo wieder"
 msgid "Hey there"
 msgstr "Hallo"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1328
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1544
 #, elixir-autogen, elixir-format
 msgid "Manage Notifications"
 msgstr "Benachrichtigungen verwalten"
@@ -13111,12 +13112,12 @@ msgstr "Das Secret im Schlüsselspeicher (%{location}) wurde als kürzer als das
 msgid "The secret in the key store was rejected as too short"
 msgstr "Das Secret im Schlüsselspeicher wurde als zu kurz abgelehnt"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:492
+#: lib/phoenix_kit_web/live/components/user_settings.ex:539
 #, elixir-autogen, elixir-format
 msgid "Timezone set to %{zone}."
 msgstr "Zeitzone auf %{zone} gesetzt."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:885
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1009
 #, elixir-autogen, elixir-format
 msgid "Use %{zone}"
 msgstr "%{zone} verwenden"
@@ -13136,17 +13137,17 @@ msgstr "Wohin der Eintrag „Einstellungen“ im Benutzermenü führt. Leer = di
 msgid "Working late"
 msgstr "Noch spät im Einsatz"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:690
+#: lib/phoenix_kit_web/live/components/user_settings.ex:737
 #, elixir-autogen, elixir-format
 msgid "Your browser reports %{browser}, but this account is set to %{saved}. Times on this site will be shown in %{saved}."
 msgstr "Ihr Browser meldet %{browser}, dieses Konto ist jedoch auf %{saved} eingestellt. Zeiten auf dieser Website werden in %{saved} angezeigt."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:681
+#: lib/phoenix_kit_web/live/components/user_settings.ex:728
 #, elixir-autogen, elixir-format
 msgid "Your browser reports %{zone}. This account still stores a fixed UTC offset, which cannot follow daylight saving — it will drift by an hour at the next change."
 msgstr "Ihr Browser meldet %{zone}. Dieses Konto speichert weiterhin einen festen UTC-Versatz, der der Sommerzeit nicht folgen kann – bei der nächsten Umstellung weicht er um eine Stunde ab."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:674
+#: lib/phoenix_kit_web/live/components/user_settings.ex:721
 #, elixir-autogen, elixir-format
 msgid "Your browser reports %{zone}. You have not set a timezone, so times are shown using the site default."
 msgstr "Ihr Browser meldet %{zone}. Sie haben keine Zeitzone festgelegt, daher werden Zeiten mit der Standardzeitzone der Website angezeigt."
@@ -14246,12 +14247,12 @@ msgstr "Diese Funktion hat keinen Schalter."
 msgid "Site is closed to visitors"
 msgstr "Website ist für Besucher geschlossen"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1479
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1695
 #, elixir-autogen, elixir-format
 msgid "Manage Integrations"
 msgstr "Integrationen verwalten"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1487
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1703
 #, elixir-autogen, elixir-format
 msgid "No personal integrations yet."
 msgstr "Noch keine persönlichen Integrationen."
@@ -14262,7 +14263,7 @@ msgstr "Noch keine persönlichen Integrationen."
 msgid "You don't have access to Integrations."
 msgstr "Sie haben keinen Zugriff auf Integrationen."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1483
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1699
 #, elixir-autogen, elixir-format
 msgid "Your own API keys and bot connections — only you can see or use these."
 msgstr "Ihre eigenen API-Schlüssel und Bot-Verbindungen — nur Sie können diese sehen oder verwenden."
@@ -14420,3 +14421,38 @@ msgstr "Quellen"
 #, elixir-autogen, elixir-format
 msgid "Storage buckets and file processing"
 msgstr ""
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1051
+#, elixir-autogen, elixir-format
+msgid "Adjust Avatar Crop"
+msgstr "Avatar-Ausschnitt anpassen"
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:943
+#, elixir-autogen, elixir-format
+msgid "Adjust Crop"
+msgstr "Ausschnitt anpassen"
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:499
+#, elixir-autogen, elixir-format
+msgid "Avatar crop reset."
+msgstr "Avatar-Ausschnitt zurückgesetzt."
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:487
+#, elixir-autogen, elixir-format
+msgid "Avatar crop updated!"
+msgstr "Avatar-Ausschnitt aktualisiert!"
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:871
+#, elixir-autogen, elixir-format
+msgid "Failed to update avatar crop"
+msgstr "Avatar-Ausschnitt konnte nicht aktualisiert werden"
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1127
+#, elixir-autogen, elixir-format
+msgid "Save Crop"
+msgstr "Ausschnitt speichern"
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1088
+#, elixir-autogen, elixir-format
+msgid "Zoom"
+msgstr "Zoom"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -125,8 +125,8 @@ msgstr ""
 #: lib/phoenix_kit_web/users/forgot_password.html.heex:15
 #: lib/phoenix_kit_web/users/magic_link.html.heex:30
 #: lib/phoenix_kit_web/users/registration.html.heex:56
-#: lib/phoenix_kit_web/users/user_form.html.heex:761
-#: lib/phoenix_kit_web/users/user_form.html.heex:840
+#: lib/phoenix_kit_web/users/user_form.html.heex:769
+#: lib/phoenix_kit_web/users/user_form.html.heex:848
 #, elixir-autogen
 msgid "Email"
 msgstr ""
@@ -187,7 +187,7 @@ msgstr ""
 
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:259
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:264
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1399
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1615
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:18
 #, elixir-autogen
 msgid "Active Sessions"
@@ -378,7 +378,7 @@ msgstr ""
 #: lib/phoenix_kit_web/live/users/users.ex:1200
 #: lib/phoenix_kit_web/live/users/users.html.heex:248
 #: lib/phoenix_kit_web/live/users/users.html.heex:573
-#: lib/phoenix_kit_web/users/user_form.html.heex:786
+#: lib/phoenix_kit_web/users/user_form.html.heex:794
 #, elixir-autogen
 msgid "Active"
 msgstr ""
@@ -398,7 +398,7 @@ msgstr ""
 #: lib/phoenix_kit_web/live/modules.html.heex:284
 #: lib/phoenix_kit_web/live/modules.html.heex:349
 #: lib/phoenix_kit_web/live/modules.html.heex:405
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:59
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:61
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:49
 #: lib/phoenix_kit_web/live/settings/send_profile_form.html.heex:90
 #: lib/phoenix_kit_web/live/settings/users.html.heex:465
@@ -439,7 +439,7 @@ msgstr ""
 msgid "%{language} (Published)"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:403
+#: lib/phoenix_kit_web/live/components/user_settings.ex:384
 #, elixir-autogen, elixir-format
 msgid "%{provider} account disconnected successfully"
 msgstr ""
@@ -459,7 +459,7 @@ msgstr ""
 msgid "123 Business Street"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:250
+#: lib/phoenix_kit_web/live/components/user_settings.ex:231
 #, elixir-autogen, elixir-format
 msgid "A link to confirm your email change has been sent to the new address."
 msgstr ""
@@ -506,8 +506,8 @@ msgstr ""
 #: lib/phoenix_kit_web/live/users/roles.html.heex:163
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:269
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:651
-#: lib/phoenix_kit_web/users/user_form.html.heex:763
-#: lib/phoenix_kit_web/users/user_form.html.heex:843
+#: lib/phoenix_kit_web/users/user_form.html.heex:771
+#: lib/phoenix_kit_web/users/user_form.html.heex:851
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
@@ -516,7 +516,7 @@ msgstr ""
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:610
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:314
 #: lib/phoenix_kit_web/live/settings/users.html.heex:795
-#: lib/phoenix_kit_web/users/user_form.html.heex:742
+#: lib/phoenix_kit_web/users/user_form.html.heex:750
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr ""
@@ -646,7 +646,8 @@ msgstr ""
 #: lib/phoenix_kit_web/components/media_browser.html.heex:2440
 #: lib/phoenix_kit_web/components/user_dashboard_nav.ex:317
 #: lib/phoenix_kit_web/live/components/media_selector_modal.html.heex:65
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1327
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1113
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1543
 #: lib/phoenix_kit_web/live/notifications/settings.ex:434
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:493
 #: lib/phoenix_kit_web/live/settings/send_profile_form.html.heex:152
@@ -686,12 +687,12 @@ msgstr ""
 msgid "Cannot delete your own account"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:437
+#: lib/phoenix_kit_web/live/components/user_settings.ex:418
 #, elixir-autogen, elixir-format
 msgid "Cannot disconnect %{provider}. Please ensure you have at least one sign-in method available."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:432
+#: lib/phoenix_kit_web/live/components/user_settings.ex:413
 #, elixir-autogen, elixir-format
 msgid "Cannot disconnect %{provider}. This is your only sign-in method. Please set a password or connect another provider first."
 msgstr ""
@@ -1098,7 +1099,7 @@ msgstr ""
 msgid "Failed to delete user"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:423
+#: lib/phoenix_kit_web/live/components/user_settings.ex:404
 #, elixir-autogen, elixir-format
 msgid "Failed to disconnect provider. Please try again."
 msgstr ""
@@ -1237,7 +1238,7 @@ msgstr ""
 #: lib/phoenix_kit_web/live/users/users.ex:1200
 #: lib/phoenix_kit_web/live/users/users.html.heex:249
 #: lib/phoenix_kit_web/live/users/users.html.heex:577
-#: lib/phoenix_kit_web/users/user_form.html.heex:790
+#: lib/phoenix_kit_web/users/user_form.html.heex:798
 #, elixir-autogen, elixir-format
 msgid "Inactive"
 msgstr ""
@@ -1480,7 +1481,7 @@ msgstr ""
 msgid "Only the Owner can edit Admin permissions"
 msgstr ""
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:236
+#: lib/phoenix_kit_web/users/user_form.html.heex:244
 #, elixir-autogen, elixir-format
 msgid "Optional"
 msgstr ""
@@ -1542,7 +1543,7 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:301
+#: lib/phoenix_kit_web/live/components/user_settings.ex:282
 #, elixir-autogen, elixir-format
 msgid "Password changed successfully."
 msgstr ""
@@ -1625,7 +1626,7 @@ msgstr ""
 msgid "Profile"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:362
+#: lib/phoenix_kit_web/live/components/user_settings.ex:343
 #, elixir-autogen, elixir-format
 msgid "Profile updated successfully"
 msgstr ""
@@ -1641,7 +1642,7 @@ msgstr ""
 msgid "Protected core roles"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:413
+#: lib/phoenix_kit_web/live/components/user_settings.ex:394
 #, elixir-autogen, elixir-format
 msgid "Provider not found"
 msgstr ""
@@ -1945,7 +1946,7 @@ msgstr ""
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:294
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:650
 #: lib/phoenix_kit_web/live/users/users.html.heex:263
-#: lib/phoenix_kit_web/users/user_form.html.heex:762
+#: lib/phoenix_kit_web/users/user_form.html.heex:770
 #, elixir-autogen, elixir-format
 msgid "Status"
 msgstr ""
@@ -2140,7 +2141,7 @@ msgstr ""
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:695
 #: lib/phoenix_kit_web/live/users/users.html.heex:667
 #: lib/phoenix_kit_web/live/users/users.html.heex:794
-#: lib/phoenix_kit_web/users/user_form.html.heex:801
+#: lib/phoenix_kit_web/users/user_form.html.heex:809
 #, elixir-autogen, elixir-format
 msgid "View"
 msgstr ""
@@ -2272,7 +2273,7 @@ msgstr ""
 #: lib/modules/storage/web/dimensions.html.heex:466
 #: lib/modules/storage/web/settings.html.heex:221
 #: lib/modules/storage/web/settings.html.heex:257
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:126
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:128
 #: lib/phoenix_kit_web/live/settings/users.html.heex:563
 #: lib/phoenix_kit_web/live/settings/users.html.heex:609
 #, elixir-autogen, elixir-format
@@ -2298,7 +2299,7 @@ msgstr ""
 
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:166
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:268
-#: lib/phoenix_kit_web/users/user_form.html.heex:842
+#: lib/phoenix_kit_web/users/user_form.html.heex:850
 #, elixir-autogen, elixir-format
 msgid "Expires"
 msgstr ""
@@ -2314,7 +2315,7 @@ msgstr ""
 msgid "Hide"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:400
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:402
 #, elixir-autogen, elixir-format
 msgid "Live Preview"
 msgstr ""
@@ -2359,9 +2360,9 @@ msgstr ""
 msgid "Revoke all"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:117
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:230
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:234
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:119
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:232
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:236
 #, elixir-autogen, elixir-format
 msgid "Set Default"
 msgstr ""
@@ -3250,6 +3251,7 @@ msgid "Required field"
 msgstr ""
 
 #: lib/phoenix_kit_web/components/core/column_settings.ex:136
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1104
 #: lib/phoenix_kit_web/live/settings.html.heex:640
 #, elixir-autogen, elixir-format
 msgid "Reset"
@@ -3474,7 +3476,7 @@ msgid "Type an option and press Enter or click Add"
 msgstr ""
 
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:262
-#: lib/phoenix_kit_web/users/user_form.html.heex:760
+#: lib/phoenix_kit_web/users/user_form.html.heex:768
 #, elixir-autogen, elixir-format
 msgid "User"
 msgstr ""
@@ -3860,7 +3862,7 @@ msgstr ""
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:210
 #: lib/phoenix_kit_web/users/registration.html.heex:119
-#: lib/phoenix_kit_web/users/user_form.html.heex:166
+#: lib/phoenix_kit_web/users/user_form.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "Account Type"
 msgstr ""
@@ -3946,7 +3948,7 @@ msgstr ""
 msgid "Authorize access to your %{provider} account. This will open a sign-in page where you choose which account to connect."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:111
+#: lib/phoenix_kit_web/live/components/user_settings.ex:825
 #, elixir-autogen, elixir-format
 msgid "Avatar updated successfully!"
 msgstr ""
@@ -3986,12 +3988,12 @@ msgstr ""
 msgid "CRF 0-51, lower = higher quality. 18-28 recommended."
 msgstr ""
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:862
+#: lib/phoenix_kit_web/users/user_form.html.heex:870
 #, elixir-autogen, elixir-format
 msgid "Cancel invitation"
 msgstr ""
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:863
+#: lib/phoenix_kit_web/users/user_form.html.heex:871
 #, elixir-autogen, elixir-format
 msgid "Cancel this invitation?"
 msgstr ""
@@ -4049,7 +4051,7 @@ msgstr ""
 msgid "Company info, tax settings, and bank details are shared across Legal, Billing, and Shop modules."
 msgstr ""
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:199
+#: lib/phoenix_kit_web/users/user_form.html.heex:207
 #, elixir-autogen, elixir-format
 msgid "Company or organization name"
 msgstr ""
@@ -4334,7 +4336,7 @@ msgstr ""
 msgid "Failed to save"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:542
+#: lib/phoenix_kit_web/live/components/user_settings.ex:589
 #, elixir-autogen, elixir-format
 msgid "Failed to save notification preferences."
 msgstr ""
@@ -4344,7 +4346,7 @@ msgstr ""
 msgid "Failed to send invitation"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:118
+#: lib/phoenix_kit_web/live/components/user_settings.ex:833
 #, elixir-autogen, elixir-format
 msgid "Failed to update avatar"
 msgstr ""
@@ -4467,7 +4469,7 @@ msgid "Integration deleted"
 msgstr ""
 
 #: lib/phoenix_kit/dashboard/admin_tabs.ex:308
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1476
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1692
 #: lib/phoenix_kit_web/live/settings/integration_form.html.heex:10
 #: lib/phoenix_kit_web/live/settings/integrations.ex:31
 #: lib/phoenix_kit_web/live/users/permissions_matrix.html.heex:75
@@ -4505,17 +4507,17 @@ msgstr ""
 msgid "Invitation sent to %{email}"
 msgstr ""
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:885
+#: lib/phoenix_kit_web/users/user_form.html.heex:893
 #, elixir-autogen, elixir-format
 msgid "Invite"
 msgstr ""
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:881
+#: lib/phoenix_kit_web/users/user_form.html.heex:889
 #, elixir-autogen, elixir-format
 msgid "Invite by email..."
 msgstr ""
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:841
+#: lib/phoenix_kit_web/users/user_form.html.heex:849
 #, elixir-autogen, elixir-format
 msgid "Invited"
 msgstr ""
@@ -4662,12 +4664,12 @@ msgid "No integrations match your search."
 msgstr ""
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:641
-#: lib/phoenix_kit_web/users/user_form.html.heex:752
+#: lib/phoenix_kit_web/users/user_form.html.heex:760
 #, elixir-autogen, elixir-format
 msgid "No members yet"
 msgstr ""
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:834
+#: lib/phoenix_kit_web/users/user_form.html.heex:842
 #, elixir-autogen, elixir-format
 msgid "No pending invitations"
 msgstr ""
@@ -4693,13 +4695,13 @@ msgstr ""
 msgid "Not tested"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:535
+#: lib/phoenix_kit_web/live/components/user_settings.ex:582
 #: lib/phoenix_kit_web/live/notifications/settings.ex:66
 #, elixir-autogen, elixir-format
 msgid "Notification preferences saved."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1314
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1530
 #: lib/phoenix_kit_web/live/integrations/my_integration_form.ex:483
 #: lib/phoenix_kit_web/live/modules.html.heex:337
 #: lib/phoenix_kit_web/live/settings.html.heex:382
@@ -4735,14 +4737,14 @@ msgstr ""
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:228
 #: lib/phoenix_kit_web/live/users/users.html.heex:203
 #: lib/phoenix_kit_web/users/registration.html.heex:136
-#: lib/phoenix_kit_web/users/user_form.html.heex:187
-#: lib/phoenix_kit_web/users/user_form.html.heex:235
+#: lib/phoenix_kit_web/users/user_form.html.heex:195
+#: lib/phoenix_kit_web/users/user_form.html.heex:243
 #, elixir-autogen, elixir-format
 msgid "Organization"
 msgstr ""
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:637
-#: lib/phoenix_kit_web/users/user_form.html.heex:716
+#: lib/phoenix_kit_web/users/user_form.html.heex:724
 #, elixir-autogen, elixir-format
 msgid "Organization Members"
 msgstr ""
@@ -4750,7 +4752,7 @@ msgstr ""
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:220
 #: lib/phoenix_kit_web/users/magic_link_registration.html.heex:58
 #: lib/phoenix_kit_web/users/registration.html.heex:148
-#: lib/phoenix_kit_web/users/user_form.html.heex:198
+#: lib/phoenix_kit_web/users/user_form.html.heex:206
 #, elixir-autogen, elixir-format
 msgid "Organization Name"
 msgstr ""
@@ -4760,7 +4762,7 @@ msgstr ""
 msgid "Pause"
 msgstr ""
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:827
+#: lib/phoenix_kit_web/users/user_form.html.heex:835
 #, elixir-autogen, elixir-format
 msgid "Pending Invitations"
 msgstr ""
@@ -4773,12 +4775,12 @@ msgstr ""
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:161
 #: lib/phoenix_kit_web/live/users/users.html.heex:202
 #: lib/phoenix_kit_web/users/registration.html.heex:130
-#: lib/phoenix_kit_web/users/user_form.html.heex:177
+#: lib/phoenix_kit_web/users/user_form.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "Personal"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1353
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1569
 #, elixir-autogen, elixir-format
 msgid "Pick which notification types you want to receive. Unchecked types are muted — activities still record in the audit log but no bell notification is created for you."
 msgstr ""
@@ -4829,12 +4831,12 @@ msgid "Redundancy target: %{n} copies"
 msgstr ""
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:704
-#: lib/phoenix_kit_web/users/user_form.html.heex:810
+#: lib/phoenix_kit_web/users/user_form.html.heex:818
 #, elixir-autogen, elixir-format
 msgid "Remove from organization"
 msgstr ""
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:811
+#: lib/phoenix_kit_web/users/user_form.html.heex:819
 #, elixir-autogen, elixir-format
 msgid "Remove this member from the organization?"
 msgstr ""
@@ -4859,7 +4861,7 @@ msgstr ""
 msgid "Save Tax Settings"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1383
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1599
 #: lib/phoenix_kit_web/live/notifications/settings.ex:348
 #, elixir-autogen, elixir-format
 msgid "Save preferences"
@@ -4880,7 +4882,7 @@ msgstr ""
 msgid "Security check failed. Please try connecting again."
 msgstr ""
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:731
+#: lib/phoenix_kit_web/users/user_form.html.heex:739
 #, elixir-autogen, elixir-format
 msgid "Select a user to add..."
 msgstr ""
@@ -5074,7 +5076,7 @@ msgstr ""
 msgid "Unknown provider"
 msgstr ""
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:753
+#: lib/phoenix_kit_web/users/user_form.html.heex:761
 #, elixir-autogen, elixir-format
 msgid "Use the dropdown above to add members"
 msgstr ""
@@ -5627,7 +5629,6 @@ msgstr ""
 
 #: lib/phoenix_kit_web/live/modules.html.heex:77
 #: lib/phoenix_kit_web/live/modules/languages.ex:46
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr ""
@@ -5808,112 +5809,112 @@ msgid_plural "%{count}d ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:19
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:21
 #, elixir-autogen
 msgid "Summary"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:24
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:26
 #, elixir-autogen
 msgid "Languages Enabled"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:28
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:147
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:30
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:149
 #, elixir-autogen
 msgid "Countries Covered"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:37
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:39
 #, elixir-autogen
 msgid "Enabled Languages"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:134
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:136
 #, elixir-autogen
 msgid "Default language"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:164
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:166
 #, elixir-autogen
 msgid "Available Languages"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:266
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:268
 #, elixir-autogen
 msgid "Language Configuration"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:312
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:314
 #, elixir-autogen
 msgid "Frontend Language Switcher"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:322
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:324
 #, elixir-autogen
 msgid "Switcher Settings"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:327
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:329
 #, elixir-autogen
 msgid "Show Flags"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:341
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:343
 #, elixir-autogen
 msgid "Show Names"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:355
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:357
 #, elixir-autogen
 msgid "Native Names"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:369
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:371
 #, elixir-autogen
 msgid "Go to Home"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:383
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:385
 #, elixir-autogen
 msgid "Hide Current"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:414
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:416
 #, elixir-autogen
 msgid "Generated Code"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:429
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:431
 #, elixir-autogen
 msgid "Implementation Notes"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:447
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:449
 #, elixir-autogen
 msgid "Enable and Configure Languages"
 msgstr ""
 
 #: lib/phoenix_kit_web/components/media_browser.html.heex:623
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:47
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:49
 #, elixir-autogen
 msgid "Done"
 msgstr ""
 
 #: lib/phoenix_kit_web/components/core/reorder_modal.ex:65
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:49
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:51
 #, elixir-autogen
 msgid "Reorder"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:54
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:219
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:56
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:221
 #: lib/phoenix_kit_web/live/users/users.html.heex:1206
 #, elixir-autogen
 msgid "Default"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:155
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:157
 #, elixir-autogen
 msgid "No languages enabled yet."
 msgstr ""
@@ -7271,12 +7272,12 @@ msgstr ""
 msgid "Status:"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:280
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:282
 #, elixir-autogen, elixir-format
 msgid "Controls how the primary language appears in URLs across the site — admin pages, public pages, sitemap, and redirects."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:290
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:292
 #, elixir-autogen, elixir-format
 msgid "Default Language Without Prefix"
 msgstr ""
@@ -7286,12 +7287,12 @@ msgstr ""
 msgid "Failed to update URL behavior setting"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:278
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:280
 #, elixir-autogen, elixir-format
 msgid "URL Behavior"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:293
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:295
 #, elixir-autogen, elixir-format
 msgid "When on, the primary language drops its locale segment in every URL (e.g. /admin/users instead of /en/admin/users, /blog/post instead of /en/blog/post). Other languages always keep their prefix."
 msgstr ""
@@ -10179,12 +10180,12 @@ msgstr ""
 msgid "xAI requires a funded account before the API will return completions"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:618
+#: lib/phoenix_kit_web/live/components/user_settings.ex:665
 #, elixir-autogen, elixir-format
 msgid "Active now"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1410
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1626
 #, elixir-autogen, elixir-format
 msgid "Devices currently signed in to your account. If you don't recognize one, sign it out."
 msgstr ""
@@ -10199,58 +10200,58 @@ msgstr ""
 msgid "New sign-in to your account."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1443
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1659
 #, elixir-autogen, elixir-format
 msgid "Sign out"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1454
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1670
 #, elixir-autogen, elixir-format
 msgid "Sign out of all other sessions?"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1457
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1673
 #, elixir-autogen, elixir-format
 msgid "Sign out other sessions"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:569
+#: lib/phoenix_kit_web/live/components/user_settings.ex:616
 #, elixir-autogen, elixir-format
 msgid "Signed out of all other sessions."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:552
+#: lib/phoenix_kit_web/live/components/user_settings.ex:599
 #, elixir-autogen, elixir-format
 msgid "Signed out of that session."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:553
+#: lib/phoenix_kit_web/live/components/user_settings.ex:600
 #, elixir-autogen, elixir-format
 msgid "That session is no longer active."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1427
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1643
 #, elixir-autogen, elixir-format
 msgid "This device"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:610
+#: lib/phoenix_kit_web/live/components/user_settings.ex:657
 #: lib/phoenix_kit_web/live/users/sessions.ex:342
 #, elixir-autogen, elixir-format
 msgid "Unknown device"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:632
+#: lib/phoenix_kit_web/live/components/user_settings.ex:679
 #, elixir-autogen, elixir-format
 msgid "Active %{date} at %{time}"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:626
+#: lib/phoenix_kit_web/live/components/user_settings.ex:673
 #, elixir-autogen, elixir-format
 msgid "Active today at %{time}"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:629
+#: lib/phoenix_kit_web/live/components/user_settings.ex:676
 #, elixir-autogen, elixir-format
 msgid "Active yesterday at %{time}"
 msgstr ""
@@ -12346,8 +12347,8 @@ msgstr ""
 msgid "Select Audio"
 msgstr ""
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:997
-#: lib/phoenix_kit_web/users/user_form.html.heex:1009
+#: lib/phoenix_kit_web/users/user_form.html.heex:1005
+#: lib/phoenix_kit_web/users/user_form.html.heex:1017
 #, elixir-autogen, elixir-format
 msgid "Select Avatar"
 msgstr ""
@@ -12911,7 +12912,7 @@ msgstr ""
 msgid "Too many registration attempts. Please try again later."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1335
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1551
 #, elixir-autogen, elixir-format
 msgid "%{enabled} of %{total} notification types enabled"
 msgstr ""
@@ -12951,12 +12952,12 @@ msgstr ""
 msgid "Back at it"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:892
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1016
 #, elixir-autogen, elixir-format
 msgid "Browser detected: %{zone}"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:871
+#: lib/phoenix_kit_web/live/components/user_settings.ex:995
 #, elixir-autogen, elixir-format
 msgid "Check your timezone"
 msgstr ""
@@ -13036,7 +13037,7 @@ msgstr ""
 msgid "Hey there"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1328
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1544
 #, elixir-autogen, elixir-format
 msgid "Manage Notifications"
 msgstr ""
@@ -13111,12 +13112,12 @@ msgstr ""
 msgid "The secret in the key store was rejected as too short"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:492
+#: lib/phoenix_kit_web/live/components/user_settings.ex:539
 #, elixir-autogen, elixir-format
 msgid "Timezone set to %{zone}."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:885
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1009
 #, elixir-autogen, elixir-format
 msgid "Use %{zone}"
 msgstr ""
@@ -13136,17 +13137,17 @@ msgstr ""
 msgid "Working late"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:690
+#: lib/phoenix_kit_web/live/components/user_settings.ex:737
 #, elixir-autogen, elixir-format
 msgid "Your browser reports %{browser}, but this account is set to %{saved}. Times on this site will be shown in %{saved}."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:681
+#: lib/phoenix_kit_web/live/components/user_settings.ex:728
 #, elixir-autogen, elixir-format
 msgid "Your browser reports %{zone}. This account still stores a fixed UTC offset, which cannot follow daylight saving — it will drift by an hour at the next change."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:674
+#: lib/phoenix_kit_web/live/components/user_settings.ex:721
 #, elixir-autogen, elixir-format
 msgid "Your browser reports %{zone}. You have not set a timezone, so times are shown using the site default."
 msgstr ""
@@ -14246,12 +14247,12 @@ msgstr ""
 msgid "Site is closed to visitors"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1479
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1695
 #, elixir-autogen, elixir-format
 msgid "Manage Integrations"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1487
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1703
 #, elixir-autogen, elixir-format
 msgid "No personal integrations yet."
 msgstr ""
@@ -14262,7 +14263,7 @@ msgstr ""
 msgid "You don't have access to Integrations."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1483
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1699
 #, elixir-autogen, elixir-format
 msgid "Your own API keys and bot connections — only you can see or use these."
 msgstr ""
@@ -14419,4 +14420,39 @@ msgstr ""
 #: lib/modules/storage/web/settings.html.heex:7
 #, elixir-autogen, elixir-format
 msgid "Storage buckets and file processing"
+msgstr ""
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1051
+#, elixir-autogen, elixir-format
+msgid "Adjust Avatar Crop"
+msgstr ""
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:943
+#, elixir-autogen, elixir-format
+msgid "Adjust Crop"
+msgstr ""
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:499
+#, elixir-autogen, elixir-format
+msgid "Avatar crop reset."
+msgstr ""
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:487
+#, elixir-autogen, elixir-format
+msgid "Avatar crop updated!"
+msgstr ""
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:871
+#, elixir-autogen, elixir-format
+msgid "Failed to update avatar crop"
+msgstr ""
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1127
+#, elixir-autogen, elixir-format
+msgid "Save Crop"
+msgstr ""
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1088
+#, elixir-autogen, elixir-format
+msgid "Zoom"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -127,8 +127,8 @@ msgstr ""
 #: lib/phoenix_kit_web/users/forgot_password.html.heex:15
 #: lib/phoenix_kit_web/users/magic_link.html.heex:30
 #: lib/phoenix_kit_web/users/registration.html.heex:56
-#: lib/phoenix_kit_web/users/user_form.html.heex:761
-#: lib/phoenix_kit_web/users/user_form.html.heex:840
+#: lib/phoenix_kit_web/users/user_form.html.heex:769
+#: lib/phoenix_kit_web/users/user_form.html.heex:848
 #, elixir-autogen
 msgid "Email"
 msgstr ""
@@ -188,7 +188,7 @@ msgstr ""
 
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:259
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:264
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1399
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1615
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:18
 #, elixir-autogen
 msgid "Active Sessions"
@@ -379,7 +379,7 @@ msgstr ""
 #: lib/phoenix_kit_web/live/users/users.ex:1200
 #: lib/phoenix_kit_web/live/users/users.html.heex:248
 #: lib/phoenix_kit_web/live/users/users.html.heex:573
-#: lib/phoenix_kit_web/users/user_form.html.heex:786
+#: lib/phoenix_kit_web/users/user_form.html.heex:794
 #, elixir-autogen
 msgid "Active"
 msgstr ""
@@ -399,7 +399,7 @@ msgstr ""
 #: lib/phoenix_kit_web/live/modules.html.heex:284
 #: lib/phoenix_kit_web/live/modules.html.heex:349
 #: lib/phoenix_kit_web/live/modules.html.heex:405
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:59
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:61
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:49
 #: lib/phoenix_kit_web/live/settings/send_profile_form.html.heex:90
 #: lib/phoenix_kit_web/live/settings/users.html.heex:465
@@ -439,7 +439,7 @@ msgstr ""
 msgid "%{language} (Published)"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:403
+#: lib/phoenix_kit_web/live/components/user_settings.ex:384
 #, elixir-autogen, elixir-format
 msgid "%{provider} account disconnected successfully"
 msgstr ""
@@ -459,7 +459,7 @@ msgstr ""
 msgid "123 Business Street"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:250
+#: lib/phoenix_kit_web/live/components/user_settings.ex:231
 #, elixir-autogen, elixir-format
 msgid "A link to confirm your email change has been sent to the new address."
 msgstr ""
@@ -506,8 +506,8 @@ msgstr ""
 #: lib/phoenix_kit_web/live/users/roles.html.heex:163
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:269
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:651
-#: lib/phoenix_kit_web/users/user_form.html.heex:763
-#: lib/phoenix_kit_web/users/user_form.html.heex:843
+#: lib/phoenix_kit_web/users/user_form.html.heex:771
+#: lib/phoenix_kit_web/users/user_form.html.heex:851
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
@@ -516,7 +516,7 @@ msgstr ""
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:610
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:314
 #: lib/phoenix_kit_web/live/settings/users.html.heex:795
-#: lib/phoenix_kit_web/users/user_form.html.heex:742
+#: lib/phoenix_kit_web/users/user_form.html.heex:750
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr ""
@@ -646,7 +646,8 @@ msgstr ""
 #: lib/phoenix_kit_web/components/media_browser.html.heex:2440
 #: lib/phoenix_kit_web/components/user_dashboard_nav.ex:317
 #: lib/phoenix_kit_web/live/components/media_selector_modal.html.heex:65
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1327
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1113
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1543
 #: lib/phoenix_kit_web/live/notifications/settings.ex:434
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:493
 #: lib/phoenix_kit_web/live/settings/send_profile_form.html.heex:152
@@ -686,12 +687,12 @@ msgstr ""
 msgid "Cannot delete your own account"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:437
+#: lib/phoenix_kit_web/live/components/user_settings.ex:418
 #, elixir-autogen, elixir-format
 msgid "Cannot disconnect %{provider}. Please ensure you have at least one sign-in method available."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:432
+#: lib/phoenix_kit_web/live/components/user_settings.ex:413
 #, elixir-autogen, elixir-format
 msgid "Cannot disconnect %{provider}. This is your only sign-in method. Please set a password or connect another provider first."
 msgstr ""
@@ -1098,7 +1099,7 @@ msgstr ""
 msgid "Failed to delete user"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:423
+#: lib/phoenix_kit_web/live/components/user_settings.ex:404
 #, elixir-autogen, elixir-format
 msgid "Failed to disconnect provider. Please try again."
 msgstr ""
@@ -1237,7 +1238,7 @@ msgstr ""
 #: lib/phoenix_kit_web/live/users/users.ex:1200
 #: lib/phoenix_kit_web/live/users/users.html.heex:249
 #: lib/phoenix_kit_web/live/users/users.html.heex:577
-#: lib/phoenix_kit_web/users/user_form.html.heex:790
+#: lib/phoenix_kit_web/users/user_form.html.heex:798
 #, elixir-autogen, elixir-format
 msgid "Inactive"
 msgstr ""
@@ -1480,7 +1481,7 @@ msgstr ""
 msgid "Only the Owner can edit Admin permissions"
 msgstr ""
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:236
+#: lib/phoenix_kit_web/users/user_form.html.heex:244
 #, elixir-autogen, elixir-format
 msgid "Optional"
 msgstr ""
@@ -1542,7 +1543,7 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:301
+#: lib/phoenix_kit_web/live/components/user_settings.ex:282
 #, elixir-autogen, elixir-format
 msgid "Password changed successfully."
 msgstr ""
@@ -1625,7 +1626,7 @@ msgstr ""
 msgid "Profile"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:362
+#: lib/phoenix_kit_web/live/components/user_settings.ex:343
 #, elixir-autogen, elixir-format
 msgid "Profile updated successfully"
 msgstr ""
@@ -1641,7 +1642,7 @@ msgstr ""
 msgid "Protected core roles"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:413
+#: lib/phoenix_kit_web/live/components/user_settings.ex:394
 #, elixir-autogen, elixir-format
 msgid "Provider not found"
 msgstr ""
@@ -1945,7 +1946,7 @@ msgstr ""
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:294
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:650
 #: lib/phoenix_kit_web/live/users/users.html.heex:263
-#: lib/phoenix_kit_web/users/user_form.html.heex:762
+#: lib/phoenix_kit_web/users/user_form.html.heex:770
 #, elixir-autogen, elixir-format
 msgid "Status"
 msgstr ""
@@ -2140,7 +2141,7 @@ msgstr ""
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:695
 #: lib/phoenix_kit_web/live/users/users.html.heex:667
 #: lib/phoenix_kit_web/live/users/users.html.heex:794
-#: lib/phoenix_kit_web/users/user_form.html.heex:801
+#: lib/phoenix_kit_web/users/user_form.html.heex:809
 #, elixir-autogen, elixir-format
 msgid "View"
 msgstr ""
@@ -2272,7 +2273,7 @@ msgstr ""
 #: lib/modules/storage/web/dimensions.html.heex:466
 #: lib/modules/storage/web/settings.html.heex:221
 #: lib/modules/storage/web/settings.html.heex:257
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:126
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:128
 #: lib/phoenix_kit_web/live/settings/users.html.heex:563
 #: lib/phoenix_kit_web/live/settings/users.html.heex:609
 #, elixir-autogen, elixir-format
@@ -2298,7 +2299,7 @@ msgstr ""
 
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:166
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:268
-#: lib/phoenix_kit_web/users/user_form.html.heex:842
+#: lib/phoenix_kit_web/users/user_form.html.heex:850
 #, elixir-autogen, elixir-format
 msgid "Expires"
 msgstr ""
@@ -2314,7 +2315,7 @@ msgstr ""
 msgid "Hide"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:400
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:402
 #, elixir-autogen, elixir-format
 msgid "Live Preview"
 msgstr ""
@@ -2359,9 +2360,9 @@ msgstr ""
 msgid "Revoke all"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:117
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:230
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:234
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:119
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:232
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:236
 #, elixir-autogen, elixir-format
 msgid "Set Default"
 msgstr ""
@@ -3250,6 +3251,7 @@ msgid "Required field"
 msgstr ""
 
 #: lib/phoenix_kit_web/components/core/column_settings.ex:136
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1104
 #: lib/phoenix_kit_web/live/settings.html.heex:640
 #, elixir-autogen, elixir-format
 msgid "Reset"
@@ -3474,7 +3476,7 @@ msgid "Type an option and press Enter or click Add"
 msgstr ""
 
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:262
-#: lib/phoenix_kit_web/users/user_form.html.heex:760
+#: lib/phoenix_kit_web/users/user_form.html.heex:768
 #, elixir-autogen, elixir-format
 msgid "User"
 msgstr ""
@@ -3860,7 +3862,7 @@ msgstr ""
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:210
 #: lib/phoenix_kit_web/users/registration.html.heex:119
-#: lib/phoenix_kit_web/users/user_form.html.heex:166
+#: lib/phoenix_kit_web/users/user_form.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "Account Type"
 msgstr ""
@@ -3946,7 +3948,7 @@ msgstr ""
 msgid "Authorize access to your %{provider} account. This will open a sign-in page where you choose which account to connect."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:111
+#: lib/phoenix_kit_web/live/components/user_settings.ex:825
 #, elixir-autogen, elixir-format
 msgid "Avatar updated successfully!"
 msgstr ""
@@ -3986,12 +3988,12 @@ msgstr ""
 msgid "CRF 0-51, lower = higher quality. 18-28 recommended."
 msgstr ""
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:862
+#: lib/phoenix_kit_web/users/user_form.html.heex:870
 #, elixir-autogen, elixir-format
 msgid "Cancel invitation"
 msgstr ""
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:863
+#: lib/phoenix_kit_web/users/user_form.html.heex:871
 #, elixir-autogen, elixir-format
 msgid "Cancel this invitation?"
 msgstr ""
@@ -4049,7 +4051,7 @@ msgstr ""
 msgid "Company info, tax settings, and bank details are shared across Legal, Billing, and Shop modules."
 msgstr ""
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:199
+#: lib/phoenix_kit_web/users/user_form.html.heex:207
 #, elixir-autogen, elixir-format
 msgid "Company or organization name"
 msgstr ""
@@ -4334,7 +4336,7 @@ msgstr ""
 msgid "Failed to save"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:542
+#: lib/phoenix_kit_web/live/components/user_settings.ex:589
 #, elixir-autogen, elixir-format
 msgid "Failed to save notification preferences."
 msgstr ""
@@ -4344,7 +4346,7 @@ msgstr ""
 msgid "Failed to send invitation"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:118
+#: lib/phoenix_kit_web/live/components/user_settings.ex:833
 #, elixir-autogen, elixir-format
 msgid "Failed to update avatar"
 msgstr ""
@@ -4467,7 +4469,7 @@ msgid "Integration deleted"
 msgstr ""
 
 #: lib/phoenix_kit/dashboard/admin_tabs.ex:308
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1476
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1692
 #: lib/phoenix_kit_web/live/settings/integration_form.html.heex:10
 #: lib/phoenix_kit_web/live/settings/integrations.ex:31
 #: lib/phoenix_kit_web/live/users/permissions_matrix.html.heex:75
@@ -4505,17 +4507,17 @@ msgstr ""
 msgid "Invitation sent to %{email}"
 msgstr ""
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:885
+#: lib/phoenix_kit_web/users/user_form.html.heex:893
 #, elixir-autogen, elixir-format
 msgid "Invite"
 msgstr ""
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:881
+#: lib/phoenix_kit_web/users/user_form.html.heex:889
 #, elixir-autogen, elixir-format
 msgid "Invite by email..."
 msgstr ""
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:841
+#: lib/phoenix_kit_web/users/user_form.html.heex:849
 #, elixir-autogen, elixir-format
 msgid "Invited"
 msgstr ""
@@ -4662,12 +4664,12 @@ msgid "No integrations match your search."
 msgstr ""
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:641
-#: lib/phoenix_kit_web/users/user_form.html.heex:752
+#: lib/phoenix_kit_web/users/user_form.html.heex:760
 #, elixir-autogen, elixir-format
 msgid "No members yet"
 msgstr ""
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:834
+#: lib/phoenix_kit_web/users/user_form.html.heex:842
 #, elixir-autogen, elixir-format
 msgid "No pending invitations"
 msgstr ""
@@ -4693,13 +4695,13 @@ msgstr ""
 msgid "Not tested"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:535
+#: lib/phoenix_kit_web/live/components/user_settings.ex:582
 #: lib/phoenix_kit_web/live/notifications/settings.ex:66
 #, elixir-autogen, elixir-format
 msgid "Notification preferences saved."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1314
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1530
 #: lib/phoenix_kit_web/live/integrations/my_integration_form.ex:483
 #: lib/phoenix_kit_web/live/modules.html.heex:337
 #: lib/phoenix_kit_web/live/settings.html.heex:382
@@ -4735,14 +4737,14 @@ msgstr ""
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:228
 #: lib/phoenix_kit_web/live/users/users.html.heex:203
 #: lib/phoenix_kit_web/users/registration.html.heex:136
-#: lib/phoenix_kit_web/users/user_form.html.heex:187
-#: lib/phoenix_kit_web/users/user_form.html.heex:235
+#: lib/phoenix_kit_web/users/user_form.html.heex:195
+#: lib/phoenix_kit_web/users/user_form.html.heex:243
 #, elixir-autogen, elixir-format
 msgid "Organization"
 msgstr ""
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:637
-#: lib/phoenix_kit_web/users/user_form.html.heex:716
+#: lib/phoenix_kit_web/users/user_form.html.heex:724
 #, elixir-autogen, elixir-format
 msgid "Organization Members"
 msgstr ""
@@ -4750,7 +4752,7 @@ msgstr ""
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:220
 #: lib/phoenix_kit_web/users/magic_link_registration.html.heex:58
 #: lib/phoenix_kit_web/users/registration.html.heex:148
-#: lib/phoenix_kit_web/users/user_form.html.heex:198
+#: lib/phoenix_kit_web/users/user_form.html.heex:206
 #, elixir-autogen, elixir-format
 msgid "Organization Name"
 msgstr ""
@@ -4760,7 +4762,7 @@ msgstr ""
 msgid "Pause"
 msgstr ""
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:827
+#: lib/phoenix_kit_web/users/user_form.html.heex:835
 #, elixir-autogen, elixir-format
 msgid "Pending Invitations"
 msgstr ""
@@ -4773,12 +4775,12 @@ msgstr ""
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:161
 #: lib/phoenix_kit_web/live/users/users.html.heex:202
 #: lib/phoenix_kit_web/users/registration.html.heex:130
-#: lib/phoenix_kit_web/users/user_form.html.heex:177
+#: lib/phoenix_kit_web/users/user_form.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "Personal"
 msgstr "Personal"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1353
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1569
 #, elixir-autogen, elixir-format
 msgid "Pick which notification types you want to receive. Unchecked types are muted — activities still record in the audit log but no bell notification is created for you."
 msgstr ""
@@ -4829,12 +4831,12 @@ msgid "Redundancy target: %{n} copies"
 msgstr ""
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:704
-#: lib/phoenix_kit_web/users/user_form.html.heex:810
+#: lib/phoenix_kit_web/users/user_form.html.heex:818
 #, elixir-autogen, elixir-format
 msgid "Remove from organization"
 msgstr ""
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:811
+#: lib/phoenix_kit_web/users/user_form.html.heex:819
 #, elixir-autogen, elixir-format
 msgid "Remove this member from the organization?"
 msgstr ""
@@ -4859,7 +4861,7 @@ msgstr ""
 msgid "Save Tax Settings"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1383
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1599
 #: lib/phoenix_kit_web/live/notifications/settings.ex:348
 #, elixir-autogen, elixir-format
 msgid "Save preferences"
@@ -4880,7 +4882,7 @@ msgstr ""
 msgid "Security check failed. Please try connecting again."
 msgstr ""
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:731
+#: lib/phoenix_kit_web/users/user_form.html.heex:739
 #, elixir-autogen, elixir-format
 msgid "Select a user to add..."
 msgstr ""
@@ -5074,7 +5076,7 @@ msgstr ""
 msgid "Unknown provider"
 msgstr ""
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:753
+#: lib/phoenix_kit_web/users/user_form.html.heex:761
 #, elixir-autogen, elixir-format
 msgid "Use the dropdown above to add members"
 msgstr ""
@@ -5627,7 +5629,6 @@ msgstr ""
 
 #: lib/phoenix_kit_web/live/modules.html.heex:77
 #: lib/phoenix_kit_web/live/modules/languages.ex:46
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr ""
@@ -5808,112 +5809,112 @@ msgid_plural "%{count}d ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:19
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:21
 #, elixir-autogen
 msgid "Summary"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:24
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:26
 #, elixir-autogen
 msgid "Languages Enabled"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:28
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:147
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:30
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:149
 #, elixir-autogen
 msgid "Countries Covered"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:37
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:39
 #, elixir-autogen
 msgid "Enabled Languages"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:134
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:136
 #, elixir-autogen
 msgid "Default language"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:164
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:166
 #, elixir-autogen
 msgid "Available Languages"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:266
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:268
 #, elixir-autogen
 msgid "Language Configuration"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:312
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:314
 #, elixir-autogen
 msgid "Frontend Language Switcher"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:322
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:324
 #, elixir-autogen
 msgid "Switcher Settings"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:327
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:329
 #, elixir-autogen
 msgid "Show Flags"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:341
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:343
 #, elixir-autogen
 msgid "Show Names"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:355
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:357
 #, elixir-autogen
 msgid "Native Names"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:369
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:371
 #, elixir-autogen
 msgid "Go to Home"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:383
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:385
 #, elixir-autogen
 msgid "Hide Current"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:414
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:416
 #, elixir-autogen
 msgid "Generated Code"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:429
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:431
 #, elixir-autogen
 msgid "Implementation Notes"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:447
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:449
 #, elixir-autogen
 msgid "Enable and Configure Languages"
 msgstr ""
 
 #: lib/phoenix_kit_web/components/media_browser.html.heex:623
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:47
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:49
 #, elixir-autogen
 msgid "Done"
 msgstr ""
 
 #: lib/phoenix_kit_web/components/core/reorder_modal.ex:65
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:49
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:51
 #, elixir-autogen
 msgid "Reorder"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:54
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:219
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:56
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:221
 #: lib/phoenix_kit_web/live/users/users.html.heex:1206
 #, elixir-autogen
 msgid "Default"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:155
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:157
 #, elixir-autogen
 msgid "No languages enabled yet."
 msgstr ""
@@ -7271,12 +7272,12 @@ msgstr ""
 msgid "Status:"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:280
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:282
 #, elixir-autogen, elixir-format
 msgid "Controls how the primary language appears in URLs across the site — admin pages, public pages, sitemap, and redirects."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:290
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:292
 #, elixir-autogen, elixir-format
 msgid "Default Language Without Prefix"
 msgstr ""
@@ -7286,12 +7287,12 @@ msgstr ""
 msgid "Failed to update URL behavior setting"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:278
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:280
 #, elixir-autogen, elixir-format
 msgid "URL Behavior"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:293
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:295
 #, elixir-autogen, elixir-format
 msgid "When on, the primary language drops its locale segment in every URL (e.g. /admin/users instead of /en/admin/users, /blog/post instead of /en/blog/post). Other languages always keep their prefix."
 msgstr ""
@@ -10179,12 +10180,12 @@ msgstr ""
 msgid "xAI requires a funded account before the API will return completions"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:618
+#: lib/phoenix_kit_web/live/components/user_settings.ex:665
 #, elixir-autogen, elixir-format
 msgid "Active now"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1410
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1626
 #, elixir-autogen, elixir-format
 msgid "Devices currently signed in to your account. If you don't recognize one, sign it out."
 msgstr ""
@@ -10199,58 +10200,58 @@ msgstr ""
 msgid "New sign-in to your account."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1443
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1659
 #, elixir-autogen, elixir-format
 msgid "Sign out"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1454
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1670
 #, elixir-autogen, elixir-format
 msgid "Sign out of all other sessions?"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1457
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1673
 #, elixir-autogen, elixir-format
 msgid "Sign out other sessions"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:569
+#: lib/phoenix_kit_web/live/components/user_settings.ex:616
 #, elixir-autogen, elixir-format
 msgid "Signed out of all other sessions."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:552
+#: lib/phoenix_kit_web/live/components/user_settings.ex:599
 #, elixir-autogen, elixir-format
 msgid "Signed out of that session."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:553
+#: lib/phoenix_kit_web/live/components/user_settings.ex:600
 #, elixir-autogen, elixir-format
 msgid "That session is no longer active."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1427
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1643
 #, elixir-autogen, elixir-format
 msgid "This device"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:610
+#: lib/phoenix_kit_web/live/components/user_settings.ex:657
 #: lib/phoenix_kit_web/live/users/sessions.ex:342
 #, elixir-autogen, elixir-format
 msgid "Unknown device"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:632
+#: lib/phoenix_kit_web/live/components/user_settings.ex:679
 #, elixir-autogen, elixir-format
 msgid "Active %{date} at %{time}"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:626
+#: lib/phoenix_kit_web/live/components/user_settings.ex:673
 #, elixir-autogen, elixir-format
 msgid "Active today at %{time}"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:629
+#: lib/phoenix_kit_web/live/components/user_settings.ex:676
 #, elixir-autogen, elixir-format
 msgid "Active yesterday at %{time}"
 msgstr ""
@@ -12346,8 +12347,8 @@ msgstr ""
 msgid "Select Audio"
 msgstr ""
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:997
-#: lib/phoenix_kit_web/users/user_form.html.heex:1009
+#: lib/phoenix_kit_web/users/user_form.html.heex:1005
+#: lib/phoenix_kit_web/users/user_form.html.heex:1017
 #, elixir-autogen, elixir-format
 msgid "Select Avatar"
 msgstr ""
@@ -12911,7 +12912,7 @@ msgstr ""
 msgid "Too many registration attempts. Please try again later."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1335
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1551
 #, elixir-autogen, elixir-format
 msgid "%{enabled} of %{total} notification types enabled"
 msgstr ""
@@ -12951,12 +12952,12 @@ msgstr ""
 msgid "Back at it"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:892
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1016
 #, elixir-autogen, elixir-format
 msgid "Browser detected: %{zone}"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:871
+#: lib/phoenix_kit_web/live/components/user_settings.ex:995
 #, elixir-autogen, elixir-format
 msgid "Check your timezone"
 msgstr ""
@@ -13036,7 +13037,7 @@ msgstr ""
 msgid "Hey there"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1328
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1544
 #, elixir-autogen, elixir-format
 msgid "Manage Notifications"
 msgstr ""
@@ -13111,12 +13112,12 @@ msgstr ""
 msgid "The secret in the key store was rejected as too short"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:492
+#: lib/phoenix_kit_web/live/components/user_settings.ex:539
 #, elixir-autogen, elixir-format
 msgid "Timezone set to %{zone}."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:885
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1009
 #, elixir-autogen, elixir-format
 msgid "Use %{zone}"
 msgstr ""
@@ -13136,17 +13137,17 @@ msgstr ""
 msgid "Working late"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:690
+#: lib/phoenix_kit_web/live/components/user_settings.ex:737
 #, elixir-autogen, elixir-format
 msgid "Your browser reports %{browser}, but this account is set to %{saved}. Times on this site will be shown in %{saved}."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:681
+#: lib/phoenix_kit_web/live/components/user_settings.ex:728
 #, elixir-autogen, elixir-format
 msgid "Your browser reports %{zone}. This account still stores a fixed UTC offset, which cannot follow daylight saving — it will drift by an hour at the next change."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:674
+#: lib/phoenix_kit_web/live/components/user_settings.ex:721
 #, elixir-autogen, elixir-format
 msgid "Your browser reports %{zone}. You have not set a timezone, so times are shown using the site default."
 msgstr ""
@@ -14246,12 +14247,12 @@ msgstr ""
 msgid "Site is closed to visitors"
 msgstr "Site is closed to visitors"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1479
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1695
 #, elixir-autogen, elixir-format
 msgid "Manage Integrations"
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1487
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1703
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No personal integrations yet."
 msgstr ""
@@ -14262,7 +14263,7 @@ msgstr ""
 msgid "You don't have access to Integrations."
 msgstr ""
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1483
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1699
 #, elixir-autogen, elixir-format
 msgid "Your own API keys and bot connections — only you can see or use these."
 msgstr ""
@@ -14419,4 +14420,39 @@ msgstr ""
 #: lib/modules/storage/web/settings.html.heex:7
 #, elixir-autogen, elixir-format
 msgid "Storage buckets and file processing"
+msgstr ""
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1051
+#, elixir-autogen, elixir-format
+msgid "Adjust Avatar Crop"
+msgstr ""
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:943
+#, elixir-autogen, elixir-format
+msgid "Adjust Crop"
+msgstr ""
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:499
+#, elixir-autogen, elixir-format
+msgid "Avatar crop reset."
+msgstr ""
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:487
+#, elixir-autogen, elixir-format
+msgid "Avatar crop updated!"
+msgstr ""
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:871
+#, elixir-autogen, elixir-format
+msgid "Failed to update avatar crop"
+msgstr ""
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1127
+#, elixir-autogen, elixir-format
+msgid "Save Crop"
+msgstr ""
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1088
+#, elixir-autogen, elixir-format
+msgid "Zoom"
 msgstr ""

--- a/priv/gettext/es/LC_MESSAGES/default.po
+++ b/priv/gettext/es/LC_MESSAGES/default.po
@@ -128,8 +128,8 @@ msgstr "Crear nueva cuenta"
 #: lib/phoenix_kit_web/users/forgot_password.html.heex:15
 #: lib/phoenix_kit_web/users/magic_link.html.heex:30
 #: lib/phoenix_kit_web/users/registration.html.heex:56
-#: lib/phoenix_kit_web/users/user_form.html.heex:761
-#: lib/phoenix_kit_web/users/user_form.html.heex:840
+#: lib/phoenix_kit_web/users/user_form.html.heex:769
+#: lib/phoenix_kit_web/users/user_form.html.heex:848
 #, elixir-autogen
 msgid "Email"
 msgstr "Correo Electrónico"
@@ -190,7 +190,7 @@ msgstr "Cuentas registradas"
 
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:259
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:264
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1399
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1615
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:18
 #, elixir-autogen
 msgid "Active Sessions"
@@ -381,7 +381,7 @@ msgstr "Autenticación"
 #: lib/phoenix_kit_web/live/users/users.ex:1200
 #: lib/phoenix_kit_web/live/users/users.html.heex:248
 #: lib/phoenix_kit_web/live/users/users.html.heex:573
-#: lib/phoenix_kit_web/users/user_form.html.heex:786
+#: lib/phoenix_kit_web/users/user_form.html.heex:794
 #, elixir-autogen
 msgid "Active"
 msgstr "Activo"
@@ -401,7 +401,7 @@ msgstr "Activo"
 #: lib/phoenix_kit_web/live/modules.html.heex:284
 #: lib/phoenix_kit_web/live/modules.html.heex:349
 #: lib/phoenix_kit_web/live/modules.html.heex:405
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:59
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:61
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:49
 #: lib/phoenix_kit_web/live/settings/send_profile_form.html.heex:90
 #: lib/phoenix_kit_web/live/settings/users.html.heex:465
@@ -442,7 +442,7 @@ msgstr "%{language} (borrador)"
 msgid "%{language} (Published)"
 msgstr "%{language} (publicado)"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:403
+#: lib/phoenix_kit_web/live/components/user_settings.ex:384
 #, elixir-autogen, elixir-format
 msgid "%{provider} account disconnected successfully"
 msgstr "Cuenta de %{provider} desconectada correctamente"
@@ -462,7 +462,7 @@ msgstr "(opcional)"
 msgid "123 Business Street"
 msgstr "Calle Comercial 123"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:250
+#: lib/phoenix_kit_web/live/components/user_settings.ex:231
 #, elixir-autogen, elixir-format
 msgid "A link to confirm your email change has been sent to the new address."
 msgstr "Se ha enviado un enlace para confirmar el cambio de correo a la nueva dirección."
@@ -509,8 +509,8 @@ msgstr "Información de la cuenta"
 #: lib/phoenix_kit_web/live/users/roles.html.heex:163
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:269
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:651
-#: lib/phoenix_kit_web/users/user_form.html.heex:763
-#: lib/phoenix_kit_web/users/user_form.html.heex:843
+#: lib/phoenix_kit_web/users/user_form.html.heex:771
+#: lib/phoenix_kit_web/users/user_form.html.heex:851
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr "Acciones"
@@ -519,7 +519,7 @@ msgstr "Acciones"
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:610
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:314
 #: lib/phoenix_kit_web/live/settings/users.html.heex:795
-#: lib/phoenix_kit_web/users/user_form.html.heex:742
+#: lib/phoenix_kit_web/users/user_form.html.heex:750
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr "Agregar"
@@ -649,7 +649,8 @@ msgstr "Lista con viñetas"
 #: lib/phoenix_kit_web/components/media_browser.html.heex:2440
 #: lib/phoenix_kit_web/components/user_dashboard_nav.ex:317
 #: lib/phoenix_kit_web/live/components/media_selector_modal.html.heex:65
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1327
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1113
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1543
 #: lib/phoenix_kit_web/live/notifications/settings.ex:434
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:493
 #: lib/phoenix_kit_web/live/settings/send_profile_form.html.heex:152
@@ -689,12 +690,12 @@ msgstr "No se puede eliminar el último propietario del sistema"
 msgid "Cannot delete your own account"
 msgstr "No puede eliminar su propia cuenta"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:437
+#: lib/phoenix_kit_web/live/components/user_settings.ex:418
 #, elixir-autogen, elixir-format
 msgid "Cannot disconnect %{provider}. Please ensure you have at least one sign-in method available."
 msgstr "No se puede desconectar %{provider}. Asegúrese de tener al menos un método de inicio de sesión disponible."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:432
+#: lib/phoenix_kit_web/live/components/user_settings.ex:413
 #, elixir-autogen, elixir-format
 msgid "Cannot disconnect %{provider}. This is your only sign-in method. Please set a password or connect another provider first."
 msgstr "No se puede desconectar %{provider}. Es su único método de inicio de sesión. Establezca una contraseña o conecte otro proveedor primero."
@@ -1101,7 +1102,7 @@ msgstr "No se pudo eliminar el rol"
 msgid "Failed to delete user"
 msgstr "No se pudo eliminar el usuario"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:423
+#: lib/phoenix_kit_web/live/components/user_settings.ex:404
 #, elixir-autogen, elixir-format
 msgid "Failed to disconnect provider. Please try again."
 msgstr "No se pudo desconectar el proveedor. Inténtelo de nuevo."
@@ -1240,7 +1241,7 @@ msgstr "Imagen"
 #: lib/phoenix_kit_web/live/users/users.ex:1200
 #: lib/phoenix_kit_web/live/users/users.html.heex:249
 #: lib/phoenix_kit_web/live/users/users.html.heex:577
-#: lib/phoenix_kit_web/users/user_form.html.heex:790
+#: lib/phoenix_kit_web/users/user_form.html.heex:798
 #, elixir-autogen, elixir-format
 msgid "Inactive"
 msgstr "Inactivo"
@@ -1483,7 +1484,7 @@ msgstr "Aceptar"
 msgid "Only the Owner can edit Admin permissions"
 msgstr "Solo el propietario puede editar los permisos de administrador"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:236
+#: lib/phoenix_kit_web/users/user_form.html.heex:244
 #, elixir-autogen, elixir-format
 msgid "Optional"
 msgstr "Opcional"
@@ -1545,7 +1546,7 @@ msgstr "Página publicada correctamente"
 msgid "Password"
 msgstr "Contraseña"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:301
+#: lib/phoenix_kit_web/live/components/user_settings.ex:282
 #, elixir-autogen, elixir-format
 msgid "Password changed successfully."
 msgstr "Contraseña cambiada correctamente."
@@ -1628,7 +1629,7 @@ msgstr "Preferencias de privacidad"
 msgid "Profile"
 msgstr "Perfil"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:362
+#: lib/phoenix_kit_web/live/components/user_settings.ex:343
 #, elixir-autogen, elixir-format
 msgid "Profile updated successfully"
 msgstr "Perfil actualizado correctamente"
@@ -1644,7 +1645,7 @@ msgstr "Protegido"
 msgid "Protected core roles"
 msgstr "Roles principales protegidos"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:413
+#: lib/phoenix_kit_web/live/components/user_settings.ex:394
 #, elixir-autogen, elixir-format
 msgid "Provider not found"
 msgstr "Proveedor no encontrado"
@@ -1948,7 +1949,7 @@ msgstr "Estado/Provincia"
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:294
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:650
 #: lib/phoenix_kit_web/live/users/users.html.heex:263
-#: lib/phoenix_kit_web/users/user_form.html.heex:762
+#: lib/phoenix_kit_web/users/user_form.html.heex:770
 #, elixir-autogen, elixir-format
 msgid "Status"
 msgstr "Estado"
@@ -2144,7 +2145,7 @@ msgstr "Vídeo"
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:695
 #: lib/phoenix_kit_web/live/users/users.html.heex:667
 #: lib/phoenix_kit_web/live/users/users.html.heex:794
-#: lib/phoenix_kit_web/users/user_form.html.heex:801
+#: lib/phoenix_kit_web/users/user_form.html.heex:809
 #, elixir-autogen, elixir-format
 msgid "View"
 msgstr "Ver"
@@ -2277,7 +2278,7 @@ msgstr "Eliminar bucket"
 #: lib/modules/storage/web/dimensions.html.heex:466
 #: lib/modules/storage/web/settings.html.heex:221
 #: lib/modules/storage/web/settings.html.heex:257
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:126
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:128
 #: lib/phoenix_kit_web/live/settings/users.html.heex:563
 #: lib/phoenix_kit_web/live/settings/users.html.heex:609
 #, elixir-autogen, elixir-format
@@ -2303,7 +2304,7 @@ msgstr "Habilitar"
 
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:166
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:268
-#: lib/phoenix_kit_web/users/user_form.html.heex:842
+#: lib/phoenix_kit_web/users/user_form.html.heex:850
 #, elixir-autogen, elixir-format
 msgid "Expires"
 msgstr "Caduca"
@@ -2319,7 +2320,7 @@ msgstr "No se pudo %{action} el módulo Legal"
 msgid "Hide"
 msgstr "Ocultar"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:400
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:402
 #, elixir-autogen, elixir-format
 msgid "Live Preview"
 msgstr "Vista previa en vivo"
@@ -2364,9 +2365,9 @@ msgstr "Revocar"
 msgid "Revoke all"
 msgstr "Revocar todo"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:117
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:230
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:234
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:119
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:232
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:236
 #, elixir-autogen, elixir-format
 msgid "Set Default"
 msgstr "Establecer como predeterminado"
@@ -3256,6 +3257,7 @@ msgid "Required field"
 msgstr "Campo obligatorio"
 
 #: lib/phoenix_kit_web/components/core/column_settings.ex:136
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1104
 #: lib/phoenix_kit_web/live/settings.html.heex:640
 #, elixir-autogen, elixir-format
 msgid "Reset"
@@ -3481,7 +3483,7 @@ msgstr "Escriba una opción y pulse Intro o haga clic en Agregar"
 
 ## Navigation menu items
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:262
-#: lib/phoenix_kit_web/users/user_form.html.heex:760
+#: lib/phoenix_kit_web/users/user_form.html.heex:768
 #, elixir-autogen, elixir-format
 msgid "User"
 msgstr "Usuario"
@@ -3867,7 +3869,7 @@ msgstr "Cuenta"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:210
 #: lib/phoenix_kit_web/users/registration.html.heex:119
-#: lib/phoenix_kit_web/users/user_form.html.heex:166
+#: lib/phoenix_kit_web/users/user_form.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "Account Type"
 msgstr "Tipo de cuenta"
@@ -3953,7 +3955,7 @@ msgstr "La autorización falló: %{reason}"
 msgid "Authorize access to your %{provider} account. This will open a sign-in page where you choose which account to connect."
 msgstr "Autorice el acceso a su cuenta de %{provider}. Se abrirá una página de inicio de sesión donde elegirá qué cuenta conectar."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:111
+#: lib/phoenix_kit_web/live/components/user_settings.ex:825
 #, elixir-autogen, elixir-format
 msgid "Avatar updated successfully!"
 msgstr "¡Avatar actualizado correctamente!"
@@ -3993,12 +3995,12 @@ msgstr "Acciones del bucket"
 msgid "CRF 0-51, lower = higher quality. 18-28 recommended."
 msgstr "CRF de 0 a 51, menor = mejor calidad. Se recomienda 18-28."
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:862
+#: lib/phoenix_kit_web/users/user_form.html.heex:870
 #, elixir-autogen, elixir-format
 msgid "Cancel invitation"
 msgstr "Cancelar la invitación"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:863
+#: lib/phoenix_kit_web/users/user_form.html.heex:871
 #, elixir-autogen, elixir-format
 msgid "Cancel this invitation?"
 msgstr "¿Cancelar esta invitación?"
@@ -4056,7 +4058,7 @@ msgstr "Punto de conexión de Cloudflare"
 msgid "Company info, tax settings, and bank details are shared across Legal, Billing, and Shop modules."
 msgstr "La información de la empresa, los ajustes fiscales y los datos bancarios se comparten entre los módulos Legal, Facturación y Tienda."
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:199
+#: lib/phoenix_kit_web/users/user_form.html.heex:207
 #, elixir-autogen, elixir-format
 msgid "Company or organization name"
 msgstr "Nombre de la empresa u organización"
@@ -4341,7 +4343,7 @@ msgstr "No se pudo quitar al miembro"
 msgid "Failed to save"
 msgstr "No se pudo guardar"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:542
+#: lib/phoenix_kit_web/live/components/user_settings.ex:589
 #, elixir-autogen, elixir-format
 msgid "Failed to save notification preferences."
 msgstr "No se pudieron guardar las preferencias de notificación."
@@ -4351,7 +4353,7 @@ msgstr "No se pudieron guardar las preferencias de notificación."
 msgid "Failed to send invitation"
 msgstr "No se pudo enviar la invitación"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:118
+#: lib/phoenix_kit_web/live/components/user_settings.ex:833
 #, elixir-autogen, elixir-format
 msgid "Failed to update avatar"
 msgstr "No se pudo actualizar el avatar"
@@ -4474,7 +4476,7 @@ msgid "Integration deleted"
 msgstr "Integración eliminada"
 
 #: lib/phoenix_kit/dashboard/admin_tabs.ex:308
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1476
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1692
 #: lib/phoenix_kit_web/live/settings/integration_form.html.heex:10
 #: lib/phoenix_kit_web/live/settings/integrations.ex:31
 #: lib/phoenix_kit_web/live/users/permissions_matrix.html.heex:75
@@ -4512,17 +4514,17 @@ msgstr "Invitación rechazada."
 msgid "Invitation sent to %{email}"
 msgstr "Invitación enviada a %{email}"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:885
+#: lib/phoenix_kit_web/users/user_form.html.heex:893
 #, elixir-autogen, elixir-format
 msgid "Invite"
 msgstr "Invitar"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:881
+#: lib/phoenix_kit_web/users/user_form.html.heex:889
 #, elixir-autogen, elixir-format
 msgid "Invite by email..."
 msgstr "Invitar por correo…"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:841
+#: lib/phoenix_kit_web/users/user_form.html.heex:849
 #, elixir-autogen, elixir-format
 msgid "Invited"
 msgstr "Invitado"
@@ -4669,12 +4671,12 @@ msgid "No integrations match your search."
 msgstr "Ninguna integración coincide con su búsqueda."
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:641
-#: lib/phoenix_kit_web/users/user_form.html.heex:752
+#: lib/phoenix_kit_web/users/user_form.html.heex:760
 #, elixir-autogen, elixir-format
 msgid "No members yet"
 msgstr "Aún no hay miembros"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:834
+#: lib/phoenix_kit_web/users/user_form.html.heex:842
 #, elixir-autogen, elixir-format
 msgid "No pending invitations"
 msgstr "No hay invitaciones pendientes"
@@ -4700,13 +4702,13 @@ msgstr "Sin conectar"
 msgid "Not tested"
 msgstr "Sin probar"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:535
+#: lib/phoenix_kit_web/live/components/user_settings.ex:582
 #: lib/phoenix_kit_web/live/notifications/settings.ex:66
 #, elixir-autogen, elixir-format
 msgid "Notification preferences saved."
 msgstr "Preferencias de notificación guardadas."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1314
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1530
 #: lib/phoenix_kit_web/live/integrations/my_integration_form.ex:483
 #: lib/phoenix_kit_web/live/modules.html.heex:337
 #: lib/phoenix_kit_web/live/settings.html.heex:382
@@ -4742,14 +4744,14 @@ msgstr "Org."
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:228
 #: lib/phoenix_kit_web/live/users/users.html.heex:203
 #: lib/phoenix_kit_web/users/registration.html.heex:136
-#: lib/phoenix_kit_web/users/user_form.html.heex:187
-#: lib/phoenix_kit_web/users/user_form.html.heex:235
+#: lib/phoenix_kit_web/users/user_form.html.heex:195
+#: lib/phoenix_kit_web/users/user_form.html.heex:243
 #, elixir-autogen, elixir-format
 msgid "Organization"
 msgstr "Organización"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:637
-#: lib/phoenix_kit_web/users/user_form.html.heex:716
+#: lib/phoenix_kit_web/users/user_form.html.heex:724
 #, elixir-autogen, elixir-format
 msgid "Organization Members"
 msgstr "Miembros de la organización"
@@ -4757,7 +4759,7 @@ msgstr "Miembros de la organización"
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:220
 #: lib/phoenix_kit_web/users/magic_link_registration.html.heex:58
 #: lib/phoenix_kit_web/users/registration.html.heex:148
-#: lib/phoenix_kit_web/users/user_form.html.heex:198
+#: lib/phoenix_kit_web/users/user_form.html.heex:206
 #, elixir-autogen, elixir-format
 msgid "Organization Name"
 msgstr "Nombre de la organización"
@@ -4767,7 +4769,7 @@ msgstr "Nombre de la organización"
 msgid "Pause"
 msgstr "Pausar"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:827
+#: lib/phoenix_kit_web/users/user_form.html.heex:835
 #, elixir-autogen, elixir-format
 msgid "Pending Invitations"
 msgstr "Invitaciones pendientes"
@@ -4780,12 +4782,12 @@ msgstr "Bandeja de entrada por usuario basada en el registro de actividad"
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:161
 #: lib/phoenix_kit_web/live/users/users.html.heex:202
 #: lib/phoenix_kit_web/users/registration.html.heex:130
-#: lib/phoenix_kit_web/users/user_form.html.heex:177
+#: lib/phoenix_kit_web/users/user_form.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "Personal"
 msgstr "Particular"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1353
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1569
 #, elixir-autogen, elixir-format
 msgid "Pick which notification types you want to receive. Unchecked types are muted — activities still record in the audit log but no bell notification is created for you."
 msgstr "Elija qué tipos de notificación desea recibir. Los tipos sin marcar quedan silenciados: las actividades se siguen registrando en el historial, pero no se crea ninguna notificación en la campana."
@@ -4836,12 +4838,12 @@ msgid "Redundancy target: %{n} copies"
 msgstr "Objetivo de redundancia: %{n} copias"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:704
-#: lib/phoenix_kit_web/users/user_form.html.heex:810
+#: lib/phoenix_kit_web/users/user_form.html.heex:818
 #, elixir-autogen, elixir-format
 msgid "Remove from organization"
 msgstr "Quitar de la organización"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:811
+#: lib/phoenix_kit_web/users/user_form.html.heex:819
 #, elixir-autogen, elixir-format
 msgid "Remove this member from the organization?"
 msgstr "¿Quitar a este miembro de la organización?"
@@ -4866,7 +4868,7 @@ msgstr "Guardar bucket"
 msgid "Save Tax Settings"
 msgstr "Guardar los ajustes fiscales"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1383
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1599
 #: lib/phoenix_kit_web/live/notifications/settings.ex:348
 #, elixir-autogen, elixir-format
 msgid "Save preferences"
@@ -4887,7 +4889,7 @@ msgstr "Buscar integraciones…"
 msgid "Security check failed. Please try connecting again."
 msgstr "La comprobación de seguridad falló. Intente conectarse de nuevo."
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:731
+#: lib/phoenix_kit_web/users/user_form.html.heex:739
 #, elixir-autogen, elixir-format
 msgid "Select a user to add..."
 msgstr "Seleccione un usuario para agregar…"
@@ -5081,7 +5083,7 @@ msgstr "Con replicación insuficiente"
 msgid "Unknown provider"
 msgstr "Proveedor desconocido"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:753
+#: lib/phoenix_kit_web/users/user_form.html.heex:761
 #, elixir-autogen, elixir-format
 msgid "Use the dropdown above to add members"
 msgstr "Use el desplegable de arriba para agregar miembros"
@@ -5634,7 +5636,6 @@ msgstr "Tareas"
 
 #: lib/phoenix_kit_web/live/modules.html.heex:77
 #: lib/phoenix_kit_web/live/modules/languages.ex:46
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr "Idiomas"
@@ -5815,112 +5816,112 @@ msgid_plural "%{count}d ago"
 msgstr[0] "hace %{count} d"
 msgstr[1] "hace %{count} d"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:19
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:21
 #, elixir-autogen
 msgid "Summary"
 msgstr "Resumen"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:24
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:26
 #, elixir-autogen
 msgid "Languages Enabled"
 msgstr "Idiomas habilitados"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:28
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:147
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:30
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:149
 #, elixir-autogen
 msgid "Countries Covered"
 msgstr "Países cubiertos"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:37
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:39
 #, elixir-autogen
 msgid "Enabled Languages"
 msgstr "Idiomas habilitados"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:134
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:136
 #, elixir-autogen
 msgid "Default language"
 msgstr "Idioma predeterminado"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:164
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:166
 #, elixir-autogen
 msgid "Available Languages"
 msgstr "Idiomas disponibles"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:266
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:268
 #, elixir-autogen
 msgid "Language Configuration"
 msgstr "Configuración de idiomas"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:312
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:314
 #, elixir-autogen
 msgid "Frontend Language Switcher"
 msgstr "Selector de idioma del frontend"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:322
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:324
 #, elixir-autogen
 msgid "Switcher Settings"
 msgstr "Ajustes del selector"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:327
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:329
 #, elixir-autogen
 msgid "Show Flags"
 msgstr "Mostrar banderas"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:341
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:343
 #, elixir-autogen
 msgid "Show Names"
 msgstr "Mostrar nombres"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:355
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:357
 #, elixir-autogen
 msgid "Native Names"
 msgstr "Nombres nativos"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:369
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:371
 #, elixir-autogen
 msgid "Go to Home"
 msgstr "Ir al inicio"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:383
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:385
 #, elixir-autogen
 msgid "Hide Current"
 msgstr "Ocultar el actual"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:414
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:416
 #, elixir-autogen
 msgid "Generated Code"
 msgstr "Código generado"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:429
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:431
 #, elixir-autogen
 msgid "Implementation Notes"
 msgstr "Notas de implementación"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:447
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:449
 #, elixir-autogen
 msgid "Enable and Configure Languages"
 msgstr "Habilitar y configurar idiomas"
 
 #: lib/phoenix_kit_web/components/media_browser.html.heex:623
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:47
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:49
 #, elixir-autogen
 msgid "Done"
 msgstr "Listo"
 
 #: lib/phoenix_kit_web/components/core/reorder_modal.ex:65
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:49
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:51
 #, elixir-autogen
 msgid "Reorder"
 msgstr "Reordenar"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:54
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:219
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:56
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:221
 #: lib/phoenix_kit_web/live/users/users.html.heex:1206
 #, elixir-autogen
 msgid "Default"
 msgstr "Predeterminado"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:155
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:157
 #, elixir-autogen
 msgid "No languages enabled yet."
 msgstr "Aún no hay idiomas habilitados."
@@ -7278,12 +7279,12 @@ msgstr "Ordenar por"
 msgid "Status:"
 msgstr "Estado:"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:280
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:282
 #, elixir-autogen, elixir-format
 msgid "Controls how the primary language appears in URLs across the site — admin pages, public pages, sitemap, and redirects."
 msgstr "Controla cómo aparece el idioma principal en las URL de todo el sitio: páginas de administración, páginas públicas, sitemap y redirecciones."
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:290
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:292
 #, elixir-autogen, elixir-format
 msgid "Default Language Without Prefix"
 msgstr "Idioma predeterminado sin prefijo"
@@ -7293,12 +7294,12 @@ msgstr "Idioma predeterminado sin prefijo"
 msgid "Failed to update URL behavior setting"
 msgstr "No se pudo actualizar la configuración"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:278
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:280
 #, elixir-autogen, elixir-format
 msgid "URL Behavior"
 msgstr "Comportamiento de las URL"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:293
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:295
 #, elixir-autogen, elixir-format
 msgid "When on, the primary language drops its locale segment in every URL (e.g. /admin/users instead of /en/admin/users, /blog/post instead of /en/blog/post). Other languages always keep their prefix."
 msgstr "Si está activado, el idioma principal omite su segmento de configuración regional en todas las URL (p. ej., /admin/users en lugar de /en/admin/users, /blog/post en lugar de /en/blog/post). Los demás idiomas siempre conservan su prefijo."
@@ -10187,12 +10188,12 @@ msgstr "xAI"
 msgid "xAI requires a funded account before the API will return completions"
 msgstr "xAI requiere una cuenta con saldo para que la API devuelva completions"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:618
+#: lib/phoenix_kit_web/live/components/user_settings.ex:665
 #, elixir-autogen, elixir-format
 msgid "Active now"
 msgstr "Activo ahora"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1410
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1626
 #, elixir-autogen, elixir-format
 msgid "Devices currently signed in to your account. If you don't recognize one, sign it out."
 msgstr "Dispositivos con la sesión iniciada en su cuenta. Si no reconoce alguno, ciérrele la sesión."
@@ -10207,58 +10208,58 @@ msgstr "Nuevo inicio de sesión en su cuenta desde %{details}."
 msgid "New sign-in to your account."
 msgstr "Nuevo inicio de sesión en su cuenta."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1443
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1659
 #, elixir-autogen, elixir-format
 msgid "Sign out"
 msgstr "Cerrar sesión"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1454
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1670
 #, elixir-autogen, elixir-format
 msgid "Sign out of all other sessions?"
 msgstr "¿Cerrar todas las demás sesiones?"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1457
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1673
 #, elixir-autogen, elixir-format
 msgid "Sign out other sessions"
 msgstr "Cerrar las demás sesiones"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:569
+#: lib/phoenix_kit_web/live/components/user_settings.ex:616
 #, elixir-autogen, elixir-format
 msgid "Signed out of all other sessions."
 msgstr "Se cerraron todas las demás sesiones."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:552
+#: lib/phoenix_kit_web/live/components/user_settings.ex:599
 #, elixir-autogen, elixir-format
 msgid "Signed out of that session."
 msgstr "Se cerró esa sesión."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:553
+#: lib/phoenix_kit_web/live/components/user_settings.ex:600
 #, elixir-autogen, elixir-format
 msgid "That session is no longer active."
 msgstr "Esa sesión ya no está activa."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1427
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1643
 #, elixir-autogen, elixir-format
 msgid "This device"
 msgstr "Este dispositivo"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:610
+#: lib/phoenix_kit_web/live/components/user_settings.ex:657
 #: lib/phoenix_kit_web/live/users/sessions.ex:342
 #, elixir-autogen, elixir-format
 msgid "Unknown device"
 msgstr "Dispositivo desconocido"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:632
+#: lib/phoenix_kit_web/live/components/user_settings.ex:679
 #, elixir-autogen, elixir-format
 msgid "Active %{date} at %{time}"
 msgstr "Activo el %{date} a las %{time}"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:626
+#: lib/phoenix_kit_web/live/components/user_settings.ex:673
 #, elixir-autogen, elixir-format
 msgid "Active today at %{time}"
 msgstr "Activo hoy a las %{time}"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:629
+#: lib/phoenix_kit_web/live/components/user_settings.ex:676
 #, elixir-autogen, elixir-format
 msgid "Active yesterday at %{time}"
 msgstr "Activo ayer a las %{time}"
@@ -12354,8 +12355,8 @@ msgstr "Procesando en el servidor…"
 msgid "Select Audio"
 msgstr "Seleccionar audio"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:997
-#: lib/phoenix_kit_web/users/user_form.html.heex:1009
+#: lib/phoenix_kit_web/users/user_form.html.heex:1005
+#: lib/phoenix_kit_web/users/user_form.html.heex:1017
 #, elixir-autogen, elixir-format
 msgid "Select Avatar"
 msgstr "Seleccionar avatar"
@@ -12919,7 +12920,7 @@ msgstr "Introduzca un nombre"
 msgid "Too many registration attempts. Please try again later."
 msgstr "Demasiados intentos de registro. Inténtelo de nuevo más tarde."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1335
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1551
 #, elixir-autogen, elixir-format
 msgid "%{enabled} of %{total} notification types enabled"
 msgstr "%{enabled} de %{total} tipos de notificación activados"
@@ -12959,12 +12960,12 @@ msgstr "Hay un almacén de claves configurado, pero no se pudo leer su secreto, 
 msgid "Back at it"
 msgstr "De vuelta al trabajo"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:892
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1016
 #, elixir-autogen, elixir-format
 msgid "Browser detected: %{zone}"
 msgstr "Detectado por el navegador: %{zone}"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:871
+#: lib/phoenix_kit_web/live/components/user_settings.ex:995
 #, elixir-autogen, elixir-format
 msgid "Check your timezone"
 msgstr "Compruebe su zona horaria"
@@ -13044,7 +13045,7 @@ msgstr "Hola de nuevo"
 msgid "Hey there"
 msgstr "Hola"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1328
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1544
 #, elixir-autogen, elixir-format
 msgid "Manage Notifications"
 msgstr "Gestionar las notificaciones"
@@ -13119,12 +13120,12 @@ msgstr "El secreto del almacén de claves (%{location}) se rechazó por ser más
 msgid "The secret in the key store was rejected as too short"
 msgstr "El secreto del almacén de claves se rechazó por ser demasiado corto"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:492
+#: lib/phoenix_kit_web/live/components/user_settings.ex:539
 #, elixir-autogen, elixir-format
 msgid "Timezone set to %{zone}."
 msgstr "Zona horaria establecida en %{zone}."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:885
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1009
 #, elixir-autogen, elixir-format
 msgid "Use %{zone}"
 msgstr "Usar %{zone}"
@@ -13144,17 +13145,17 @@ msgstr "Adónde lleva la entrada «Ajustes» del menú de usuario. Vacío = la p
 msgid "Working late"
 msgstr "Trabajando hasta tarde"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:690
+#: lib/phoenix_kit_web/live/components/user_settings.ex:737
 #, elixir-autogen, elixir-format
 msgid "Your browser reports %{browser}, but this account is set to %{saved}. Times on this site will be shown in %{saved}."
 msgstr "Su navegador indica %{browser}, pero esta cuenta está configurada en %{saved}. Las horas de este sitio se mostrarán en %{saved}."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:681
+#: lib/phoenix_kit_web/live/components/user_settings.ex:728
 #, elixir-autogen, elixir-format
 msgid "Your browser reports %{zone}. This account still stores a fixed UTC offset, which cannot follow daylight saving — it will drift by an hour at the next change."
 msgstr "Su navegador indica %{zone}. Esta cuenta sigue guardando un desfase UTC fijo, que no puede seguir el horario de verano: se desviará una hora en el próximo cambio."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:674
+#: lib/phoenix_kit_web/live/components/user_settings.ex:721
 #, elixir-autogen, elixir-format
 msgid "Your browser reports %{zone}. You have not set a timezone, so times are shown using the site default."
 msgstr "Su navegador indica %{zone}. No ha establecido una zona horaria, así que las horas se muestran con la predeterminada del sitio."
@@ -14254,12 +14255,12 @@ msgstr "Esa función no tiene interruptor."
 msgid "Site is closed to visitors"
 msgstr "El sitio está cerrado a los visitantes"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1479
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1695
 #, elixir-autogen, elixir-format
 msgid "Manage Integrations"
 msgstr "Gestionar integraciones"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1487
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1703
 #, elixir-autogen, elixir-format
 msgid "No personal integrations yet."
 msgstr "Aún no hay integraciones personales."
@@ -14270,7 +14271,7 @@ msgstr "Aún no hay integraciones personales."
 msgid "You don't have access to Integrations."
 msgstr "No tiene acceso a las integraciones."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1483
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1699
 #, elixir-autogen, elixir-format
 msgid "Your own API keys and bot connections — only you can see or use these."
 msgstr "Tus propias claves de API y conexiones de bots — solo tú puedes verlas o usarlas."
@@ -14428,3 +14429,38 @@ msgstr "Fuentes"
 #, elixir-autogen, elixir-format
 msgid "Storage buckets and file processing"
 msgstr ""
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1051
+#, elixir-autogen, elixir-format
+msgid "Adjust Avatar Crop"
+msgstr "Ajustar recorte del avatar"
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:943
+#, elixir-autogen, elixir-format
+msgid "Adjust Crop"
+msgstr "Ajustar recorte"
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:499
+#, elixir-autogen, elixir-format
+msgid "Avatar crop reset."
+msgstr "Recorte del avatar restablecido."
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:487
+#, elixir-autogen, elixir-format
+msgid "Avatar crop updated!"
+msgstr "¡Recorte del avatar actualizado!"
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:871
+#, elixir-autogen, elixir-format
+msgid "Failed to update avatar crop"
+msgstr "No se pudo actualizar el recorte del avatar"
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1127
+#, elixir-autogen, elixir-format
+msgid "Save Crop"
+msgstr "Guardar recorte"
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1088
+#, elixir-autogen, elixir-format
+msgid "Zoom"
+msgstr "Zoom"

--- a/priv/gettext/et/LC_MESSAGES/default.po
+++ b/priv/gettext/et/LC_MESSAGES/default.po
@@ -128,8 +128,8 @@ msgstr "Loo uus konto"
 #: lib/phoenix_kit_web/users/forgot_password.html.heex:15
 #: lib/phoenix_kit_web/users/magic_link.html.heex:30
 #: lib/phoenix_kit_web/users/registration.html.heex:56
-#: lib/phoenix_kit_web/users/user_form.html.heex:761
-#: lib/phoenix_kit_web/users/user_form.html.heex:840
+#: lib/phoenix_kit_web/users/user_form.html.heex:769
+#: lib/phoenix_kit_web/users/user_form.html.heex:848
 #, elixir-autogen
 msgid "Email"
 msgstr "E-post"
@@ -190,7 +190,7 @@ msgstr "Registreeritud kontod"
 
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:259
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:264
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1399
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1615
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:18
 #, elixir-autogen
 msgid "Active Sessions"
@@ -381,7 +381,7 @@ msgstr "Autentimine"
 #: lib/phoenix_kit_web/live/users/users.ex:1200
 #: lib/phoenix_kit_web/live/users/users.html.heex:248
 #: lib/phoenix_kit_web/live/users/users.html.heex:573
-#: lib/phoenix_kit_web/users/user_form.html.heex:786
+#: lib/phoenix_kit_web/users/user_form.html.heex:794
 #, elixir-autogen
 msgid "Active"
 msgstr "Aktiivne"
@@ -401,7 +401,7 @@ msgstr "Aktiivne"
 #: lib/phoenix_kit_web/live/modules.html.heex:284
 #: lib/phoenix_kit_web/live/modules.html.heex:349
 #: lib/phoenix_kit_web/live/modules.html.heex:405
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:59
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:61
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:49
 #: lib/phoenix_kit_web/live/settings/send_profile_form.html.heex:90
 #: lib/phoenix_kit_web/live/settings/users.html.heex:465
@@ -442,7 +442,7 @@ msgstr "%{language} (Mustand)"
 msgid "%{language} (Published)"
 msgstr "%{language} (Avaldatud)"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:403
+#: lib/phoenix_kit_web/live/components/user_settings.ex:384
 #, elixir-autogen, elixir-format
 msgid "%{provider} account disconnected successfully"
 msgstr "%{provider} konto lahti ühendatud edukalt"
@@ -462,7 +462,7 @@ msgstr "(valikuline)"
 msgid "123 Business Street"
 msgstr "123 Äritänav"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:250
+#: lib/phoenix_kit_web/live/components/user_settings.ex:231
 #, elixir-autogen, elixir-format
 msgid "A link to confirm your email change has been sent to the new address."
 msgstr "E-posti muutmise kinnituslink on saadetud uuele aadressile."
@@ -509,8 +509,8 @@ msgstr "Konto teave"
 #: lib/phoenix_kit_web/live/users/roles.html.heex:163
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:269
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:651
-#: lib/phoenix_kit_web/users/user_form.html.heex:763
-#: lib/phoenix_kit_web/users/user_form.html.heex:843
+#: lib/phoenix_kit_web/users/user_form.html.heex:771
+#: lib/phoenix_kit_web/users/user_form.html.heex:851
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr "Tegevused"
@@ -519,7 +519,7 @@ msgstr "Tegevused"
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:610
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:314
 #: lib/phoenix_kit_web/live/settings/users.html.heex:795
-#: lib/phoenix_kit_web/users/user_form.html.heex:742
+#: lib/phoenix_kit_web/users/user_form.html.heex:750
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr "Lisa"
@@ -649,7 +649,8 @@ msgstr "Punktloend"
 #: lib/phoenix_kit_web/components/media_browser.html.heex:2440
 #: lib/phoenix_kit_web/components/user_dashboard_nav.ex:317
 #: lib/phoenix_kit_web/live/components/media_selector_modal.html.heex:65
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1327
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1113
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1543
 #: lib/phoenix_kit_web/live/notifications/settings.ex:434
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:493
 #: lib/phoenix_kit_web/live/settings/send_profile_form.html.heex:152
@@ -689,12 +690,12 @@ msgstr "Viimast süsteemi omanikku ei saa kustutada"
 msgid "Cannot delete your own account"
 msgstr "Oma kontot ei saa kustutada"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:437
+#: lib/phoenix_kit_web/live/components/user_settings.ex:418
 #, elixir-autogen, elixir-format
 msgid "Cannot disconnect %{provider}. Please ensure you have at least one sign-in method available."
 msgstr "Ei saa %{provider} lahti ühendada. Palun veendu, et sul on vähemalt üks sisselogimismeetod saadaval."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:432
+#: lib/phoenix_kit_web/live/components/user_settings.ex:413
 #, elixir-autogen, elixir-format
 msgid "Cannot disconnect %{provider}. This is your only sign-in method. Please set a password or connect another provider first."
 msgstr "Ei saa %{provider} lahti ühendada. See on sinu ainus sisselogimismeetod. Palun määra parool või ühenda kõigepealt teine teenusepakkuja."
@@ -1101,7 +1102,7 @@ msgstr "Rolli kustutamine ebaõnnestus"
 msgid "Failed to delete user"
 msgstr "Kasutaja kustutamine ebaõnnestus"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:423
+#: lib/phoenix_kit_web/live/components/user_settings.ex:404
 #, elixir-autogen, elixir-format
 msgid "Failed to disconnect provider. Please try again."
 msgstr "Teenusepakkuja lahtiühendamine ebaõnnestus. Palun proovi uuesti."
@@ -1240,7 +1241,7 @@ msgstr "Pilt"
 #: lib/phoenix_kit_web/live/users/users.ex:1200
 #: lib/phoenix_kit_web/live/users/users.html.heex:249
 #: lib/phoenix_kit_web/live/users/users.html.heex:577
-#: lib/phoenix_kit_web/users/user_form.html.heex:790
+#: lib/phoenix_kit_web/users/user_form.html.heex:798
 #, elixir-autogen, elixir-format
 msgid "Inactive"
 msgstr "Mitteaktiivne"
@@ -1483,7 +1484,7 @@ msgstr "OK"
 msgid "Only the Owner can edit Admin permissions"
 msgstr "Ainult Omanik saab muuta Administraatori õigusi"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:236
+#: lib/phoenix_kit_web/users/user_form.html.heex:244
 #, elixir-autogen, elixir-format
 msgid "Optional"
 msgstr "Valikuline"
@@ -1545,7 +1546,7 @@ msgstr "Leht avaldatud edukalt"
 msgid "Password"
 msgstr "Parool"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:301
+#: lib/phoenix_kit_web/live/components/user_settings.ex:282
 #, elixir-autogen, elixir-format
 msgid "Password changed successfully."
 msgstr "Parool muudetud edukalt."
@@ -1628,7 +1629,7 @@ msgstr "Privaatsuse eelistused"
 msgid "Profile"
 msgstr "Profiil"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:362
+#: lib/phoenix_kit_web/live/components/user_settings.ex:343
 #, elixir-autogen, elixir-format
 msgid "Profile updated successfully"
 msgstr "Profiil uuendatud edukalt"
@@ -1644,7 +1645,7 @@ msgstr "Kaitstud"
 msgid "Protected core roles"
 msgstr "Kaitstud põhirollid"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:413
+#: lib/phoenix_kit_web/live/components/user_settings.ex:394
 #, elixir-autogen, elixir-format
 msgid "Provider not found"
 msgstr "Teenusepakkujat ei leitud"
@@ -1949,7 +1950,7 @@ msgstr "Maakond/provints"
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:294
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:650
 #: lib/phoenix_kit_web/live/users/users.html.heex:263
-#: lib/phoenix_kit_web/users/user_form.html.heex:762
+#: lib/phoenix_kit_web/users/user_form.html.heex:770
 #, elixir-autogen, elixir-format
 msgid "Status"
 msgstr "Olek"
@@ -2144,7 +2145,7 @@ msgstr "Video"
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:695
 #: lib/phoenix_kit_web/live/users/users.html.heex:667
 #: lib/phoenix_kit_web/live/users/users.html.heex:794
-#: lib/phoenix_kit_web/users/user_form.html.heex:801
+#: lib/phoenix_kit_web/users/user_form.html.heex:809
 #, elixir-autogen, elixir-format
 msgid "View"
 msgstr "Vaata"
@@ -2276,7 +2277,7 @@ msgstr "Kustuta bucket"
 #: lib/modules/storage/web/dimensions.html.heex:466
 #: lib/modules/storage/web/settings.html.heex:221
 #: lib/modules/storage/web/settings.html.heex:257
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:126
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:128
 #: lib/phoenix_kit_web/live/settings/users.html.heex:563
 #: lib/phoenix_kit_web/live/settings/users.html.heex:609
 #, elixir-autogen, elixir-format
@@ -2302,7 +2303,7 @@ msgstr "Luba"
 
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:166
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:268
-#: lib/phoenix_kit_web/users/user_form.html.heex:842
+#: lib/phoenix_kit_web/users/user_form.html.heex:850
 #, elixir-autogen, elixir-format
 msgid "Expires"
 msgstr "Aegub"
@@ -2318,7 +2319,7 @@ msgstr "Juriidilise mooduli %{action} ebaõnnestus"
 msgid "Hide"
 msgstr "Peida"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:400
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:402
 #, elixir-autogen, elixir-format
 msgid "Live Preview"
 msgstr "Reaalajas eelvaade"
@@ -2363,9 +2364,9 @@ msgstr "Tühista"
 msgid "Revoke all"
 msgstr "Tühista kõik"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:117
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:230
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:234
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:119
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:232
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:236
 #, elixir-autogen, elixir-format
 msgid "Set Default"
 msgstr "Määra vaikimisi"
@@ -3254,6 +3255,7 @@ msgid "Required field"
 msgstr "Kohustuslik väli"
 
 #: lib/phoenix_kit_web/components/core/column_settings.ex:136
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1104
 #: lib/phoenix_kit_web/live/settings.html.heex:640
 #, elixir-autogen, elixir-format
 msgid "Reset"
@@ -3479,7 +3481,7 @@ msgstr "Sisesta valik ja vajuta Enter või klõpsa Lisa"
 
 ## Navigation menu items
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:262
-#: lib/phoenix_kit_web/users/user_form.html.heex:760
+#: lib/phoenix_kit_web/users/user_form.html.heex:768
 #, elixir-autogen, elixir-format
 msgid "User"
 msgstr "Kasutaja"
@@ -3865,7 +3867,7 @@ msgstr "Konto"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:210
 #: lib/phoenix_kit_web/users/registration.html.heex:119
-#: lib/phoenix_kit_web/users/user_form.html.heex:166
+#: lib/phoenix_kit_web/users/user_form.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "Account Type"
 msgstr "Konto tüüp"
@@ -3951,7 +3953,7 @@ msgstr "Volitamine ebaõnnestus: %{reason}"
 msgid "Authorize access to your %{provider} account. This will open a sign-in page where you choose which account to connect."
 msgstr "Volita juurdepääs oma %{provider} kontole. See avab sisselogimislehe, kus saad valida, millise konto ühendada."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:111
+#: lib/phoenix_kit_web/live/components/user_settings.ex:825
 #, elixir-autogen, elixir-format
 msgid "Avatar updated successfully!"
 msgstr "Avatar uuendatud edukalt!"
@@ -3991,12 +3993,12 @@ msgstr "Bucketi tegevused"
 msgid "CRF 0-51, lower = higher quality. 18-28 recommended."
 msgstr "CRF 0-51, madalam = parem kvaliteet. 18-28 on soovituslik."
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:862
+#: lib/phoenix_kit_web/users/user_form.html.heex:870
 #, elixir-autogen, elixir-format
 msgid "Cancel invitation"
 msgstr "Tühista kutse"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:863
+#: lib/phoenix_kit_web/users/user_form.html.heex:871
 #, elixir-autogen, elixir-format
 msgid "Cancel this invitation?"
 msgstr "Kas tühistada see kutse?"
@@ -4054,7 +4056,7 @@ msgstr "Cloudflare lõpp-punkt"
 msgid "Company info, tax settings, and bank details are shared across Legal, Billing, and Shop modules."
 msgstr "Ettevõtte teave, maksuseaded ja pangaandmed jagatud Juriidilise, Arvelduse ja Poe moodulitega."
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:199
+#: lib/phoenix_kit_web/users/user_form.html.heex:207
 #, elixir-autogen, elixir-format
 msgid "Company or organization name"
 msgstr "Ettevõtte või organisatsiooni nimi"
@@ -4339,7 +4341,7 @@ msgstr "Liikme eemaldamine ebaõnnestus"
 msgid "Failed to save"
 msgstr "Salvestamine ebaõnnestus"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:542
+#: lib/phoenix_kit_web/live/components/user_settings.ex:589
 #, elixir-autogen, elixir-format
 msgid "Failed to save notification preferences."
 msgstr "Teatiste eelistuste salvestamine ebaõnnestus."
@@ -4349,7 +4351,7 @@ msgstr "Teatiste eelistuste salvestamine ebaõnnestus."
 msgid "Failed to send invitation"
 msgstr "Kutse saatmine ebaõnnestus"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:118
+#: lib/phoenix_kit_web/live/components/user_settings.ex:833
 #, elixir-autogen, elixir-format
 msgid "Failed to update avatar"
 msgstr "Avatari uuendamine ebaõnnestus"
@@ -4472,7 +4474,7 @@ msgid "Integration deleted"
 msgstr "Integratsioon kustutatud"
 
 #: lib/phoenix_kit/dashboard/admin_tabs.ex:308
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1476
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1692
 #: lib/phoenix_kit_web/live/settings/integration_form.html.heex:10
 #: lib/phoenix_kit_web/live/settings/integrations.ex:31
 #: lib/phoenix_kit_web/live/users/permissions_matrix.html.heex:75
@@ -4510,17 +4512,17 @@ msgstr "Kutsest keelduti."
 msgid "Invitation sent to %{email}"
 msgstr "Kutse saadetud aadressile %{email}"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:885
+#: lib/phoenix_kit_web/users/user_form.html.heex:893
 #, elixir-autogen, elixir-format
 msgid "Invite"
 msgstr "Kutsu"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:881
+#: lib/phoenix_kit_web/users/user_form.html.heex:889
 #, elixir-autogen, elixir-format
 msgid "Invite by email..."
 msgstr "Kutsu e-postiga..."
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:841
+#: lib/phoenix_kit_web/users/user_form.html.heex:849
 #, elixir-autogen, elixir-format
 msgid "Invited"
 msgstr "Kutsutud"
@@ -4667,12 +4669,12 @@ msgid "No integrations match your search."
 msgstr "Ükski integratsioon ei vasta teie otsingule."
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:641
-#: lib/phoenix_kit_web/users/user_form.html.heex:752
+#: lib/phoenix_kit_web/users/user_form.html.heex:760
 #, elixir-autogen, elixir-format
 msgid "No members yet"
 msgstr "Liikmeid pole veel"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:834
+#: lib/phoenix_kit_web/users/user_form.html.heex:842
 #, elixir-autogen, elixir-format
 msgid "No pending invitations"
 msgstr "Ootel kutseid pole"
@@ -4698,13 +4700,13 @@ msgstr "Ühendamata"
 msgid "Not tested"
 msgstr "Testimata"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:535
+#: lib/phoenix_kit_web/live/components/user_settings.ex:582
 #: lib/phoenix_kit_web/live/notifications/settings.ex:66
 #, elixir-autogen, elixir-format
 msgid "Notification preferences saved."
 msgstr "Teatiste eelistused salvestatud."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1314
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1530
 #: lib/phoenix_kit_web/live/integrations/my_integration_form.ex:483
 #: lib/phoenix_kit_web/live/modules.html.heex:337
 #: lib/phoenix_kit_web/live/settings.html.heex:382
@@ -4740,14 +4742,14 @@ msgstr "Org"
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:228
 #: lib/phoenix_kit_web/live/users/users.html.heex:203
 #: lib/phoenix_kit_web/users/registration.html.heex:136
-#: lib/phoenix_kit_web/users/user_form.html.heex:187
-#: lib/phoenix_kit_web/users/user_form.html.heex:235
+#: lib/phoenix_kit_web/users/user_form.html.heex:195
+#: lib/phoenix_kit_web/users/user_form.html.heex:243
 #, elixir-autogen, elixir-format
 msgid "Organization"
 msgstr "Organisatsioon"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:637
-#: lib/phoenix_kit_web/users/user_form.html.heex:716
+#: lib/phoenix_kit_web/users/user_form.html.heex:724
 #, elixir-autogen, elixir-format
 msgid "Organization Members"
 msgstr "Organisatsiooni liikmed"
@@ -4755,7 +4757,7 @@ msgstr "Organisatsiooni liikmed"
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:220
 #: lib/phoenix_kit_web/users/magic_link_registration.html.heex:58
 #: lib/phoenix_kit_web/users/registration.html.heex:148
-#: lib/phoenix_kit_web/users/user_form.html.heex:198
+#: lib/phoenix_kit_web/users/user_form.html.heex:206
 #, elixir-autogen, elixir-format
 msgid "Organization Name"
 msgstr "Organisatsiooni nimi"
@@ -4765,7 +4767,7 @@ msgstr "Organisatsiooni nimi"
 msgid "Pause"
 msgstr "Peata"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:827
+#: lib/phoenix_kit_web/users/user_form.html.heex:835
 #, elixir-autogen, elixir-format
 msgid "Pending Invitations"
 msgstr "Ootel kutsed"
@@ -4778,12 +4780,12 @@ msgstr "Kasutajapõhine postkast, mida juhib tegevusvoog"
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:161
 #: lib/phoenix_kit_web/live/users/users.html.heex:202
 #: lib/phoenix_kit_web/users/registration.html.heex:130
-#: lib/phoenix_kit_web/users/user_form.html.heex:177
+#: lib/phoenix_kit_web/users/user_form.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "Personal"
 msgstr "Eraisik"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1353
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1569
 #, elixir-autogen, elixir-format
 msgid "Pick which notification types you want to receive. Unchecked types are muted — activities still record in the audit log but no bell notification is created for you."
 msgstr "Vali, milliseid teatiste tüüpe soovid saada. Märkimata tüübid on summutatud — tegevused salvestatakse ikkagi auditilogi, kuid kellukese teatist ei looda."
@@ -4834,12 +4836,12 @@ msgid "Redundancy target: %{n} copies"
 msgstr "Redundantsuse eesmärk: %{n} koopiat"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:704
-#: lib/phoenix_kit_web/users/user_form.html.heex:810
+#: lib/phoenix_kit_web/users/user_form.html.heex:818
 #, elixir-autogen, elixir-format
 msgid "Remove from organization"
 msgstr "Eemalda organisatsioonist"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:811
+#: lib/phoenix_kit_web/users/user_form.html.heex:819
 #, elixir-autogen, elixir-format
 msgid "Remove this member from the organization?"
 msgstr "Eemaldada see liige organisatsioonist?"
@@ -4864,7 +4866,7 @@ msgstr "Salvesta bucket"
 msgid "Save Tax Settings"
 msgstr "Salvesta maksuseaded"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1383
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1599
 #: lib/phoenix_kit_web/live/notifications/settings.ex:348
 #, elixir-autogen, elixir-format
 msgid "Save preferences"
@@ -4885,7 +4887,7 @@ msgstr "Otsi integratsioone..."
 msgid "Security check failed. Please try connecting again."
 msgstr "Turvaline kontroll ebaõnnestus. Palun proovi uuesti ühendada."
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:731
+#: lib/phoenix_kit_web/users/user_form.html.heex:739
 #, elixir-autogen, elixir-format
 msgid "Select a user to add..."
 msgstr "Vali lisatav kasutaja..."
@@ -5079,7 +5081,7 @@ msgstr "Ebapiisav replikatsioon"
 msgid "Unknown provider"
 msgstr "Tundmatu teenusepakkuja"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:753
+#: lib/phoenix_kit_web/users/user_form.html.heex:761
 #, elixir-autogen, elixir-format
 msgid "Use the dropdown above to add members"
 msgstr "Kasuta ülalolevat rippmenüüd liikmete lisamiseks"
@@ -5632,7 +5634,6 @@ msgstr "Tööd"
 
 #: lib/phoenix_kit_web/live/modules.html.heex:77
 #: lib/phoenix_kit_web/live/modules/languages.ex:46
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr "Keeled"
@@ -5813,112 +5814,112 @@ msgid_plural "%{count}d ago"
 msgstr[0] "%{count} päeva tagasi"
 msgstr[1] "%{count} päeva tagasi"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:19
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:21
 #, elixir-autogen
 msgid "Summary"
 msgstr "Kokkuvõte"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:24
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:26
 #, elixir-autogen
 msgid "Languages Enabled"
 msgstr "Lubatud keeled"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:28
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:147
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:30
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:149
 #, elixir-autogen
 msgid "Countries Covered"
 msgstr "Kaetud riigid"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:37
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:39
 #, elixir-autogen
 msgid "Enabled Languages"
 msgstr "Lubatud keeled"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:134
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:136
 #, elixir-autogen
 msgid "Default language"
 msgstr "Vaikekeel"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:164
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:166
 #, elixir-autogen
 msgid "Available Languages"
 msgstr "Saadaolevad keeled"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:266
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:268
 #, elixir-autogen
 msgid "Language Configuration"
 msgstr "Keele seadistus"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:312
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:314
 #, elixir-autogen
 msgid "Frontend Language Switcher"
 msgstr "Esikülje keelevahetaja"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:322
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:324
 #, elixir-autogen
 msgid "Switcher Settings"
 msgstr "Vahetaja seaded"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:327
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:329
 #, elixir-autogen
 msgid "Show Flags"
 msgstr "Näita lippe"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:341
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:343
 #, elixir-autogen
 msgid "Show Names"
 msgstr "Näita nimesid"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:355
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:357
 #, elixir-autogen
 msgid "Native Names"
 msgstr "Emakeelsed nimed"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:369
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:371
 #, elixir-autogen
 msgid "Go to Home"
 msgstr "Mine avalehele"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:383
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:385
 #, elixir-autogen
 msgid "Hide Current"
 msgstr "Peida praegune"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:414
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:416
 #, elixir-autogen
 msgid "Generated Code"
 msgstr "Genereeritud kood"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:429
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:431
 #, elixir-autogen
 msgid "Implementation Notes"
 msgstr "Rakenduse märkused"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:447
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:449
 #, elixir-autogen
 msgid "Enable and Configure Languages"
 msgstr "Luba ja seadista keeled"
 
 #: lib/phoenix_kit_web/components/media_browser.html.heex:623
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:47
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:49
 #, elixir-autogen
 msgid "Done"
 msgstr "Valmis"
 
 #: lib/phoenix_kit_web/components/core/reorder_modal.ex:65
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:49
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:51
 #, elixir-autogen
 msgid "Reorder"
 msgstr "Muuda järjekorda"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:54
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:219
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:56
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:221
 #: lib/phoenix_kit_web/live/users/users.html.heex:1206
 #, elixir-autogen
 msgid "Default"
 msgstr "Vaikimisi"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:155
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:157
 #, elixir-autogen
 msgid "No languages enabled yet."
 msgstr "Ühtegi keelt pole veel lubatud."
@@ -7276,12 +7277,12 @@ msgstr "Sorteeri"
 msgid "Status:"
 msgstr "Olek:"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:280
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:282
 #, elixir-autogen, elixir-format
 msgid "Controls how the primary language appears in URLs across the site — admin pages, public pages, sitemap, and redirects."
 msgstr "Määrab, kuidas põhikeel kuvatakse URL-ides kogu saidil — halduslehtedel, avalikel lehtedel, saidikaval ja ümbersuunamistel."
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:290
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:292
 #, elixir-autogen, elixir-format
 msgid "Default Language Without Prefix"
 msgstr "Vaikekeel ilma prefiksita"
@@ -7291,12 +7292,12 @@ msgstr "Vaikekeel ilma prefiksita"
 msgid "Failed to update URL behavior setting"
 msgstr "URL-i käitumise seade uuendamine ebaõnnestus"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:278
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:280
 #, elixir-autogen, elixir-format
 msgid "URL Behavior"
 msgstr "URL-i käitumine"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:293
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:295
 #, elixir-autogen, elixir-format
 msgid "When on, the primary language drops its locale segment in every URL (e.g. /admin/users instead of /en/admin/users, /blog/post instead of /en/blog/post). Other languages always keep their prefix."
 msgstr "Kui sisse lülitatud, eemaldab põhikeel oma keelesegmendi igast URL-ist (nt /en/admin/users asemel /admin/users, /en/blog/post asemel /blog/post). Teised keeled säilitavad alati oma prefiksi."
@@ -10187,12 +10188,12 @@ msgstr "xAI"
 msgid "xAI requires a funded account before the API will return completions"
 msgstr "xAI nõuab krediidiga kontot, muidu API vastuseid ei tagasta"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:618
+#: lib/phoenix_kit_web/live/components/user_settings.ex:665
 #, elixir-autogen, elixir-format
 msgid "Active now"
 msgstr "Praegu aktiivne"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1410
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1626
 #, elixir-autogen, elixir-format
 msgid "Devices currently signed in to your account. If you don't recognize one, sign it out."
 msgstr "Seadmed, millest on praegu teie kontosse sisse logitud. Kui te ei tunne mõnda neist ära, logige see välja."
@@ -10208,58 +10209,58 @@ msgid "New sign-in to your account."
 msgstr "Uus sisselogimine teie kontosse."
 
 ## Login page translations
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1443
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1659
 #, elixir-autogen, elixir-format
 msgid "Sign out"
 msgstr "Logi välja"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1454
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1670
 #, elixir-autogen, elixir-format
 msgid "Sign out of all other sessions?"
 msgstr "Kas logida välja kõigist teistest seanssidest?"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1457
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1673
 #, elixir-autogen, elixir-format
 msgid "Sign out other sessions"
 msgstr "Logi välja teistest seanssidest"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:569
+#: lib/phoenix_kit_web/live/components/user_settings.ex:616
 #, elixir-autogen, elixir-format
 msgid "Signed out of all other sessions."
 msgstr "Olete välja logitud kõigist teistest seanssidest."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:552
+#: lib/phoenix_kit_web/live/components/user_settings.ex:599
 #, elixir-autogen, elixir-format
 msgid "Signed out of that session."
 msgstr "Seanss lõpetatud."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:553
+#: lib/phoenix_kit_web/live/components/user_settings.ex:600
 #, elixir-autogen, elixir-format
 msgid "That session is no longer active."
 msgstr "See seanss ei ole enam aktiivne."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1427
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1643
 #, elixir-autogen, elixir-format
 msgid "This device"
 msgstr "See seade"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:610
+#: lib/phoenix_kit_web/live/components/user_settings.ex:657
 #: lib/phoenix_kit_web/live/users/sessions.ex:342
 #, elixir-autogen, elixir-format
 msgid "Unknown device"
 msgstr "Tundmatu seade"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:632
+#: lib/phoenix_kit_web/live/components/user_settings.ex:679
 #, elixir-autogen, elixir-format
 msgid "Active %{date} at %{time}"
 msgstr "Aktiivne %{date} kell %{time}"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:626
+#: lib/phoenix_kit_web/live/components/user_settings.ex:673
 #, elixir-autogen, elixir-format
 msgid "Active today at %{time}"
 msgstr "Aktiivne täna kell %{time}"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:629
+#: lib/phoenix_kit_web/live/components/user_settings.ex:676
 #, elixir-autogen, elixir-format
 msgid "Active yesterday at %{time}"
 msgstr "Aktiivne eile kell %{time}"
@@ -12355,8 +12356,8 @@ msgstr "Serveris töötlemine…"
 msgid "Select Audio"
 msgstr "Vali helifail"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:997
-#: lib/phoenix_kit_web/users/user_form.html.heex:1009
+#: lib/phoenix_kit_web/users/user_form.html.heex:1005
+#: lib/phoenix_kit_web/users/user_form.html.heex:1017
 #, elixir-autogen, elixir-format
 msgid "Select Avatar"
 msgstr "Vali avatar"
@@ -12920,7 +12921,7 @@ msgstr "Palun sisestage kehtiv e-posti aadress."
 msgid "Too many registration attempts. Please try again later."
 msgstr "Liiga palju registreerimiskatseid. Palun proovige hiljem uuesti."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1335
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1551
 #, elixir-autogen, elixir-format
 msgid "%{enabled} of %{total} notification types enabled"
 msgstr "%{enabled} teavitustüüpi %{total}-st lubatud"
@@ -12960,12 +12961,12 @@ msgstr "Võtmehoidla on seadistatud, kuid selle saladust ei õnnestunud lugeda, 
 msgid "Back at it"
 msgstr "Tagasi asja kallal"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:892
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1016
 #, elixir-autogen, elixir-format
 msgid "Browser detected: %{zone}"
 msgstr "Brauser tuvastas: %{zone}"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:871
+#: lib/phoenix_kit_web/live/components/user_settings.ex:995
 #, elixir-autogen, elixir-format
 msgid "Check your timezone"
 msgstr "Kontrolli oma ajavööndit"
@@ -13045,7 +13046,7 @@ msgstr "Tere taas"
 msgid "Hey there"
 msgstr "Tere-tere"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1328
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1544
 #, elixir-autogen, elixir-format
 msgid "Manage Notifications"
 msgstr "Halda teavitusi"
@@ -13120,12 +13121,12 @@ msgstr "Võtmehoidla (%{location}) saladus lükati miinimumist lühemana tagasi,
 msgid "The secret in the key store was rejected as too short"
 msgstr "Võtmehoidla saladus lükati liiga lühikesena tagasi"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:492
+#: lib/phoenix_kit_web/live/components/user_settings.ex:539
 #, elixir-autogen, elixir-format
 msgid "Timezone set to %{zone}."
 msgstr "Ajavöönd seatud: %{zone}."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:885
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1009
 #, elixir-autogen, elixir-format
 msgid "Use %{zone}"
 msgstr "Kasuta %{zone}"
@@ -13145,17 +13146,17 @@ msgstr "Kuhu viib kasutajamenüü \"Seaded\" kirje. Tühi = PhoenixKiti enda pro
 msgid "Working late"
 msgstr "Töötad hilja"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:690
+#: lib/phoenix_kit_web/live/components/user_settings.ex:737
 #, elixir-autogen, elixir-format
 msgid "Your browser reports %{browser}, but this account is set to %{saved}. Times on this site will be shown in %{saved}."
 msgstr "Sinu brauser teatab %{browser}, kuid see konto on seatud vööndile %{saved}. Ajad sellel saidil kuvatakse vööndis %{saved}."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:681
+#: lib/phoenix_kit_web/live/components/user_settings.ex:728
 #, elixir-autogen, elixir-format
 msgid "Your browser reports %{zone}. This account still stores a fixed UTC offset, which cannot follow daylight saving — it will drift by an hour at the next change."
 msgstr "Sinu brauser teatab %{zone}. See konto hoiab endiselt fikseeritud UTC-nihet, mis ei järgi suveaega — järgmisel muutusel nihkub see tunni võrra."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:674
+#: lib/phoenix_kit_web/live/components/user_settings.ex:721
 #, elixir-autogen, elixir-format
 msgid "Your browser reports %{zone}. You have not set a timezone, so times are shown using the site default."
 msgstr "Sinu brauser teatab %{zone}. Sa pole ajavööndit seadnud, seega ajad kuvatakse saidi vaikevööndis."
@@ -14255,12 +14256,12 @@ msgstr "Sellel funktsioonil pole lülitit."
 msgid "Site is closed to visitors"
 msgstr "Sait on külastajatele suletud"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1479
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1695
 #, elixir-autogen, elixir-format
 msgid "Manage Integrations"
 msgstr "Halda integratsioone"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1487
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1703
 #, elixir-autogen, elixir-format
 msgid "No personal integrations yet."
 msgstr "Isiklikke integratsioone veel pole."
@@ -14271,7 +14272,7 @@ msgstr "Isiklikke integratsioone veel pole."
 msgid "You don't have access to Integrations."
 msgstr "Sul puudub ligipääs integratsioonidele."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1483
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1699
 #, elixir-autogen, elixir-format
 msgid "Your own API keys and bot connections — only you can see or use these."
 msgstr "Sinu enda API-võtmed ja robotiühendused — ainult sina näed ja saad neid kasutada."
@@ -14429,3 +14430,38 @@ msgstr "Allikad"
 #, elixir-autogen, elixir-format
 msgid "Storage buckets and file processing"
 msgstr ""
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1051
+#, elixir-autogen, elixir-format
+msgid "Adjust Avatar Crop"
+msgstr "Kohanda avatari kadreeringut"
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:943
+#, elixir-autogen, elixir-format
+msgid "Adjust Crop"
+msgstr "Kohanda kadreeringut"
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:499
+#, elixir-autogen, elixir-format
+msgid "Avatar crop reset."
+msgstr "Avatari kadreering lähtestatud."
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:487
+#, elixir-autogen, elixir-format
+msgid "Avatar crop updated!"
+msgstr "Avatari kadreering uuendatud!"
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:871
+#, elixir-autogen, elixir-format
+msgid "Failed to update avatar crop"
+msgstr "Avatari kadreeringu uuendamine ebaõnnestus"
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1127
+#, elixir-autogen, elixir-format
+msgid "Save Crop"
+msgstr "Salvesta kadreering"
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1088
+#, elixir-autogen, elixir-format
+msgid "Zoom"
+msgstr "Suum"

--- a/priv/gettext/fr/LC_MESSAGES/default.po
+++ b/priv/gettext/fr/LC_MESSAGES/default.po
@@ -127,8 +127,8 @@ msgstr "Créer un nouveau compte"
 #: lib/phoenix_kit_web/users/forgot_password.html.heex:15
 #: lib/phoenix_kit_web/users/magic_link.html.heex:30
 #: lib/phoenix_kit_web/users/registration.html.heex:56
-#: lib/phoenix_kit_web/users/user_form.html.heex:761
-#: lib/phoenix_kit_web/users/user_form.html.heex:840
+#: lib/phoenix_kit_web/users/user_form.html.heex:769
+#: lib/phoenix_kit_web/users/user_form.html.heex:848
 #, elixir-autogen
 msgid "Email"
 msgstr "E-mail"
@@ -188,7 +188,7 @@ msgstr "Comptes enregistrés"
 
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:259
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:264
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1399
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1615
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:18
 #, elixir-autogen
 msgid "Active Sessions"
@@ -379,7 +379,7 @@ msgstr "Authentification"
 #: lib/phoenix_kit_web/live/users/users.ex:1200
 #: lib/phoenix_kit_web/live/users/users.html.heex:248
 #: lib/phoenix_kit_web/live/users/users.html.heex:573
-#: lib/phoenix_kit_web/users/user_form.html.heex:786
+#: lib/phoenix_kit_web/users/user_form.html.heex:794
 #, elixir-autogen
 msgid "Active"
 msgstr "Actif"
@@ -399,7 +399,7 @@ msgstr "Actif"
 #: lib/phoenix_kit_web/live/modules.html.heex:284
 #: lib/phoenix_kit_web/live/modules.html.heex:349
 #: lib/phoenix_kit_web/live/modules.html.heex:405
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:59
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:61
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:49
 #: lib/phoenix_kit_web/live/settings/send_profile_form.html.heex:90
 #: lib/phoenix_kit_web/live/settings/users.html.heex:465
@@ -439,7 +439,7 @@ msgstr "%{language} (Brouillon)"
 msgid "%{language} (Published)"
 msgstr "%{language} (Publié)"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:403
+#: lib/phoenix_kit_web/live/components/user_settings.ex:384
 #, elixir-autogen, elixir-format
 msgid "%{provider} account disconnected successfully"
 msgstr "Compte %{provider} déconnecté avec succès"
@@ -459,7 +459,7 @@ msgstr "(facultatif)"
 msgid "123 Business Street"
 msgstr "123 rue du Commerce"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:250
+#: lib/phoenix_kit_web/live/components/user_settings.ex:231
 #, elixir-autogen, elixir-format
 msgid "A link to confirm your email change has been sent to the new address."
 msgstr "Un lien pour confirmer le changement de votre e-mail a été envoyé à la nouvelle adresse."
@@ -506,8 +506,8 @@ msgstr "Informations du compte"
 #: lib/phoenix_kit_web/live/users/roles.html.heex:163
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:269
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:651
-#: lib/phoenix_kit_web/users/user_form.html.heex:763
-#: lib/phoenix_kit_web/users/user_form.html.heex:843
+#: lib/phoenix_kit_web/users/user_form.html.heex:771
+#: lib/phoenix_kit_web/users/user_form.html.heex:851
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr "Actions"
@@ -516,7 +516,7 @@ msgstr "Actions"
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:610
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:314
 #: lib/phoenix_kit_web/live/settings/users.html.heex:795
-#: lib/phoenix_kit_web/users/user_form.html.heex:742
+#: lib/phoenix_kit_web/users/user_form.html.heex:750
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr "Ajouter"
@@ -646,7 +646,8 @@ msgstr "Liste à puces"
 #: lib/phoenix_kit_web/components/media_browser.html.heex:2440
 #: lib/phoenix_kit_web/components/user_dashboard_nav.ex:317
 #: lib/phoenix_kit_web/live/components/media_selector_modal.html.heex:65
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1327
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1113
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1543
 #: lib/phoenix_kit_web/live/notifications/settings.ex:434
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:493
 #: lib/phoenix_kit_web/live/settings/send_profile_form.html.heex:152
@@ -686,12 +687,12 @@ msgstr "Impossible de supprimer le dernier propriétaire du système"
 msgid "Cannot delete your own account"
 msgstr "Impossible de supprimer votre propre compte"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:437
+#: lib/phoenix_kit_web/live/components/user_settings.ex:418
 #, elixir-autogen, elixir-format
 msgid "Cannot disconnect %{provider}. Please ensure you have at least one sign-in method available."
 msgstr "Impossible de déconnecter %{provider}. Veuillez vous assurer de disposer d'au moins une méthode de connexion disponible."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:432
+#: lib/phoenix_kit_web/live/components/user_settings.ex:413
 #, elixir-autogen, elixir-format
 msgid "Cannot disconnect %{provider}. This is your only sign-in method. Please set a password or connect another provider first."
 msgstr "Impossible de déconnecter %{provider}. Il s'agit de votre seule méthode de connexion. Veuillez d'abord définir un mot de passe ou connecter un autre fournisseur."
@@ -1098,7 +1099,7 @@ msgstr "Échec de la suppression du rôle"
 msgid "Failed to delete user"
 msgstr "Échec de la suppression de l'utilisateur"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:423
+#: lib/phoenix_kit_web/live/components/user_settings.ex:404
 #, elixir-autogen, elixir-format
 msgid "Failed to disconnect provider. Please try again."
 msgstr "Échec de la déconnexion du fournisseur. Veuillez réessayer."
@@ -1237,7 +1238,7 @@ msgstr "Image"
 #: lib/phoenix_kit_web/live/users/users.ex:1200
 #: lib/phoenix_kit_web/live/users/users.html.heex:249
 #: lib/phoenix_kit_web/live/users/users.html.heex:577
-#: lib/phoenix_kit_web/users/user_form.html.heex:790
+#: lib/phoenix_kit_web/users/user_form.html.heex:798
 #, elixir-autogen, elixir-format
 msgid "Inactive"
 msgstr "Inactif"
@@ -1480,7 +1481,7 @@ msgstr "OK"
 msgid "Only the Owner can edit Admin permissions"
 msgstr "Seul le Propriétaire peut modifier les permissions Admin"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:236
+#: lib/phoenix_kit_web/users/user_form.html.heex:244
 #, elixir-autogen, elixir-format
 msgid "Optional"
 msgstr "Facultatif"
@@ -1542,7 +1543,7 @@ msgstr "Page publiée avec succès"
 msgid "Password"
 msgstr "Mot de passe"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:301
+#: lib/phoenix_kit_web/live/components/user_settings.ex:282
 #, elixir-autogen, elixir-format
 msgid "Password changed successfully."
 msgstr "Mot de passe modifié avec succès."
@@ -1625,7 +1626,7 @@ msgstr "Préférences de confidentialité"
 msgid "Profile"
 msgstr "Profil"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:362
+#: lib/phoenix_kit_web/live/components/user_settings.ex:343
 #, elixir-autogen, elixir-format
 msgid "Profile updated successfully"
 msgstr "Profil mis à jour avec succès"
@@ -1641,7 +1642,7 @@ msgstr "Protégé"
 msgid "Protected core roles"
 msgstr "Rôles principaux protégés"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:413
+#: lib/phoenix_kit_web/live/components/user_settings.ex:394
 #, elixir-autogen, elixir-format
 msgid "Provider not found"
 msgstr "Fournisseur introuvable"
@@ -1945,7 +1946,7 @@ msgstr "État/province"
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:294
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:650
 #: lib/phoenix_kit_web/live/users/users.html.heex:263
-#: lib/phoenix_kit_web/users/user_form.html.heex:762
+#: lib/phoenix_kit_web/users/user_form.html.heex:770
 #, elixir-autogen, elixir-format
 msgid "Status"
 msgstr "Statut"
@@ -2140,7 +2141,7 @@ msgstr "Vidéo"
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:695
 #: lib/phoenix_kit_web/live/users/users.html.heex:667
 #: lib/phoenix_kit_web/live/users/users.html.heex:794
-#: lib/phoenix_kit_web/users/user_form.html.heex:801
+#: lib/phoenix_kit_web/users/user_form.html.heex:809
 #, elixir-autogen, elixir-format
 msgid "View"
 msgstr "Voir"
@@ -2272,7 +2273,7 @@ msgstr "Supprimer le bucket"
 #: lib/modules/storage/web/dimensions.html.heex:466
 #: lib/modules/storage/web/settings.html.heex:221
 #: lib/modules/storage/web/settings.html.heex:257
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:126
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:128
 #: lib/phoenix_kit_web/live/settings/users.html.heex:563
 #: lib/phoenix_kit_web/live/settings/users.html.heex:609
 #, elixir-autogen, elixir-format
@@ -2298,7 +2299,7 @@ msgstr "Activer"
 
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:166
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:268
-#: lib/phoenix_kit_web/users/user_form.html.heex:842
+#: lib/phoenix_kit_web/users/user_form.html.heex:850
 #, elixir-autogen, elixir-format
 msgid "Expires"
 msgstr "Expire"
@@ -2314,7 +2315,7 @@ msgstr "Échec de %{action} du module Légal"
 msgid "Hide"
 msgstr "Masquer"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:400
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:402
 #, elixir-autogen, elixir-format
 msgid "Live Preview"
 msgstr "Aperçu en direct"
@@ -2359,9 +2360,9 @@ msgstr "Révoquer"
 msgid "Revoke all"
 msgstr "Tout révoquer"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:117
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:230
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:234
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:119
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:232
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:236
 #, elixir-autogen, elixir-format
 msgid "Set Default"
 msgstr "Définir par défaut"
@@ -3250,6 +3251,7 @@ msgid "Required field"
 msgstr "Champ obligatoire"
 
 #: lib/phoenix_kit_web/components/core/column_settings.ex:136
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1104
 #: lib/phoenix_kit_web/live/settings.html.heex:640
 #, elixir-autogen, elixir-format
 msgid "Reset"
@@ -3474,7 +3476,7 @@ msgid "Type an option and press Enter or click Add"
 msgstr "Saisissez une option et appuyez sur Entrée ou cliquez sur Ajouter"
 
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:262
-#: lib/phoenix_kit_web/users/user_form.html.heex:760
+#: lib/phoenix_kit_web/users/user_form.html.heex:768
 #, elixir-autogen, elixir-format
 msgid "User"
 msgstr "Utilisateur"
@@ -3860,7 +3862,7 @@ msgstr "Compte"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:210
 #: lib/phoenix_kit_web/users/registration.html.heex:119
-#: lib/phoenix_kit_web/users/user_form.html.heex:166
+#: lib/phoenix_kit_web/users/user_form.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "Account Type"
 msgstr "Type de compte"
@@ -3946,7 +3948,7 @@ msgstr "Échec de l'autorisation : %{reason}"
 msgid "Authorize access to your %{provider} account. This will open a sign-in page where you choose which account to connect."
 msgstr "Autorisez l'accès à votre compte %{provider}. Cela ouvrira une page de connexion où vous pourrez choisir le compte à connecter."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:111
+#: lib/phoenix_kit_web/live/components/user_settings.ex:825
 #, elixir-autogen, elixir-format
 msgid "Avatar updated successfully!"
 msgstr "Avatar mis à jour avec succès !"
@@ -3986,12 +3988,12 @@ msgstr "Actions sur le bucket"
 msgid "CRF 0-51, lower = higher quality. 18-28 recommended."
 msgstr "CRF 0-51, plus bas = meilleure qualité. 18-28 recommandé."
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:862
+#: lib/phoenix_kit_web/users/user_form.html.heex:870
 #, elixir-autogen, elixir-format
 msgid "Cancel invitation"
 msgstr "Annuler l'invitation"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:863
+#: lib/phoenix_kit_web/users/user_form.html.heex:871
 #, elixir-autogen, elixir-format
 msgid "Cancel this invitation?"
 msgstr "Annuler cette invitation ?"
@@ -4049,7 +4051,7 @@ msgstr "Point de terminaison Cloudflare"
 msgid "Company info, tax settings, and bank details are shared across Legal, Billing, and Shop modules."
 msgstr "Les informations de l'entreprise, les paramètres fiscaux et les coordonnées bancaires sont partagés entre les modules Juridique, Facturation et Boutique."
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:199
+#: lib/phoenix_kit_web/users/user_form.html.heex:207
 #, elixir-autogen, elixir-format
 msgid "Company or organization name"
 msgstr "Nom de l'entreprise ou de l'organisation"
@@ -4334,7 +4336,7 @@ msgstr "Échec de la suppression du membre"
 msgid "Failed to save"
 msgstr "Échec de l'enregistrement"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:542
+#: lib/phoenix_kit_web/live/components/user_settings.ex:589
 #, elixir-autogen, elixir-format
 msgid "Failed to save notification preferences."
 msgstr "Échec de l'enregistrement des préférences de notification."
@@ -4344,7 +4346,7 @@ msgstr "Échec de l'enregistrement des préférences de notification."
 msgid "Failed to send invitation"
 msgstr "Impossible d'envoyer l'invitation"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:118
+#: lib/phoenix_kit_web/live/components/user_settings.ex:833
 #, elixir-autogen, elixir-format
 msgid "Failed to update avatar"
 msgstr "Échec de la mise à jour de l'avatar"
@@ -4467,7 +4469,7 @@ msgid "Integration deleted"
 msgstr "Intégration supprimée"
 
 #: lib/phoenix_kit/dashboard/admin_tabs.ex:308
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1476
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1692
 #: lib/phoenix_kit_web/live/settings/integration_form.html.heex:10
 #: lib/phoenix_kit_web/live/settings/integrations.ex:31
 #: lib/phoenix_kit_web/live/users/permissions_matrix.html.heex:75
@@ -4505,17 +4507,17 @@ msgstr "Invitation refusée."
 msgid "Invitation sent to %{email}"
 msgstr "Invitation envoyée à %{email}"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:885
+#: lib/phoenix_kit_web/users/user_form.html.heex:893
 #, elixir-autogen, elixir-format
 msgid "Invite"
 msgstr "Inviter"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:881
+#: lib/phoenix_kit_web/users/user_form.html.heex:889
 #, elixir-autogen, elixir-format
 msgid "Invite by email..."
 msgstr "Inviter par e-mail..."
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:841
+#: lib/phoenix_kit_web/users/user_form.html.heex:849
 #, elixir-autogen, elixir-format
 msgid "Invited"
 msgstr "Invité"
@@ -4662,12 +4664,12 @@ msgid "No integrations match your search."
 msgstr "Aucune intégration ne correspond à votre recherche."
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:641
-#: lib/phoenix_kit_web/users/user_form.html.heex:752
+#: lib/phoenix_kit_web/users/user_form.html.heex:760
 #, elixir-autogen, elixir-format
 msgid "No members yet"
 msgstr "Aucun membre pour le moment"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:834
+#: lib/phoenix_kit_web/users/user_form.html.heex:842
 #, elixir-autogen, elixir-format
 msgid "No pending invitations"
 msgstr "Aucune invitation en attente"
@@ -4693,13 +4695,13 @@ msgstr "Non connecté"
 msgid "Not tested"
 msgstr "Non testé"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:535
+#: lib/phoenix_kit_web/live/components/user_settings.ex:582
 #: lib/phoenix_kit_web/live/notifications/settings.ex:66
 #, elixir-autogen, elixir-format
 msgid "Notification preferences saved."
 msgstr "Préférences de notification enregistrées."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1314
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1530
 #: lib/phoenix_kit_web/live/integrations/my_integration_form.ex:483
 #: lib/phoenix_kit_web/live/modules.html.heex:337
 #: lib/phoenix_kit_web/live/settings.html.heex:382
@@ -4735,14 +4737,14 @@ msgstr "Org"
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:228
 #: lib/phoenix_kit_web/live/users/users.html.heex:203
 #: lib/phoenix_kit_web/users/registration.html.heex:136
-#: lib/phoenix_kit_web/users/user_form.html.heex:187
-#: lib/phoenix_kit_web/users/user_form.html.heex:235
+#: lib/phoenix_kit_web/users/user_form.html.heex:195
+#: lib/phoenix_kit_web/users/user_form.html.heex:243
 #, elixir-autogen, elixir-format
 msgid "Organization"
 msgstr "Organisation"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:637
-#: lib/phoenix_kit_web/users/user_form.html.heex:716
+#: lib/phoenix_kit_web/users/user_form.html.heex:724
 #, elixir-autogen, elixir-format
 msgid "Organization Members"
 msgstr "Membres de l'organisation"
@@ -4750,7 +4752,7 @@ msgstr "Membres de l'organisation"
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:220
 #: lib/phoenix_kit_web/users/magic_link_registration.html.heex:58
 #: lib/phoenix_kit_web/users/registration.html.heex:148
-#: lib/phoenix_kit_web/users/user_form.html.heex:198
+#: lib/phoenix_kit_web/users/user_form.html.heex:206
 #, elixir-autogen, elixir-format
 msgid "Organization Name"
 msgstr "Nom de l'organisation"
@@ -4760,7 +4762,7 @@ msgstr "Nom de l'organisation"
 msgid "Pause"
 msgstr "Suspendre"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:827
+#: lib/phoenix_kit_web/users/user_form.html.heex:835
 #, elixir-autogen, elixir-format
 msgid "Pending Invitations"
 msgstr "Invitations en attente"
@@ -4773,12 +4775,12 @@ msgstr "Boîte de réception par utilisateur alimentée par le flux d'activité"
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:161
 #: lib/phoenix_kit_web/live/users/users.html.heex:202
 #: lib/phoenix_kit_web/users/registration.html.heex:130
-#: lib/phoenix_kit_web/users/user_form.html.heex:177
+#: lib/phoenix_kit_web/users/user_form.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "Personal"
 msgstr "Particulier"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1353
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1569
 #, elixir-autogen, elixir-format
 msgid "Pick which notification types you want to receive. Unchecked types are muted — activities still record in the audit log but no bell notification is created for you."
 msgstr "Choisissez les types de notification que vous souhaitez recevoir. Les types non cochés sont désactivés — les activités sont toujours enregistrées dans le journal d'audit, mais aucune notification cloche n'est créée pour vous."
@@ -4829,12 +4831,12 @@ msgid "Redundancy target: %{n} copies"
 msgstr "Objectif de redondance : %{n} copies"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:704
-#: lib/phoenix_kit_web/users/user_form.html.heex:810
+#: lib/phoenix_kit_web/users/user_form.html.heex:818
 #, elixir-autogen, elixir-format
 msgid "Remove from organization"
 msgstr "Retirer de l'organisation"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:811
+#: lib/phoenix_kit_web/users/user_form.html.heex:819
 #, elixir-autogen, elixir-format
 msgid "Remove this member from the organization?"
 msgstr "Retirer ce membre de l'organisation ?"
@@ -4859,7 +4861,7 @@ msgstr "Enregistrer le bucket"
 msgid "Save Tax Settings"
 msgstr "Enregistrer les paramètres de taxe"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1383
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1599
 #: lib/phoenix_kit_web/live/notifications/settings.ex:348
 #, elixir-autogen, elixir-format
 msgid "Save preferences"
@@ -4880,7 +4882,7 @@ msgstr "Rechercher des intégrations..."
 msgid "Security check failed. Please try connecting again."
 msgstr "Échec de la vérification de sécurité. Veuillez réessayer de vous connecter."
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:731
+#: lib/phoenix_kit_web/users/user_form.html.heex:739
 #, elixir-autogen, elixir-format
 msgid "Select a user to add..."
 msgstr "Sélectionnez un utilisateur à ajouter..."
@@ -5074,7 +5076,7 @@ msgstr "Sous-répliqué"
 msgid "Unknown provider"
 msgstr "Fournisseur inconnu"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:753
+#: lib/phoenix_kit_web/users/user_form.html.heex:761
 #, elixir-autogen, elixir-format
 msgid "Use the dropdown above to add members"
 msgstr "Utilisez la liste déroulante ci-dessus pour ajouter des membres"
@@ -5627,7 +5629,6 @@ msgstr "Tâches"
 
 #: lib/phoenix_kit_web/live/modules.html.heex:77
 #: lib/phoenix_kit_web/live/modules/languages.ex:46
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr "Langues"
@@ -5808,112 +5809,112 @@ msgid_plural "%{count}d ago"
 msgstr[0] "il y a %{count}j"
 msgstr[1] "il y a %{count}j"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:19
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:21
 #, elixir-autogen
 msgid "Summary"
 msgstr "Résumé"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:24
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:26
 #, elixir-autogen
 msgid "Languages Enabled"
 msgstr "Langues activées"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:28
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:147
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:30
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:149
 #, elixir-autogen
 msgid "Countries Covered"
 msgstr "Pays couverts"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:37
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:39
 #, elixir-autogen
 msgid "Enabled Languages"
 msgstr "Langues activées"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:134
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:136
 #, elixir-autogen
 msgid "Default language"
 msgstr "Langue par défaut"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:164
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:166
 #, elixir-autogen
 msgid "Available Languages"
 msgstr "Langues disponibles"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:266
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:268
 #, elixir-autogen
 msgid "Language Configuration"
 msgstr "Configuration des langues"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:312
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:314
 #, elixir-autogen
 msgid "Frontend Language Switcher"
 msgstr "Sélecteur de langue du site"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:322
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:324
 #, elixir-autogen
 msgid "Switcher Settings"
 msgstr "Paramètres du sélecteur"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:327
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:329
 #, elixir-autogen
 msgid "Show Flags"
 msgstr "Afficher les drapeaux"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:341
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:343
 #, elixir-autogen
 msgid "Show Names"
 msgstr "Afficher les noms"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:355
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:357
 #, elixir-autogen
 msgid "Native Names"
 msgstr "Noms natifs"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:369
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:371
 #, elixir-autogen
 msgid "Go to Home"
 msgstr "Aller à l'accueil"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:383
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:385
 #, elixir-autogen
 msgid "Hide Current"
 msgstr "Masquer la langue actuelle"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:414
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:416
 #, elixir-autogen
 msgid "Generated Code"
 msgstr "Code généré"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:429
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:431
 #, elixir-autogen
 msgid "Implementation Notes"
 msgstr "Notes d'implémentation"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:447
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:449
 #, elixir-autogen
 msgid "Enable and Configure Languages"
 msgstr "Activer et configurer les langues"
 
 #: lib/phoenix_kit_web/components/media_browser.html.heex:623
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:47
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:49
 #, elixir-autogen
 msgid "Done"
 msgstr "Terminé"
 
 #: lib/phoenix_kit_web/components/core/reorder_modal.ex:65
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:49
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:51
 #, elixir-autogen
 msgid "Reorder"
 msgstr "Réorganiser"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:54
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:219
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:56
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:221
 #: lib/phoenix_kit_web/live/users/users.html.heex:1206
 #, elixir-autogen
 msgid "Default"
 msgstr "Par défaut"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:155
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:157
 #, elixir-autogen
 msgid "No languages enabled yet."
 msgstr "Aucune langue activée pour le moment."
@@ -7271,12 +7272,12 @@ msgstr "Trier par"
 msgid "Status:"
 msgstr "Statut :"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:280
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:282
 #, elixir-autogen, elixir-format
 msgid "Controls how the primary language appears in URLs across the site — admin pages, public pages, sitemap, and redirects."
 msgstr "Détermine comment la langue principale apparaît dans les URL du site — pages d'administration, pages publiques, plan du site et redirections."
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:290
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:292
 #, elixir-autogen, elixir-format
 msgid "Default Language Without Prefix"
 msgstr "Langue par défaut sans préfixe"
@@ -7286,12 +7287,12 @@ msgstr "Langue par défaut sans préfixe"
 msgid "Failed to update URL behavior setting"
 msgstr "Impossible de mettre à jour le paramètre"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:278
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:280
 #, elixir-autogen, elixir-format
 msgid "URL Behavior"
 msgstr "Comportement des URL"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:293
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:295
 #, elixir-autogen, elixir-format
 msgid "When on, the primary language drops its locale segment in every URL (e.g. /admin/users instead of /en/admin/users, /blog/post instead of /en/blog/post). Other languages always keep their prefix."
 msgstr "Lorsque cette option est activée, la langue principale supprime son segment de locale dans chaque URL (par ex. /admin/users au lieu de /en/admin/users, /blog/post au lieu de /en/blog/post). Les autres langues conservent toujours leur préfixe."
@@ -10179,12 +10180,12 @@ msgstr "xAI"
 msgid "xAI requires a funded account before the API will return completions"
 msgstr "xAI exige un compte crédité avant que l'API ne renvoie des complétions"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:618
+#: lib/phoenix_kit_web/live/components/user_settings.ex:665
 #, elixir-autogen, elixir-format
 msgid "Active now"
 msgstr "Actif maintenant"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1410
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1626
 #, elixir-autogen, elixir-format
 msgid "Devices currently signed in to your account. If you don't recognize one, sign it out."
 msgstr "Appareils actuellement connectés à votre compte. Si vous n'en reconnaissez pas un, déconnectez-le."
@@ -10199,58 +10200,58 @@ msgstr "Nouvelle connexion à votre compte depuis %{details}."
 msgid "New sign-in to your account."
 msgstr "Nouvelle connexion à votre compte."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1443
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1659
 #, elixir-autogen, elixir-format
 msgid "Sign out"
 msgstr "Se déconnecter"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1454
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1670
 #, elixir-autogen, elixir-format
 msgid "Sign out of all other sessions?"
 msgstr "Se déconnecter de toutes les autres sessions ?"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1457
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1673
 #, elixir-autogen, elixir-format
 msgid "Sign out other sessions"
 msgstr "Déconnecter les autres sessions"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:569
+#: lib/phoenix_kit_web/live/components/user_settings.ex:616
 #, elixir-autogen, elixir-format
 msgid "Signed out of all other sessions."
 msgstr "Déconnecté de toutes les autres sessions."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:552
+#: lib/phoenix_kit_web/live/components/user_settings.ex:599
 #, elixir-autogen, elixir-format
 msgid "Signed out of that session."
 msgstr "Déconnecté de cette session."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:553
+#: lib/phoenix_kit_web/live/components/user_settings.ex:600
 #, elixir-autogen, elixir-format
 msgid "That session is no longer active."
 msgstr "Cette session n'est plus active."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1427
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1643
 #, elixir-autogen, elixir-format
 msgid "This device"
 msgstr "Cet appareil"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:610
+#: lib/phoenix_kit_web/live/components/user_settings.ex:657
 #: lib/phoenix_kit_web/live/users/sessions.ex:342
 #, elixir-autogen, elixir-format
 msgid "Unknown device"
 msgstr "Appareil inconnu"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:632
+#: lib/phoenix_kit_web/live/components/user_settings.ex:679
 #, elixir-autogen, elixir-format
 msgid "Active %{date} at %{time}"
 msgstr "Actif le %{date} à %{time}"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:626
+#: lib/phoenix_kit_web/live/components/user_settings.ex:673
 #, elixir-autogen, elixir-format
 msgid "Active today at %{time}"
 msgstr "Actif aujourd'hui à %{time}"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:629
+#: lib/phoenix_kit_web/live/components/user_settings.ex:676
 #, elixir-autogen, elixir-format
 msgid "Active yesterday at %{time}"
 msgstr "Actif hier à %{time}"
@@ -12346,8 +12347,8 @@ msgstr "Traitement sur le serveur…"
 msgid "Select Audio"
 msgstr "Sélectionner un fichier audio"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:997
-#: lib/phoenix_kit_web/users/user_form.html.heex:1009
+#: lib/phoenix_kit_web/users/user_form.html.heex:1005
+#: lib/phoenix_kit_web/users/user_form.html.heex:1017
 #, elixir-autogen, elixir-format
 msgid "Select Avatar"
 msgstr "Sélectionner un avatar"
@@ -12911,7 +12912,7 @@ msgstr "Veuillez saisir un nom"
 msgid "Too many registration attempts. Please try again later."
 msgstr "Trop de tentatives d'inscription. Veuillez réessayer plus tard."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1335
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1551
 #, elixir-autogen, elixir-format
 msgid "%{enabled} of %{total} notification types enabled"
 msgstr "%{enabled} type(s) de notification activé(s) sur %{total}"
@@ -12951,12 +12952,12 @@ msgstr "Un magasin de clés est configuré mais son secret n'a pas pu être lu :
 msgid "Back at it"
 msgstr "De retour au travail"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:892
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1016
 #, elixir-autogen, elixir-format
 msgid "Browser detected: %{zone}"
 msgstr "Détecté par le navigateur : %{zone}"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:871
+#: lib/phoenix_kit_web/live/components/user_settings.ex:995
 #, elixir-autogen, elixir-format
 msgid "Check your timezone"
 msgstr "Vérifiez votre fuseau horaire"
@@ -13036,7 +13037,7 @@ msgstr "Rebonjour"
 msgid "Hey there"
 msgstr "Salut"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1328
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1544
 #, elixir-autogen, elixir-format
 msgid "Manage Notifications"
 msgstr "Gérer les notifications"
@@ -13111,12 +13112,12 @@ msgstr "Le secret du magasin de clés (%{location}) a été rejeté car plus cou
 msgid "The secret in the key store was rejected as too short"
 msgstr "Le secret du magasin de clés a été rejeté car trop court"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:492
+#: lib/phoenix_kit_web/live/components/user_settings.ex:539
 #, elixir-autogen, elixir-format
 msgid "Timezone set to %{zone}."
 msgstr "Fuseau horaire défini sur %{zone}."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:885
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1009
 #, elixir-autogen, elixir-format
 msgid "Use %{zone}"
 msgstr "Utiliser %{zone}"
@@ -13136,17 +13137,17 @@ msgstr "Destination de l'entrée « Paramètres » du menu utilisateur. Vide = l
 msgid "Working late"
 msgstr "Au travail tard le soir"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:690
+#: lib/phoenix_kit_web/live/components/user_settings.ex:737
 #, elixir-autogen, elixir-format
 msgid "Your browser reports %{browser}, but this account is set to %{saved}. Times on this site will be shown in %{saved}."
 msgstr "Votre navigateur indique %{browser}, mais ce compte est réglé sur %{saved}. Les heures de ce site seront affichées en %{saved}."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:681
+#: lib/phoenix_kit_web/live/components/user_settings.ex:728
 #, elixir-autogen, elixir-format
 msgid "Your browser reports %{zone}. This account still stores a fixed UTC offset, which cannot follow daylight saving — it will drift by an hour at the next change."
 msgstr "Votre navigateur indique %{zone}. Ce compte enregistre encore un décalage UTC fixe, qui ne peut pas suivre l'heure d'été — il dérivera d'une heure au prochain changement."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:674
+#: lib/phoenix_kit_web/live/components/user_settings.ex:721
 #, elixir-autogen, elixir-format
 msgid "Your browser reports %{zone}. You have not set a timezone, so times are shown using the site default."
 msgstr "Votre navigateur indique %{zone}. Vous n'avez pas défini de fuseau horaire : les heures sont affichées avec celui par défaut du site."
@@ -14246,12 +14247,12 @@ msgstr "Cette fonction n'a pas d'interrupteur."
 msgid "Site is closed to visitors"
 msgstr "Le site est fermé aux visiteurs"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1479
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1695
 #, elixir-autogen, elixir-format
 msgid "Manage Integrations"
 msgstr "Gérer les intégrations"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1487
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1703
 #, elixir-autogen, elixir-format
 msgid "No personal integrations yet."
 msgstr "Aucune intégration personnelle pour l'instant."
@@ -14262,7 +14263,7 @@ msgstr "Aucune intégration personnelle pour l'instant."
 msgid "You don't have access to Integrations."
 msgstr "Vous n'avez pas accès aux intégrations."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1483
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1699
 #, elixir-autogen, elixir-format
 msgid "Your own API keys and bot connections — only you can see or use these."
 msgstr "Vos propres clés API et connexions de bots — vous seul pouvez les voir ou les utiliser."
@@ -14420,3 +14421,38 @@ msgstr "Sources"
 #, elixir-autogen, elixir-format
 msgid "Storage buckets and file processing"
 msgstr ""
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1051
+#, elixir-autogen, elixir-format
+msgid "Adjust Avatar Crop"
+msgstr "Ajuster le cadrage de l'avatar"
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:943
+#, elixir-autogen, elixir-format
+msgid "Adjust Crop"
+msgstr "Ajuster le cadrage"
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:499
+#, elixir-autogen, elixir-format
+msgid "Avatar crop reset."
+msgstr "Cadrage de l'avatar réinitialisé."
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:487
+#, elixir-autogen, elixir-format
+msgid "Avatar crop updated!"
+msgstr "Cadrage de l'avatar mis à jour !"
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:871
+#, elixir-autogen, elixir-format
+msgid "Failed to update avatar crop"
+msgstr "Échec de la mise à jour du cadrage de l'avatar"
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1127
+#, elixir-autogen, elixir-format
+msgid "Save Crop"
+msgstr "Enregistrer le cadrage"
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1088
+#, elixir-autogen, elixir-format
+msgid "Zoom"
+msgstr "Zoom"

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -127,8 +127,8 @@ msgstr "Crea un nuovo account"
 #: lib/phoenix_kit_web/users/forgot_password.html.heex:15
 #: lib/phoenix_kit_web/users/magic_link.html.heex:30
 #: lib/phoenix_kit_web/users/registration.html.heex:56
-#: lib/phoenix_kit_web/users/user_form.html.heex:761
-#: lib/phoenix_kit_web/users/user_form.html.heex:840
+#: lib/phoenix_kit_web/users/user_form.html.heex:769
+#: lib/phoenix_kit_web/users/user_form.html.heex:848
 #, elixir-autogen
 msgid "Email"
 msgstr "Email"
@@ -188,7 +188,7 @@ msgstr "Account registrati"
 
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:259
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:264
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1399
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1615
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:18
 #, elixir-autogen
 msgid "Active Sessions"
@@ -379,7 +379,7 @@ msgstr "Autenticazione"
 #: lib/phoenix_kit_web/live/users/users.ex:1200
 #: lib/phoenix_kit_web/live/users/users.html.heex:248
 #: lib/phoenix_kit_web/live/users/users.html.heex:573
-#: lib/phoenix_kit_web/users/user_form.html.heex:786
+#: lib/phoenix_kit_web/users/user_form.html.heex:794
 #, elixir-autogen
 msgid "Active"
 msgstr "Attivo"
@@ -399,7 +399,7 @@ msgstr "Attivo"
 #: lib/phoenix_kit_web/live/modules.html.heex:284
 #: lib/phoenix_kit_web/live/modules.html.heex:349
 #: lib/phoenix_kit_web/live/modules.html.heex:405
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:59
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:61
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:49
 #: lib/phoenix_kit_web/live/settings/send_profile_form.html.heex:90
 #: lib/phoenix_kit_web/live/settings/users.html.heex:465
@@ -439,7 +439,7 @@ msgstr "%{language} (bozza)"
 msgid "%{language} (Published)"
 msgstr "%{language} (pubblicato)"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:403
+#: lib/phoenix_kit_web/live/components/user_settings.ex:384
 #, elixir-autogen, elixir-format
 msgid "%{provider} account disconnected successfully"
 msgstr "Account %{provider} disconnesso con successo"
@@ -459,7 +459,7 @@ msgstr "(opzionale)"
 msgid "123 Business Street"
 msgstr "Via Roma 123"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:250
+#: lib/phoenix_kit_web/live/components/user_settings.ex:231
 #, elixir-autogen, elixir-format
 msgid "A link to confirm your email change has been sent to the new address."
 msgstr "Un link per confermare la modifica dell'email è stato inviato al nuovo indirizzo."
@@ -506,8 +506,8 @@ msgstr "Informazioni sull'account"
 #: lib/phoenix_kit_web/live/users/roles.html.heex:163
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:269
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:651
-#: lib/phoenix_kit_web/users/user_form.html.heex:763
-#: lib/phoenix_kit_web/users/user_form.html.heex:843
+#: lib/phoenix_kit_web/users/user_form.html.heex:771
+#: lib/phoenix_kit_web/users/user_form.html.heex:851
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr "Azioni"
@@ -516,7 +516,7 @@ msgstr "Azioni"
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:610
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:314
 #: lib/phoenix_kit_web/live/settings/users.html.heex:795
-#: lib/phoenix_kit_web/users/user_form.html.heex:742
+#: lib/phoenix_kit_web/users/user_form.html.heex:750
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr "Aggiungi"
@@ -646,7 +646,8 @@ msgstr "Elenco puntato"
 #: lib/phoenix_kit_web/components/media_browser.html.heex:2440
 #: lib/phoenix_kit_web/components/user_dashboard_nav.ex:317
 #: lib/phoenix_kit_web/live/components/media_selector_modal.html.heex:65
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1327
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1113
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1543
 #: lib/phoenix_kit_web/live/notifications/settings.ex:434
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:493
 #: lib/phoenix_kit_web/live/settings/send_profile_form.html.heex:152
@@ -686,12 +687,12 @@ msgstr "Impossibile eliminare l'ultimo proprietario del sistema"
 msgid "Cannot delete your own account"
 msgstr "Non puoi eliminare il tuo account"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:437
+#: lib/phoenix_kit_web/live/components/user_settings.ex:418
 #, elixir-autogen, elixir-format
 msgid "Cannot disconnect %{provider}. Please ensure you have at least one sign-in method available."
 msgstr "Impossibile disconnettere %{provider}. Assicurati di avere almeno un metodo di accesso disponibile."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:432
+#: lib/phoenix_kit_web/live/components/user_settings.ex:413
 #, elixir-autogen, elixir-format
 msgid "Cannot disconnect %{provider}. This is your only sign-in method. Please set a password or connect another provider first."
 msgstr "Impossibile disconnettere %{provider}. È il tuo unico metodo di accesso. Imposta prima una password o collega un altro provider."
@@ -1098,7 +1099,7 @@ msgstr "Impossibile eliminare il ruolo"
 msgid "Failed to delete user"
 msgstr "Impossibile eliminare l'utente"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:423
+#: lib/phoenix_kit_web/live/components/user_settings.ex:404
 #, elixir-autogen, elixir-format
 msgid "Failed to disconnect provider. Please try again."
 msgstr "Impossibile disconnettere il provider. Riprova."
@@ -1237,7 +1238,7 @@ msgstr "Immagine"
 #: lib/phoenix_kit_web/live/users/users.ex:1200
 #: lib/phoenix_kit_web/live/users/users.html.heex:249
 #: lib/phoenix_kit_web/live/users/users.html.heex:577
-#: lib/phoenix_kit_web/users/user_form.html.heex:790
+#: lib/phoenix_kit_web/users/user_form.html.heex:798
 #, elixir-autogen, elixir-format
 msgid "Inactive"
 msgstr "Inattivo"
@@ -1480,7 +1481,7 @@ msgstr "OK"
 msgid "Only the Owner can edit Admin permissions"
 msgstr "Solo il proprietario può modificare i permessi di amministratore"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:236
+#: lib/phoenix_kit_web/users/user_form.html.heex:244
 #, elixir-autogen, elixir-format
 msgid "Optional"
 msgstr "Opzionale"
@@ -1542,7 +1543,7 @@ msgstr "Pagina pubblicata con successo"
 msgid "Password"
 msgstr "Password"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:301
+#: lib/phoenix_kit_web/live/components/user_settings.ex:282
 #, elixir-autogen, elixir-format
 msgid "Password changed successfully."
 msgstr "Password modificata con successo."
@@ -1625,7 +1626,7 @@ msgstr "Preferenze sulla privacy"
 msgid "Profile"
 msgstr "Profilo"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:362
+#: lib/phoenix_kit_web/live/components/user_settings.ex:343
 #, elixir-autogen, elixir-format
 msgid "Profile updated successfully"
 msgstr "Profilo aggiornato con successo"
@@ -1641,7 +1642,7 @@ msgstr "Protetto"
 msgid "Protected core roles"
 msgstr "Ruoli principali protetti"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:413
+#: lib/phoenix_kit_web/live/components/user_settings.ex:394
 #, elixir-autogen, elixir-format
 msgid "Provider not found"
 msgstr "Provider non trovato"
@@ -1945,7 +1946,7 @@ msgstr "Stato/Provincia"
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:294
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:650
 #: lib/phoenix_kit_web/live/users/users.html.heex:263
-#: lib/phoenix_kit_web/users/user_form.html.heex:762
+#: lib/phoenix_kit_web/users/user_form.html.heex:770
 #, elixir-autogen, elixir-format
 msgid "Status"
 msgstr "Stato"
@@ -2140,7 +2141,7 @@ msgstr "Video"
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:695
 #: lib/phoenix_kit_web/live/users/users.html.heex:667
 #: lib/phoenix_kit_web/live/users/users.html.heex:794
-#: lib/phoenix_kit_web/users/user_form.html.heex:801
+#: lib/phoenix_kit_web/users/user_form.html.heex:809
 #, elixir-autogen, elixir-format
 msgid "View"
 msgstr "Visualizza"
@@ -2272,7 +2273,7 @@ msgstr "Elimina bucket"
 #: lib/modules/storage/web/dimensions.html.heex:466
 #: lib/modules/storage/web/settings.html.heex:221
 #: lib/modules/storage/web/settings.html.heex:257
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:126
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:128
 #: lib/phoenix_kit_web/live/settings/users.html.heex:563
 #: lib/phoenix_kit_web/live/settings/users.html.heex:609
 #, elixir-autogen, elixir-format
@@ -2298,7 +2299,7 @@ msgstr "Attiva"
 
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:166
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:268
-#: lib/phoenix_kit_web/users/user_form.html.heex:842
+#: lib/phoenix_kit_web/users/user_form.html.heex:850
 #, elixir-autogen, elixir-format
 msgid "Expires"
 msgstr "Scade"
@@ -2314,7 +2315,7 @@ msgstr "Impossibile %{action} il modulo Legale"
 msgid "Hide"
 msgstr "Nascondi"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:400
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:402
 #, elixir-autogen, elixir-format
 msgid "Live Preview"
 msgstr "Anteprima in tempo reale"
@@ -2359,9 +2360,9 @@ msgstr "Revoca"
 msgid "Revoke all"
 msgstr "Revoca tutti"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:117
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:230
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:234
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:119
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:232
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:236
 #, elixir-autogen, elixir-format
 msgid "Set Default"
 msgstr "Imposta come predefinito"
@@ -3250,6 +3251,7 @@ msgid "Required field"
 msgstr "Campo obbligatorio"
 
 #: lib/phoenix_kit_web/components/core/column_settings.ex:136
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1104
 #: lib/phoenix_kit_web/live/settings.html.heex:640
 #, elixir-autogen, elixir-format
 msgid "Reset"
@@ -3474,7 +3476,7 @@ msgid "Type an option and press Enter or click Add"
 msgstr "Digita un'opzione e premi Invio oppure fai clic su Aggiungi"
 
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:262
-#: lib/phoenix_kit_web/users/user_form.html.heex:760
+#: lib/phoenix_kit_web/users/user_form.html.heex:768
 #, elixir-autogen, elixir-format
 msgid "User"
 msgstr "Utente"
@@ -3860,7 +3862,7 @@ msgstr "Account"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:210
 #: lib/phoenix_kit_web/users/registration.html.heex:119
-#: lib/phoenix_kit_web/users/user_form.html.heex:166
+#: lib/phoenix_kit_web/users/user_form.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "Account Type"
 msgstr "Tipo di account"
@@ -3946,7 +3948,7 @@ msgstr "Autorizzazione non riuscita: %{reason}"
 msgid "Authorize access to your %{provider} account. This will open a sign-in page where you choose which account to connect."
 msgstr "Autorizza l'accesso al tuo account %{provider}. Si aprirà una pagina di accesso in cui scegliere quale account collegare."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:111
+#: lib/phoenix_kit_web/live/components/user_settings.ex:825
 #, elixir-autogen, elixir-format
 msgid "Avatar updated successfully!"
 msgstr "Avatar aggiornato con successo!"
@@ -3986,12 +3988,12 @@ msgstr "Azioni sul bucket"
 msgid "CRF 0-51, lower = higher quality. 18-28 recommended."
 msgstr "CRF da 0 a 51, più basso = qualità migliore. Consigliato 18-28."
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:862
+#: lib/phoenix_kit_web/users/user_form.html.heex:870
 #, elixir-autogen, elixir-format
 msgid "Cancel invitation"
 msgstr "Annulla l'invito"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:863
+#: lib/phoenix_kit_web/users/user_form.html.heex:871
 #, elixir-autogen, elixir-format
 msgid "Cancel this invitation?"
 msgstr "Annullare questo invito?"
@@ -4049,7 +4051,7 @@ msgstr "Endpoint Cloudflare"
 msgid "Company info, tax settings, and bank details are shared across Legal, Billing, and Shop modules."
 msgstr "Le informazioni aziendali, le impostazioni fiscali e i dati bancari sono condivisi tra i moduli Legale, Fatturazione e Negozio."
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:199
+#: lib/phoenix_kit_web/users/user_form.html.heex:207
 #, elixir-autogen, elixir-format
 msgid "Company or organization name"
 msgstr "Nome dell'azienda o dell'organizzazione"
@@ -4334,7 +4336,7 @@ msgstr "Impossibile rimuovere il membro"
 msgid "Failed to save"
 msgstr "Salvataggio non riuscito"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:542
+#: lib/phoenix_kit_web/live/components/user_settings.ex:589
 #, elixir-autogen, elixir-format
 msgid "Failed to save notification preferences."
 msgstr "Impossibile salvare le preferenze di notifica."
@@ -4344,7 +4346,7 @@ msgstr "Impossibile salvare le preferenze di notifica."
 msgid "Failed to send invitation"
 msgstr "Impossibile inviare l'invito"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:118
+#: lib/phoenix_kit_web/live/components/user_settings.ex:833
 #, elixir-autogen, elixir-format
 msgid "Failed to update avatar"
 msgstr "Impossibile aggiornare l'avatar"
@@ -4467,7 +4469,7 @@ msgid "Integration deleted"
 msgstr "Integrazione eliminata"
 
 #: lib/phoenix_kit/dashboard/admin_tabs.ex:308
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1476
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1692
 #: lib/phoenix_kit_web/live/settings/integration_form.html.heex:10
 #: lib/phoenix_kit_web/live/settings/integrations.ex:31
 #: lib/phoenix_kit_web/live/users/permissions_matrix.html.heex:75
@@ -4505,17 +4507,17 @@ msgstr "Invito rifiutato."
 msgid "Invitation sent to %{email}"
 msgstr "Invito inviato a %{email}"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:885
+#: lib/phoenix_kit_web/users/user_form.html.heex:893
 #, elixir-autogen, elixir-format
 msgid "Invite"
 msgstr "Invita"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:881
+#: lib/phoenix_kit_web/users/user_form.html.heex:889
 #, elixir-autogen, elixir-format
 msgid "Invite by email..."
 msgstr "Invita per email…"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:841
+#: lib/phoenix_kit_web/users/user_form.html.heex:849
 #, elixir-autogen, elixir-format
 msgid "Invited"
 msgstr "Invitato"
@@ -4662,12 +4664,12 @@ msgid "No integrations match your search."
 msgstr "Nessuna integrazione corrisponde alla ricerca."
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:641
-#: lib/phoenix_kit_web/users/user_form.html.heex:752
+#: lib/phoenix_kit_web/users/user_form.html.heex:760
 #, elixir-autogen, elixir-format
 msgid "No members yet"
 msgstr "Ancora nessun membro"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:834
+#: lib/phoenix_kit_web/users/user_form.html.heex:842
 #, elixir-autogen, elixir-format
 msgid "No pending invitations"
 msgstr "Nessun invito in attesa"
@@ -4693,13 +4695,13 @@ msgstr "Non collegato"
 msgid "Not tested"
 msgstr "Non testato"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:535
+#: lib/phoenix_kit_web/live/components/user_settings.ex:582
 #: lib/phoenix_kit_web/live/notifications/settings.ex:66
 #, elixir-autogen, elixir-format
 msgid "Notification preferences saved."
 msgstr "Preferenze di notifica salvate."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1314
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1530
 #: lib/phoenix_kit_web/live/integrations/my_integration_form.ex:483
 #: lib/phoenix_kit_web/live/modules.html.heex:337
 #: lib/phoenix_kit_web/live/settings.html.heex:382
@@ -4735,14 +4737,14 @@ msgstr "Org."
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:228
 #: lib/phoenix_kit_web/live/users/users.html.heex:203
 #: lib/phoenix_kit_web/users/registration.html.heex:136
-#: lib/phoenix_kit_web/users/user_form.html.heex:187
-#: lib/phoenix_kit_web/users/user_form.html.heex:235
+#: lib/phoenix_kit_web/users/user_form.html.heex:195
+#: lib/phoenix_kit_web/users/user_form.html.heex:243
 #, elixir-autogen, elixir-format
 msgid "Organization"
 msgstr "Organizzazione"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:637
-#: lib/phoenix_kit_web/users/user_form.html.heex:716
+#: lib/phoenix_kit_web/users/user_form.html.heex:724
 #, elixir-autogen, elixir-format
 msgid "Organization Members"
 msgstr "Membri dell'organizzazione"
@@ -4750,7 +4752,7 @@ msgstr "Membri dell'organizzazione"
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:220
 #: lib/phoenix_kit_web/users/magic_link_registration.html.heex:58
 #: lib/phoenix_kit_web/users/registration.html.heex:148
-#: lib/phoenix_kit_web/users/user_form.html.heex:198
+#: lib/phoenix_kit_web/users/user_form.html.heex:206
 #, elixir-autogen, elixir-format
 msgid "Organization Name"
 msgstr "Nome dell'organizzazione"
@@ -4760,7 +4762,7 @@ msgstr "Nome dell'organizzazione"
 msgid "Pause"
 msgstr "Pausa"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:827
+#: lib/phoenix_kit_web/users/user_form.html.heex:835
 #, elixir-autogen, elixir-format
 msgid "Pending Invitations"
 msgstr "Inviti in attesa"
@@ -4773,12 +4775,12 @@ msgstr "Posta in arrivo per utente basata sul feed delle attività"
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:161
 #: lib/phoenix_kit_web/live/users/users.html.heex:202
 #: lib/phoenix_kit_web/users/registration.html.heex:130
-#: lib/phoenix_kit_web/users/user_form.html.heex:177
+#: lib/phoenix_kit_web/users/user_form.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "Personal"
 msgstr "Privato"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1353
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1569
 #, elixir-autogen, elixir-format
 msgid "Pick which notification types you want to receive. Unchecked types are muted — activities still record in the audit log but no bell notification is created for you."
 msgstr "Scegli quali tipi di notifica vuoi ricevere. I tipi non selezionati sono silenziati: le attività vengono comunque registrate nel log di audit, ma non viene creata alcuna notifica nella campanella."
@@ -4829,12 +4831,12 @@ msgid "Redundancy target: %{n} copies"
 msgstr "Obiettivo di ridondanza: %{n} copie"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:704
-#: lib/phoenix_kit_web/users/user_form.html.heex:810
+#: lib/phoenix_kit_web/users/user_form.html.heex:818
 #, elixir-autogen, elixir-format
 msgid "Remove from organization"
 msgstr "Rimuovi dall'organizzazione"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:811
+#: lib/phoenix_kit_web/users/user_form.html.heex:819
 #, elixir-autogen, elixir-format
 msgid "Remove this member from the organization?"
 msgstr "Rimuovere questo membro dall'organizzazione?"
@@ -4859,7 +4861,7 @@ msgstr "Salva bucket"
 msgid "Save Tax Settings"
 msgstr "Salva le impostazioni fiscali"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1383
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1599
 #: lib/phoenix_kit_web/live/notifications/settings.ex:348
 #, elixir-autogen, elixir-format
 msgid "Save preferences"
@@ -4880,7 +4882,7 @@ msgstr "Cerca integrazioni…"
 msgid "Security check failed. Please try connecting again."
 msgstr "Controllo di sicurezza non riuscito. Prova a collegarti di nuovo."
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:731
+#: lib/phoenix_kit_web/users/user_form.html.heex:739
 #, elixir-autogen, elixir-format
 msgid "Select a user to add..."
 msgstr "Seleziona un utente da aggiungere…"
@@ -5074,7 +5076,7 @@ msgstr "Replicazione insufficiente"
 msgid "Unknown provider"
 msgstr "Provider sconosciuto"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:753
+#: lib/phoenix_kit_web/users/user_form.html.heex:761
 #, elixir-autogen, elixir-format
 msgid "Use the dropdown above to add members"
 msgstr "Usa il menu a tendina qui sopra per aggiungere membri"
@@ -5627,7 +5629,6 @@ msgstr "Job"
 
 #: lib/phoenix_kit_web/live/modules.html.heex:77
 #: lib/phoenix_kit_web/live/modules/languages.ex:46
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr "Lingue"
@@ -5808,112 +5809,112 @@ msgid_plural "%{count}d ago"
 msgstr[0] "%{count} g fa"
 msgstr[1] "%{count} g fa"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:19
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:21
 #, elixir-autogen
 msgid "Summary"
 msgstr "Riepilogo"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:24
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:26
 #, elixir-autogen
 msgid "Languages Enabled"
 msgstr "Lingue attive"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:28
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:147
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:30
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:149
 #, elixir-autogen
 msgid "Countries Covered"
 msgstr "Paesi coperti"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:37
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:39
 #, elixir-autogen
 msgid "Enabled Languages"
 msgstr "Lingue attive"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:134
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:136
 #, elixir-autogen
 msgid "Default language"
 msgstr "Lingua predefinita"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:164
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:166
 #, elixir-autogen
 msgid "Available Languages"
 msgstr "Lingue disponibili"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:266
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:268
 #, elixir-autogen
 msgid "Language Configuration"
 msgstr "Configurazione delle lingue"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:312
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:314
 #, elixir-autogen
 msgid "Frontend Language Switcher"
 msgstr "Selettore di lingua nel frontend"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:322
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:324
 #, elixir-autogen
 msgid "Switcher Settings"
 msgstr "Impostazioni del selettore"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:327
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:329
 #, elixir-autogen
 msgid "Show Flags"
 msgstr "Mostra le bandiere"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:341
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:343
 #, elixir-autogen
 msgid "Show Names"
 msgstr "Mostra i nomi"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:355
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:357
 #, elixir-autogen
 msgid "Native Names"
 msgstr "Nomi nativi"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:369
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:371
 #, elixir-autogen
 msgid "Go to Home"
 msgstr "Vai alla home"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:383
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:385
 #, elixir-autogen
 msgid "Hide Current"
 msgstr "Nascondi l'attuale"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:414
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:416
 #, elixir-autogen
 msgid "Generated Code"
 msgstr "Codice generato"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:429
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:431
 #, elixir-autogen
 msgid "Implementation Notes"
 msgstr "Note di implementazione"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:447
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:449
 #, elixir-autogen
 msgid "Enable and Configure Languages"
 msgstr "Attiva e configura le lingue"
 
 #: lib/phoenix_kit_web/components/media_browser.html.heex:623
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:47
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:49
 #, elixir-autogen
 msgid "Done"
 msgstr "Fatto"
 
 #: lib/phoenix_kit_web/components/core/reorder_modal.ex:65
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:49
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:51
 #, elixir-autogen
 msgid "Reorder"
 msgstr "Riordina"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:54
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:219
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:56
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:221
 #: lib/phoenix_kit_web/live/users/users.html.heex:1206
 #, elixir-autogen
 msgid "Default"
 msgstr "Predefinito"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:155
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:157
 #, elixir-autogen
 msgid "No languages enabled yet."
 msgstr "Nessuna lingua ancora attiva."
@@ -7271,12 +7272,12 @@ msgstr "Ordina per"
 msgid "Status:"
 msgstr "Stato:"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:280
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:282
 #, elixir-autogen, elixir-format
 msgid "Controls how the primary language appears in URLs across the site — admin pages, public pages, sitemap, and redirects."
 msgstr "Controlla come la lingua principale appare negli URL di tutto il sito — pagine di amministrazione, pagine pubbliche, sitemap e reindirizzamenti."
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:290
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:292
 #, elixir-autogen, elixir-format
 msgid "Default Language Without Prefix"
 msgstr "Lingua predefinita senza prefisso"
@@ -7286,12 +7287,12 @@ msgstr "Lingua predefinita senza prefisso"
 msgid "Failed to update URL behavior setting"
 msgstr "Impossibile aggiornare l'impostazione"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:278
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:280
 #, elixir-autogen, elixir-format
 msgid "URL Behavior"
 msgstr "Comportamento degli URL"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:293
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:295
 #, elixir-autogen, elixir-format
 msgid "When on, the primary language drops its locale segment in every URL (e.g. /admin/users instead of /en/admin/users, /blog/post instead of /en/blog/post). Other languages always keep their prefix."
 msgstr "Se attivo, la lingua principale perde il segmento della lingua in ogni URL (es. /admin/users invece di /en/admin/users, /blog/post invece di /en/blog/post). Le altre lingue mantengono sempre il prefisso."
@@ -10179,12 +10180,12 @@ msgstr "xAI"
 msgid "xAI requires a funded account before the API will return completions"
 msgstr "xAI richiede un account con credito prima che l'API restituisca completion"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:618
+#: lib/phoenix_kit_web/live/components/user_settings.ex:665
 #, elixir-autogen, elixir-format
 msgid "Active now"
 msgstr "Attivo ora"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1410
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1626
 #, elixir-autogen, elixir-format
 msgid "Devices currently signed in to your account. If you don't recognize one, sign it out."
 msgstr "Dispositivi attualmente connessi al tuo account. Se non ne riconosci uno, disconnettilo."
@@ -10199,58 +10200,58 @@ msgstr "Nuovo accesso al tuo account da %{details}."
 msgid "New sign-in to your account."
 msgstr "Nuovo accesso al tuo account."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1443
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1659
 #, elixir-autogen, elixir-format
 msgid "Sign out"
 msgstr "Esci"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1454
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1670
 #, elixir-autogen, elixir-format
 msgid "Sign out of all other sessions?"
 msgstr "Disconnettersi da tutte le altre sessioni?"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1457
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1673
 #, elixir-autogen, elixir-format
 msgid "Sign out other sessions"
 msgstr "Disconnetti le altre sessioni"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:569
+#: lib/phoenix_kit_web/live/components/user_settings.ex:616
 #, elixir-autogen, elixir-format
 msgid "Signed out of all other sessions."
 msgstr "Disconnesso da tutte le altre sessioni."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:552
+#: lib/phoenix_kit_web/live/components/user_settings.ex:599
 #, elixir-autogen, elixir-format
 msgid "Signed out of that session."
 msgstr "Disconnesso da quella sessione."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:553
+#: lib/phoenix_kit_web/live/components/user_settings.ex:600
 #, elixir-autogen, elixir-format
 msgid "That session is no longer active."
 msgstr "Quella sessione non è più attiva."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1427
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1643
 #, elixir-autogen, elixir-format
 msgid "This device"
 msgstr "Questo dispositivo"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:610
+#: lib/phoenix_kit_web/live/components/user_settings.ex:657
 #: lib/phoenix_kit_web/live/users/sessions.ex:342
 #, elixir-autogen, elixir-format
 msgid "Unknown device"
 msgstr "Dispositivo sconosciuto"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:632
+#: lib/phoenix_kit_web/live/components/user_settings.ex:679
 #, elixir-autogen, elixir-format
 msgid "Active %{date} at %{time}"
 msgstr "Attivo il %{date} alle %{time}"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:626
+#: lib/phoenix_kit_web/live/components/user_settings.ex:673
 #, elixir-autogen, elixir-format
 msgid "Active today at %{time}"
 msgstr "Attivo oggi alle %{time}"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:629
+#: lib/phoenix_kit_web/live/components/user_settings.ex:676
 #, elixir-autogen, elixir-format
 msgid "Active yesterday at %{time}"
 msgstr "Attivo ieri alle %{time}"
@@ -12346,8 +12347,8 @@ msgstr "Elaborazione sul server…"
 msgid "Select Audio"
 msgstr "Seleziona audio"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:997
-#: lib/phoenix_kit_web/users/user_form.html.heex:1009
+#: lib/phoenix_kit_web/users/user_form.html.heex:1005
+#: lib/phoenix_kit_web/users/user_form.html.heex:1017
 #, elixir-autogen, elixir-format
 msgid "Select Avatar"
 msgstr "Seleziona avatar"
@@ -12911,7 +12912,7 @@ msgstr "Inserisci un nome"
 msgid "Too many registration attempts. Please try again later."
 msgstr "Troppi tentativi di registrazione. Riprova più tardi."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1335
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1551
 #, elixir-autogen, elixir-format
 msgid "%{enabled} of %{total} notification types enabled"
 msgstr "%{enabled} di %{total} tipi di notifica attivi"
@@ -12951,12 +12952,12 @@ msgstr "È configurato un key store, ma non è stato possibile leggerne il secre
 msgid "Back at it"
 msgstr "Di nuovo al lavoro"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:892
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1016
 #, elixir-autogen, elixir-format
 msgid "Browser detected: %{zone}"
 msgstr "Rilevato dal browser: %{zone}"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:871
+#: lib/phoenix_kit_web/live/components/user_settings.ex:995
 #, elixir-autogen, elixir-format
 msgid "Check your timezone"
 msgstr "Controlla il tuo fuso orario"
@@ -13036,7 +13037,7 @@ msgstr "Ciao di nuovo"
 msgid "Hey there"
 msgstr "Ciao"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1328
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1544
 #, elixir-autogen, elixir-format
 msgid "Manage Notifications"
 msgstr "Gestisci le notifiche"
@@ -13111,12 +13112,12 @@ msgstr "Il secret nel key store (%{location}) è stato rifiutato perché più co
 msgid "The secret in the key store was rejected as too short"
 msgstr "Il secret nel key store è stato rifiutato perché troppo corto"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:492
+#: lib/phoenix_kit_web/live/components/user_settings.ex:539
 #, elixir-autogen, elixir-format
 msgid "Timezone set to %{zone}."
 msgstr "Fuso orario impostato su %{zone}."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:885
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1009
 #, elixir-autogen, elixir-format
 msgid "Use %{zone}"
 msgstr "Usa %{zone}"
@@ -13136,17 +13137,17 @@ msgstr "Dove porta la voce «Impostazioni» nel menu utente. Vuoto = la pagina d
 msgid "Working late"
 msgstr "Al lavoro fino a tardi"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:690
+#: lib/phoenix_kit_web/live/components/user_settings.ex:737
 #, elixir-autogen, elixir-format
 msgid "Your browser reports %{browser}, but this account is set to %{saved}. Times on this site will be shown in %{saved}."
 msgstr "Il tuo browser indica %{browser}, ma questo account è impostato su %{saved}. Gli orari di questo sito saranno mostrati in %{saved}."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:681
+#: lib/phoenix_kit_web/live/components/user_settings.ex:728
 #, elixir-autogen, elixir-format
 msgid "Your browser reports %{zone}. This account still stores a fixed UTC offset, which cannot follow daylight saving — it will drift by an hour at the next change."
 msgstr "Il tuo browser indica %{zone}. Questo account memorizza ancora uno scostamento UTC fisso, che non può seguire l'ora legale: al prossimo cambio si scosterà di un'ora."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:674
+#: lib/phoenix_kit_web/live/components/user_settings.ex:721
 #, elixir-autogen, elixir-format
 msgid "Your browser reports %{zone}. You have not set a timezone, so times are shown using the site default."
 msgstr "Il tuo browser indica %{zone}. Non hai impostato un fuso orario, quindi gli orari sono mostrati con quello predefinito del sito."
@@ -14246,12 +14247,12 @@ msgstr "Quella funzione non ha un interruttore."
 msgid "Site is closed to visitors"
 msgstr "Il sito è chiuso ai visitatori"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1479
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1695
 #, elixir-autogen, elixir-format
 msgid "Manage Integrations"
 msgstr "Gestisci integrazioni"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1487
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1703
 #, elixir-autogen, elixir-format
 msgid "No personal integrations yet."
 msgstr "Ancora nessuna integrazione personale."
@@ -14262,7 +14263,7 @@ msgstr "Ancora nessuna integrazione personale."
 msgid "You don't have access to Integrations."
 msgstr "Non hai accesso alle integrazioni."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1483
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1699
 #, elixir-autogen, elixir-format
 msgid "Your own API keys and bot connections — only you can see or use these."
 msgstr "Le tue chiavi API personali e le connessioni bot — solo tu puoi vederle o usarle."
@@ -14420,3 +14421,38 @@ msgstr "Fonti"
 #, elixir-autogen, elixir-format
 msgid "Storage buckets and file processing"
 msgstr ""
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1051
+#, elixir-autogen, elixir-format
+msgid "Adjust Avatar Crop"
+msgstr "Regola il ritaglio dell'avatar"
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:943
+#, elixir-autogen, elixir-format
+msgid "Adjust Crop"
+msgstr "Regola ritaglio"
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:499
+#, elixir-autogen, elixir-format
+msgid "Avatar crop reset."
+msgstr "Ritaglio dell'avatar ripristinato."
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:487
+#, elixir-autogen, elixir-format
+msgid "Avatar crop updated!"
+msgstr "Ritaglio dell'avatar aggiornato!"
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:871
+#, elixir-autogen, elixir-format
+msgid "Failed to update avatar crop"
+msgstr "Impossibile aggiornare il ritaglio dell'avatar"
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1127
+#, elixir-autogen, elixir-format
+msgid "Save Crop"
+msgstr "Salva ritaglio"
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1088
+#, elixir-autogen, elixir-format
+msgid "Zoom"
+msgstr "Zoom"

--- a/priv/gettext/pl/LC_MESSAGES/default.po
+++ b/priv/gettext/pl/LC_MESSAGES/default.po
@@ -127,8 +127,8 @@ msgstr "Utwórz nowe konto"
 #: lib/phoenix_kit_web/users/forgot_password.html.heex:15
 #: lib/phoenix_kit_web/users/magic_link.html.heex:30
 #: lib/phoenix_kit_web/users/registration.html.heex:56
-#: lib/phoenix_kit_web/users/user_form.html.heex:761
-#: lib/phoenix_kit_web/users/user_form.html.heex:840
+#: lib/phoenix_kit_web/users/user_form.html.heex:769
+#: lib/phoenix_kit_web/users/user_form.html.heex:848
 #, elixir-autogen
 msgid "Email"
 msgstr "E-mail"
@@ -188,7 +188,7 @@ msgstr "Zarejestrowane konta"
 
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:259
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:264
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1399
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1615
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:18
 #, elixir-autogen
 msgid "Active Sessions"
@@ -379,7 +379,7 @@ msgstr "Uwierzytelnianie"
 #: lib/phoenix_kit_web/live/users/users.ex:1200
 #: lib/phoenix_kit_web/live/users/users.html.heex:248
 #: lib/phoenix_kit_web/live/users/users.html.heex:573
-#: lib/phoenix_kit_web/users/user_form.html.heex:786
+#: lib/phoenix_kit_web/users/user_form.html.heex:794
 #, elixir-autogen
 msgid "Active"
 msgstr "Aktywny"
@@ -399,7 +399,7 @@ msgstr "Aktywny"
 #: lib/phoenix_kit_web/live/modules.html.heex:284
 #: lib/phoenix_kit_web/live/modules.html.heex:349
 #: lib/phoenix_kit_web/live/modules.html.heex:405
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:59
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:61
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:49
 #: lib/phoenix_kit_web/live/settings/send_profile_form.html.heex:90
 #: lib/phoenix_kit_web/live/settings/users.html.heex:465
@@ -439,7 +439,7 @@ msgstr "%{language} (szkic)"
 msgid "%{language} (Published)"
 msgstr "%{language} (opublikowany)"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:403
+#: lib/phoenix_kit_web/live/components/user_settings.ex:384
 #, elixir-autogen, elixir-format
 msgid "%{provider} account disconnected successfully"
 msgstr "Konto %{provider} zostało odłączone"
@@ -459,7 +459,7 @@ msgstr "(opcjonalnie)"
 msgid "123 Business Street"
 msgstr "ul. Przykładowa 123"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:250
+#: lib/phoenix_kit_web/live/components/user_settings.ex:231
 #, elixir-autogen, elixir-format
 msgid "A link to confirm your email change has been sent to the new address."
 msgstr "Link potwierdzający zmianę adresu e-mail został wysłany na nowy adres."
@@ -506,8 +506,8 @@ msgstr "Informacje o koncie"
 #: lib/phoenix_kit_web/live/users/roles.html.heex:163
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:269
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:651
-#: lib/phoenix_kit_web/users/user_form.html.heex:763
-#: lib/phoenix_kit_web/users/user_form.html.heex:843
+#: lib/phoenix_kit_web/users/user_form.html.heex:771
+#: lib/phoenix_kit_web/users/user_form.html.heex:851
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr "Akcje"
@@ -516,7 +516,7 @@ msgstr "Akcje"
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:610
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:314
 #: lib/phoenix_kit_web/live/settings/users.html.heex:795
-#: lib/phoenix_kit_web/users/user_form.html.heex:742
+#: lib/phoenix_kit_web/users/user_form.html.heex:750
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr "Dodaj"
@@ -646,7 +646,8 @@ msgstr "Lista wypunktowana"
 #: lib/phoenix_kit_web/components/media_browser.html.heex:2440
 #: lib/phoenix_kit_web/components/user_dashboard_nav.ex:317
 #: lib/phoenix_kit_web/live/components/media_selector_modal.html.heex:65
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1327
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1113
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1543
 #: lib/phoenix_kit_web/live/notifications/settings.ex:434
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:493
 #: lib/phoenix_kit_web/live/settings/send_profile_form.html.heex:152
@@ -686,12 +687,12 @@ msgstr "Nie można usunąć ostatniego właściciela systemu"
 msgid "Cannot delete your own account"
 msgstr "Nie możesz usunąć własnego konta"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:437
+#: lib/phoenix_kit_web/live/components/user_settings.ex:418
 #, elixir-autogen, elixir-format
 msgid "Cannot disconnect %{provider}. Please ensure you have at least one sign-in method available."
 msgstr "Nie można odłączyć %{provider}. Upewnij się, że pozostanie co najmniej jedna metoda logowania."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:432
+#: lib/phoenix_kit_web/live/components/user_settings.ex:413
 #, elixir-autogen, elixir-format
 msgid "Cannot disconnect %{provider}. This is your only sign-in method. Please set a password or connect another provider first."
 msgstr "Nie można odłączyć %{provider}. To jedyna metoda logowania. Najpierw ustaw hasło lub połącz innego dostawcę."
@@ -1098,7 +1099,7 @@ msgstr "Nie udało się usunąć roli"
 msgid "Failed to delete user"
 msgstr "Nie udało się usunąć użytkownika"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:423
+#: lib/phoenix_kit_web/live/components/user_settings.ex:404
 #, elixir-autogen, elixir-format
 msgid "Failed to disconnect provider. Please try again."
 msgstr "Nie udało się odłączyć dostawcy. Spróbuj ponownie."
@@ -1237,7 +1238,7 @@ msgstr "Obraz"
 #: lib/phoenix_kit_web/live/users/users.ex:1200
 #: lib/phoenix_kit_web/live/users/users.html.heex:249
 #: lib/phoenix_kit_web/live/users/users.html.heex:577
-#: lib/phoenix_kit_web/users/user_form.html.heex:790
+#: lib/phoenix_kit_web/users/user_form.html.heex:798
 #, elixir-autogen, elixir-format
 msgid "Inactive"
 msgstr "Nieaktywny"
@@ -1480,7 +1481,7 @@ msgstr "OK"
 msgid "Only the Owner can edit Admin permissions"
 msgstr "Tylko właściciel może edytować uprawnienia administratora"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:236
+#: lib/phoenix_kit_web/users/user_form.html.heex:244
 #, elixir-autogen, elixir-format
 msgid "Optional"
 msgstr "Opcjonalnie"
@@ -1542,7 +1543,7 @@ msgstr "Strona została opublikowana pomyślnie"
 msgid "Password"
 msgstr "Hasło"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:301
+#: lib/phoenix_kit_web/live/components/user_settings.ex:282
 #, elixir-autogen, elixir-format
 msgid "Password changed successfully."
 msgstr "Hasło zostało zmienione."
@@ -1625,7 +1626,7 @@ msgstr "Ustawienia prywatności"
 msgid "Profile"
 msgstr "Profil"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:362
+#: lib/phoenix_kit_web/live/components/user_settings.ex:343
 #, elixir-autogen, elixir-format
 msgid "Profile updated successfully"
 msgstr "Profil został zaktualizowany"
@@ -1641,7 +1642,7 @@ msgstr "Chronione"
 msgid "Protected core roles"
 msgstr "Chronione role systemowe"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:413
+#: lib/phoenix_kit_web/live/components/user_settings.ex:394
 #, elixir-autogen, elixir-format
 msgid "Provider not found"
 msgstr "Nie znaleziono dostawcy"
@@ -1945,7 +1946,7 @@ msgstr "Województwo/Region"
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:294
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:650
 #: lib/phoenix_kit_web/live/users/users.html.heex:263
-#: lib/phoenix_kit_web/users/user_form.html.heex:762
+#: lib/phoenix_kit_web/users/user_form.html.heex:770
 #, elixir-autogen, elixir-format
 msgid "Status"
 msgstr "Status"
@@ -2140,7 +2141,7 @@ msgstr "Wideo"
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:695
 #: lib/phoenix_kit_web/live/users/users.html.heex:667
 #: lib/phoenix_kit_web/live/users/users.html.heex:794
-#: lib/phoenix_kit_web/users/user_form.html.heex:801
+#: lib/phoenix_kit_web/users/user_form.html.heex:809
 #, elixir-autogen, elixir-format
 msgid "View"
 msgstr "Wyświetl"
@@ -2272,7 +2273,7 @@ msgstr "Usuń zasobnik"
 #: lib/modules/storage/web/dimensions.html.heex:466
 #: lib/modules/storage/web/settings.html.heex:221
 #: lib/modules/storage/web/settings.html.heex:257
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:126
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:128
 #: lib/phoenix_kit_web/live/settings/users.html.heex:563
 #: lib/phoenix_kit_web/live/settings/users.html.heex:609
 #, elixir-autogen, elixir-format
@@ -2298,7 +2299,7 @@ msgstr "Włącz"
 
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:166
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:268
-#: lib/phoenix_kit_web/users/user_form.html.heex:842
+#: lib/phoenix_kit_web/users/user_form.html.heex:850
 #, elixir-autogen, elixir-format
 msgid "Expires"
 msgstr "Wygasa"
@@ -2314,7 +2315,7 @@ msgstr "Nie udało się %{action} moduł Informacje prawne"
 msgid "Hide"
 msgstr "Ukryj"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:400
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:402
 #, elixir-autogen, elixir-format
 msgid "Live Preview"
 msgstr "Podgląd na żywo"
@@ -2359,9 +2360,9 @@ msgstr "Odbierz"
 msgid "Revoke all"
 msgstr "Odbierz wszystkie"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:117
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:230
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:234
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:119
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:232
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:236
 #, elixir-autogen, elixir-format
 msgid "Set Default"
 msgstr "Ustaw jako domyślne"
@@ -3250,6 +3251,7 @@ msgid "Required field"
 msgstr "Pole wymagane"
 
 #: lib/phoenix_kit_web/components/core/column_settings.ex:136
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1104
 #: lib/phoenix_kit_web/live/settings.html.heex:640
 #, elixir-autogen, elixir-format
 msgid "Reset"
@@ -3474,7 +3476,7 @@ msgid "Type an option and press Enter or click Add"
 msgstr "Wpisz opcję i naciśnij Enter lub kliknij Dodaj"
 
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:262
-#: lib/phoenix_kit_web/users/user_form.html.heex:760
+#: lib/phoenix_kit_web/users/user_form.html.heex:768
 #, elixir-autogen, elixir-format
 msgid "User"
 msgstr "Użytkownik"
@@ -3860,7 +3862,7 @@ msgstr "Konto"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:210
 #: lib/phoenix_kit_web/users/registration.html.heex:119
-#: lib/phoenix_kit_web/users/user_form.html.heex:166
+#: lib/phoenix_kit_web/users/user_form.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "Account Type"
 msgstr "Typ konta"
@@ -3946,7 +3948,7 @@ msgstr "Autoryzacja nie powiodła się: %{reason}"
 msgid "Authorize access to your %{provider} account. This will open a sign-in page where you choose which account to connect."
 msgstr "Zezwól na dostęp do swojego konta %{provider}. Otworzy się strona logowania, na której wybierzesz konto do połączenia."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:111
+#: lib/phoenix_kit_web/live/components/user_settings.ex:825
 #, elixir-autogen, elixir-format
 msgid "Avatar updated successfully!"
 msgstr "Awatar został zaktualizowany!"
@@ -3986,12 +3988,12 @@ msgstr "Akcje zasobnika"
 msgid "CRF 0-51, lower = higher quality. 18-28 recommended."
 msgstr "CRF 0–51, niżej = wyższa jakość. Zalecane 18–28."
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:862
+#: lib/phoenix_kit_web/users/user_form.html.heex:870
 #, elixir-autogen, elixir-format
 msgid "Cancel invitation"
 msgstr "Anuluj zaproszenie"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:863
+#: lib/phoenix_kit_web/users/user_form.html.heex:871
 #, elixir-autogen, elixir-format
 msgid "Cancel this invitation?"
 msgstr "Anulować to zaproszenie?"
@@ -4049,7 +4051,7 @@ msgstr "Punkt końcowy Cloudflare"
 msgid "Company info, tax settings, and bank details are shared across Legal, Billing, and Shop modules."
 msgstr "Informacje o firmie, ustawienia podatkowe i dane bankowe są wspólne dla modułów Informacje prawne, Rozliczenia i Sklep."
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:199
+#: lib/phoenix_kit_web/users/user_form.html.heex:207
 #, elixir-autogen, elixir-format
 msgid "Company or organization name"
 msgstr "Nazwa firmy lub organizacji"
@@ -4334,7 +4336,7 @@ msgstr "Nie udało się usunąć członka"
 msgid "Failed to save"
 msgstr "Nie udało się zapisać"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:542
+#: lib/phoenix_kit_web/live/components/user_settings.ex:589
 #, elixir-autogen, elixir-format
 msgid "Failed to save notification preferences."
 msgstr "Nie udało się zapisać preferencji powiadomień."
@@ -4344,7 +4346,7 @@ msgstr "Nie udało się zapisać preferencji powiadomień."
 msgid "Failed to send invitation"
 msgstr "Nie udało się wysłać zaproszenia"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:118
+#: lib/phoenix_kit_web/live/components/user_settings.ex:833
 #, elixir-autogen, elixir-format
 msgid "Failed to update avatar"
 msgstr "Nie udało się zaktualizować awatara"
@@ -4467,7 +4469,7 @@ msgid "Integration deleted"
 msgstr "Integracja usunięta"
 
 #: lib/phoenix_kit/dashboard/admin_tabs.ex:308
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1476
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1692
 #: lib/phoenix_kit_web/live/settings/integration_form.html.heex:10
 #: lib/phoenix_kit_web/live/settings/integrations.ex:31
 #: lib/phoenix_kit_web/live/users/permissions_matrix.html.heex:75
@@ -4505,17 +4507,17 @@ msgstr "Zaproszenie odrzucone."
 msgid "Invitation sent to %{email}"
 msgstr "Zaproszenie wysłane na %{email}"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:885
+#: lib/phoenix_kit_web/users/user_form.html.heex:893
 #, elixir-autogen, elixir-format
 msgid "Invite"
 msgstr "Zaproś"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:881
+#: lib/phoenix_kit_web/users/user_form.html.heex:889
 #, elixir-autogen, elixir-format
 msgid "Invite by email..."
 msgstr "Zaproś przez e-mail…"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:841
+#: lib/phoenix_kit_web/users/user_form.html.heex:849
 #, elixir-autogen, elixir-format
 msgid "Invited"
 msgstr "Zaproszono"
@@ -4662,12 +4664,12 @@ msgid "No integrations match your search."
 msgstr "Żadna integracja nie odpowiada wyszukiwaniu."
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:641
-#: lib/phoenix_kit_web/users/user_form.html.heex:752
+#: lib/phoenix_kit_web/users/user_form.html.heex:760
 #, elixir-autogen, elixir-format
 msgid "No members yet"
 msgstr "Brak członków"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:834
+#: lib/phoenix_kit_web/users/user_form.html.heex:842
 #, elixir-autogen, elixir-format
 msgid "No pending invitations"
 msgstr "Brak oczekujących zaproszeń"
@@ -4693,13 +4695,13 @@ msgstr "Niepołączone"
 msgid "Not tested"
 msgstr "Nietestowane"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:535
+#: lib/phoenix_kit_web/live/components/user_settings.ex:582
 #: lib/phoenix_kit_web/live/notifications/settings.ex:66
 #, elixir-autogen, elixir-format
 msgid "Notification preferences saved."
 msgstr "Preferencje powiadomień zapisane."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1314
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1530
 #: lib/phoenix_kit_web/live/integrations/my_integration_form.ex:483
 #: lib/phoenix_kit_web/live/modules.html.heex:337
 #: lib/phoenix_kit_web/live/settings.html.heex:382
@@ -4735,14 +4737,14 @@ msgstr "Org."
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:228
 #: lib/phoenix_kit_web/live/users/users.html.heex:203
 #: lib/phoenix_kit_web/users/registration.html.heex:136
-#: lib/phoenix_kit_web/users/user_form.html.heex:187
-#: lib/phoenix_kit_web/users/user_form.html.heex:235
+#: lib/phoenix_kit_web/users/user_form.html.heex:195
+#: lib/phoenix_kit_web/users/user_form.html.heex:243
 #, elixir-autogen, elixir-format
 msgid "Organization"
 msgstr "Organizacja"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:637
-#: lib/phoenix_kit_web/users/user_form.html.heex:716
+#: lib/phoenix_kit_web/users/user_form.html.heex:724
 #, elixir-autogen, elixir-format
 msgid "Organization Members"
 msgstr "Członkowie organizacji"
@@ -4750,7 +4752,7 @@ msgstr "Członkowie organizacji"
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:220
 #: lib/phoenix_kit_web/users/magic_link_registration.html.heex:58
 #: lib/phoenix_kit_web/users/registration.html.heex:148
-#: lib/phoenix_kit_web/users/user_form.html.heex:198
+#: lib/phoenix_kit_web/users/user_form.html.heex:206
 #, elixir-autogen, elixir-format
 msgid "Organization Name"
 msgstr "Nazwa organizacji"
@@ -4760,7 +4762,7 @@ msgstr "Nazwa organizacji"
 msgid "Pause"
 msgstr "Wstrzymaj"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:827
+#: lib/phoenix_kit_web/users/user_form.html.heex:835
 #, elixir-autogen, elixir-format
 msgid "Pending Invitations"
 msgstr "Oczekujące zaproszenia"
@@ -4773,12 +4775,12 @@ msgstr "Skrzynka dla użytkownika oparta na strumieniu aktywności"
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:161
 #: lib/phoenix_kit_web/live/users/users.html.heex:202
 #: lib/phoenix_kit_web/users/registration.html.heex:130
-#: lib/phoenix_kit_web/users/user_form.html.heex:177
+#: lib/phoenix_kit_web/users/user_form.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "Personal"
 msgstr "Osoba prywatna"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1353
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1569
 #, elixir-autogen, elixir-format
 msgid "Pick which notification types you want to receive. Unchecked types are muted — activities still record in the audit log but no bell notification is created for you."
 msgstr "Wybierz, jakie typy powiadomień chcesz otrzymywać. Niezaznaczone typy są wyciszone — aktywności nadal są zapisywane w dzienniku audytu, ale powiadomienie w dzwonku nie jest tworzone."
@@ -4829,12 +4831,12 @@ msgid "Redundancy target: %{n} copies"
 msgstr "Docelowa nadmiarowość: %{n} kopii"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:704
-#: lib/phoenix_kit_web/users/user_form.html.heex:810
+#: lib/phoenix_kit_web/users/user_form.html.heex:818
 #, elixir-autogen, elixir-format
 msgid "Remove from organization"
 msgstr "Usuń z organizacji"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:811
+#: lib/phoenix_kit_web/users/user_form.html.heex:819
 #, elixir-autogen, elixir-format
 msgid "Remove this member from the organization?"
 msgstr "Usunąć tego członka z organizacji?"
@@ -4859,7 +4861,7 @@ msgstr "Zapisz zasobnik"
 msgid "Save Tax Settings"
 msgstr "Zapisz ustawienia podatkowe"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1383
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1599
 #: lib/phoenix_kit_web/live/notifications/settings.ex:348
 #, elixir-autogen, elixir-format
 msgid "Save preferences"
@@ -4880,7 +4882,7 @@ msgstr "Szukaj integracji…"
 msgid "Security check failed. Please try connecting again."
 msgstr "Kontrola bezpieczeństwa nie powiodła się. Spróbuj połączyć się ponownie."
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:731
+#: lib/phoenix_kit_web/users/user_form.html.heex:739
 #, elixir-autogen, elixir-format
 msgid "Select a user to add..."
 msgstr "Wybierz użytkownika do dodania…"
@@ -5074,7 +5076,7 @@ msgstr "Niedostatecznie zreplikowane"
 msgid "Unknown provider"
 msgstr "Nieznany dostawca"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:753
+#: lib/phoenix_kit_web/users/user_form.html.heex:761
 #, elixir-autogen, elixir-format
 msgid "Use the dropdown above to add members"
 msgstr "Użyj listy powyżej, aby dodać członków"
@@ -5627,7 +5629,6 @@ msgstr "Zadania"
 
 #: lib/phoenix_kit_web/live/modules.html.heex:77
 #: lib/phoenix_kit_web/live/modules/languages.ex:46
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr "Języki"
@@ -5811,112 +5812,112 @@ msgstr[0] "%{count} dn. temu"
 msgstr[1] "%{count} dn. temu"
 msgstr[2] "%{count} dn. temu"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:19
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:21
 #, elixir-autogen
 msgid "Summary"
 msgstr "Podsumowanie"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:24
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:26
 #, elixir-autogen
 msgid "Languages Enabled"
 msgstr "Włączone języki"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:28
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:147
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:30
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:149
 #, elixir-autogen
 msgid "Countries Covered"
 msgstr "Objęte kraje"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:37
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:39
 #, elixir-autogen
 msgid "Enabled Languages"
 msgstr "Włączone języki"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:134
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:136
 #, elixir-autogen
 msgid "Default language"
 msgstr "Język domyślny"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:164
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:166
 #, elixir-autogen
 msgid "Available Languages"
 msgstr "Dostępne języki"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:266
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:268
 #, elixir-autogen
 msgid "Language Configuration"
 msgstr "Konfiguracja języków"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:312
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:314
 #, elixir-autogen
 msgid "Frontend Language Switcher"
 msgstr "Przełącznik języka na stronie"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:322
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:324
 #, elixir-autogen
 msgid "Switcher Settings"
 msgstr "Ustawienia przełącznika"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:327
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:329
 #, elixir-autogen
 msgid "Show Flags"
 msgstr "Pokaż flagi"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:341
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:343
 #, elixir-autogen
 msgid "Show Names"
 msgstr "Pokaż nazwy"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:355
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:357
 #, elixir-autogen
 msgid "Native Names"
 msgstr "Nazwy własne"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:369
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:371
 #, elixir-autogen
 msgid "Go to Home"
 msgstr "Przejdź do strony głównej"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:383
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:385
 #, elixir-autogen
 msgid "Hide Current"
 msgstr "Ukryj bieżący"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:414
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:416
 #, elixir-autogen
 msgid "Generated Code"
 msgstr "Wygenerowany kod"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:429
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:431
 #, elixir-autogen
 msgid "Implementation Notes"
 msgstr "Uwagi wdrożeniowe"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:447
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:449
 #, elixir-autogen
 msgid "Enable and Configure Languages"
 msgstr "Włącz i skonfiguruj języki"
 
 #: lib/phoenix_kit_web/components/media_browser.html.heex:623
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:47
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:49
 #, elixir-autogen
 msgid "Done"
 msgstr "Gotowe"
 
 #: lib/phoenix_kit_web/components/core/reorder_modal.ex:65
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:49
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:51
 #, elixir-autogen
 msgid "Reorder"
 msgstr "Zmień kolejność"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:54
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:219
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:56
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:221
 #: lib/phoenix_kit_web/live/users/users.html.heex:1206
 #, elixir-autogen
 msgid "Default"
 msgstr "Domyślne"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:155
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:157
 #, elixir-autogen
 msgid "No languages enabled yet."
 msgstr "Nie włączono jeszcze żadnych języków."
@@ -7292,12 +7293,12 @@ msgstr "Sortuj według"
 msgid "Status:"
 msgstr "Status:"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:280
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:282
 #, elixir-autogen, elixir-format
 msgid "Controls how the primary language appears in URLs across the site — admin pages, public pages, sitemap, and redirects."
 msgstr "Określa, jak język główny pojawia się w adresach URL w całej witrynie — na stronach administracyjnych, publicznych, w mapie witryny i przekierowaniach."
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:290
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:292
 #, elixir-autogen, elixir-format
 msgid "Default Language Without Prefix"
 msgstr "Język domyślny bez prefiksu"
@@ -7307,12 +7308,12 @@ msgstr "Język domyślny bez prefiksu"
 msgid "Failed to update URL behavior setting"
 msgstr "Nie udało się zaktualizować ustawienia"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:278
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:280
 #, elixir-autogen, elixir-format
 msgid "URL Behavior"
 msgstr "Zachowanie adresów URL"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:293
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:295
 #, elixir-autogen, elixir-format
 msgid "When on, the primary language drops its locale segment in every URL (e.g. /admin/users instead of /en/admin/users, /blog/post instead of /en/blog/post). Other languages always keep their prefix."
 msgstr "Gdy włączone, język główny nie ma segmentu lokalizacji w żadnym adresie URL (np. /admin/users zamiast /en/admin/users, /blog/post zamiast /en/blog/post). Pozostałe języki zawsze zachowują prefiks."
@@ -10204,12 +10205,12 @@ msgstr "xAI"
 msgid "xAI requires a funded account before the API will return completions"
 msgstr "xAI wymaga zasilonego konta, aby API zwracało uzupełnienia"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:618
+#: lib/phoenix_kit_web/live/components/user_settings.ex:665
 #, elixir-autogen, elixir-format
 msgid "Active now"
 msgstr "Aktywny teraz"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1410
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1626
 #, elixir-autogen, elixir-format
 msgid "Devices currently signed in to your account. If you don't recognize one, sign it out."
 msgstr "Urządzenia obecnie zalogowane na Twoje konto. Jeśli któregoś nie rozpoznajesz, wyloguj je."
@@ -10224,58 +10225,58 @@ msgstr "Nowe logowanie na Twoje konto z %{details}."
 msgid "New sign-in to your account."
 msgstr "Nowe logowanie na Twoje konto."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1443
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1659
 #, elixir-autogen, elixir-format
 msgid "Sign out"
 msgstr "Wyloguj się"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1454
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1670
 #, elixir-autogen, elixir-format
 msgid "Sign out of all other sessions?"
 msgstr "Wylogować się ze wszystkich innych sesji?"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1457
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1673
 #, elixir-autogen, elixir-format
 msgid "Sign out other sessions"
 msgstr "Wyloguj inne sesje"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:569
+#: lib/phoenix_kit_web/live/components/user_settings.ex:616
 #, elixir-autogen, elixir-format
 msgid "Signed out of all other sessions."
 msgstr "Wylogowano ze wszystkich innych sesji."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:552
+#: lib/phoenix_kit_web/live/components/user_settings.ex:599
 #, elixir-autogen, elixir-format
 msgid "Signed out of that session."
 msgstr "Wylogowano z tej sesji."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:553
+#: lib/phoenix_kit_web/live/components/user_settings.ex:600
 #, elixir-autogen, elixir-format
 msgid "That session is no longer active."
 msgstr "Ta sesja nie jest już aktywna."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1427
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1643
 #, elixir-autogen, elixir-format
 msgid "This device"
 msgstr "To urządzenie"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:610
+#: lib/phoenix_kit_web/live/components/user_settings.ex:657
 #: lib/phoenix_kit_web/live/users/sessions.ex:342
 #, elixir-autogen, elixir-format
 msgid "Unknown device"
 msgstr "Nieznane urządzenie"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:632
+#: lib/phoenix_kit_web/live/components/user_settings.ex:679
 #, elixir-autogen, elixir-format
 msgid "Active %{date} at %{time}"
 msgstr "Aktywny %{date} o %{time}"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:626
+#: lib/phoenix_kit_web/live/components/user_settings.ex:673
 #, elixir-autogen, elixir-format
 msgid "Active today at %{time}"
 msgstr "Aktywny dziś o %{time}"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:629
+#: lib/phoenix_kit_web/live/components/user_settings.ex:676
 #, elixir-autogen, elixir-format
 msgid "Active yesterday at %{time}"
 msgstr "Aktywny wczoraj o %{time}"
@@ -12374,8 +12375,8 @@ msgstr "Przetwarzanie na serwerze…"
 msgid "Select Audio"
 msgstr "Wybierz audio"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:997
-#: lib/phoenix_kit_web/users/user_form.html.heex:1009
+#: lib/phoenix_kit_web/users/user_form.html.heex:1005
+#: lib/phoenix_kit_web/users/user_form.html.heex:1017
 #, elixir-autogen, elixir-format
 msgid "Select Avatar"
 msgstr "Wybierz awatar"
@@ -12939,7 +12940,7 @@ msgstr "Podaj nazwę"
 msgid "Too many registration attempts. Please try again later."
 msgstr "Zbyt wiele prób rejestracji. Spróbuj ponownie później."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1335
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1551
 #, elixir-autogen, elixir-format
 msgid "%{enabled} of %{total} notification types enabled"
 msgstr "Włączono %{enabled} z %{total} typów powiadomień"
@@ -12979,12 +12980,12 @@ msgstr "Skonfigurowano magazyn kluczy, ale nie udało się odczytać jego sekret
 msgid "Back at it"
 msgstr "Znowu do dzieła"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:892
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1016
 #, elixir-autogen, elixir-format
 msgid "Browser detected: %{zone}"
 msgstr "Wykryto w przeglądarce: %{zone}"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:871
+#: lib/phoenix_kit_web/live/components/user_settings.ex:995
 #, elixir-autogen, elixir-format
 msgid "Check your timezone"
 msgstr "Sprawdź swoją strefę czasową"
@@ -13064,7 +13065,7 @@ msgstr "Witaj ponownie"
 msgid "Hey there"
 msgstr "Cześć"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1328
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1544
 #, elixir-autogen, elixir-format
 msgid "Manage Notifications"
 msgstr "Zarządzaj powiadomieniami"
@@ -13139,12 +13140,12 @@ msgstr "Sekret w magazynie kluczy (%{location}) odrzucono jako krótszy niż min
 msgid "The secret in the key store was rejected as too short"
 msgstr "Sekret w magazynie kluczy odrzucono jako zbyt krótki"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:492
+#: lib/phoenix_kit_web/live/components/user_settings.ex:539
 #, elixir-autogen, elixir-format
 msgid "Timezone set to %{zone}."
 msgstr "Ustawiono strefę czasową %{zone}."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:885
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1009
 #, elixir-autogen, elixir-format
 msgid "Use %{zone}"
 msgstr "Użyj %{zone}"
@@ -13164,17 +13165,17 @@ msgstr "Dokąd prowadzi pozycja „Ustawienia” w menu użytkownika. Puste = w�
 msgid "Working late"
 msgstr "Praca do późna"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:690
+#: lib/phoenix_kit_web/live/components/user_settings.ex:737
 #, elixir-autogen, elixir-format
 msgid "Your browser reports %{browser}, but this account is set to %{saved}. Times on this site will be shown in %{saved}."
 msgstr "Twoja przeglądarka zgłasza %{browser}, ale to konto jest ustawione na %{saved}. Godziny w tej witrynie będą pokazywane w %{saved}."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:681
+#: lib/phoenix_kit_web/live/components/user_settings.ex:728
 #, elixir-autogen, elixir-format
 msgid "Your browser reports %{zone}. This account still stores a fixed UTC offset, which cannot follow daylight saving — it will drift by an hour at the next change."
 msgstr "Twoja przeglądarka zgłasza %{zone}. To konto wciąż przechowuje stałe przesunięcie UTC, które nie nadąża za czasem letnim — przy najbliższej zmianie rozjedzie się o godzinę."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:674
+#: lib/phoenix_kit_web/live/components/user_settings.ex:721
 #, elixir-autogen, elixir-format
 msgid "Your browser reports %{zone}. You have not set a timezone, so times are shown using the site default."
 msgstr "Twoja przeglądarka zgłasza %{zone}. Nie ustawiono strefy czasowej, więc godziny są pokazywane w domyślnej strefie witryny."
@@ -14275,12 +14276,12 @@ msgstr "Ta funkcja nie ma przełącznika."
 msgid "Site is closed to visitors"
 msgstr "Strona jest zamknięta dla odwiedzających"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1479
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1695
 #, elixir-autogen, elixir-format
 msgid "Manage Integrations"
 msgstr "Zarządzaj integracjami"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1487
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1703
 #, elixir-autogen, elixir-format
 msgid "No personal integrations yet."
 msgstr "Brak integracji osobistych."
@@ -14291,7 +14292,7 @@ msgstr "Brak integracji osobistych."
 msgid "You don't have access to Integrations."
 msgstr "Nie masz dostępu do integracji."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1483
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1699
 #, elixir-autogen, elixir-format
 msgid "Your own API keys and bot connections — only you can see or use these."
 msgstr "Twoje własne klucze API i połączenia botów — tylko Ty możesz je widzieć i używać."
@@ -14449,3 +14450,38 @@ msgstr "Źródła"
 #, elixir-autogen, elixir-format
 msgid "Storage buckets and file processing"
 msgstr ""
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1051
+#, elixir-autogen, elixir-format
+msgid "Adjust Avatar Crop"
+msgstr "Dostosuj kadr awatara"
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:943
+#, elixir-autogen, elixir-format
+msgid "Adjust Crop"
+msgstr "Dostosuj kadr"
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:499
+#, elixir-autogen, elixir-format
+msgid "Avatar crop reset."
+msgstr "Kadr awatara zresetowany."
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:487
+#, elixir-autogen, elixir-format
+msgid "Avatar crop updated!"
+msgstr "Kadr awatara zaktualizowany!"
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:871
+#, elixir-autogen, elixir-format
+msgid "Failed to update avatar crop"
+msgstr "Nie udało się zaktualizować kadru awatara"
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1127
+#, elixir-autogen, elixir-format
+msgid "Save Crop"
+msgstr "Zapisz kadr"
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1088
+#, elixir-autogen, elixir-format
+msgid "Zoom"
+msgstr "Powiększenie"

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -128,8 +128,8 @@ msgstr "Создать новую учетную запись"
 #: lib/phoenix_kit_web/users/forgot_password.html.heex:15
 #: lib/phoenix_kit_web/users/magic_link.html.heex:30
 #: lib/phoenix_kit_web/users/registration.html.heex:56
-#: lib/phoenix_kit_web/users/user_form.html.heex:761
-#: lib/phoenix_kit_web/users/user_form.html.heex:840
+#: lib/phoenix_kit_web/users/user_form.html.heex:769
+#: lib/phoenix_kit_web/users/user_form.html.heex:848
 #, elixir-autogen
 msgid "Email"
 msgstr "Электронная почта"
@@ -190,7 +190,7 @@ msgstr "Зарегистрированные аккаунты"
 
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:259
 #: lib/phoenix_kit_web/components/core/dashboard_overview.ex:264
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1399
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1615
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:18
 #, elixir-autogen
 msgid "Active Sessions"
@@ -381,7 +381,7 @@ msgstr "Аутентификация"
 #: lib/phoenix_kit_web/live/users/users.ex:1200
 #: lib/phoenix_kit_web/live/users/users.html.heex:248
 #: lib/phoenix_kit_web/live/users/users.html.heex:573
-#: lib/phoenix_kit_web/users/user_form.html.heex:786
+#: lib/phoenix_kit_web/users/user_form.html.heex:794
 #, elixir-autogen
 msgid "Active"
 msgstr "Активно"
@@ -401,7 +401,7 @@ msgstr "Активно"
 #: lib/phoenix_kit_web/live/modules.html.heex:284
 #: lib/phoenix_kit_web/live/modules.html.heex:349
 #: lib/phoenix_kit_web/live/modules.html.heex:405
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:59
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:61
 #: lib/phoenix_kit_web/live/settings/crawlers.html.heex:49
 #: lib/phoenix_kit_web/live/settings/send_profile_form.html.heex:90
 #: lib/phoenix_kit_web/live/settings/users.html.heex:465
@@ -442,7 +442,7 @@ msgstr "%{language} (Черновик)"
 msgid "%{language} (Published)"
 msgstr "%{language} (Опубликовано)"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:403
+#: lib/phoenix_kit_web/live/components/user_settings.ex:384
 #, elixir-autogen, elixir-format
 msgid "%{provider} account disconnected successfully"
 msgstr "Аккаунт %{provider} успешно отключён"
@@ -462,7 +462,7 @@ msgstr "(необязательно)"
 msgid "123 Business Street"
 msgstr "ул. Примерная, 123"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:250
+#: lib/phoenix_kit_web/live/components/user_settings.ex:231
 #, elixir-autogen, elixir-format
 msgid "A link to confirm your email change has been sent to the new address."
 msgstr "Ссылка для подтверждения смены email отправлена на новый адрес."
@@ -509,8 +509,8 @@ msgstr "Информация об аккаунте"
 #: lib/phoenix_kit_web/live/users/roles.html.heex:163
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:269
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:651
-#: lib/phoenix_kit_web/users/user_form.html.heex:763
-#: lib/phoenix_kit_web/users/user_form.html.heex:843
+#: lib/phoenix_kit_web/users/user_form.html.heex:771
+#: lib/phoenix_kit_web/users/user_form.html.heex:851
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr "Действия"
@@ -519,7 +519,7 @@ msgstr "Действия"
 #: lib/phoenix_kit_web/live/settings/authorization.html.heex:610
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:314
 #: lib/phoenix_kit_web/live/settings/users.html.heex:795
-#: lib/phoenix_kit_web/users/user_form.html.heex:742
+#: lib/phoenix_kit_web/users/user_form.html.heex:750
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr "Добавить"
@@ -649,7 +649,8 @@ msgstr "Маркированный список"
 #: lib/phoenix_kit_web/components/media_browser.html.heex:2440
 #: lib/phoenix_kit_web/components/user_dashboard_nav.ex:317
 #: lib/phoenix_kit_web/live/components/media_selector_modal.html.heex:65
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1327
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1113
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1543
 #: lib/phoenix_kit_web/live/notifications/settings.ex:434
 #: lib/phoenix_kit_web/live/settings/organization.html.heex:493
 #: lib/phoenix_kit_web/live/settings/send_profile_form.html.heex:152
@@ -689,12 +690,12 @@ msgstr "Невозможно удалить последнего системн�
 msgid "Cannot delete your own account"
 msgstr "Невозможно удалить свой собственный аккаунт"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:437
+#: lib/phoenix_kit_web/live/components/user_settings.ex:418
 #, elixir-autogen, elixir-format
 msgid "Cannot disconnect %{provider}. Please ensure you have at least one sign-in method available."
 msgstr "Невозможно отключить %{provider}. Убедитесь, что у вас есть хотя бы один способ входа."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:432
+#: lib/phoenix_kit_web/live/components/user_settings.ex:413
 #, elixir-autogen, elixir-format
 msgid "Cannot disconnect %{provider}. This is your only sign-in method. Please set a password or connect another provider first."
 msgstr "Невозможно отключить %{provider}. Это ваш единственный способ входа. Сначала установите пароль или подключите другой провайдер."
@@ -1101,7 +1102,7 @@ msgstr "Не удалось удалить роль"
 msgid "Failed to delete user"
 msgstr "Не удалось удалить пользователя"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:423
+#: lib/phoenix_kit_web/live/components/user_settings.ex:404
 #, elixir-autogen, elixir-format
 msgid "Failed to disconnect provider. Please try again."
 msgstr "Не удалось отключить провайдер. Попробуйте ещё раз."
@@ -1240,7 +1241,7 @@ msgstr "Изображение"
 #: lib/phoenix_kit_web/live/users/users.ex:1200
 #: lib/phoenix_kit_web/live/users/users.html.heex:249
 #: lib/phoenix_kit_web/live/users/users.html.heex:577
-#: lib/phoenix_kit_web/users/user_form.html.heex:790
+#: lib/phoenix_kit_web/users/user_form.html.heex:798
 #, elixir-autogen, elixir-format
 msgid "Inactive"
 msgstr "Неактивен"
@@ -1483,7 +1484,7 @@ msgstr "ОК"
 msgid "Only the Owner can edit Admin permissions"
 msgstr "Только Владелец может редактировать права Администратора"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:236
+#: lib/phoenix_kit_web/users/user_form.html.heex:244
 #, elixir-autogen, elixir-format
 msgid "Optional"
 msgstr "Необязательно"
@@ -1545,7 +1546,7 @@ msgstr "Страница успешно опубликована"
 msgid "Password"
 msgstr "Пароль"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:301
+#: lib/phoenix_kit_web/live/components/user_settings.ex:282
 #, elixir-autogen, elixir-format
 msgid "Password changed successfully."
 msgstr "Пароль успешно изменён."
@@ -1628,7 +1629,7 @@ msgstr "Настройки конфиденциальности"
 msgid "Profile"
 msgstr "Профиль"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:362
+#: lib/phoenix_kit_web/live/components/user_settings.ex:343
 #, elixir-autogen, elixir-format
 msgid "Profile updated successfully"
 msgstr "Профиль успешно обновлён"
@@ -1644,7 +1645,7 @@ msgstr "Защищённая"
 msgid "Protected core roles"
 msgstr "Защищённые системные роли"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:413
+#: lib/phoenix_kit_web/live/components/user_settings.ex:394
 #, elixir-autogen, elixir-format
 msgid "Provider not found"
 msgstr "Провайдер не найден"
@@ -1949,7 +1950,7 @@ msgstr "Регион/Область"
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:294
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:650
 #: lib/phoenix_kit_web/live/users/users.html.heex:263
-#: lib/phoenix_kit_web/users/user_form.html.heex:762
+#: lib/phoenix_kit_web/users/user_form.html.heex:770
 #, elixir-autogen, elixir-format
 msgid "Status"
 msgstr "Статус"
@@ -2145,7 +2146,7 @@ msgstr "Видео"
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:695
 #: lib/phoenix_kit_web/live/users/users.html.heex:667
 #: lib/phoenix_kit_web/live/users/users.html.heex:794
-#: lib/phoenix_kit_web/users/user_form.html.heex:801
+#: lib/phoenix_kit_web/users/user_form.html.heex:809
 #, elixir-autogen, elixir-format
 msgid "View"
 msgstr "Просмотр"
@@ -2278,7 +2279,7 @@ msgstr "Удалить бакет"
 #: lib/modules/storage/web/dimensions.html.heex:466
 #: lib/modules/storage/web/settings.html.heex:221
 #: lib/modules/storage/web/settings.html.heex:257
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:126
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:128
 #: lib/phoenix_kit_web/live/settings/users.html.heex:563
 #: lib/phoenix_kit_web/live/settings/users.html.heex:609
 #, elixir-autogen, elixir-format
@@ -2304,7 +2305,7 @@ msgstr "Включить"
 
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:166
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:268
-#: lib/phoenix_kit_web/users/user_form.html.heex:842
+#: lib/phoenix_kit_web/users/user_form.html.heex:850
 #, elixir-autogen, elixir-format
 msgid "Expires"
 msgstr "Истекает"
@@ -2320,7 +2321,7 @@ msgstr "Не удалось %{action} модуль Юридический"
 msgid "Hide"
 msgstr "Скрыть"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:400
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:402
 #, elixir-autogen, elixir-format
 msgid "Live Preview"
 msgstr "Живой предварительный просмотр"
@@ -2365,9 +2366,9 @@ msgstr "Отозвать"
 msgid "Revoke all"
 msgstr "Отозвать все"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:117
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:230
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:234
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:119
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:232
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:236
 #, elixir-autogen, elixir-format
 msgid "Set Default"
 msgstr "Установить по умолчанию"
@@ -3257,6 +3258,7 @@ msgid "Required field"
 msgstr "Обязательное поле"
 
 #: lib/phoenix_kit_web/components/core/column_settings.ex:136
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1104
 #: lib/phoenix_kit_web/live/settings.html.heex:640
 #, elixir-autogen, elixir-format
 msgid "Reset"
@@ -3482,7 +3484,7 @@ msgstr "Введите вариант и нажмите Enter или кнопк�
 
 ## Navigation menu items
 #: lib/phoenix_kit_web/live/users/sessions.html.heex:262
-#: lib/phoenix_kit_web/users/user_form.html.heex:760
+#: lib/phoenix_kit_web/users/user_form.html.heex:768
 #, elixir-autogen, elixir-format
 msgid "User"
 msgstr "Пользователь"
@@ -3868,7 +3870,7 @@ msgstr "Аккаунт"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:210
 #: lib/phoenix_kit_web/users/registration.html.heex:119
-#: lib/phoenix_kit_web/users/user_form.html.heex:166
+#: lib/phoenix_kit_web/users/user_form.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "Account Type"
 msgstr "Тип аккаунта"
@@ -3954,7 +3956,7 @@ msgstr "Авторизация не удалась: %{reason}"
 msgid "Authorize access to your %{provider} account. This will open a sign-in page where you choose which account to connect."
 msgstr "Авторизуйте доступ к вашему аккаунту %{provider}. Откроется страница входа, где вы выберете аккаунт для подключения."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:111
+#: lib/phoenix_kit_web/live/components/user_settings.ex:825
 #, elixir-autogen, elixir-format
 msgid "Avatar updated successfully!"
 msgstr "Аватар успешно обновлён!"
@@ -3994,12 +3996,12 @@ msgstr "Действия с бакетом"
 msgid "CRF 0-51, lower = higher quality. 18-28 recommended."
 msgstr "CRF 0–51, ниже = лучше качество. Рекомендуется 18–28."
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:862
+#: lib/phoenix_kit_web/users/user_form.html.heex:870
 #, elixir-autogen, elixir-format
 msgid "Cancel invitation"
 msgstr "Отменить приглашение"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:863
+#: lib/phoenix_kit_web/users/user_form.html.heex:871
 #, elixir-autogen, elixir-format
 msgid "Cancel this invitation?"
 msgstr "Отменить это приглашение?"
@@ -4057,7 +4059,7 @@ msgstr "Конечная точка Cloudflare"
 msgid "Company info, tax settings, and bank details are shared across Legal, Billing, and Shop modules."
 msgstr "Информация о компании, налоговые настройки и банковские реквизиты используются совместно модулями Юридический, Выставление счетов и Магазин."
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:199
+#: lib/phoenix_kit_web/users/user_form.html.heex:207
 #, elixir-autogen, elixir-format
 msgid "Company or organization name"
 msgstr "Название компании или организации"
@@ -4342,7 +4344,7 @@ msgstr "Не удалось удалить участника"
 msgid "Failed to save"
 msgstr "Не удалось сохранить"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:542
+#: lib/phoenix_kit_web/live/components/user_settings.ex:589
 #, elixir-autogen, elixir-format
 msgid "Failed to save notification preferences."
 msgstr "Не удалось сохранить настройки уведомлений."
@@ -4352,7 +4354,7 @@ msgstr "Не удалось сохранить настройки уведомл
 msgid "Failed to send invitation"
 msgstr "Не удалось отправить приглашение"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:118
+#: lib/phoenix_kit_web/live/components/user_settings.ex:833
 #, elixir-autogen, elixir-format
 msgid "Failed to update avatar"
 msgstr "Не удалось обновить аватар"
@@ -4475,7 +4477,7 @@ msgid "Integration deleted"
 msgstr "Интеграция удалена"
 
 #: lib/phoenix_kit/dashboard/admin_tabs.ex:308
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1476
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1692
 #: lib/phoenix_kit_web/live/settings/integration_form.html.heex:10
 #: lib/phoenix_kit_web/live/settings/integrations.ex:31
 #: lib/phoenix_kit_web/live/users/permissions_matrix.html.heex:75
@@ -4513,17 +4515,17 @@ msgstr "Приглашение отклонено."
 msgid "Invitation sent to %{email}"
 msgstr "Приглашение отправлено на %{email}"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:885
+#: lib/phoenix_kit_web/users/user_form.html.heex:893
 #, elixir-autogen, elixir-format
 msgid "Invite"
 msgstr "Пригласить"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:881
+#: lib/phoenix_kit_web/users/user_form.html.heex:889
 #, elixir-autogen, elixir-format
 msgid "Invite by email..."
 msgstr "Пригласить по email..."
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:841
+#: lib/phoenix_kit_web/users/user_form.html.heex:849
 #, elixir-autogen, elixir-format
 msgid "Invited"
 msgstr "Приглашён"
@@ -4670,12 +4672,12 @@ msgid "No integrations match your search."
 msgstr "Интеграции не соответствуют вашему запросу."
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:641
-#: lib/phoenix_kit_web/users/user_form.html.heex:752
+#: lib/phoenix_kit_web/users/user_form.html.heex:760
 #, elixir-autogen, elixir-format
 msgid "No members yet"
 msgstr "Участников пока нет"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:834
+#: lib/phoenix_kit_web/users/user_form.html.heex:842
 #, elixir-autogen, elixir-format
 msgid "No pending invitations"
 msgstr "Нет ожидающих приглашений"
@@ -4701,13 +4703,13 @@ msgstr "Не подключено"
 msgid "Not tested"
 msgstr "Не проверено"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:535
+#: lib/phoenix_kit_web/live/components/user_settings.ex:582
 #: lib/phoenix_kit_web/live/notifications/settings.ex:66
 #, elixir-autogen, elixir-format
 msgid "Notification preferences saved."
 msgstr "Настройки уведомлений сохранены."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1314
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1530
 #: lib/phoenix_kit_web/live/integrations/my_integration_form.ex:483
 #: lib/phoenix_kit_web/live/modules.html.heex:337
 #: lib/phoenix_kit_web/live/settings.html.heex:382
@@ -4743,14 +4745,14 @@ msgstr "Орг."
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:228
 #: lib/phoenix_kit_web/live/users/users.html.heex:203
 #: lib/phoenix_kit_web/users/registration.html.heex:136
-#: lib/phoenix_kit_web/users/user_form.html.heex:187
-#: lib/phoenix_kit_web/users/user_form.html.heex:235
+#: lib/phoenix_kit_web/users/user_form.html.heex:195
+#: lib/phoenix_kit_web/users/user_form.html.heex:243
 #, elixir-autogen, elixir-format
 msgid "Organization"
 msgstr "Организация"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:637
-#: lib/phoenix_kit_web/users/user_form.html.heex:716
+#: lib/phoenix_kit_web/users/user_form.html.heex:724
 #, elixir-autogen, elixir-format
 msgid "Organization Members"
 msgstr "Участники организации"
@@ -4758,7 +4760,7 @@ msgstr "Участники организации"
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:220
 #: lib/phoenix_kit_web/users/magic_link_registration.html.heex:58
 #: lib/phoenix_kit_web/users/registration.html.heex:148
-#: lib/phoenix_kit_web/users/user_form.html.heex:198
+#: lib/phoenix_kit_web/users/user_form.html.heex:206
 #, elixir-autogen, elixir-format
 msgid "Organization Name"
 msgstr "Название организации"
@@ -4768,7 +4770,7 @@ msgstr "Название организации"
 msgid "Pause"
 msgstr "Пауза"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:827
+#: lib/phoenix_kit_web/users/user_form.html.heex:835
 #, elixir-autogen, elixir-format
 msgid "Pending Invitations"
 msgstr "Ожидающие приглашения"
@@ -4781,12 +4783,12 @@ msgstr "Персональный почтовый ящик, управляемы
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:161
 #: lib/phoenix_kit_web/live/users/users.html.heex:202
 #: lib/phoenix_kit_web/users/registration.html.heex:130
-#: lib/phoenix_kit_web/users/user_form.html.heex:177
+#: lib/phoenix_kit_web/users/user_form.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "Personal"
 msgstr "Физическое лицо"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1353
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1569
 #, elixir-autogen, elixir-format
 msgid "Pick which notification types you want to receive. Unchecked types are muted — activities still record in the audit log but no bell notification is created for you."
 msgstr "Выберите типы уведомлений, которые хотите получать. Отключённые типы заглушены — действия по-прежнему записываются в журнал аудита, но для вас не создаются уведомления колокольчика."
@@ -4837,12 +4839,12 @@ msgid "Redundancy target: %{n} copies"
 msgstr "Цель резервирования: %{n} копий"
 
 #: lib/phoenix_kit_web/live/users/user_details.html.heex:704
-#: lib/phoenix_kit_web/users/user_form.html.heex:810
+#: lib/phoenix_kit_web/users/user_form.html.heex:818
 #, elixir-autogen, elixir-format
 msgid "Remove from organization"
 msgstr "Удалить из организации"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:811
+#: lib/phoenix_kit_web/users/user_form.html.heex:819
 #, elixir-autogen, elixir-format
 msgid "Remove this member from the organization?"
 msgstr "Удалить этого участника из организации?"
@@ -4867,7 +4869,7 @@ msgstr "Сохранить бакет"
 msgid "Save Tax Settings"
 msgstr "Сохранить налоговые настройки"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1383
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1599
 #: lib/phoenix_kit_web/live/notifications/settings.ex:348
 #, elixir-autogen, elixir-format
 msgid "Save preferences"
@@ -4888,7 +4890,7 @@ msgstr "Поиск интеграций..."
 msgid "Security check failed. Please try connecting again."
 msgstr "Проверка безопасности не пройдена. Попробуйте подключиться снова."
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:731
+#: lib/phoenix_kit_web/users/user_form.html.heex:739
 #, elixir-autogen, elixir-format
 msgid "Select a user to add..."
 msgstr "Выберите пользователя для добавления..."
@@ -5082,7 +5084,7 @@ msgstr "Недостаточно реплицировано"
 msgid "Unknown provider"
 msgstr "Неизвестный провайдер"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:753
+#: lib/phoenix_kit_web/users/user_form.html.heex:761
 #, elixir-autogen, elixir-format
 msgid "Use the dropdown above to add members"
 msgstr "Используйте выпадающий список выше для добавления участников"
@@ -5635,7 +5637,6 @@ msgstr "Задачи"
 
 #: lib/phoenix_kit_web/live/modules.html.heex:77
 #: lib/phoenix_kit_web/live/modules/languages.ex:46
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr "Языки"
@@ -5819,112 +5820,112 @@ msgstr[0] "%{count} дн назад"
 msgstr[1] "%{count} дн назад"
 msgstr[2] "%{count} дн назад"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:19
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:21
 #, elixir-autogen
 msgid "Summary"
 msgstr "Сводка"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:24
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:26
 #, elixir-autogen
 msgid "Languages Enabled"
 msgstr "Включенные языки"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:28
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:147
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:30
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:149
 #, elixir-autogen
 msgid "Countries Covered"
 msgstr "Охваченные страны"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:37
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:39
 #, elixir-autogen
 msgid "Enabled Languages"
 msgstr "Включенные языки"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:134
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:136
 #, elixir-autogen
 msgid "Default language"
 msgstr "Язык по умолчанию"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:164
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:166
 #, elixir-autogen
 msgid "Available Languages"
 msgstr "Доступные языки"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:266
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:268
 #, elixir-autogen
 msgid "Language Configuration"
 msgstr "Настройка языков"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:312
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:314
 #, elixir-autogen
 msgid "Frontend Language Switcher"
 msgstr "Переключатель языков на фронтенде"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:322
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:324
 #, elixir-autogen
 msgid "Switcher Settings"
 msgstr "Настройки переключателя"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:327
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:329
 #, elixir-autogen
 msgid "Show Flags"
 msgstr "Показывать флаги"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:341
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:343
 #, elixir-autogen
 msgid "Show Names"
 msgstr "Показывать названия"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:355
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:357
 #, elixir-autogen
 msgid "Native Names"
 msgstr "Названия на родном языке"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:369
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:371
 #, elixir-autogen
 msgid "Go to Home"
 msgstr "Перейти на главную"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:383
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:385
 #, elixir-autogen
 msgid "Hide Current"
 msgstr "Скрыть текущий"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:414
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:416
 #, elixir-autogen
 msgid "Generated Code"
 msgstr "Сгенерированный код"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:429
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:431
 #, elixir-autogen
 msgid "Implementation Notes"
 msgstr "Заметки по внедрению"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:447
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:449
 #, elixir-autogen
 msgid "Enable and Configure Languages"
 msgstr "Включить и настроить языки"
 
 #: lib/phoenix_kit_web/components/media_browser.html.heex:623
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:47
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:49
 #, elixir-autogen
 msgid "Done"
 msgstr "Готово"
 
 #: lib/phoenix_kit_web/components/core/reorder_modal.ex:65
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:49
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:51
 #, elixir-autogen
 msgid "Reorder"
 msgstr "Изменить порядок"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:54
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:219
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:56
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:221
 #: lib/phoenix_kit_web/live/users/users.html.heex:1206
 #, elixir-autogen
 msgid "Default"
 msgstr "По умолчанию"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:155
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:157
 #, elixir-autogen
 msgid "No languages enabled yet."
 msgstr "Языки ещё не включены."
@@ -7300,12 +7301,12 @@ msgstr "Сортировать по"
 msgid "Status:"
 msgstr "Статус:"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:280
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:282
 #, elixir-autogen, elixir-format
 msgid "Controls how the primary language appears in URLs across the site — admin pages, public pages, sitemap, and redirects."
 msgstr "Определяет, как основной язык отображается в URL-адресах по всему сайту — на страницах администрирования, публичных страницах, в карте сайта и при перенаправлениях."
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:290
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:292
 #, elixir-autogen, elixir-format
 msgid "Default Language Without Prefix"
 msgstr "Язык по умолчанию без префикса"
@@ -7315,12 +7316,12 @@ msgstr "Язык по умолчанию без префикса"
 msgid "Failed to update URL behavior setting"
 msgstr "Не удалось обновить настройку поведения URL"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:278
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:280
 #, elixir-autogen, elixir-format
 msgid "URL Behavior"
 msgstr "Поведение URL"
 
-#: lib/phoenix_kit_web/live/modules/languages.html.heex:293
+#: lib/phoenix_kit_web/live/modules/languages.html.heex:295
 #, elixir-autogen, elixir-format
 msgid "When on, the primary language drops its locale segment in every URL (e.g. /admin/users instead of /en/admin/users, /blog/post instead of /en/blog/post). Other languages always keep their prefix."
 msgstr "Когда включено, основной язык убирает свой языковой сегмент из всех URL-адресов (например, /admin/users вместо /en/admin/users, /blog/post вместо /en/blog/post). Остальные языки всегда сохраняют свой префикс."
@@ -10215,12 +10216,12 @@ msgstr "xAI"
 msgid "xAI requires a funded account before the API will return completions"
 msgstr "xAI требует пополненного аккаунта, иначе API не будет возвращать ответы"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:618
+#: lib/phoenix_kit_web/live/components/user_settings.ex:665
 #, elixir-autogen, elixir-format
 msgid "Active now"
 msgstr "Активен сейчас"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1410
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1626
 #, elixir-autogen, elixir-format
 msgid "Devices currently signed in to your account. If you don't recognize one, sign it out."
 msgstr "Устройства, на которых выполнен вход в ваш аккаунт. Если вы не узнаёте одно из них, завершите его сеанс."
@@ -10236,58 +10237,58 @@ msgid "New sign-in to your account."
 msgstr "Новый вход в ваш аккаунт."
 
 ## Login page translations
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1443
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1659
 #, elixir-autogen, elixir-format
 msgid "Sign out"
 msgstr "Выйти"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1454
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1670
 #, elixir-autogen, elixir-format
 msgid "Sign out of all other sessions?"
 msgstr "Завершить все остальные сеансы?"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1457
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1673
 #, elixir-autogen, elixir-format
 msgid "Sign out other sessions"
 msgstr "Завершить остальные сеансы"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:569
+#: lib/phoenix_kit_web/live/components/user_settings.ex:616
 #, elixir-autogen, elixir-format
 msgid "Signed out of all other sessions."
 msgstr "Вы вышли из всех остальных сеансов."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:552
+#: lib/phoenix_kit_web/live/components/user_settings.ex:599
 #, elixir-autogen, elixir-format
 msgid "Signed out of that session."
 msgstr "Сеанс завершён."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:553
+#: lib/phoenix_kit_web/live/components/user_settings.ex:600
 #, elixir-autogen, elixir-format
 msgid "That session is no longer active."
 msgstr "Этот сеанс уже неактивен."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1427
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1643
 #, elixir-autogen, elixir-format
 msgid "This device"
 msgstr "Это устройство"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:610
+#: lib/phoenix_kit_web/live/components/user_settings.ex:657
 #: lib/phoenix_kit_web/live/users/sessions.ex:342
 #, elixir-autogen, elixir-format
 msgid "Unknown device"
 msgstr "Неизвестное устройство"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:632
+#: lib/phoenix_kit_web/live/components/user_settings.ex:679
 #, elixir-autogen, elixir-format
 msgid "Active %{date} at %{time}"
 msgstr "Активен %{date} в %{time}"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:626
+#: lib/phoenix_kit_web/live/components/user_settings.ex:673
 #, elixir-autogen, elixir-format
 msgid "Active today at %{time}"
 msgstr "Активен сегодня в %{time}"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:629
+#: lib/phoenix_kit_web/live/components/user_settings.ex:676
 #, elixir-autogen, elixir-format
 msgid "Active yesterday at %{time}"
 msgstr "Активен вчера в %{time}"
@@ -12386,8 +12387,8 @@ msgstr "Обработка на сервере…"
 msgid "Select Audio"
 msgstr "Выбрать аудио"
 
-#: lib/phoenix_kit_web/users/user_form.html.heex:997
-#: lib/phoenix_kit_web/users/user_form.html.heex:1009
+#: lib/phoenix_kit_web/users/user_form.html.heex:1005
+#: lib/phoenix_kit_web/users/user_form.html.heex:1017
 #, elixir-autogen, elixir-format
 msgid "Select Avatar"
 msgstr "Выбрать аватар"
@@ -12951,7 +12952,7 @@ msgstr "Введите корректный адрес электронной п
 msgid "Too many registration attempts. Please try again later."
 msgstr "Слишком много попыток регистрации. Повторите попытку позже."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1335
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1551
 #, elixir-autogen, elixir-format
 msgid "%{enabled} of %{total} notification types enabled"
 msgstr "Включено типов уведомлений: %{enabled} из %{total}"
@@ -12991,12 +12992,12 @@ msgstr "Хранилище ключей настроено, но его секр
 msgid "Back at it"
 msgstr "Снова за дело"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:892
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1016
 #, elixir-autogen, elixir-format
 msgid "Browser detected: %{zone}"
 msgstr "Браузер определил: %{zone}"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:871
+#: lib/phoenix_kit_web/live/components/user_settings.ex:995
 #, elixir-autogen, elixir-format
 msgid "Check your timezone"
 msgstr "Проверьте свой часовой пояс"
@@ -13076,7 +13077,7 @@ msgstr "Снова здравствуйте"
 msgid "Hey there"
 msgstr "Привет"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1328
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1544
 #, elixir-autogen, elixir-format
 msgid "Manage Notifications"
 msgstr "Управление уведомлениями"
@@ -13151,12 +13152,12 @@ msgstr "Секрет в хранилище (%{location}) отклонён как
 msgid "The secret in the key store was rejected as too short"
 msgstr "Секрет в хранилище отклонён как слишком короткий"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:492
+#: lib/phoenix_kit_web/live/components/user_settings.ex:539
 #, elixir-autogen, elixir-format
 msgid "Timezone set to %{zone}."
 msgstr "Часовой пояс установлен: %{zone}."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:885
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1009
 #, elixir-autogen, elixir-format
 msgid "Use %{zone}"
 msgstr "Использовать %{zone}"
@@ -13176,17 +13177,17 @@ msgstr "Куда ведёт пункт \"Настройки\" в меню пол
 msgid "Working late"
 msgstr "Работаете допоздна"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:690
+#: lib/phoenix_kit_web/live/components/user_settings.ex:737
 #, elixir-autogen, elixir-format
 msgid "Your browser reports %{browser}, but this account is set to %{saved}. Times on this site will be shown in %{saved}."
 msgstr "Ваш браузер сообщает %{browser}, но для этого аккаунта задан %{saved}. Время на этом сайте будет показано в %{saved}."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:681
+#: lib/phoenix_kit_web/live/components/user_settings.ex:728
 #, elixir-autogen, elixir-format
 msgid "Your browser reports %{zone}. This account still stores a fixed UTC offset, which cannot follow daylight saving — it will drift by an hour at the next change."
 msgstr "Ваш браузер сообщает %{zone}. Для аккаунта всё ещё хранится фиксированное смещение UTC, которое не учитывает переход на летнее время — при следующем переходе оно сместится на час."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:674
+#: lib/phoenix_kit_web/live/components/user_settings.ex:721
 #, elixir-autogen, elixir-format
 msgid "Your browser reports %{zone}. You have not set a timezone, so times are shown using the site default."
 msgstr "Ваш браузер сообщает %{zone}. Часовой пояс не задан, поэтому время показывается по умолчанию сайта."
@@ -14287,12 +14288,12 @@ msgstr "У этой функции нет переключателя."
 msgid "Site is closed to visitors"
 msgstr "Сайт закрыт для посетителей"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1479
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1695
 #, elixir-autogen, elixir-format
 msgid "Manage Integrations"
 msgstr "Управление интеграциями"
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1487
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1703
 #, elixir-autogen, elixir-format
 msgid "No personal integrations yet."
 msgstr "Пока нет личных интеграций."
@@ -14303,7 +14304,7 @@ msgstr "Пока нет личных интеграций."
 msgid "You don't have access to Integrations."
 msgstr "У вас нет доступа к интеграциям."
 
-#: lib/phoenix_kit_web/live/components/user_settings.ex:1483
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1699
 #, elixir-autogen, elixir-format
 msgid "Your own API keys and bot connections — only you can see or use these."
 msgstr "Ваши личные ключи API и подключения ботов — видеть и использовать их можете только вы."
@@ -14461,3 +14462,38 @@ msgstr "Источники"
 #, elixir-autogen, elixir-format
 msgid "Storage buckets and file processing"
 msgstr ""
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1051
+#, elixir-autogen, elixir-format
+msgid "Adjust Avatar Crop"
+msgstr "Настроить кадрирование аватара"
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:943
+#, elixir-autogen, elixir-format
+msgid "Adjust Crop"
+msgstr "Настроить кадр"
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:499
+#, elixir-autogen, elixir-format
+msgid "Avatar crop reset."
+msgstr "Кадрирование аватара сброшено."
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:487
+#, elixir-autogen, elixir-format
+msgid "Avatar crop updated!"
+msgstr "Кадрирование аватара обновлено!"
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:871
+#, elixir-autogen, elixir-format
+msgid "Failed to update avatar crop"
+msgstr "Не удалось обновить кадрирование аватара"
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1127
+#, elixir-autogen, elixir-format
+msgid "Save Crop"
+msgstr "Сохранить кадр"
+
+#: lib/phoenix_kit_web/live/components/user_settings.ex:1088
+#, elixir-autogen, elixir-format
+msgid "Zoom"
+msgstr "Масштаб"

--- a/priv/static/assets/phoenix_kit.js
+++ b/priv/static/assets/phoenix_kit.js
@@ -7523,9 +7523,16 @@ if (typeof window.Chart === "undefined") {
       // avatar has no stored crop and starts from ar = 1 until then.
       var adoptNaturalRatio = function () {
         if (self.img.naturalWidth > 0 && self.img.naturalHeight > 0) {
-          self.crop.ar = self.img.naturalWidth / self.img.naturalHeight;
-          self._render();
-          self._push();
+          var ar = self.img.naturalWidth / self.img.naturalHeight;
+          // Only bother the server when the truth differs from the stored
+          // value — on a reopened editor they already match.
+          if (Math.abs(ar - self.crop.ar) > 0.001) {
+            self.crop.ar = ar;
+            self._render();
+            self._push();
+          } else {
+            self._render();
+          }
         }
       };
       if (this.img.complete && this.img.naturalWidth > 0) {
@@ -7550,16 +7557,18 @@ if (typeof window.Chart === "undefined") {
       // being looked at sits further LEFT in the image.
       var drag = null;
       this._onPointerDown = function (e) {
-        drag = { x: e.clientX, y: e.clientY };
+        // The frame cannot resize mid-drag; one layout read per gesture,
+        // not one per pointermove.
+        var rect = self.frame.getBoundingClientRect();
+        drag = { x: e.clientX, y: e.clientY, w: rect.width, h: rect.height };
         self.frame.setPointerCapture(e.pointerId);
         self.frame.style.cursor = "grabbing";
       };
       this._onPointerMove = function (e) {
         if (!drag) return;
-        var rect = self.frame.getBoundingClientRect();
         var l = avatarCropLayout(self.crop);
-        var widthPx = (rect.width * l.width) / 100;
-        var heightPx = (rect.height * l.height) / 100;
+        var widthPx = (drag.w * l.width) / 100;
+        var heightPx = (drag.h * l.height) / 100;
         self.crop.x -= (e.clientX - drag.x) / widthPx;
         self.crop.y -= (e.clientY - drag.y) / heightPx;
         drag = { x: e.clientX, y: e.clientY };
@@ -7594,6 +7603,24 @@ if (typeof window.Chart === "undefined") {
       this.frame.addEventListener("pointercancel", this._onPointerUp);
       this.frame.addEventListener("wheel", this._onWheel, { passive: false });
 
+      // The wheel push is debounced, so a Save clicked inside the window
+      // would persist the pre-wheel crop — and the modal's teardown would
+      // cancel the pending push outright. Flushing on the Save button's
+      // capture phase puts the final crop on the wire before the phx-click
+      // does; same websocket, so order is guaranteed.
+      this._saveBtn =
+        (this.el.closest("dialog") || document).querySelector("[data-crop-save-btn]");
+      this._onSaveClick = function () {
+        if (self._wheelTimer) {
+          clearTimeout(self._wheelTimer);
+          self._wheelTimer = null;
+          self._push();
+        }
+      };
+      if (this._saveBtn) {
+        this._saveBtn.addEventListener("click", this._onSaveClick, true);
+      }
+
       this._render();
     },
 
@@ -7617,6 +7644,9 @@ if (typeof window.Chart === "undefined") {
 
     destroyed() {
       clearTimeout(this._wheelTimer);
+      if (this._saveBtn) {
+        this._saveBtn.removeEventListener("click", this._onSaveClick, true);
+      }
       if (this.frame) {
         this.frame.removeEventListener("pointerdown", this._onPointerDown);
         this.frame.removeEventListener("pointermove", this._onPointerMove);

--- a/priv/static/assets/phoenix_kit.js
+++ b/priv/static/assets/phoenix_kit.js
@@ -7439,3 +7439,197 @@ if (typeof window.Chart === "undefined") {
     module.exports.contextMenuPosition = contextMenuPosition;
   }
 })();
+
+// ---------------------------------------------------------------------------
+// AvatarCrop — the non-destructive avatar crop editor.
+//
+// The crop is data (focal point x/y, zoom, aspect ratio), applied as CSS by
+// the server-rendered avatar component; this hook is only the editor for
+// those four numbers. Drag pans the focal point, the slider and the wheel
+// zoom toward it, and the end of every gesture pushes the current values to
+// the owning LiveComponent (the element carries phx-target) so "Save"
+// persists exactly what the preview shows.
+//
+// avatarCropLayout mirrors PhoenixKit.Users.AvatarCrop.layout/1 — the
+// preview must use the same math the avatar later renders with, or the
+// saved crop drifts from what the person approved. Change one, change both.
+// ---------------------------------------------------------------------------
+(function () {
+  if (window.PhoenixKitAvatarCrop) return;
+  window.PhoenixKitAvatarCrop = true;
+  window.PhoenixKitHooks = window.PhoenixKitHooks || {};
+
+  function clamp(v, lo, hi) {
+    return Math.min(hi, Math.max(lo, v));
+  }
+
+  // The image's placement inside its square frame, in percent of the frame.
+  // Mirror of PhoenixKit.Users.AvatarCrop.layout/1.
+  function avatarCropLayout(crop) {
+    var zoom = crop.zoom;
+    var ar = crop.ar;
+    var width, height;
+    if (ar >= 1) {
+      width = 100 * zoom * ar;
+      height = 100 * zoom;
+    } else {
+      width = 100 * zoom;
+      height = (100 * zoom) / ar;
+    }
+    return {
+      width: width,
+      height: height,
+      left: clamp(50 - crop.x * width, 100 - width, 0),
+      top: clamp(50 - crop.y * height, 100 - height, 0)
+    };
+  }
+
+  // Focal coordinates that would render clamped are snapped back into the
+  // reachable range, so a drag never has a dead zone at the edges: with the
+  // image W% wide, the frame center can only sit between 50/W and 1 - 50/W
+  // of the image (the whole axis collapses to 0.5 when the image just fits).
+  function clampAvatarCropFocal(crop) {
+    var l = avatarCropLayout(crop);
+    var x = l.width <= 100 ? 0.5 : clamp(crop.x, 50 / l.width, 1 - 50 / l.width);
+    var y = l.height <= 100 ? 0.5 : clamp(crop.y, 50 / l.height, 1 - 50 / l.height);
+    return { x: x, y: y, zoom: crop.zoom, ar: crop.ar };
+  }
+
+  window.PhoenixKitHooks.AvatarCrop = {
+    mounted() {
+      var self = this;
+      var maxZoom = parseFloat(this.el.dataset.maxZoom || "8");
+
+      var stored = {};
+      try {
+        stored = JSON.parse(this.el.dataset.crop || "{}") || {};
+      } catch (_e) {
+        stored = {};
+      }
+
+      this.crop = {
+        x: typeof stored.x === "number" ? stored.x : 0.5,
+        y: typeof stored.y === "number" ? stored.y : 0.5,
+        zoom: typeof stored.zoom === "number" ? stored.zoom : 1,
+        ar: typeof stored.ar === "number" ? stored.ar : 1
+      };
+
+      this.frame = this.el.querySelector("[data-crop-frame]");
+      this.img = this.el.querySelector("[data-crop-img]");
+      this.slider = this.el.querySelector("[data-crop-zoom]");
+
+      // The stored aspect ratio was captured from this same file, but the
+      // image itself is the authority once it arrives — a freshly picked
+      // avatar has no stored crop and starts from ar = 1 until then.
+      var adoptNaturalRatio = function () {
+        if (self.img.naturalWidth > 0 && self.img.naturalHeight > 0) {
+          self.crop.ar = self.img.naturalWidth / self.img.naturalHeight;
+          self._render();
+          self._push();
+        }
+      };
+      if (this.img.complete && this.img.naturalWidth > 0) {
+        adoptNaturalRatio();
+      } else {
+        this.img.addEventListener("load", adoptNaturalRatio);
+      }
+
+      if (this.slider) {
+        this.slider.value = String(this.crop.zoom);
+        this.slider.addEventListener("input", function () {
+          self.crop.zoom = clamp(parseFloat(self.slider.value) || 1, 1, maxZoom);
+          self.crop = clampAvatarCropFocal(self.crop);
+          self._render();
+        });
+        this.slider.addEventListener("change", function () {
+          self._push();
+        });
+      }
+
+      // Drag pans the focal point: moving the image right means the point
+      // being looked at sits further LEFT in the image.
+      var drag = null;
+      this._onPointerDown = function (e) {
+        drag = { x: e.clientX, y: e.clientY };
+        self.frame.setPointerCapture(e.pointerId);
+        self.frame.style.cursor = "grabbing";
+      };
+      this._onPointerMove = function (e) {
+        if (!drag) return;
+        var rect = self.frame.getBoundingClientRect();
+        var l = avatarCropLayout(self.crop);
+        var widthPx = (rect.width * l.width) / 100;
+        var heightPx = (rect.height * l.height) / 100;
+        self.crop.x -= (e.clientX - drag.x) / widthPx;
+        self.crop.y -= (e.clientY - drag.y) / heightPx;
+        drag = { x: e.clientX, y: e.clientY };
+        self.crop = clampAvatarCropFocal(self.crop);
+        self._render();
+      };
+      this._onPointerUp = function (e) {
+        if (!drag) return;
+        drag = null;
+        self.frame.style.cursor = "grab";
+        if (self.frame.hasPointerCapture(e.pointerId)) {
+          self.frame.releasePointerCapture(e.pointerId);
+        }
+        self._push();
+      };
+      this._onWheel = function (e) {
+        e.preventDefault();
+        var factor = e.deltaY < 0 ? 1.08 : 1 / 1.08;
+        self.crop.zoom = clamp(self.crop.zoom * factor, 1, maxZoom);
+        self.crop = clampAvatarCropFocal(self.crop);
+        if (self.slider) self.slider.value = String(self.crop.zoom);
+        self._render();
+        clearTimeout(self._wheelTimer);
+        self._wheelTimer = setTimeout(function () {
+          self._push();
+        }, 250);
+      };
+
+      this.frame.addEventListener("pointerdown", this._onPointerDown);
+      this.frame.addEventListener("pointermove", this._onPointerMove);
+      this.frame.addEventListener("pointerup", this._onPointerUp);
+      this.frame.addEventListener("pointercancel", this._onPointerUp);
+      this.frame.addEventListener("wheel", this._onWheel, { passive: false });
+
+      this._render();
+    },
+
+    _render() {
+      var l = avatarCropLayout(this.crop);
+      this.img.style.width = l.width + "%";
+      this.img.style.height = l.height + "%";
+      this.img.style.left = l.left + "%";
+      this.img.style.top = l.top + "%";
+    },
+
+    _push() {
+      // phx-target on the element routes this to the owning LiveComponent.
+      this.pushEventTo(this.el, "avatar_crop_changed", {
+        x: this.crop.x,
+        y: this.crop.y,
+        zoom: this.crop.zoom,
+        ar: this.crop.ar
+      });
+    },
+
+    destroyed() {
+      clearTimeout(this._wheelTimer);
+      if (this.frame) {
+        this.frame.removeEventListener("pointerdown", this._onPointerDown);
+        this.frame.removeEventListener("pointermove", this._onPointerMove);
+        this.frame.removeEventListener("pointerup", this._onPointerUp);
+        this.frame.removeEventListener("pointercancel", this._onPointerUp);
+        this.frame.removeEventListener("wheel", this._onWheel);
+      }
+    }
+  };
+
+  // Exported for the Node test harness (test/js); harmless in a browser.
+  if (typeof module === "object" && module.exports) {
+    module.exports.avatarCropLayout = avatarCropLayout;
+    module.exports.clampAvatarCropFocal = clampAvatarCropFocal;
+  }
+})();

--- a/test/integration/users/avatar_crop_stale_test.exs
+++ b/test/integration/users/avatar_crop_stale_test.exs
@@ -1,0 +1,73 @@
+defmodule PhoenixKit.Users.AvatarCropStaleTest do
+  @moduledoc """
+  A crop must never outlive its file.
+
+  The stored crop bakes in the image's aspect ratio, so applied to a
+  different image it renders stretched and mis-framed on every surface.
+  The invariant is enforced at the one custom-fields merge every write
+  goes through — because per-call-site enforcement already failed once:
+  the settings page cleared the crop on a new pick while the admin form
+  and `update_user_avatar/4` did not.
+  """
+  use PhoenixKit.DataCase, async: true
+
+  alias PhoenixKit.Users.Auth
+
+  @crop %{"x" => 0.3, "y" => 0.4, "zoom" => 2.0, "ar" => 1.5}
+
+  defp user_with_cropped_avatar do
+    {:ok, user} =
+      Auth.register_user(%{
+        "email" => "crop-stale-#{System.unique_integer([:positive])}@example.com",
+        "password" => "Password123!long"
+      })
+
+    {:ok, user} =
+      Auth.update_user_fields(user, %{"avatar_file_uuid" => "file-one", "avatar_crop" => @crop})
+
+    user
+  end
+
+  test "changing the avatar file drops the old file's crop" do
+    user = user_with_cropped_avatar()
+
+    # The admin form and update_user_avatar/4 write exactly this shape:
+    # a new file uuid with no opinion about the crop.
+    {:ok, updated} = Auth.update_user_fields(user, %{"avatar_file_uuid" => "file-two"})
+
+    assert updated.custom_fields["avatar_file_uuid"] == "file-two"
+
+    assert updated.custom_fields["avatar_crop"] == nil,
+           "the old image's geometry must not frame the new image"
+  end
+
+  test "a caller that sets the crop alongside the file wins" do
+    user = user_with_cropped_avatar()
+    new_crop = %{"x" => 0.5, "y" => 0.5, "zoom" => 3.0, "ar" => 0.8}
+
+    {:ok, updated} =
+      Auth.update_user_fields(user, %{
+        "avatar_file_uuid" => "file-two",
+        "avatar_crop" => new_crop
+      })
+
+    assert updated.custom_fields["avatar_crop"] == new_crop
+  end
+
+  test "re-writing the same file keeps the crop" do
+    user = user_with_cropped_avatar()
+
+    {:ok, updated} = Auth.update_user_fields(user, %{"avatar_file_uuid" => "file-one"})
+
+    assert updated.custom_fields["avatar_crop"] == @crop,
+           "the crop still describes the file it was made against"
+  end
+
+  test "unrelated custom-field writes leave the crop alone" do
+    user = user_with_cropped_avatar()
+
+    {:ok, updated} = Auth.update_user_fields(user, %{"preferred_locale" => "et"})
+
+    assert updated.custom_fields["avatar_crop"] == @crop
+  end
+end

--- a/test/js/avatar_crop.test.cjs
+++ b/test/js/avatar_crop.test.cjs
@@ -1,0 +1,128 @@
+"use strict";
+
+// Unit tests for `avatarCropLayout` / `clampAvatarCropFocal` in
+// priv/static/assets/phoenix_kit.js — the geometry behind the AvatarCrop
+// hook. The same math lives server-side in PhoenixKit.Users.AvatarCrop
+// (layout/1), where its own tests pin the same cases: the preview must
+// render exactly what the avatar component will later render.
+//
+// Run: mix test.js  (node --test needs the explicit file on Node 25)
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const noop = () => {};
+
+function stubElement() {
+  return {
+    style: {},
+    dataset: {},
+    classList: { add: noop, remove: noop, toggle: noop, contains: () => false },
+    setAttribute: noop,
+    getAttribute: () => null,
+    removeAttribute: noop,
+    appendChild: noop,
+    remove: noop,
+    addEventListener: noop,
+    removeEventListener: noop,
+    querySelector: () => null,
+    querySelectorAll: () => [],
+  };
+}
+
+global.document = {
+  documentElement: stubElement(),
+  head: stubElement(),
+  body: stubElement(),
+  createElement: stubElement,
+  createTextNode: () => ({}),
+  getElementById: () => null,
+  querySelector: () => null,
+  querySelectorAll: () => [],
+  addEventListener: noop,
+  removeEventListener: noop,
+  cookie: "",
+};
+
+const storage = { getItem: () => null, setItem: noop, removeItem: noop };
+
+global.window = {
+  addEventListener: noop,
+  removeEventListener: noop,
+  matchMedia: () => ({ matches: false, addEventListener: noop, removeEventListener: noop }),
+  localStorage: storage,
+  sessionStorage: storage,
+  location: { href: "http://localhost/", reload: noop },
+  navigator: { userAgent: "node" },
+  document: global.document,
+  setTimeout,
+  clearTimeout,
+};
+
+global.localStorage = storage;
+global.sessionStorage = storage;
+
+const {
+  avatarCropLayout,
+  clampAvatarCropFocal,
+} = require("../../priv/static/assets/phoenix_kit.js");
+
+function near(actual, expected, message) {
+  assert.ok(Math.abs(actual - expected) < 0.0001, `${message}: ${actual} vs ${expected}`);
+}
+
+test("zoom 1 centered is exactly the cover fit", () => {
+  // A 3:2 landscape at zoom 1: height fills the frame, width overflows
+  // symmetrically — what object-fit: cover with a centered position shows.
+  const l = avatarCropLayout({ x: 0.5, y: 0.5, zoom: 1, ar: 1.5 });
+  near(l.width, 150, "width");
+  near(l.height, 100, "height");
+  near(l.left, -25, "left");
+  near(l.top, 0, "top");
+});
+
+test("portrait mirrors landscape", () => {
+  const l = avatarCropLayout({ x: 0.5, y: 0.5, zoom: 1, ar: 0.5 });
+  near(l.width, 100, "width");
+  near(l.height, 200, "height");
+  near(l.left, 0, "left");
+  near(l.top, -50, "top");
+});
+
+test("zoom magnifies around the focal point", () => {
+  const l = avatarCropLayout({ x: 0.5, y: 0.5, zoom: 2, ar: 1 });
+  near(l.width, 200, "width");
+  near(l.height, 200, "height");
+  // The focal center stays at the frame center: 50 - 0.5*200 = -50.
+  near(l.left, -50, "left");
+  near(l.top, -50, "top");
+});
+
+test("the frame never sees past an edge", () => {
+  // Focal point dragged all the way into a corner: the offsets clamp so the
+  // image still covers the whole frame — no background peeking through.
+  const l = avatarCropLayout({ x: 0, y: 0, zoom: 2, ar: 1 });
+  near(l.left, 0, "left clamps at the leading edge");
+  near(l.top, 0, "top clamps at the leading edge");
+
+  const r = avatarCropLayout({ x: 1, y: 1, zoom: 2, ar: 1 });
+  near(r.left, -100, "left clamps at the trailing edge");
+  near(r.top, -100, "top clamps at the trailing edge");
+});
+
+test("focal clamping keeps the drag alive at the edges", () => {
+  // A focal value that would render clamped snaps back into the reachable
+  // range — otherwise dragging near an edge accumulates invisible distance
+  // that must be dragged back before anything moves again.
+  const c = clampAvatarCropFocal({ x: 0, y: 1, zoom: 2, ar: 1 });
+  near(c.x, 0.25, "x snaps to the edge of the reachable range");
+  near(c.y, 0.75, "y snaps to the edge of the reachable range");
+});
+
+test("an axis the image only just covers pins to center", () => {
+  // Landscape at zoom 1: the height exactly fits the frame, so there is no
+  // vertical freedom at all — y collapses to 0.5, x keeps its freedom.
+  const c = clampAvatarCropFocal({ x: 0.9, y: 0.1, zoom: 1, ar: 2 });
+  near(c.y, 0.5, "no vertical freedom");
+  near(c.x, 0.75, "horizontal freedom is real but clamped");
+});

--- a/test/phoenix_kit/users/avatar_crop_test.exs
+++ b/test/phoenix_kit/users/avatar_crop_test.exs
@@ -104,7 +104,7 @@ defmodule PhoenixKit.Users.AvatarCropTest do
     end
   end
 
-  describe "variant_for/2" do
+  describe "variant_for/3" do
     test "uncropped sizes match the ladder" do
       # 32px box at 2x needs 64px: small. 160px box needs 320px: medium.
       assert AvatarCrop.variant_for(32) == "small"
@@ -117,8 +117,47 @@ defmodule PhoenixKit.Users.AvatarCropTest do
       assert AvatarCrop.variant_for(160, 3.0) == "large"
     end
 
-    test "past the ladder, the original" do
-      assert AvatarCrop.variant_for(160, 8.0) == "original"
+    test "a landscape image needs its width to cover for its short side" do
+      # Variants scale by width, but the frame is covered by the short
+      # side. A 2:1 landscape at the settings size needs 320·2 = 640px of
+      # WIDTH before its 320px-tall short side suffices — and at zoom 2
+      # that doubles again, past medium.
+      assert AvatarCrop.variant_for(160, 1.0, 2.0) == "medium"
+      assert AvatarCrop.variant_for(160, 2.0, 2.0) == "large"
+      # Portrait width IS the short side; no penalty.
+      assert AvatarCrop.variant_for(160, 1.0, 0.5) == "medium"
+    end
+
+    test "capped at large — never the unbounded original" do
+      assert AvatarCrop.variant_for(160, 8.0) == "large"
+      assert AvatarCrop.variant_for(160, 8.0, 4.0) == "large"
+    end
+  end
+
+  describe "drop_identity/1" do
+    test "centered at cover fit is no crop at all" do
+      assert AvatarCrop.drop_identity(%{"x" => 0.5, "y" => 0.5, "zoom" => 1.0, "ar" => 1.5}) ==
+               nil
+
+      # Float noise from a drag still counts as untouched.
+      assert AvatarCrop.drop_identity(%{
+               "x" => 0.5004,
+               "y" => 0.4997,
+               "zoom" => 1.0009,
+               "ar" => 1.5
+             }) == nil
+    end
+
+    test "any real adjustment survives" do
+      crop = %{"x" => 0.5, "y" => 0.5, "zoom" => 2.0, "ar" => 1.5}
+      assert AvatarCrop.drop_identity(crop) == crop
+
+      panned = %{"x" => 0.3, "y" => 0.5, "zoom" => 1.0, "ar" => 2.0}
+      assert AvatarCrop.drop_identity(panned) == panned
+    end
+
+    test "nil passes through" do
+      assert AvatarCrop.drop_identity(nil) == nil
     end
   end
 

--- a/test/phoenix_kit/users/avatar_crop_test.exs
+++ b/test/phoenix_kit/users/avatar_crop_test.exs
@@ -1,0 +1,135 @@
+defmodule PhoenixKit.Users.AvatarCropTest do
+  @moduledoc """
+  The geometry behind non-destructive avatar cropping.
+
+  `layout/1` is mirrored by `avatarCropLayout` in
+  `priv/static/assets/phoenix_kit.js` (tested in
+  `test/js/avatar_crop.test.cjs`) — several cases here pin the same numbers
+  as the JS suite on purpose: the editor's preview must render exactly what
+  the avatar component later renders, so the two implementations are held
+  to the same answers.
+  """
+  use ExUnit.Case, async: true
+
+  alias PhoenixKit.Users.AvatarCrop
+
+  defp near(actual, expected) do
+    assert_in_delta actual, expected, 0.0001
+  end
+
+  describe "layout/1 — mirrored by the JS suite" do
+    test "zoom 1 centered is exactly the cover fit" do
+      l = AvatarCrop.layout(%{"x" => 0.5, "y" => 0.5, "zoom" => 1.0, "ar" => 1.5})
+      near(l.width, 150.0)
+      near(l.height, 100.0)
+      near(l.left, -25.0)
+      near(l.top, 0.0)
+    end
+
+    test "portrait mirrors landscape" do
+      l = AvatarCrop.layout(%{"x" => 0.5, "y" => 0.5, "zoom" => 1.0, "ar" => 0.5})
+      near(l.width, 100.0)
+      near(l.height, 200.0)
+      near(l.left, 0.0)
+      near(l.top, -50.0)
+    end
+
+    test "zoom magnifies around the focal point" do
+      l = AvatarCrop.layout(%{"x" => 0.5, "y" => 0.5, "zoom" => 2.0, "ar" => 1.0})
+      near(l.width, 200.0)
+      near(l.left, -50.0)
+    end
+
+    test "the frame never sees past an edge" do
+      l = AvatarCrop.layout(%{"x" => 0.0, "y" => 0.0, "zoom" => 2.0, "ar" => 1.0})
+      near(l.left, 0.0)
+      near(l.top, 0.0)
+
+      r = AvatarCrop.layout(%{"x" => 1.0, "y" => 1.0, "zoom" => 2.0, "ar" => 1.0})
+      near(r.left, -100.0)
+      near(r.top, -100.0)
+    end
+  end
+
+  describe "normalize/1" do
+    test "clamps rather than refuses — an overshoot is intent to reach the edge" do
+      crop = AvatarCrop.normalize(%{"x" => 1.7, "y" => -2, "zoom" => 99, "ar" => 0})
+
+      assert crop["x"] == 1.0
+      assert crop["y"] == 0.0
+      assert crop["zoom"] == 8.0
+      assert_in_delta crop["ar"], 0.05, 0.0001
+    end
+
+    test "accepts the JS hook's numeric strings" do
+      assert %{"x" => 0.25, "zoom" => 2.5} =
+               AvatarCrop.normalize(%{
+                 "x" => "0.25",
+                 "y" => "0.5",
+                 "zoom" => "2.5",
+                 "ar" => "1.5"
+               })
+    end
+
+    test "a zoom below cover fit is raised to it" do
+      assert %{"zoom" => 1.0} =
+               AvatarCrop.normalize(%{"x" => 0.5, "y" => 0.5, "zoom" => 0.2, "ar" => 1.0})
+    end
+
+    test "half a crop is no crop" do
+      assert AvatarCrop.normalize(%{"x" => 0.5, "zoom" => 2}) == nil
+      assert AvatarCrop.normalize(%{"x" => "wat", "y" => 0.5, "zoom" => 2, "ar" => 1}) == nil
+      assert AvatarCrop.normalize("not a map") == nil
+      assert AvatarCrop.normalize(nil) == nil
+    end
+  end
+
+  describe "from_user/1" do
+    test "reads the stored crop" do
+      user = %{
+        custom_fields: %{
+          "avatar_crop" => %{"x" => 0.4, "y" => 0.3, "zoom" => 2, "ar" => 1.5}
+        }
+      }
+
+      assert %{"x" => 0.4, "zoom" => 2.0} = AvatarCrop.from_user(user)
+    end
+
+    test "no key, a nil value, or junk all read as uncropped" do
+      assert AvatarCrop.from_user(%{custom_fields: %{}}) == nil
+      assert AvatarCrop.from_user(%{custom_fields: %{"avatar_crop" => nil}}) == nil
+      assert AvatarCrop.from_user(%{custom_fields: %{"avatar_crop" => "junk"}}) == nil
+      assert AvatarCrop.from_user(%{custom_fields: nil}) == nil
+      assert AvatarCrop.from_user(nil) == nil
+    end
+  end
+
+  describe "variant_for/2" do
+    test "uncropped sizes match the ladder" do
+      # 32px box at 2x needs 64px: small. 160px box needs 320px: medium.
+      assert AvatarCrop.variant_for(32) == "small"
+      assert AvatarCrop.variant_for(160) == "medium"
+    end
+
+    test "zoom buys resolution from the next variant up" do
+      # A 3x zoom shows a third of the source, so the 160px settings preview
+      # needs 960px of source — past medium (800), into large.
+      assert AvatarCrop.variant_for(160, 3.0) == "large"
+    end
+
+    test "past the ladder, the original" do
+      assert AvatarCrop.variant_for(160, 8.0) == "original"
+    end
+  end
+
+  describe "img_style/1" do
+    test "emits the geometry and undoes Tailwind's img max-width" do
+      style = AvatarCrop.img_style(%{"x" => 0.5, "y" => 0.5, "zoom" => 2.0, "ar" => 1.0})
+
+      assert style =~ "position:absolute"
+      assert style =~ "max-width:none"
+      assert style =~ "width:200.00%"
+      assert style =~ "left:-50.00%"
+    end
+  end
+end

--- a/test/phoenix_kit_web/components/core/user_avatar_crop_test.exs
+++ b/test/phoenix_kit_web/components/core/user_avatar_crop_test.exs
@@ -99,4 +99,19 @@ defmodule PhoenixKitWeb.Components.Core.UserAvatarCropTest do
     assert html =~ "object-cover"
     refute html =~ "max-width:none"
   end
+
+  test "a landscape crop buys an even sharper variant" do
+    # Width-scaled variants cover the frame with their SHORT side, so a
+    # 2:1 image at xl needs large where a square one was fine on medium.
+    html =
+      avatar(
+        %{
+          "avatar_file_uuid" => @uuid,
+          "avatar_crop" => %{"x" => 0.5, "y" => 0.5, "zoom" => 2, "ar" => 2}
+        },
+        size: "xl"
+      )
+
+    assert html =~ "/#{@uuid}/large/"
+  end
 end

--- a/test/phoenix_kit_web/components/core/user_avatar_crop_test.exs
+++ b/test/phoenix_kit_web/components/core/user_avatar_crop_test.exs
@@ -1,0 +1,102 @@
+defmodule PhoenixKitWeb.Components.Core.UserAvatarCropTest do
+  @moduledoc """
+  The avatar component applying a stored non-destructive crop.
+
+  The crop is data in `custom_fields["avatar_crop"]`; rendering turns it
+  into an inline style on the `<img>` and, when zoomed, a sharper storage
+  variant. No crop means the exact markup that always rendered.
+  """
+  use ExUnit.Case, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias PhoenixKitWeb.Components.Core.UserInfo
+
+  @uuid "0198e004-2265-7000-8000-000000000000"
+
+  defp user(custom_fields) do
+    %{email: "crop@example.com", custom_fields: custom_fields}
+  end
+
+  defp avatar(custom_fields, opts \\ []) do
+    render_component(
+      &UserInfo.user_avatar/1,
+      Keyword.merge([user: user(custom_fields), size: "sm"], opts)
+    )
+  end
+
+  test "no crop renders the classic object-cover image" do
+    html = avatar(%{"avatar_file_uuid" => @uuid})
+
+    assert html =~ "object-cover"
+    refute html =~ "max-width:none"
+    assert html =~ "/#{@uuid}/small/"
+  end
+
+  test "a crop becomes an inline style instead of object-cover" do
+    html =
+      avatar(%{
+        "avatar_file_uuid" => @uuid,
+        "avatar_crop" => %{"x" => 0.5, "y" => 0.5, "zoom" => 2, "ar" => 1}
+      })
+
+    assert html =~ "max-width:none"
+    assert html =~ "width:200.00%"
+    assert html =~ "left:-50.00%"
+    refute html =~ "object-cover"
+  end
+
+  test "zoom buys a sharper variant for the same box" do
+    # A small (sm = 32px) box normally loads "small"; the xl settings
+    # preview at 3x zoom needs more source than medium holds.
+    html =
+      avatar(%{
+        "avatar_file_uuid" => @uuid,
+        "avatar_crop" => %{"x" => 0.5, "y" => 0.5, "zoom" => 3, "ar" => 1}
+      })
+
+    assert html =~ "/#{@uuid}/small/"
+
+    xl =
+      avatar(
+        %{
+          "avatar_file_uuid" => @uuid,
+          "avatar_crop" => %{"x" => 0.5, "y" => 0.5, "zoom" => 3, "ar" => 1}
+        },
+        size: "xl"
+      )
+
+    assert xl =~ "/#{@uuid}/large/"
+  end
+
+  test "the xl size loads medium, not the 150px thumbnail" do
+    # The settings-page blur: a 160px circle fed the "thumbnail" variant.
+    html = avatar(%{"avatar_file_uuid" => @uuid}, size: "xl")
+
+    assert html =~ "/#{@uuid}/medium/"
+    refute html =~ "/thumbnail/"
+  end
+
+  test "a crop without an uploaded file changes nothing" do
+    # OAuth avatars have no variants; the crop key must not touch them.
+    html =
+      avatar(%{
+        "oauth_avatar_url" => "https://example.com/pic.jpg",
+        "avatar_crop" => %{"x" => 0.5, "y" => 0.5, "zoom" => 2, "ar" => 1}
+      })
+
+    assert html =~ "object-cover"
+    refute html =~ "max-width:none"
+  end
+
+  test "an invalid stored crop degrades to uncropped" do
+    html =
+      avatar(%{
+        "avatar_file_uuid" => @uuid,
+        "avatar_crop" => %{"x" => "junk"}
+      })
+
+    assert html =~ "object-cover"
+    refute html =~ "max-width:none"
+  end
+end


### PR DESCRIPTION
Apple-Photos-style avatar cropping: the crop is **data, never pixels**. `custom_fields["avatar_crop"]` stores a focal point, zoom, and the image's aspect ratio; the uploaded file and all its variants stay untouched. Open the editor again and the crop is sitting where you left it — loosen it, recenter it, zoom back out, or reset to the full image, with nothing ever re-encoded and no quality lost. No migration: the key rides the users table's existing JSONB and is registered in `CustomFields.@internal_keys`.

**Why it's fast with many avatars on a page:** the storage module's variants are aspect-preserving scales of the original, so the normalized crop numbers hold against any variant. List pages keep loading the same `small` variants they load today — the crop is a few floats already inside the user record, applied as an inline style by the shared `user_avatar` component. No extra requests, no imaging jobs, no per-crop files. When a crop is zoomed, the component buys sharpness from the variant ladder instead (a 3× crop shows ⅓ of the source, so the same box needs a bigger variant), falling back to the original past `large`.

**The editor** lives in a modal on `/profile/settings`: drag to position, slider or wheel to zoom. The `AvatarCrop` hook's `avatarCropLayout` is a mirror of `PhoenixKit.Users.AvatarCrop.layout/1`, and both test suites pin the same numeric cases — the preview must render exactly what the avatar later renders. Gesture ends push the numbers to the LiveComponent, so Save persists what's on screen. Picking a different media file drops the old file's crop; OAuth/Gravatar avatars (no variants) are never cropped.

**Also fixes the blurry settings preview**: it was loading the 150px `thumbnail` variant into a 160px circle (320px on 2× displays). The preview now goes through the shared `user_avatar` component at a new `"xl"` size, which loads `medium` — same as the admin user form always did. The admin form's preview also applies the stored crop to the current avatar (a pending selection previews uncropped; its crop doesn't exist yet).

**Verification**
- `mix precommit` green: format, credo --strict, dialyzer, `mix test.js` (87 passing, 6 new for the crop geometry).
- Full suite against real PostgreSQL: **42 doctests, 4763 tests, 0 failures**.
- 20 new Elixir tests (geometry mirror cases, normalize clamping, variant ladder, rendered-HTML component tests), mutation-checked: crop-never-applied, zoom-never-sharpens, and xl-blurry-again all fail the suite.
- End-to-end in headless Chromium against a real stored image (1600×900 through `Auth.update_user_avatar`): logged in, opened the editor, zoomed to 2.5× and dragged; the saved preview's inline geometry matched the editor's to the rounding digit and the persisted map read `%{"ar" => 1.777…, "x" => 0.57, "y" => 0.56, "zoom" => 2.5}`.
- New UI strings extracted and translated in all seven locales (the two fuzzy guesses from the merge corrected).

No version bump — that call is yours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)