### PR TITLE
Public-page Edit link: documented helper API, component, per-module permission gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## Unreleased
+
+### Added
+
+- **Public "Edit link" API** — `PhoenixKitWeb.AdminEditHelper.assign_admin_edit/3`
+  is now a documented public API: a host LiveView or a module's own public
+  controller/LiveView calls it to declare a public page's matching admin
+  edit target. The label argument now also accepts a keyword list
+  (`label:`, `permission:`), gating the link on a specific module's
+  `Scope.has_module_access?/2` in addition to the existing admin-area check,
+  while every existing string-label call site keeps working unchanged. A new
+  `PhoenixKitWeb.Components.Core.AdminEditLink.admin_edit_link/1` component
+  (`<.admin_edit_link .../>`) renders the link — as a standalone button or a
+  `:menu_item` for dropdowns — and renders nothing when there is no URL, so
+  hosts can drop one line into their public layout unconditionally. See the
+  "Edit link on public pages" section in `guides/integration.md`.
+
 ## 2.22.0 - 2026-09-08
 
 ### Added
@@ -231,6 +248,7 @@
   "Province"; the real value from `beamlab_countries` is "Provinces and
   territories".
 
+||||||| parent of 8fbfa12992 (Make the public-page Edit link a documented API with a component and a permission gate)
 ## 2.19.0 - 2026-09-07
 
 ### Changed

--- a/guides/integration.md
+++ b/guides/integration.md
@@ -270,6 +270,57 @@ Scope.accessible_modules(scope)  # MapSet of granted permission keys
 
 **Route enforcement**: PhoenixKit's `phoenix_kit_ensure_admin` and `phoenix_kit_ensure_module_access` on_mount hooks automatically enforce permissions on admin routes. Sidebar navigation is gated per-user.
 
+### Edit link on public pages
+
+When an admin is viewing a public page — a host LiveView, or a module's own
+public controller/LiveView — you can offer them a one-click "Edit" link into
+that page's admin counterpart.
+
+Declare the edit target from `handle_params`/`mount` (or a controller action)
+with `PhoenixKitWeb.AdminEditHelper.assign_admin_edit/3`:
+
+```elixir
+def handle_params(%{"slug" => slug}, _uri, socket) do
+  post = Blog.get_post_by_slug!(slug)
+
+  socket =
+    PhoenixKitWeb.AdminEditHelper.assign_admin_edit(socket, "/admin/posts/#{post.id}/edit")
+
+  {:noreply, assign(socket, :post, post)}
+end
+```
+
+The third argument accepts a plain string label (used as-is) or a keyword
+list — `label:` (default: gettext "Edit") and `permission:` (a module
+permission key, e.g. `"publishing"`, checked with
+`Scope.has_module_access?/2`):
+
+```elixir
+PhoenixKitWeb.AdminEditHelper.assign_admin_edit(
+  socket,
+  "/admin/publishing/posts/#{post.id}/edit",
+  label: "Edit Post",
+  permission: "publishing"
+)
+```
+
+The link is only assigned when the current scope can access the admin area
+at all and — when `permission:` is given — holds that specific module's
+access. Otherwise nothing is assigned, so the render side never sees a URL
+it shouldn't.
+
+Then drop the renderer into your public layout once:
+
+```heex
+<.admin_edit_link url={assigns[:admin_edit_url]} label={assigns[:admin_edit_label]} />
+```
+
+`PhoenixKitWeb.Components.Core.AdminEditLink.admin_edit_link/1` renders
+nothing when there is no URL, so this line is safe to leave in every public
+layout unconditionally. Pass `variant={:menu_item}` to render it as a
+daisyUI `menu` `<li>` instead of a standalone button, for dropping into an
+existing dropdown menu.
+
 ### User Registration
 
 ```elixir

--- a/lib/phoenix_kit_web.ex
+++ b/lib/phoenix_kit_web.ex
@@ -192,6 +192,7 @@ defmodule PhoenixKitWeb do
       import PhoenixKitWeb.Components.Core.FormSection
       import PhoenixKitWeb.Components.Core.FormActions
       import PhoenixKitWeb.Components.Core.BulkActionsBar
+      import PhoenixKitWeb.Components.Core.AdminEditLink
     end
   end
 

--- a/lib/phoenix_kit_web/components/core/admin_edit_link.ex
+++ b/lib/phoenix_kit_web/components/core/admin_edit_link.ex
@@ -1,0 +1,68 @@
+defmodule PhoenixKitWeb.Components.Core.AdminEditLink do
+  @moduledoc """
+  Renders the "Edit" link a host drops into a public page's layout to reach
+  the matching admin page.
+
+  Reads plain assigns — no scope check happens here. The gate lives in
+  `PhoenixKitWeb.AdminEditHelper.assign_admin_edit/3`, the producer that sets
+  `:admin_edit_url`/`:admin_edit_label`; this component only decides how to
+  render them, and renders nothing when `:url` is `nil` (unauthenticated
+  visitor, non-admin, or a page nobody called the producer for).
+
+  ## Examples
+
+      <.admin_edit_link url={assigns[:admin_edit_url]} label={assigns[:admin_edit_label]} />
+
+      <.admin_edit_link
+        url={assigns[:admin_edit_url]}
+        label={assigns[:admin_edit_label]}
+        variant={:menu_item}
+      />
+  """
+  use Phoenix.Component
+  use Gettext, backend: PhoenixKitWeb.Gettext
+
+  alias PhoenixKitWeb.Components.Core.Icon
+
+  @doc """
+  Renders an edit link into the matching admin page.
+
+  ## Attributes
+
+    * `:url` — the admin page path. Renders nothing when `nil` (default).
+    * `:label` — link text. Defaults to gettext "Edit" when `nil`.
+    * `:variant` — `:button` (default, a standalone outlined button) or
+      `:menu_item` (a daisyUI `menu` `<li>`, for dropdowns like
+      `PhoenixKitWeb.Components.UserDashboardNav.user_dropdown/1`).
+    * `:class` — extra classes appended to the variant's base classes.
+    * `:rest` — passed through to the underlying `<.link>`.
+  """
+  attr :url, :string, default: nil
+  attr :label, :string, default: nil
+  attr :variant, :atom, default: :button, values: [:button, :menu_item]
+  attr :class, :any, default: nil
+  attr :rest, :global
+
+  def admin_edit_link(%{url: nil} = assigns) do
+    ~H""
+  end
+
+  def admin_edit_link(%{variant: :button} = assigns) do
+    ~H"""
+    <.link navigate={@url} class={["btn btn-sm btn-outline gap-2", @class]} {@rest}>
+      <Icon.icon name="hero-pencil-square" class="w-4 h-4" /> {@label || gettext("Edit")}
+    </.link>
+    """
+  end
+
+  def admin_edit_link(%{variant: :menu_item} = assigns) do
+    ~H"""
+    <li>
+      <.link navigate={@url} class={["flex items-center gap-3", @class]} {@rest}>
+        <Icon.icon name="hero-pencil-square" class="w-4 h-4" />
+        <span>{@label || gettext("Edit")}</span>
+      </.link>
+    </li>
+    """
+  end
+end

--- a/lib/phoenix_kit_web/components/user_dashboard_nav.ex
+++ b/lib/phoenix_kit_web/components/user_dashboard_nav.ex
@@ -140,17 +140,11 @@ defmodule PhoenixKitWeb.Components.UserDashboardNav do
                 <span>{admin_entry_label(@scope)}</span>
               </.link>
             </li>
-            <%= if @admin_edit_url do %>
-              <li>
-                <a
-                  href={@admin_edit_url}
-                  class="flex items-center gap-3"
-                >
-                  <.icon name="hero-pencil-square" class="w-4 h-4" />
-                  <span>{@admin_edit_label || "Edit"}</span>
-                </a>
-              </li>
-            <% end %>
+            <PhoenixKitWeb.Components.Core.AdminEditLink.admin_edit_link
+              url={@admin_edit_url}
+              label={@admin_edit_label}
+              variant={:menu_item}
+            />
           <% end %>
 
           <li :if={

--- a/lib/phoenix_kit_web/helpers/admin_edit_helper.ex
+++ b/lib/phoenix_kit_web/helpers/admin_edit_helper.ex
@@ -1,19 +1,75 @@
 defmodule PhoenixKitWeb.AdminEditHelper do
   @moduledoc """
-  Universal admin edit URL helper.
-  Assigns admin_edit_url and admin_edit_label to conn/socket if user is admin.
-  Works with both Plug.Conn (controllers) and Phoenix.LiveView.Socket (LiveViews).
+  Public API for an "Edit" link from a public page into its matching admin page.
+
+  A host viewing a public page (a host LiveView, or a module's own public
+  controller/LiveView) calls `assign_admin_edit/3` to declare where that
+  page's admin counterpart lives. The visitor gets nothing unless they can
+  reach the admin area at all, and — when the caller names a `:permission`
+  module key — unless they also hold access to that specific module, so an
+  admin scoped to Publishing never sees an Edit link into Ecommerce.
+
+  Renders via `PhoenixKitWeb.Components.Core.AdminEditLink.admin_edit_link/1`,
+  which reads the `:admin_edit_url`/`:admin_edit_label` assigns this module
+  sets and renders nothing when no URL was assigned.
+
+  ## Host LiveView example
+
+      def handle_params(%{"slug" => slug}, _uri, socket) do
+        post = Blog.get_post_by_slug!(slug)
+
+        socket =
+          AdminEditHelper.assign_admin_edit(socket, "/admin/posts/\#{post.id}/edit")
+
+        {:noreply, assign(socket, :post, post)}
+      end
+
+  ## Module controller example
+
+  A module's own public controller can declare the same edit target,
+  guarding the call the way `phoenix_kit_publishing` guards every optional
+  core API it depends on — so it still compiles and runs against a core
+  release that predates this helper:
+
+      if Code.ensure_loaded?(PhoenixKitWeb.AdminEditHelper) and
+           function_exported?(PhoenixKitWeb.AdminEditHelper, :assign_admin_edit, 3) do
+        conn =
+          PhoenixKitWeb.AdminEditHelper.assign_admin_edit(
+            conn,
+            "/admin/publishing/posts/\#{post.id}/edit",
+            permission: "publishing"
+          )
+      end
   """
+  use Gettext, backend: PhoenixKitWeb.Gettext
+
   alias PhoenixKit.Users.Auth.Scope
 
   @doc """
-  Assigns `:admin_edit_url` and `:admin_edit_label` if the current user is an admin.
-  Returns conn/socket unchanged for non-admins or unauthenticated users.
-  """
-  def assign_admin_edit(conn_or_socket, path, label \\ "Edit")
+  Assigns `:admin_edit_url` and `:admin_edit_label` when the current scope
+  may see the edit link; otherwise returns the conn/socket unchanged (the
+  assigns are absent, not `nil`).
 
-  def assign_admin_edit(%Plug.Conn{} = conn, path, label) do
-    if admin?(conn.assigns[:phoenix_kit_current_scope]) do
+  `label_or_opts` (default `"Edit"`, gettext-translated) is either:
+
+    * a plain string — used as the label as-is; every existing caller keeps
+      working unchanged.
+    * a keyword list:
+      * `:label` — the link's label (default: gettext "Edit").
+      * `:permission` — a module permission key (the same string used as a
+        module's `permission_metadata/0` `:key` or a `PhoenixKit.Dashboard.Tab`
+        `:permission`). When given, the scope must also hold
+        `Scope.has_module_access?/2` for that key.
+
+  In all cases the scope must be non-`nil` and
+  `Scope.can_access_admin_area?/1` must be true.
+  """
+  def assign_admin_edit(conn_or_socket, path, label_or_opts \\ "Edit")
+
+  def assign_admin_edit(%Plug.Conn{} = conn, path, label_or_opts) do
+    {label, permission} = normalize(label_or_opts)
+
+    if allowed?(conn.assigns[:phoenix_kit_current_scope], permission) do
       conn
       |> Plug.Conn.assign(:admin_edit_url, path)
       |> Plug.Conn.assign(:admin_edit_label, label)
@@ -22,8 +78,10 @@ defmodule PhoenixKitWeb.AdminEditHelper do
     end
   end
 
-  def assign_admin_edit(%Phoenix.LiveView.Socket{} = socket, path, label) do
-    if admin?(socket.assigns[:phoenix_kit_current_scope]) do
+  def assign_admin_edit(%Phoenix.LiveView.Socket{} = socket, path, label_or_opts) do
+    {label, permission} = normalize(label_or_opts)
+
+    if allowed?(socket.assigns[:phoenix_kit_current_scope], permission) do
       socket
       |> Phoenix.Component.assign(:admin_edit_url, path)
       |> Phoenix.Component.assign(:admin_edit_label, label)
@@ -32,5 +90,16 @@ defmodule PhoenixKitWeb.AdminEditHelper do
     end
   end
 
-  defp admin?(scope), do: scope != nil and Scope.can_access_admin_area?(scope)
+  defp normalize(label) when is_binary(label), do: {label, nil}
+
+  defp normalize(opts) when is_list(opts) do
+    label = Keyword.get(opts, :label, gettext("Edit"))
+    permission = Keyword.get(opts, :permission)
+    {label, permission}
+  end
+
+  defp allowed?(scope, permission) do
+    scope != nil and Scope.can_access_admin_area?(scope) and
+      (is_nil(permission) or Scope.has_module_access?(scope, permission))
+  end
 end

--- a/test/phoenix_kit_web/components/core/admin_edit_link_test.exs
+++ b/test/phoenix_kit_web/components/core/admin_edit_link_test.exs
@@ -1,0 +1,84 @@
+defmodule PhoenixKitWeb.Components.Core.AdminEditLinkTest do
+  @moduledoc """
+  Renderer half of the "Edit link on public pages" feature. It reads whatever
+  `PhoenixKitWeb.AdminEditHelper.assign_admin_edit/3` assigned and renders
+  nothing when there is no URL — a host wires this up unconditionally in its
+  public layout, so the no-`url` case (guest, non-admin, ungated page) has to
+  produce zero markup, not an empty shell.
+
+  DB-free: this component takes plain assigns, no scope/context needed.
+  """
+  use ExUnit.Case, async: true
+
+  import Phoenix.LiveViewTest, only: [render_component: 2]
+
+  alias PhoenixKitWeb.Components.Core.AdminEditLink
+
+  test "no url: renders nothing" do
+    html =
+      render_component(&AdminEditLink.admin_edit_link/1, %{
+        url: nil,
+        label: nil,
+        variant: :button,
+        class: nil
+      })
+
+    assert String.trim(html) == ""
+  end
+
+  test "button variant: renders a link with the button classes, icon, and given label" do
+    html =
+      render_component(&AdminEditLink.admin_edit_link/1, %{
+        url: "/admin/posts/1/edit",
+        label: "Edit Post",
+        variant: :button,
+        class: nil
+      })
+
+    assert html =~ ~s(href="/admin/posts/1/edit")
+    assert html =~ "btn btn-sm btn-outline"
+    assert html =~ "hero-pencil-square"
+    assert html =~ "Edit Post"
+  end
+
+  test "button variant: nil label falls back to gettext \"Edit\"" do
+    html =
+      render_component(&AdminEditLink.admin_edit_link/1, %{
+        url: "/admin/posts/1/edit",
+        label: nil,
+        variant: :button,
+        class: nil
+      })
+
+    assert html =~ "Edit"
+  end
+
+  test "menu_item variant: renders a daisyUI menu <li> with the link inside" do
+    html =
+      render_component(&AdminEditLink.admin_edit_link/1, %{
+        url: "/admin/posts/1/edit",
+        label: "Edit Post",
+        variant: :menu_item,
+        class: nil
+      })
+
+    assert html =~ "<li>"
+    assert html =~ ~s(href="/admin/posts/1/edit")
+    assert html =~ "flex items-center gap-3"
+    assert html =~ "hero-pencil-square"
+    assert html =~ "Edit Post"
+  end
+
+  test "extra class is appended, not replacing the base classes" do
+    html =
+      render_component(&AdminEditLink.admin_edit_link/1, %{
+        url: "/admin/posts/1/edit",
+        label: "Edit",
+        variant: :button,
+        class: "ml-2"
+      })
+
+    assert html =~ "btn btn-sm btn-outline"
+    assert html =~ "ml-2"
+  end
+end

--- a/test/phoenix_kit_web/helpers/admin_edit_helper_test.exs
+++ b/test/phoenix_kit_web/helpers/admin_edit_helper_test.exs
@@ -1,0 +1,180 @@
+defmodule PhoenixKitWeb.AdminEditHelperTest do
+  @moduledoc """
+  `assign_admin_edit/3` is the public producer API a host LiveView or a
+  module's own controller/LiveView calls to say "this public page's edit
+  target is `path`". It has to behave the same for `Plug.Conn` and
+  `Phoenix.LiveView.Socket`, keep accepting a bare string label (every
+  existing caller, including publishing, passes one), and additionally gate
+  on a per-module permission key when the caller opts into one — an admin
+  who can only see Publishing must not get an Edit link into Ecommerce.
+
+  DB-free: scopes are literal structs, the pattern used across
+  `test/phoenix_kit_web/components/*_test.exs`.
+  """
+  use ExUnit.Case, async: true
+
+  alias PhoenixKit.Users.Auth.{Scope, User}
+  alias PhoenixKitWeb.AdminEditHelper
+
+  defp scope(roles, permissions) do
+    %Scope{
+      user: %User{uuid: "0193a5e4-0000-7000-8000-0000000000e1", email: "editor@example.com"},
+      authenticated?: true,
+      cached_roles: roles,
+      cached_permissions: MapSet.new(permissions)
+    }
+  end
+
+  defp admin_scope(permissions \\ []), do: scope(["Admin"], permissions)
+  defp plain_user_scope, do: scope(["User"], [])
+
+  defp conn(scope) do
+    %Plug.Conn{assigns: %{phoenix_kit_current_scope: scope}}
+  end
+
+  defp socket(scope) do
+    %Phoenix.LiveView.Socket{
+      assigns: %{phoenix_kit_current_scope: scope, __changed__: %{}}
+    }
+  end
+
+  describe "Plug.Conn — no permission key required" do
+    test "no scope assigned: conn returned untouched" do
+      result = AdminEditHelper.assign_admin_edit(%Plug.Conn{assigns: %{}}, "/admin/posts/1/edit")
+
+      refute Map.has_key?(result.assigns, :admin_edit_url)
+      refute Map.has_key?(result.assigns, :admin_edit_label)
+    end
+
+    test "non-admin scope: conn returned untouched" do
+      result =
+        AdminEditHelper.assign_admin_edit(conn(plain_user_scope()), "/admin/posts/1/edit")
+
+      refute Map.has_key?(result.assigns, :admin_edit_url)
+      refute Map.has_key?(result.assigns, :admin_edit_label)
+    end
+
+    test "admin scope, default label: assigns url and the gettext default label" do
+      result = AdminEditHelper.assign_admin_edit(conn(admin_scope()), "/admin/posts/1/edit")
+
+      assert result.assigns.admin_edit_url == "/admin/posts/1/edit"
+      assert result.assigns.admin_edit_label == "Edit"
+    end
+
+    test "admin scope, string label (existing callers): assigns the given string as-is" do
+      result =
+        AdminEditHelper.assign_admin_edit(
+          conn(admin_scope()),
+          "/admin/posts/1/edit",
+          "Edit Post"
+        )
+
+      assert result.assigns.admin_edit_url == "/admin/posts/1/edit"
+      assert result.assigns.admin_edit_label == "Edit Post"
+    end
+  end
+
+  describe "Plug.Conn — with a `permission:` key" do
+    test "admin without the module permission: conn returned untouched" do
+      result =
+        AdminEditHelper.assign_admin_edit(
+          conn(admin_scope(["publishing"])),
+          "/admin/ecommerce/products/1/edit",
+          permission: "ecommerce"
+        )
+
+      refute Map.has_key?(result.assigns, :admin_edit_url)
+      refute Map.has_key?(result.assigns, :admin_edit_label)
+    end
+
+    test "admin with the module permission: conn gets both assigns" do
+      result =
+        AdminEditHelper.assign_admin_edit(
+          conn(admin_scope(["ecommerce"])),
+          "/admin/ecommerce/products/1/edit",
+          label: "Edit Product",
+          permission: "ecommerce"
+        )
+
+      assert result.assigns.admin_edit_url == "/admin/ecommerce/products/1/edit"
+      assert result.assigns.admin_edit_label == "Edit Product"
+    end
+
+    test "non-admin scope with a permission key: still returned untouched" do
+      result =
+        AdminEditHelper.assign_admin_edit(
+          conn(plain_user_scope()),
+          "/admin/ecommerce/products/1/edit",
+          permission: "ecommerce"
+        )
+
+      refute Map.has_key?(result.assigns, :admin_edit_url)
+    end
+
+    test "keyword opts without a permission key: only the admin-area gate applies" do
+      result =
+        AdminEditHelper.assign_admin_edit(
+          conn(admin_scope([])),
+          "/admin/posts/1/edit",
+          label: "Edit Post"
+        )
+
+      assert result.assigns.admin_edit_url == "/admin/posts/1/edit"
+      assert result.assigns.admin_edit_label == "Edit Post"
+    end
+  end
+
+  describe "Phoenix.LiveView.Socket" do
+    test "no scope assigned: socket returned untouched" do
+      result =
+        AdminEditHelper.assign_admin_edit(
+          %Phoenix.LiveView.Socket{assigns: %{}},
+          "/admin/posts/1/edit"
+        )
+
+      refute Map.has_key?(result.assigns, :admin_edit_url)
+    end
+
+    test "non-admin scope: socket returned untouched" do
+      result =
+        AdminEditHelper.assign_admin_edit(socket(plain_user_scope()), "/admin/posts/1/edit")
+
+      refute Map.has_key?(result.assigns, :admin_edit_url)
+    end
+
+    test "admin without the module permission: socket returned untouched" do
+      result =
+        AdminEditHelper.assign_admin_edit(
+          socket(admin_scope(["publishing"])),
+          "/admin/ecommerce/products/1/edit",
+          permission: "ecommerce"
+        )
+
+      refute Map.has_key?(result.assigns, :admin_edit_url)
+    end
+
+    test "admin with the module permission, default label: assigns both" do
+      result =
+        AdminEditHelper.assign_admin_edit(
+          socket(admin_scope(["ecommerce"])),
+          "/admin/ecommerce/products/1/edit",
+          permission: "ecommerce"
+        )
+
+      assert result.assigns.admin_edit_url == "/admin/ecommerce/products/1/edit"
+      assert result.assigns.admin_edit_label == "Edit"
+    end
+
+    test "admin scope, string label (existing callers): assigns the given string as-is" do
+      result =
+        AdminEditHelper.assign_admin_edit(
+          socket(admin_scope()),
+          "/admin/posts/1/edit",
+          "Edit Post"
+        )
+
+      assert result.assigns.admin_edit_url == "/admin/posts/1/edit"
+      assert result.assigns.admin_edit_label == "Edit Post"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

When an admin views a public page (a host LiveView, or a module's own public controller/LiveView such as publishing's), the host can show an "Edit" link into the matching admin page with one line in its layout.

`PhoenixKitWeb.AdminEditHelper.assign_admin_edit/3` already existed, but only the admin dashboard layout ever rendered the assigns it sets; on public pages every host re-implemented "is this an admin, build the admin URL" by hand.

- **Producer API** — `assign_admin_edit/3` is now documented as the public API. The third argument still accepts a string label (all existing callers unchanged) and also `[label: ..., permission: "publishing"]`. With `permission:` the scope must hold `Scope.has_module_access?/2` for that module key in addition to `Scope.can_access_admin_area?/1`, so an admin scoped to Publishing never gets an Edit link into Ecommerce. Non-admins get no assigns at all (absent, not nil).
- **Renderer** — new `PhoenixKitWeb.Components.Core.AdminEditLink.admin_edit_link/1`, imported alongside the other core components. `variant={:button}` (default, outlined button with the pencil icon) or `:menu_item` (daisyUI menu `<li>` for dropdowns). Renders nothing when `url` is nil, so a host writes `<.admin_edit_link url={assigns[:admin_edit_url]} label={assigns[:admin_edit_label]} />` unconditionally.
- `UserDashboardNav.user_dropdown/1` now renders its Edit item through the component.
- Guide: "Edit link on public pages" in `guides/integration.md`; CHANGELOG "Unreleased" entry.

Companion module PRs already use the helper with a string label (no dependency on this PR): BeamLabEU/phoenix_kit_publishing#46, BeamLabEU/phoenix_kit_ecommerce#41.

## Tests

- New `test/phoenix_kit_web/helpers/admin_edit_helper_test.exs` (conn and socket × no scope / non-admin / admin without the module permission / admin with it / string label / keyword opts) and `test/phoenix_kit_web/components/core/admin_edit_link_test.exs` (nil url, both variants, label fallback).
- `MIX_ENV=test mix test test/phoenix_kit_web/helpers test/phoenix_kit_web/components`: 695 tests, 0 failures. `mix format --check-formatted`, `mix credo --strict` clean. Full-suite and dialyzer results follow in a comment.

## Follow-ups noticed, not changed here

- `mix.exs` sets `plt_file: "priv/plts/dialyzer.plt"` under `def cli`, not `def project`, so dialyxir ignores it and rebuilds the default PLT.
- With `PGDATABASE=phoenix_kit_dev` exported, `LiveDatabaseGuard` correctly refuses to run tests; `unset PGDATABASE` first.