### PR TITLE
Point the Integrations sidebar tab at the renamed route

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,7 +93,7 @@ The chain supports running into a named Postgres schema (`prefix:` opt / `--pref
 Centralized OAuth / API key / bot token / credential management. Full reference: `dev_docs/guides/2026-07-27-integrations-system.md`; design: `dev_docs/plans/integrations-system.md`.
 
 - **Storage:** `phoenix_kit_settings` JSONB, keys `integration:{provider}:{name}`. Consumers reference connections by storage-row **uuid** — all public API except `add_connection/3` and the read shims is uuid-strict.
-- **Owner scopes:** `:system` (website-wide UI `/admin/settings/integrations/website`) vs `{:user, uuid}` (personal UI `/admin/settings/integrations`). Every context call takes an `:owner` opt, **default `:system`** — pass `owner:` explicitly on the personal path or a forgotten owner silently births a SYSTEM row. Never encrypt `owner_uuid`.
+- **Owner scopes:** `:system` (website-wide UI `/admin/settings/integrations`) vs `{:user, uuid}` (personal UI `/profile/settings/integrations`). Every context call takes an `:owner` opt, **default `:system`** — pass `owner:` explicitly on the personal path or a forgotten owner silently births a SYSTEM row. Never encrypt `owner_uuid`.
 - **Module callbacks:** `required_integrations/0`, `integration_providers/0`, optional `migrate_legacy/0` (run via `ModuleRegistry.run_all_legacy_migrations/0`).
 
 ## Core Form Components

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## Unreleased
+
+### Fixed
+
+- The **Integrations** sidebar tab still pointed at
+  `/admin/settings/integrations/website`, the path 2.21.3 renamed to
+  `/admin/settings/integrations`. That URL does not 404 as the rename note
+  expected — it matches `/admin/settings/integrations/:uuid` with
+  `uuid = "website"`, so `Repo.get/2` raises `Ecto.Query.CastError` and
+  LiveView returns a 400 reload response, which loops. The two README route
+  lists and `AGENTS.md`'s owner-scope note were stale from the same rename
+  and are corrected alongside it.
+
 ## 2.22.0 - 2026-09-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -466,7 +466,7 @@ See [OAuth Setup Guide](guides/oauth-and-magic-link-setup.md) for details.
 - `GET {prefix}/admin/media` - Media/storage browser
 - `GET {prefix}/admin/modules` - Enable/disable modules
 - `GET {prefix}/admin/settings` - System settings
-- `GET {prefix}/admin/settings/integrations/website` - System-wide integration credentials
+- `GET {prefix}/admin/settings/integrations` - System-wide integration credentials
 
 Companion packages (if installed) register additional routes under `{prefix}/admin/*` automatically via module discovery — see "External Module Route Discovery" in this project's `AGENTS.md`.
 
@@ -636,8 +636,8 @@ PhoenixKitAI.disable_system()
 - `{prefix}/admin/settings/media` - Storage buckets and image dimensions
 - `{prefix}/admin/settings/sitemap` - Sitemap generation settings
 - `{prefix}/admin/settings/crawlers` - Crawler / bot-policy configuration
-- `{prefix}/admin/settings/integrations` - Personal (per-user) integration credentials
-- `{prefix}/admin/settings/integrations/website` - System-wide integration credentials (OAuth/API keys/bot tokens)
+- `{prefix}/profile/settings/integrations` - Personal (per-user) integration credentials
+- `{prefix}/admin/settings/integrations` - System-wide integration credentials (OAuth/API keys/bot tokens)
 
 **The following require installing their companion package** (see "Companion Modules" above) — they 404 until that package is added:
 

--- a/lib/phoenix_kit/dashboard/admin_tabs.ex
+++ b/lib/phoenix_kit/dashboard/admin_tabs.ex
@@ -307,7 +307,7 @@ defmodule PhoenixKit.Dashboard.AdminTabs do
         :admin_settings_integrations,
         gettext_noop("Integrations"),
         "hero-globe-alt",
-        "integrations/website",
+        "integrations",
         920,
         :admin_settings,
         "integrations_system"


### PR DESCRIPTION
The website-wide Integrations page moved from `/admin/settings/integrations/website` to `/admin/settings/integrations` (documented as a breaking change in the changelog), but the sidebar tab that leads there kept the old path in `AdminTabs`. Clicking **Settings → Integrations** therefore lands on the old URL.

The release note expected old `/website` URLs to 404. They do not: `/admin/settings/integrations/website` still matches the `:edit` route `/admin/settings/integrations/:uuid` with `uuid = "website"`. `get_setting_by_uuid/1` passes that straight to `Repo.get/2`, Ecto raises `Ecto.Query.CastError` casting `"website"` to a UUID, and LiveView converts the crash during connected mount into a `ReloadError` with a 400 response. The browser reloads into the same URL, so it loops.

Observed on 2.22.0:

```
** (Phoenix.LiveView.ReloadError) PhoenixKitWeb.Live.Settings.IntegrationForm
   raised Ecto.Query.CastError during connected mount sending a 400 response
    (phoenix_kit 2.22.0) lib/phoenix_kit/integrations/integrations.ex:162:
      PhoenixKit.Integrations.get_integration_by_uuid/2
    (phoenix_kit 2.22.0) lib/phoenix_kit_web/live/settings/integration_form.ex:81:
      PhoenixKitWeb.Live.Settings.IntegrationForm.apply_action/3
```

**Changes**

- `AdminTabs`: the `:admin_settings_integrations` subtab path `integrations/website` → `integrations`, so it resolves to `/admin/settings/integrations`.
- `README.md`: both route lists still documented the old `/website` path; the neighbouring personal-integrations entry is repointed at `/profile/settings/integrations`, where that page now lives.

**Not covered here:** a malformed `:uuid` in the URL still crash-loops rather than showing a not-found page, so any external bookmark of the old link keeps hitting a 400. `get_integration_by_uuid/2` already declares `{:error, :invalid_uuid}` in its spec but never returns it. Happy to send that as a separate PR if you want it.