### PR TITLE
V188 unique indexes, a shared test-helper DB preflight, and a docs cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,7 +100,7 @@ Var name = dep app upper-cased + `_PATH`; unset = published Hex pin (`mix hex.pu
   ```
 - **CHANGELOG entries:** write against the bumped `@version` heading; match existing style (Added / Changed / Fixed / i18n, bullets from PR scopes + post-merge review fixes).
 - **PR reviews:** `dev_docs/pull_requests/{year}/{pr_number}-{slug}/{AGENT}_REVIEW.md` (`CLAUDE_REVIEW.md` for Claude). Severities: `BUG - CRITICAL/HIGH/MEDIUM`, `IMPROVEMENT - HIGH/MEDIUM`, `NITPICK`.
-- **Publish:** `mix hex.build`, `mix hex.publish`, `mix docs`.
+- **Publish:** `mix prerelease` first — it is the gate, running `deps.get --check-locked`, `deps.unlock --check-unused`, a prod `compile --warnings-as-errors`, `quality.ci`, `deps.audit`, `hex.audit`, `docs`, `hex.build` and `phoenix_kit.release_check`. Then `mix hex.publish`.
 
 ## Database
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,38 @@ Test DB `phoenix_kit_test` uses embedded `PhoenixKit.Test.Repo` (`test/support/t
 
 **Without PostgreSQL:** integration tests are auto-excluded; unit tests still run (banner printed, exit 0).
 
+**`PhoenixKit.TestSupport.PostgresPreflight`** is the shared connection check every
+package's `test_helper.exs` runs before starting its repo. It ships in `lib/`
+deliberately: the sibling packages depend on core through Hex, where a
+`test/support` directory is unreachable (the precedent is
+`Ecto.Adapters.SQL.Sandbox`). Never call it from application code.
+
+It exists because a wrong `PGUSER` did not look like a wrong `PGUSER`. The
+suites run through the SQL sandbox, so a rejected login was queued and retried
+and surfaced minutes later as a **pool checkout timeout** that reads like a
+flaky test — nine repos had documented that as a landmine. It replaced a
+`psql -lqt` listing, which asked the wrong question entirely: that ran as the
+shell's user over a unix socket and said nothing about whether the CONFIGURED
+role could connect over TCP.
+
+Two things about the implementation are load-bearing and easy to undo by
+accident:
+
+- It probes with **`Postgrex.Protocol.connect/1`**, not `Postgrex.start_link/1`.
+  `start_link/1` returns `{:ok, pid}` even for a bad role, a missing database
+  and a closed port — `sync_connect: true` does not change that — and the
+  failure then happens inside the connection process. Verified against a live
+  server. `Protocol.connect/1` is undocumented, so the call is guarded and any
+  surprise degrades to "no opinion" rather than to a broken run.
+- It **whitelists** connection keys off the repo config. Passing the config
+  through would carry `pool: Ecto.Adapters.SQL.Sandbox` and rebuild the very
+  pool whose timeout is being diagnosed.
+
+`check/1` never raises (most suites degrade to unit-only); `check!/1` is for a
+suite with no unit-only mode. It is a **connection** preflight, not a
+"database ready" check — it says nothing about migrations, privileges or
+sandbox ownership, and must not grow into a second copy of repo startup.
+
 DB tests: `use PhoenixKit.DataCase, async: true` — auto-tags `:integration`.
 
 ### Local cross-repo development

--- a/dev_docs/pull_requests/2026/509-legal-i18n-css-string-entries/CLAUDE_REVIEW.md
+++ b/dev_docs/pull_requests/2026/509-legal-i18n-css-string-entries/CLAUDE_REVIEW.md
@@ -61,7 +61,7 @@ File: `lib/mix/tasks/compile.phoenix_kit_css_sources.ex:81`
 defp format_source(entry, _deps) when is_binary(entry), do: source_for_path(entry)
 ```
 
-A typo'd path (`"/Users/me/projects/foo"` when the dir doesn't exist, or a stale absolute path from a different machine) still emits a `@source` line. Tailwind silently scans nothing and the project loses styles in production with no error.
+A typo'd path (`"~/projects/foo"` when the dir doesn't exist, or a stale absolute path from a different machine) still emits a `@source` line. Tailwind silently scans nothing and the project loses styles in production with no error.
 
 A `Logger.warning("[PhoenixKit] css_sources path not found: #{path}")` when `not File.dir?(path) and not File.regular?(path)` catches typos at compile time without making the compiler fail (paths can legitimately be glob-shaped or live outside the build env).
 

--- a/dev_docs/pull_requests/2026/590-media-admin-back-breadcrumb-title-leaf/CLAUDE_REVIEW.md
+++ b/dev_docs/pull_requests/2026/590-media-admin-back-breadcrumb-title-leaf/CLAUDE_REVIEW.md
@@ -10,7 +10,7 @@ Commit `630e6933` ("Move media browser title above the folder description") acci
 staged a stray dev symlink:
 
 ```
-priv/static/assets/leaf.js -> /Users/don/Projects/elixir/work/pk/leaf/priv/static/assets/leaf.js
+priv/static/assets/leaf.js -> ~/Projects/elixir/work/pk/leaf/priv/static/assets/leaf.js
 ```
 
 - Mode `120000`, an **absolute** path that only exists on the author's machine. On every

--- a/guides/phk-publishing-format.md
+++ b/guides/phk-publishing-format.md
@@ -26,8 +26,8 @@ title: Simple Version (Original Size)
 status: draft            # draft | published | archived
 published_at: 2025-11-07T22:42:00Z
 created_at: 2025-11-07T22:42:17.231679Z
-created_by_email: max@don.ee
-updated_by_email: max@don.ee
+created_by_email: author@example.com
+updated_by_email: author@example.com
 ---
 
 # Heading 1

--- a/lib/phoenix_kit/migrations/expected_schema.ex
+++ b/lib/phoenix_kit/migrations/expected_schema.ex
@@ -157,6 +157,21 @@ defmodule PhoenixKit.Migrations.ExpectedSchema do
   # over the 49 shipped files; the real-database integration suite re-ran
   # clean against a DB migrated through V183.
   #
+  # V188 (2026-09-08) DECLARES three objects here by hand, all new and all
+  # indexes: `index:phoenix_kit_user_follows_unique_idx` (follower_uuid,
+  # followed_uuid), `index:phoenix_kit_user_blocks_unique_idx` (blocker_uuid,
+  # blocked_uuid) and
+  # `index:phoenix_kit_user_connections_requester_recipient_uidx`
+  # (requester_uuid, recipient_uuid) — the three UNIQUE indexes the
+  # phoenix_kit_user_connections schemas have always named in a
+  # `unique_constraint/3` and which have never existed, so those constraints
+  # were inert. No table or column changes. Shapes transcribed from a real
+  # database migrated through V188 (`pg_get_indexdef`, `pg_index.indisunique`,
+  # `pg_opclass`), not typed from the migration. `chain_hash` restamped over
+  # the shipped file set; V188's own up/down/dedupe behaviour was verified
+  # against a scratch database through
+  # `PhoenixKit.Squash.MigrationRunner.run_pinned_wrapper/4`.
+  #
   # V187 (2026-09-06) DECLARES nine objects here by hand, all new:
   # `table:phoenix_kit_access_attempts` (every try at the website password
   # gate), its six columns (`uuid` v7 PK, `verdict` varchar(16) NOT NULL,
@@ -279,7 +294,7 @@ defmodule PhoenixKit.Migrations.ExpectedSchema do
   @schema_token "__SCHEMA__"
   @name_marker_exempt "__PK_NAME_EXEMPT__"
   @name_marker_always "__PK_NAME_ALWAYS__"
-  @chain_hash "95a72e523c8c0a332537b8d713756be269a5091660cd0f73d64183ed58475e1c"
+  @chain_hash "b89e2f3118c4c5871f71520be95bd089e82447a13d151cb5078a2ecefe5c3499"
 
   def objects(prefix) do
     prefix = normalize_prefix!(prefix)
@@ -70825,6 +70840,99 @@ defmodule PhoenixKit.Migrations.ExpectedSchema do
                "CREATE INDEX phoenix_kit_access_attempts_address_inserted_at_index ON __SCHEMA__.phoenix_kit_access_attempts USING btree (address, inserted_at)",
              predicate: nil,
              opclasses: ["text_ops", "timestamp_ops"],
+             name_template: nil
+           }}
+        ],
+        presence: :required,
+        backfill: nil
+      },
+      %{
+        id: "index:phoenix_kit_user_follows_unique_idx",
+        owner: :core,
+        check:
+          {:catalog,
+           %{
+             name: "phoenix_kit_user_follows_unique_idx",
+             table: "phoenix_kit_user_follows",
+             kind: :index
+           }},
+        create:
+          "CREATE UNIQUE INDEX IF NOT EXISTS phoenix_kit_user_follows_unique_idx ON __SCHEMA__.phoenix_kit_user_follows USING btree (follower_uuid, followed_uuid)",
+        since: 188,
+        class: :index,
+        revisions: [
+          {188,
+           %{
+             table: "phoenix_kit_user_follows",
+             keys: ["follower_uuid", "followed_uuid"],
+             unique: true,
+             method: "btree",
+             definition:
+               "CREATE UNIQUE INDEX phoenix_kit_user_follows_unique_idx ON __SCHEMA__.phoenix_kit_user_follows USING btree (follower_uuid, followed_uuid)",
+             predicate: nil,
+             opclasses: ["uuid_ops", "uuid_ops"],
+             name_template: nil
+           }}
+        ],
+        presence: :required,
+        backfill: nil
+      },
+      %{
+        id: "index:phoenix_kit_user_blocks_unique_idx",
+        owner: :core,
+        check:
+          {:catalog,
+           %{
+             name: "phoenix_kit_user_blocks_unique_idx",
+             table: "phoenix_kit_user_blocks",
+             kind: :index
+           }},
+        create:
+          "CREATE UNIQUE INDEX IF NOT EXISTS phoenix_kit_user_blocks_unique_idx ON __SCHEMA__.phoenix_kit_user_blocks USING btree (blocker_uuid, blocked_uuid)",
+        since: 188,
+        class: :index,
+        revisions: [
+          {188,
+           %{
+             table: "phoenix_kit_user_blocks",
+             keys: ["blocker_uuid", "blocked_uuid"],
+             unique: true,
+             method: "btree",
+             definition:
+               "CREATE UNIQUE INDEX phoenix_kit_user_blocks_unique_idx ON __SCHEMA__.phoenix_kit_user_blocks USING btree (blocker_uuid, blocked_uuid)",
+             predicate: nil,
+             opclasses: ["uuid_ops", "uuid_ops"],
+             name_template: nil
+           }}
+        ],
+        presence: :required,
+        backfill: nil
+      },
+      %{
+        id: "index:phoenix_kit_user_connections_requester_recipient_uidx",
+        owner: :core,
+        check:
+          {:catalog,
+           %{
+             name: "phoenix_kit_user_connections_requester_recipient_uidx",
+             table: "phoenix_kit_user_connections",
+             kind: :index
+           }},
+        create:
+          "CREATE UNIQUE INDEX IF NOT EXISTS phoenix_kit_user_connections_requester_recipient_uidx ON __SCHEMA__.phoenix_kit_user_connections USING btree (requester_uuid, recipient_uuid)",
+        since: 188,
+        class: :index,
+        revisions: [
+          {188,
+           %{
+             table: "phoenix_kit_user_connections",
+             keys: ["requester_uuid", "recipient_uuid"],
+             unique: true,
+             method: "btree",
+             definition:
+               "CREATE UNIQUE INDEX phoenix_kit_user_connections_requester_recipient_uidx ON __SCHEMA__.phoenix_kit_user_connections USING btree (requester_uuid, recipient_uuid)",
+             predicate: nil,
+             opclasses: ["uuid_ops", "uuid_ops"],
              name_template: nil
            }}
         ],

--- a/lib/phoenix_kit/migrations/expected_schema.ex
+++ b/lib/phoenix_kit/migrations/expected_schema.ex
@@ -162,7 +162,9 @@ defmodule PhoenixKit.Migrations.ExpectedSchema do
   # followed_uuid), `index:phoenix_kit_user_blocks_unique_idx` (blocker_uuid,
   # blocked_uuid) and
   # `index:phoenix_kit_user_connections_requester_recipient_uidx`
-  # (requester_uuid, recipient_uuid) — the three UNIQUE indexes the
+  # (an EXPRESSION index on LEAST/GREATEST of the pair — connections are
+  # undirected, so the unordered pair is the key; follows and blocks are
+  # directed and index the ordered pair) — the three UNIQUE indexes the
   # phoenix_kit_user_connections schemas have always named in a
   # `unique_constraint/3` and which have never existed, so those constraints
   # were inert. No table or column changes. Shapes transcribed from a real
@@ -294,7 +296,7 @@ defmodule PhoenixKit.Migrations.ExpectedSchema do
   @schema_token "__SCHEMA__"
   @name_marker_exempt "__PK_NAME_EXEMPT__"
   @name_marker_always "__PK_NAME_ALWAYS__"
-  @chain_hash "b89e2f3118c4c5871f71520be95bd089e82447a13d151cb5078a2ecefe5c3499"
+  @chain_hash "b31cd24d2f1d905455e5be3db11ce46a09eba374ec99f2fa988a35e7f6493fbc"
 
   def objects(prefix) do
     prefix = normalize_prefix!(prefix)
@@ -70919,18 +70921,21 @@ defmodule PhoenixKit.Migrations.ExpectedSchema do
              kind: :index
            }},
         create:
-          "CREATE UNIQUE INDEX IF NOT EXISTS phoenix_kit_user_connections_requester_recipient_uidx ON __SCHEMA__.phoenix_kit_user_connections USING btree (requester_uuid, recipient_uuid)",
+          "CREATE UNIQUE INDEX IF NOT EXISTS phoenix_kit_user_connections_requester_recipient_uidx ON __SCHEMA__.phoenix_kit_user_connections USING btree (LEAST(requester_uuid, recipient_uuid), GREATEST(requester_uuid, recipient_uuid))",
         since: 188,
         class: :index,
         revisions: [
           {188,
            %{
              table: "phoenix_kit_user_connections",
-             keys: ["requester_uuid", "recipient_uuid"],
+             keys: [
+               "LEAST(requester_uuid, recipient_uuid)",
+               "GREATEST(requester_uuid, recipient_uuid)"
+             ],
              unique: true,
              method: "btree",
              definition:
-               "CREATE UNIQUE INDEX phoenix_kit_user_connections_requester_recipient_uidx ON __SCHEMA__.phoenix_kit_user_connections USING btree (requester_uuid, recipient_uuid)",
+               "CREATE UNIQUE INDEX phoenix_kit_user_connections_requester_recipient_uidx ON __SCHEMA__.phoenix_kit_user_connections USING btree (LEAST(requester_uuid, recipient_uuid), GREATEST(requester_uuid, recipient_uuid))",
              predicate: nil,
              opclasses: ["uuid_ops", "uuid_ops"],
              name_template: nil

--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -7,7 +7,17 @@ defmodule PhoenixKit.Migrations.Postgres do
 
   ## Migration Versions
 
-  ### V187 - Website access: every try at the password gate is kept ⚡ LATEST
+  ### V188 - User connections: the three unique indexes the schemas name ⚡ LATEST
+
+  Creates `phoenix_kit_user_follows_unique_idx`,
+  `phoenix_kit_user_blocks_unique_idx` and
+  `phoenix_kit_user_connections_requester_recipient_uidx`, after removing any
+  duplicate rows. The `phoenix_kit_user_connections` schemas have always
+  declared `unique_constraint/3` under these names, but no index existed, so
+  the constraints were inert and two concurrent writes could both insert the
+  same relationship.
+
+  ### V187 - Website access: every try at the password gate is kept
 
   `phoenix_kit_access_attempts` records each attempt at the website password
   gate — what was typed on a failed one, where from, with what browser, when
@@ -723,7 +733,7 @@ defmodule PhoenixKit.Migrations.Postgres do
   alias PhoenixKit.Migrations.Repair.Environment
 
   @initial_version 135
-  @current_version 187
+  @current_version 188
   @default_prefix "public"
 
   # The frozen pre-squash bridge: the last 1.7.x release, which still carries

--- a/lib/phoenix_kit/migrations/postgres/v188.ex
+++ b/lib/phoenix_kit/migrations/postgres/v188.ex
@@ -1,0 +1,101 @@
+defmodule PhoenixKit.Migrations.Postgres.V188 do
+  @moduledoc """
+  V188: the three uniqueness guarantees `phoenix_kit_user_connections`
+  already believed it had.
+
+  ## Why
+
+  The module's schemas each declare a `unique_constraint/3` naming an index
+  — `phoenix_kit_user_follows_unique_idx`,
+  `phoenix_kit_user_blocks_unique_idx`,
+  `phoenix_kit_user_connections_requester_recipient_uidx` — and none of the
+  three has ever existed. `unique_constraint/3` only translates a database
+  violation into a changeset error; with no index there is no violation, so
+  the constraints were inert and the only guard was the module's
+  read-then-write pre-check. Two concurrent follows, blocks or requests both
+  pass that check and both insert, leaving a duplicate relationship no code
+  path can produce deliberately and which every count then double-reports.
+
+  ## What it does
+
+  Removes existing duplicates, then creates the three unique indexes under
+  exactly the names the schemas name, so those `unique_constraint/3` calls
+  start working with no change to the module.
+
+  De-duplication keeps the EARLIEST row of each duplicate set. All three
+  tables have a UUIDv7 primary key, which is time-ordered, so the smallest
+  `uuid` in a set is the first one written — `a.uuid > b.uuid` removes the
+  later arrival and keeps the relationship the user established first.
+  Nothing is lost that the pair still needs: a follow, block or connection
+  between the same two users still exists afterwards, with its original
+  timestamp. The module's `*_history` tables are untouched and keep the full
+  record either way.
+
+  The connection index is on `(requester_uuid, recipient_uuid)` because that
+  is the pair the schema names. It deliberately does NOT normalise the pair:
+  A→B and B→A remain two insertable rows, which is the existing behaviour
+  `request_connection/2` relies on when it auto-accepts a mutual pending
+  request. Making the pair order-independent would change module behaviour
+  rather than enforce what the module already claims.
+
+  Rolling back drops the three indexes. It cannot bring back removed
+  duplicates, which is correct: they were never valid.
+  """
+
+  use Ecto.Migration
+
+  def up(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    dedupe(p, "phoenix_kit_user_follows", "follower_uuid", "followed_uuid")
+    dedupe(p, "phoenix_kit_user_blocks", "blocker_uuid", "blocked_uuid")
+    dedupe(p, "phoenix_kit_user_connections", "requester_uuid", "recipient_uuid")
+
+    execute("""
+    CREATE UNIQUE INDEX IF NOT EXISTS phoenix_kit_user_follows_unique_idx
+      ON #{p}phoenix_kit_user_follows USING btree (follower_uuid, followed_uuid)
+    """)
+
+    execute("""
+    CREATE UNIQUE INDEX IF NOT EXISTS phoenix_kit_user_blocks_unique_idx
+      ON #{p}phoenix_kit_user_blocks USING btree (blocker_uuid, blocked_uuid)
+    """)
+
+    execute("""
+    CREATE UNIQUE INDEX IF NOT EXISTS phoenix_kit_user_connections_requester_recipient_uidx
+      ON #{p}phoenix_kit_user_connections USING btree (requester_uuid, recipient_uuid)
+    """)
+
+    # Single-step runs rely on the migration stamping its own marker — the
+    # runner only writes it for multi-step ranges.
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '188'")
+  end
+
+  def down(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    execute("DROP INDEX IF EXISTS #{p}phoenix_kit_user_follows_unique_idx")
+    execute("DROP INDEX IF EXISTS #{p}phoenix_kit_user_blocks_unique_idx")
+    execute("DROP INDEX IF EXISTS #{p}phoenix_kit_user_connections_requester_recipient_uidx")
+
+    execute("COMMENT ON TABLE #{p}phoenix_kit IS '187'")
+  end
+
+  # Keeps the smallest uuid per pair. UUIDv7 is time-ordered, so that is the
+  # row written first. Runs before the index so CREATE UNIQUE INDEX cannot
+  # fail on an install that already raced one in.
+  defp dedupe(p, table, left, right) do
+    execute("""
+    DELETE FROM #{p}#{table} a
+    USING #{p}#{table} b
+    WHERE a.#{left} = b.#{left}
+      AND a.#{right} = b.#{right}
+      AND a.uuid > b.uuid
+    """)
+  end
+
+  defp prefix_str("public"), do: "public."
+  defp prefix_str(prefix), do: "#{prefix}."
+end

--- a/lib/phoenix_kit/migrations/postgres/v188.ex
+++ b/lib/phoenix_kit/migrations/postgres/v188.ex
@@ -22,21 +22,47 @@ defmodule PhoenixKit.Migrations.Postgres.V188 do
   exactly the names the schemas name, so those `unique_constraint/3` calls
   start working with no change to the module.
 
-  De-duplication keeps the EARLIEST row of each duplicate set. All three
-  tables have a UUIDv7 primary key, which is time-ordered, so the smallest
-  `uuid` in a set is the first one written — `a.uuid > b.uuid` removes the
-  later arrival and keeps the relationship the user established first.
-  Nothing is lost that the pair still needs: a follow, block or connection
-  between the same two users still exists afterwards, with its original
-  timestamp. The module's `*_history` tables are untouched and keep the full
-  record either way.
+  ## Directed vs undirected, and why they differ
 
-  The connection index is on `(requester_uuid, recipient_uuid)` because that
-  is the pair the schema names. It deliberately does NOT normalise the pair:
-  A→B and B→A remain two insertable rows, which is the existing behaviour
-  `request_connection/2` relies on when it auto-accepts a mutual pending
-  request. Making the pair order-independent would change module behaviour
-  rather than enforce what the module already claims.
+  Follows and blocks are DIRECTED. "A follows B" and "B follows A" are two
+  different relationships, so their indexes are on the ordered pair and only
+  an exact repeat of one direction is a duplicate.
+
+  Connections are UNDIRECTED — one row represents one relationship, stored in
+  whichever direction it was asked — so the index is on the unordered pair:
+
+      (LEAST(requester_uuid, recipient_uuid),
+       GREATEST(requester_uuid, recipient_uuid))
+
+  An ordered index here would leave the race that actually matters open. Two
+  users clicking "connect" on each other at the same moment both pass
+  `request_connection/2`'s pre-check (`connected?/2` finds no accepted row,
+  and each direction-specific pending lookup finds nothing) and both insert —
+  one A→B row and one B→A row, which an ordered index permits. The damage is
+  not cosmetic: the next request auto-accepts ONE of them and leaves the other
+  as a live pending request between two already-connected users;
+  `remove_connection/2` then deletes only the accepted row and leaves that
+  ghost behind; and `get_accepted_connection/2` uses `Repo.one/1`, so a pair
+  that ends up accepted twice raises `Ecto.MultipleResultsError`.
+
+  The expression index is still reported under its own name in a `23505`, so
+  the schema's existing `unique_constraint/3` keeps working unchanged — the
+  field list only decides where the error is attached.
+
+  Nothing legitimately needs both directions at once: a mutual request UPDATES
+  the existing row to "accepted" rather than inserting a reverse one, and a
+  removed connection deletes its row, freeing the pair for a later request.
+
+  ## De-duplication
+
+  Existing duplicates are removed first, or `CREATE UNIQUE INDEX` would fail.
+  For follows and blocks the surviving row is the smallest `uuid`, which under
+  UUIDv7's time ordering is the one written first. Connections rank
+  "accepted" above "pending" before falling back to that rule, because the two
+  can only coexist through the race being closed and the accepted row is the
+  live relationship — dropping it for an older pending request would
+  disconnect two connected users. The `*_history` tables are untouched and
+  keep the full record either way.
 
   Rolling back drops the three indexes. It cannot bring back removed
   duplicates, which is correct: they were never valid.
@@ -48,9 +74,9 @@ defmodule PhoenixKit.Migrations.Postgres.V188 do
     prefix = Map.get(opts, :prefix, "public")
     p = prefix_str(prefix)
 
-    dedupe(p, "phoenix_kit_user_follows", "follower_uuid", "followed_uuid")
-    dedupe(p, "phoenix_kit_user_blocks", "blocker_uuid", "blocked_uuid")
-    dedupe(p, "phoenix_kit_user_connections", "requester_uuid", "recipient_uuid")
+    dedupe_directed(p, "phoenix_kit_user_follows", "follower_uuid", "followed_uuid")
+    dedupe_directed(p, "phoenix_kit_user_blocks", "blocker_uuid", "blocked_uuid")
+    dedupe_connection_pairs(p)
 
     execute("""
     CREATE UNIQUE INDEX IF NOT EXISTS phoenix_kit_user_follows_unique_idx
@@ -64,7 +90,8 @@ defmodule PhoenixKit.Migrations.Postgres.V188 do
 
     execute("""
     CREATE UNIQUE INDEX IF NOT EXISTS phoenix_kit_user_connections_requester_recipient_uidx
-      ON #{p}phoenix_kit_user_connections USING btree (requester_uuid, recipient_uuid)
+      ON #{p}phoenix_kit_user_connections
+      USING btree (LEAST(requester_uuid, recipient_uuid), GREATEST(requester_uuid, recipient_uuid))
     """)
 
     # Single-step runs rely on the migration stamping its own marker — the
@@ -83,16 +110,47 @@ defmodule PhoenixKit.Migrations.Postgres.V188 do
     execute("COMMENT ON TABLE #{p}phoenix_kit IS '187'")
   end
 
-  # Keeps the smallest uuid per pair. UUIDv7 is time-ordered, so that is the
-  # row written first. Runs before the index so CREATE UNIQUE INDEX cannot
-  # fail on an install that already raced one in.
-  defp dedupe(p, table, left, right) do
+  # Follows and blocks are DIRECTED: "A follows B" and "B follows A" are two
+  # different relationships and both must survive. Only an exact repeat of the
+  # same direction is a duplicate. Keeps the smallest uuid, which under UUIDv7's
+  # time ordering is the row written first.
+  defp dedupe_directed(p, table, left, right) do
     execute("""
     DELETE FROM #{p}#{table} a
     USING #{p}#{table} b
     WHERE a.#{left} = b.#{left}
       AND a.#{right} = b.#{right}
       AND a.uuid > b.uuid
+    """)
+  end
+
+  # Connections are UNDIRECTED, so the duplicate set is the unordered pair and
+  # a cross-direction pair (A->B and B->A) is just as much a duplicate as a
+  # repeat of one direction. Both must go before the index can be built.
+  #
+  # Which row survives is not arbitrary:
+  #
+  #   * an "accepted" row outranks a "pending" one. The two can coexist only
+  #     because of the race this migration closes, and the accepted row is the
+  #     live relationship — deleting it in favour of an older pending request
+  #     would disconnect two connected users.
+  #   * within one rank the smallest uuid wins, which under UUIDv7 is the row
+  #     written first, so "who asked" is preserved.
+  #
+  # Only "pending" and "accepted" ever persist ("rejected" and "cancelled"
+  # delete the row), so those two ranks cover every stored row.
+  defp dedupe_connection_pairs(p) do
+    table = "#{p}phoenix_kit_user_connections"
+
+    execute("""
+    DELETE FROM #{table} a
+    USING #{table} b
+    WHERE LEAST(a.requester_uuid, a.recipient_uuid) = LEAST(b.requester_uuid, b.recipient_uuid)
+      AND GREATEST(a.requester_uuid, a.recipient_uuid) = GREATEST(b.requester_uuid, b.recipient_uuid)
+      AND a.uuid <> b.uuid
+      AND ( (b.status = 'accepted')::int > (a.status = 'accepted')::int
+            OR ( (b.status = 'accepted')::int = (a.status = 'accepted')::int
+                 AND b.uuid < a.uuid ) )
     """)
   end
 

--- a/lib/phoenix_kit/test_support/postgres_preflight.ex
+++ b/lib/phoenix_kit/test_support/postgres_preflight.ex
@@ -1,0 +1,294 @@
+defmodule PhoenixKit.TestSupport.PostgresPreflight do
+  @moduledoc """
+  One bounded, classified PostgreSQL connection attempt, for use from a
+  `test_helper.exs`.
+
+  ## Why this exists
+
+  Every package in this ecosystem defaults its test role to `postgres`
+  (`System.get_env("PGUSER", "postgres")`). That default is right for CI and
+  for Debian, and wrong for a Homebrew install, where `initdb` names the
+  superuser after the OS user and no `postgres` role exists.
+
+  The problem is not the default — it is what a wrong one looks like. These
+  suites run through the Ecto SQL sandbox, so a rejected login does not
+  surface as "authentication failed". `DBConnection` queues the checkout and
+  retries with backoff, and the run dies minutes later on a **pool checkout
+  timeout** that reads exactly like a flaky test. That disguise is the defect
+  this module removes, and the only one it claims to.
+
+  ## What a pass does and does not prove
+
+  A pass means the endpoint was reachable, TLS and protocol negotiation
+  succeeded, the credentials were accepted, and the target database could be
+  selected. It is a **connection** preflight, not a "database is ready" check.
+  It says nothing about whether the pool can open all its connections, whether
+  migrations have run, whether the caller has table privileges, or whether
+  sandbox ownership is configured correctly. Those already fail loudly and are
+  deliberately out of scope — do not grow this into a second copy of the repo
+  startup path.
+
+  ## Usage
+
+  `check/1` never converts a connection problem into a raise, because most
+  suites here degrade to unit-only rather than fail when there is no database:
+
+      case PhoenixKit.TestSupport.PostgresPreflight.check(MyApp.Test.Repo) do
+        :ok ->
+          start_repo_and_migrate()
+
+        {:error, _reason, message} ->
+          IO.puts(:stderr, message)
+          ExUnit.configure(exclude: [:integration])
+      end
+
+  `check!/1` is for a suite that has no meaningful unit-only mode.
+
+  > #### Not application code {: .warning}
+  >
+  > This ships in `lib/` because sibling packages depend on `phoenix_kit`
+  > through Hex, where a `test/support` directory is unreachable. It follows
+  > the precedent of `Ecto.Adapters.SQL.Sandbox`. Never call it from
+  > application code.
+  """
+
+  # Only real connection settings reach Postgrex. Passing a repo's config
+  # wholesale would carry `:pool` (the sandbox), ownership and queue timeouts
+  # with it — which rebuilds the very pool whose checkout timeout is the
+  # failure being diagnosed.
+  @connection_keys [
+    :hostname,
+    :port,
+    :database,
+    :username,
+    :password,
+    :ssl,
+    :ssl_opts,
+    :socket,
+    :socket_dir,
+    :socket_options,
+    :parameters,
+    :endpoints,
+    :types
+  ]
+
+  # Not caller-overridable.
+  @forced [connect_timeout: 2_000, types: Postgrex.DefaultTypes]
+
+  @type reason ::
+          :auth_rejected
+          | :database_not_found
+          | :insufficient_privilege
+          | :too_many_connections
+          | :server_unavailable
+          | :unreachable
+          | :unknown
+
+  @doc """
+  Attempts one connection. Returns `:ok`, or `{:error, reason, message}` with
+  a message safe to print — it names the effective host, port, database and
+  username, and never the password.
+
+  Accepts a repo module or a keyword list of repo config.
+  """
+  @spec check(module() | keyword()) :: :ok | {:error, reason(), String.t()}
+  def check(repo_or_config) do
+    opts = connection_opts(repo_or_config)
+
+    case start_probe(opts) do
+      :ok ->
+        :ok
+
+      # The probe itself could not run. Say nothing and let the suite proceed
+      # exactly as it did before this module existed: a diagnostic that cannot
+      # diagnose must never be the reason a test run stops.
+      :probe_unavailable ->
+        :ok
+
+      {:error, error} ->
+        {reason, detail} = classify(error)
+        {:error, reason, message(opts, reason, detail)}
+    end
+  end
+
+  @doc """
+  `check/1`, but raises `RuntimeError` on failure. For a suite with no
+  unit-only mode.
+  """
+  @spec check!(module() | keyword()) :: :ok
+  def check!(repo_or_config) do
+    case check(repo_or_config) do
+      :ok -> :ok
+      {:error, _reason, message} -> raise message
+    end
+  end
+
+  # `Postgrex.Protocol.connect/1` rather than `Postgrex.start_link/1`, and the
+  # reason is the whole point of this module.
+  #
+  # `start_link/1` returns `{:ok, pid}` even when the credentials are wrong —
+  # `sync_connect: true` does not change that here — and the authentication
+  # failure then happens inside the connection process. Measured against a
+  # live server: a bad role, a missing database and a closed port ALL return
+  # `{:ok, pid}`, and asking that connection for `SELECT 1` gets the generic
+  # "connection not available ... dropped from queue after 4000ms", which is
+  # precisely the misleading message this module exists to replace.
+  # `Ecto.Adapters.Postgres.storage_status/1` is no better: a bad role gives
+  # `{:error, {:error, %RuntimeError{message: "killed"}}}`.
+  #
+  # `Protocol.connect/1` is synchronous and returns the real classified error
+  # (`28000` naming the missing role, `3D000` naming the database,
+  # `:econnrefused`). It is undocumented, so every call is guarded and any
+  # surprise degrades to "no opinion" rather than to a broken test run.
+  defp start_probe(opts) do
+    if protocol_probe_available?() do
+      # No catch-all clause: dialyzer proves the two below cover the return
+      # type, and a shape change in this undocumented function would raise a
+      # CaseClauseError, which the rescue turns into :probe_unavailable — the
+      # same outcome a catch-all would give.
+      case Postgrex.Protocol.connect(opts) do
+        {:ok, state} -> disconnect(state)
+        {:error, error} -> {:error, error}
+      end
+    else
+      :probe_unavailable
+    end
+  rescue
+    # A shape change in the internal API, bad SSL options, malformed config.
+    _ -> :probe_unavailable
+  catch
+    :exit, _ -> :probe_unavailable
+  end
+
+  defp protocol_probe_available? do
+    Code.ensure_loaded?(Postgrex.Protocol) and
+      function_exported?(Postgrex.Protocol, :connect, 1)
+  end
+
+  # `disconnect/2` takes an EXCEPTION, not `:normal` — it is the DBConnection
+  # callback shape, where the first argument is the error that caused the
+  # disconnect. Passing an atom happens to close the socket anyway, but it does
+  # not type-check, so a real exception is used.
+  defp disconnect(state) do
+    if function_exported?(Postgrex.Protocol, :disconnect, 2) do
+      Postgrex.Protocol.disconnect(
+        DBConnection.ConnectionError.exception("preflight complete"),
+        state
+      )
+    end
+
+    :ok
+  rescue
+    _ -> :ok
+  end
+
+  defp connection_opts(repo) when is_atom(repo), do: repo |> repo_config() |> connection_opts()
+
+  defp connection_opts(config) when is_list(config) do
+    config
+    |> Keyword.take(@connection_keys)
+    |> Keyword.merge(@forced)
+  end
+
+  defp repo_config(repo) do
+    if Code.ensure_loaded?(repo) and function_exported?(repo, :config, 0) do
+      repo.config()
+    else
+      []
+    end
+  end
+
+  # Codes are read for their semantics, never mapped to a guess. In
+  # particular: a nonexistent role and a wrong password are NOT reliably
+  # distinguishable — depending on the pg_hba method, a missing role is
+  # answered with the same 28P01 as a bad password — so both are reported as
+  # "credentials rejected" and the server's own wording is passed through
+  # when it happens to say more.
+  defp classify(%Postgrex.Error{postgres: %{} = pg}) do
+    code = Map.get(pg, :pg_code) || Map.get(pg, :code)
+    detail = Map.get(pg, :message)
+
+    reason =
+      case to_string(code) do
+        c
+        when c in ["28P01", "28000", "invalid_password", "invalid_authorization_specification"] ->
+          :auth_rejected
+
+        c when c in ["3D000", "invalid_catalog_name"] ->
+          :database_not_found
+
+        c when c in ["42501", "insufficient_privilege"] ->
+          :insufficient_privilege
+
+        c when c in ["53300", "too_many_connections"] ->
+          :too_many_connections
+
+        c when c in ["57P03", "cannot_connect_now"] ->
+          :server_unavailable
+
+        "08" <> _ ->
+          :unreachable
+
+        _ ->
+          :unknown
+      end
+
+    {reason, detail}
+  end
+
+  # Every DBConnection-level failure here is "nothing answered on that
+  # endpoint" — econnrefused, nxdomain, ehostunreach, enoent on a socket path,
+  # a connect timeout. The distinction between them is in the message, which
+  # is passed through, and does not change the advice.
+  defp classify(%DBConnection.ConnectionError{} = error) do
+    {:unreachable, Exception.message(error)}
+  end
+
+  defp classify(error) when is_exception(error), do: {:unknown, Exception.message(error)}
+  defp classify(other), do: {:unknown, inspect(other, limit: 5)}
+
+  defp message(opts, reason, detail) do
+    """
+    #{header(reason)}
+
+      host:     #{Keyword.get(opts, :hostname, "(socket)")}:#{Keyword.get(opts, :port, 5432)}
+      database: #{Keyword.get(opts, :database, "(unset)")}
+      username: #{Keyword.get(opts, :username, "(unset)")}
+
+    #{advice(reason)}#{server_said(detail)}
+    """
+  end
+
+  defp header(:auth_rejected), do: "PostgreSQL refused the credentials."
+  defp header(:database_not_found), do: "The PostgreSQL database does not exist."
+  defp header(:insufficient_privilege), do: "PostgreSQL refused access to that database."
+  defp header(:too_many_connections), do: "PostgreSQL has no free connection slots."
+  defp header(:server_unavailable), do: "PostgreSQL is not accepting connections yet."
+  defp header(:unreachable), do: "No PostgreSQL server answered."
+  defp header(:unknown), do: "Could not connect to PostgreSQL."
+
+  defp advice(:auth_rejected) do
+    """
+    Set PGUSER / PGPASSWORD to a role this server accepts, or add a matching
+    pg_hba.conf rule. A Homebrew install has no `postgres` role by default —
+    its superuser is named after your OS user.
+    """
+  end
+
+  defp advice(:database_not_found), do: "Run `mix test.setup` (or `createdb`) to create it.\n"
+  defp advice(:insufficient_privilege), do: "Grant the role CONNECT on that database.\n"
+  defp advice(:too_many_connections), do: "Lower PGPOOL, or raise the server's max_connections.\n"
+
+  defp advice(:server_unavailable),
+    do: "The server is starting up or recovering; retry shortly.\n"
+
+  defp advice(:unreachable) do
+    "Check PGHOST / PGPORT and that the server is running.\n"
+  end
+
+  defp advice(:unknown), do: ""
+
+  defp server_said(nil), do: ""
+  defp server_said(""), do: ""
+  defp server_said(detail), do: "\nPostgreSQL said: #{detail}\n"
+end

--- a/test/integration/postgres_preflight_test.exs
+++ b/test/integration/postgres_preflight_test.exs
@@ -1,0 +1,124 @@
+defmodule PhoenixKit.TestSupport.PostgresPreflightTest do
+  @moduledoc """
+  The preflight has to be right about the thing it replaces, so these assert
+  against a REAL server rather than a stubbed classifier.
+
+  The behaviour under test is not "it returns an error" — the old code did
+  that too, eventually. It is that a rejected login is reported *as a rejected
+  login*, *immediately*, instead of as the pool checkout timeout that reads
+  like a flaky test.
+  """
+  use ExUnit.Case, async: true
+
+  @moduletag :integration
+
+  alias PhoenixKit.Test.Repo, as: TestRepo
+  alias PhoenixKit.TestSupport.PostgresPreflight
+
+  defp base do
+    config = TestRepo.config()
+
+    [
+      hostname: Keyword.get(config, :hostname, "localhost"),
+      port: Keyword.get(config, :port, 5432),
+      username: Keyword.fetch!(config, :username),
+      password: Keyword.get(config, :password),
+      database: Keyword.fetch!(config, :database)
+    ]
+  end
+
+  describe "check/1" do
+    test "passes against the repo the suite is already using" do
+      assert :ok = PostgresPreflight.check(base())
+      assert :ok = PostgresPreflight.check(TestRepo)
+    end
+
+    test "a role the server rejects is reported as such, not as a timeout" do
+      opts =
+        Keyword.put(
+          base(),
+          :username,
+          "definitely_not_a_role_#{System.unique_integer([:positive])}"
+        )
+
+      {elapsed_us, result} = :timer.tc(fn -> PostgresPreflight.check(opts) end)
+
+      assert {:error, :auth_rejected, message} = result
+
+      # The whole point. The old path took ~4s to produce "connection not
+      # available and request was dropped from queue", which is why nine repos
+      # documented this as flakiness. Anything near a second means the probe
+      # has fallen back into the pool.
+      assert elapsed_us < 1_000_000
+
+      assert message =~ "refused the credentials"
+      assert message =~ "PGUSER"
+      refute message =~ "dropped from queue"
+    end
+
+    test "a missing database is distinguished from a rejected login" do
+      opts = Keyword.put(base(), :database, "no_such_db_#{System.unique_integer([:positive])}")
+
+      assert {:error, :database_not_found, message} = PostgresPreflight.check(opts)
+      assert message =~ "does not exist"
+      assert message =~ "test.setup"
+    end
+
+    test "nothing listening is distinguished from both" do
+      assert {:error, :unreachable, message} =
+               PostgresPreflight.check(Keyword.put(base(), :port, 59_999))
+
+      assert message =~ "No PostgreSQL server answered"
+      assert message =~ "PGHOST"
+    end
+
+    test "the message names host, database and user but never the password" do
+      opts =
+        base()
+        |> Keyword.put(:username, "nope_#{System.unique_integer([:positive])}")
+        |> Keyword.put(:password, "correct-horse-battery-staple")
+
+      assert {:error, _, message} = PostgresPreflight.check(opts)
+
+      assert message =~ Keyword.fetch!(opts, :database)
+      assert message =~ Keyword.fetch!(opts, :username)
+      refute message =~ "correct-horse-battery-staple"
+    end
+
+    # Load-bearing: a repo's config carries `pool: Ecto.Adapters.SQL.Sandbox`
+    # and its ownership/queue timeouts. Letting those through would rebuild the
+    # very pool whose checkout timeout is the failure being diagnosed.
+    test "sandbox and pool settings in the config are stripped, not honoured" do
+      opts =
+        base() ++
+          [
+            pool: Ecto.Adapters.SQL.Sandbox,
+            pool_size: 25,
+            ownership_timeout: 1,
+            queue_target: 1,
+            queue_interval: 1,
+            telemetry_prefix: [:irrelevant]
+          ]
+
+      assert :ok = PostgresPreflight.check(opts)
+    end
+
+    test "an unknown repo module yields no opinion rather than a crash" do
+      assert :ok = PostgresPreflight.check(NotARepo.That.Exists)
+    end
+  end
+
+  describe "check!/1" do
+    test "returns :ok when the connection works" do
+      assert :ok = PostgresPreflight.check!(base())
+    end
+
+    test "raises with the same guidance when it does not" do
+      opts = Keyword.put(base(), :username, "nope_#{System.unique_integer([:positive])}")
+
+      assert_raise RuntimeError, ~r/refused the credentials/, fn ->
+        PostgresPreflight.check!(opts)
+      end
+    end
+  end
+end

--- a/test/integration/user_connections_uniqueness_test.exs
+++ b/test/integration/user_connections_uniqueness_test.exs
@@ -74,10 +74,6 @@ defmodule PhoenixKit.Migrations.UserConnectionsUniquenessTest do
       assert {:error, %Postgrex.Error{postgres: pg}} = insert_follow(a, b)
       assert pg.code == :unique_violation
       assert pg.constraint == "phoenix_kit_user_follows_unique_idx"
-
-      # The reverse direction is a different relationship and must stay
-      # insertable — a follow is one-way.
-      assert {:ok, _} = insert_follow(b, a)
     end
 
     test "a duplicate block is refused by the index the schema names" do
@@ -89,11 +85,13 @@ defmodule PhoenixKit.Migrations.UserConnectionsUniquenessTest do
       assert {:error, %Postgrex.Error{postgres: pg}} = insert_block(a, b)
       assert pg.code == :unique_violation
       assert pg.constraint == "phoenix_kit_user_blocks_unique_idx"
-
-      assert {:ok, _} = insert_block(b, a)
     end
 
-    test "a duplicate connection request is refused, but the mutual one is not" do
+    # Connections are UNDIRECTED: one row is one relationship, stored in
+    # whichever direction it was asked. So BOTH a same-direction repeat and a
+    # cross-direction row are duplicates, and the index is on the unordered
+    # pair.
+    test "a duplicate connection request is refused in either direction" do
       a = user!("c1")
       b = user!("c2")
 
@@ -103,11 +101,30 @@ defmodule PhoenixKit.Migrations.UserConnectionsUniquenessTest do
       assert pg.code == :unique_violation
       assert pg.constraint == "phoenix_kit_user_connections_requester_recipient_uidx"
 
-      # Load-bearing, and the reason this index is NOT on a normalised pair:
-      # `PhoenixKitUserConnections.request_connection/2` auto-accepts when B
-      # requests while A→B is already pending, which needs B→A to be
-      # insertable. An order-independent index would break that flow.
-      assert {:ok, _} = insert_connection(b, a)
+      # The one that matters, and the one an ordered index would have let
+      # through: two users clicking "connect" on each other at the same moment.
+      # Both pass request_connection/2's pre-check, and without this the pair
+      # ends up with two rows — one of which survives a later auto-accept as a
+      # live pending request between two already-connected users, while
+      # get_accepted_connection/2's Repo.one/1 raises if both become accepted.
+      assert {:error, %Postgrex.Error{postgres: reverse}} = insert_connection(b, a)
+      assert reverse.code == :unique_violation
+      assert reverse.constraint == "phoenix_kit_user_connections_requester_recipient_uidx"
+    end
+
+    # The contrast that keeps the two shapes honest: follows and blocks are
+    # DIRECTED, so their reverse is a different relationship and must stay
+    # insertable. A future migration that "tidied" all three onto one shape
+    # would break this.
+    test "the directed relationships keep both directions" do
+      a = user!("d1")
+      b = user!("d2")
+
+      assert {:ok, _} = insert_follow(a, b)
+      assert {:ok, _} = insert_follow(b, a)
+
+      assert {:ok, _} = insert_block(a, b)
+      assert {:ok, _} = insert_block(b, a)
     end
   end
 end

--- a/test/integration/user_connections_uniqueness_test.exs
+++ b/test/integration/user_connections_uniqueness_test.exs
@@ -1,0 +1,113 @@
+defmodule PhoenixKit.Migrations.UserConnectionsUniquenessTest do
+  @moduledoc """
+  V188's three unique indexes, checked by behaviour rather than by catalog.
+
+  `phoenix_kit_user_connections`' schemas have always declared a
+  `unique_constraint/3` naming each of these indexes, and until V188 none of
+  them existed. `unique_constraint/3` only turns a DATABASE violation into a
+  changeset error, so with no index there was no violation and the constraints
+  were inert — the module's read-then-write pre-check was the only guard, and
+  two concurrent writes sailed through it.
+
+  `HandDeclaredManifestTest` already proves the manifest agrees with the chain
+  for V171+, which covers these three objects structurally. What it cannot
+  show is that they ENFORCE anything, or that the pair order is the one the
+  module needs. That is what this file pins, because both are the properties a
+  future migration could quietly break while leaving the catalog shape intact.
+  """
+  use PhoenixKit.DataCase, async: false
+
+  alias PhoenixKit.Test.Repo
+
+  defp user!(tag) do
+    uuid = Ecto.UUID.generate()
+
+    Repo.query!(
+      """
+      INSERT INTO phoenix_kit_users (uuid, email, hashed_password, is_active, inserted_at, updated_at)
+      VALUES ($1::text::uuid, $2, 'x', true, now(), now())
+      """,
+      [uuid, "uniq-#{tag}-#{System.unique_integer([:positive])}@example.com"]
+    )
+
+    uuid
+  end
+
+  defp insert_follow(a, b) do
+    Repo.query(
+      """
+      INSERT INTO phoenix_kit_user_follows (uuid, follower_uuid, followed_uuid, inserted_at)
+      VALUES (uuid_generate_v7(), $1::text::uuid, $2::text::uuid, now())
+      """,
+      [a, b]
+    )
+  end
+
+  defp insert_block(a, b) do
+    Repo.query(
+      """
+      INSERT INTO phoenix_kit_user_blocks (uuid, blocker_uuid, blocked_uuid, inserted_at)
+      VALUES (uuid_generate_v7(), $1::text::uuid, $2::text::uuid, now())
+      """,
+      [a, b]
+    )
+  end
+
+  defp insert_connection(a, b) do
+    Repo.query(
+      """
+      INSERT INTO phoenix_kit_user_connections
+        (uuid, requester_uuid, recipient_uuid, status, requested_at, inserted_at, updated_at)
+      VALUES (uuid_generate_v7(), $1::text::uuid, $2::text::uuid, 'pending', now(), now(), now())
+      """,
+      [a, b]
+    )
+  end
+
+  describe "V188 unique indexes" do
+    test "a duplicate follow is refused by the index the schema names" do
+      a = user!("f1")
+      b = user!("f2")
+
+      assert {:ok, _} = insert_follow(a, b)
+
+      assert {:error, %Postgrex.Error{postgres: pg}} = insert_follow(a, b)
+      assert pg.code == :unique_violation
+      assert pg.constraint == "phoenix_kit_user_follows_unique_idx"
+
+      # The reverse direction is a different relationship and must stay
+      # insertable — a follow is one-way.
+      assert {:ok, _} = insert_follow(b, a)
+    end
+
+    test "a duplicate block is refused by the index the schema names" do
+      a = user!("b1")
+      b = user!("b2")
+
+      assert {:ok, _} = insert_block(a, b)
+
+      assert {:error, %Postgrex.Error{postgres: pg}} = insert_block(a, b)
+      assert pg.code == :unique_violation
+      assert pg.constraint == "phoenix_kit_user_blocks_unique_idx"
+
+      assert {:ok, _} = insert_block(b, a)
+    end
+
+    test "a duplicate connection request is refused, but the mutual one is not" do
+      a = user!("c1")
+      b = user!("c2")
+
+      assert {:ok, _} = insert_connection(a, b)
+
+      assert {:error, %Postgrex.Error{postgres: pg}} = insert_connection(a, b)
+      assert pg.code == :unique_violation
+      assert pg.constraint == "phoenix_kit_user_connections_requester_recipient_uidx"
+
+      # Load-bearing, and the reason this index is NOT on a normalised pair:
+      # `PhoenixKitUserConnections.request_connection/2` auto-accepts when B
+      # requests while A→B is already pending, which needs B→A to be
+      # insertable. An order-independent index would break that flow.
+      assert {:ok, _} = insert_connection(b, a)
+    end
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -9,30 +9,24 @@ db_name =
 
 PhoenixKit.Test.LiveDatabaseGuard.check!(db_name)
 
-# Check if the test database exists before trying to connect.
-# Uses `psql -lqt` for a fast check that avoids Postgrex connection hangs.
-# Falls back to attempting connection directly if psql is unavailable (e.g., CI).
-
+# One classified connection attempt, with the repo's OWN credentials and
+# transport, before anything starts the pool.
+#
+# This replaces a `psql -lqt` listing. That check asked the wrong question: it
+# ran as the shell's user over a unix socket, so it reported "the database is
+# there" and told us nothing about whether the CONFIGURED role could reach it
+# over TCP. When it could not, the answer arrived minutes later as a pool
+# checkout timeout that reads like a flaky test.
 db_check =
-  try do
-    case System.cmd("psql", ["-lqt"], stderr_to_stdout: true) do
-      {output, 0} ->
-        exists =
-          output
-          |> String.split("\n")
-          |> Enum.any?(fn line ->
-            line |> String.split("|") |> List.first("") |> String.trim() == db_name
-          end)
+  case PhoenixKit.TestSupport.PostgresPreflight.check(
+         Application.get_env(:phoenix_kit, PhoenixKit.Test.Repo, [])
+       ) do
+    :ok ->
+      :exists
 
-        if exists, do: :exists, else: :not_found
-
-      _ ->
-        # psql not available (CI without postgresql-client) — try connecting directly
-        :try_connect
-    end
-  rescue
-    # psql binary not found on this system — try connecting directly
-    ErlangError -> :try_connect
+    {:error, _reason, message} ->
+      IO.puts(:stderr, "\n" <> message)
+      :not_found
   end
 
 # Started before the repo block: the Owner seed below promotes through
@@ -44,8 +38,8 @@ db_check =
 repo_available =
   if db_check == :not_found do
     IO.puts("""
-    \n⚠  Test database "#{db_name}" not found — integration tests will be excluded.
-       Run `mix test.setup` to create the test database.
+    \n⚠  Cannot reach test database "#{db_name}" — integration tests will be excluded.
+       The reason is printed above.
     """)
 
     false


### PR DESCRIPTION
Three changes on `main`. The V188 migration is the substantial one; the other
two are follow-ups from the same pass.

---

# 1. V188 — unique indexes for user connections, follows and blocks

## The defect

The three `phoenix_kit_user_connections` schemas each declare a `unique_constraint/3` naming an index:

- `phoenix_kit_user_follows_unique_idx`
- `phoenix_kit_user_blocks_unique_idx`
- `phoenix_kit_user_connections_requester_recipient_uidx`

**None of the three has ever existed.** `unique_constraint/3` only translates a database violation into a changeset error, so with no index there is no violation — the constraints were inert, and the module's read-then-write pre-check was the only guard. Two concurrent follows, blocks or requests both pass that check and both insert.

## Directed vs undirected — the part worth reviewing

Follows and blocks are **directed**: "A follows B" and "B follows A" are two different relationships, so those index the ordered pair.

Connections are **undirected** — one row is one relationship, stored in whichever direction it was asked — so that index is an expression index on `(LEAST(requester_uuid, recipient_uuid), GREATEST(...))`.

An ordered index there would leave the race that actually matters open. Two users clicking "connect" on each other at the same instant both pass `request_connection/2`'s pre-check (`connected?/2` finds no accepted row; each direction-specific pending lookup finds nothing) and both insert. The damage is not cosmetic:

- the next request auto-accepts **one** row and leaves the other as a live pending request between two already-connected users;
- `remove_connection/2` then deletes only the accepted row and leaves that ghost behind;
- `get_accepted_connection/2` uses `Repo.one/1`, so a pair accepted twice raises `Ecto.MultipleResultsError`.

Nothing legitimately needs both directions at once: a mutual request **updates** the existing row to `accepted` rather than inserting a reverse one, and a removed connection deletes its row, freeing the pair.

The expression index is still reported under its own name in a `23505`, so the schema's existing `unique_constraint(name:)` keeps working with no change — the field list only decides where the error is attached.

## De-duplication

Existing duplicates are removed first, or `CREATE UNIQUE INDEX` fails. Follows and blocks keep the smallest `uuid` (UUIDv7 is time-ordered, so that is the row written first). Connections collapse the **unordered** pair and rank `accepted` above `pending` before falling back to that rule — the two can only coexist through the race being closed, and dropping the accepted row for an older pending request would disconnect two connected users. The `*_history` tables are untouched.

## Verification

On a scratch database through `PhoenixKit.Squash.MigrationRunner` (it applies or undoes a single version, which the chain wrapper cannot):

| Step | Result |
|---|---|
| Fresh install | 3 indexes created |
| Undo V188 — the state every existing install is in | 0 indexes |
| Seed same-direction **and** cross-direction duplicates | 2 / 2 / 3 rows |
| Re-apply over dirty data | 1 / 1 / 1 — earliest kept, accepted preserved |
| Duplicate follow / cross-direction connection | both refused, `23505` under the right index |
| Reverse **follow** (directed) | still inserts, as it must |
| Apply twice more | nothing changes |

**Manifest:** three objects hand-declared in `expected_schema.ex`, shapes transcribed from a real V188 database (`pg_get_indexdef`, `pg_index.indisunique`, `pg_opclass`) — including the expression keys rather than column names; `chain_hash` restamped over the 54 shipped files. `s7`/`s8` skip here (they need a generated manifest, and the generator aborts on the pre-existing slug-function mismatch the V184 note records), so the equivalent was used: the repair planner reports **no V188 findings** on a freshly-migrated database, and after dropping one index reports *"comment claims V188 but V188 is the first version whose objects are not all present"*.

**Gates:** `mix phoenix_kit.release_check` passes every migration check (`current_version/0 == v188.ex`, V135..V188 contiguous, `chain_hash` matches 54 files). `mix precommit` clean. Full suite green.

`hand_declared_manifest_test.exs` covers these objects structurally (it pins the manifest against a chain-built schema for V171+). `test/integration/user_connections_uniqueness_test.exs` (new, 4 tests) covers what it cannot: that the indexes enforce, that the connection pair is refused in **either** direction, and that follows and blocks keep both directions.

## Companion change

`phoenix_kit_user_connections` PR #9 handles the consequence: the losing insert now gets a `23505` instead of reaching the auto-accept branch, so `create_pending_connection/2` surfaces `:pair_exists` and `reconcile_pair_conflict/2` re-reads the pair once. Verified with 250 concurrent mutual-click rounds — one row per pair every time, 250 `{:ok, "pending"}` + 250 `{:ok, "accepted"}`, no caller raising.

No version bump and no CHANGELOG entry — those are yours.

---

# 2. `PhoenixKit.TestSupport.PostgresPreflight` — a shared connection check

A wrong `PGUSER` did not look like a wrong `PGUSER`. The module suites run
through the Ecto SQL sandbox, so a rejected login was queued and retried and
surfaced minutes later as a **pool checkout timeout** that reads like a flaky
test — nine repos had ended up documenting that as a landmine in their
`AGENTS.md`.

The default itself is fine and stays: falling back to `$USER` would break CI,
where the OS user is `runner` while the role is `postgres`. This fixes the
failure **mode**, not the configuration.

The helper makes one bounded, classified connection attempt and reports the
reason — credentials rejected, database missing, nothing listening, no free
slots — naming the effective host, database and username, and never the
password. It replaces each module's `psql -lqt` listing, which asked the wrong
question entirely: that ran as the *shell's* user over a unix socket and said
nothing about whether the **configured** role could connect over TCP.

It ships in `lib/` because the sibling packages depend on core through Hex,
where a `test/support` directory is unreachable; the precedent is
`Ecto.Adapters.SQL.Sandbox`.

Two implementation details are load-bearing, and both were established by
measuring against a live server rather than from the documentation:

- It probes with **`Postgrex.Protocol.connect/1`**, not `Postgrex.start_link/1`.
  `start_link/1` returns `{:ok, pid}` for a bad role, a missing database **and**
  a closed port — `sync_connect: true` does not change that — and the failure
  then happens inside the connection process, which is the original bug. Asking
  that connection for `SELECT 1` returns the generic "dropped from queue after
  4000ms". `Ecto.Adapters.Postgres.storage_status/1` is no better: a bad role
  gives `{:error, {:error, %RuntimeError{message: "killed"}}}`.
  `Protocol.connect/1` is undocumented, so the call is guarded and any surprise
  degrades to "no opinion" rather than to a broken run.
- It **whitelists** connection keys off the repo config. Passing the config
  through would carry `pool: Ecto.Adapters.SQL.Sandbox` and rebuild the very
  pool whose timeout is being diagnosed.

`check/1` never raises (most suites degrade to unit-only); `check!/1` is for a
suite with no unit-only mode. It is a **connection** preflight, not a "database
ready" check — it says nothing about migrations, privileges or sandbox
ownership.

Nine tests cover it against a real server, including that a rejected role is
reported in **under a second** rather than as a queue timeout, and that sandbox
settings in the config are stripped. The companion PRs wire it into each
module's `test_helper.exs`.

---

# 3. Remove local paths and personal identifiers from committed docs

Absolute paths inside one developer's home directory, written into review
documents by the AI review tools themselves (they cite files by absolute path)
and into follow-up notes referencing a local agent-memory directory. Rewritten
to repo-relative paths, which is what a reader of a public repository can
actually use. No content changed beyond the paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
