### PR TITLE
V189: remove the dead billing_default_currency setting

### DIFF
--- a/lib/phoenix_kit/migrations/expected_schema.ex
+++ b/lib/phoenix_kit/migrations/expected_schema.ex
@@ -157,6 +157,20 @@ defmodule PhoenixKit.Migrations.ExpectedSchema do
   # over the 49 shipped files; the real-database integration suite re-ran
   # clean against a DB migrated through V183.
   #
+  # V189 (2026-09-08, per-domain currency Э5) declares NO object here, and
+  # cannot: it is a pure data migration — `DELETE FROM phoenix_kit_settings
+  # WHERE "key" = 'billing_default_currency'` (a dead setting seeded by V135
+  # that nothing reads, and that actively disagreed with the currency
+  # table's `is_default` row it duplicates), plus the version-marker
+  # COMMENT. No table, column, index or constraint is added, dropped or
+  # reshaped — the same V182/V184 class — so `chain_hash` is restamped over
+  # the 55 shipped files rather than the manifest being regenerated. The
+  # chain was re-run end to end into a fresh database (V135→V189) and the
+  # migration's real statements are exercised against a seeded settings row
+  # by test/phoenix_kit/migrations/v189_test.exs, including down/1 never
+  # clobbering a value an operator re-created by hand — the same shape as
+  # V184's `shop_currency` removal.
+  #
   # V188 (2026-09-08) DECLARES three objects here by hand, all new and all
   # indexes: `index:phoenix_kit_user_follows_unique_idx` (follower_uuid,
   # followed_uuid), `index:phoenix_kit_user_blocks_unique_idx` (blocker_uuid,
@@ -296,7 +310,7 @@ defmodule PhoenixKit.Migrations.ExpectedSchema do
   @schema_token "__SCHEMA__"
   @name_marker_exempt "__PK_NAME_EXEMPT__"
   @name_marker_always "__PK_NAME_ALWAYS__"
-  @chain_hash "b31cd24d2f1d905455e5be3db11ce46a09eba374ec99f2fa988a35e7f6493fbc"
+  @chain_hash "2379effc7f93d11d2010c9f4cf0b1774865de371fe91a2674e96d958e4fbfabe"
 
   def objects(prefix) do
     prefix = normalize_prefix!(prefix)

--- a/lib/phoenix_kit/migrations/postgres.ex
+++ b/lib/phoenix_kit/migrations/postgres.ex
@@ -7,7 +7,21 @@ defmodule PhoenixKit.Migrations.Postgres do
 
   ## Migration Versions
 
-  ### V188 - User connections: the three unique indexes the schemas name ⚡ LATEST
+  ### V189 - Settings: dead `billing_default_currency` removed ⚡ LATEST
+
+  Deletes the `billing_default_currency` row `V135` seeds into
+  `phoenix_kit_settings`. Nothing reads it — confirmed by a full grep over
+  `phoenix_kit`, `phoenix_kit_billing`, `phoenix_kit_ecommerce`, and a host
+  application. The base currency a shop actually uses is the
+  `is_default = true` row of `phoenix_kit_currencies`; the removed setting
+  did not merely go unread, it actively disagreed with that row (seeded
+  `'EUR'` while the currency table's default is `USD`), which is worse than
+  no setting at all. `down/1` restores the row with V135's exact seed
+  statement (`ON CONFLICT ("key") DO NOTHING`), so a rollback never
+  overwrites a value an operator re-created by hand — the same shape as
+  V184's `shop_currency` removal.
+
+  ### V188 - User connections: the three unique indexes the schemas name
 
   Creates `phoenix_kit_user_follows_unique_idx`,
   `phoenix_kit_user_blocks_unique_idx` and
@@ -733,7 +747,7 @@ defmodule PhoenixKit.Migrations.Postgres do
   alias PhoenixKit.Migrations.Repair.Environment
 
   @initial_version 135
-  @current_version 188
+  @current_version 189
   @default_prefix "public"
 
   # The frozen pre-squash bridge: the last 1.7.x release, which still carries

--- a/lib/phoenix_kit/migrations/postgres/v189.ex
+++ b/lib/phoenix_kit/migrations/postgres/v189.ex
@@ -1,0 +1,95 @@
+defmodule PhoenixKit.Migrations.Postgres.V189 do
+  @moduledoc """
+  V189: removes the `billing_default_currency` setting seeded by V135.
+
+  Nothing reads it — confirmed by a full grep over `phoenix_kit`,
+  `phoenix_kit_billing`, `phoenix_kit_ecommerce`, and a host application: the
+  only occurrences of the key are the V135 seed itself and this package's
+  `ExpectedSchema` manifest that audits V135's shape. The base currency a
+  shop actually uses is the `is_default = true` row of
+  `phoenix_kit_currencies`, resolved through
+  `PhoenixKitBilling.get_default_currency/0` — and nothing else. Worse than
+  merely unread, the stored value actively disagrees with that row on this
+  package's own hosts: V135 seeds `'EUR'` here while the currency table's
+  `is_default` row is USD. A dead setting that answers a live question
+  wrongly is worse than no setting, because the next reader who finds it
+  will believe it. This is the same defect V184 removed for the sibling
+  `shop_currency` key, and this migration follows that one's shape exactly.
+
+  ## Why V135 itself is not edited
+
+  The seed is `INSERT ... ON CONFLICT ("key") DO NOTHING`. Every host that
+  has already migrated already has the row — deleting the line from V135's
+  text changes nothing for them, since a past migration's `execute/1` calls
+  do not re-run. It would only change behavior for a brand-new install,
+  exactly the population that has no problem to fix. Worse, `V135` is a
+  released, hashed baseline: editing it changes
+  `ExpectedSchema.chain_hash/0` and fails `mix phoenix_kit.release_check`
+  for every host already on this version, for a change that helps nobody.
+  The correct place for a removal is a new chain version, which is what
+  this migration is.
+
+  ## down/1
+
+  Restores the row with the exact statement V135 seeded it with (copied
+  verbatim, including the `ON CONFLICT ("key") DO NOTHING`), so a rollback
+  never overwrites a value an operator may have re-created by hand after
+  the key was deleted — it only recreates the row if one is not already
+  there.
+
+  Restoring is the deliberate choice here even though the restored value is
+  the same wrong `'EUR'` V135 always seeded: `down/1`'s job is to undo
+  `up/1`, i.e. return the database to the state it was in immediately
+  before this version applied — not to also repair a pre-existing data
+  defect that predates this migration and is V135's to fix, not V189's.
+  Making `down/1` asymmetric with V184's identical precedent would itself
+  become a trap: a reader who has just read V184's `down/1` and sees this
+  one behave differently, for the structurally identical situation, has to
+  wonder what distinguishes them — nothing does.
+  """
+
+  use Ecto.Migration
+
+  def up(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    Enum.each(up_statements(p), &execute/1)
+  end
+
+  def down(opts) do
+    prefix = Map.get(opts, :prefix, "public")
+    p = prefix_str(prefix)
+
+    Enum.each(down_statements(p), &execute/1)
+  end
+
+  # Public (and idempotent) so the suite can run the REAL statements against a
+  # seeded settings row — `up/1` itself can't be invoked outside an
+  # `Ecto.Migrator` runner (same constraint as V182Test and friends), and by
+  # the time any test runs, the chain has already deleted the row from an
+  # install that starts with no problem to prove. `p` is the rendered prefix
+  # including the trailing dot.
+  @doc false
+  def up_statements(p) do
+    [
+      "DELETE FROM #{p}phoenix_kit_settings WHERE \"key\" = 'billing_default_currency'",
+      "COMMENT ON TABLE #{p}phoenix_kit IS '189'"
+    ]
+  end
+
+  @doc false
+  def down_statements(p) do
+    [
+      """
+      INSERT INTO #{p}phoenix_kit_settings ("key", "module", "value", "value_json")
+      VALUES ('billing_default_currency', 'billing', 'EUR', NULL)
+      ON CONFLICT ("key") DO NOTHING
+      """,
+      "COMMENT ON TABLE #{p}phoenix_kit IS '188'"
+    ]
+  end
+
+  defp prefix_str("public"), do: "public."
+  defp prefix_str(prefix), do: "#{prefix}."
+end

--- a/test/phoenix_kit/migrations/v189_test.exs
+++ b/test/phoenix_kit/migrations/v189_test.exs
@@ -1,0 +1,106 @@
+defmodule PhoenixKit.Migrations.Postgres.V189Test do
+  @moduledoc """
+  V189's `billing_default_currency` deletion, run against a seeded settings
+  row.
+
+  `V189.up/1` can't be invoked outside an `Ecto.Migrator` runner (same
+  constraint as V182Test/V184Test and friends), and by the time any test
+  runs the chain has already deleted the row — from an install that had no
+  `billing_default_currency` problem to prove in the first place. So the
+  migration exposes its statements via `up_statements/1`/`down_statements/1`
+  (`up/1` and `down/1` execute exactly those lists), and this suite seeds
+  the row back first, then runs the REAL SQL against it.
+  """
+
+  use PhoenixKit.DataCase, async: false
+
+  alias PhoenixKit.Migrations.Postgres.V189
+  alias PhoenixKit.Test.Repo
+
+  @table "phoenix_kit"
+
+  defp seed_billing_default_currency! do
+    Repo.query!("""
+    INSERT INTO phoenix_kit_settings ("key", "module", "value", "value_json")
+    VALUES ('billing_default_currency', 'billing', 'EUR', NULL)
+    ON CONFLICT ("key") DO NOTHING
+    """)
+  end
+
+  defp run_up, do: Enum.each(V189.up_statements("public."), &Repo.query!/1)
+  defp run_down, do: Enum.each(V189.down_statements("public."), &Repo.query!/1)
+
+  defp billing_default_currency_count do
+    %{rows: [[count]]} =
+      Repo.query!(
+        "SELECT count(*) FROM phoenix_kit_settings WHERE \"key\" = 'billing_default_currency'"
+      )
+
+    count
+  end
+
+  defp billing_default_currency_value do
+    case Repo.query!(
+           "SELECT value FROM phoenix_kit_settings WHERE \"key\" = 'billing_default_currency'"
+         ) do
+      %{rows: [[value]]} -> value
+      %{rows: []} -> nil
+    end
+  end
+
+  defp table_marker do
+    %{rows: [[marker]]} = Repo.query!("SELECT obj_description('#{@table}'::regclass)")
+    marker
+  end
+
+  test "up deletes the dead billing_default_currency setting and stamps the version marker" do
+    seed_billing_default_currency!()
+    assert billing_default_currency_count() == 1
+
+    run_up()
+
+    assert billing_default_currency_count() == 0
+    assert table_marker() == "189"
+  end
+
+  test "is a no-op when the row is already absent (a fresh install has never seeded it)" do
+    assert billing_default_currency_count() == 0
+
+    run_up()
+
+    assert billing_default_currency_count() == 0
+    assert table_marker() == "189"
+  end
+
+  test "down restores the row exactly as V135 seeded it, and stamps the prior marker" do
+    seed_billing_default_currency!()
+    run_up()
+    assert billing_default_currency_count() == 0
+
+    run_down()
+
+    assert billing_default_currency_count() == 1
+    assert billing_default_currency_value() == "EUR"
+    assert table_marker() == "188"
+  end
+
+  test "down never clobbers a value an operator re-created by hand" do
+    seed_billing_default_currency!()
+    run_up()
+    assert billing_default_currency_count() == 0
+
+    # A host re-creates the setting by hand after the deletion, with a value
+    # that is not the V135 default — e.g. it configured a real billing
+    # currency under this key before ever seeing this migration.
+    Repo.query!("""
+    INSERT INTO phoenix_kit_settings ("key", "module", "value", "value_json")
+    VALUES ('billing_default_currency', 'billing', 'USD', NULL)
+    """)
+
+    run_down()
+
+    # ON CONFLICT DO NOTHING: the hand-created row survives untouched.
+    assert billing_default_currency_value() == "USD"
+    assert table_marker() == "188"
+  end
+end


### PR DESCRIPTION
Removes a dead setting that answers a live question wrongly.

`phoenix_kit_settings` carries `billing_default_currency`, seeded by V135. Nothing has read it since `phoenix_kit_billing` moved the base currency to the `is_default` row of `phoenix_kit_currencies`, and on a real shop its stored value (`EUR`) contradicts the actual base (`USD`). A setting nobody reads is clutter; a setting nobody reads that states the opposite of the truth is a trap for the next person who greps for it.

This follows V184 exactly, which removed the sibling `shop_currency` key for the same reason: a pure data migration, `DELETE` on up, and on down an `INSERT ... ON CONFLICT ("key") DO NOTHING` restoring V135's original row.

**On `down/1` restoring a value we just called wrong.** Deliberate. A `down` undoes its own `up` and returns the database to its immediately prior state; it is not the place to also repair a V135-era defect that predates this version. The conflict clause means it never clobbers a value an operator recreated by hand after the deletion. Diverging from V184's shape for a structurally identical situation would itself be the trap — a reader has no reason to expect two sibling migrations to behave differently.

No schema object is declared, so the chain hash is restamped rather than the manifest regenerated, matching how V182 and V184 were handled.

## A note on the number

This was built as V188 first. Before finalising, a re-fetch showed upstream had merged its own, unrelated V188 (the user-connections unique indexes) in the meantime. The work was reverted off the shared files, fast-forwarded onto the new tip, and rebuilt as V189 on top of the real V188 — which is untouched here; the diff against `main` in `postgres.ex` and `expected_schema.ex` is additive only. This project has previously had to untangle a fork and upstream claiming the same chain number on a live database by hand, which is why the number was re-read rather than trusted.

## Verified

- Four new tests exercising the real SQL against a seeded row: the row is removed, running against an absent row is a no-op, `down` restores it, and `down` leaves a hand-recreated value alone.
- The chain applies end to end, 135 through 189, and the version marker advances and retreats correctly.
- Full suite: 4864 tests with one failure, a flash double-render race in the auth-flow tests. That failure reproduces identically on a clean `main` worktree with its own database, so it predates and is unrelated to this change.
- Format and static analysis clean.

Independent review published below.
