### PR TITLE
load_more: forward extra attributes to the button

### DIFF
--- a/lib/phoenix_kit_web/components/core/pagination.ex
+++ b/lib/phoenix_kit_web/components/core/pagination.ex
@@ -359,6 +359,13 @@ defmodule PhoenixKitWeb.Components.Core.Pagination do
   attr :infinite, :boolean, default: false
   attr :cursor, :string, default: ""
 
+  attr :rest, :global,
+    doc: """
+    Forwarded to the button, so a page with more than one load-more list can
+    tell its handler which one was clicked (`phx-value-*`). Without this a
+    caller has to mint a separate event name per list.
+    """
+
   def load_more(assigns) do
     if assigns.infinite and is_nil(assigns.id) do
       raise ArgumentError,
@@ -395,6 +402,7 @@ defmodule PhoenixKitWeb.Components.Core.Pagination do
         class="btn btn-sm"
         phx-click={@on_load_more}
         phx-disable-with={gettext("Loading…")}
+        {@rest}
       >
         {gettext("Load more")}
       </button>

--- a/test/phoenix_kit_web/components/core/load_more_test.exs
+++ b/test/phoenix_kit_web/components/core/load_more_test.exs
@@ -62,6 +62,21 @@ defmodule PhoenixKitWeb.Components.Core.LoadMoreTest do
       assert result =~ ~s(phx-click="my_load_event")
     end
 
+    test "extra attributes ride along to the button" do
+      # A page with more than one load-more list needs to tell its handler
+      # which list was clicked; without a passthrough each list would need
+      # an event name of its own.
+      assigns = %{}
+
+      result =
+        rendered_to_string(~H"""
+        <.load_more loaded={10} total={50} on_load_more="load_more_rows" phx-value-field="title" />
+        """)
+
+      assert result =~ ~s(phx-value-field="title")
+      assert result =~ ~s(phx-click="load_more_rows")
+    end
+
     test "loaded == 0 with total > 0 renders the button" do
       assigns = %{}
 


### PR DESCRIPTION
## What

`<.load_more>` renders its own button and dropped everything the caller passed, so `phx-value-*` never reached the DOM. A page with more than one load-more list therefore had no way to tell its handler which list was clicked, short of minting a separate event name per list.

## How

`attr :rest, :global`, spread on the button. Callers that pass nothing render exactly as before.

Found while moving the Shopify sync page in `phoenix_kit_ecommerce` off a hand-rolled prev/next pager onto this component: that page has six independently paged sections on one screen.

## Checklist

- [x] `mix test test/phoenix_kit_web/components/core/load_more_test.exs` — 6 tests, 0 failures (one new, covering the passthrough)
- [x] `mix format`
- [x] Review published, then un-draft