### PR TITLE
Let a module own the /admin landing page, and let users pick their start page

### DIFF
--- a/lib/phoenix_kit/users/auth.ex
+++ b/lib/phoenix_kit/users/auth.ex
@@ -1955,6 +1955,63 @@ defmodule PhoenixKit.Users.Auth do
   end
 
   @doc """
+  The page this user has chosen to land on after signing in, or `nil`.
+
+  A RELATIVE path (`"/admin/projects"`), never a resolved URL: the PhoenixKit
+  prefix and the active locale are applied at redirect time, so a preference
+  saved in Estonian still works in English and survives a prefix change.
+
+  Stored in `custom_fields` under a reserved key, exactly like
+  `preferred_locale` — an internal preference, not an admin-managed custom
+  field.
+  """
+  @spec user_start_page(User.t() | nil) :: String.t() | nil
+  def user_start_page(%User{custom_fields: fields}) when is_map(fields) do
+    case Map.get(fields, "start_page") do
+      path when is_binary(path) and path != "" -> path
+      _ -> nil
+    end
+  end
+
+  def user_start_page(_user), do: nil
+
+  @doc """
+  Sets (or clears, with `nil`) where this user lands after signing in.
+
+  Refuses anything that is not a local relative path — a stored `//evil.test`
+  or a full URL would turn a saved preference into an open redirect fired on
+  every login. Writes through the atomic single-key primitives with
+  `ensure_definitions: false`, the same discipline as
+  `update_user_locale_preference/2`, so a concurrent writer of another
+  `custom_fields` key is never lost.
+  """
+  @spec update_user_start_page(User.t(), String.t() | nil) ::
+          {:ok, User.t()} | {:error, String.t()} | {:error, :not_found}
+  def update_user_start_page(%User{} = user, path) do
+    cond do
+      is_nil(path) or path == "" ->
+        delete_user_custom_field(user, "start_page")
+
+      local_relative_path?(path) ->
+        merge_user_custom_fields(user, %{"start_page" => path}, ensure_definitions: false)
+
+      true ->
+        {:error, "must be a path within this site"}
+    end
+  end
+
+  # One leading slash and no scheme or host. `//host` and `/\host` are both
+  # protocol-relative and must not pass.
+  defp local_relative_path?(path) when is_binary(path) do
+    String.starts_with?(path, "/") and
+      not String.starts_with?(path, "//") and
+      not String.starts_with?(path, "/\\") and
+      not String.contains?(path, "://")
+  end
+
+  defp local_relative_path?(_path), do: false
+
+  @doc """
   Updates user custom fields.
 
   Custom fields are stored as JSONB and can contain arbitrary key-value pairs

--- a/lib/phoenix_kit_web/live/components/user_settings.ex
+++ b/lib/phoenix_kit_web/live/components/user_settings.ex
@@ -559,14 +559,14 @@ defmodule PhoenixKitWeb.Live.Components.UserSettings do
   end
 
   def handle_event("update_start_page", %{"start_page" => path}, socket) do
-    user = socket.assigns.phoenix_kit_current_user
+    user = socket.assigns.user
     chosen = if path == "", do: nil, else: path
 
     case Auth.update_user_start_page(user, chosen) do
       {:ok, updated} ->
         {:noreply,
          socket
-         |> assign(:phoenix_kit_current_user, updated)
+         |> assign(:user, updated)
          |> assign(:start_page, chosen)
          |> assign(:start_page_message, gettext("Saved."))}
 
@@ -648,7 +648,11 @@ defmodule PhoenixKitWeb.Live.Components.UserSettings do
   # render, so one naming a page they have since lost simply stops being
   # selected rather than stranding them.
   defp assign_start_page(socket) do
-    user = socket.assigns[:phoenix_kit_current_user]
+    # `:user` is this component's assign for the current user — the parent
+    # passes `user={@phoenix_kit_current_user}` and nothing else. Reading the
+    # parent's name here got nil, built an ANONYMOUS scope, and the picker
+    # offered only the one tab that needs no permission.
+    user = socket.assigns[:user]
     scope = socket.assigns[:phoenix_kit_current_scope] || Scope.for_user(user)
 
     options =

--- a/lib/phoenix_kit_web/live/components/user_settings.ex
+++ b/lib/phoenix_kit_web/live/components/user_settings.ex
@@ -43,6 +43,8 @@ defmodule PhoenixKitWeb.Live.Components.UserSettings do
 
   require Logger
 
+  alias PhoenixKit.Dashboard.Registry, as: TabRegistry
+  alias PhoenixKit.Dashboard.Tab
   alias PhoenixKit.Integrations
   alias PhoenixKit.Integrations.Providers
   alias PhoenixKit.Modules.Storage.URLSigner
@@ -50,6 +52,7 @@ defmodule PhoenixKitWeb.Live.Components.UserSettings do
   alias PhoenixKit.Notifications.Types, as: NotificationTypes
   alias PhoenixKit.Settings
   alias PhoenixKit.Users.Auth
+  alias PhoenixKit.Users.Auth.Scope
   alias PhoenixKit.Users.AvatarCrop
   alias PhoenixKit.Users.CustomFields
   alias PhoenixKit.Users.OAuth
@@ -66,6 +69,7 @@ defmodule PhoenixKitWeb.Live.Components.UserSettings do
   # `PhoenixKitWeb.Live.Users.ProfileSettings` for the reference caller.
   @default_sections [
     :identity,
+    :start_page,
     :custom_fields,
     :email,
     :password,
@@ -152,6 +156,8 @@ defmodule PhoenixKitWeb.Live.Components.UserSettings do
       |> assign_new(:browser_timezone_name, fn -> nil end)
       |> assign_new(:browser_timezone_offset, fn -> nil end)
       |> assign_new(:timezone_mismatch_warning, fn -> nil end)
+      |> assign_new(:start_page_message, fn -> nil end)
+      |> assign_start_page()
       |> assign_new(:trigger_submit, fn -> false end)
       |> assign_new(:oauth_providers, fn -> OAuth.get_user_oauth_providers(user.uuid) end)
       |> assign_new(:oauth_available, fn -> OAuthAvailability.oauth_available?() end)
@@ -552,6 +558,26 @@ defmodule PhoenixKitWeb.Live.Components.UserSettings do
      assign(socket, :show_notification_prefs, not socket.assigns.show_notification_prefs)}
   end
 
+  def handle_event("update_start_page", %{"start_page" => path}, socket) do
+    user = socket.assigns.phoenix_kit_current_user
+    chosen = if path == "", do: nil, else: path
+
+    case Auth.update_user_start_page(user, chosen) do
+      {:ok, updated} ->
+        {:noreply,
+         socket
+         |> assign(:phoenix_kit_current_user, updated)
+         |> assign(:start_page, chosen)
+         |> assign(:start_page_message, gettext("Saved."))}
+
+      {:error, message} when is_binary(message) ->
+        {:noreply, assign(socket, :start_page_message, message)}
+
+      _ ->
+        {:noreply, assign(socket, :start_page_message, gettext("Could not save that."))}
+    end
+  end
+
   def handle_event("update_notification_prefs", params, socket) do
     user = socket.assigns.user
 
@@ -614,6 +640,41 @@ defmodule PhoenixKitWeb.Live.Components.UserSettings do
      socket
      |> assign(:sessions, load_sessions(user, socket.assigns.current_session_token))
      |> assign(:session_success_message, gettext("Signed out of all other sessions."))}
+  end
+
+  # The pages this person may actually land on: their own visible, top-level
+  # admin tabs. Built per viewer rather than from a fixed list, so a tab they
+  # cannot reach is never offered — and a preference is re-derived on every
+  # render, so one naming a page they have since lost simply stops being
+  # selected rather than stranding them.
+  defp assign_start_page(socket) do
+    user = socket.assigns[:phoenix_kit_current_user]
+    scope = socket.assigns[:phoenix_kit_current_scope] || Scope.for_user(user)
+
+    options =
+      scope
+      |> admin_tab_options()
+      |> Enum.uniq_by(&elem(&1, 1))
+
+    socket
+    |> assign(:start_page_options, options)
+    |> assign(:start_page, Auth.user_start_page(user))
+  end
+
+  defp admin_tab_options(scope) do
+    for tab <- TabRegistry.get_admin_tabs(scope: scope),
+        is_nil(tab.parent),
+        # A parameterized path is a route, not a destination.
+        # `to_string/1` rather than `|| ""`: `Tab.path` is typed non-nil, so
+        # the nil branch is dead code Dialyzer rejects, but a struct built by
+        # hand can still carry nil.
+        not String.contains?(to_string(tab.path), ":"),
+        label = Tab.localized_label(tab),
+        is_binary(label) do
+      {label, "/admin/" <> String.trim_leading(to_string(tab.path), "/")}
+    end
+  rescue
+    _ -> []
   end
 
   # Private helpers
@@ -1520,6 +1581,44 @@ defmodule PhoenixKitWeb.Live.Components.UserSettings do
         <% end %>
 
         <%!-- Notifications Section --%>
+        <%!-- Start page. Somebody who lives in one module should not have to
+        navigate out of the admin home every morning; core has no per-user
+        preference store, so this rides in `custom_fields` under a reserved
+        key, exactly as `preferred_locale` does. --%>
+        <%= if :start_page in @sections and @start_page_options != [] do %>
+          <div class="divider"></div>
+          <div>
+            <h2 class="text-lg font-semibold flex items-center gap-2 mb-3">
+              <.icon name="hero-home" class="w-5 h-5 text-primary" /> {gettext("Start page")}
+            </h2>
+            <p class="text-sm text-base-content/60 mb-3">
+              {gettext("Where to go after you sign in.")}
+            </p>
+            <form
+              phx-submit="update_start_page"
+              phx-target={@myself}
+              class="flex flex-wrap items-end gap-2"
+            >
+              <label class="form-control min-w-64">
+                <select name="start_page" class="select select-bordered select-sm">
+                  <option value="">{gettext("The admin home")}</option>
+                  <option
+                    :for={{label, path} <- @start_page_options}
+                    value={path}
+                    selected={@start_page == path}
+                  >
+                    {label}
+                  </option>
+                </select>
+              </label>
+              <button type="submit" class="btn btn-primary btn-sm">{gettext("Save")}</button>
+              <span :if={@start_page_message} class="text-sm text-success">
+                {@start_page_message}
+              </span>
+            </form>
+          </div>
+        <% end %>
+
         <%= if :notifications in @sections and @notification_types != [] do %>
           <%= if Enum.any?([:identity, :custom_fields, :email, :password, :oauth], & &1 in @sections) do %>
             <div class="divider"></div>

--- a/lib/phoenix_kit_web/live/components/user_settings.ex
+++ b/lib/phoenix_kit_web/live/components/user_settings.ex
@@ -664,14 +664,17 @@ defmodule PhoenixKitWeb.Live.Components.UserSettings do
   defp admin_tab_options(scope) do
     for tab <- TabRegistry.get_admin_tabs(scope: scope),
         is_nil(tab.parent),
+        # Registered paths are MIXED — modules declare relative ones
+        # ("dashboards") while core resolves some already ("/admin/settings").
+        # `resolve_path/2` handles both and passes an absolute one through;
+        # hand-prefixing produced "/admin/admin/notifications" and collapsed
+        # the rest into one entry when they deduped.
+        resolved = Tab.resolve_path(tab, :admin).path,
         # A parameterized path is a route, not a destination.
-        # `to_string/1` rather than `|| ""`: `Tab.path` is typed non-nil, so
-        # the nil branch is dead code Dialyzer rejects, but a struct built by
-        # hand can still carry nil.
-        not String.contains?(to_string(tab.path), ":"),
+        not String.contains?(to_string(resolved), ":"),
         label = Tab.localized_label(tab),
         is_binary(label) do
-      {label, "/admin/" <> String.trim_leading(to_string(tab.path), "/")}
+      {label, resolved}
     end
   rescue
     _ -> []

--- a/lib/phoenix_kit_web/live/dashboard.ex
+++ b/lib/phoenix_kit_web/live/dashboard.ex
@@ -40,6 +40,25 @@ defmodule PhoenixKitWeb.Live.Dashboard do
   use Gettext, backend: PhoenixKitWeb.Gettext
   use PhoenixKitWeb.Live.Dashboard.Overview
 
+  # These MUST sit immediately after `use Overview`, which injects its own
+  # `handle_info/2` clause here — Elixir warns when one function's clauses are
+  # not grouped, and `mix precommit` compiles with `--warnings-as-errors`. See
+  # `Overview`'s moduledoc.
+  #
+  # The embedded admin-home view (an optional module's, rendered below) reports
+  # whether it has a dashboard to show, so the built-in overview can hide and
+  # come back LIVE as an administrator binds or unbinds one — rather than this
+  # page deciding once at mount and needing a reload.
+  # Deliberately NO catch-all below it: `Overview`'s guard names its ten tags
+  # and nothing else precisely so the host keeps control of every other
+  # message, and a test asserts that an unrelated one still raises rather than
+  # being silently swallowed. The embedded home view runs in its own process
+  # and sends only this one message, so nothing else arrives here.
+  @impl true
+  def handle_info({:admin_home, state}, socket) when state in [:shown, :empty] do
+    {:noreply, assign(socket, :home_dashboard?, state == :shown)}
+  end
+
   alias PhoenixKit.Settings
   alias PhoenixKit.Users.Auth.Scope
   alias PhoenixKit.Users.Auth.User
@@ -75,8 +94,55 @@ defmodule PhoenixKitWeb.Live.Dashboard do
       # them at once: the scope-refresh hook calls the same function through the
       # `phoenix_kit_scope_changed/1` callback `use Overview` injects.
       |> Overview.assign_overview(session, Routes.path("/admin"))
+      |> assign_home_view(session)
 
     {:ok, socket}
+  end
+
+  # The dashboards module, when installed AND enabled, may own this page. It is
+  # resolved duck-typed — `Code.ensure_loaded?/1` before `function_exported?/3`,
+  # since on a cold VM the latter answers false without loading the module — so
+  # core keeps no dependency on an optional package and this page is unchanged
+  # wherever that package is absent.
+  #
+  # `home_dashboard?` starts false so the very first paint is the built-in
+  # overview; the child view flips it the moment it reports a dashboard. That
+  # ordering matters: an admin with nothing bound must never see the page
+  # flicker through an empty state.
+  defp assign_home_view(socket, session) do
+    socket
+    |> assign(:home_view, home_view())
+    |> assign(:home_dashboard?, false)
+    |> assign(:home_session, %{
+      "current_user_uuid" => current_user_uuid(socket),
+      "locale" => session["locale"],
+      "parent_pid" => self()
+    })
+  end
+
+  defp home_view do
+    module = PhoenixKitDashboards.Web.AdminHomeLive
+
+    if Code.ensure_loaded?(module) and enabled_module?(PhoenixKitDashboards) do
+      module
+    end
+  rescue
+    _ -> nil
+  end
+
+  defp enabled_module?(module) do
+    Code.ensure_loaded?(module) and function_exported?(module, :enabled?, 0) and module.enabled?()
+  rescue
+    _ -> false
+  catch
+    :exit, _ -> false
+  end
+
+  defp current_user_uuid(socket) do
+    case socket.assigns[:phoenix_kit_current_user] do
+      %{uuid: uuid} -> uuid
+      _ -> nil
+    end
   end
 
   attr :scope, :any,

--- a/lib/phoenix_kit_web/live/dashboard.ex
+++ b/lib/phoenix_kit_web/live/dashboard.ex
@@ -105,14 +105,16 @@ defmodule PhoenixKitWeb.Live.Dashboard do
   # core keeps no dependency on an optional package and this page is unchanged
   # wherever that package is absent.
   #
-  # `home_dashboard?` starts false so the very first paint is the built-in
-  # overview; the child view flips it the moment it reports a dashboard. That
-  # ordering matters: an admin with nothing bound must never see the page
-  # flicker through an empty state.
+  # `home_dashboard?` is answered UP FRONT, by asking the module's own
+  # `admin_home_dashboards/1` for this viewer. The child view flips it later
+  # too — that is what makes binding and unbinding a dashboard land live — but
+  # it cannot be the FIRST answer: the child renders its board in the very same
+  # pass, so a page that starts with "no dashboard" paints the board and the
+  # built-in overview stacked together until the child's message arrives.
   defp assign_home_view(socket, session) do
     socket
     |> assign(:home_view, home_view())
-    |> assign(:home_dashboard?, false)
+    |> assign(:home_dashboard?, home_dashboard?(socket))
     |> assign(:home_session, %{
       "current_user_uuid" => current_user_uuid(socket),
       "locale" => session["locale"],
@@ -129,6 +131,31 @@ defmodule PhoenixKitWeb.Live.Dashboard do
   rescue
     _ -> nil
   end
+
+  # Whether anything is bound to the home place FOR THIS VIEWER — audience
+  # rules included, so a role-only board does not blank the overview for
+  # everyone else. Resolved through the same duck-typed contract as the view
+  # itself, and false on any failure: an optional module must never be able to
+  # leave `/admin` with neither half rendered.
+  defp home_dashboard?(socket), do: home_dashboard?(PhoenixKitDashboards, scope_of(socket))
+
+  # The module arrives as an argument for the same reason it does in
+  # `enabled_module?/1`: core does not depend on this package, and a call
+  # written against the literal alias warns at compile time here. Public only
+  # so a test can drive it with a stand-in module — core has no dependency to
+  # drive it with.
+  @doc false
+  def home_dashboard?(module, scope) do
+    Code.ensure_loaded?(module) and
+      function_exported?(module, :admin_home_dashboards, 1) and
+      match?({_tier, [_ | _]}, module.admin_home_dashboards(scope))
+  rescue
+    _ -> false
+  catch
+    :exit, _ -> false
+  end
+
+  defp scope_of(socket), do: socket.assigns[:phoenix_kit_current_scope]
 
   defp enabled_module?(module) do
     Code.ensure_loaded?(module) and function_exported?(module, :enabled?, 0) and module.enabled?()

--- a/lib/phoenix_kit_web/live/dashboard.html.heex
+++ b/lib/phoenix_kit_web/live/dashboard.html.heex
@@ -19,9 +19,18 @@
          holding no permissions. --%>
     <.welcome_block scope={assigns[:phoenix_kit_current_scope]} greeting={@greeting_key} />
 
+    <%!-- The admin-home dashboard, when the dashboards module is installed,
+         enabled, and something is bound to the home place. It reports back
+         whether it has anything to show, and the built-in overview below
+         steps aside only while it does. --%>
+    <div :if={@home_view} class="mt-8">
+      {live_render(@socket, @home_view, id: "pk-admin-home", session: @home_session)}
+    </div>
+
     <%!-- The operator half. Renders nothing at all when every block is gated
          off, so the `mt-8` gap exists only when there is something below. --%>
     <PhoenixKitWeb.Components.Core.DashboardOverview.dashboard_overview
+      :if={!@home_dashboard?}
       class="mt-8"
       show_users_card={@show_users_card}
       show_roles_card={@show_roles_card}

--- a/lib/phoenix_kit_web/users/auth.ex
+++ b/lib/phoenix_kit_web/users/auth.ex
@@ -2795,7 +2795,26 @@ defmodule PhoenixKitWeb.Users.Auth do
   # on_mount hooks bounce an authenticated visitor right back through here, so
   # a blind `"/"` here would undo the guarantee one hop later.
   defp signed_in_path(source) do
-    Routes.post_auth_path([], context: source, scope: source_scope(source))
+    Routes.post_auth_path(start_page_candidates(source),
+      context: source,
+      scope: source_scope(source)
+    )
+  end
+
+  # The visitor's own "start on this page" preference, offered as the FIRST
+  # candidate so it wins over the configured default — and offered as a
+  # candidate rather than returned directly, so it inherits every check the
+  # chain already applies (local, not an auth page, routable in this host).
+  # A preference naming a page that has since been removed simply fails those
+  # and the chain carries on to the usual landing, which is why a stale one
+  # cannot strand anyone.
+  defp start_page_candidates(source) do
+    case Auth.user_start_page(source.assigns[:phoenix_kit_current_user]) do
+      nil -> []
+      path -> [Routes.path(path)]
+    end
+  rescue
+    _ -> []
   end
 
   # `:phoenix_kit_redirect_if_user_is_authenticated` assigns only the user, the

--- a/lib/phoenix_kit_web/users/auth.ex
+++ b/lib/phoenix_kit_web/users/auth.ex
@@ -154,8 +154,13 @@ defmodule PhoenixKitWeb.Users.Auth do
     # it routes one, and a core-owned landing everywhere else. The subject is
     # the user being logged IN — `conn.assigns` still describes whoever the
     # pipeline saw, which for a fresh login is nobody.
+    # The user's own "start on this page" preference sits AFTER an explicit
+    # return_to — going back to the page you were actually trying to reach
+    # beats a standing preference — and BEFORE the configured default, which
+    # is the thing a personal choice is meant to override.
     user_return_to =
-      Routes.post_auth_path([params["return_to"], get_session(conn, :user_return_to)],
+      Routes.post_auth_path(
+        [params["return_to"], get_session(conn, :user_return_to)] ++ start_page_candidates(user),
         context: conn,
         scope: Scope.for_user(user)
       )
@@ -2795,7 +2800,7 @@ defmodule PhoenixKitWeb.Users.Auth do
   # on_mount hooks bounce an authenticated visitor right back through here, so
   # a blind `"/"` here would undo the guarantee one hop later.
   defp signed_in_path(source) do
-    Routes.post_auth_path(start_page_candidates(source),
+    Routes.post_auth_path(start_page_candidates(source.assigns[:phoenix_kit_current_user]),
       context: source,
       scope: source_scope(source)
     )
@@ -2808,14 +2813,16 @@ defmodule PhoenixKitWeb.Users.Auth do
   # A preference naming a page that has since been removed simply fails those
   # and the chain carries on to the usual landing, which is why a stale one
   # cannot strand anyone.
-  defp start_page_candidates(source) do
-    case Auth.user_start_page(source.assigns[:phoenix_kit_current_user]) do
+  defp start_page_candidates(%User{} = user) do
+    case Auth.user_start_page(user) do
       nil -> []
       path -> [Routes.path(path)]
     end
   rescue
     _ -> []
   end
+
+  defp start_page_candidates(_user), do: []
 
   # `:phoenix_kit_redirect_if_user_is_authenticated` assigns only the user, the
   # scope variants assign a scope, and `redirect_if_user_is_authenticated/2`

--- a/test/phoenix_kit/users/start_page_preference_test.exs
+++ b/test/phoenix_kit/users/start_page_preference_test.exs
@@ -1,0 +1,101 @@
+defmodule PhoenixKit.Users.StartPagePreferenceTest do
+  @moduledoc """
+  The per-user "start on this page" preference.
+
+  It rides in `custom_fields` under a reserved key, so the tests that matter
+  are about what it refuses to store: a preference fired on every login is a
+  redirect primitive, and an unvalidated one is an open redirect.
+  """
+  use PhoenixKit.DataCase, async: false
+
+  alias PhoenixKit.Users.Auth
+
+  defp user_fixture do
+    {:ok, user} =
+      Auth.register_user(%{
+        email: "start-page-#{System.unique_integer([:positive])}@example.com",
+        password: "hello world!"
+      })
+
+    user
+  end
+
+  describe "update_user_start_page/2" do
+    test "stores a relative path and reads it back" do
+      user = user_fixture()
+
+      assert {:ok, updated} = Auth.update_user_start_page(user, "/admin/projects")
+      assert Auth.user_start_page(updated) == "/admin/projects"
+    end
+
+    test "nil clears it" do
+      user = user_fixture()
+      {:ok, set} = Auth.update_user_start_page(user, "/admin/projects")
+
+      assert {:ok, cleared} = Auth.update_user_start_page(set, nil)
+      assert Auth.user_start_page(cleared) == nil
+    end
+
+    test "an empty string clears it too" do
+      user = user_fixture()
+      {:ok, set} = Auth.update_user_start_page(user, "/admin/projects")
+
+      assert {:ok, cleared} = Auth.update_user_start_page(set, "")
+      assert Auth.user_start_page(cleared) == nil
+    end
+
+    test "refuses an absolute URL" do
+      user = user_fixture()
+      assert {:error, _} = Auth.update_user_start_page(user, "https://evil.test/steal")
+    end
+
+    test "refuses a protocol-relative path" do
+      # `//evil.test` is a URL, not a path — the browser treats it as another
+      # host. Stored, it would be an open redirect fired on every login.
+      user = user_fixture()
+      assert {:error, _} = Auth.update_user_start_page(user, "//evil.test")
+      assert {:error, _} = Auth.update_user_start_page(user, "/\\evil.test")
+    end
+
+    test "refuses anything that is not a path at all" do
+      user = user_fixture()
+      assert {:error, _} = Auth.update_user_start_page(user, "admin/projects")
+      assert {:error, _} = Auth.update_user_start_page(user, "javascript:alert(1)")
+    end
+
+    test "leaves other custom fields alone" do
+      user = user_fixture()
+      {:ok, user} = Auth.merge_user_custom_fields(user, %{"department" => "Kitchens"})
+
+      {:ok, updated} = Auth.update_user_start_page(user, "/admin/projects")
+
+      assert updated.custom_fields["department"] == "Kitchens"
+      assert Auth.user_start_page(updated) == "/admin/projects"
+    end
+
+    test "clearing leaves other custom fields alone" do
+      user = user_fixture()
+      {:ok, user} = Auth.merge_user_custom_fields(user, %{"department" => "Kitchens"})
+      {:ok, user} = Auth.update_user_start_page(user, "/admin/projects")
+
+      {:ok, cleared} = Auth.update_user_start_page(user, nil)
+
+      assert cleared.custom_fields["department"] == "Kitchens"
+      assert Auth.user_start_page(cleared) == nil
+    end
+  end
+
+  describe "user_start_page/1" do
+    test "nil for a user who never set one, and for no user at all" do
+      assert Auth.user_start_page(user_fixture()) == nil
+      assert Auth.user_start_page(nil) == nil
+    end
+
+    test "nil for a blank stored value rather than an empty redirect" do
+      user = user_fixture()
+      {:ok, user} = Auth.merge_user_custom_fields(user, %{"start_page" => ""})
+
+      assert Auth.user_start_page(user) == nil
+    end
+  end
+end

--- a/test/phoenix_kit_web/live/dashboard_home_binding_test.exs
+++ b/test/phoenix_kit_web/live/dashboard_home_binding_test.exs
@@ -1,0 +1,64 @@
+defmodule PhoenixKitWeb.Live.DashboardHomeBindingTest do
+  @moduledoc """
+  Whether `/admin` hides its built-in overview, decided at MOUNT.
+
+  The embedded admin-home view also reports this, live, as an administrator
+  binds or unbinds a dashboard — but it cannot be the first answer. It renders
+  its board in the same pass as the page, so a page that assumes "nothing is
+  bound" paints the board and the overview stacked together until the child's
+  message lands.
+
+  DB-free: every case drives the duck-typed contract with a stand-in module,
+  which is the only way to exercise it here — core has no dependency on the
+  package that implements it.
+  """
+  use ExUnit.Case, async: true
+
+  alias PhoenixKitWeb.Live.Dashboard
+
+  defmodule Bound do
+    def admin_home_dashboards(_scope), do: {:everyone, [%{uuid: "a"}]}
+  end
+
+  defmodule Unbound do
+    def admin_home_dashboards(_scope), do: {:none, []}
+  end
+
+  defmodule NoContract do
+    def something_else, do: :ok
+  end
+
+  defmodule Raises do
+    def admin_home_dashboards(_scope), do: raise("boom")
+  end
+
+  defmodule Exits do
+    def admin_home_dashboards(_scope), do: exit(:no_repo)
+  end
+
+  test "a bound dashboard hides the overview from the first paint" do
+    assert Dashboard.home_dashboard?(Bound, nil)
+  end
+
+  test "nothing bound keeps the overview" do
+    refute Dashboard.home_dashboard?(Unbound, nil)
+  end
+
+  test "a module without the contract keeps the overview" do
+    refute Dashboard.home_dashboard?(NoContract, nil)
+  end
+
+  test "a module that is not there at all keeps the overview" do
+    refute Dashboard.home_dashboard?(NoSuchModuleAnywhere, nil)
+  end
+
+  # An optional module must never be able to leave /admin with neither half
+  # rendered — a missing repo exits rather than raises, so both are caught.
+  test "a raising contract keeps the overview" do
+    refute Dashboard.home_dashboard?(Raises, nil)
+  end
+
+  test "an exiting contract keeps the overview" do
+    refute Dashboard.home_dashboard?(Exits, nil)
+  end
+end


### PR DESCRIPTION
Two related changes to where a signed-in user lands.

Companion PRs: BeamLabEU/phoenix_kit_dashboards (the placement system) and
BeamLabEU/phoenix_kit_projects.

## An installed dashboards module may own the `/admin` landing page

`/admin` keeps its built-in overview. When `phoenix_kit_dashboards` is
installed, enabled, and something is bound to the admin-home place, that
dashboard renders instead — resolved duck-typed (`Code.ensure_loaded?` before
`function_exported?`, since on a cold VM the latter answers false without
loading the module), so core keeps no dependency on the optional package and
this page is unchanged wherever it is absent.

The decision is made at **mount**, by asking the module's own
`admin_home_dashboards/1` with the viewer's scope. The embedded view also
reports live, which is what makes binding and unbinding land without a reload —
but it cannot be the first answer: it renders its board in the same pass, so a
page that assumes nothing is bound paints the board and the overview stacked
together until the child's message arrives.

Two properties worth keeping when touching this:

- The question carries the **viewer's scope**, so a role-only board does not
  blank the overview for everyone else.
- Every failure path answers "keep the overview". An optional module must never
  be able to leave `/admin` with neither half rendered — hence `rescue` **and**
  `catch :exit` (an unreachable DB raises on an unowned checkout but *exits* on
  a dead pool).

`home_dashboard?/2` is public with `@doc false` purely as a test seam: core has
no dependency to drive the contract with, so the six cases (bound, unbound, no
contract, module absent, raising, exiting) use stand-in modules.

## A user can choose where they land after signing in

A per-user start-page preference, resolved through `Tab.resolve_path/2` so it
follows a renamed admin segment and offers only tabs the user can actually
reach. Honoured on the login redirect as well as on direct navigation, and the
stored value is validated on the way in — the accompanying test pins what it
refuses.

4892 tests (1 pre-existing failure in `auth_flows_test.exs`, reproduced on a
pristine tree), `mix precommit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142crsEkz7e968Pptp45WwF
