### PR TITLE
Fix the open version ceilings on the other pinned-bundle deps

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -230,9 +230,18 @@ defmodule PhoenixKit.MixProject do
       # of the original for deep zoom on >4K images (no OpenSeadragon). The
       # tile overlay rides Fresco's stage transform so it stays glued to the
       # image. JS hooks lazy-load from jsdelivr pinned to the matching tag.
-      {:fresco, "~> 0.10"},
-      {:tessera, "~> 0.3"},
-      {:etcher, "~> 0.9"},
+      #
+      # Ceilings carry a patch segment for the same reason :leaf's do (see
+      # the comment there): each of these serves its browser half from an
+      # exact jsDelivr tag in phoenix_kit.js, and a patch-less `~> 0.N`
+      # reads as "the 0.N line" while meaning `< 1.0.0` — an open ceiling
+      # that lets a host float the Elixir half past the frozen bundle the
+      # day the next minor ships. `vendored_cdn_pins_test.exs` holds each
+      # ceiling to the pinned minor; the next minor of any of them needs
+      # the same requirement + lock + CDN-pin move :leaf gets.
+      {:fresco, "~> 0.10.0 or ~> 0.11.0"},
+      {:tessera, "~> 0.3.0"},
+      {:etcher, "~> 0.9.0 or ~> 0.10.0 or ~> 0.11.0 or ~> 0.12.0 or ~> 0.13.0"},
 
       # QR device-handoff login ("scan to sign in" on the login page).
       #

--- a/test/phoenix_kit_web/vendored_cdn_pins_test.exs
+++ b/test/phoenix_kit_web/vendored_cdn_pins_test.exs
@@ -71,6 +71,42 @@ defmodule PhoenixKitWeb.VendoredCdnPinsTest do
     end
   end
 
+  for {app, _} <- @pinned do
+    test "the #{app} requirement's ceiling stops at the pinned minor" do
+      # The other half of the pin discipline, sibling to leaf_bundle_pin's
+      # ceiling test: `~> 0.N` without a patch segment reads as "the 0.N
+      # line" but means `< 1.0.0`, so one patch-less alternative silently
+      # admits every later 0.x — and a host is then free to resolve the
+      # Elixir half past the tag this file's other tests hold the bundle
+      # to. Neither the tag test above nor the lock can see that: both only
+      # look at versions THIS project resolved.
+      app = unquote(app)
+
+      requirement =
+        File.read!(Path.join(__DIR__, "../../mix.exs"))
+        |> then(&Regex.run(~r/\{:#{app}, "([^"]+)"/, &1))
+        |> then(fn [_, req] -> req end)
+
+      resolved = to_string(Application.spec(app, :vsn))
+
+      assert Version.match?(resolved, requirement),
+             "#{app} #{resolved} no longer satisfies its own requirement #{inspect(requirement)}"
+
+      %Version{major: major, minor: minor} = Version.parse!(resolved)
+      next_minor = "#{major}.#{minor + 1}.0"
+
+      refute Version.match?(next_minor, requirement),
+             """
+             The #{app} requirement #{inspect(requirement)} admits \
+             #{next_minor}, one minor past the bundle tag this file pins. \
+             Give every alternative a patch segment (`~> #{major}.#{minor}.0`, \
+             not `~> #{major}.#{minor}`) so the ceiling stops at the pinned \
+             minor, and move the requirement, the lock and the CDN pin \
+             together.
+             """
+    end
+  end
+
   test "every gh/ pin in the bundle is covered by this test" do
     # A fifth sibling added with a pin this file doesn't know about would
     # re-open the exact hole this test exists to close.


### PR DESCRIPTION
Completes the leaf-requirement ceiling fix for its three siblings. The same patch-less-alternative bug — a lone `~> 0.N` means `< 1.0.0`, so the enumeration reads as a curated window while admitting the whole 0.x line — was present on:

- `fresco "~> 0.10"` (CDN pin v0.11.0 — the floor even admits 0.10.x hosts running under the 0.11 bundle)
- `tessera "~> 0.3"` (pin v0.3.5)
- `etcher "~> 0.9"` (pin v0.13.1 — four minors of open ceiling)

Every alternative now carries a patch segment so each ceiling stops at the pinned minor, mix.lock resolutions are unchanged.

The guard gap closes with it: `leaf_bundle_pin_test`'s ceiling check covered only leaf, and `vendored_cdn_pins_test` compared only versions this project resolved. The ceiling test is now generalized across every pinned sibling (resolved version satisfies the requirement; the next minor above it must not), so the next patch-less `~>` fails in the suite instead of in a host the day the next minor ships. 13 pin tests green.