### PR TITLE
Make folder listings and folder actions link-aware in Storage and the Media browser

### DIFF
--- a/lib/modules/storage/storage.ex
+++ b/lib/modules/storage/storage.ex
@@ -1587,8 +1587,9 @@ defmodule PhoenixKit.Modules.Storage do
         scope_subtree_query(scope_folder_id)
 
       true ->
-        # Scope root without search: show only direct children (files directly in scope)
-        from(f in PhoenixKit.Modules.Storage.File, where: f.folder_uuid == ^scope_folder_id)
+        # Scope root without search: the scope folder's own contents
+        # (home files plus files linked into it), not the subtree.
+        folder_contents_query(scope_folder_id)
     end
     |> apply_file_search(search)
   end
@@ -1681,6 +1682,167 @@ defmodule PhoenixKit.Modules.Storage do
         |> Ecto.Changeset.change(%{folder_uuid: target_folder_uuid})
         |> repo().update()
     end
+  end
+
+  @doc """
+  Moves a file as SEEN in `from_folder_uuid` to `target_folder_uuid`.
+
+  A file that is merely linked into `from_folder_uuid` (its home is
+  another folder) has its LINK re-pointed at the target — the file
+  itself stays where it lives, and every other folder holding it keeps
+  it. A file whose home is `from_folder_uuid` (or that is viewed
+  outside any folder) moves as `move_file_to_folder/3` always has.
+  Folder listings show linked files (2026-09-12), so a move from a
+  folder must act on what that folder holds, not on the file's home.
+  """
+  def move_file_between_folders(file_uuid, from_folder_uuid, target_folder_uuid, scope_folder_id) do
+    case folder_link(from_folder_uuid, file_uuid) do
+      %FolderLink{} = link ->
+        cond do
+          not within_scope?(target_folder_uuid, scope_folder_id) ->
+            {:error, :out_of_scope}
+
+          to_string(target_folder_uuid) == to_string(from_folder_uuid) ->
+            {:ok, link}
+
+          true ->
+            relink(link, file_uuid, target_folder_uuid)
+        end
+
+      nil ->
+        move_file_to_folder(file_uuid, target_folder_uuid, scope_folder_id)
+    end
+  end
+
+  @doc """
+  Removes a file from `folder_uuid`'s view — what "trash" means when
+  done FROM a folder listing, now that listings show linked files:
+
+    * linked into `folder_uuid` (home elsewhere) → the link is deleted;
+      the file and every other folder holding it are untouched
+      (`{:ok, :unlinked, file}`);
+    * home is `folder_uuid` and another folder links to it → the file is
+      re-homed to that folder (consuming the link) rather than trashed
+      out from under it (`{:ok, :rehomed, file}`);
+    * home is `folder_uuid` and nothing else holds it, or the file is
+      viewed outside any folder (`nil`) → soft-trashed
+      (`{:ok, :trashed, file}`).
+
+  Trashing the record directly from a folder that only LINKED it would
+  destroy it for its owner — the same rule the catalogue's own attachment
+  removal has always applied.
+  """
+  def remove_file_from_folder(%PhoenixKit.Modules.Storage.File{} = file, folder_uuid)
+      when is_binary(folder_uuid) do
+    cond do
+      to_string(file.folder_uuid) == to_string(folder_uuid) ->
+        case other_folder_links(file.uuid, folder_uuid) do
+          [] ->
+            with {:ok, trashed} <- trash_file(file), do: {:ok, :trashed, trashed}
+
+          [%FolderLink{} = link | _] ->
+            repo().transaction(fn ->
+              {:ok, rehomed} =
+                file
+                |> Ecto.Changeset.change(%{folder_uuid: link.folder_uuid})
+                |> repo().update()
+
+              {:ok, _} = repo().delete(link)
+              rehomed
+            end)
+            |> case do
+              {:ok, rehomed} -> {:ok, :rehomed, rehomed}
+              {:error, reason} -> {:error, reason}
+            end
+        end
+
+      link = folder_link(folder_uuid, file.uuid) ->
+        with {:ok, _} <- repo().delete(link), do: {:ok, :unlinked, file}
+
+      # Neither homed nor linked here: a stale or forged row. Refuse
+      # rather than trash a file this folder never held.
+      true ->
+        {:error, :not_in_folder}
+    end
+  end
+
+  def remove_file_from_folder(%PhoenixKit.Modules.Storage.File{} = file, _no_folder) do
+    with {:ok, trashed} <- trash_file(file), do: {:ok, :trashed, trashed}
+  end
+
+  @doc """
+  Puts an existing file into `folder_uuid` the way every attach surface
+  should: a file with no home is adopted (its `folder_uuid` is set); a
+  file already homed there is left alone; a file homed ELSEWHERE gets a
+  `FolderLink` into `folder_uuid` (idempotent) rather than being moved
+  out from under whatever holds it. This is the rule the catalogue's
+  attachments and the media selector already followed; the media
+  browser's own upload path used to MOVE a content-duplicate's home
+  instead, silently emptying the folder that owned it.
+  """
+  def attach_file_to_folder(%PhoenixKit.Modules.Storage.File{} = file, folder_uuid)
+      when is_binary(folder_uuid) do
+    cond do
+      to_string(file.folder_uuid) == to_string(folder_uuid) ->
+        {:ok, file}
+
+      is_nil(file.folder_uuid) ->
+        file |> Ecto.Changeset.change(%{folder_uuid: folder_uuid}) |> repo().update()
+
+      true ->
+        %FolderLink{}
+        |> FolderLink.changeset(%{folder_uuid: folder_uuid, file_uuid: file.uuid})
+        |> repo().insert(on_conflict: :nothing)
+        |> case do
+          {:ok, _} -> {:ok, file}
+          {:error, changeset} -> {:error, changeset}
+        end
+    end
+  end
+
+  @doc "The `FolderLink` holding `file_uuid` in `folder_uuid`, or nil."
+  def folder_link(folder_uuid, file_uuid) when is_binary(folder_uuid) and is_binary(file_uuid) do
+    repo().get_by(FolderLink, folder_uuid: folder_uuid, file_uuid: file_uuid)
+  end
+
+  def folder_link(_, _), do: nil
+
+  # One transaction: the source link goes only if the target attach
+  # lands. A link cannot live at the root (nil target), so moving a
+  # linked appearance to the root simply drops it; landing on the file's
+  # own home, or on a folder that already links it, adds nothing
+  # (`attach_file_to_folder/2` is idempotent) — never a self-link
+  # counted twice.
+  defp relink(link, file_uuid, target_folder_uuid) do
+    repo().transaction(fn ->
+      with {:ok, _} <- repo().delete(link),
+           %PhoenixKit.Modules.Storage.File{} = file <-
+             repo().get(PhoenixKit.Modules.Storage.File, file_uuid),
+           {:ok, result} <- attach_to_target(file, target_folder_uuid) do
+        result
+      else
+        nil -> repo().rollback(:not_found)
+        {:error, reason} -> repo().rollback(reason)
+      end
+    end)
+  end
+
+  defp attach_to_target(file, nil), do: {:ok, file}
+
+  defp attach_to_target(file, target_folder_uuid),
+    do: attach_file_to_folder(file, target_folder_uuid)
+
+  # Links into LIVE folders only: re-homing a file into a trashed folder
+  # would strand it — listed nowhere, and not in the file trash either.
+  defp other_folder_links(file_uuid, except_folder_uuid) do
+    from(fl in FolderLink,
+      join: fo in Folder,
+      on: fo.uuid == fl.folder_uuid,
+      where: fl.file_uuid == ^file_uuid and fl.folder_uuid != ^except_folder_uuid,
+      where: is_nil(fo.trashed_at),
+      order_by: [asc: fl.inserted_at]
+    )
+    |> repo().all()
   end
 
   @doc "Creates a link (shortcut) of a file in a folder."

--- a/lib/modules/storage/storage.ex
+++ b/lib/modules/storage/storage.ex
@@ -1567,7 +1567,7 @@ defmodule PhoenixKit.Modules.Storage do
   end
 
   defp build_scope_file_query(nil, folder_uuid, search, _orphaned) when not is_nil(folder_uuid) do
-    from(f in PhoenixKit.Modules.Storage.File, where: f.folder_uuid == ^folder_uuid)
+    folder_contents_query(folder_uuid)
     |> apply_file_search(search)
   end
 
@@ -1580,7 +1580,7 @@ defmodule PhoenixKit.Modules.Storage do
     cond do
       folder_uuid ->
         # Specific folder already validated within scope — no CTE needed
-        from(f in PhoenixKit.Modules.Storage.File, where: f.folder_uuid == ^folder_uuid)
+        folder_contents_query(folder_uuid)
 
       search && search != "" ->
         # Search: walk the full scope subtree via recursive CTE
@@ -1591,6 +1591,22 @@ defmodule PhoenixKit.Modules.Storage do
         from(f in PhoenixKit.Modules.Storage.File, where: f.folder_uuid == ^scope_folder_id)
     end
     |> apply_file_search(search)
+  end
+
+  # A folder's contents are its home files PLUS the files linked into it
+  # via `FolderLink` — the shape `assign_file_to_folder/2` produces when a
+  # file that already lives elsewhere is attached here (a content
+  # duplicate, a media-selector pick). `count_folder_contents/1` has
+  # always counted both; the listing read the home rows only, so a
+  # linked file showed in the sidebar count and not in the grid (found
+  # from the catalogue's item attachments, 2026-09-12).
+  defp folder_contents_query(folder_uuid) do
+    linked =
+      from(fl in FolderLink, where: fl.folder_uuid == ^folder_uuid, select: fl.file_uuid)
+
+    from(f in PhoenixKit.Modules.Storage.File,
+      where: f.folder_uuid == ^folder_uuid or f.uuid in subquery(linked)
+    )
   end
 
   defp scope_subtree_query(scope_folder_id) do

--- a/lib/modules/storage/storage.ex
+++ b/lib/modules/storage/storage.ex
@@ -1200,7 +1200,17 @@ defmodule PhoenixKit.Modules.Storage do
       from(f in Folder, where: f.uuid in ^subtree_uuids)
       |> repo().update_all(set: [trashed_at: now, updated_at: now])
 
-      # Trash every file whose folder is in the subtree. Files use both
+      # A file homed in the subtree but ALSO linked into a folder outside it
+      # is shown there too (a product's attachment, say — content de-dup
+      # links the second upload): re-home it there instead of trashing it,
+      # exactly as `delete_folder_completely/2` does. Trashing it hid the
+      # attachment from every reader outside this folder (2026-09-12).
+      from(f in PhoenixKit.Modules.Storage.File, where: f.folder_uuid in ^subtree_uuids)
+      |> repo().all()
+      |> Enum.filter(&linked_outside_subtree?(&1.uuid, subtree_uuids))
+      |> Enum.each(&promote_out_of_subtree(&1, subtree_uuids))
+
+      # Trash every file still homed in the subtree. Files use both
       # `status: "trashed"` and `trashed_at` (the V99 convention) so the
       # existing file-listing filters (`status != "trashed"`) already
       # hide them without further changes.

--- a/lib/phoenix_kit_web/components/media_browser.ex
+++ b/lib/phoenix_kit_web/components/media_browser.ex
@@ -1092,7 +1092,9 @@ defmodule PhoenixKitWeb.Components.MediaBrowser do
     # `move_file_to_folder/3` would reject it with `:out_of_scope`.
     target = if folder_uuid == "", do: scope, else: folder_uuid
 
-    case Storage.move_file_to_folder(file_uuid, target, scope) do
+    from = appearance_folder_of(socket, file_uuid)
+
+    case Storage.move_file_between_folders(file_uuid, from, target, scope) do
       {:ok, _} ->
         {:noreply, socket |> put_flash(:info, gettext("File moved")) |> reload_current_page()}
 
@@ -1154,21 +1156,20 @@ defmodule PhoenixKitWeb.Components.MediaBrowser do
     scope = scope_folder_id(socket)
     repo = PhoenixKit.Config.get_repo()
     file = repo.get(Storage.File, file_uuid)
+    viewed = file && appearance_folder(socket, file)
 
     cond do
       is_nil(file) ->
         {:noreply, put_flash(socket, :error, gettext("File not found"))}
 
-      not Storage.within_scope?(file.folder_uuid, scope) ->
+      not removable_here?(file, viewed, scope) ->
         {:noreply,
          put_flash(socket, :error, gettext("Cannot move file outside the allowed scope"))}
 
       true ->
-        Storage.trash_file(file)
-
         {:noreply,
          socket
-         |> put_flash(:info, gettext("File moved to trash"))
+         |> put_flash(:info, removal_flash(Storage.remove_file_from_folder(file, viewed)))
          |> reload_current_page()}
     end
   end
@@ -1955,7 +1956,8 @@ defmodule PhoenixKitWeb.Components.MediaBrowser do
     target = if folder_uuid == "", do: scope, else: folder_uuid
 
     Enum.each(socket.assigns.selected_files, fn file_uuid ->
-      Storage.move_file_to_folder(file_uuid, target, scope)
+      from = appearance_folder_of(socket, file_uuid)
+      Storage.move_file_between_folders(file_uuid, from, target, scope)
     end)
 
     Enum.each(socket.assigns.selected_folders, fn sel_folder_uuid ->
@@ -1998,12 +2000,14 @@ defmodule PhoenixKitWeb.Components.MediaBrowser do
         end
       end)
     else
-      # Soft-delete to trash
+      # Soft-delete to trash — folder-aware: a file only LINKED into the
+      # viewed folder is unlinked, not trashed for its owner.
       Enum.each(socket.assigns.selected_files, fn file_uuid ->
         file = repo.get(Storage.File, file_uuid)
+        viewed = file && appearance_folder(socket, file)
 
-        if file && Storage.within_scope?(file.folder_uuid, scope) do
-          Storage.trash_file(file)
+        if file && removable_here?(file, viewed, scope) do
+          Storage.remove_file_from_folder(file, viewed)
         end
       end)
     end
@@ -2053,7 +2057,7 @@ defmodule PhoenixKitWeb.Components.MediaBrowser do
     files =
       from(f in Storage.File, where: f.uuid in ^uuids)
       |> repo.all()
-      |> Enum.filter(&Storage.within_scope?(&1.folder_uuid, scope))
+      |> Enum.filter(&removable_here?(&1, appearance_folder(socket, &1), scope))
       |> enrich_files()
       |> Enum.map(fn f ->
         %{url: Map.get(f.urls, "original") || Map.get(f.urls, :original), name: f.filename}
@@ -2077,7 +2081,7 @@ defmodule PhoenixKitWeb.Components.MediaBrowser do
     scope = scope_folder_id(socket)
 
     with %Storage.File{} = file <- Storage.get_file(file_uuid),
-         true <- Storage.within_scope?(file.folder_uuid, scope) do
+         true <- removable_here?(file, appearance_folder(socket, file), scope) do
       current = normalized_rotation(Map.get(file.metadata || %{}, "rotation"))
       next = Integer.mod(current + delta, 360)
       merged = Map.put(file.metadata || %{}, "rotation", next)
@@ -2100,20 +2104,19 @@ defmodule PhoenixKitWeb.Components.MediaBrowser do
     repo = PhoenixKit.Config.get_repo()
     file = repo.get(Storage.File, file_uuid)
 
-    if file && Storage.within_scope?(file.folder_uuid, scope) do
+    viewed = file && appearance_folder(socket, file)
+
+    if file && removable_here?(file, viewed, scope) do
       # Same status guard as delete_selected: permanent deletion only for
       # files actually in the trash (the row could have been restored from
       # another session since this view rendered).
-      if socket.assigns.filter_trash and file.status == "trashed" do
-        Storage.delete_file_completely(file)
-      else
-        Storage.trash_file(file)
-      end
-
       flash =
-        if socket.assigns.filter_trash,
-          do: gettext("File permanently deleted"),
-          else: gettext("File moved to trash")
+        if socket.assigns.filter_trash and file.status == "trashed" do
+          Storage.delete_file_completely(file)
+          gettext("File permanently deleted")
+        else
+          removal_flash(Storage.remove_file_from_folder(file, viewed))
+        end
 
       {:noreply,
        socket
@@ -2657,6 +2660,48 @@ defmodule PhoenixKitWeb.Components.MediaBrowser do
   end
 
   defp assign_stacks(socket), do: socket
+
+  # A file listed in the viewed folder is either homed there (scope-checked
+  # on its home) or LINKED into it — a link is in scope by construction,
+  # wherever the file's home lives. Gates every per-file action taken
+  # from a listing: trash, move, download, rotate.
+  defp removable_here?(file, viewed, scope) do
+    if is_binary(viewed) do
+      # Inside a folder view the file must actually appear here — a
+      # stale or forged uuid of some other in-scope file is refused.
+      to_string(file.folder_uuid) == to_string(viewed) or
+        not is_nil(Storage.folder_link(viewed, file.uuid))
+    else
+      Storage.within_scope?(file.folder_uuid, scope)
+    end
+  end
+
+  # The folder a listed file APPEARS in: the folder being viewed when it
+  # holds the file (home or link), else the first expanded stack that
+  # does — a stack shows a child folder's files at the parent level, so
+  # the viewed folder alone would act on the wrong appearance (or, at
+  # the root, on the file's home). Nil only when no folder view shows
+  # it: the root / All Files / search, where actions address the file.
+  defp appearance_folder(socket, file) do
+    candidates =
+      List.wrap(current_folder_uuid(socket)) ++ (socket.assigns[:expanded_stacks] || [])
+
+    Enum.find(candidates, fn folder_uuid ->
+      to_string(file.folder_uuid) == to_string(folder_uuid) or
+        not is_nil(Storage.folder_link(folder_uuid, file.uuid))
+    end)
+  end
+
+  defp appearance_folder_of(socket, file_uuid) do
+    case Storage.get_file(file_uuid) do
+      %Storage.File{} = file -> appearance_folder(socket, file)
+      _ -> current_folder_uuid(socket)
+    end
+  end
+
+  defp removal_flash({:ok, :trashed, _}), do: gettext("File moved to trash")
+  defp removal_flash({:ok, _unlinked_or_rehomed, _}), do: gettext("File removed from this folder")
+  defp removal_flash(_), do: gettext("Failed to move file")
 
   # Enriched files directly in a folder, for an expanded stack grid. `limit`
   # caps how many are loaded (always from the top) — never the whole folder, so
@@ -3505,11 +3550,11 @@ defmodule PhoenixKitWeb.Components.MediaBrowser do
         :ok
 
       is_nil(scope) or Storage.within_scope?(folder_uuid, scope) ->
-        # The target folder is verified in-scope above, so passing nil as the
-        # scope arg to move_file_to_folder/3 is safe — it skips the scope
-        # re-check against the file's current folder (which is the real root
-        # for a fresh upload and would fail the gate).
-        Storage.move_file_to_folder(file.uuid, folder_uuid, nil)
+        # The target folder is verified in-scope above. A fresh upload is
+        # adopted; a content-duplicate that already lives in another
+        # folder is LINKED here, never moved — moving it emptied the
+        # folder that owned it (2026-09-12).
+        Storage.attach_file_to_folder(file, folder_uuid)
 
       true ->
         Logger.warning(

--- a/lib/phoenix_kit_web/users/auth.ex
+++ b/lib/phoenix_kit_web/users/auth.ex
@@ -967,10 +967,10 @@ defmodule PhoenixKitWeb.Users.Auth do
       :ok ->
         {:cont, socket}
 
-      {:halt, message, target} ->
+      {:halt, kind, message, target} ->
         socket =
           socket
-          |> Phoenix.LiveView.put_flash(:error, message)
+          |> Phoenix.LiveView.put_flash(kind, message)
           |> Phoenix.LiveView.redirect(to: path_with_return_to(socket, target))
 
         {:halt, socket}
@@ -2521,9 +2521,9 @@ defmodule PhoenixKitWeb.Users.Auth do
         :ok ->
           conn
 
-        {:halt, message, target} ->
+        {:halt, kind, message, target} ->
           conn
-          |> put_flash(:error, message)
+          |> put_flash(kind, message)
           |> maybe_store_return_to()
           |> redirect(to: Routes.path(target))
           |> halt()
@@ -2576,17 +2576,22 @@ defmodule PhoenixKitWeb.Users.Auth do
   # which is how the invite-only gate reached eleven call sites without eleven
   # copies of the rule.
   #
-  # Returns `:ok`, or `{:halt, flash_message, path}` where `path` is the page
-  # that will unblock the user. Callers turn that into a conn or socket
-  # redirect and are responsible for carrying `return_to`.
+  # Returns `:ok`, or `{:halt, flash_kind, flash_message, path}` where `path`
+  # is the page that will unblock the user. Callers turn that into a conn or
+  # socket redirect and are responsible for carrying `return_to`.
+  #
+  # Both halts are `:warning`, not `:error`: the account is fine and the user
+  # is being asked to do one routine thing ("check your inbox", "enter your
+  # code"). Error styling made a first visit to the app look like a failure
+  # (reported from topp.ee).
   defp account_gate(subject) do
     cond do
       not email_confirmed?(subject) and confirmation_required?() ->
-        {:halt, gettext("Please confirm your email before accessing the application."),
+        {:halt, :warning, gettext("Please confirm your email before accessing the application."),
          "/users/confirm"}
 
       not Referrals.access_satisfied?(subject) ->
-        {:halt, gettext("Enter your referral code to continue."), "/users/referral"}
+        {:halt, :warning, gettext("Enter your referral code to continue."), "/users/referral"}
 
       true ->
         :ok
@@ -2612,10 +2617,10 @@ defmodule PhoenixKitWeb.Users.Auth do
   # asks them to satisfy their account is nonsense.
   defp enforce_account_gate(conn, scope) do
     with true <- Scope.authenticated?(scope),
-         {:halt, message, target} <- account_gate(scope) do
+         {:halt, kind, message, target} <- account_gate(scope) do
       {:halt,
        conn
-       |> put_flash(:error, message)
+       |> put_flash(kind, message)
        |> maybe_store_return_to()
        |> redirect(to: Routes.path(target))
        |> halt()}

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -6886,6 +6886,10 @@ msgstr "Datei / Bild"
 msgid "File moved to trash"
 msgstr "Datei in den Papierkorb verschoben"
 
+#, elixir-autogen, elixir-format
+msgid "File removed from this folder"
+msgstr "Datei aus diesem Ordner entfernt"
+
 #: lib/phoenix_kit_web/components/media_browser.ex:1160
 #: lib/phoenix_kit_web/components/media_viewer.html.heex:41
 #, elixir-autogen, elixir-format

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -6886,6 +6886,10 @@ msgstr ""
 msgid "File moved to trash"
 msgstr ""
 
+#, elixir-autogen, elixir-format
+msgid "File removed from this folder"
+msgstr ""
+
 #: lib/phoenix_kit_web/components/media_browser.ex:1160
 #: lib/phoenix_kit_web/components/media_viewer.html.heex:41
 #, elixir-autogen, elixir-format

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -6886,6 +6886,10 @@ msgstr ""
 msgid "File moved to trash"
 msgstr ""
 
+#, elixir-autogen, elixir-format
+msgid "File removed from this folder"
+msgstr "File removed from this folder"
+
 #: lib/phoenix_kit_web/components/media_browser.ex:1160
 #: lib/phoenix_kit_web/components/media_viewer.html.heex:41
 #, elixir-autogen, elixir-format

--- a/priv/gettext/es/LC_MESSAGES/default.po
+++ b/priv/gettext/es/LC_MESSAGES/default.po
@@ -6893,6 +6893,10 @@ msgstr "Archivo / imagen"
 msgid "File moved to trash"
 msgstr "Archivo movido a la papelera"
 
+#, elixir-autogen, elixir-format
+msgid "File removed from this folder"
+msgstr "Archivo quitado de esta carpeta"
+
 #: lib/phoenix_kit_web/components/media_browser.ex:1160
 #: lib/phoenix_kit_web/components/media_viewer.html.heex:41
 #, elixir-autogen, elixir-format

--- a/priv/gettext/et/LC_MESSAGES/default.po
+++ b/priv/gettext/et/LC_MESSAGES/default.po
@@ -6891,6 +6891,10 @@ msgstr "Fail / Pilt"
 msgid "File moved to trash"
 msgstr "Fail teisaldati prügikasti"
 
+#, elixir-autogen, elixir-format
+msgid "File removed from this folder"
+msgstr "Fail eemaldati sellest kaustast"
+
 #: lib/phoenix_kit_web/components/media_browser.ex:1160
 #: lib/phoenix_kit_web/components/media_viewer.html.heex:41
 #, elixir-autogen, elixir-format

--- a/priv/gettext/fr/LC_MESSAGES/default.po
+++ b/priv/gettext/fr/LC_MESSAGES/default.po
@@ -6886,6 +6886,10 @@ msgstr "Fichier / Image"
 msgid "File moved to trash"
 msgstr "Fichier déplacé vers la corbeille"
 
+#, elixir-autogen, elixir-format
+msgid "File removed from this folder"
+msgstr "Fichier retiré de ce dossier"
+
 #: lib/phoenix_kit_web/components/media_browser.ex:1160
 #: lib/phoenix_kit_web/components/media_viewer.html.heex:41
 #, elixir-autogen, elixir-format

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -6886,6 +6886,10 @@ msgstr "File / immagine"
 msgid "File moved to trash"
 msgstr "File spostato nel cestino"
 
+#, elixir-autogen, elixir-format
+msgid "File removed from this folder"
+msgstr "File rimosso da questa cartella"
+
 #: lib/phoenix_kit_web/components/media_browser.ex:1160
 #: lib/phoenix_kit_web/components/media_viewer.html.heex:41
 #, elixir-autogen, elixir-format

--- a/priv/gettext/pl/LC_MESSAGES/default.po
+++ b/priv/gettext/pl/LC_MESSAGES/default.po
@@ -6906,6 +6906,10 @@ msgstr "Plik / obraz"
 msgid "File moved to trash"
 msgstr "Plik przeniesiony do kosza"
 
+#, elixir-autogen, elixir-format
+msgid "File removed from this folder"
+msgstr "Plik usunięto z tego folderu"
+
 #: lib/phoenix_kit_web/components/media_browser.ex:1160
 #: lib/phoenix_kit_web/components/media_viewer.html.heex:41
 #, elixir-autogen, elixir-format

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -6914,6 +6914,10 @@ msgstr "Файл / Изображение"
 msgid "File moved to trash"
 msgstr "Файл перемещён в корзину"
 
+#, elixir-autogen, elixir-format
+msgid "File removed from this folder"
+msgstr "Файл удалён из этой папки"
+
 #: lib/phoenix_kit_web/components/media_browser.ex:1160
 #: lib/phoenix_kit_web/components/media_viewer.html.heex:41
 #, elixir-autogen, elixir-format

--- a/test/integration/phoenix_kit_web/users/auth_flows_test.exs
+++ b/test/integration/phoenix_kit_web/users/auth_flows_test.exs
@@ -576,6 +576,32 @@ defmodule PhoenixKitWeb.Users.AuthFlowsTest do
       assert get_session(conn, :user_return_to)
     end
 
+    # The account is fine; the user is asked to do one routine thing. Error
+    # styling made a first visit look like a failure (reported from topp.ee).
+    test "the confirmation halt is a warning flash, not an error", %{conn: conn} do
+      user = register_user()
+
+      conn = conn |> plug_conn(user) |> UserAuth.require_authenticated_user([])
+
+      assert Phoenix.Flash.get(conn.assigns.flash, :warning) =~ "confirm your email"
+      refute Phoenix.Flash.get(conn.assigns.flash, :error)
+    end
+
+    test "the scope-based plug halts with the same warning flash", %{conn: conn} do
+      user = register_user()
+
+      conn =
+        conn
+        |> plug_conn(user)
+        |> Plug.Conn.assign(:phoenix_kit_current_scope, Scope.for_user(user))
+        |> UserAuth.require_authenticated_scope([])
+
+      assert conn.halted
+      assert redirected_to(conn) == Routes.path("/users/confirm")
+      assert Phoenix.Flash.get(conn.assigns.flash, :warning) =~ "confirm your email"
+      refute Phoenix.Flash.get(conn.assigns.flash, :error)
+    end
+
     test "off: unconfirmed users pass through", %{conn: conn} do
       Settings.update_setting("require_email_confirmation", "false")
       user = register_user()

--- a/test/integration/storage/scope_test.exs
+++ b/test/integration/storage/scope_test.exs
@@ -779,6 +779,143 @@ defmodule PhoenixKit.Integration.Storage.ScopeTest do
     end
   end
 
+  describe "folder-aware removal and moves (linked files, 2026-09-12)" do
+    test "removing a linked file from the linking folder only drops the link" do
+      home = create_folder!(%{name: "rm_home_#{System.unique_integer([:positive])}"})
+      other = create_folder!(%{name: "rm_other_#{System.unique_integer([:positive])}"})
+      file = create_file!(home.uuid)
+      {:ok, _} = Storage.create_folder_link(other.uuid, file.uuid)
+
+      assert {:ok, :unlinked, _} = Storage.remove_file_from_folder(file, other.uuid)
+      reloaded = Repo.get!(StorageFile, file.uuid)
+      assert reloaded.status == "active"
+      assert reloaded.folder_uuid == home.uuid
+      refute Storage.folder_link(other.uuid, file.uuid)
+    end
+
+    test "removing a file from its home re-homes it to a folder that links it" do
+      home = create_folder!(%{name: "rh_home_#{System.unique_integer([:positive])}"})
+      other = create_folder!(%{name: "rh_other_#{System.unique_integer([:positive])}"})
+      file = create_file!(home.uuid)
+      {:ok, _} = Storage.create_folder_link(other.uuid, file.uuid)
+
+      assert {:ok, :rehomed, rehomed} = Storage.remove_file_from_folder(file, home.uuid)
+      assert rehomed.folder_uuid == other.uuid
+      assert rehomed.status == "active"
+      refute Storage.folder_link(other.uuid, file.uuid)
+    end
+
+    test "removing a file nothing else holds trashes it; outside a folder likewise" do
+      home = create_folder!(%{name: "tr_home_#{System.unique_integer([:positive])}"})
+      file = create_file!(home.uuid)
+      assert {:ok, :trashed, trashed} = Storage.remove_file_from_folder(file, home.uuid)
+      assert trashed.status == "trashed"
+
+      loose = create_file!(nil)
+      assert {:ok, :trashed, _} = Storage.remove_file_from_folder(loose, nil)
+    end
+
+    test "attach_file_to_folder/2 adopts, no-ops, or links — never moves a home" do
+      home = create_folder!(%{name: "at_home_#{System.unique_integer([:positive])}"})
+      other = create_folder!(%{name: "at_other_#{System.unique_integer([:positive])}"})
+
+      loose = create_file!(nil)
+      assert {:ok, adopted} = Storage.attach_file_to_folder(loose, home.uuid)
+      assert adopted.folder_uuid == home.uuid
+
+      assert {:ok, ^adopted} = Storage.attach_file_to_folder(adopted, home.uuid)
+
+      assert {:ok, _} = Storage.attach_file_to_folder(adopted, other.uuid)
+      assert Repo.get!(StorageFile, adopted.uuid).folder_uuid == home.uuid
+      assert Storage.folder_link(other.uuid, adopted.uuid)
+      # Idempotent: a second attach into the same folder adds nothing.
+      assert {:ok, _} = Storage.attach_file_to_folder(adopted, other.uuid)
+      assert Storage.count_folder_contents(other.uuid) == 1
+    end
+
+    test "moving a linked file onto its own home just drops the link" do
+      home = create_folder!(%{name: "sl_home_#{System.unique_integer([:positive])}"})
+      from = create_folder!(%{name: "sl_from_#{System.unique_integer([:positive])}"})
+      file = create_file!(home.uuid)
+      {:ok, _} = Storage.create_folder_link(from.uuid, file.uuid)
+
+      assert {:ok, _} = Storage.move_file_between_folders(file.uuid, from.uuid, home.uuid, nil)
+      refute Storage.folder_link(from.uuid, file.uuid)
+      refute Storage.folder_link(home.uuid, file.uuid)
+      assert Storage.count_folder_contents(home.uuid) == 1
+    end
+
+    test "a folder refuses to trash a file it never held" do
+      home = create_folder!(%{name: "nf_home_#{System.unique_integer([:positive])}"})
+      other = create_folder!(%{name: "nf_other_#{System.unique_integer([:positive])}"})
+      file = create_file!(home.uuid)
+
+      assert {:error, :not_in_folder} = Storage.remove_file_from_folder(file, other.uuid)
+      assert Repo.get!(StorageFile, file.uuid).status == "active"
+    end
+
+    test "re-homing prefers a live folder over a trashed one" do
+      home = create_folder!(%{name: "rl_home_#{System.unique_integer([:positive])}"})
+      trashed = create_folder!(%{name: "rl_trashed_#{System.unique_integer([:positive])}"})
+      live = create_folder!(%{name: "rl_live_#{System.unique_integer([:positive])}"})
+      file = create_file!(home.uuid)
+      {:ok, _} = Storage.create_folder_link(trashed.uuid, file.uuid)
+      {:ok, _} = Storage.create_folder_link(live.uuid, file.uuid)
+      {:ok, _} = Storage.trash_folder(trashed, nil)
+
+      assert {:ok, :rehomed, rehomed} = Storage.remove_file_from_folder(file, home.uuid)
+      assert rehomed.folder_uuid == live.uuid
+    end
+
+    test "moving a linked appearance to the root drops the link; onto a folder already linking it adds nothing" do
+      home = create_folder!(%{name: "mr_home_#{System.unique_integer([:positive])}"})
+      from = create_folder!(%{name: "mr_from_#{System.unique_integer([:positive])}"})
+      also = create_folder!(%{name: "mr_also_#{System.unique_integer([:positive])}"})
+      file = create_file!(home.uuid)
+      {:ok, _} = Storage.create_folder_link(from.uuid, file.uuid)
+      {:ok, _} = Storage.create_folder_link(also.uuid, file.uuid)
+
+      assert {:ok, _} = Storage.move_file_between_folders(file.uuid, from.uuid, also.uuid, nil)
+      refute Storage.folder_link(from.uuid, file.uuid)
+      assert Storage.count_folder_contents(also.uuid) == 1
+
+      {:ok, _} = Storage.create_folder_link(from.uuid, file.uuid)
+      assert {:ok, _} = Storage.move_file_between_folders(file.uuid, from.uuid, nil, nil)
+      refute Storage.folder_link(from.uuid, file.uuid)
+      assert Repo.get!(StorageFile, file.uuid).folder_uuid == home.uuid
+    end
+
+    test "a scoped browser's root lists files linked into the scope folder" do
+      scope = create_folder!(%{name: "sr_scope_#{System.unique_integer([:positive])}"})
+      outside = create_folder!(%{name: "sr_outside_#{System.unique_integer([:positive])}"})
+      linked = create_file!(outside.uuid)
+      {:ok, _} = Storage.create_folder_link(scope.uuid, linked.uuid)
+
+      # The browser's real root call passes the scope and no folder_uuid.
+      {files, _} = Storage.list_files_in_scope(scope.uuid)
+      assert linked.uuid in Enum.map(files, & &1.uuid)
+    end
+
+    test "moving a linked file out of the linking folder re-points the link, not the file" do
+      home = create_folder!(%{name: "mv_home_#{System.unique_integer([:positive])}"})
+      from = create_folder!(%{name: "mv_from_#{System.unique_integer([:positive])}"})
+      target = create_folder!(%{name: "mv_target_#{System.unique_integer([:positive])}"})
+      file = create_file!(home.uuid)
+      {:ok, _} = Storage.create_folder_link(from.uuid, file.uuid)
+
+      assert {:ok, _} = Storage.move_file_between_folders(file.uuid, from.uuid, target.uuid, nil)
+      assert Repo.get!(StorageFile, file.uuid).folder_uuid == home.uuid
+      refute Storage.folder_link(from.uuid, file.uuid)
+      assert Storage.folder_link(target.uuid, file.uuid)
+
+      # A home file moves as before.
+      assert {:ok, moved} =
+               Storage.move_file_between_folders(file.uuid, home.uuid, target.uuid, nil)
+
+      assert moved.folder_uuid == target.uuid
+    end
+  end
+
   describe "list_files_in_scope with UUID search" do
     test "partial UUID prefix matches file" do
       file = create_file!(nil)

--- a/test/integration/storage/scope_test.exs
+++ b/test/integration/storage/scope_test.exs
@@ -747,6 +747,38 @@ defmodule PhoenixKit.Integration.Storage.ScopeTest do
   # UUID search in list_files_in_scope
   # ---------------------------------------------------------------------------
 
+  describe "list_files_in_scope/2 and folder links" do
+    # `assign_file_to_folder`-style attachment links a file that already
+    # lives elsewhere into a second folder via `FolderLink` instead of
+    # moving it. `count_folder_contents/1` always counted those; the
+    # listing read home rows only, so a linked file showed in the
+    # sidebar count and not in the grid (2026-09-12).
+    test "a folder's listing includes files linked into it, unscoped and scoped" do
+      home = create_folder!(%{name: "link_home_#{System.unique_integer([:positive])}"})
+      other = create_folder!(%{name: "link_other_#{System.unique_integer([:positive])}"})
+      own = create_file!(home.uuid)
+      linked = create_file!(other.uuid)
+
+      {:ok, _} =
+        %FolderLink{}
+        |> FolderLink.changeset(%{folder_uuid: home.uuid, file_uuid: linked.uuid})
+        |> Repo.insert()
+
+      {files, total} = Storage.list_files_in_scope(nil, folder_uuid: home.uuid)
+      assert Enum.sort(Enum.map(files, & &1.uuid)) == Enum.sort([own.uuid, linked.uuid])
+      assert total == 2
+      assert Storage.count_folder_contents(home.uuid) == 2
+
+      # Scoped variant (a folder inside a scope) reads the same set.
+      {scoped, _} = Storage.list_files_in_scope(home.uuid, folder_uuid: home.uuid)
+      assert Enum.sort(Enum.map(scoped, & &1.uuid)) == Enum.sort([own.uuid, linked.uuid])
+
+      # The other folder still lists only its own home file.
+      {others, _} = Storage.list_files_in_scope(nil, folder_uuid: other.uuid)
+      assert Enum.map(others, & &1.uuid) == [linked.uuid]
+    end
+  end
+
   describe "list_files_in_scope with UUID search" do
     test "partial UUID prefix matches file" do
       file = create_file!(nil)

--- a/test/integration/storage/scope_test.exs
+++ b/test/integration/storage/scope_test.exs
@@ -1,6 +1,8 @@
 defmodule PhoenixKit.Integration.Storage.ScopeTest do
   use PhoenixKit.DataCase, async: true
 
+  import Ecto.Query
+
   alias PhoenixKit.Modules.Storage
   alias PhoenixKit.Modules.Storage.File, as: StorageFile
   alias PhoenixKit.Modules.Storage.FolderLink
@@ -658,6 +660,27 @@ defmodule PhoenixKit.Integration.Storage.ScopeTest do
       reloaded = Repo.get(StorageFile, file.uuid)
       assert reloaded.status == "trashed"
       assert reloaded.trashed_at
+    end
+
+    test "a file also linked into a folder outside the subtree is re-homed there, not trashed" do
+      # Content de-dup links a second upload of the same bytes into the
+      # second folder; trashing the first folder must not hide the file
+      # from the second (2026-09-12: a product's attachment vanished).
+      %{scope: scope, child_a: child_a, sibling: sibling} = build_tree()
+      file = create_file!(child_a.uuid)
+      {:ok, _link} = Storage.create_folder_link(sibling.uuid, file.uuid, nil)
+
+      assert {:ok, _} = Storage.trash_folder(child_a, scope.uuid)
+
+      reloaded = Repo.get(StorageFile, file.uuid)
+      assert reloaded.status == "active"
+      assert reloaded.folder_uuid == sibling.uuid
+
+      refute Repo.exists?(
+               from(fl in PhoenixKit.Modules.Storage.FolderLink,
+                 where: fl.file_uuid == ^file.uuid
+               )
+             )
     end
 
     test "trashed folders disappear from list_folders/list_folder_tree" do


### PR DESCRIPTION
## Summary

A file can live in one folder and be linked into others (`FolderLink`): that is what a content-duplicate upload or a media-selector pick becomes. `count_folder_contents/1` always counted those links, but the folder listing read home rows only, so the Media sidebar said N while the grid showed fewer, and a file the catalogue's item editor listed was missing from the folder view.

### What changed

- `list_files_in_scope/2`'s folder branches, and a scoped browser's root, read `folder_contents_query/1`: home files or files linked into the folder. Search inside a folder covers both.
- Because linked files are now visible, per-file actions taken from a listing act on the **appearance**, not the record:
  - `remove_file_from_folder/2`: a linked file is unlinked; a home file another folder still links is re-homed there (a live folder, never a trashed one); a file nothing else holds is trashed; a file the folder never held is refused.
  - `move_file_between_folders/4`: a linked file's link moves, atomically; to the root it is simply dropped; onto its own home, or a folder already linking it, nothing is added.
  - `attach_file_to_folder/2`: adopt a homeless file, no-op when already home, link otherwise — the rule the catalogue and the media selector followed; the Media browser's own upload path used to **move** a duplicate's home out from under the folder that owned it.
- The Media browser's trash, delete, bulk delete, drag and bulk move, download and rotate resolve the folder a file appears in (the viewed folder, or an expanded stack) and use those operations. A stale or forged uuid of some other in-scope file is refused inside a folder view. Flash "File removed from this folder" in all eight locales.

### Review round

codex, GLM-5.3 and grok reviewed the diff with the catalogue PR; every finding reproduced before acting. Fixed from it: files inside expanded stacks acting on the wrong folder, the non-atomic link move and its self-link and root cases, the fall-through trash for a non-member, the scoped virtual root omitting links, download and rotate rejecting visible linked files, and re-homing into a trashed folder.

### Also on this PR: trashing a folder no longer hides a file another folder shows

Sweep of the day's bug shapes: `trash_folder/2` trashed every file homed in the subtree, including one also linked into a folder outside it (a product's attachment, which content de-dup links rather than copies), so tidying the Media library made the attachment vanish from the product. `delete_folder_completely/2` already re-homed such files into their outside folder; trash now does the same before trashing what is left. Pinned in `scope_test.exs`; storage and media browser suites 92/0, `mix precommit` exit 0.

### Also on this PR: the confirmation gate halts with a note, not an error

An unconfirmed account reaching the app was parked at `/users/confirm` with "Please confirm your email before accessing the application." styled as an *error* flash, so a routine first visit looked like a failure (reported from topp.ee). `account_gate/1` now returns the flash kind with the message and all three callers use it; both halts (confirmation, referral code) are `:warning`. Two tests pin the kind on the conn and scope plugs; `mix precommit` exit 0.

## Verification

- Storage and Media browser integration tests: 115 tests, 1 failure — "info sidebar collapse in the popup", which fails identically on upstream's tip without these commits.
- `mix precommit`: exit 0.
- Nine new storage tests pin listing with links, attach/adopt/link, removal outcomes, live-folder re-homing, link moves including root and existing-target cases, and the scoped root.

## Test plan

- [x] `mix precommit`
- [x] `mix test test/integration/storage ...`
- [ ] Post-merge check of the Media page on a box with linked files (tim-dev has catalogue-linked files)


